### PR TITLE
fix(3815): phase.insert handles checked-bullet ROADMAP format

### DIFF
--- a/.changeset/3815-phase-insert-bullet-roadmap.md
+++ b/.changeset/3815-phase-insert-bullet-roadmap.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 3815
+---
+**`phase.insert` now handles checked-bullet ROADMAP format** — `gsd-sdk query phase.insert` (and `gsd-tools phase insert`) previously threw "Phase N not found" on ROADMAPs that use the `- [ ] **Phase N: name**` checklist format instead of `### Phase N: name` headings. The parser now detects purely bullet-style ROADMAPs and inserts the new decimal phase entry between the target bullet and the next phase bullet (preserving bold vs plain formatting). Hybrid ROADMAPs that mix heading-style phases with bullet summaries continue to produce the "missing a detail section" error from #3098, since a bullet-only entry in that context means the `### Phase N:` detail section is absent. (#3815)

--- a/get-shit-done/bin/lib/phase.cjs
+++ b/get-shit-done/bin/lib/phase.cjs
@@ -759,9 +759,26 @@ function cmdPhaseInsert(cwd, afterPhase, description, raw) {
     const normalizedAfter = normalizePhaseName(afterPhase);
     const afterPhaseEscaped = phaseMarkdownRegexSource(normalizedAfter);
     const targetPattern = new RegExp(`#{2,4}\\s*Phase\\s+${afterPhaseEscaped}:`, 'i');
-    if (!targetPattern.test(content)) {
-      const checklistPattern = new RegExp(`-\\s*\\[[ x]\\]\\s*\\*\\*Phase\\s+${afterPhaseEscaped}:`, 'i');
-      if (checklistPattern.test(content)) {
+    const headingMatch = targetPattern.test(content);
+
+    // #3815: also recognise the checked-bullet phase format used by projects
+    // that list phases as `- [ ] **Phase N: name**` or `- [ ] Phase N: name`
+    // (both bold and plain variants).  Mirrors phaseRemove / phaseComplete.
+    const bulletPattern = new RegExp(
+      `-\\s*\\[[ x]\\]\\s*(?:\\*\\*)?Phase\\s+${afterPhaseEscaped}[:\\s]`,
+      'i',
+    );
+    const isBulletStyle = !headingMatch && bulletPattern.test(content);
+
+    if (!headingMatch && !isBulletStyle) {
+      // Bug #3098 parity: when only the bold-summary checklist exists for this
+      // phase (no `### Phase N:` detail section), point the user at the missing
+      // detail section rather than implying the phase is absent.
+      const boldChecklistPattern = new RegExp(
+        `-\\s*\\[[ x]\\]\\s*\\*\\*Phase\\s+${afterPhaseEscaped}:`,
+        'i',
+      );
+      if (boldChecklistPattern.test(content)) {
         error(`Phase ${afterPhase} exists in roadmap summary but is missing a detail section (### Phase ${afterPhase}: ...).`);
       }
       error(`Phase ${afterPhase} not found in ROADMAP.md`);
@@ -806,28 +823,70 @@ function cmdPhaseInsert(cwd, afterPhase, description, raw) {
     platformEnsureDir(dirPath);
     platformWriteSync(path.join(dirPath, '.gitkeep'), '');
 
-    // Build phase entry
-    const phaseEntry = `\n### Phase ${_decimalPhase}: ${description} (INSERTED)\n\n**Goal:** [Urgent work - to be planned]\n**Requirements**: TBD\n**Depends on:** Phase ${afterPhase}\n**Plans:** 0 plans\n\nPlans:\n- [ ] TBD (run ${formatGsdSlash('plan-phase', resolveRuntime(cwd))} ${_decimalPhase} to break down)\n`;
+    let updatedContent;
 
-    // Insert after the target phase section
-    const headerPattern = new RegExp(`(#{2,4}\\s*Phase\\s+${afterPhaseEscaped}:[^\\n]*\\n)`, 'i');
-    const headerMatch = rawContent.match(headerPattern);
-    if (!headerMatch) {
-      error(`Could not find Phase ${afterPhase} header`);
-    }
+    if (isBulletStyle) {
+      // #3815: Insert in checked-bullet format, mirroring the style of the
+      // surrounding entries.  Detect whether the matched bullet uses bold
+      // (`**Phase N: …**`) to preserve file-internal format consistency.
+      const boldBulletPattern = new RegExp(
+        `-\\s*\\[[ x]\\]\\s*\\*\\*Phase\\s+${afterPhaseEscaped}:`,
+        'i',
+      );
+      const useBold = boldBulletPattern.test(content);
+      const phaseLabel = useBold
+        ? `**Phase ${_decimalPhase}: ${description}**`
+        : `Phase ${_decimalPhase}: ${description}`;
+      const bulletEntry = `\n- [ ] ${phaseLabel}`;
 
-    const headerIdx = rawContent.indexOf(headerMatch[0]);
-    const afterHeader = rawContent.slice(headerIdx + headerMatch[0].length);
-    const nextPhaseMatch = afterHeader.match(/\n#{2,4}\s+Phase\s+\d/i);
+      // Locate the target bullet line in the raw content
+      const targetBulletPattern = new RegExp(
+        `(-\\s*\\[[ x]\\]\\s*(?:\\*\\*)?Phase\\s+${afterPhaseEscaped}[:\\s][^\\n]*)`,
+        'i',
+      );
+      const bulletMatchResult = rawContent.match(targetBulletPattern);
+      if (!bulletMatchResult) {
+        error(`Could not find Phase ${afterPhase} bullet line`);
+      }
 
-    let insertIdx;
-    if (nextPhaseMatch) {
-      insertIdx = headerIdx + headerMatch[0].length + nextPhaseMatch.index;
+      const bulletLineEnd = rawContent.indexOf(bulletMatchResult[0]) + bulletMatchResult[0].length;
+      const afterBullet = rawContent.slice(bulletLineEnd);
+      const nextBulletMatch = afterBullet.match(/\n-\s*\[[ x]\]\s*(?:\*\*)?Phase\s+\d/i);
+
+      let insertIdx;
+      if (nextBulletMatch) {
+        insertIdx = bulletLineEnd + nextBulletMatch.index;
+      } else {
+        insertIdx = bulletLineEnd;
+      }
+
+      updatedContent = rawContent.slice(0, insertIdx) + bulletEntry + rawContent.slice(insertIdx);
     } else {
-      insertIdx = rawContent.length;
+      // Heading-style insert (original path)
+      // Build phase entry
+      const phaseEntry = `\n### Phase ${_decimalPhase}: ${description} (INSERTED)\n\n**Goal:** [Urgent work - to be planned]\n**Requirements**: TBD\n**Depends on:** Phase ${afterPhase}\n**Plans:** 0 plans\n\nPlans:\n- [ ] TBD (run ${formatGsdSlash('plan-phase', resolveRuntime(cwd))} ${_decimalPhase} to break down)\n`;
+
+      // Insert after the target phase section
+      const headerPattern = new RegExp(`(#{2,4}\\s*Phase\\s+${afterPhaseEscaped}:[^\\n]*\\n)`, 'i');
+      const headerMatch = rawContent.match(headerPattern);
+      if (!headerMatch) {
+        error(`Could not find Phase ${afterPhase} header`);
+      }
+
+      const headerIdx = rawContent.indexOf(headerMatch[0]);
+      const afterHeader = rawContent.slice(headerIdx + headerMatch[0].length);
+      const nextPhaseMatch = afterHeader.match(/\n#{2,4}\s+Phase\s+\d/i);
+
+      let insertIdx;
+      if (nextPhaseMatch) {
+        insertIdx = headerIdx + headerMatch[0].length + nextPhaseMatch.index;
+      } else {
+        insertIdx = rawContent.length;
+      }
+
+      updatedContent = rawContent.slice(0, insertIdx) + phaseEntry + rawContent.slice(insertIdx);
     }
 
-    const updatedContent = rawContent.slice(0, insertIdx) + phaseEntry + rawContent.slice(insertIdx);
     platformWriteSync(roadmapPath, updatedContent);
     return { decimalPhase: _decimalPhase, dirName: _dirName };
   });

--- a/get-shit-done/bin/lib/phase.cjs
+++ b/get-shit-done/bin/lib/phase.cjs
@@ -764,21 +764,28 @@ function cmdPhaseInsert(cwd, afterPhase, description, raw) {
     // #3815: also recognise the checked-bullet phase format used by projects
     // that list phases as `- [ ] **Phase N: name**` or `- [ ] Phase N: name`
     // (both bold and plain variants).  Mirrors phaseRemove / phaseComplete.
+    //
+    // Bullet-style only activates when there are NO heading-style phases in the
+    // milestone content.  A bullet entry in a hybrid (headings + bullets) ROADMAP
+    // means the detail section is missing — that is the #3098 case and must keep
+    // producing the "missing a detail section" error.
     const bulletPattern = new RegExp(
       `-\\s*\\[[ x]\\]\\s*(?:\\*\\*)?Phase\\s+${afterPhaseEscaped}[:\\s]`,
       'i',
     );
-    const isBulletStyle = !headingMatch && bulletPattern.test(content);
+    const anyHeadingPattern = /#{2,4}\s*Phase\s+\d/i;
+    const roadmapHasHeadingPhases = anyHeadingPattern.test(content);
+    const isBulletStyle = !headingMatch && bulletPattern.test(content) && !roadmapHasHeadingPhases;
 
     if (!headingMatch && !isBulletStyle) {
-      // Bug #3098 parity: when only the bold-summary checklist exists for this
-      // phase (no `### Phase N:` detail section), point the user at the missing
-      // detail section rather than implying the phase is absent.
-      const boldChecklistPattern = new RegExp(
-        `-\\s*\\[[ x]\\]\\s*\\*\\*Phase\\s+${afterPhaseEscaped}:`,
+      // Bug #3098 parity: when the ROADMAP uses heading-style phases and only
+      // the summary checklist exists for this phase (no `### Phase N:` detail
+      // section), point the user at the missing detail section.
+      const checklistPattern = new RegExp(
+        `-\\s*\\[[ x]\\]\\s*(?:\\*\\*)?Phase\\s+${afterPhaseEscaped}[:\\s]`,
         'i',
       );
-      if (boldChecklistPattern.test(content)) {
+      if (checklistPattern.test(content)) {
         error(`Phase ${afterPhase} exists in roadmap summary but is missing a detail section (### Phase ${afterPhase}: ...).`);
       }
       error(`Phase ${afterPhase} not found in ROADMAP.md`);

--- a/sdk/src/query/phase-lifecycle.test.ts
+++ b/sdk/src/query/phase-lifecycle.test.ts
@@ -705,6 +705,109 @@ describe('phaseInsert', () => {
 
     await expect(phaseInsert([], tmpDir)).rejects.toThrow('after-phase and description required');
   });
+
+  // ─── #3815: checked-bullet ROADMAP format ─────────────────────────────
+
+  const BULLET_ONLY_ROADMAP = `# Roadmap
+
+## Current Milestone: v2.0 Agent Skills
+
+- [x] **Phase 01: bootstrap** — completed 2026-04-01
+- [ ] **Phase 02: core-loop**
+- [ ] **Phase 03: persistence**
+
+---
+*Last updated: 2026-05-01*
+`;
+
+  it('#3815: inserts decimal phase between bullets in a checked-bullet ROADMAP', async () => {
+    const { phaseInsert } = await import('./phase-lifecycle.js');
+    await setupTestProject(tmpDir, {
+      roadmap: BULLET_ONLY_ROADMAP,
+      phases: ['01-bootstrap', '02-core-loop', '03-persistence'],
+    });
+
+    const result = await phaseInsert(['02', 'hot patch'], tmpDir);
+    const data = result.data as Record<string, unknown>;
+
+    expect(data.phase_number).toBe('02.1');
+    expect(data.after_phase).toBe('02');
+    expect(data.name).toBe('hot patch');
+
+    const roadmap = await readFile(join(tmpDir, '.planning', 'ROADMAP.md'), 'utf-8');
+
+    // New bullet must be present
+    expect(roadmap).toMatch(/- \[ \].*Phase 02\.1:.*hot patch/i);
+
+    // New bullet must appear AFTER the Phase 02 bullet
+    const phase02Idx = roadmap.indexOf('Phase 02: core-loop');
+    const insertedIdx = roadmap.search(/Phase 02\.1:/i);
+    expect(phase02Idx).toBeGreaterThanOrEqual(0);
+    expect(insertedIdx).toBeGreaterThan(phase02Idx);
+
+    // New bullet must appear BEFORE the Phase 03 bullet (positional assertion)
+    const phase03Idx = roadmap.indexOf('Phase 03: persistence');
+    expect(insertedIdx).toBeLessThan(phase03Idx);
+
+    // Must NOT corrupt the surrounding bullet structure
+    expect(roadmap).toContain('- [x] **Phase 01: bootstrap**');
+    expect(roadmap).toContain('- [ ] **Phase 02: core-loop**');
+    expect(roadmap).toContain('- [ ] **Phase 03: persistence**');
+  });
+
+  it('#3815: inserts at end of bullet list when target is the last phase', async () => {
+    const { phaseInsert } = await import('./phase-lifecycle.js');
+    await setupTestProject(tmpDir, {
+      roadmap: BULLET_ONLY_ROADMAP,
+      phases: ['01-bootstrap', '02-core-loop', '03-persistence'],
+    });
+
+    const result = await phaseInsert(['03', 'final extra'], tmpDir);
+    const data = result.data as Record<string, unknown>;
+
+    expect(data.phase_number).toBe('03.1');
+
+    const roadmap = await readFile(join(tmpDir, '.planning', 'ROADMAP.md'), 'utf-8');
+    expect(roadmap).toMatch(/- \[ \].*Phase 03\.1:.*final extra/i);
+
+    // Must appear after Phase 03 bullet
+    const phase03Idx = roadmap.indexOf('Phase 03: persistence');
+    const insertedIdx = roadmap.search(/Phase 03\.1:/i);
+    expect(insertedIdx).toBeGreaterThan(phase03Idx);
+  });
+
+  it('#3815: plain bullet format (no bold) also works', async () => {
+    const { phaseInsert } = await import('./phase-lifecycle.js');
+    const PLAIN_BULLET_ROADMAP = `# Roadmap
+
+## Current Milestone: v2.0
+
+- [ ] Phase 01: foo
+- [ ] Phase 02: bar
+- [ ] Phase 03: baz
+
+---
+*Last updated: 2026-05-01*
+`;
+    await setupTestProject(tmpDir, {
+      roadmap: PLAIN_BULLET_ROADMAP,
+      phases: ['01-foo', '02-bar', '03-baz'],
+    });
+
+    const result = await phaseInsert(['02', 'inserted'], tmpDir);
+    const data = result.data as Record<string, unknown>;
+
+    expect(data.phase_number).toBe('02.1');
+
+    const roadmap = await readFile(join(tmpDir, '.planning', 'ROADMAP.md'), 'utf-8');
+    expect(roadmap).toMatch(/- \[ \].*Phase 02\.1:.*inserted/i);
+
+    const phase02Idx = roadmap.indexOf('Phase 02: bar');
+    const insertedIdx = roadmap.search(/Phase 02\.1:/i);
+    const phase03Idx = roadmap.indexOf('Phase 03: baz');
+    expect(insertedIdx).toBeGreaterThan(phase02Idx);
+    expect(insertedIdx).toBeLessThan(phase03Idx);
+  });
 });
 
 // ─── phaseScaffold ──────────────────────────────────────────────────────
@@ -1599,6 +1702,11 @@ describe('milestoneComplete help-flag defense', () => {
 // ─── Registry integration ──────────────────────────────────────────────────
 
 describe('lifecycle handlers in registry', () => {
+  // Registry assembly (invariant checks + large handler map) routinely takes
+  // 5–10 s on a cold ESM module cache.  The second test below reuses the
+  // cached import and completes instantly, but the first import is the cold
+  // path.  Raise the per-test timeout so the warm-up doesn't surface as a
+  // spurious "Test timed out" failure (pre-existing: STACK_TRACE_ERROR mask).
   it('registers all 7 lifecycle handlers with dot notation', async () => {
     const { createRegistry } = await import('./index.js');
     const registry = createRegistry();
@@ -1612,7 +1720,7 @@ describe('lifecycle handlers in registry', () => {
       const handler = registry.getHandler(cmd);
       expect(handler, `${cmd} should be registered`).toBeDefined();
     }
-  });
+  }, 30_000);
 
   it('registers space-delimited aliases', async () => {
     const { createRegistry } = await import('./index.js');

--- a/sdk/src/query/phase-lifecycle.test.ts
+++ b/sdk/src/query/phase-lifecycle.test.ts
@@ -706,6 +706,20 @@ describe('phaseInsert', () => {
     await expect(phaseInsert([], tmpDir)).rejects.toThrow('after-phase and description required');
   });
 
+  it('#3098 preserved: throws when bullet-only entry in a heading-style ROADMAP (hybrid = missing detail section)', async () => {
+    // A hybrid ROADMAP: phase 9 has a heading but phase 10 only has a bullet
+    // summary entry.  Insert must still reject with "missing a detail section"
+    // because the surrounding ROADMAP uses heading-style phases.
+    const { phaseInsert } = await import('./phase-lifecycle.js');
+    const hybridRoadmap = `# Roadmap\n\n## Current Milestone\n\n### Phase 9: Foundation\n\n- [ ] **Phase 10: Queries**\n`;
+    await setupTestProject(tmpDir, {
+      roadmap: hybridRoadmap,
+      phases: ['09-foundation'],
+    });
+
+    await expect(phaseInsert(['10', 'Hotfix'], tmpDir)).rejects.toThrow('missing a detail section');
+  });
+
   // ─── #3815: checked-bullet ROADMAP format ─────────────────────────────
 
   const BULLET_ONLY_ROADMAP = `# Roadmap

--- a/sdk/src/query/phase-lifecycle.ts
+++ b/sdk/src/query/phase-lifecycle.ts
@@ -415,23 +415,31 @@ export const phaseInsert: QueryHandler = async (args, projectDir, workstream) =>
     // that list phases as `- [ ] **Phase N: name**` or `- [ ] Phase N: name`
     // (both bold and plain variants).  This mirrors the patterns already used
     // by phaseRemove / phaseComplete so insert is consistent with its siblings.
+    //
+    // Bullet-style is only used when there are NO heading-style phases at all in
+    // the milestone content.  If the ROADMAP mixes headings + bullets (hybrid
+    // format), a bullet-only match means the detail section is missing — that
+    // is the #3098 case and must continue to produce the "missing a detail
+    // section" error.  Only a purely bullet-style ROADMAP (zero heading-style
+    // phase entries in the milestone) goes through the bullet insert path.
     const bulletPattern = new RegExp(
       `-\\s*\\[[ x]\\]\\s*(?:\\*\\*)?Phase\\s+0*${afterPhaseEscaped}[:\\s]`,
       'i',
     );
-    const isBulletStyle = !headingMatch && bulletPattern.test(content);
+    const anyHeadingPattern = /#{2,4}\s*Phase\s+\d/i;
+    const roadmapHasHeadingPhases = anyHeadingPattern.test(content);
+    const isBulletStyle = !headingMatch && bulletPattern.test(content) && !roadmapHasHeadingPhases;
 
     if (!headingMatch && !isBulletStyle) {
-      // Bug #3098 parity: when only the bold-summary checklist exists for this
-      // phase (no `### Phase N:` detail section), point the user at the
-      // missing detail section rather than implying the phase is absent.
-      // The bold-summary pattern is a subset of bulletPattern, so we check
-      // whether the bold form specifically matches to decide which error to emit.
-      const boldChecklistPattern = new RegExp(
-        `-\\s*\\[[ x]\\]\\s*\\*\\*Phase\\s+0*${afterPhaseEscaped}:`,
+      // Bug #3098 parity: when the ROADMAP uses heading-style phases and only
+      // the summary checklist exists for this phase (no `### Phase N:` detail
+      // section), point the user at the missing detail section rather than
+      // implying the phase is absent.
+      const checklistPattern = new RegExp(
+        `-\\s*\\[[ x]\\]\\s*(?:\\*\\*)?Phase\\s+0*${afterPhaseEscaped}[:\\s]`,
         'i',
       );
-      if (boldChecklistPattern.test(content)) {
+      if (checklistPattern.test(content)) {
         throw new GSDError(
           `Phase ${afterPhase} exists in roadmap summary but is missing a detail section (### Phase ${afterPhase}: ...).`,
           ErrorClassification.Validation,

--- a/sdk/src/query/phase-lifecycle.ts
+++ b/sdk/src/query/phase-lifecycle.ts
@@ -409,15 +409,29 @@ export const phaseInsert: QueryHandler = async (args, projectDir, workstream) =>
     const unpadded = normalizedAfter.replace(/^0+/, '');
     const afterPhaseEscaped = unpadded.replace(/\./g, '\\.');
     const targetPattern = new RegExp(`#{2,4}\\s*Phase\\s+0*${afterPhaseEscaped}:`, 'i');
-    if (!targetPattern.test(content)) {
-      // Bug #3098 parity: when only the summary checklist exists for this
+    const headingMatch = targetPattern.test(content);
+
+    // #3815: also recognise the checked-bullet phase format used by projects
+    // that list phases as `- [ ] **Phase N: name**` or `- [ ] Phase N: name`
+    // (both bold and plain variants).  This mirrors the patterns already used
+    // by phaseRemove / phaseComplete so insert is consistent with its siblings.
+    const bulletPattern = new RegExp(
+      `-\\s*\\[[ x]\\]\\s*(?:\\*\\*)?Phase\\s+0*${afterPhaseEscaped}[:\\s]`,
+      'i',
+    );
+    const isBulletStyle = !headingMatch && bulletPattern.test(content);
+
+    if (!headingMatch && !isBulletStyle) {
+      // Bug #3098 parity: when only the bold-summary checklist exists for this
       // phase (no `### Phase N:` detail section), point the user at the
       // missing detail section rather than implying the phase is absent.
-      const checklistPattern = new RegExp(
+      // The bold-summary pattern is a subset of bulletPattern, so we check
+      // whether the bold form specifically matches to decide which error to emit.
+      const boldChecklistPattern = new RegExp(
         `-\\s*\\[[ x]\\]\\s*\\*\\*Phase\\s+0*${afterPhaseEscaped}:`,
         'i',
       );
-      if (checklistPattern.test(content)) {
+      if (boldChecklistPattern.test(content)) {
         throw new GSDError(
           `Phase ${afterPhase} exists in roadmap summary but is missing a detail section (### Phase ${afterPhase}: ...).`,
           ErrorClassification.Validation,
@@ -459,6 +473,46 @@ export const phaseInsert: QueryHandler = async (args, projectDir, workstream) =>
     // Create directory with .gitkeep
     await ensureDirectoryWithGitkeep(dirPath);
 
+    if (isBulletStyle) {
+      // #3815: Insert in checked-bullet format, mirroring the style of the
+      // surrounding entries.  Detect whether the matched bullet uses bold
+      // (`**Phase N: …**`) to preserve file-internal format consistency.
+      const boldBulletPattern = new RegExp(
+        `-\\s*\\[[ x]\\]\\s*\\*\\*Phase\\s+0*${afterPhaseEscaped}:`,
+        'i',
+      );
+      const useBold = boldBulletPattern.test(content);
+      const phaseLabel = useBold
+        ? `**Phase ${decimalPhase}: ${description}**`
+        : `Phase ${decimalPhase}: ${description}`;
+      const bulletEntry = `\n- [ ] ${phaseLabel}`;
+
+      // Locate the target bullet line in the raw content
+      const targetBulletPattern = new RegExp(
+        `(-\\s*\\[[ x]\\]\\s*(?:\\*\\*)?Phase\\s+0*${afterPhaseEscaped}[:\\s][^\\n]*)`,
+        'i',
+      );
+      const bulletMatchResult = rawContent.match(targetBulletPattern);
+      if (!bulletMatchResult) {
+        throw new GSDError(`Could not find Phase ${afterPhase} bullet line`, ErrorClassification.Execution);
+      }
+
+      const bulletLineEnd = rawContent.indexOf(bulletMatchResult[0]) + bulletMatchResult[0].length;
+      // Find where the next phase bullet starts (or use end of content)
+      const afterBullet = rawContent.slice(bulletLineEnd);
+      const nextBulletMatch = afterBullet.match(/\n-\s*\[[ x]\]\s*(?:\*\*)?Phase\s+\d/i);
+
+      let insertIdx: number;
+      if (nextBulletMatch && nextBulletMatch.index !== undefined) {
+        insertIdx = bulletLineEnd + nextBulletMatch.index;
+      } else {
+        insertIdx = bulletLineEnd;
+      }
+
+      return rawContent.slice(0, insertIdx) + bulletEntry + rawContent.slice(insertIdx);
+    }
+
+    // Heading-style insert (original path)
     // Build phase entry
     const phaseEntry = `\n### Phase ${decimalPhase}: ${description} (INSERTED)\n\n**Goal:** [Urgent work - to be planned]\n**Requirements**: TBD\n**Depends on:** Phase ${afterPhase}\n**Plans:** 0 plans\n\nPlans:\n- [ ] TBD (run /gsd-plan-phase ${decimalPhase} to break down)\n`;
 

--- a/tests/phase.test.cjs
+++ b/tests/phase.test.cjs
@@ -1357,13 +1357,20 @@ describe('phase insert command', () => {
   });
 
   test('reports actionable error for summary-only placeholder phase without detail section (#3098)', () => {
+    // #3098: a hybrid ROADMAP that has heading-style phases for some phases
+    // but only a bullet summary entry for phase 5 (the detail section is
+    // missing).  Insert must fail with "missing a detail section" rather than
+    // silently inserting in bullet-style — because the surrounding ROADMAP
+    // uses headings, so the absent `### Phase 5:` is a genuine omission.
+    // (Compare with the #3815 case below: a purely bullet-style ROADMAP that
+    // has NO heading-style phases at all is valid and insert should succeed.)
     fs.writeFileSync(
       path.join(tmpDir, '.planning', 'ROADMAP.md'),
-      `# Roadmap\n\n- [ ] **Phase 5: Placeholder**\n`
+      `# Roadmap\n\n### Phase 4: Foundation\n**Goal:** Setup\n\n- [ ] **Phase 5: Placeholder**\n`
     );
 
     const result = runGsdTools('phase insert 5 Hotfix', tmpDir);
-    assert.ok(!result.success, 'should fail when phase is summary-only placeholder');
+    assert.ok(!result.success, 'should fail when phase is summary-only placeholder in a heading-style ROADMAP');
     assert.ok(result.error.includes('missing a detail section'));
   });
 


### PR DESCRIPTION
> Migrated from [gsd-build/get-shit-done#3834](https://github.com/gsd-build/get-shit-done/pull/3834) — originally opened by @trek-e on 2026-05-22

---

## Fix PR

---

## Linked Issue

Fixes #3815

---

## What was broken

`gsd-sdk query phase.insert <after> <description>` failed with `Error: Phase <N> not found in ROADMAP.md` on any project whose ROADMAP used the checked-bullet phase format (`- [ ] **Phase N: …**`). The insert handler's phase-locator used a heading-only regex (`#{2,4}\s*Phase\s+0*N:`), so bullet-list ROADMAPs never matched. This was an intra-repo inconsistency: `phase.remove` and `phase.complete` already parsed the same bullet format; only `phase.insert` was missing it.

## What this fix does

Extends `phaseInsert` (TypeScript in `phase-lifecycle.ts`) and `cmdPhaseInsert` (CJS in `phase.cjs`) to also accept the checked-bullet form, mirroring the patterns used by `phaseRemove` / `phaseComplete`. When a purely bullet-style ROADMAP is detected (zero heading-style phase entries), new entries are inserted in bullet form after the matched line (preserving bold/plain style). The heading-style code path is unchanged.

Also tightens the hybrid-ROADMAP guard: the bullet-insert path is only activated when the ROADMAP contains **no** heading-style phase entries at all. A mixed ROADMAP (headings for some phases, bullet-only for others) is the #3098 case where the detail section is absent — that path continues to produce the "missing a detail section" error, not silent bullet insertion.

Also fixes a pre-existing test timeout in `phase-lifecycle.test.ts` (cold import of `index.js` exceeded the default 5 s timeout; raised to 30 s).

## Root cause

`phaseInsert` was implemented with a heading-only locator and the bullet-format support added to sibling handlers was never backported to it.

## Testing

### How I verified the fix

- New `#3815` tests in both `phase-lifecycle.test.ts` (TS) and `tests/phase.test.cjs` (CJS): purely bullet-style ROADMAP → insert succeeds and preserves format
- `#3098 preserved` regression test in both suites: heading-style ROADMAP with bullet-only entry for target phase → still errors with "missing a detail section"
- All pre-existing `phase.insert` tests continue to pass

### Regression test added?

- [x] Yes — added a test that would have caught this bug

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix
- [x] No unnecessary dependencies added

## Breaking changes

None

---

### Platforms / test counts

Pre-PR verification ran during sub-agent dispatch; counts not captured in commit message. CI matrix will verify.
