### PR TITLE
fix(13): emit raw scalar strings for sdk --pick

### DIFF
--- a/.changeset/proud-elks-snooze.md
+++ b/.changeset/proud-elks-snooze.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 13
+---
+**`gsd-sdk query --pick` now emits raw string scalars (CJS parity restored)** — the SDK dispatch formatter previously JSON-stringified picked values, which wrapped string outputs in literal quotes and broke shell capture/path composition. The pick formatter now returns raw string scalars with newline while preserving JSON output for non-string picks. (#13)

--- a/sdk/src/query/query-dispatch.test.ts
+++ b/sdk/src/query/query-dispatch.test.ts
@@ -178,6 +178,12 @@ describe('stage: formatting', () => {
     expect(formatSuccess({ nested: { value: 3 } }, 'json', 'nested.value')).toBe('3\n');
   });
 
+  it('formatSuccess emits raw scalar for picked string fields', () => {
+    expect(formatSuccess({ slug: 'cli-agent-transcript-persistence' }, 'json', 'slug')).toBe(
+      'cli-agent-transcript-persistence\n',
+    );
+  });
+
   it('formatPick returns input unchanged when no pickField provided', () => {
     const input = { ok: true };
     expect(formatPick(input)).toBe(input);
@@ -359,6 +365,23 @@ describe('end-to-end IR contract', () => {
     expect(out.ok).toBe(true);
     if (!out.ok) throw new Error('expected success');
     expect(out.stdout).toBe('7\n');
+    expect(out.exit_code).toBe(0);
+  });
+
+  it('applies --pick to native json string output without quote wrapping', async () => {
+    const registry = createRegistry();
+    const out = await runQueryDispatch({
+      registry,
+      projectDir: tmpDir,
+      cjsFallbackEnabled: true,
+      resolveGsdToolsPath: () => '',
+      dispatchNative: async () => ({ data: { slug: 'cli-agent-transcript-persistence' } }),
+      topology: createCommandTopology(registry),
+    }, ['generate-slug', 'CLI agent transcript persistence', '--pick', 'slug']);
+
+    expect(out.ok).toBe(true);
+    if (!out.ok) throw new Error('expected success');
+    expect(out.stdout).toBe('cli-agent-transcript-persistence\n');
     expect(out.exit_code).toBe(0);
   });
 

--- a/sdk/src/query/query-dispatch.ts
+++ b/sdk/src/query/query-dispatch.ts
@@ -86,6 +86,9 @@ export function formatSuccess(data: unknown, format: DispatchSuccessFormat, pick
     return data.endsWith('\n') ? data : `${data}\n`;
   }
   const output = formatPick(data, pickField);
+  if (pickField && typeof output === 'string') {
+    return output.endsWith('\n') ? output : `${output}\n`;
+  }
   return `${JSON.stringify(output === undefined ? null : output, null, 2)}\n`;
 }
 


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

> **Required.** This PR will be auto-closed if no valid issue link is found.

Fixes #13

> The linked issue must have the `confirmed-bug` label. If it doesn't, ask a maintainer to confirm the bug before continuing.

---

## What was broken

`gsd-sdk query ... --pick <string-field>` emitted JSON-quoted string scalars (for example `"slug"`) instead of raw scalar output, breaking shell capture and diverging from CJS `gsd-tools --pick` behavior.

## What this fix does

Updates SDK query-dispatch formatting so picked string scalars are emitted raw with trailing newline, while preserving JSON formatting for non-string picks.

## Root cause

In `formatSuccess`, picked output was always passed to `JSON.stringify`, which wraps string scalars in literal surrounding quotes.

## Testing

### How I verified the fix

- Red/green unit + dispatch path:
  - `cd sdk && npm test -- query-dispatch.test.ts`
- Built SDK CLI and replayed original repro with byte-level check:
  - `cd sdk && npm run build`
  - `node dist/cli.js query generate-slug "CLI agent transcript persistence" --pick slug | xxd`
  - verified output bytes are raw slug + `0x0a` (no `0x22` quote bytes)
- Required pre-submission gate run immediately before PR creation:
  - `gsd-test-summary --both`
  - `Docker: 0 failed`
  - `Mac: 0 failed`

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [ ] All existing tests pass (`npm test`)
  - Focused validation run for touched surface: `sdk/src/query/query-dispatch.test.ts` + CLI repro + required gate
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None
