### PR TITLE
docs(adr): ADR-0174 — retire @opengsd/gsd-sdk package boundary

### DIFF
--- a/docs/adr/0005-sdk-architecture-seam-map.md
+++ b/docs/adr/0005-sdk-architecture-seam-map.md
@@ -1,6 +1,6 @@
 # SDK Architecture seam map for query/runtime surfaces
 
-- **Status:** Accepted
+- **Status:** Superseded by ADR-XXXX (2026-05-23); originally Accepted (2026-05-09)
 - **Date:** 2026-05-09
 
 We decided to keep SDK architecture explicitly module-seamed rather than allow feature logic to spread across query handlers, runtime adapters, and compatibility shims. This ADR is the top-level map for SDK seams and their ownership boundaries.

--- a/docs/adr/0005-sdk-architecture-seam-map.md
+++ b/docs/adr/0005-sdk-architecture-seam-map.md
@@ -1,6 +1,6 @@
 # SDK Architecture seam map for query/runtime surfaces
 
-- **Status:** Superseded by ADR-XXXX (2026-05-23); originally Accepted (2026-05-09)
+- **Status:** Superseded by ADR-0174 (2026-05-23); originally Accepted (2026-05-09)
 - **Date:** 2026-05-09
 
 We decided to keep SDK architecture explicitly module-seamed rather than allow feature logic to spread across query handlers, runtime adapters, and compatibility shims. This ADR is the top-level map for SDK seams and their ownership boundaries.

--- a/docs/adr/0007-sdk-package-seam-module.md
+++ b/docs/adr/0007-sdk-package-seam-module.md
@@ -1,6 +1,6 @@
 # SDK Package Seam Module owns SDK-to-get-shit-done-redux compatibility
 
-- **Status:** Accepted
+- **Status:** Superseded by ADR-XXXX (2026-05-23); originally Accepted (2026-05-07)
 - **Date:** 2026-05-07
 
 We decided to define one explicit SDK Package Seam Module for the `@opengsd/gsd-sdk` → `@opengsd/get-shit-done-redux` transition. During this transition, install-layout probing, legacy `gsd-tools.cjs` discovery, legacy `core.cjs` discovery, and compatibility-only missing-asset diagnostics must live behind one seam instead of leaking across SDK Modules. This keeps callers thin, raises leverage for standalone-SDK testing, and improves locality by making package-readiness bugs land in one place. First tracer-bullet slice: add one compatibility Adapter Module at this seam and migrate current legacy asset callers onto it before broader native replacement work.

--- a/docs/adr/0007-sdk-package-seam-module.md
+++ b/docs/adr/0007-sdk-package-seam-module.md
@@ -1,6 +1,6 @@
 # SDK Package Seam Module owns SDK-to-get-shit-done-redux compatibility
 
-- **Status:** Superseded by ADR-XXXX (2026-05-23); originally Accepted (2026-05-07)
+- **Status:** Superseded by ADR-0174 (2026-05-23); originally Accepted (2026-05-07)
 - **Date:** 2026-05-07
 
 We decided to define one explicit SDK Package Seam Module for the `@opengsd/gsd-sdk` → `@opengsd/get-shit-done-redux` transition. During this transition, install-layout probing, legacy `gsd-tools.cjs` discovery, legacy `core.cjs` discovery, and compatibility-only missing-asset diagnostics must live behind one seam instead of leaking across SDK Modules. This keeps callers thin, raises leverage for standalone-SDK testing, and improves locality by making package-readiness bugs land in one place. First tracer-bullet slice: add one compatibility Adapter Module at this seam and migrate current legacy asset callers onto it before broader native replacement work.

--- a/docs/adr/0012-command-routing-hub.md
+++ b/docs/adr/0012-command-routing-hub.md
@@ -1,6 +1,6 @@
 # CommandRoutingHub as single dispatch seam for CJS command families
 
