### PR TITLE
fix(#275): align decision coverage gate with CLI output shape

### DIFF
--- a/.changeset/zesty-voles-roar.md
+++ b/.changeset/zesty-voles-roar.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 275
+---
+Fixed plan-phase decision coverage gate compatibility with top-level .passed/.message command output.

--- a/get-shit-done/workflows/plan-phase.md
+++ b/get-shit-done/workflows/plan-phase.md
@@ -1522,8 +1522,8 @@ if [ "$GATE_CFG" != "false" ]; then
   # `passed: true` covers both real-pass and skipped cases (gate disabled / no CONTEXT.md /
   # no trackable decisions). Verify-phase counterpart deliberately omits this exit-1 — that
   # gate is non-blocking by design (review finding F15).
-  echo "$GATE_RESULT" | jq -e '.data.passed == true' >/dev/null || {
-    echo "$GATE_RESULT" | jq -r '.data.message'
+  echo "$GATE_RESULT" | jq -e '(.passed // .data.passed) == true' >/dev/null || {
+    echo "$GATE_RESULT" | jq -r '(.message // .data.message // "Decision coverage gate failed.")'
     exit 1
   }
 fi

--- a/tests/bug-2492-context-coverage-gate.test.cjs
+++ b/tests/bug-2492-context-coverage-gate.test.cjs
@@ -94,11 +94,24 @@ describe('plan-phase decision-coverage gate (#2492)', () => {
     assert.ok(gateIdx !== -1);
     const snippet = md.slice(gateIdx, gateIdx + 800);
     // Accept either an inline `|| exit 1` or a `|| { ...; exit 1; }` group.
-    const hasJqGuard = /jq[^\n]*passed\s*==\s*true/.test(snippet);
+    const hasJqGuard =
+      /jq[^\n]*\.data\.passed\s*==\s*true/.test(snippet) ||
+      /jq[^\n]*\(\.passed\s*\/\/\s*\.data\.passed\)\s*==\s*true/.test(snippet);
     const hasExitOne = /\|\|\s*(?:exit\s+1|\{[\s\S]{0,200}?exit\s+1)/.test(snippet);
     assert.ok(
       hasJqGuard && hasExitOne,
       'plan-phase gate must guard with `jq -e .passed == true || exit 1` (or `|| { ...; exit 1; }`) to actually block',
+    );
+  });
+
+  test('plan-phase gate accepts top-level .passed field from CLI output (#275)', () => {
+    const gateIdx = md.indexOf('check.decision-coverage-plan');
+    assert.ok(gateIdx !== -1, 'check.decision-coverage-plan invocation must exist');
+    const snippet = md.slice(gateIdx, gateIdx + 800);
+    assert.ok(
+      /\.(?:passed)\s*==\s*true\s*\|\|\s*\.data\.passed\s*==\s*true/.test(snippet) ||
+      /\(\.passed\s*\/\/\s*\.data\.passed\)\s*==\s*true/.test(snippet),
+      'plan-phase gate must explicitly check top-level .passed with a compatibility fallback to .data.passed',
     );
   });
 });


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

> **Required.** This PR will be auto-closed if no valid issue link is found.

Fixes #275

> The linked issue must have the `confirmed-bug` label. If it doesn't, ask a maintainer to confirm the bug before continuing.

---

## What was broken

Plan-phase decision gate expected `.data.passed` / `.data.message`, while runtime output can be top-level `.passed` / `.message`, causing false blocking.

## What this fix does

Makes plan-phase gate read top-level fields with backward-compatible fallback to `.data.*`.

## Root cause

Gate parsing logic drifted from CLI result shape assumptions.

## Testing

### How I verified the fix

- `node --test tests/bug-2492-context-coverage-gate.test.cjs`
- `gsd-test-summary --both --base next`
  - Docker: 0 failed
  - Mac: 0 failed

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [x] Other: node:test + gsd-test-summary
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [ ] All existing tests pass (`npm test`) (not run in this cycle)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None
