### PR TITLE
fix(ci): reference NPM publish secret as GETSHITDONEREDUXNPMTOKEN

### DIFF
--- a/.github/workflows/hotfix.yml
+++ b/.github/workflows/hotfix.yml
@@ -376,7 +376,7 @@ jobs:
 
       - name: Dry-run publish validation
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GETSHITDONEREDUXNPMTOKEN }}
         run: npm publish --dry-run --tag latest
 
       - name: Tag and push
@@ -400,14 +400,14 @@ jobs:
       - name: Publish to npm (latest)
         if: ${{ !inputs.dry_run && steps.prior_publish.outputs.skip_publish != 'true' }}
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GETSHITDONEREDUXNPMTOKEN }}
         run: npm publish --provenance --access public --tag latest
 
       - name: Re-point next dist-tag at this hotfix
         if: ${{ !inputs.dry_run }}
         env:
           VERSION: ${{ inputs.version }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GETSHITDONEREDUXNPMTOKEN }}
         run: |
           npm dist-tag add "get-shit-done-redux@${VERSION}" next
           echo "✅ next dist-tag re-pointed to v${VERSION} (matches latest)"

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -632,7 +632,7 @@ jobs:
         if: ${{ steps.prior_publish.outputs.skip_publish != 'true' }}
         env:
           TAG: ${{ steps.ver.outputs.tag }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GETSHITDONEREDUXNPMTOKEN }}
         run: npm publish --dry-run --tag "$TAG"
 
       - name: Tag and push
@@ -651,7 +651,7 @@ jobs:
         if: ${{ !inputs.dry_run && steps.prior_publish.outputs.skip_publish != 'true' }}
         env:
           TAG: ${{ steps.ver.outputs.tag }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GETSHITDONEREDUXNPMTOKEN }}
         run: npm publish --provenance --access public --tag "$TAG"
 
       # Keep `next` from going stale relative to `latest`. When publishing a
@@ -662,7 +662,7 @@ jobs:
         if: ${{ !inputs.dry_run && steps.ver.outputs.tag == 'latest' }}
         env:
           VERSION: ${{ steps.ver.outputs.version }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GETSHITDONEREDUXNPMTOKEN }}
         run: |
           npm dist-tag add "@opengsd/get-shit-done-redux@${VERSION}" next
           echo "✅ next dist-tag re-pointed to v${VERSION} (matches latest)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,7 +202,7 @@ jobs:
           npm publish --dry-run --tag next
           cd sdk && npm publish --dry-run --tag next
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GETSHITDONEREDUXNPMTOKEN }}
 
       - name: Tag and push
         if: ${{ !inputs.dry_run }}
@@ -227,13 +227,13 @@ jobs:
         if: ${{ !inputs.dry_run }}
         run: npm publish --provenance --access public --tag next
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GETSHITDONEREDUXNPMTOKEN }}
 
       - name: Publish SDK to npm (next)
         if: ${{ !inputs.dry_run }}
         run: cd sdk && npm publish --provenance --access public --tag next
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GETSHITDONEREDUXNPMTOKEN }}
 
       - name: Create GitHub pre-release
         if: ${{ !inputs.dry_run }}
@@ -350,7 +350,7 @@ jobs:
           npm publish --dry-run
           cd sdk && npm publish --dry-run
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GETSHITDONEREDUXNPMTOKEN }}
 
       - name: Create PR to merge release back to main
         if: ${{ !inputs.dry_run }}
@@ -405,13 +405,13 @@ jobs:
         if: ${{ !inputs.dry_run }}
         run: npm publish --provenance --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GETSHITDONEREDUXNPMTOKEN }}
 
       - name: Publish SDK to npm (latest)
         if: ${{ !inputs.dry_run }}
         run: cd sdk && npm publish --provenance --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GETSHITDONEREDUXNPMTOKEN }}
 
       - name: Create GitHub Release
         if: ${{ !inputs.dry_run }}
@@ -428,7 +428,7 @@ jobs:
         if: ${{ !inputs.dry_run }}
         env:
           VERSION: ${{ inputs.version }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GETSHITDONEREDUXNPMTOKEN }}
         run: |
           # Point next to the stable release so @next never returns something
           # older than @latest. This prevents stale pre-release installs.


### PR DESCRIPTION
<!-- pr-template-exempt: CI-only workflow credential rename — only .github/workflows/*.yml files touched; auto-detected as CI/tooling PR by path -->

## Fix PR

## Linked Issue

Fixes #205

---

## What was broken

The `release-finalize`, `hotfix`, and `release-sdk` CI workflows referenced `secrets.NPM_TOKEN` when passing credentials to `npm publish`. The actual secret in the repository/environment settings is named `GETSHITDONEREDUXNPMTOKEN`. npm received no auth token and rejected every publish with `ENEEDAUTH`.

Failed run: https://github.com/open-gsd/get-shit-done-redux/actions/runs/26351934927/job/77571659108

## What this fix does

Renames all 13 occurrences of `secrets.NPM_TOKEN` → `secrets.GETSHITDONEREDUXNPMTOKEN` across the three affected workflow files. Pure credential-name rename; no logic or behavior change.

## Root cause

The environment secret was provisioned as `GETSHITDONEREDUXNPMTOKEN` but the workflow files were authored with the generic `NPM_TOKEN` name. The two never matched, so every publish attempt since the secret was set up has failed.

## Testing

### How I verified the fix

The rename is a pure string substitution — verified by diffing the three files. The next release run will confirm the publish succeeds end-to-end (cannot be tested locally without the secret value).

### Regression test added?

- [x] No — explain why: CI-only change; the correct behavior is verified by the next successful release run, not a unit test

### Platforms tested

- [x] N/A (not platform-specific)

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #205` — **PR will be auto-closed if missing**
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`) — workflow-only change, no code touched
- [x] `no-changelog` label applied — CI infrastructure change, not user-facing
- [x] No unnecessary dependencies added

## Breaking changes

None