### PR TITLE
fix(ci): harden test workflow git auth on github-hosted runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   # Static lint: test-suite and PR-check contracts.
   # Runs once (not per matrix node version) since it is a file-content check.
@@ -36,6 +39,9 @@ jobs:
     timeout-minutes: 2
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: true
+          token: ${{ github.token }}
       - name: Set up Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
@@ -72,6 +78,17 @@ jobs:
         with:
           # Fetch full history so we can merge origin/main for stale-base detection.
           fetch-depth: 0
+          persist-credentials: true
+          token: ${{ github.token }}
+
+      - name: Guard — require GitHub-hosted runner
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${RUNNER_ENVIRONMENT:-}" != "github-hosted" ]; then
+            echo "::error::Expected github-hosted runner. RUNNER_ENVIRONMENT=${RUNNER_ENVIRONMENT:-unset}"
+            exit 1
+          fi
 
       # GitHub's `refs/pull/N/merge` is cached against the recorded merge-base.
       # When main advances after a PR is opened, the cache stays stale and CI
@@ -82,11 +99,23 @@ jobs:
       - name: Rebase check — merge origin/main into PR head
         if: github.event_name == 'pull_request'
         shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           git config user.email "ci@gsd-redux"
           git config user.name "CI Rebase Check"
-          git fetch origin main
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          for attempt in 1 2 3; do
+            if git fetch origin main; then
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "::error::git fetch origin main failed after 3 attempts."
+              exit 1
+            fi
+            sleep $((attempt * 4))
+          done
           if ! git merge --no-edit --no-ff origin/main; then
             echo "::error::This PR cannot cleanly merge origin/main. Rebase your branch onto current main and push again."
             echo "::error::Conflicting files:"
@@ -216,14 +245,36 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: true
+          token: ${{ github.token }}
+      - name: Guard — require GitHub-hosted runner
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${RUNNER_ENVIRONMENT:-}" != "github-hosted" ]; then
+            echo "::error::Expected github-hosted runner. RUNNER_ENVIRONMENT=${RUNNER_ENVIRONMENT:-unset}"
+            exit 1
+          fi
       - name: Rebase check — merge origin/main into PR head
         if: github.event_name == 'pull_request'
         shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           git config user.email "ci@gsd-redux"
           git config user.name "CI Rebase Check"
-          git fetch origin main
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          for attempt in 1 2 3; do
+            if git fetch origin main; then
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "::error::git fetch origin main failed after 3 attempts."
+              exit 1
+            fi
+            sleep $((attempt * 4))
+          done
           if ! git merge --no-edit --no-ff origin/main; then
             echo "::error::This PR cannot cleanly merge origin/main. Rebase your branch onto current main and push again."
             git merge --abort


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

> **Required.** This PR will be auto-closed if no valid issue link is found.

Fixes #152

> The linked issue must have the `confirmed-bug` label. If it doesn't, ask a maintainer to confirm the bug before continuing.

---

## What was broken

Some CI lanes failed before tests ran because checkout/rebase fetch intermittently attempted unauthenticated HTTPS Git access and failed with terminal-prompt-disabled auth errors.

## What this fix does

This hardens `.github/workflows/test.yml` by enforcing GitHub-hosted runners, wiring explicit token-backed checkout credentials, forcing tokenized `origin` for rebase fetches, and retrying transient fetch failures.

## Root cause

Rebase-check fetch depended on ambient git credential state, which can be unstable across runner lanes and retry windows.

## Testing

### How I verified the fix

- Verified workflow YAML contains explicit `permissions.contents: read` and tokenized checkout settings.
- Verified rebase-check steps now set tokenized origin and bounded retries.
- Verified guard step fails fast when `RUNNER_ENVIRONMENT` is not `github-hosted`.

### Regression test added?

- [ ] Yes — added a test that would have caught this bug
- [x] No — explain why: workflow/auth behavior is validated by GH Actions execution, not unit-testable in node:test.

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [ ] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None
