### PR TITLE
fix(#280): anchor execute-phase files_to_read to project root

### DIFF
--- a/.changeset/zesty-quails-wave.md
+++ b/.changeset/zesty-quails-wave.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 280
+---
+Fixed execute-phase subagent prompt file paths to anchor reads to PROJECT_ROOT in worktree execution.

--- a/get-shit-done/workflows/execute-phase.md
+++ b/get-shit-done/workflows/execute-phase.md
@@ -619,18 +619,20 @@ increases monotonically across waves. `{status}` is `complete` (success),
        </execution_context>
 
        <files_to_read>
-       Read these files at execution start using the Read tool:
-       - {phase_dir}/{plan_file} (Plan)
-       - .planning/PROJECT.md (Project context — core value, requirements, evolution rules)
-       - .planning/STATE.md (State)
-       - .planning/config.json (Config, if exists)
+       Read these files at execution start using the Read tool.
+       First resolve repo root so every path is anchored:
+       \`PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)\`
+       - ${PROJECT_ROOT}/{phase_dir}/{plan_file} (Plan)
+       - ${PROJECT_ROOT}/.planning/PROJECT.md (Project context — core value, requirements, evolution rules)
+       - ${PROJECT_ROOT}/.planning/STATE.md (State)
+       - ${PROJECT_ROOT}/.planning/config.json (Config, if exists)
        ${CONTEXT_WINDOW >= 500000 ? `
-       - ${phase_dir}/*-CONTEXT.md (User decisions from discuss-phase — honors locked choices)
-       - ${phase_dir}/*-RESEARCH.md (Technical research — pitfalls and patterns to follow)
-       - ${prior_wave_summaries} (SUMMARY.md files from earlier waves in this phase — what was already built)
+       - ${PROJECT_ROOT}/${phase_dir}/*-CONTEXT.md (User decisions from discuss-phase — honors locked choices)
+       - ${PROJECT_ROOT}/${phase_dir}/*-RESEARCH.md (Technical research — pitfalls and patterns to follow)
+       - ${PROJECT_ROOT}/${prior_wave_summaries} (SUMMARY.md files from earlier waves in this phase — what was already built)
        ` : ''}
-       - ./CLAUDE.md (Project instructions, if exists — follow project-specific guidelines and coding conventions)
-       - .claude/skills/ or .agents/skills/ (Project skills, if either exists — list skills, read SKILL.md for each, follow relevant rules during implementation)
+       - ${PROJECT_ROOT}/CLAUDE.md (Project instructions, if exists — follow project-specific guidelines and coding conventions)
+       - ${PROJECT_ROOT}/.claude/skills/ or ${PROJECT_ROOT}/.agents/skills/ (Project skills, if either exists — list skills, read SKILL.md for each, follow relevant rules during implementation)
        </files_to_read>
 
        ${AGENT_SKILLS}

--- a/tests/bug-3097-3099-executor-worktree-path-safety.test.cjs
+++ b/tests/bug-3097-3099-executor-worktree-path-safety.test.cjs
@@ -84,6 +84,20 @@ describe('bug #3099: absolute-path safety guidance in gsd-executor.md', () => {
     );
   });
 
+  test('execute-phase prompt anchors subagent file paths to project_root before files_to_read (#280)', () => {
+    const filesIdx = executePhaseSrc.indexOf('<files_to_read>');
+    assert.ok(filesIdx !== -1, 'files_to_read block not found in execute-phase.md');
+    const dispatchSnippet = executePhaseSrc.slice(filesIdx, filesIdx + 1800);
+    assert.ok(
+      dispatchSnippet.includes('PROJECT_ROOT=$(git rev-parse --show-toplevel'),
+      'executor dispatch must compute PROJECT_ROOT in the prompt before file reads',
+    );
+    assert.ok(
+      dispatchSnippet.includes('${PROJECT_ROOT}/'),
+      'executor files_to_read paths must be anchored to ${PROJECT_ROOT}/',
+    );
+  });
+
   test('worktree-path-safety.md reference file exists', () => {
     assert.ok(
       fs.existsSync(path.join(ROOT, 'get-shit-done', 'references', 'worktree-path-safety.md')),


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

> **Required.** This PR will be auto-closed if no valid issue link is found.

Fixes #280

> The linked issue must have the `confirmed-bug` label. If it doesn't, ask a maintainer to confirm the bug before continuing.

---

## What was broken

Execute-phase subagent prompt emitted relative `files_to_read` paths without explicit project-root anchoring, which is fragile under cwd drift in worktree execution.

## What this fix does

Anchors file paths using `PROJECT_ROOT` from `git rev-parse --show-toplevel` before writing `files_to_read` entries in the prompt.

## Root cause

Prompt-generation logic relied on implicit cwd expectations instead of explicit root anchoring.

## Testing

### How I verified the fix

- `node --test tests/bug-3097-3099-executor-worktree-path-safety.test.cjs`
- `gsd-test-summary --both --base next`
  - Docker: 0 failed
  - Mac: 0 failed

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [x] Other: node:test + gsd-test-summary
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [ ] All existing tests pass (`npm test`) (not run in this cycle)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None
