### PR TITLE
fix(#229): normalize verify-reapply hook-version substitution

### DIFF
--- a/.changeset/jolly-hawks-forage.md
+++ b/.changeset/jolly-hawks-forage.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 229
+---
+Fixed verify-reapply false fail_user_lines_missing when gsd-hook-version lines are install-time substituted.

--- a/get-shit-done/bin/verify-reapply-patches.cjs
+++ b/get-shit-done/bin/verify-reapply-patches.cjs
@@ -34,6 +34,7 @@ const path = require('node:path');
 const crypto = require('node:crypto');
 
 const SIGNIFICANT_MIN_CHARS = 12;
+const GSD_HOOK_VERSION_LINE_RE = /^(?:\/\/|#)\s*gsd-hook-version:\s*\S+\s*$/i;
 
 function parseArgs(argv) {
   const opts = { patchesDir: null, configDir: null, pristineDir: null, json: false };
@@ -65,6 +66,16 @@ function isSignificantLine(line) {
   // Generic decorative comments like `// ----` similarly fail the test.
   if (/^[\s\-=#*/]+$/.test(trimmed)) return false;
   return true;
+}
+
+function normalizeUpstreamOwnedLine(line) {
+  const trimmed = line.trim();
+  if (!trimmed) return line;
+  if (GSD_HOOK_VERSION_LINE_RE.test(trimmed)) {
+    const prefix = trimmed.startsWith('#') ? '#' : '//';
+    return `${prefix} gsd-hook-version: __GSD_VERSION_TOKEN__`;
+  }
+  return line;
 }
 
 /**
@@ -124,8 +135,13 @@ function computeUserAddedLines(backupContent, pristineContent) {
   if (!pristineContent) {
     return backupLines.filter(isSignificantLine);
   }
-  const pristineSet = new Set(pristineContent.split(/\r?\n/));
-  return backupLines.filter((line) => isSignificantLine(line) && !pristineSet.has(line));
+  const pristineSet = new Set(
+    pristineContent.split(/\r?\n/).map(normalizeUpstreamOwnedLine),
+  );
+  return backupLines.filter((line) => {
+    if (!isSignificantLine(line)) return false;
+    return !pristineSet.has(normalizeUpstreamOwnedLine(line));
+  });
 }
 
 /**

--- a/tests/bug-2969-verify-reapply-patches.test.cjs
+++ b/tests/bug-2969-verify-reapply-patches.test.cjs
@@ -210,4 +210,35 @@ describe('Bug #2969: deterministic Step 5 verification gate', () => {
     assert.ok(report.results[0].missing.includes(droppedLine));
     assert.ok(!report.results[0].missing.includes(presentLine));
   });
+
+  test('treats gsd-hook-version install-time substitution as upstream-owned, not missing user content (#229)', () => {
+    resetFixture();
+    const rel = path.join('hooks', 'gsd-statusline.js');
+    const pristine = [
+      '// gsd-hook-version: {{GSD_VERSION}}',
+      'console.log("statusline hook");',
+      '',
+    ].join('\n');
+    const backup = [
+      '// gsd-hook-version: 1.41.0',
+      'console.log("statusline hook");',
+      '',
+    ].join('\n');
+    const installed = [
+      '// gsd-hook-version: 1.42.3',
+      'console.log("statusline hook");',
+      '',
+    ].join('\n');
+
+    writeFile(path.join(pristineDir, rel), pristine);
+    writeFile(path.join(patchesDir, rel), backup);
+    writeFile(path.join(configDir, rel), installed);
+
+    const { status, report } = runVerifier();
+    assert.equal(status, 0, `expected pass for upstream-owned version substitution; report=${JSON.stringify(report)}`);
+    assert.equal(report.failures, 0);
+    assert.equal(report.checked, 1);
+    assert.equal(report.results[0].status, 'ok');
+    assert.deepStrictEqual(report.results[0].missing, []);
+  });
 });


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

> **Required.** This PR will be auto-closed if no valid issue link is found.

Fixes #229

> The linked issue must have the `confirmed-bug` label. If it doesn't, ask a maintainer to confirm the bug before continuing.

---

## What was broken

`verify-reapply-patches` reported `fail_user_lines_missing` when installed hook files substituted `gsd-hook-version` comment lines at install time.

## What this fix does

Normalizes `gsd-hook-version` comment lines as upstream-owned before diff verification, so install-time version substitutions do not count as missing user content.

## Root cause

Verification compared raw line content between backup and pristine/installed files without accounting for expected install-time token substitution.

## Testing

### How I verified the fix

- `node --test tests/bug-2969-verify-reapply-patches.test.cjs`
- `gsd-test-summary --both --base next`
  - Docker: 0 failed
  - Mac: 0 failed

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [x] Other: node:test + gsd-test-summary
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [ ] All existing tests pass (`npm test`) (not run in this cycle)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None
