### PR TITLE
refactor(#182): migrate project-root resolution module to sdk/src/runtime

### DIFF
--- a/get-shit-done/bin/lib/project-root.generated.cjs
+++ b/get-shit-done/bin/lib/project-root.generated.cjs
@@ -3,7 +3,7 @@
 /**
  * GENERATED FILE — DO NOT EDIT.
  *
- * Source: sdk/src/project-root/index.ts
+ * Source: sdk/src/runtime/project-root.ts
  * Regenerate: cd sdk && npm run gen:project-root
  *
  * Project-Root Resolution Module — resolves a project root from a starting

--- a/sdk/scripts/gen-project-root.mjs
+++ b/sdk/scripts/gen-project-root.mjs
@@ -2,7 +2,7 @@
 /**
  * Generator for the Project-Root Resolution Module CJS artifact.
  *
- * Imports the compiled ESM output from sdk/dist/project-root/index.js,
+ * Imports the compiled ESM output from sdk/dist/runtime/project-root.js,
  * captures findProjectRoot via Function.prototype.toString(), then emits
  * get-shit-done/bin/lib/project-root.generated.cjs.
  *
@@ -14,14 +14,14 @@ import { writeFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import { requireFreshDist } from './_gen-helpers.mjs';
 
-requireFreshDist('sdk/dist/project-root/index.js', 'sdk/src/project-root/index.ts');
+requireFreshDist('sdk/dist/runtime/project-root.js', 'sdk/src/runtime/project-root.ts');
 
 const BANNER = `'use strict';
 
 /**
  * GENERATED FILE — DO NOT EDIT.
  *
- * Source: sdk/src/project-root/index.ts
+ * Source: sdk/src/runtime/project-root.ts
  * Regenerate: cd sdk && npm run gen:project-root
  *
  * Project-Root Resolution Module — resolves a project root from a starting
@@ -41,7 +41,7 @@ const BANNER = `'use strict';
  * duplicating the logic.
  */
 export async function buildProjectRootCjs() {
-  const distUrl = new URL('../dist/project-root/index.js', import.meta.url);
+  const distUrl = new URL('../dist/runtime/project-root.js', import.meta.url);
   const { findProjectRoot, FIND_PROJECT_ROOT_MAX_DEPTH } = await import(distUrl.href);
 
   const findProjectRootBody = findProjectRoot.toString();

--- a/sdk/src/query/helpers.ts
+++ b/sdk/src/query/helpers.ts
@@ -502,9 +502,9 @@ export function planningPaths(projectDir: string, workstream?: string): Planning
 }
 
 // ─── findProjectRoot (multi-repo .planning resolution) ─────────────────────
-// Implementation lives in sdk/src/project-root/index.ts — re-exported here
+// Implementation lives in sdk/src/runtime/project-root.ts — re-exported here
 // so that existing consumers of helpers.ts continue to work unchanged.
-export { findProjectRoot } from '../project-root/index.js';
+export { findProjectRoot } from '../runtime/project-root.js';
 
 // ─── resolvePathUnderProject ───────────────────────────────────────────────
 

--- a/sdk/src/runtime/project-root.test.ts
+++ b/sdk/src/runtime/project-root.test.ts
@@ -1,5 +1,5 @@
 /**
- * Pinning tests for sdk/src/project-root/index.ts
+ * Pinning tests for sdk/src/runtime/project-root.ts
  *
  * These tests pin the behaviour of findProjectRoot before the CJS refactor
  * in Cycle 2. They must remain GREEN throughout (never bend the implementation
@@ -14,7 +14,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { findProjectRoot } from './index.js';
+import { findProjectRoot } from './project-root.js';
 
 describe('findProjectRoot (project-root module)', () => {
   let workspace: string;

--- a/sdk/src/runtime/project-root.ts
+++ b/sdk/src/runtime/project-root.ts
@@ -10,7 +10,8 @@
  * Bounded by FIND_PROJECT_ROOT_MAX_DEPTH ancestors. Sync I/O.
  *
  * Source of truth for `findProjectRoot` — the CJS artifact at
- * get-shit-done/bin/lib/project-root.generated.cjs is generated from this file.
+ * get-shit-done/bin/lib/project-root.generated.cjs is generated from
+ * sdk/src/runtime/project-root.ts.
  */
 
 import { dirname, resolve, sep, relative, parse as parsePath } from 'node:path';

--- a/tests/gen-staleness-check.test.cjs
+++ b/tests/gen-staleness-check.test.cjs
@@ -53,8 +53,8 @@ const GENERATORS = [
   },
   {
     script: 'gen-project-root.mjs',
-    dist: 'sdk/dist/project-root/index.js',
-    ts: 'sdk/src/project-root/index.ts',
+    dist: 'sdk/dist/runtime/project-root.js',
+    ts: 'sdk/src/runtime/project-root.ts',
   },
   {
     script: 'gen-workstream-inventory-builder.mjs',

--- a/tests/project-root-generator.test.cjs
+++ b/tests/project-root-generator.test.cjs
@@ -2,7 +2,7 @@
 /**
  * CJS parity test — project-root module
  *
- * For every fixture from sdk/src/project-root/index.test.ts, asserts that
+ * For every fixture from sdk/src/runtime/project-root.test.ts, asserts that
  * both the SDK (ESM, via dynamic import) and the generated CJS artifact
  * return identical paths. This confirms that the generator correctly
  * captures the function body and that all dependencies (sep, dirname,
@@ -21,7 +21,7 @@ const { findProjectRoot: findProjectRootCjs } = require('../get-shit-done/bin/li
 // SDK ESM — loaded once before all tests via dynamic import
 let findProjectRootSdk;
 before(async () => {
-  const mod = await import('../sdk/dist/project-root/index.js');
+  const mod = await import('../sdk/dist/runtime/project-root.js');
   findProjectRootSdk = mod.findProjectRoot;
 });
 


### PR DESCRIPTION
## Enhancement PR

> **Using the wrong template?**
> — Bug fix: use [fix.md](?template=fix.md)
> — New feature: use [feature.md](?template=feature.md)

---

## Linked Issue

> **Required.** This PR will be auto-closed if no valid issue link is found.
> The linked issue **must** have the `approved-enhancement` label. If it does not, this PR will be closed without review.

Closes #182

> ⛔ **No `approved-enhancement` label on the issue = immediate close.**
> Do not open this PR if a maintainer has not yet approved the enhancement proposal.

---

## What this enhancement improves

Project-Root Resolution Module source layout for Epic #174 Phase 2.4 by moving the canonical TypeScript source to `sdk/src/runtime/project-root.ts`.

## Before / After

**Before:**
Project-root source and tests lived under `sdk/src/project-root/`, with generator/staleness/parity references targeting `sdk/src/project-root/index.ts` and `sdk/dist/project-root/index.js`.

**After:**
Project-root source and tests live under `sdk/src/runtime/`, and generator/staleness/parity references now target `sdk/src/runtime/project-root.ts` and `sdk/dist/runtime/project-root.js` with no behavior change.

## How it was implemented

- Moved module and tests:
  - `sdk/src/project-root/index.ts` → `sdk/src/runtime/project-root.ts`
  - `sdk/src/project-root/index.test.ts` → `sdk/src/runtime/project-root.test.ts`
- Updated SDK re-export path in `sdk/src/query/helpers.ts`.
- Updated project-root generator and emitted CJS banner/source path:
  - `sdk/scripts/gen-project-root.mjs`
  - `get-shit-done/bin/lib/project-root.generated.cjs`
- Updated parity/staleness tests to new runtime paths:
  - `tests/project-root-generator.test.cjs`
  - `tests/gen-staleness-check.test.cjs`

## Testing

### How I verified the enhancement works

- `gsd-test-summary --both` passed:
  - Docker: `0 failed`
  - Mac: `0 failed`
- `node --test tests/project-root-generator.test.cjs` passed
- `node --test tests/gen-staleness-check.test.cjs` passed
- `node --test tests/feat-3598-generator-correctness.test.cjs` passed
- `node sdk/scripts/check-project-root-fresh.mjs` reports fresh

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue — no additions or removals
- [x] If scope changed during implementation, I updated the issue and got re-approval before continuing

---

## Documentation

- [ ] Updated the relevant file(s) under `docs/` to reflect this change
- [x] All `docs/` content added in this PR is written in English
- [x] If genuinely no user-facing docs impact (infrastructure / internal refactor / test-only),
      apply the `no-docs` label **or** add `<!-- docs-exempt: <reason> -->` inside each
      triggering changeset fragment and leave a comment explaining why.

No user-facing docs impact; this is an internal source relocation refactor and is submitted with `no-changelog`.

## Checklist

- [x] Issue linked above with `Closes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `approved-enhancement` label — **PR will be closed if missing**
- [x] Changes are scoped to the approved enhancement — nothing extra included
- [x] All existing tests pass (`npm test`)
- [x] New or updated tests cover the enhanced behavior
- [x] `.changeset/` fragment added (`npm run changeset -- --type Changed --pr <NNN> --body "..."`) — or `no-changelog` label applied if not user-facing
- [x] No unnecessary dependencies added

## Breaking changes

None
