### PR TITLE
fix(#279): add codex Agent mapping and deferred discovery guidance

### DIFF
--- a/.changeset/tidy-orcas-romp.md
+++ b/.changeset/tidy-orcas-romp.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 279
+---
+Fixed Codex adapter guidance to include Agent() mapping and deferred spawn_agent discovery via tool_search.

--- a/bin/install.js
+++ b/bin/install.js
@@ -2612,6 +2612,7 @@ GSD workflows use \`Task(...)\` (Claude Code syntax). Translate to Codex collabo
 
 Direct mapping:
 - \`Task(subagent_type="X", prompt="Y")\` → \`spawn_agent(agent_type="X", message="Y")\`
+- \`Agent(subagent_type="X", prompt="Y")\` → \`spawn_agent(agent_type="X", message="Y")\`
 - \`Task(model="...")\` → omit. \`spawn_agent\` has no inline \`model\` parameter;
   GSD embeds the resolved per-agent model directly into each agent's \`.toml\`
   at install time so \`model_overrides\` from \`.planning/config.json\` and
@@ -2630,6 +2631,9 @@ Spawn restriction:
 - Codex restricts \`spawn_agent\` to cases where the user has explicitly
   requested sub-agents. When automatic spawning is not permitted, do the
   work inline in the current agent rather than attempting to force a spawn.
+- In some Codex sessions, multi-agent tooling can be deferred. If \`spawn_agent\`
+  is not currently visible, discover tools first via \`tool_search\` before
+  defaulting to inline execution.
 
 Parallel fan-out:
 - Spawn multiple agents → collect agent IDs → \`wait(ids)\` for all to complete

--- a/tests/bug-279-codex-agent-mapping.test.cjs
+++ b/tests/bug-279-codex-agent-mapping.test.cjs
@@ -1,0 +1,27 @@
+'use strict';
+// allow-test-rule: source-text-is-the-product [adapter header contract in bin/install.js]
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const INSTALL_JS = path.join(__dirname, '..', 'bin', 'install.js');
+const src = fs.readFileSync(INSTALL_JS, 'utf8');
+
+describe('bug #279: Codex adapter documents Agent() and deferred tool discovery', () => {
+  test('adapter mapping section includes explicit Agent(...) -> spawn_agent mapping', () => {
+    assert.ok(
+      /Task\(subagent_type="X", prompt="Y"\).*spawn_agent\(agent_type="X", message="Y"\)/.test(src) &&
+      /Agent\(subagent_type="X", prompt="Y"\).*spawn_agent\(agent_type="X", message="Y"\)/.test(src),
+      'Codex adapter must explicitly map both Task(...) and Agent(...) to spawn_agent',
+    );
+  });
+
+  test('adapter includes deferred tool_search discovery guidance before inline fallback', () => {
+    assert.ok(
+      src.includes('deferred') && src.includes('tool_search') && src.includes('spawn_agent'),
+      'Codex adapter must instruct deferred tool discovery via tool_search before deciding to run inline',
+    );
+  });
+});


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

> **Required.** This PR will be auto-closed if no valid issue link is found.

Fixes #279

> The linked issue must have the `confirmed-bug` label. If it doesn't, ask a maintainer to confirm the bug before continuing.

---

## What was broken

Codex adapter text missed explicit `Agent(...)` mapping and deferred discovery guidance for `spawn_agent` tools.

## What this fix does

Adds explicit `Agent(...) -> spawn_agent(...)` mapping and guidance to use `tool_search` first when multi-agent tools are deferred.

## Root cause

Adapter documentation drifted from the current plugin/tool discovery contract.

## Testing

### How I verified the fix

- `node --test tests/bug-279-codex-agent-mapping.test.cjs`
- `gsd-test-summary --both --base next`
  - Docker: 0 failed
  - Mac: 0 failed

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [x] Other: node:test + gsd-test-summary
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [ ] All existing tests pass (`npm test`) (not run in this cycle)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None
