### PR TITLE
fix(3804): worktree.cleanup-wave rescues uncommitted SUMMARY.md

### DIFF
--- a/.changeset/3804-worktree-cleanup-summary-rescue.md
+++ b/.changeset/3804-worktree-cleanup-summary-rescue.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 3804
+---
+**`worktree.cleanup-wave` no longer blocks on executor's uncommitted SUMMARY.md** — `executeWorktreeWaveCleanupPlan` previously returned `cleanup_blocked` / `worktree_dirty` when the executor left `<quick_id>-SUMMARY.md` uncommitted in the worktree's `.planning/` directory (the documented contract — the orchestrator commits it). The fix ports the shell-fallback rescue logic from `quick.md` into the CJS function: before the dirty-state check, all `*SUMMARY.md` files under `<worktree>/.planning/` are copied to the main tree (if absent or divergent), then filtered out of the porcelain output. Only non-SUMMARY dirty files now block cleanup. (#3804, mirrors #2296/#2070/#2838)

--- a/get-shit-done/bin/lib/worktree-safety.cjs
+++ b/get-shit-done/bin/lib/worktree-safety.cjs
@@ -385,6 +385,94 @@ function gitResultOk(result) {
   return result && result.exitCode === 0 && !result.timedOut;
 }
 
+/**
+ * Walk <worktreePath>/.planning/ recursively and collect absolute paths of
+ * all files whose names match *SUMMARY.md.  Returns [] when the directory
+ * does not exist or cannot be read.
+ *
+ * Mirrors the shell fallback in quick.md (#2296, #2070, #2838):
+ *   find "$WT/.planning" -name "*SUMMARY.md"
+ */
+function defaultFindSummaryFiles(worktreePath) {
+  const planningDir = path.join(worktreePath, '.planning');
+  const results = [];
+  function walk(dir) {
+    let entries;
+    try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return; }
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (entry.isFile() && entry.name.endsWith('SUMMARY.md')) {
+        results.push(full);
+      }
+    }
+  }
+  walk(planningDir);
+  return results;
+}
+
+/**
+ * Rescue uncommitted SUMMARY.md artifacts from a worktree into the main repo
+ * tree before the dirty-state check.  Mirrors the shell-fallback rescue block
+ * in quick.md (lines 878–891, #2296/#2070/#2838).
+ *
+ * For each *SUMMARY.md found under <worktreePath>/.planning/:
+ *   - compute relative path from worktree root  → .planning/<id>-SUMMARY.md
+ *   - destination = <repoRoot>/<relPath>
+ *   - copy when dest is absent or content differs
+ *
+ * Returns a Set of worktree-relative paths (e.g. ".planning/q1-SUMMARY.md")
+ * that were eligible for rescue (regardless of whether a copy was needed).
+ * These paths are filtered out of the git-status porcelain output so a
+ * SUMMARY-only dirty worktree does not block cleanup.
+ *
+ * Injected deps (all optional — falls back to real FS):
+ *   findSummaryFiles(worktreePath) → string[]
+ *   existsSync(path) → boolean
+ *   readFileSync(path) → string
+ *   mkdirSync(dir, opts)
+ *   copyFileSync(src, dest)
+ */
+function rescueSummaryArtifacts(worktreePath, repoRoot, deps) {
+  const findSummaryFiles = deps.findSummaryFiles || defaultFindSummaryFiles;
+  const existsSync = deps.existsSync || fs.existsSync;
+  const readFileSync = deps.readFileSync || ((p) => fs.readFileSync(p, 'utf8'));
+  const mkdirSync = deps.mkdirSync || ((d, o) => fs.mkdirSync(d, o));
+  const copyFileSync = deps.copyFileSync || fs.copyFileSync;
+
+  const summaryPaths = findSummaryFiles(worktreePath);
+  const rescuedRelPaths = new Set();
+
+  for (const absPath of summaryPaths) {
+    // relPath is the path relative to the worktree root (e.g. ".planning/q1-SUMMARY.md")
+    const relPath = absPath.slice(worktreePath.length).replace(/^[/\\]/, '');
+    rescuedRelPaths.add(relPath);
+
+    const dest = path.join(repoRoot, relPath);
+    let needsCopy = !existsSync(dest);
+    if (!needsCopy) {
+      try {
+        const srcContent = readFileSync(absPath);
+        const destContent = readFileSync(dest);
+        needsCopy = srcContent !== destContent;
+      } catch {
+        needsCopy = true;
+      }
+    }
+    if (needsCopy) {
+      try {
+        mkdirSync(path.dirname(dest), { recursive: true });
+        copyFileSync(absPath, dest);
+      } catch {
+        // Best-effort rescue — if it fails the dirty check below will decide fate
+      }
+    }
+  }
+
+  return rescuedRelPaths;
+}
+
 function executeWorktreeWaveCleanupPlan(plan, deps = {}) {
   const execGit = deps.execGit || execGitDefault;
   const entries = Array.isArray(plan?.entries) ? plan.entries : [];
@@ -453,11 +541,36 @@ function executeWorktreeWaveCleanupPlan(plan, deps = {}) {
       break;
     }
 
+    // Safety net: rescue uncommitted SUMMARY.md artifacts before the dirty check.
+    // The executor leaves <quick_id>-SUMMARY.md uncommitted by contract — the
+    // orchestrator commits it.  Mirrors quick.md shell fallback (#2296, #2070, #2838, #3804).
+    const rescuedRelPaths = rescueSummaryArtifacts(entry.worktree_path, plan.repoRoot, deps);
+
     const worktreeStatus = execGit(['-C', entry.worktree_path, 'status', '--porcelain', '--untracked-files=all'], { cwd: plan.repoRoot });
-    if (!gitResultOk(worktreeStatus) || worktreeStatus.stdout) {
+    if (!gitResultOk(worktreeStatus)) {
       result.status = 'blocked';
       result.reason = 'worktree_dirty';
-      result.stderr = worktreeStatus?.stdout || worktreeStatus?.stderr || '';
+      result.stderr = worktreeStatus?.stderr || '';
+      results.push(result);
+      pending.push(...entries.slice(i + 1));
+      ok = false;
+      break;
+    }
+    // Filter rescued SUMMARY paths out of the porcelain output before deciding dirty.
+    // A line like "?? .planning/q1-SUMMARY.md" should not block when the SUMMARY
+    // has already been rescued into the main tree.
+    const dirtyLines = (worktreeStatus.stdout || '')
+      .split('\n')
+      .filter((line) => {
+        if (!line.trim()) return false;
+        // porcelain v1 format: "XY path" (3-char prefix + space + path)
+        const filePath = line.slice(3).trim();
+        return !rescuedRelPaths.has(filePath);
+      });
+    if (dirtyLines.length > 0) {
+      result.status = 'blocked';
+      result.reason = 'worktree_dirty';
+      result.stderr = dirtyLines.join('\n');
       results.push(result);
       pending.push(...entries.slice(i + 1));
       ok = false;

--- a/get-shit-done/bin/lib/worktree-safety.cjs
+++ b/get-shit-done/bin/lib/worktree-safety.cjs
@@ -446,7 +446,9 @@ function rescueSummaryArtifacts(worktreePath, repoRoot, deps) {
 
   for (const absPath of summaryPaths) {
     // relPath is the path relative to the worktree root (e.g. ".planning/q1-SUMMARY.md")
-    const relPath = absPath.slice(worktreePath.length).replace(/^[/\\]/, '');
+    // Normalize to forward slashes so the Set comparison against `git status --porcelain`
+    // output works on Windows too (git always emits forward slashes in porcelain output).
+    const relPath = absPath.slice(worktreePath.length).replace(/^[/\\]/, '').replace(/\\/g, '/');
     rescuedRelPaths.add(relPath);
 
     const dest = path.join(repoRoot, relPath);

--- a/tests/worktree-safety.test.cjs
+++ b/tests/worktree-safety.test.cjs
@@ -716,7 +716,8 @@ describe('executeWorktreeWaveCleanupPlan', () => {
     // SUMMARY was rescued into the main tree
     assert.equal(rescued.length, 1, 'SUMMARY.md must be rescued (copied) to main tree');
     assert.equal(rescued[0].src, '/repo/.claude/worktrees/agent-a1/.planning/q1-SUMMARY.md');
-    assert.equal(rescued[0].dest, '/repo/main/.planning/q1-SUMMARY.md');
+    // Normalize to forward slashes for cross-platform assertion (path.join uses \ on Windows)
+    assert.equal(rescued[0].dest.replace(/\\/g, '/'), '/repo/main/.planning/q1-SUMMARY.md');
 
     // Cleanup succeeded — SUMMARY-only dirty state must not block
     assert.equal(result.ok, true, 'cleanup must succeed when only SUMMARY.md is dirty');

--- a/tests/worktree-safety.test.cjs
+++ b/tests/worktree-safety.test.cjs
@@ -651,6 +651,126 @@ describe('executeWorktreeWaveCleanupPlan', () => {
     assert.deepEqual(result.pending.map((entry) => entry.branch), ['worktree-agent-a2']);
   });
 
+  test('#3804: rescues uncommitted SUMMARY.md from worktree .planning/ before dirty check', () => {
+    // Fixture: the only dirty file is .planning/q1-SUMMARY.md (executor left it uncommitted
+    // per documented contract — orchestrator commits it).  cleanup-wave MUST rescue it
+    // (copy to main tree) and succeed, not return worktree_dirty.
+    const calls = [];
+    const rescued = [];
+    const plan = {
+      ok: true,
+      repoRoot: '/repo/main',
+      action: 'cleanup_wave',
+      discovery: 'manifest',
+      entries: [{
+        agent_id: 'a1',
+        worktree_path: '/repo/.claude/worktrees/agent-a1',
+        branch: 'worktree-agent-a1',
+        expected_base: 'abc123',
+      }],
+    };
+    const result = executeWorktreeWaveCleanupPlan(plan, {
+      execGit: (args) => {
+        calls.push(args.join(' '));
+        const key = args.join(' ');
+        if (key === '-C /repo/.claude/worktrees/agent-a1 rev-parse --abbrev-ref HEAD') {
+          return { exitCode: 0, stdout: 'worktree-agent-a1', stderr: '' };
+        }
+        if (key === 'merge-base HEAD worktree-agent-a1') {
+          return { exitCode: 0, stdout: 'abc123', stderr: '' };
+        }
+        if (key === 'diff --diff-filter=D --name-only HEAD...worktree-agent-a1') {
+          return { exitCode: 0, stdout: '', stderr: '' };
+        }
+        if (key === '-C /repo/.claude/worktrees/agent-a1 status --porcelain --untracked-files=all') {
+          // Only the SUMMARY is dirty — no other modified files
+          return { exitCode: 0, stdout: '?? .planning/q1-SUMMARY.md', stderr: '' };
+        }
+        if (key.startsWith('merge worktree-agent-a1')) {
+          return { exitCode: 0, stdout: '', stderr: '' };
+        }
+        if (key === 'worktree remove /repo/.claude/worktrees/agent-a1 --force') {
+          return { exitCode: 0, stdout: '', stderr: '' };
+        }
+        if (key === 'branch -D worktree-agent-a1') {
+          return { exitCode: 0, stdout: '', stderr: '' };
+        }
+        return { exitCode: 0, stdout: '', stderr: '' };
+      },
+      // Inject FS deps so tests don't touch the real filesystem
+      findSummaryFiles: (worktreePath) => {
+        if (worktreePath === '/repo/.claude/worktrees/agent-a1') {
+          return ['/repo/.claude/worktrees/agent-a1/.planning/q1-SUMMARY.md'];
+        }
+        return [];
+      },
+      readFileSync: (p) => {
+        if (p === '/repo/.claude/worktrees/agent-a1/.planning/q1-SUMMARY.md') return 'summary content';
+        return '';
+      },
+      existsSync: (_p) => false,
+      mkdirSync: () => {},
+      copyFileSync: (src, dest) => { rescued.push({ src, dest }); },
+    });
+
+    // SUMMARY was rescued into the main tree
+    assert.equal(rescued.length, 1, 'SUMMARY.md must be rescued (copied) to main tree');
+    assert.equal(rescued[0].src, '/repo/.claude/worktrees/agent-a1/.planning/q1-SUMMARY.md');
+    assert.equal(rescued[0].dest, '/repo/main/.planning/q1-SUMMARY.md');
+
+    // Cleanup succeeded — SUMMARY-only dirty state must not block
+    assert.equal(result.ok, true, 'cleanup must succeed when only SUMMARY.md is dirty');
+    assert.equal(result.entries[0].status, 'merged_removed');
+    assert.equal(result.entries[0].reason, 'ok');
+  });
+
+  test('#3804: still blocks when worktree has non-SUMMARY dirty files alongside SUMMARY', () => {
+    // If there are OTHER dirty files (not SUMMARY), cleanup must still block.
+    const plan = {
+      ok: true,
+      repoRoot: '/repo/main',
+      action: 'cleanup_wave',
+      discovery: 'manifest',
+      entries: [{
+        agent_id: 'a1',
+        worktree_path: '/repo/.claude/worktrees/agent-a1',
+        branch: 'worktree-agent-a1',
+        expected_base: 'abc123',
+      }],
+    };
+    const result = executeWorktreeWaveCleanupPlan(plan, {
+      execGit: (args) => {
+        const key = args.join(' ');
+        if (key === '-C /repo/.claude/worktrees/agent-a1 rev-parse --abbrev-ref HEAD') {
+          return { exitCode: 0, stdout: 'worktree-agent-a1', stderr: '' };
+        }
+        if (key === 'merge-base HEAD worktree-agent-a1') {
+          return { exitCode: 0, stdout: 'abc123', stderr: '' };
+        }
+        if (key === 'diff --diff-filter=D --name-only HEAD...worktree-agent-a1') {
+          return { exitCode: 0, stdout: '', stderr: '' };
+        }
+        if (key === '-C /repo/.claude/worktrees/agent-a1 status --porcelain --untracked-files=all') {
+          // SUMMARY plus another dirty file
+          return { exitCode: 0, stdout: '?? .planning/q1-SUMMARY.md\nM  src/foo.js', stderr: '' };
+        }
+        throw new Error(`unexpected git call after dirty check: ${key}`);
+      },
+      findSummaryFiles: (worktreePath) => {
+        if (worktreePath === '/repo/.claude/worktrees/agent-a1') {
+          return ['/repo/.claude/worktrees/agent-a1/.planning/q1-SUMMARY.md'];
+        }
+        return [];
+      },
+      readFileSync: () => 'summary content',
+      existsSync: () => false,
+      mkdirSync: () => {},
+      copyFileSync: () => {},
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.entries[0].reason, 'worktree_dirty');
+  });
+
   test('blocks dirty worktrees before merge/remove/delete', () => {
     const calls = [];
     const plan = {


### PR DESCRIPTION
> Migrated from [gsd-build/get-shit-done#3832](https://github.com/gsd-build/get-shit-done/pull/3832) — originally opened by @trek-e on 2026-05-22

---

## Fix PR

---

## Linked Issue

Fixes #3804

---

## What was broken

`gsd-sdk query worktree.cleanup-wave` blocked on a worktree-isolated executor's uncommitted `SUMMARY.md` instead of rescuing it. The executor follows its documented contract (from `quick.md`) of leaving `SUMMARY.md` uncommitted for the orchestrator to commit, but `cleanup-wave` treated that file as a blocking dirty state and returned `cleanup_blocked` / `worktree_dirty`, halting cleanup mid-flow on every worktree-isolated quick task.

## What this fix does

Ports the SUMMARY rescue logic from the `quick.md` shell-fallback path into `executeWorktreeWaveCleanupPlan`. Before the dirty-state check, all `*SUMMARY.md` files under `<worktree>/.planning/` are copied to the main tree (if absent or divergent) and then filtered out of the `git status --porcelain` output. A worktree whose only dirty file is the executor's uncommitted `SUMMARY.md` now proceeds to merge + remove instead of returning blocked.

Also normalizes rescued relative paths to forward slashes so the Set membership check works on Windows, where `git status --porcelain` always emits forward slashes but `path` APIs produce backslashes.

## Root cause

The shell-fallback rescue block in `quick.md` (introduced for #2296, hardened against #2070 and #2838) was never ported to the SDK `executeWorktreeWaveCleanupPlan` path when `worktree.cleanup-wave` was introduced by #3384. The preferred SDK path was strictly weaker than the fallback it was meant to supersede.

## Testing

### How I verified the fix

Two TDD tests added to `tests/worktree-safety.test.cjs`:
- `#3804: rescues uncommitted SUMMARY.md from worktree .planning/ before dirty check` — asserts rescue (copy to main tree) AND cleanup completes with `status: merged_removed`
- `#3804: still blocks when worktree has non-SUMMARY dirty files alongside SUMMARY` — asserts non-SUMMARY dirty files still block

Both tests use injected FS deps so no real filesystem is touched.

### Regression test added?

- [x] Yes — added a test that would have caught this bug

### Platforms tested

- [x] macOS
- [x] Windows (path normalization fix for backslash vs forward-slash in porcelain Set membership)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [ ] N/A (not runtime-specific)

### Platform / test counts (gsd-test-summary --both)

- [x] Mac: 9943 passed, 17 failed (all 17 pre-existing — 0 related to worktree-safety)
- [x] Docker: 9960 passed, 0 failed ✓

---

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] This PR has a linked issue
- [x] Tests were added or updated
- [x] The change is scoped to a single fix