### PR TITLE
fix: avoid Windows current-timestamp crash by bypassing SDK bridge

### DIFF
--- a/.changeset/sturdy-lynx-forage.md
+++ b/.changeset/sturdy-lynx-forage.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 258
+---
+**`current-timestamp` now runs on the CJS fast path to avoid intermittent Windows Node 24 crash exits in CI.**

--- a/get-shit-done/bin/gsd-tools.cjs
+++ b/get-shit-done/bin/gsd-tools.cjs
@@ -771,19 +771,11 @@ async function runCommand(command, args, cwd, raw, defaultValue, originalCommand
     }
 
     case 'current-timestamp': {
-      // Phase 6 (#3575): dispatch via SDK executeForCjs when available.
-      // SDK handler: currentTimestamp in sdk/src/query/utils.ts.
-      const handled = _dispatchNonFamily({
-        registryCommand: 'current-timestamp',
-        registryArgs: args.slice(1),
-        legacyCommand: 'current-timestamp',
-        legacyArgs: args.slice(1),
-        cwd,
-        raw,
-        error,
-        output: core.output,
-      });
-      if (!handled) commands.cmdCurrentTimestamp(args[1] || 'full', raw);
+      // Keep this command on the CJS fast path.
+      // Rationale: it is a pure local formatter and avoids SDK bridge startup
+      // in tight subprocess loops where Windows CI has shown intermittent
+      // native crashes (0xC0000005 / 3221225477).
+      commands.cmdCurrentTimestamp(args[1] || 'full', raw);
       break;
     }
 

--- a/tests/commands.test.cjs
+++ b/tests/commands.test.cjs
@@ -888,6 +888,24 @@ describe('current-timestamp command', () => {
     const output = JSON.parse(result.output);
     assert.match(output.timestamp, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/, 'default should be full ISO format');
   });
+
+  test('dispatches directly to CJS handler (no SDK bridge) to avoid Windows native crash path', () => {
+    const sourcePath = path.join(__dirname, '..', 'get-shit-done', 'bin', 'gsd-tools.cjs');
+    const source = fs.readFileSync(sourcePath, 'utf8');
+    const match = source.match(/case 'current-timestamp':\s*\{[\s\S]*?\n\s*break;\n\s*\}/);
+
+    assert.ok(match, 'current-timestamp case block must exist in gsd-tools.cjs');
+
+    const block = match[0];
+    assert.ok(
+      !block.includes('_dispatchNonFamily('),
+      'current-timestamp must not route through SDK bridge'
+    );
+    assert.ok(
+      block.includes("commands.cmdCurrentTimestamp(args[1] || 'full', raw);"),
+      'current-timestamp must call the CJS handler directly'
+    );
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
This fixes an intermittent Windows Node 24 CI failure where `current-timestamp date` occasionally crashed with `0xC0000005` (`3221225477`) inside `test (windows-latest, 24)`.

## Root Cause
`current-timestamp` was routed through the SDK non-family bridge path even though the command is a pure local timestamp formatter. Under heavy Windows CI subprocess load, this bridge path can intermittently crash natively before JS-level fallback handling can run.

## Changes
- Route `current-timestamp` directly to `commands.cmdCurrentTimestamp(...)` in `get-shit-done/bin/gsd-tools.cjs`.
- Add regression guard in `tests/commands.test.cjs` asserting the `current-timestamp` case does not use `_dispatchNonFamily` and does call the direct CJS handler.

## Verification
- `node --test tests/commands.test.cjs --test-name-pattern "current-timestamp command|dispatches directly to CJS handler"`
- `gsd-test-summary --both`
  - Binary: `v1.3.2`
  - Targets: `linux,macos`
  - Docker: `0 failed`
  - Mac: `0 failed`

Fixes #257
Refs https://github.com/open-gsd/get-shit-done-redux/actions/runs/26378060094/job/77641908759
