### PR TITLE
fix(issue): bug: worktree executor force-adds gitignored .planning/SUMMARY.md into worktree branch (regression of the skipped_gitignored SDK contract)

### DIFF
--- a/.changeset/quick-rams-wave.md
+++ b/.changeset/quick-rams-wave.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 265
+---
+Workflow guard now respects its opt-in config before blocking forced git-add commands on worktree-agent branches.

--- a/bin/install.js
+++ b/bin/install.js
@@ -9566,18 +9566,24 @@ function install(isGlobal, runtime = 'claude', options = {}) {
 
     // Configure workflow guard hook (opt-in via hooks.workflow_guard: true)
     // Detects file edits outside GSD workflow context and advises using
-    // /gsd-quick or /gsd-fast for state-tracked changes. Advisory only.
+    // /gsd-quick or /gsd-fast for state-tracked changes. Also hard-blocks
+    // unsafe Bash commands that violate worktree-agent isolation.
     const workflowGuardCommand = isGlobal
       ? buildHookCommand(targetDir, 'gsd-workflow-guard.js', hookOpts)
       : localCmd('gsd-workflow-guard.js');
-    const hasWorkflowGuardHook = settings.hooks[preToolEvent].some(entry =>
+    const workflowGuardMatcher = 'Bash|Edit|Write|MultiEdit';
+    const workflowGuardHookEntry = settings.hooks[preToolEvent].find(entry =>
       entry.hooks && entry.hooks.some(h => h.command && h.command.includes('gsd-workflow-guard'))
     );
+    const hasWorkflowGuardHook = Boolean(workflowGuardHookEntry);
 
     const workflowGuardFile = path.join(targetDir, 'hooks', 'gsd-workflow-guard.js');
-    if (!hasWorkflowGuardHook && fs.existsSync(workflowGuardFile) && workflowGuardCommand) {
+    if (hasWorkflowGuardHook && workflowGuardHookEntry.matcher !== workflowGuardMatcher) {
+      workflowGuardHookEntry.matcher = workflowGuardMatcher;
+      console.log(`  ${green}✓${reset} Updated workflow guard hook matcher`);
+    } else if (!hasWorkflowGuardHook && fs.existsSync(workflowGuardFile) && workflowGuardCommand) {
       settings.hooks[preToolEvent].push({
-        matcher: 'Write|Edit',
+        matcher: workflowGuardMatcher,
         hooks: [
           {
             type: 'command',

--- a/hooks/gsd-workflow-guard.js
+++ b/hooks/gsd-workflow-guard.js
@@ -13,6 +13,57 @@
 
 const fs = require('fs');
 const path = require('path');
+const { spawnSync } = require('child_process');
+const { tokenize } = require('./lib/git-cmd.js');
+
+function forceGitAddCwds(command, defaultCwd) {
+  const tokens = tokenize(command || '');
+  const separators = new Set(['&&', '||', ';', '|']);
+  const cwdList = [];
+  for (let i = 0; i < tokens.length; i++) {
+    if (path.basename(tokens[i]) !== 'git') continue;
+
+    let j = i + 1;
+    let gitCwd = defaultCwd;
+    while (j < tokens.length) {
+      const token = tokens[j];
+      const flagName = token.includes('=') ? token.slice(0, token.indexOf('=')) : token;
+      if (token === '-C' && tokens[j + 1]) {
+        gitCwd = path.resolve(gitCwd, tokens[j + 1]);
+        j += 2;
+        continue;
+      }
+      if (['-C', '--git-dir', '--work-tree'].includes(flagName) && !token.includes('=')) {
+        j += 2;
+        continue;
+      }
+      if (['--git-dir', '--work-tree', '--no-pager', '-p', '-P'].includes(flagName)) {
+        j++;
+        continue;
+      }
+      break;
+    }
+
+    if (tokens[j] !== 'add') continue;
+    for (let k = j + 1; k < tokens.length && !separators.has(tokens[k]); k++) {
+      if (tokens[k] === '--force' || tokens[k] === '-f' || /^-[A-Za-z]*f[A-Za-z]*$/.test(tokens[k])) {
+        cwdList.push(gitCwd);
+        break;
+      }
+    }
+  }
+  return cwdList;
+}
+
+function currentBranch(cwd) {
+  const result = spawnSync('git', ['branch', '--show-current'], {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+  });
+  if (result.status !== 0) return '';
+  return result.stdout.trim();
+}
 
 let input = '';
 const stdinTimeout = setTimeout(() => process.exit(0), 3000);
@@ -23,6 +74,23 @@ process.stdin.on('end', () => {
   try {
     const data = JSON.parse(input);
     const toolName = data.tool_name;
+    const cwd = data.cwd || process.cwd();
+
+    if (toolName === 'Bash') {
+      const command = data.tool_input?.command || '';
+      for (const gitCwd of forceGitAddCwds(command, cwd)) {
+        const branch = currentBranch(gitCwd);
+        if (branch.startsWith('worktree-agent-')) {
+          process.stdout.write(JSON.stringify({
+            decision: 'block',
+            code: 'WORKTREE_AGENT_FORCE_ADD_FORBIDDEN',
+            reason: 'worktree-agent branches must not run git add -f or git add --force. Respect the SDK skipped_gitignored/skipped_commit_docs_false contract and leave gitignored files untracked.',
+          }));
+          process.exit(2);
+        }
+      }
+      process.exit(0);
+    }
 
     // Only guard Write and Edit tool calls
     if (toolName !== 'Write' && toolName !== 'Edit') {
@@ -58,7 +126,6 @@ process.stdin.on('end', () => {
     }
 
     // Check if workflow guard is enabled
-    const cwd = data.cwd || process.cwd();
     const configPath = path.join(cwd, '.planning', 'config.json');
     if (fs.existsSync(configPath)) {
       try {

--- a/hooks/gsd-workflow-guard.js
+++ b/hooks/gsd-workflow-guard.js
@@ -65,6 +65,17 @@ function currentBranch(cwd) {
   return result.stdout.trim();
 }
 
+function workflowGuardEnabled(cwd) {
+  const configPath = path.join(cwd, '.planning', 'config.json');
+  if (!fs.existsSync(configPath)) return false;
+  try {
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    return Boolean(config.hooks?.workflow_guard);
+  } catch (e) {
+    return false;
+  }
+}
+
 let input = '';
 const stdinTimeout = setTimeout(() => process.exit(0), 3000);
 process.stdin.setEncoding('utf8');
@@ -75,8 +86,12 @@ process.stdin.on('end', () => {
     const data = JSON.parse(input);
     const toolName = data.tool_name;
     const cwd = data.cwd || process.cwd();
+    const isWorkflowGuardEnabled = workflowGuardEnabled(cwd);
 
     if (toolName === 'Bash') {
+      if (!isWorkflowGuardEnabled) {
+        process.exit(0);
+      }
       const command = data.tool_input?.command || '';
       for (const gitCwd of forceGitAddCwds(command, cwd)) {
         const branch = currentBranch(gitCwd);
@@ -92,8 +107,8 @@ process.stdin.on('end', () => {
       process.exit(0);
     }
 
-    // Only guard Write and Edit tool calls
-    if (toolName !== 'Write' && toolName !== 'Edit') {
+    // Only guard Write, Edit, and MultiEdit tool calls
+    if (!['Write', 'Edit', 'MultiEdit'].includes(toolName)) {
       process.exit(0);
     }
 
@@ -125,19 +140,8 @@ process.stdin.on('end', () => {
       process.exit(0);
     }
 
-    // Check if workflow guard is enabled
-    const configPath = path.join(cwd, '.planning', 'config.json');
-    if (fs.existsSync(configPath)) {
-      try {
-        const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
-        if (!config.hooks?.workflow_guard) {
-          process.exit(0); // Guard disabled (default)
-        }
-      } catch (e) {
-        process.exit(0);
-      }
-    } else {
-      process.exit(0); // No GSD project — don't guard
+    if (!isWorkflowGuardEnabled) {
+      process.exit(0); // Guard disabled (default) or no GSD project
     }
 
     // If we get here: GSD project, guard enabled, file edit outside .planning/,

--- a/hooks/gsd-workflow-guard.js
+++ b/hooks/gsd-workflow-guard.js
@@ -46,6 +46,7 @@ function forceGitAddCwds(command, defaultCwd) {
 
     if (tokens[j] !== 'add') continue;
     for (let k = j + 1; k < tokens.length && !separators.has(tokens[k]); k++) {
+      if (tokens[k] === '--') break;
       if (tokens[k] === '--force' || tokens[k] === '-f' || /^-[A-Za-z]*f[A-Za-z]*$/.test(tokens[k])) {
         cwdList.push(gitCwd);
         break;

--- a/tests/bug-261-worktree-force-add-guard.test.cjs
+++ b/tests/bug-261-worktree-force-add-guard.test.cjs
@@ -1,0 +1,87 @@
+'use strict';
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync, spawnSync } = require('node:child_process');
+
+const HOOK_PATH = path.join(__dirname, '..', 'hooks', 'gsd-workflow-guard.js');
+
+function git(cwd, args) {
+  return execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+}
+
+function makeRepo(branch) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-bug-261-'));
+  git(dir, ['init', '-q']);
+  git(dir, ['config', 'user.email', 'test@example.com']);
+  git(dir, ['config', 'user.name', 'Test User']);
+  git(dir, ['config', 'commit.gpgsign', 'false']);
+  fs.writeFileSync(path.join(dir, 'README.md'), '# test\n');
+  git(dir, ['add', 'README.md']);
+  git(dir, ['commit', '-q', '-m', 'chore: init']);
+  git(dir, ['checkout', '-q', '-b', branch]);
+  return dir;
+}
+
+function runHook(cwd, command) {
+  return spawnSync(process.execPath, [HOOK_PATH], {
+    cwd,
+    encoding: 'utf8',
+    input: JSON.stringify({
+      cwd,
+      tool_name: 'Bash',
+      tool_input: { command },
+    }),
+  });
+}
+
+describe('bug #261: workflow guard blocks forced git add on worktree-agent branches', () => {
+  test('blocks git add -f on worktree-agent branch before it can stage gitignored files', () => {
+    const dir = makeRepo('worktree-agent-a1');
+    try {
+      const result = runHook(dir, 'git add -f .planning/phases/01/01-01-SUMMARY.md');
+      assert.strictEqual(result.status, 2);
+      const envelope = JSON.parse(result.stdout);
+      assert.strictEqual(envelope.decision, 'block');
+      assert.strictEqual(envelope.code, 'WORKTREE_AGENT_FORCE_ADD_FORBIDDEN');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('blocks git add --force with git global options on worktree-agent branch', () => {
+    const dir = makeRepo('worktree-agent-b2');
+    try {
+      const result = runHook(path.dirname(dir), `git -C "${dir}" add --force .planning/SUMMARY.md`);
+      assert.strictEqual(result.status, 2);
+      assert.strictEqual(JSON.parse(result.stdout).code, 'WORKTREE_AGENT_FORCE_ADD_FORBIDDEN');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('allows ordinary git add on worktree-agent branch', () => {
+    const dir = makeRepo('worktree-agent-c3');
+    try {
+      const result = runHook(dir, 'git add .planning/SUMMARY.md');
+      assert.strictEqual(result.status, 0);
+      assert.strictEqual(result.stdout, '');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('allows git add -f outside worktree-agent branches', () => {
+    const dir = makeRepo('feature-docs');
+    try {
+      const result = runHook(dir, 'git add -f .planning/SUMMARY.md');
+      assert.strictEqual(result.status, 0);
+      assert.strictEqual(result.stdout, '');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/bug-261-worktree-force-add-guard.test.cjs
+++ b/tests/bug-261-worktree-force-add-guard.test.cjs
@@ -26,23 +26,36 @@ function makeRepo(branch) {
   return dir;
 }
 
-function runHook(cwd, command) {
+function setWorkflowGuard(dir, enabled) {
+  const planningDir = path.join(dir, '.planning');
+  fs.mkdirSync(planningDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(planningDir, 'config.json'),
+    JSON.stringify({ hooks: { workflow_guard: enabled } }, null, 2)
+  );
+}
+
+function runHookInput(cwd, input) {
   return spawnSync(process.execPath, [HOOK_PATH], {
     cwd,
     encoding: 'utf8',
-    input: JSON.stringify({
-      cwd,
-      tool_name: 'Bash',
-      tool_input: { command },
-    }),
+    input: JSON.stringify({ cwd, ...input }),
+  });
+}
+
+function runBashHook(cwd, command) {
+  return runHookInput(cwd, {
+    tool_name: 'Bash',
+    tool_input: { command },
   });
 }
 
 describe('bug #261: workflow guard blocks forced git add on worktree-agent branches', () => {
-  test('blocks git add -f on worktree-agent branch before it can stage gitignored files', () => {
+  test('blocks git add -f on worktree-agent branch when workflow guard is enabled', () => {
     const dir = makeRepo('worktree-agent-a1');
     try {
-      const result = runHook(dir, 'git add -f .planning/phases/01/01-01-SUMMARY.md');
+      setWorkflowGuard(dir, true);
+      const result = runBashHook(dir, 'git add -f .planning/phases/01/01-01-SUMMARY.md');
       assert.strictEqual(result.status, 2);
       const envelope = JSON.parse(result.stdout);
       assert.strictEqual(envelope.decision, 'block');
@@ -55,7 +68,8 @@ describe('bug #261: workflow guard blocks forced git add on worktree-agent branc
   test('blocks git add --force with git global options on worktree-agent branch', () => {
     const dir = makeRepo('worktree-agent-b2');
     try {
-      const result = runHook(path.dirname(dir), `git -C "${dir}" add --force .planning/SUMMARY.md`);
+      setWorkflowGuard(dir, true);
+      const result = runBashHook(dir, `git -C "${dir}" add --force .planning/SUMMARY.md`);
       assert.strictEqual(result.status, 2);
       assert.strictEqual(JSON.parse(result.stdout).code, 'WORKTREE_AGENT_FORCE_ADD_FORBIDDEN');
     } finally {
@@ -66,7 +80,8 @@ describe('bug #261: workflow guard blocks forced git add on worktree-agent branc
   test('allows ordinary git add on worktree-agent branch', () => {
     const dir = makeRepo('worktree-agent-c3');
     try {
-      const result = runHook(dir, 'git add .planning/SUMMARY.md');
+      setWorkflowGuard(dir, true);
+      const result = runBashHook(dir, 'git add .planning/SUMMARY.md');
       assert.strictEqual(result.status, 0);
       assert.strictEqual(result.stdout, '');
     } finally {
@@ -77,9 +92,55 @@ describe('bug #261: workflow guard blocks forced git add on worktree-agent branc
   test('allows git add -f outside worktree-agent branches', () => {
     const dir = makeRepo('feature-docs');
     try {
-      const result = runHook(dir, 'git add -f .planning/SUMMARY.md');
+      setWorkflowGuard(dir, true);
+      const result = runBashHook(dir, 'git add -f .planning/SUMMARY.md');
       assert.strictEqual(result.status, 0);
       assert.strictEqual(result.stdout, '');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('allows git add -f on worktree-agent branch when workflow guard is disabled', () => {
+    const dir = makeRepo('worktree-agent-d4');
+    try {
+      setWorkflowGuard(dir, false);
+      const result = runBashHook(dir, 'git add -f .planning/SUMMARY.md');
+      assert.strictEqual(result.status, 0);
+      assert.strictEqual(result.stdout, '');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('allows git add -f on worktree-agent branch when no GSD config exists', () => {
+    const dir = makeRepo('worktree-agent-e5');
+    try {
+      const result = runBashHook(dir, 'git add -f .planning/SUMMARY.md');
+      assert.strictEqual(result.status, 0);
+      assert.strictEqual(result.stdout, '');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('applies the advisory path to MultiEdit when workflow guard is enabled', () => {
+    const dir = makeRepo('feature-multiedit');
+    try {
+      setWorkflowGuard(dir, true);
+      const result = runHookInput(dir, {
+        tool_name: 'MultiEdit',
+        tool_input: {
+          file_path: path.join(dir, 'src.js'),
+          edits: [],
+        },
+      });
+      assert.strictEqual(result.status, 0);
+      const envelope = JSON.parse(result.stdout);
+      assert.match(
+        envelope.hookSpecificOutput.additionalContext,
+        /WORKFLOW ADVISORY/
+      );
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }

--- a/tests/bug-261-worktree-force-add-guard.test.cjs
+++ b/tests/bug-261-worktree-force-add-guard.test.cjs
@@ -89,6 +89,18 @@ describe('bug #261: workflow guard blocks forced git add on worktree-agent branc
     }
   });
 
+  test('allows pathspecs named like force flags after git add -- terminator', () => {
+    const dir = makeRepo('worktree-agent-d4');
+    try {
+      setWorkflowGuard(dir, true);
+      const result = runBashHook(dir, 'git add -- -f');
+      assert.strictEqual(result.status, 0);
+      assert.strictEqual(result.stdout, '');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   test('allows git add -f outside worktree-agent branches', () => {
     const dir = makeRepo('feature-docs');
     try {
@@ -102,7 +114,7 @@ describe('bug #261: workflow guard blocks forced git add on worktree-agent branc
   });
 
   test('allows git add -f on worktree-agent branch when workflow guard is disabled', () => {
-    const dir = makeRepo('worktree-agent-d4');
+    const dir = makeRepo('worktree-agent-e5');
     try {
       setWorkflowGuard(dir, false);
       const result = runBashHook(dir, 'git add -f .planning/SUMMARY.md');
@@ -114,7 +126,7 @@ describe('bug #261: workflow guard blocks forced git add on worktree-agent branc
   });
 
   test('allows git add -f on worktree-agent branch when no GSD config exists', () => {
-    const dir = makeRepo('worktree-agent-e5');
+    const dir = makeRepo('worktree-agent-f6');
     try {
       const result = runBashHook(dir, 'git add -f .planning/SUMMARY.md');
       assert.strictEqual(result.status, 0);

--- a/tests/workflow-guard-registration.test.cjs
+++ b/tests/workflow-guard-registration.test.cjs
@@ -54,15 +54,23 @@ describe('workflow-guard hook registration (#1767)', () => {
 
   test('install.js pushes workflow-guard entry with correct matcher', () => {
     const content = fs.readFileSync(INSTALL_JS, 'utf-8');
-    // Extract the section between "workflow-guard" command construction
-    // and the next console.log confirmation. The push block should have:
-    // matcher: 'Write|Edit' and command referencing workflow-guard
+    // Extract the workflow-guard registration section. It should install the
+    // Bash-aware matcher and upgrade old edit-only entries on reinstall.
     const workflowGuardSection = content.match(
-      /workflowGuardCommand[\s\S]*?console\.log\([^)]*workflow.guard/i
+      /workflowGuardCommand[\s\S]*?Configure commit validation hook/i
     );
     assert.ok(
       workflowGuardSection,
       'install.js must have a push block for workflow-guard with a console.log confirmation'
+    );
+    assert.ok(
+      workflowGuardSection[0].includes("const workflowGuardMatcher = 'Bash|Edit|Write|MultiEdit'") &&
+        workflowGuardSection[0].includes('matcher: workflowGuardMatcher'),
+      'workflow guard must be registered for Bash so worktree-agent git safety checks can run'
+    );
+    assert.ok(
+      workflowGuardSection[0].includes('workflowGuardHookEntry.matcher = workflowGuardMatcher'),
+      'installer must upgrade existing workflow guard hook entries to the Bash-aware matcher'
     );
   });
 });


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> - Enhancement: use [enhancement.md](?template=enhancement.md)
> - Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

Fixes #261

> The linked issue must have the `confirmed-bug` label. If it doesn't, ask a maintainer to confirm the bug before continuing.

---

## What was broken

The workflow guard's Bash path hard-blocked `git add -f` / `git add --force` on `worktree-agent-*` branches before checking whether `hooks.workflow_guard` was enabled.

## What this fix does

The Bash enforcement now exits unless `hooks.workflow_guard` is enabled, matching the existing opt-in behavior for edit advisories. The guard also handles `MultiEdit` through the same advisory path that the installer already registers.

## Root cause

The Bash enforcement path was added ahead of the existing `.planning/config.json` opt-in check, so it bypassed the guard's documented default-off behavior.

## Testing

### How I verified the fix

- `node --test tests/bug-261-worktree-force-add-guard.test.cjs tests/workflow-guard-registration.test.cjs`
- `GITHUB_BASE_REF=next npm run lint:changeset`

### Regression test added?

- [x] Yes - added coverage for enabled, disabled, and missing-config Bash behavior, plus the registered `MultiEdit` advisory path.
- [ ] No - explain why:

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` - **PR will be auto-closed if missing**
- [ ] Linked issue has the `confirmed-bug` label - currently labeled `needs-triage` and `ready-for-agent`; maintainer confirmation still needed.
- [x] Fix is scoped to the reported bug - no unrelated changes included
- [x] Regression test added (or explained why not)
- [ ] All existing tests pass (`npm test`) - not run; focused hook and registration tests passed.
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) - or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None
