### PR TITLE
fix(rulesets): correct status-check context order (os, node)

### DIFF
--- a/.github/rulesets/main-protection.json
+++ b/.github/rulesets/main-protection.json
@@ -35,12 +35,12 @@
         "strict_required_status_checks_policy": true,
         "required_status_checks": [
           { "context": "lint-tests" },
-          { "context": "test (22, ubuntu-latest)" },
-          { "context": "test (22, macos-latest)" },
-          { "context": "test (22, windows-latest)" },
-          { "context": "test (24, ubuntu-latest)" },
-          { "context": "test (24, macos-latest)" },
-          { "context": "test (24, windows-latest)" },
+          { "context": "test (ubuntu-latest, 22)" },
+          { "context": "test (macos-latest, 22)" },
+          { "context": "test (windows-latest, 22)" },
+          { "context": "test (ubuntu-latest, 24)" },
+          { "context": "test (macos-latest, 24)" },
+          { "context": "test (windows-latest, 24)" },
           { "context": "Changeset Required" },
           { "context": "require-issue-link" },
           { "context": "pr-template-format" }

--- a/.github/rulesets/release-branches.json
+++ b/.github/rulesets/release-branches.json
@@ -32,12 +32,12 @@
         "strict_required_status_checks_policy": true,
         "required_status_checks": [
           { "context": "lint-tests" },
-          { "context": "test (22, ubuntu-latest)" },
-          { "context": "test (22, macos-latest)" },
-          { "context": "test (22, windows-latest)" },
-          { "context": "test (24, ubuntu-latest)" },
-          { "context": "test (24, macos-latest)" },
-          { "context": "test (24, windows-latest)" },
+          { "context": "test (ubuntu-latest, 22)" },
+          { "context": "test (macos-latest, 22)" },
+          { "context": "test (windows-latest, 22)" },
+          { "context": "test (ubuntu-latest, 24)" },
+          { "context": "test (macos-latest, 24)" },
+          { "context": "test (windows-latest, 24)" },
           { "context": "Changeset Required" },
           { "context": "require-issue-link" },
           { "context": "pr-template-format" }


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Closes #111

---

## What was broken

The ruleset JSON files specified required status check contexts as `test (<node>, <os>)` (e.g. `test (22, ubuntu-latest)`), but the GitHub Actions matrix emits contexts in `test (<os>, <node>)` order (e.g. `test (ubuntu-latest, 22)`). The rulesets were watching for names that never appear in any check run.

## What this fix does

Corrects all 6 `test (...)` context strings in both `.github/rulesets/main-protection.json` and `.github/rulesets/release-branches.json` from `test (<node>, <os>)` to `test (<os>, <node>)`.

## Root cause

The order of arguments in the matrix context name was assumed to be `{node, os}` when writing the ruleset JSON, but the `test.yml` matrix is ordered `{os, node-version}`, which is what GitHub uses to construct the check name.

## Testing

### How I verified the fix

Verified BEFORE and AFTER states verbatim with `jq '[.rules[] | select(.type=="required_status_checks") | .parameters.required_status_checks[].context]'` on both files. Also confirmed via GitHub API after push.

### Regression test added?

- [ ] Yes — added a test that would have caught this bug
- [x] No — explain why: This is a config-only JSON fix; the correct format is validated by comparing against the matrix definition in `test.yml`

### Platforms tested

- [x] N/A (not platform-specific)

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [ ] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix — N/A, no production code paths touched; `no-changelog` label to be applied
- [x] No unnecessary dependencies added

## Breaking changes

None

---

Refs #107