### PR TITLE
fix(11): detect cross-name hand-sync pairs from allowlist

### DIFF
--- a/scripts/lint-shared-module-handsync.cjs
+++ b/scripts/lint-shared-module-handsync.cjs
@@ -12,6 +12,10 @@
  * `bin/lib/foo.cjs` and ts `sdk/src/foo.ts` only allow-throughs that exact
  * pair — a sibling at `sdk/src/query/foo.ts` is still flagged.
  *
+ * Cross-name pairs are also supported when declared in the allowlist
+ * (for example `verify.cjs` <-> `validate.ts`), so cooperating siblings are
+ * observable even when basenames differ.
+ *
  * If a pair is found:
  *   - cooperatingSiblings (matching cjs + ts): accepted silently (exit 0).
  *   - migrateMeBacklog (matching cjs + ts): emits a WARNING only when
@@ -95,6 +99,17 @@ const cooperatingPairs = new Set(
 const migrateMap = new Map(
   (allowlist.migrateMeBacklog || []).map((e) => [`${e.cjs}::${e.ts}`, e])
 );
+
+/** @type {Map<string, Set<string>>} cjs rel path -> explicit declared ts rel paths */
+const explicitTsByCjs = new Map();
+for (const entry of [
+  ...(allowlist.cooperatingSiblings || []),
+  ...(allowlist.migrateMeBacklog || []),
+]) {
+  if (!entry || typeof entry.cjs !== 'string' || typeof entry.ts !== 'string') continue;
+  if (!explicitTsByCjs.has(entry.cjs)) explicitTsByCjs.set(entry.cjs, new Set());
+  explicitTsByCjs.get(entry.cjs).add(entry.ts);
+}
 
 // ---------------------------------------------------------------------------
 // Build SDK name index: name -> array of absolute TS paths
@@ -212,13 +227,36 @@ function main() {
   const errors = [];
   const warnings = [];
 
-  for (const { name, absPath } of cjsFiles) {
-    // Is there a matching TS file?
-    if (!sdkIndex.has(name)) continue;
+  function candidateTsPathsFor(relCjs, name) {
+    const byName = sdkIndex.has(name)
+      ? sdkIndex
+          .get(name)
+          .map((p) => path.relative(ROOT, p).replace(/\\/g, '/'))
+      : [];
 
-    // Compute the relative paths the allowlist uses
+    const declared = explicitTsByCjs.has(relCjs)
+      ? Array.from(explicitTsByCjs.get(relCjs))
+      : [];
+
+    const declaredExisting = declared.filter((relTs) => {
+      const abs = path.join(ROOT, relTs);
+      return (
+        relTs.endsWith('.ts') &&
+        !relTs.endsWith('.generated.ts') &&
+        !relTs.endsWith('.test.ts') &&
+        fs.existsSync(abs) &&
+        fs.statSync(abs).isFile()
+      );
+    });
+
+    return Array.from(new Set([...byName, ...declaredExisting]));
+  }
+
+  for (const { name, absPath } of cjsFiles) {
+    // Compute relative CJS path and all declared/discovered TS candidates.
     const relCjs = path.relative(ROOT, absPath).replace(/\\/g, '/');
-    const tsPaths = sdkIndex.get(name).map((p) => path.relative(ROOT, p).replace(/\\/g, '/'));
+    const tsPaths = candidateTsPathsFor(relCjs, name);
+    if (tsPaths.length === 0) continue;
 
     // Pair-aware matching, per ts sibling. Each ts candidate is classified
     // independently against the allowlist so a partially-allowlisted set of
@@ -247,12 +285,10 @@ function main() {
   // Count cjs files whose pair identity (cjs+ts) is on cooperatingSiblings.
   // A file with multiple ts candidates is counted once if any pair matches.
   const cooperatingCount = cjsFiles.filter((f) => {
-    if (!sdkIndex.has(f.name)) return false;
     const relCjs = path.relative(ROOT, f.absPath).replace(/\\/g, '/');
-    return sdkIndex.get(f.name).some((tsAbs) => {
-      const relTs = path.relative(ROOT, tsAbs).replace(/\\/g, '/');
-      return cooperatingPairs.has(`${relCjs}::${relTs}`);
-    });
+    return candidateTsPathsFor(relCjs, f.name).some((relTs) =>
+      cooperatingPairs.has(`${relCjs}::${relTs}`)
+    );
   }).length;
 
   // -------------------------------------------------------------------------

--- a/scripts/shared-module-handsync-allowlist.json
+++ b/scripts/shared-module-handsync-allowlist.json
@@ -147,5 +147,13 @@
       "justification": "CJS prompt-budget.cjs provides the applyBudget implementation used by gsd-tools.cjs case 'prompt-budget'. SDK prompt-budget.ts is the native QueryHandler port for gsd-sdk query dispatch (#3081). The SDK handler ports the pure budget logic and adds CLI arg parsing / file I/O directly, satisfying the registry-integration drift-guard without duplicating shared state."
     }
   ],
-  "migrateMeBacklog": []
+  "migrateMeBacklog": [
+    {
+      "cjs": "get-shit-done/bin/lib/verify.cjs",
+      "ts": "sdk/src/query/validate.ts",
+      "classification": "drift-anti-pattern",
+      "justification": "Cross-name cooperating pair where validate policy changes can drift from verify checks; keep explicitly visible until Shared Module extraction removes hand-sync risk.",
+      "trackedIn": "#11"
+    }
+  ]
 }

--- a/tests/lint-shared-module-handsync.test.cjs
+++ b/tests/lint-shared-module-handsync.test.cjs
@@ -367,3 +367,44 @@ describe('lint-shared-module-handsync: allowlist entry honored', () => {
     }
   });
 });
