### PR TITLE
chore: enable next-branch automation (Phase 2 flips)

### DIFF
--- a/.github/workflows/auto-backmerge.yml
+++ b/.github/workflows/auto-backmerge.yml
@@ -27,7 +27,7 @@ permissions:
 jobs:
   backmerge:
     # Phase-1 gate: leave false until `next` exists. Flip to `true` in Phase 2.
-    if: false
+    if: true
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/pr-target-validator.yml
+++ b/.github/workflows/pr-target-validator.yml
@@ -26,7 +26,7 @@ jobs:
     timeout-minutes: 2
     env:
       # Phase-1: warn only. Phase-2: set to 'false' to enforce.
-      WARN_ONLY: 'true'
+      WARN_ONLY: 'false'
     steps:
       - name: Validate PR target branch
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0


### PR DESCRIPTION
Phase 2 follow-up to the `next` integration-branch rollout.

This PR flips the two phase-gate flags that shipped inert in Phase 1:

- `auto-backmerge.yml`: `if: false` → `if: true` (the back-merge job now runs on every push to main)
- `pr-target-validator.yml`: `WARN_ONLY: 'true'` → `'false'` (the validator now fails the check instead of just commenting)

The `next` branch and branch-protection rules were created/applied out-of-band by `scripts/rollout-next-phase2.sh` before this PR.

After this merges, the model is fully live. New PRs should target `next` (it's the default now); the validator will catch mistakes and tell contributors how to retarget. 

Closes #230 

Closes #230