-- **Status:** Accepted
+- **Status:** Superseded by ADR-XXXX (2026-05-23); originally Accepted (2026-05-20)
 - **Date:** 2026-05-20
 
 ## Context

--- a/docs/adr/0012-command-routing-hub.md
+++ b/docs/adr/0012-command-routing-hub.md
@@ -1,6 +1,6 @@
 # CommandRoutingHub as single dispatch seam for CJS command families
 
-- **Status:** Superseded by ADR-XXXX (2026-05-23); originally Accepted (2026-05-20)
+- **Status:** Superseded by ADR-0174 (2026-05-23); originally Accepted (2026-05-20)
 - **Date:** 2026-05-20
 
 ## Context

--- a/docs/adr/0174-retire-gsd-sdk-package-boundary.md
+++ b/docs/adr/0174-retire-gsd-sdk-package-boundary.md
@@ -1,8 +1,8 @@
-# ADR-XXXX: Retire @opengsd/gsd-sdk package boundary — single-runtime collapse
+# ADR-0174: Retire @opengsd/gsd-sdk package boundary — single-runtime collapse
 
 - **Status:** Accepted (2026-05-23)
 - **Date:** 2026-05-23
-- **Tracking issue:** [#UMBRELLA] — to be linked once the umbrella issue is opened
+- **Tracking issue:** [#174](https://github.com/open-gsd/get-shit-done-redux/issues/174) — sub-issues #175–#197
 
 ## Supersedes
 
@@ -146,4 +146,4 @@ Seven phases, ~15–18 PRs total. Each phase is a coherent slice that leaves the
 | 6 — Docs cleanup | Update CONTEXT.md, `docs/`, workflow markdown, and localized docs to remove SDK references. | ~4 |
 | 7 — Land this ADR's PR | The PR for this ADR closes the umbrella tracking issue. | 1 (this PR) |
 
-Implementation is tracked in [#UMBRELLA] — to be filled once the umbrella issue is opened.
+Implementation is tracked in [#174 — sub-issues #175–#197](https://github.com/open-gsd/get-shit-done-redux/issues/174).

--- a/docs/adr/3524-cjs-sdk-hard-seam.md
+++ b/docs/adr/3524-cjs-sdk-hard-seam.md
@@ -1,6 +1,6 @@
 # CJS↔SDK hard seam — one source of truth per Shared Module
 
-- **Status:** Proposed
+- **Status:** Superseded by ADR-XXXX (2026-05-23); originally Proposed (2026-05-14)
 - **Date:** 2026-05-14
 - **Tracking issue:** [#3524](https://github.com/open-gsd/get-shit-done-redux/issues/3524)
 - **Related PRD:** [`docs/prd/3524-cjs-sdk-hard-seam.md`](../prd/3524-cjs-sdk-hard-seam.md)

--- a/docs/adr/3524-cjs-sdk-hard-seam.md
+++ b/docs/adr/3524-cjs-sdk-hard-seam.md
@@ -1,6 +1,6 @@
 # CJS↔SDK hard seam — one source of truth per Shared Module
 
-- **Status:** Superseded by ADR-XXXX (2026-05-23); originally Proposed (2026-05-14)
+- **Status:** Superseded by ADR-0174 (2026-05-23); originally Proposed (2026-05-14)
 - **Date:** 2026-05-14
 - **Tracking issue:** [#3524](https://github.com/open-gsd/get-shit-done-redux/issues/3524)
 - **Related PRD:** [`docs/prd/3524-cjs-sdk-hard-seam.md`](../prd/3524-cjs-sdk-hard-seam.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -34,9 +34,9 @@ See **[CONTRIBUTING.md — "Proposing an ADR or PRD"](../../CONTRIBUTING.md#prop
 | [0002-command-contract-validation-module.md](0002-command-contract-validation-module.md) | Command Contract Validation Module | Accepted |
 | [0003-model-catalog-module.md](0003-model-catalog-module.md) | Model Catalog Module as single source of truth for agent profiles and runtime tier defaults | Accepted |
 | [0004-worktree-workstream-seam-module.md](0004-worktree-workstream-seam-module.md) | Planning Workspace Module as single seam for worktree and workstream state | Accepted |
-| [0005-sdk-architecture-seam-map.md](0005-sdk-architecture-seam-map.md) | SDK Architecture seam map for query/runtime surfaces | Accepted |
+| [0005-sdk-architecture-seam-map.md](0005-sdk-architecture-seam-map.md) | SDK Architecture seam map for query/runtime surfaces | Superseded by ADR-0174 |
 | [0006-planning-path-projection-module.md](0006-planning-path-projection-module.md) | Planning Path Projection Module for SDK query handlers | Accepted |
-| [0007-sdk-package-seam-module.md](0007-sdk-package-seam-module.md) | SDK Package Seam Module owns SDK-to-get-shit-done-redux compatibility | Accepted |
+| [0007-sdk-package-seam-module.md](0007-sdk-package-seam-module.md) | SDK Package Seam Module owns SDK-to-get-shit-done-redux compatibility | Superseded by ADR-0174 |
 | [0008-installer-migration-module.md](0008-installer-migration-module.md) | Installer Migration Module owns install-time upgrade safety | Accepted |
 | [0009-shell-command-projection-module.md](0009-shell-command-projection-module.md) | Shell Command Projection Module owns runtime-aware OS command rendering | Accepted |
 | [0010-file-operation-engine-module.md](0010-file-operation-engine-module.md) | File Operation Engine Module owns safe runtime/config file mutations | Proposed |
@@ -44,9 +44,10 @@ See **[CONTRIBUTING.md — "Proposing an ADR or PRD"](../../CONTRIBUTING.md#prop
 | [0011-skill-surface-budget-module.md](0011-skill-surface-budget-module.md) | Skill Surface Budget Module owns install-time profile staging and runtime surface control | Accepted |
 | [0011-review-default-reviewers.md](0011-review-default-reviewers.md) | Review default-reviewers selection policy for /gsd:review | Accepted |
 | [0011-review-default-reviewers-prd.md](0011-review-default-reviewers-prd.md) | PRD for review.default_reviewers feature (#3464) | Reference |
-| [0012-command-routing-hub.md](0012-command-routing-hub.md) | CommandRoutingHub as single dispatch seam for CJS command families | Accepted |
-| [3524-cjs-sdk-hard-seam.md](3524-cjs-sdk-hard-seam.md) | CJS↔SDK hard seam — single canonical owner per responsibility (#3524) | Proposed |
+| [0012-command-routing-hub.md](0012-command-routing-hub.md) | CommandRoutingHub as single dispatch seam for CJS command families | Superseded by ADR-0174 |
+| [3524-cjs-sdk-hard-seam.md](3524-cjs-sdk-hard-seam.md) | CJS↔SDK hard seam — single canonical owner per responsibility (#3524) | Superseded by ADR-0174 |
 | [3660-runtime-artifact-layout-module.md](3660-runtime-artifact-layout-module.md) | Runtime Artifact Layout Module owns per-runtime artifact placement | Proposed |
+| [0174-retire-gsd-sdk-package-boundary.md](0174-retire-gsd-sdk-package-boundary.md) | Retire @opengsd/gsd-sdk package boundary — single-runtime collapse | Accepted |
 
 ## Seam map
 

--- a/docs/adr/XXXX-retire-gsd-sdk-package-boundary.md
+++ b/docs/adr/XXXX-retire-gsd-sdk-package-boundary.md
@@ -1,0 +1,149 @@
+# ADR-XXXX: Retire @opengsd/gsd-sdk package boundary — single-runtime collapse
+
+- **Status:** Accepted (2026-05-23)
+- **Date:** 2026-05-23
+- **Tracking issue:** [#UMBRELLA] — to be linked once the umbrella issue is opened
+
+## Supersedes
+
+| ADR | What it said | Why it is superseded |
+|-----|-------------|----------------------|
+| [ADR-0005](0005-sdk-architecture-seam-map.md) | Established the SDK as a composition of explicit seam Modules with thin Adapters, with the SDK package itself as the composition root. | The SDK package boundary is being retired; the seam-Module vocabulary survives intact under a single `src/` tree inside `get-shit-done-cc`. |
+| [ADR-0007](0007-sdk-package-seam-module.md) | Defined one explicit SDK Package Seam Module for the `@opengsd/gsd-sdk` → `@opengsd/get-shit-done-redux` compatibility transition. | The transition scaffolding this Module owned (install-layout probing, legacy-asset discovery, compatibility diagnostics) is deleted when the SDK package boundary is retired. |
+| [ADR-0012](0012-command-routing-hub.md) | Introduced `CommandRoutingHub` with a `mode: 'sdk' \| 'cjs'` parameter, `sdkLoader`, `cjsRegistry`, and the `SdkDispatchFailed` / `SdkLoadFailed` errorKinds as the dispatch seam for CJS command families. | The Hub survives but is simplified: `mode`, `sdkLoader`, `cjsRegistry`, and SDK-failure errorKinds are deleted because there is no second runtime to select. The four surviving cross-cutting concerns (errors, manifest, args, observability) remain in the Hub and are now unambiguously load-bearing. |
+| [ADR-3524](3524-cjs-sdk-hard-seam.md) | Hardened the CJS↔SDK seam with a generator-based Shared-Module Source Policy (one source of truth per Module, generated artifacts, freshness checks, hand-sync pair lint) as the canonical Phase 5 engine. | The generator pattern solved drift within the dual-runtime world. Collapsing onto a single TypeScript source tree in `src/` eliminates the seam these generators bridged; tsc replaces every `.generated.cjs` artifact. |
+
+## Context
+
+The following forced-decisions explain why this consolidation is happening now rather than continuing the ADR-3524 trajectory:
+
+1. **Lived cost of dual-runtime exceeded the value of a separately-installable typed package.** ADR-3524 was correct about the drift problem and correct that a generator pattern was better than hand-sync. But the generator pattern is infrastructure to maintain parity between two runtimes, not value delivered to users. The total scaffolding footprint reached ~120 files: worker pool, per-Module generators, freshness checks, parity tests, transition shims, two release pipelines, and the bridge that ran the async SDK handler synchronously via `synckit` for CJS callers. None of that scaffolding was visible to users as a feature.
+
+2. **CJS already provides the feature set in-process; the SDK package boundary added cost without user-visible capability.** Every capability the SDK was being built to expose — typed dispatch, structured results, observability, command metadata — can be compiled out of a single TypeScript source tree and required directly. The separately-installable `@opengsd/gsd-sdk` package had no external programmatic API user requirement driving it. It was scaffolding for scaffolding.
+
+3. **The deletion test concentrated complexity rather than spreading it.** Removing the SDK package as a whole eliminates an entire surface: the bridge, the generators, the release pipeline, the parity tests. Keeping the SDK package and merging only the bridge would have preserved parity tests, generators, and the second release pipeline indefinitely.
+
+4. **ADR-0012's `mode` parameter was the contested part of the Hub design.** Review comments during the ADR-0012 PR identified mode-selection, sdkLoader injection, and the SdkDispatchFailed errorKind as the fragile parts of the Hub contract. These concerns disappear when there is one runtime. The four surviving concerns — uniform error contract, manifest-backed resolution, arg shape coercion, observability — are clearly load-bearing and uncontested. Stripping mode makes the Hub stronger, not weaker.
+
+5. **External programmatic API surface is not a user requirement.** The user does not need `@opengsd/gsd-sdk` to be installable by external consumers. The typed contract is internal. Retaining the package boundary would mean paying for SDK scaffolding in perpetuity to support a use case that does not exist.
+
+## Decision
+
+### 1. Single npm package
+
+`get-shit-done-cc` is the sole npm package. `@opengsd/gsd-sdk` is retired. No external programmatic API is exposed. The typed contract is internal to `get-shit-done-cc`.
+
+### 2. Source shape — TypeScript canonical in `src/`, compiled to CJS in `dist/`
+
+`src/` is the hand-authored source of truth for all Modules. `tsc` on `prepublishOnly` compiles `src/` to CJS in `dist/`. `bin/gsd-tools.cjs` becomes a thin shim that `require`s from `dist/`. No `synckit`, no worker pool, no generator scripts replacing tsc. The `.generated.cjs` artifacts in `bin/lib/` are deleted; their callers are updated to require from `dist/`.
+
+### 3. Source tree — seam-aligned subdirectories under `src/`
+
+Each subdirectory maps 1:1 to an architectural concern, preserving the seam-Module vocabulary from ADR-0005 under a single tree:
+
+| Directory | Concern |
+|-----------|---------|
+| `src/dispatch/` | The simplified Hub |
+| `src/handlers/` | Command implementations grouped by family (`phase/`, `roadmap/`, `state/`, `init/`, …) |
+| `src/errors/` | `GSDError`, `errorKind` enum, error classification |
+| `src/manifest/` | Command metadata, alias resolution |
+| `src/config/` | Configuration Module (was Shared CJS/SDK) |
+| `src/state/` | STATE.md Document Module |
+| `src/workstream/` | Workstream Inventory Module |
+| `src/runtime/` | Runtime Name Policy, project-root resolution |
+| `src/cli/` | `gsd-tools` entrypoint code |
+| `src/observability/` | DispatchLogger, redaction |
+
+### 4. Hub simplified — four cross-cutting concerns, no mode parameter
+
+`CommandRoutingHub` is retained with its no-throw contract and closed `errorKind` enum, but the following are deleted: `mode: 'sdk' | 'cjs'` parameter, `sdkLoader`, `cjsRegistry`, `SdkDispatchFailed` errorKind, `SdkLoadFailed` errorKind.
+
+The Hub owns exactly four cross-cutting concerns:
+
+1. **Uniform error contract** — all internal throws are caught and converted to structured `Result` values; the Hub never calls `process.exit` or prints to stdout/stderr.
+2. **Manifest-backed resolution** — command lookup and alias resolution are routed through `src/manifest/`.
+3. **Arg shape coercion** — incoming arg shapes are normalized before handler invocation.
+4. **Observability** — DispatchLogger is injected; the Hub emits `DispatchEvent` records on every dispatch path.
+
+### 5. Sync dispatch with tight-typed `Result<T>` per `errorKind` variant
+
+Dispatch is synchronous: `dispatch<T>(req: DispatchRequest): Result<T>`.
+
+Rationale: continuous stack traces, no async-boundary races in the logger, no orphaned side effects, SIGINT shows what is actually running. `synckit` dependency is removed.
+
+The `Result<T>` type is a discriminated union per `errorKind` variant, not a flat string field:
+
+```ts
+type Result<T> =
+  | { ok: true; data: T }
+  | { ok: false; kind: 'Unknown'; command: string }
+  | { ok: false; kind: 'BadArgs'; arg: string; reason: string }
+  | { ok: false; kind: 'ValidationFailed'; field: string; expected: string; actual: unknown }
+  | { ok: false; kind: 'HandlerFailed'; message: string; cause?: Error }
+  | { ok: false; kind: 'NotImplemented'; command: string };
+```
+
+Adding a new variant requires amending this ADR (preserving the drift-prevention property from ADR-0012).
+
+### 6. Observability seam — silent on success, structured JSON on error, opt-in audit
+
+- **Silent on success** — no stdout/stderr output from the Hub on a successful dispatch.
+- **Structured JSON to stderr on error** — every `Result` with `ok: false` emits a structured JSON line to stderr with `traceId`, `kind`, and the variant's typed payload.
+- **Opt-in file audit** — `GSD_AUDIT=1` env var or `config.audit.enabled: true` writes `DispatchEvent` records to `.planning/.gsd-trace.jsonl`. Args are excluded by default (privacy); `GSD_AUDIT_ARGS=1` opts in.
+- **Trace identity** — every `DispatchEvent` carries a `traceId`. Composed dispatches set `parentTraceId` to link children to the parent invocation.
+- **Injected logger** — the Hub accepts a `DispatchLogger` interface. The default implementation writes per the rules above. The test implementation is in-memory and carries no I/O side effects.
+
+### 7. `Init.*` family stays as a composer module
+
+`src/handlers/init/composer.ts` composes N atomic dispatches. Each child dispatch receives the parent's `traceId` as its `parentTraceId`, linking the full init tree in the audit trail. The composer is the only caller that sets `parentTraceId`; all other dispatches are leaf dispatches.
+
+## Consequences
+
+### Positive
+
+- **Locality up.** Composition concerns are concentrated in one place per seam. The seam-Module vocabulary from ADR-0005 is preserved; only the package boundary is retired.
+- **Leverage up.** One build pipeline, one `npm publish`, one CI release workflow. The `release-sdk.yml` workflow and all SDK steps in `release.yml`, `hotfix.yml`, and `install-smoke.yml` are deleted.
+- **Test surface down ~35 files; character shifts from ~40% infrastructure / 60% behavior to ~5% / 95%.** The parity tests, generator freshness checks, hand-sync pair lint, bridge unit tests, and worker-pool integration tests are deleted outright. Tests that were testing infrastructure (does the generator emit the right bytes?) become irrelevant. Tests that verify observable dispatch outcomes survive and are the dominant surface.
+- **Debuggability up.** Continuous stack traces from the caller through the Hub to the handler. `traceId` trees link composed dispatches in the audit log. No async-boundary gaps in log entries. SIGINT shows the actual call in progress.
+- **`synckit` dependency removed.** The in-process event-loop bridge that ran async SDK handlers synchronously for CJS callers is deleted with it.
+
+### Negative
+
+- **External programmatic API surface retires.** Accepted by the user — it is not a requirement. Any future external API surface would be a new design decision, not a reversion.
+- **CONTEXT.md and ~20 doc files require updating across Phase 6 PRs.** The "Shared CJS/SDK Module" qualifier, SDK seam descriptions, and references to the `sdk/` directory structure are updated in Phase 6 (deferred; this ADR does not touch CONTEXT.md).
+- **~15–18 PRs of implementation work across 7 phases.** See Migration Plan below.
+- **`tsc` build step added to `prepublishOnly`.** `get-shit-done-cc` currently has no TypeScript compilation at the root. The build step is net-simpler than the existing generator infrastructure, but it is a new step in the publish path.
+
+## Alternatives considered
+
+### Shape A — pure CJS + JSDoc, zero build step
+
+Rejected. Loses TypeScript authoring ergonomics: no structural type checking, no discriminated-union narrowing, no intra-repo cross-Module type errors caught at compile time. The SDK was correct that TypeScript authoring is worth the compilation step; this alternative gives up the wrong thing.
+
+### Shape C — CJS + `.d.ts` overlays
+
+Rejected. Recreates the parity problem at a smaller scale: hand-authored `.d.ts` files drift from the `.cjs` implementations unless a freshness check is added, which is the generator pattern again at half the scale. The root cause (two artifacts for one behavior surface) is not addressed.
+
+### Keep SDK package, merge only the bridge
+
+Rejected. Deleting `synckit` without deleting the SDK package preserves parity tests, generator scripts, and the second release pipeline indefinitely. The bridge was not the sole source of complexity — it was the most visible symptom. Merging only the bridge trades a runtime dependency for an ongoing infrastructure maintenance burden without eliminating the dual-runtime cost.
+
+### Keep dual runtime indefinitely (status quo)
+
+Rejected. Lived experience showed the cost ratio is wrong: ~120 files of scaffolding for a feature set CJS provides in-process, with no external programmatic API user requirement to justify the separately-installable package. The incremental fix cycle (each drift class fixed once in CJS, once in SDK, once in the generator) compounds with every new Module added to the Shared-Module table.
+
+## Migration plan
+
+Seven phases, ~15–18 PRs total. Each phase is a coherent slice that leaves the codebase in a working state.
+
+| Phase | Description | PRs |
+|-------|-------------|-----|
+| 1 — Simplify the Hub in place | Drop `mode`, introduce tight-typed `Result<T>`, add observability seam, add `traceId`. | ~4 |
+| 2 — Move TS source from `sdk/` to `src/` | Per-Module migration: config, state, workstream, runtime, manifest, errors, observability, dispatch, cli, handlers. | ~8 |
+| 3 — Retire parity layer | Delete parity tests; replace `.generated.cjs` generator scripts with tsc output in `dist/`; update callers. | ~3 |
+| 4 — Collapse bridge | Inline bridge logic into Hub; delete `synckit`; delete `bin/lib/cjs-sdk-bridge.cjs` and `sdk/src/runtime-bridge-sync/`. | ~1 |
+| 5 — Retire SDK package | Delete `sdk/` directory; delete `bin/gsd-sdk.js` shim and `bin/gsd-sdk` wrapper; delete `release-sdk.yml` and SDK steps in `release.yml`, `hotfix.yml`, `install-smoke.yml`. | ~2 |
+| 6 — Docs cleanup | Update CONTEXT.md, `docs/`, workflow markdown, and localized docs to remove SDK references. | ~4 |
+| 7 — Land this ADR's PR | The PR for this ADR closes the umbrella tracking issue. | 1 (this PR) |
+
+Implementation is tracked in [#UMBRELLA] — to be filled once the umbrella issue is opened.


### PR DESCRIPTION
<!-- pr-template-exempt: docs-only — changes confined to docs/adr/; auto-detected as exempt per pull_request_template.md -->

## Summary

Lands the superseding ADR (ADR-0174) capturing the decision to retire `@opengsd/gsd-sdk`, consolidate onto `src/` TypeScript inside `get-shit-done-cc`, simplify the Command Routing Hub, and adopt a single-runtime design. Marks ADR-0005, ADR-0007, ADR-0012, and ADR-3524 as Superseded. Implementation tracked in #174 and per-phase sub-issues #175–#197.

**Changes in this PR:**
- `docs/adr/XXXX-retire-gsd-sdk-package-boundary.md` → renamed to `docs/adr/0174-retire-gsd-sdk-package-boundary.md`
- All `XXXX` placeholders replaced with real ADR number `0174`
- `[#UMBRELLA]` placeholder replaced with `[#174 — sub-issues #175–#197]`
- Status lines in ADR-0005, ADR-0007, ADR-0012, ADR-3524 updated from `Superseded by ADR-XXXX` to `Superseded by ADR-0174`
- `docs/adr/README.md` index updated: ADR-0174 added as Accepted; ADR-0005, 0007, 0012, 3524 marked Superseded by ADR-0174

## Test plan

This is a docs-only change. No code paths touched.

- [ ] New ADR renders cleanly in GitHub Markdown
- [ ] Status lines in the 4 superseded ADRs correctly reference ADR-0174
- [ ] `docs/adr/README.md` ADR index reflects new statuses
- [ ] No broken cross-references (all internal links point to existing files)

**Platform verification:** N/A — docs-only change, no code executed, `gsd-test-summary --both` not applicable.

- [ ] Mac: N/A (docs-only)
- [ ] Docker/Linux: N/A (docs-only)

## Issue links

Closes #197
Part of #174