### PR TITLE
fix(critical): make hotfix + auto-branch next-aware (Phase 3)

### DIFF
--- a/.github/workflows/auto-branch.yml
+++ b/.github/workflows/auto-branch.yml
@@ -67,18 +67,31 @@ jobs:
               if (e.status !== 404) throw e;
             }
 
-            // Create branch from main HEAD
-            const mainRef = await github.rest.git.getRef({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: 'heads/main',
-            });
+            // Create branch from next HEAD (the integration branch under the
+            // next-branch model). Fall back to main if next doesn't exist —
+            // covers the brief transition window when this workflow was first
+            // deployed and any legacy single-branch state.
+            let baseRef;
+            try {
+              baseRef = await github.rest.git.getRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: 'heads/next',
+              });
+            } catch (e) {
+              if (e.status !== 404) throw e;
+              baseRef = await github.rest.git.getRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: 'heads/main',
+              });
+            }
 
             await github.rest.git.createRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
               ref: `refs/heads/${branch}`,
-              sha: mainRef.data.object.sha,
+              sha: baseRef.data.object.sha,
             });
 
             await github.rest.issues.createComment({

--- a/.github/workflows/hotfix.yml
+++ b/.github/workflows/hotfix.yml
@@ -37,7 +37,7 @@ on:
         required: true
         type: string
       auto_cherry_pick:
-        description: 'Auto-cherry-pick fix:/chore: commits from origin/main since base tag (create only)'
+        description: 'Auto-cherry-pick fix:/chore: commits from origin/next (fallback origin/main) since base tag (create only)'
         required: false
         type: boolean
         default: true
@@ -141,7 +141,7 @@ jobs:
             git push -u origin "$BRANCH"
           fi
 
-      - name: Cherry-pick fix/chore commits from origin/main since base tag
+      - name: Cherry-pick fix/chore commits from origin/next since base tag
         if: ${{ inputs.auto_cherry_pick }}
         env:
           BRANCH: ${{ needs.validate-version.outputs.branch }}
@@ -149,23 +149,35 @@ jobs:
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
           set -euo pipefail
-          git fetch origin main:refs/remotes/origin/main
 
-          # `git cherry $BASE_TAG origin/main` lists every commit on main not
+          # Under the next-branch model, day-to-day fixes land on `next` first
+          # and only reach `main` via release back-merge. So `next` is the
+          # canonical cherry-pick source. Fall back to `main` if `next` doesn't
+          # exist yet (legacy single-branch repos) or as a transition guard.
+          if git ls-remote --exit-code origin next >/dev/null 2>&1; then
+            git fetch origin next:refs/remotes/origin/next
+            SOURCE="origin/next"
+          else
+            git fetch origin main:refs/remotes/origin/main
+            SOURCE="origin/main"
+          fi
+          echo "Cherry-pick source: $SOURCE"
+
+          # `git cherry $BASE_TAG $SOURCE` lists every commit on the source not
           # patch-equivalent in BASE_TAG. + means needs picking, - means
           # already applied (skipped silently).
-          CANDIDATES=$(git cherry "$BASE_TAG" origin/main | awk '/^\+ / {print $2}')
+          CANDIDATES=$(git cherry "$BASE_TAG" "$SOURCE" | awk '/^\+ / {print $2}')
 
           if [ -z "$CANDIDATES" ]; then
-            echo "No commits on origin/main beyond $BASE_TAG."
+            echo "No commits on $SOURCE beyond $BASE_TAG."
             echo "## Cherry-pick summary" >> "$GITHUB_STEP_SUMMARY"
             echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "Base: \`$BASE_TAG\` — no commits to consider." >> "$GITHUB_STEP_SUMMARY"
+            echo "Base: \`$BASE_TAG\` (source: \`$SOURCE\`) — no commits to consider." >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
 
           # Re-order chronologically (oldest first) for predictable application.
-          ORDERED=$(git log --reverse --format='%H' "$BASE_TAG..origin/main" \
+          ORDERED=$(git log --reverse --format='%H' "$BASE_TAG..$SOURCE" \
             | grep -F -f <(echo "$CANDIDATES") || true)
 
           INCLUDED=""


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #235

## What was broken

After Phase 2 of the next-branch rollout (#230, merged via #232 + #234) flipped `next` to default and operational, two workflows still operated against `main`:

- `hotfix.yml` cherry-picks `fix:`/`chore:` commits from `origin/main`. Under the new model those commits land on `next`; `main` only moves on release back-merges. Hotfixes would ship empty between releases.
- `auto-branch.yml` creates issue-labeled branches from `heads/main`. Contributors should branch from `next` (where current work lives). Branches off `main` would be stale at birth.

## What this fix does

- `hotfix.yml`: cherry-pick from `origin/next` with fallback to `origin/main` if `next` doesn't exist (transition/legacy guard).
- `auto-branch.yml`: branch from `heads/next` with the same fallback.

Both changes are surgical — only the source ref/branch changes; cherry-pick logic, conflict handling, and step ordering are untouched.

## Root cause

Phase 3 of the ADR migration plan was deferred deliberately; the rollout did Phase 1 (additive) and Phase 2 (flip) first to validate the model. Phase 3 (retarget release/hotfix workflows) wasn't yet applied. Without it, the release flow is broken under the new branching model.

## Testing

### How I verified the fix

YAML parses (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/hotfix.yml'))"`). Logic mirrors the inline diff in the ADR, which has been reviewed.

Post-merge verification:
1. Dispatch `hotfix.yml` with `dry_run: true` and `auto_cherry_pick: true` against a recent patch version. Confirm the step log says `Cherry-pick source: origin/next` (or `origin/main` if next is missing).
2. File a test issue and label it `bug`. Watch `auto-branch.yml` create the branch; verify with `git log -1 fix/<issue#>-...` that the new branch points at `next` HEAD, not `main` HEAD.

### Regression test added?

- [ ] Yes
- [x] No — workflow YAML changes, no test surface. Validation is operational (dry-run hotfix, file test issue) as above.

### Platforms tested

- [ ] macOS
- [ ] Windows
- [ ] Linux
- [x] N/A (workflow file edits only)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A

---

## Checklist

- [x] Issue linked above with `Fixes #235`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not — workflow YAML, validated operationally)
- [x] All existing tests pass — no test-affecting changes
- [x] `no-changelog` label applied — not user-facing
- [x] No unnecessary dependencies added

## Breaking changes

None. Behavior change is intentional and matches the ADR-documented next-branch model. Fallback to `main` preserves the legacy code-path if `next` is ever missing.
