### PR TITLE
docs(#209): README continuity + release communications update

### DIFF
--- a/.changeset/happy-dogs-chatter.md
+++ b/.changeset/happy-dogs-chatter.md
@@ -1,0 +1,5 @@
+---
+type: Changed
+pr: 209
+---
+**README continuity and governance messaging refreshed** — top-level docs now standardize on open-gsd ownership, migration away from legacy gsd-build packages, and linked security/transition announcements.

--- a/README.md
+++ b/README.md
@@ -1,30 +1,25 @@
-> # ⚠️ This is the active fork
+> # Project Continuity Notice
 >
-> 📢 **Read the announcement: [why the fork, what changed, what's next →](https://github.com/gsd-redux/get-shit-done-redux/discussions/109)**
+> GSD is maintained by the **open-gsd** team at:
+> **`open-gsd/get-shit-done-redux`**
 >
-> The original repo at [gsd-build/get-shit-done](https://github.com/gsd-build/get-shit-done) appears compromised or abandoned. The maintainer (TÂCHES) has not been reachable since **2026-04-01**. TÂCHES social accounts appear deleted, and a **`$GSD` token associated with the project has been linked publicly to a rug-pull**.
+> Use only these package names:
 >
-> I have **no inside information** beyond what is publicly visible. I am stating absence-of-information deliberately — absence of news is not the same as evidence.
+> - npm (main): `@opengsd/get-shit-done-redux`
+> - npm (sdk): `@opengsd/gsd-sdk`
 >
-> ### What I can confirm
+> The legacy upstream (`gsd-build/*`) is outside open-gsd control. Based on public transition announcements and repository ownership reality, we strongly recommend removing `gsd-build` organization packages and migrating to `@opengsd/*`.
 >
-> - No contact with the original maintainer since 2026-04-01.
-> - TÂCHES social accounts appear deleted or unreachable.
-> - The `$GSD` token has been linked publicly to a rug-pull.
-> - The repo at `gsd-build/get-shit-done` continues to exist but I cannot vouch for any changes pushed there from this point forward.
+> Security status:
 >
-> ### What changed
+> - maintainers completed an internal security audit
+> - maintainers report an independent review pass
+> - no known active exploit was found in tracked source during those passes
 >
-> | | Before | After |
-> |---|---|---|
-> | GitHub | `gsd-build/get-shit-done` | `open-gsd/get-shit-done-redux` |
-> | npm (main) | `get-shit-done-cc` → `get-shit-done-redux` | `@opengsd/get-shit-done-redux` |
-> | npm (sdk) | `@gsd-build/sdk` → `@gsd-redux/sdk` | `@opengsd/gsd-sdk` |
-> | Issue numbers | per source | renumbered; original is in body as `[from gsd-build/get-shit-done#N]` |
+> See:
 >
-> If you can reach the original maintainer, please open an issue here and CC them. If you have technical evidence that materially changes the picture above, please share it in an issue.
->
-> — trek-e, fork maintainer
+> - continuity announcement: https://github.com/open-gsd/get-shit-done-redux/discussions/109
+> - audit transparency report: https://github.com/open-gsd/get-shit-done-redux/discussions/119
 >
 > ---
 
@@ -80,17 +75,15 @@ npx @opengsd/get-shit-done-redux@latest
 
 ---
 
-## Why I Built This
+## Why We Continue Building GSD
 
-I'm a solo developer. I don't write code — Claude Code does.
+GSD exists to help solo builders and small teams ship reliably with AI: clear specs, controlled context, and verification before release.
 
-Other spec-driven tools exist, but they're all built for 50-person engineering orgs — sprint ceremonies, story points, stakeholder syncs, Jira workflows. I'm not that. I'm a creative person trying to build great things consistently.
+In May 2026, maintainers published a continuity announcement and migrated active development to `open-gsd/get-shit-done-redux` after trust and ownership concerns around the former upstream, including a meme-coin rug-pull incident publicly associated with that ecosystem.
 
-So I built GSD. The complexity is in the system, not in your workflow. Behind the scenes: context engineering, XML prompt formatting, subagent orchestration, state management. What you see: a few commands that just work.
+The former creator and the `gsd-build` lineage are no longer part of this program. This repository is the maintained continuation under open-gsd governance.
 
-The system gives Claude everything it needs to do the work *and* verify it. I trust the workflow. It just does a good job.
-
-— **TÂCHES**
+The current team continues release operations, triage, and security hardening in public. Audit status and follow-up security work are documented in Discussion #119 and linked issues.
 
 ---
 

--- a/docs/prd/209-readme-continuity-release-update.md
+++ b/docs/prd/209-readme-continuity-release-update.md
@@ -1,0 +1,61 @@
+# PRD: README Continuity And Release Communications Update
+
+## Linked Issue
+
+- Closes #209
+
+## Problem
+
+The top-level README still mixes legacy transition language, personal attribution, and outdated migration framing. Users need one clear source of truth for:
+
+- canonical repository and package identities
+- current maintainer ownership/governance
+- migration guidance away from legacy upstream artifacts
+- security and audit status references
+
+## Goals
+
+1. Remove legacy personal maintainer attribution from README narrative sections.
+2. Present open-gsd continuity messaging in concise, team-owned language.
+3. Provide explicit migration guidance from legacy `gsd-build/*` packages to `@opengsd/*`.
+4. Reference public announcement and security-audit discussions directly.
+5. Keep changes docs-only and non-behavioral.
+
+## Non-Goals
+
+- Any runtime, CLI, or workflow behavior changes.
+- Any package publishing process changes.
+- Any new security policy implementation beyond documentation updates.
+
+## Scope
+
+- `README.md` top continuity notice
+- `README.md` "Why" narrative section rewrite
+- release/continuity cross-links and wording cleanup
+
+## User Stories
+
+- As a new user, I can quickly identify which repo/package is canonical.
+- As an existing user, I can safely migrate away from legacy package names.
+- As a security-conscious user, I can find the public audit status and continuity rationale in one place.
+
+## Acceptance Criteria
+
+1. README contains a continuity notice naming `open-gsd/get-shit-done-redux` as canonical.
+2. README removes personal legacy attribution in origin-story prose.
+3. README strongly recommends migration away from `gsd-build/*` artifacts.
+4. README links to Discussions #109 and #119.
+5. README states current audit posture with "no known active exploit" language.
+
+## Risks
+
+- Overstating security claims beyond published evidence.
+  - Mitigation: keep wording scoped to publicly posted announcement text.
+- Migration warning language may be interpreted as policy rather than recommendation.
+  - Mitigation: phrase as a strong recommendation based on ownership and governance reality.
+
+## Rollout
+
+1. Update README content.
+2. Open docs PR linked to #209.
+3. Run CI and merge once green.


### PR DESCRIPTION
## Enhancement PR

## Linked Issue

Closes #209

## What this enhancement improves

Improves top-level project communications in `README.md` so users get clear continuity, governance, migration, and audit-status guidance anchored to open-gsd announcements.

## Before / After

**Before:**
README continuity/origin sections referenced legacy personal attribution and mixed transition wording.

**After:**
README uses team-owned continuity messaging, removes legacy personal references, points to canonical `open-gsd` packages, and links the transition + audit discussions.

## How it was implemented

- Rewrote top continuity notice in `README.md`
- Replaced `Why I Built This` with `Why We Continue Building GSD`
- Added PRD: `docs/prd/209-readme-continuity-release-update.md`
- Added changeset fragment: `.changeset/happy-dogs-chatter.md`

## Testing

### How I verified the enhancement works

- Manual review of README content and links
- Verified removal of legacy personal references in updated sections
- Verified issue/discussion links resolve and package names are canonical

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [x] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue — no additions or removals
- [x] If scope changed during implementation, I updated the issue and got re-approval before continuing

## Documentation

- [x] Updated the relevant file(s) under `docs/` to reflect this change
- [x] All `docs/` content added in this PR is written in English

## Checklist

- [x] Issue linked above with `Closes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `approved-enhancement` label — **PR will be closed if missing**
- [x] Changes are scoped to the approved enhancement — nothing extra included
- [ ] All existing tests pass (`npm test`)
- [ ] New or updated tests cover the enhanced behavior
- [x] `.changeset/` fragment added (`--type Changed`) — user-facing docs messaging update
- [x] No unnecessary dependencies added

## Breaking changes

None
