### PR TITLE
chore: add concurrency block to 11 PR workflows

### DIFF
--- a/.github/workflows/auto-branch.yml
+++ b/.github/workflows/auto-branch.yml
@@ -4,6 +4,10 @@ on:
   issues:
     types: [labeled]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
   issues: write

--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -4,6 +4,10 @@ on:
   issues:
     types: [opened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   add-triage-label:
     runs-on: ubuntu-latest

--- a/.github/workflows/branch-cleanup.yml
+++ b/.github/workflows/branch-cleanup.yml
@@ -7,6 +7,10 @@ on:
     - cron: '0 4 * * 0'  # Sunday 4am UTC — weekly orphan sweep
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
   pull-requests: read

--- a/.github/workflows/branch-naming.yml
+++ b/.github/workflows/branch-naming.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/changeset-required.yml
+++ b/.github/workflows/changeset-required.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: read

--- a/.github/workflows/close-draft-prs.yml
+++ b/.github/workflows/close-draft-prs.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, reopened, converted_to_draft]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   pull-requests: write
 

--- a/.github/workflows/docs-required.yml
+++ b/.github/workflows/docs-required.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: read

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   pull-requests: write
   issues: write

--- a/.github/workflows/pr-template-format.yml
+++ b/.github/workflows/pr-template-format.yml
@@ -4,6 +4,10 @@ on:
   pull_request_target:
     types: [opened, edited, reopened, synchronize, ready_for_review]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   issues: write

--- a/.github/workflows/require-issue-link.yml
+++ b/.github/workflows/require-issue-link.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, edited, reopened, synchronize]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   pull-requests: write
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,6 +5,10 @@ on:
     - cron: '0 9 * * 1'  # Monday 9am UTC
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   issues: write
   pull-requests: write


### PR DESCRIPTION
> *This was generated by AI during triage.*

## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

> **Required.** This PR will be auto-closed if no valid issue link is found.

Closes #140

---

## What was broken

11 GitHub Actions workflows lacked a `concurrency:` block, causing in-flight runs to accumulate in the PR Checks tab when multiple commits are pushed to the same PR in rapid succession.

## What this fix does

Adds a `concurrency:` block with `cancel-in-progress: true` to each of the 11 affected workflows. PR-triggered workflows use `github.event.pull_request.number || github.ref` as the group key; schedule- and issue-only workflows use `github.ref`.

**Affected workflows:**
- `.github/workflows/auto-branch.yml` — `${{ github.workflow }}-${{ github.ref }}`
- `.github/workflows/auto-label-issues.yml` — `${{ github.workflow }}-${{ github.ref }}`
- `.github/workflows/branch-cleanup.yml` — `${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}`
- `.github/workflows/branch-naming.yml` — `${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}`
- `.github/workflows/changeset-required.yml` — `${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}`
- `.github/workflows/close-draft-prs.yml` — `${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}`
- `.github/workflows/docs-required.yml` — `${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}`
- `.github/workflows/pr-gate.yml` — `${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}`
- `.github/workflows/pr-template-format.yml` — `${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}`
- `.github/workflows/require-issue-link.yml` — `${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}`
- `.github/workflows/stale.yml` — `${{ github.workflow }}-${{ github.ref }}`

## Root cause

The 11 workflows were added before the project established the `concurrency:` convention. The 8 other workflows already follow this pattern.

## Testing

### How I verified the fix

YAML validity confirmed for all 11 files via `python3 -c 'import yaml,sys; yaml.safe_load(open(sys.argv[1]))'`.

### Regression test added?

- [x] No — CI-only change; concurrency behaviour is enforced by GitHub Actions infrastructure, not testable locally

### Platforms tested

- [x] N/A (not platform-specific)

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Closes #140` — **PR will be auto-closed if missing**
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] All existing tests pass (`npm test`)
- [x] `no-changelog` label applied — internal CI change, no user-facing behavior change

## Breaking changes

None