+
+describe('lint-shared-module-handsync: cross-name pair support', () => {
+  test('surfaces declared cross-name migrateMeBacklog pair in warnings', () => {
+    const cjsName = 'verify';
+    const tsName = 'validate';
+    const tmpDir = createFixture({
+      cjsName,
+      tsName,
+      tsInQuery: true,
+      allowlistExtra: {
+        migrateMeBacklog: [
+          {
+            cjs: `get-shit-done/bin/lib/${cjsName}.cjs`,
+            ts: `sdk/src/query/${tsName}.ts`,
+            classification: 'drift-anti-pattern',
+            justification: 'Test fixture: cross-name pair should be observable by lint.',
+            trackedIn: 'issue-11-test',
+          },
+        ],
+      },
+    });
+
+    try {
+      const { status, payload } = runLintJson(['--root', tmpDir]);
+      assert.strictEqual(status, 0);
+      assert.ok(payload);
+      assert.strictEqual(payload.ok, true);
+      assert.ok(Array.isArray(payload.warnings));
+      assert.ok(
+        payload.warnings.some((w) =>
+          /verify\.cjs$/.test(w.relCjs) &&
+          Array.isArray(w.tsPaths) &&
+          w.tsPaths.some((p) => /sdk\/src\/query\/validate\.ts$/.test(p))
+        ),
+        `expected cross-name verify.cjs <-> validate.ts warning, got: ${JSON.stringify(payload.warnings)}`
+      );
+    } finally {
+      cleanupFixture(tmpDir);
+    }
+  });
+});


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

> **Required.** This PR will be auto-closed if no valid issue link is found.

Fixes #11

> The linked issue must have the `confirmed-bug` label. If it doesn't, ask a maintainer to confirm the bug before continuing.

---

## What was broken

The hand-sync lint only discovered TS siblings by basename, so cross-name cooperating pairs (like `verify.cjs` ↔ `validate.ts`) were structurally invisible even when declared in the allowlist.

## What this fix does

Extends candidate discovery to include explicitly declared allowlist pairs in addition to basename-matched siblings, and adds regression coverage for cross-name pair detection.

## Root cause

The lint's discovery step depended on `sdkIndex.get(name)` only, which excludes valid declared pairs when CJS and TS filenames differ.

## Testing

### How I verified the fix

- `node --test tests/lint-shared-module-handsync.test.cjs`
- `node scripts/lint-shared-module-handsync.cjs --json`
- `node scripts/lint-shared-module-handsync.cjs --warn-all`
- Pre-PR gate run immediately before PR creation:
  - `gsd-test-summary --both`
  - `Docker: 0 failed`
  - `Mac: 0 failed`

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [ ] All existing tests pass (`npm test`)
  - Focused verification run for this fix: lint shared-module handsync suite + lint script JSON/warn-all + gsd-test-summary --both gate
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None
