### PR TITLE
fix(ci): raise Node heap to 6144 MB in release finalize job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -331,6 +331,8 @@ jobs:
           git diff --cached --quiet || git commit -m "chore: finalize v${VERSION}"
 
       - name: Install and test
+        env:
+          NODE_OPTIONS: --max-old-space-size=6144
         run: |
           npm ci
           chmod +x scripts/check-npm-integrity.sh


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

> **Required.** This PR will be auto-closed if no valid issue link is found.

Fixes #199

> The linked issue has the `confirmed-bug` label.

---

## What was broken

The `Install and test` step in the `finalize` job of `release.yml` ran `npm run test:coverage` without a Node heap cap override. After all 466 tests passed, `c8` coverage aggregation crashed with `FATAL ERROR: ... JavaScript heap out of memory` at ~4085 MB — hitting Node's default ~4 GB ceiling.

## What this fix does

Adds `NODE_OPTIONS: --max-old-space-size=6144` as an `env:` block on the `Install and test` step in the `finalize` job only, raising the heap ceiling to 6 GB. This matches the identical setting already present in `test.yml` line 354 for the equivalent coverage step.

## Root cause

The Release workflow's `finalize` job was missing the heap override that `test.yml` already applies. The crash is non-deterministic (same SHA passed once, failed twice) because c8 aggregation memory usage varies slightly by run — occasionally crossing the 4 GB threshold.

## Testing

### How I verified the fix

The failed run https://github.com/open-gsd/get-shit-done-redux/actions/runs/26350837515/job/77568785744 shows the OOM occurs 35s after all tests pass, during c8 aggregation. The fix matches the exact precedent from `test.yml:354`. No code paths are changed — only the Node heap ceiling for that one step.

### Regression test added?

- [ ] Yes — added a test that would have caught this bug
- [x] No — explain why: environment-specific OOM; not reproducible with a unit test; the fix is a one-line CI env var matching existing precedent

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [x] N/A (not platform-specific — CI-only change)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific — CI infrastructure only)

---

## Checklist

- [x] Issue linked above with `Fixes #199` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix — CI-only change, not user-facing; `no-changelog` label not available in this repo but the Changeset Required lint exempts `.github/workflows/` changes automatically
- [x] No unnecessary dependencies added

## Breaking changes

None