### PR TITLE
fix(#229,#275,#278,#279,#280): resolve confirmed workflow/codex regressions

### DIFF
--- a/.changeset/rapid-yaks-march.md
+++ b/.changeset/rapid-yaks-march.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 275
+---
+Fixed five confirmed workflow/runtime bugs: plan-phase decision coverage gate compatibility, Codex .toml agent detection, Codex Agent() adapter mapping guidance, execute-phase project-root path anchoring, and verify-reapply hook-version normalization.

--- a/bin/install.js
+++ b/bin/install.js
@@ -2612,6 +2612,7 @@ GSD workflows use \`Task(...)\` (Claude Code syntax). Translate to Codex collabo
 
 Direct mapping:
 - \`Task(subagent_type="X", prompt="Y")\` → \`spawn_agent(agent_type="X", message="Y")\`
+- \`Agent(subagent_type="X", prompt="Y")\` → \`spawn_agent(agent_type="X", message="Y")\`
 - \`Task(model="...")\` → omit. \`spawn_agent\` has no inline \`model\` parameter;
   GSD embeds the resolved per-agent model directly into each agent's \`.toml\`
   at install time so \`model_overrides\` from \`.planning/config.json\` and
@@ -2630,6 +2631,9 @@ Spawn restriction:
 - Codex restricts \`spawn_agent\` to cases where the user has explicitly
   requested sub-agents. When automatic spawning is not permitted, do the
   work inline in the current agent rather than attempting to force a spawn.
+- In some Codex sessions, multi-agent tooling can be deferred. If \`spawn_agent\`
+  is not currently visible, discover tools first via \`tool_search\` before
+  defaulting to inline execution.
 
 Parallel fan-out:
 - Spawn multiple agents → collect agent IDs → \`wait(ids)\` for all to complete

--- a/get-shit-done/bin/lib/core.cjs
+++ b/get-shit-done/bin/lib/core.cjs
@@ -1130,10 +1130,14 @@ function checkAgentsInstalled() {
   }
 
   for (const agent of expectedAgents) {
-    // Check both .md (standard) and .agent.md (Copilot) file formats.
+    // Check all runtime agent file formats:
+    // - .md        (Claude/OpenCode/Gemini/etc.)
+    // - .agent.md  (Copilot)
+    // - .toml      (Codex)
     const agentFile = path.join(agentsDir, `${agent}.md`);
     const agentFileCopilot = path.join(agentsDir, `${agent}.agent.md`);
-    if (fs.existsSync(agentFile) || fs.existsSync(agentFileCopilot)) {
+    const agentFileCodex = path.join(agentsDir, `${agent}.toml`);
+    if (fs.existsSync(agentFile) || fs.existsSync(agentFileCopilot) || fs.existsSync(agentFileCodex)) {
       installed.push(agent);
     } else {
       missing.push(agent);

--- a/get-shit-done/bin/verify-reapply-patches.cjs
+++ b/get-shit-done/bin/verify-reapply-patches.cjs
@@ -34,6 +34,7 @@ const path = require('node:path');
 const crypto = require('node:crypto');
 
 const SIGNIFICANT_MIN_CHARS = 12;
+const GSD_HOOK_VERSION_LINE_RE = /^(?:\/\/|#)\s*gsd-hook-version:\s*\S+\s*$/i;
 
 function parseArgs(argv) {
   const opts = { patchesDir: null, configDir: null, pristineDir: null, json: false };
@@ -65,6 +66,16 @@ function isSignificantLine(line) {
   // Generic decorative comments like `// ----` similarly fail the test.
   if (/^[\s\-=#*/]+$/.test(trimmed)) return false;
   return true;
+}
+
+function normalizeUpstreamOwnedLine(line) {
+  const trimmed = line.trim();
+  if (!trimmed) return line;
+  if (GSD_HOOK_VERSION_LINE_RE.test(trimmed)) {
+    const prefix = trimmed.startsWith('#') ? '#' : '//';
+    return `${prefix} gsd-hook-version: __GSD_VERSION_TOKEN__`;
+  }
+  return line;
 }
 
 /**
@@ -124,8 +135,13 @@ function computeUserAddedLines(backupContent, pristineContent) {
   if (!pristineContent) {
     return backupLines.filter(isSignificantLine);
   }
-  const pristineSet = new Set(pristineContent.split(/\r?\n/));
-  return backupLines.filter((line) => isSignificantLine(line) && !pristineSet.has(line));
+  const pristineSet = new Set(
+    pristineContent.split(/\r?\n/).map(normalizeUpstreamOwnedLine),
+  );
+  return backupLines.filter((line) => {
+    if (!isSignificantLine(line)) return false;
+    return !pristineSet.has(normalizeUpstreamOwnedLine(line));
+  });
 }
 
 /**

--- a/get-shit-done/workflows/execute-phase.md
+++ b/get-shit-done/workflows/execute-phase.md
@@ -619,18 +619,20 @@ increases monotonically across waves. `{status}` is `complete` (success),
        </execution_context>
 
        <files_to_read>
-       Read these files at execution start using the Read tool:
-       - {phase_dir}/{plan_file} (Plan)
-       - .planning/PROJECT.md (Project context — core value, requirements, evolution rules)
-       - .planning/STATE.md (State)
-       - .planning/config.json (Config, if exists)
+       Read these files at execution start using the Read tool.
+       First resolve repo root so every path is anchored:
+       \`PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)\`
+       - ${PROJECT_ROOT}/{phase_dir}/{plan_file} (Plan)
+       - ${PROJECT_ROOT}/.planning/PROJECT.md (Project context — core value, requirements, evolution rules)
+       - ${PROJECT_ROOT}/.planning/STATE.md (State)
+       - ${PROJECT_ROOT}/.planning/config.json (Config, if exists)
        ${CONTEXT_WINDOW >= 500000 ? `
-       - ${phase_dir}/*-CONTEXT.md (User decisions from discuss-phase — honors locked choices)
-       - ${phase_dir}/*-RESEARCH.md (Technical research — pitfalls and patterns to follow)
-       - ${prior_wave_summaries} (SUMMARY.md files from earlier waves in this phase — what was already built)
+       - ${PROJECT_ROOT}/${phase_dir}/*-CONTEXT.md (User decisions from discuss-phase — honors locked choices)
+       - ${PROJECT_ROOT}/${phase_dir}/*-RESEARCH.md (Technical research — pitfalls and patterns to follow)
+       - ${PROJECT_ROOT}/${prior_wave_summaries} (SUMMARY.md files from earlier waves in this phase — what was already built)
        ` : ''}
-       - ./CLAUDE.md (Project instructions, if exists — follow project-specific guidelines and coding conventions)
-       - .claude/skills/ or .agents/skills/ (Project skills, if either exists — list skills, read SKILL.md for each, follow relevant rules during implementation)
+       - ${PROJECT_ROOT}/CLAUDE.md (Project instructions, if exists — follow project-specific guidelines and coding conventions)
+       - ${PROJECT_ROOT}/.claude/skills/ or ${PROJECT_ROOT}/.agents/skills/ (Project skills, if either exists — list skills, read SKILL.md for each, follow relevant rules during implementation)
        </files_to_read>
 
        ${AGENT_SKILLS}

--- a/get-shit-done/workflows/plan-phase.md
+++ b/get-shit-done/workflows/plan-phase.md
@@ -1522,8 +1522,8 @@ if [ "$GATE_CFG" != "false" ]; then
   # `passed: true` covers both real-pass and skipped cases (gate disabled / no CONTEXT.md /
   # no trackable decisions). Verify-phase counterpart deliberately omits this exit-1 — that
   # gate is non-blocking by design (review finding F15).
-  echo "$GATE_RESULT" | jq -e '.data.passed == true' >/dev/null || {
-    echo "$GATE_RESULT" | jq -r '.data.message'
+  echo "$GATE_RESULT" | jq -e '(.passed // .data.passed) == true' >/dev/null || {
+    echo "$GATE_RESULT" | jq -r '(.message // .data.message // "Decision coverage gate failed.")'
     exit 1
   }
 fi

--- a/tests/agent-install-validation.test.cjs
+++ b/tests/agent-install-validation.test.cjs
@@ -236,6 +236,26 @@ describe('checkAgentsInstalled: Copilot .agent.md format (#1512)', () => {
       'missing_agents must be empty when all .agent.md files are present');
   });
 
+  test('agents_installed=true when agents exist as .toml (Codex format) (#278)', () => {
+    const agentsDir = path.join(tmpDir, 'codex-agents');
+    fs.mkdirSync(agentsDir, { recursive: true });
+    for (const name of EXPECTED_AGENTS) {
+      fs.writeFileSync(
+        path.join(agentsDir, `${name}.toml`),
+        `name = "${name}"\ndescription = "Test agent"\n`
+      );
+    }
+
+    const result = runGsdTools('validate agents --raw', tmpDir, { GSD_AGENTS_DIR: agentsDir });
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.agents_found, true,
+      'agents_found must be true when agents exist as .toml (Codex format)');
+    assert.deepStrictEqual(output.missing, [],
+      'missing must be empty when all agents exist as .toml');
+  });
+
   test('GSD_AGENTS_DIR env var overrides default agents directory', () => {
     // Create a custom agents dir in a subdirectory
     const customAgentsDir = path.join(tmpDir, 'custom-agents');

--- a/tests/bug-2492-context-coverage-gate.test.cjs
+++ b/tests/bug-2492-context-coverage-gate.test.cjs
@@ -94,11 +94,24 @@ describe('plan-phase decision-coverage gate (#2492)', () => {
     assert.ok(gateIdx !== -1);
     const snippet = md.slice(gateIdx, gateIdx + 800);
     // Accept either an inline `|| exit 1` or a `|| { ...; exit 1; }` group.
-    const hasJqGuard = /jq[^\n]*passed\s*==\s*true/.test(snippet);
+    const hasJqGuard =
+      /jq[^\n]*\.data\.passed\s*==\s*true/.test(snippet) ||
+      /jq[^\n]*\(\.passed\s*\/\/\s*\.data\.passed\)\s*==\s*true/.test(snippet);
     const hasExitOne = /\|\|\s*(?:exit\s+1|\{[\s\S]{0,200}?exit\s+1)/.test(snippet);
     assert.ok(
       hasJqGuard && hasExitOne,
       'plan-phase gate must guard with `jq -e .passed == true || exit 1` (or `|| { ...; exit 1; }`) to actually block',
+    );
+  });
+
+  test('plan-phase gate accepts top-level .passed field from CLI output (#275)', () => {
+    const gateIdx = md.indexOf('check.decision-coverage-plan');
+    assert.ok(gateIdx !== -1, 'check.decision-coverage-plan invocation must exist');
+    const snippet = md.slice(gateIdx, gateIdx + 800);
+    assert.ok(
+      /\.(?:passed)\s*==\s*true\s*\|\|\s*\.data\.passed\s*==\s*true/.test(snippet) ||
+      /\(\.passed\s*\/\/\s*\.data\.passed\)\s*==\s*true/.test(snippet),
+      'plan-phase gate must explicitly check top-level .passed with a compatibility fallback to .data.passed',
     );
   });
 });

--- a/tests/bug-279-codex-agent-mapping.test.cjs
+++ b/tests/bug-279-codex-agent-mapping.test.cjs
@@ -1,0 +1,27 @@
+'use strict';
+// allow-test-rule: source-text-is-the-product [adapter header contract in bin/install.js]
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const INSTALL_JS = path.join(__dirname, '..', 'bin', 'install.js');
+const src = fs.readFileSync(INSTALL_JS, 'utf8');
+
+describe('bug #279: Codex adapter documents Agent() and deferred tool discovery', () => {
+  test('adapter mapping section includes explicit Agent(...) -> spawn_agent mapping', () => {
+    assert.ok(
+      /Task\(subagent_type="X", prompt="Y"\).*spawn_agent\(agent_type="X", message="Y"\)/.test(src) &&
+      /Agent\(subagent_type="X", prompt="Y"\).*spawn_agent\(agent_type="X", message="Y"\)/.test(src),
+      'Codex adapter must explicitly map both Task(...) and Agent(...) to spawn_agent',
+    );
+  });
+
+  test('adapter includes deferred tool_search discovery guidance before inline fallback', () => {
+    assert.ok(
+      src.includes('deferred') && src.includes('tool_search') && src.includes('spawn_agent'),
+      'Codex adapter must instruct deferred tool discovery via tool_search before deciding to run inline',
+    );
+  });
+});

--- a/tests/bug-2969-verify-reapply-patches.test.cjs
+++ b/tests/bug-2969-verify-reapply-patches.test.cjs
@@ -210,4 +210,35 @@ describe('Bug #2969: deterministic Step 5 verification gate', () => {
     assert.ok(report.results[0].missing.includes(droppedLine));
     assert.ok(!report.results[0].missing.includes(presentLine));
   });
+
+  test('treats gsd-hook-version install-time substitution as upstream-owned, not missing user content (#229)', () => {
+    resetFixture();
+    const rel = path.join('hooks', 'gsd-statusline.js');
+    const pristine = [
+      '// gsd-hook-version: {{GSD_VERSION}}',
+      'console.log("statusline hook");',
+      '',
+    ].join('\n');
+    const backup = [
+      '// gsd-hook-version: 1.41.0',
+      'console.log("statusline hook");',
+      '',
+    ].join('\n');
+    const installed = [
+      '// gsd-hook-version: 1.42.3',
+      'console.log("statusline hook");',
+      '',
+    ].join('\n');
+
+    writeFile(path.join(pristineDir, rel), pristine);
+    writeFile(path.join(patchesDir, rel), backup);
+    writeFile(path.join(configDir, rel), installed);
+
+    const { status, report } = runVerifier();
+    assert.equal(status, 0, `expected pass for upstream-owned version substitution; report=${JSON.stringify(report)}`);
+    assert.equal(report.failures, 0);
+    assert.equal(report.checked, 1);
+    assert.equal(report.results[0].status, 'ok');
+    assert.deepStrictEqual(report.results[0].missing, []);
+  });
 });

--- a/tests/bug-3097-3099-executor-worktree-path-safety.test.cjs
+++ b/tests/bug-3097-3099-executor-worktree-path-safety.test.cjs
@@ -84,6 +84,20 @@ describe('bug #3099: absolute-path safety guidance in gsd-executor.md', () => {
     );
   });
 
+  test('execute-phase prompt anchors subagent file paths to project_root before files_to_read (#280)', () => {
+    const filesIdx = executePhaseSrc.indexOf('<files_to_read>');
+    assert.ok(filesIdx !== -1, 'files_to_read block not found in execute-phase.md');
+    const dispatchSnippet = executePhaseSrc.slice(filesIdx, filesIdx + 1800);
+    assert.ok(
+      dispatchSnippet.includes('PROJECT_ROOT=$(git rev-parse --show-toplevel'),
+      'executor dispatch must compute PROJECT_ROOT in the prompt before file reads',
+    );
+    assert.ok(
+      dispatchSnippet.includes('${PROJECT_ROOT}/'),
+      'executor files_to_read paths must be anchored to ${PROJECT_ROOT}/',
+    );
+  });
+
   test('worktree-path-safety.md reference file exists', () => {
     assert.ok(
       fs.existsSync(path.join(ROOT, 'get-shit-done', 'references', 'worktree-path-safety.md')),


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

> **Required.** This PR will be auto-closed if no valid issue link is found.

Fixes #229
Fixes #275
Fixes #278
Fixes #279
Fixes #280

> The linked issue must have the `confirmed-bug` label. If it doesn't, ask a maintainer to confirm the bug before continuing.

---

## What was broken

Confirmed bugs in workflow/runtime guard behavior caused false blocks or missing guidance:
- plan-phase decision gate expected `.data.passed` while command output can be top-level `.passed`
- Codex agent detection ignored `.toml` agent definitions
- Codex adapter guidance missed explicit `Agent(...)` mapping and deferred tool discovery guidance
- execute-phase prompt used relative file paths without explicit project-root anchoring
- verify-reapply patch ownership diff flagged install-time `gsd-hook-version` substitutions as user-line drift

## What this fix does

Implements targeted fixes in each affected seam and adds/updates regression tests for all five reported bugs.

## Root cause

Validation and prompt contracts drifted from actual runtime output formats and install-time normalization behavior; guard logic and adapter guidance were stricter than the real execution surfaces.

## Testing

### How I verified the fix

- `gsd-test-summary --both --base next`
  - Docker: 0 failed
  - Mac: 0 failed
- `node --test tests/bug-2492-context-coverage-gate.test.cjs tests/agent-install-validation.test.cjs tests/bug-279-codex-agent-mapping.test.cjs tests/bug-3097-3099-executor-worktree-path-safety.test.cjs tests/bug-2969-verify-reapply-patches.test.cjs`

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [x] Other: node:test regression suites + gsd-test-summary (linux/macos)
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [ ] All existing tests pass (`npm test`) (not run in this cycle)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None
