### PR TITLE
fix: bring next-branch automation flag flips to main

### DIFF
--- a/.github/workflows/auto-backmerge.yml
+++ b/.github/workflows/auto-backmerge.yml
@@ -27,7 +27,7 @@ permissions:
 jobs:
   backmerge:
     # Phase-1 gate: leave false until `next` exists. Flip to `true` in Phase 2.
-    if: false
+    if: true
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/pr-target-validator.yml
+++ b/.github/workflows/pr-target-validator.yml
@@ -26,7 +26,7 @@ jobs:
     timeout-minutes: 2
     env:
       # Phase-1: warn only. Phase-2: set to 'false' to enforce.
-      WARN_ONLY: 'true'
+      WARN_ONLY: 'false'
     steps:
       - name: Validate PR target branch
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #233

## What was broken

Phase 2 of the next-branch rollout merged operational flag flips to `next` (the new default branch), not `main`. The `auto-backmerge.yml` workflow on `main` still has `if: false`, so it skips on every push to `main` until a release back-merge naturally aligns the branches.

## What this fix does

Brings the two flag flips from `next` to `main` directly:
- `auto-backmerge.yml`: `if: false` → `if: true`
- `pr-target-validator.yml`: `WARN_ONLY: 'true'` → `'false'`

After merge, pushes to `main` trigger the automatic main→next back-merge as designed.

## Root cause

Phase 2 PR (#232) targeted `next` (the new default), so the flips landed there but did not propagate to `main` until the next release/hotfix back-merge would do so naturally. Critical because the gap leaves `main` operations un-mirrored to `next`.

## Testing

### How I verified the fix

YAML files identical to next's HEAD. Workflow logic already validated by Phase 2 PR (#232) acceptance.

### Regression test added?

- [ ] Yes
- [x] No — workflow-YAML-only state synchronization; no test surface

### Platforms tested

- [ ] macOS
- [ ] Windows
- [ ] Linux
- [x] N/A (workflow file edits only)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #233`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not — workflow YAML, no test surface)
- [x] All existing tests pass — no test-affecting changes
- [x] `no-changelog` label applied — not user-facing
- [x] No unnecessary dependencies added

## Breaking changes

None.
