### PR TITLE
fix(tests): escape '/' in forensics test regex literals

### DIFF
--- a/.changeset/forensics-regex-escape.md
+++ b/.changeset/forensics-regex-escape.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 123
 ---
 **Escape `/` in `forensics.test.cjs` regex literals** — two regexes at lines 153 and 163 contained unescaped `/` characters in `open-gsd/get-shit-done-redux`, causing a `SyntaxError: Invalid regular expression flags` at parse time on all platforms and blocking CI for every PR on the affected main state. Closes #3855.

--- a/.changeset/forensics-regex-escape.md
+++ b/.changeset/forensics-regex-escape.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**Escape `/` in `forensics.test.cjs` regex literals** — two regexes at lines 153 and 163 contained unescaped `/` characters in `open-gsd/get-shit-done-redux`, causing a `SyntaxError: Invalid regular expression flags` at parse time on all platforms and blocking CI for every PR on the affected main state. Closes #3855.

--- a/tests/forensics.test.cjs
+++ b/tests/forensics.test.cjs
@@ -150,7 +150,7 @@ describe('forensics workflow', () => {
     // contains the repo string.
     assert.match(
       content,
-      /gh issue create[\s\S]{0,250}--repo\s+open-gsd/get-shit-done-redux/,
+      /gh issue create[\s\S]{0,250}--repo\s+open-gsd\/get-shit-done-redux/,
       'gh issue create must use --repo open-gsd/get-shit-done-redux to avoid submitting to the user\'s current project repo'
     );
   });
@@ -160,7 +160,7 @@ describe('forensics workflow', () => {
     // Regex is more robust than a fixed-length slice to formatting changes
     assert.match(
       content,
-      /gh label list[\s\S]{0,250}--repo\s+open-gsd/get-shit-done-redux/,
+      /gh label list[\s\S]{0,250}--repo\s+open-gsd\/get-shit-done-redux/,
       'gh label list must target open-gsd/get-shit-done-redux'
     );
   });


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #124

---

## What was broken

Two regex literals in `tests/forensics.test.cjs` (lines 153 and 163) contained unescaped `/` characters inside the pattern `open-gsd/get-shit-done-redux`. The unescaped slash prematurely terminated each regex literal, causing a `SyntaxError: Invalid regular expression flags` at parse time on every platform, blocking CI for all PRs on the affected main state (including PR #93). Introduced by the package rename commit (#121).

## What this fix does

Escapes the literal slash to `\/` in both regex patterns so the JS parser correctly reads the entire pattern as the regex body rather than splitting at the `/` in `open-gsd/get-shit-done-redux`.

## Root cause

The package rename commit (#121) introduced `open-gsd/get-shit-done-redux` as a literal string inside regex delimiters without escaping the embedded slash.

## Testing

### How I verified the fix

- `node -e "require('./tests/forensics.test.cjs')"` — all 23 tests pass at parse check
- `node --test tests/forensics.test.cjs` — 23/23 pass locally
- Docker gate: `gsd-test-summary` — 12127 passed, 0 failed (Docker:Linux)

### Regression test added?

- [ ] Yes — added a test that would have caught this bug
- [x] No — the existing tests at lines 153 and 163 ARE the regression tests; they now pass correctly once the escape is applied

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [ ] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added (`forensics-regex-escape.md`)
- [x] No unnecessary dependencies added

## Breaking changes

None