### PR TITLE
fix(ci): escape colons in echo strings in workflow yaml

### DIFF
--- a/.changeset/yaml-echo-colon-escape.md
+++ b/.changeset/yaml-echo-colon-escape.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**YAML parse error in test-skip.yml from unescaped colon in echo strings** — two `run:` steps used unquoted `echo "...: ..."` syntax where the colon-space sequence caused `yaml.scanner.ScannerError: mapping values are not allowed here`. Fixed by wrapping the run value in YAML double-quotes so the colon is inside a quoted scalar. Closes #3857.

--- a/.changeset/yaml-echo-colon-escape.md
+++ b/.changeset/yaml-echo-colon-escape.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 125
 ---
 **YAML parse error in test-skip.yml from unescaped colon in echo strings** — two `run:` steps used unquoted `echo "...: ..."` syntax where the colon-space sequence caused `yaml.scanner.ScannerError: mapping values are not allowed here`. Fixed by wrapping the run value in YAML double-quotes so the colon is inside a quoted scalar. Closes #3857.

--- a/.github/workflows/test-skip.yml
+++ b/.github/workflows/test-skip.yml
@@ -33,7 +33,7 @@ jobs:
   lint-tests:
     runs-on: ubuntu-latest
     steps:
-      - run: echo "doc-only PR: skipping lint-tests"
+      - run: "echo 'doc-only PR: skipping lint-tests'"
         shell: bash
 
   test:
@@ -44,5 +44,5 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         node-version: [22, 24]
     steps:
-      - run: echo "doc-only PR: skipping test on node ${{ matrix.node-version }} / ${{ matrix.os }}"
+      - run: "echo 'doc-only PR: skipping test on node ${{ matrix.node-version }} / ${{ matrix.os }}'"
         shell: bash


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #3857

---

## What was broken

`.github/workflows/test-skip.yml` (introduced in `3d80494e`) had two `run:` steps using unquoted YAML scalars containing `echo "...: ..."`. The colon-space sequence inside an unquoted YAML flow scalar is parsed as a mapping indicator, causing:

```
yaml.scanner.ScannerError: mapping values are not allowed here
```

This prevented the `test-skip.yml` workflow from running on any doc-only PR.

## What this fix does

Wraps both `run:` values in YAML double-quotes so the echo command (with its colon) is parsed as a quoted scalar. Both line 37 (`lint-tests` job) and line 48 (`test` job) are fixed.

## Root cause

The original strings used `echo "doc-only PR: skipping ..."` — the outer YAML double-quotes were not present, so YAML parsed `PR:` as a new mapping key. The fix adds YAML-level quoting around the entire run value.

## Testing

### How I verified the fix

```
python3 -c "import yaml, sys; [yaml.safe_load(open(f)) for f in sys.argv[1:]] and print('OK')" .github/workflows/test-skip.yml
# YAML OK
```

### Regression test added?

- [ ] Yes — added a test that would have caught this bug
- [x] No — YAML linting is infra-only; the parse verification above is sufficient

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [x] N/A (not platform-specific — YAML syntax fix)

### Runtimes tested

- [x] N/A (not runtime-specific — workflow file fix)

---

## Checklist

- [x] Issue linked above with `Fixes #3857` (gsd-build/get-shit-done#3857)
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] `.changeset/` fragment added (`yaml-echo-colon-escape.md`)
- [x] No unnecessary dependencies added

## Breaking changes

None