### PR TITLE
fix(#278): include codex toml roles in agent install checks

### DIFF
--- a/.changeset/patient-ibex-gather.md
+++ b/.changeset/patient-ibex-gather.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 278
+---
+Fixed Codex agent detection to include .toml role files so install checks do not false-report missing agents.

--- a/get-shit-done/bin/lib/core.cjs
+++ b/get-shit-done/bin/lib/core.cjs
@@ -1130,10 +1130,14 @@ function checkAgentsInstalled() {
   }
 
   for (const agent of expectedAgents) {
-    // Check both .md (standard) and .agent.md (Copilot) file formats.
+    // Check all runtime agent file formats:
+    // - .md        (Claude/OpenCode/Gemini/etc.)
+    // - .agent.md  (Copilot)
+    // - .toml      (Codex)
     const agentFile = path.join(agentsDir, `${agent}.md`);
     const agentFileCopilot = path.join(agentsDir, `${agent}.agent.md`);
-    if (fs.existsSync(agentFile) || fs.existsSync(agentFileCopilot)) {
+    const agentFileCodex = path.join(agentsDir, `${agent}.toml`);
+    if (fs.existsSync(agentFile) || fs.existsSync(agentFileCopilot) || fs.existsSync(agentFileCodex)) {
       installed.push(agent);
     } else {
       missing.push(agent);

--- a/tests/agent-install-validation.test.cjs
+++ b/tests/agent-install-validation.test.cjs
@@ -236,6 +236,26 @@ describe('checkAgentsInstalled: Copilot .agent.md format (#1512)', () => {
       'missing_agents must be empty when all .agent.md files are present');
   });
 
+  test('agents_installed=true when agents exist as .toml (Codex format) (#278)', () => {
+    const agentsDir = path.join(tmpDir, 'codex-agents');
+    fs.mkdirSync(agentsDir, { recursive: true });
+    for (const name of EXPECTED_AGENTS) {
+      fs.writeFileSync(
+        path.join(agentsDir, `${name}.toml`),
+        `name = "${name}"\ndescription = "Test agent"\n`
+      );
+    }
+
+    const result = runGsdTools('validate agents --raw', tmpDir, { GSD_AGENTS_DIR: agentsDir });
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.agents_found, true,
+      'agents_found must be true when agents exist as .toml (Codex format)');
+    assert.deepStrictEqual(output.missing, [],
+      'missing must be empty when all agents exist as .toml');
+  });
+
   test('GSD_AGENTS_DIR env var overrides default agents directory', () => {
     // Create a custom agents dir in a subdirectory
     const customAgentsDir = path.join(tmpDir, 'custom-agents');


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

> **Required.** This PR will be auto-closed if no valid issue link is found.

Fixes #278

> The linked issue must have the `confirmed-bug` label. If it doesn't, ask a maintainer to confirm the bug before continuing.

---

## What was broken

Agent installation validation ignored Codex `.toml` role files and falsely reported missing required agents.

## What this fix does

Extends agent detection to include `.toml` files and adds regression coverage.

## Root cause

`checkAgentsInstalled()` recognized `.md` and `.agent.md` patterns but omitted Codex's `.toml` agent format.

## Testing

### How I verified the fix

- `node --test tests/agent-install-validation.test.cjs`
- `gsd-test-summary --both --base next`
  - Docker: 0 failed
  - Mac: 0 failed

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [x] Other: node:test + gsd-test-summary
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [ ] All existing tests pass (`npm test`) (not run in this cycle)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None
