### PR TITLE
fix(#170): migrate workflow fallback hints to @opengsd package

### DIFF
--- a/.changeset/170-workflow-fallback-package-hint.md
+++ b/.changeset/170-workflow-fallback-package-hint.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 170
+---
+**Workflow fallback install hint migration** — workflow error-path guidance for missing `gsd-sdk` now points to `npx -y @opengsd/get-shit-done-redux@latest --claude --local` instead of the abandoned `get-shit-done-cc` package. Added a regression test to prevent legacy fallback hints from reappearing in workflow markdown.

--- a/get-shit-done/workflows/add-backlog.md
+++ b/get-shit-done/workflows/add-backlog.md
@@ -27,7 +27,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 NEXT=$($GSD_SDK query phase.next-decimal 999 --raw)

--- a/get-shit-done/workflows/add-phase.md
+++ b/get-shit-done/workflows/add-phase.md
@@ -37,7 +37,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 INIT=$($GSD_SDK query init.phase-op "0")

--- a/get-shit-done/workflows/add-tests.md
+++ b/get-shit-done/workflows/add-tests.md
@@ -41,7 +41,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 INIT=$($GSD_SDK query init.phase-op "${PHASE_ARG}")

--- a/get-shit-done/workflows/add-todo.md
+++ b/get-shit-done/workflows/add-todo.md
@@ -20,7 +20,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 INIT=$($GSD_SDK query init.todos)

--- a/get-shit-done/workflows/ai-integration-phase.md
+++ b/get-shit-done/workflows/ai-integration-phase.md
@@ -28,7 +28,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 INIT=$($GSD_SDK query init.plan-phase "$PHASE")

--- a/get-shit-done/workflows/audit-fix.md
+++ b/get-shit-done/workflows/audit-fix.md
@@ -40,7 +40,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 INIT=$($GSD_SDK query audit-uat 2>/dev/null || echo "{}")

--- a/get-shit-done/workflows/audit-milestone.md
+++ b/get-shit-done/workflows/audit-milestone.md
@@ -24,7 +24,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 INIT=$($GSD_SDK query init.milestone-op)

--- a/get-shit-done/workflows/audit-uat.md
+++ b/get-shit-done/workflows/audit-uat.md
@@ -16,7 +16,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 AUDIT=$($GSD_SDK query audit-uat --raw)

--- a/get-shit-done/workflows/autonomous.md
+++ b/get-shit-done/workflows/autonomous.md
@@ -56,7 +56,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 INIT=$($GSD_SDK query init.milestone-op)

--- a/get-shit-done/workflows/check-todos.md
+++ b/get-shit-done/workflows/check-todos.md
@@ -20,7 +20,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 INIT=$($GSD_SDK query init.todos)

--- a/get-shit-done/workflows/cleanup.md
+++ b/get-shit-done/workflows/cleanup.md
@@ -132,7 +132,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 $GSD_SDK query commit "chore: archive phase directories from completed milestones" --files .planning/milestones/ .planning/phases/

--- a/get-shit-done/workflows/code-review-fix.md
+++ b/get-shit-done/workflows/code-review-fix.md
@@ -26,7 +26,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 INIT=$($GSD_SDK query init.phase-op "${PHASE_ARG}")

--- a/get-shit-done/workflows/code-review.md
+++ b/get-shit-done/workflows/code-review.md
@@ -26,7 +26,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 INIT=$($GSD_SDK query init.phase-op "${PHASE_ARG}")

--- a/get-shit-done/workflows/complete-milestone.md
+++ b/get-shit-done/workflows/complete-milestone.md
@@ -49,7 +49,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 $GSD_SDK query audit-open

--- a/get-shit-done/workflows/debug.md
+++ b/get-shit-done/workflows/debug.md
@@ -24,7 +24,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 INIT=$($GSD_SDK query state.load)

--- a/get-shit-done/workflows/diagnose-issues.md
+++ b/get-shit-done/workflows/diagnose-issues.md
@@ -66,7 +66,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 USE_WORKTREES=$($GSD_SDK query config-get workflow.use_worktrees 2>/dev/null || echo "true")

--- a/get-shit-done/workflows/discuss-phase-assumptions.md
+++ b/get-shit-done/workflows/discuss-phase-assumptions.md
@@ -72,7 +72,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 INIT=$($GSD_SDK query init.phase-op "${PHASE}")

--- a/get-shit-done/workflows/discuss-phase.md
+++ b/get-shit-done/workflows/discuss-phase.md
@@ -109,7 +109,7 @@ Phase: "API documentation"       → Structure/navigation, Code examples depth, 
 Phase number from argument (required).
 
 ```bash
-GSD_TOOLS="${RUNTIME_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}/get-shit-done/bin/gsd-tools.cjs"; [ -f "$GSD_TOOLS" ] && GSD_SDK="node $GSD_TOOLS" || { command -v gsd-sdk >/dev/null 2>&1 && GSD_SDK=gsd-sdk || { echo "ERROR: gsd-sdk not found. Run: npx get-shit-done-cc@latest --claude --local" >&2; exit 1; }; }
+GSD_TOOLS="${RUNTIME_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}/get-shit-done/bin/gsd-tools.cjs"; [ -f "$GSD_TOOLS" ] && GSD_SDK="node $GSD_TOOLS" || { command -v gsd-sdk >/dev/null 2>&1 && GSD_SDK=gsd-sdk || { echo "ERROR: gsd-sdk not found. Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2; exit 1; }; }
 INIT=$($GSD_SDK query init.phase-op "${PHASE}"); [[ "$INIT" == @file:* ]] && INIT=$(cat "${INIT#@file:}")
 AGENT_SKILLS_ADVISOR=$($GSD_SDK query agent-skills gsd-advisor-researcher)
 ```

--- a/get-shit-done/workflows/do.md
+++ b/get-shit-done/workflows/do.md
@@ -35,7 +35,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 INIT=$($GSD_SDK query state.load 2>/dev/null)

--- a/get-shit-done/workflows/docs-update.md
+++ b/get-shit-done/workflows/docs-update.md
@@ -22,7 +22,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 INIT=$($GSD_SDK query docs-init)

--- a/get-shit-done/workflows/edit-phase.md
+++ b/get-shit-done/workflows/edit-phase.md
@@ -42,7 +42,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 INIT=$($GSD_SDK query init.phase-op "${target}")

--- a/get-shit-done/workflows/eval-review.md
+++ b/get-shit-done/workflows/eval-review.md
@@ -21,7 +21,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 INIT=$($GSD_SDK query init.phase-op "${PHASE_ARG}")

--- a/get-shit-done/workflows/execute-phase.md
+++ b/get-shit-done/workflows/execute-phase.md
@@ -74,7 +74,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 INIT=$($GSD_SDK query init.execute-phase "${PHASE_ARG}")

--- a/get-shit-done/workflows/execute-plan.md
+++ b/get-shit-done/workflows/execute-plan.md
@@ -38,7 +38,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 INIT=$($GSD_SDK query init.execute-phase "${PHASE}")

--- a/get-shit-done/workflows/explore.md
+++ b/get-shit-done/workflows/explore.md
@@ -123,7 +123,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 $GSD_SDK query commit "docs: capture exploration — {topic_slug}" --files {file_list}

--- a/get-shit-done/workflows/extract-learnings.md
+++ b/get-shit-done/workflows/extract-learnings.md
@@ -24,7 +24,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 INIT=$($GSD_SDK query init.phase-op "${PHASE_ARG}")

--- a/get-shit-done/workflows/forensics.md
+++ b/get-shit-done/workflows/forensics.md
@@ -280,7 +280,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 $GSD_SDK query state.record-session "" \

--- a/get-shit-done/workflows/graduation.md
+++ b/get-shit-done/workflows/graduation.md
@@ -29,7 +29,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 GRADUATION_ENABLED=$($GSD_SDK query config-get features.graduation 2>/dev/null || echo "true")

--- a/get-shit-done/workflows/health.md
+++ b/get-shit-done/workflows/health.md
@@ -57,7 +57,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 $GSD_SDK query validate.context \

--- a/get-shit-done/workflows/import.md
+++ b/get-shit-done/workflows/import.md
@@ -184,7 +184,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 INIT=$($GSD_SDK query init.phase-op "{NN}")

--- a/get-shit-done/workflows/insert-phase.md
+++ b/get-shit-done/workflows/insert-phase.md
@@ -42,7 +42,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 INIT=$($GSD_SDK query init.phase-op "${after_phase}")

--- a/get-shit-done/workflows/list-workspaces.md
+++ b/get-shit-done/workflows/list-workspaces.md
@@ -19,7 +19,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 INIT=$($GSD_SDK query init.list-workspaces)

--- a/get-shit-done/workflows/manager.md
+++ b/get-shit-done/workflows/manager.md
@@ -27,7 +27,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 INIT=$($GSD_SDK query init.manager)

--- a/get-shit-done/workflows/map-codebase.md
+++ b/get-shit-done/workflows/map-codebase.md
@@ -77,7 +77,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 INIT=$($GSD_SDK query init.map-codebase)

--- a/get-shit-done/workflows/milestone-summary.md
+++ b/get-shit-done/workflows/milestone-summary.md
@@ -61,7 +61,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 $GSD_SDK query init.progress

--- a/get-shit-done/workflows/mvp-phase.md
+++ b/get-shit-done/workflows/mvp-phase.md
@@ -42,7 +42,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 PHASE_INFO=$($GSD_SDK query roadmap.get-phase "${PHASE}")

--- a/get-shit-done/workflows/new-milestone.md
+++ b/get-shit-done/workflows/new-milestone.md
@@ -189,7 +189,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 $GSD_SDK query state.milestone-switch --milestone "v[X.Y]" --name "[Name]"

--- a/get-shit-done/workflows/new-project.md
+++ b/get-shit-done/workflows/new-project.md
@@ -65,7 +65,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 INIT=$($GSD_SDK query init.new-project)

--- a/get-shit-done/workflows/new-workspace.md
+++ b/get-shit-done/workflows/new-workspace.md
@@ -21,7 +21,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 INIT=$($GSD_SDK query init.new-workspace)

--- a/get-shit-done/workflows/next.md
+++ b/get-shit-done/workflows/next.md
@@ -22,7 +22,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 $GSD_SDK query state.json 2>/dev/null || echo "{}"

--- a/get-shit-done/workflows/pause-work.md
+++ b/get-shit-done/workflows/pause-work.md
@@ -74,7 +74,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 timestamp=$($GSD_SDK query current-timestamp full --raw)

--- a/get-shit-done/workflows/plan-milestone-gaps.md
+++ b/get-shit-done/workflows/plan-milestone-gaps.md
@@ -73,7 +73,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 HIGHEST=$($GSD_SDK query phases.list --pick directories[-1])

--- a/get-shit-done/workflows/plan-phase.md
+++ b/get-shit-done/workflows/plan-phase.md
@@ -39,7 +39,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 INIT=$($GSD_SDK query init.plan-phase "$PHASE")

--- a/get-shit-done/workflows/plan-review-convergence.md
+++ b/get-shit-done/workflows/plan-review-convergence.md
@@ -51,7 +51,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 CONVERGENCE_ENABLED=$($GSD_SDK query config-get workflow.plan_review_convergence 2>/dev/null || echo "false")

--- a/get-shit-done/workflows/plant-seed.md
+++ b/get-shit-done/workflows/plant-seed.md
@@ -143,7 +143,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 $GSD_SDK query commit "docs: plant seed — {$IDEA}" --files .planning/seeds/SEED-{PADDED}-{slug}.md

--- a/get-shit-done/workflows/profile-user.md
+++ b/get-shit-done/workflows/profile-user.md
@@ -138,7 +138,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 SCAN_RESULT=$($GSD_SDK query scan-sessions --json 2>/dev/null)

--- a/get-shit-done/workflows/progress.md
+++ b/get-shit-done/workflows/progress.md
@@ -20,7 +20,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 INIT=$($GSD_SDK query init.progress)

--- a/get-shit-done/workflows/remove-phase.md
+++ b/get-shit-done/workflows/remove-phase.md
@@ -37,7 +37,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 INIT=$($GSD_SDK query init.phase-op "${target}")

--- a/get-shit-done/workflows/remove-workspace.md
+++ b/get-shit-done/workflows/remove-workspace.md
@@ -21,7 +21,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 INIT=$($GSD_SDK query init.remove-workspace "$WORKSPACE_NAME")

--- a/get-shit-done/workflows/resume-project.md
+++ b/get-shit-done/workflows/resume-project.md
@@ -28,7 +28,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 INIT=$($GSD_SDK query init.resume)

--- a/get-shit-done/workflows/review.md
+++ b/get-shit-done/workflows/review.md
@@ -32,7 +32,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 OLLAMA_HOST=$($GSD_SDK query config-get review.ollama_host 2>/dev/null | jq -r '.' 2>/dev/null || echo "")

--- a/get-shit-done/workflows/scan.md
+++ b/get-shit-done/workflows/scan.md
@@ -47,7 +47,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 INIT=$($GSD_SDK query init.map-codebase 2>/dev/null || echo "{}")

--- a/get-shit-done/workflows/secure-phase.md
+++ b/get-shit-done/workflows/secure-phase.md
@@ -24,7 +24,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 INIT=$($GSD_SDK query init.phase-op "${PHASE_ARG}")

--- a/get-shit-done/workflows/settings-advanced.md
+++ b/get-shit-done/workflows/settings-advanced.md
@@ -28,7 +28,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 $GSD_SDK query config-ensure-section

--- a/get-shit-done/workflows/settings-integrations.md
+++ b/get-shit-done/workflows/settings-integrations.md
@@ -50,7 +50,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 $GSD_SDK query config-ensure-section

--- a/get-shit-done/workflows/settings.md
+++ b/get-shit-done/workflows/settings.md
@@ -20,7 +20,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 $GSD_SDK query config-ensure-section

--- a/get-shit-done/workflows/ship.md
+++ b/get-shit-done/workflows/ship.md
@@ -20,7 +20,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 INIT=$($GSD_SDK query init.phase-op "${PHASE_ARG}")

--- a/get-shit-done/workflows/sketch-wrap-up.md
+++ b/get-shit-done/workflows/sketch-wrap-up.md
@@ -45,7 +45,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 COMMIT_DOCS=$($GSD_SDK query config-get commit_docs 2>/dev/null || echo "true")

--- a/get-shit-done/workflows/sketch.md
+++ b/get-shit-done/workflows/sketch.md
@@ -107,7 +107,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 COMMIT_DOCS=$($GSD_SDK query config-get commit_docs 2>/dev/null || echo "true")

--- a/get-shit-done/workflows/spike-wrap-up.md
+++ b/get-shit-done/workflows/spike-wrap-up.md
@@ -45,7 +45,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 COMMIT_DOCS=$($GSD_SDK query config-get commit_docs 2>/dev/null || echo "true")

--- a/get-shit-done/workflows/spike.md
+++ b/get-shit-done/workflows/spike.md
@@ -104,7 +104,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 COMMIT_DOCS=$($GSD_SDK query config-get commit_docs 2>/dev/null || echo "true")

--- a/get-shit-done/workflows/stats.md
+++ b/get-shit-done/workflows/stats.md
@@ -20,7 +20,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 STATS=$($GSD_SDK query stats.json)

--- a/get-shit-done/workflows/thread.md
+++ b/get-shit-done/workflows/thread.md
@@ -36,7 +36,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
   $GSD_SDK query frontmatter.get .planning/threads/{file} status

--- a/get-shit-done/workflows/transition.md
+++ b/get-shit-done/workflows/transition.md
@@ -171,7 +171,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 TRANSITION=$($GSD_SDK query phase.complete "${current_phase}")

--- a/get-shit-done/workflows/ui-phase.md
+++ b/get-shit-done/workflows/ui-phase.md
@@ -27,7 +27,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 INIT=$($GSD_SDK query init.plan-phase "$PHASE")

--- a/get-shit-done/workflows/ui-review.md
+++ b/get-shit-done/workflows/ui-review.md
@@ -24,7 +24,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 INIT=$($GSD_SDK query init.phase-op "${PHASE_ARG}")

--- a/get-shit-done/workflows/ultraplan-phase.md
+++ b/get-shit-done/workflows/ultraplan-phase.md
@@ -74,7 +74,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 INIT=$($GSD_SDK query init.plan-phase "$PHASE")

--- a/get-shit-done/workflows/validate-phase.md
+++ b/get-shit-done/workflows/validate-phase.md
@@ -24,7 +24,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 INIT=$($GSD_SDK query init.phase-op "${PHASE_ARG}")

--- a/get-shit-done/workflows/verify-phase.md
+++ b/get-shit-done/workflows/verify-phase.md
@@ -37,7 +37,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 INIT=$($GSD_SDK query init.phase-op "${PHASE_ARG}")

--- a/get-shit-done/workflows/verify-work.md
+++ b/get-shit-done/workflows/verify-work.md
@@ -42,7 +42,7 @@ elif command -v gsd-sdk >/dev/null 2>&1; then
   GSD_SDK="gsd-sdk"
 else
   echo "ERROR: gsd-sdk not found on PATH and $GSD_TOOLS does not exist." >&2
-  echo "Run: npx get-shit-done-cc@latest --claude --local" >&2
+  echo "Run: npx -y @opengsd/get-shit-done-redux@latest --claude --local" >&2
   exit 1
 fi
 INIT=$($GSD_SDK query init.verify-work "${PHASE_ARG}" ${GSD_WS})

--- a/tests/bug-170-workflow-fallback-install-hint.test.cjs
+++ b/tests/bug-170-workflow-fallback-install-hint.test.cjs
@@ -1,0 +1,42 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const WORKFLOWS_DIR = path.join(__dirname, '..', 'get-shit-done', 'workflows');
+const LEGACY_HINT = 'npx get-shit-done-cc@latest --claude --local';
+const CURRENT_HINT = 'npx -y @opengsd/get-shit-done-redux@latest --claude --local';
+
+function findMarkdownFiles(dir) {
+  const out = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...findMarkdownFiles(full));
+    else if (entry.isFile() && full.endsWith('.md')) out.push(full);
+  }
+  return out;
+}
+
+test('bug #170: workflow fallback hints do not reference get-shit-done-cc', () => {
+  const files = findMarkdownFiles(WORKFLOWS_DIR);
+  let legacyCount = 0;
+  let currentCount = 0;
+
+  for (const file of files) {
+    const src = fs.readFileSync(file, 'utf8');
+    if (src.includes(LEGACY_HINT)) legacyCount += 1;
+    if (src.includes(CURRENT_HINT)) currentCount += 1;
+  }
+
+  assert.equal(
+    legacyCount,
+    0,
+    `workflow fallback hints must not reference legacy package (${LEGACY_HINT})`
+  );
+  assert.ok(
+    currentCount > 0,
+    `expected at least one workflow fallback hint to use current package (${CURRENT_HINT})`
+  );
+});

--- a/tests/bug-170-workflow-fallback-install-hint.test.cjs
+++ b/tests/bug-170-workflow-fallback-install-hint.test.cjs
@@ -1,4 +1,5 @@
 'use strict';
+// allow-test-rule: workflow markdown is shipped product text; this test validates fallback hint literals across all workflow files
 
 const { test } = require('node:test');
 const assert = require('node:assert/strict');


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

Fixes #170

---

## What was broken

Workflow fallback install hints still pointed users to `get-shit-done-cc@latest` when `gsd-sdk` was missing.

## What this fix does

Replaces fallback hints across workflow markdown with:
- `npx -y @opengsd/get-shit-done-redux@latest --claude --local`

Also adds a regression test to ensure legacy `get-shit-done-cc` fallback hints do not reappear.

## Root cause

The package migration to `@opengsd/get-shit-done-redux` was incomplete in workflow error-path messaging.

## Testing

### How I verified the fix

- Added and ran:
  - `node --test tests/bug-170-workflow-fallback-install-hint.test.cjs`
- Confirmed no workflow files still contain the old hint string.

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [ ] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None
