### PR TITLE
chore(ci): adopt npm Trusted Publishers (OIDC) for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,12 +197,13 @@ jobs:
       - name: Verify tarball ships sdk/dist/cli.js (bug #2647)
         run: bash scripts/verify-tarball-sdk-dist.sh
 
+      - name: Ensure npm supports trusted publishing
+        run: npm install -g npm@latest
+
       - name: Dry-run publish validation
         run: |
           npm publish --dry-run --tag next
           cd sdk && npm publish --dry-run --tag next
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GETSHITDONEREDUXNPMTOKEN }}
 
       - name: Tag and push
         if: ${{ !inputs.dry_run }}
@@ -225,15 +226,13 @@ jobs:
 
       - name: Publish to npm (next)
         if: ${{ !inputs.dry_run }}
+        # --provenance is automatic under OIDC trusted publishing
         run: npm publish --provenance --access public --tag next
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GETSHITDONEREDUXNPMTOKEN }}
 
       - name: Publish SDK to npm (next)
         if: ${{ !inputs.dry_run }}
+        # --provenance is automatic under OIDC trusted publishing
         run: cd sdk && npm publish --provenance --access public --tag next
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GETSHITDONEREDUXNPMTOKEN }}
 
       - name: Create GitHub pre-release
         if: ${{ !inputs.dry_run }}
@@ -345,12 +344,13 @@ jobs:
       - name: Verify tarball ships sdk/dist/cli.js (bug #2647)
         run: bash scripts/verify-tarball-sdk-dist.sh
 
+      - name: Ensure npm supports trusted publishing
+        run: npm install -g npm@latest
+
       - name: Dry-run publish validation
         run: |
           npm publish --dry-run
           cd sdk && npm publish --dry-run
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GETSHITDONEREDUXNPMTOKEN }}
 
       - name: Create PR to merge release back to main
         if: ${{ !inputs.dry_run }}
@@ -403,15 +403,13 @@ jobs:
 
       - name: Publish to npm (latest)
         if: ${{ !inputs.dry_run }}
+        # --provenance is automatic under OIDC trusted publishing
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GETSHITDONEREDUXNPMTOKEN }}
 
       - name: Publish SDK to npm (latest)
         if: ${{ !inputs.dry_run }}
+        # --provenance is automatic under OIDC trusted publishing
         run: cd sdk && npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GETSHITDONEREDUXNPMTOKEN }}
 
       - name: Create GitHub Release
         if: ${{ !inputs.dry_run }}
@@ -428,7 +426,6 @@ jobs:
         if: ${{ !inputs.dry_run }}
         env:
           VERSION: ${{ inputs.version }}
-          NODE_AUTH_TOKEN: ${{ secrets.GETSHITDONEREDUXNPMTOKEN }}
         run: |
           # Point next to the stable release so @next never returns something
           # older than @latest. This prevents stale pre-release installs.


### PR DESCRIPTION
<!-- pr-template-exempt: CI/tooling-only change — only .github/workflows/release.yml is modified -->

Closes #207

## What changed

Replaces the long-lived `GETSHITDONEREDUXNPMTOKEN` secret with short-lived OIDC tokens minted per workflow run via npm Trusted Publishers.

**Removed** from `rc` and `finalize` jobs:
- `NODE_AUTH_TOKEN: ${{ secrets.GETSHITDONEREDUXNPMTOKEN }}` env block on the dry-run publish validation step
- `NODE_AUTH_TOKEN: ${{ secrets.GETSHITDONEREDUXNPMTOKEN }}` env block on each `npm publish` step (2 per job)
- `NODE_AUTH_TOKEN: ${{ secrets.GETSHITDONEREDUXNPMTOKEN }}` env block on the dist-tag cleanup step (`finalize` only)

**Added** to `rc` and `finalize` jobs:
- `npm install -g npm@latest` step before each dry-run/publish sequence — guarantees npm CLI >= 11.5.1, the minimum that supports the OIDC token exchange with npmjs.com Trusted Publishers

**Already in place** (no changes needed):
- `id-token: write` permission on both `rc` and `finalize` jobs
- `environment: npm-publish` on both jobs (required by the Trusted Publisher configuration on npmjs.com)
- `registry-url: 'https://registry.npmjs.org'` in `setup-node` (required for the OIDC handshake)

## Why

Long-lived npm tokens must be rotated manually and are a credential-leak vector. npm Trusted Publishers eliminate the static secret entirely — npm mints a short-lived token scoped to the exact GitHub org/repo/workflow/environment combination on every run.

The Trusted Publisher is already configured on npmjs.com (publisher=GitHub Actions, org=open-gsd, repo=get-shit-done-redux, workflow=release.yml, environment=npm-publish).

## Test plan

- [ ] PR CI checks pass (workflow lint, YAML validation)
- [ ] `release.yml` contains no remaining `GETSHITDONEREDUXNPMTOKEN` references (verified by diff)
- [ ] `npm install -g npm@latest` step present in both `rc` and `finalize` jobs before publish steps
- [ ] `--provenance` flag retained on all `npm publish` calls (provenance is automatic under OIDC)
- [ ] After merge: run release workflow with `dry_run: true` to confirm OIDC exchange succeeds without `NODE_AUTH_TOKEN`