### PR TITLE
feat: stabilize workstream inventory ordering

### DIFF
--- a/get-shit-done/bin/lib/workstream-inventory.cjs
+++ b/get-shit-done/bin/lib/workstream-inventory.cjs
@@ -55,6 +55,17 @@ function readStateProjection(statePath) {
   }
 }
 
+function sortWorkstreamInventories(inventories, activeWorkstreamName) {
+  return [...inventories].sort((a, b) => {
+    const aActive = a.name === activeWorkstreamName ? 1 : 0;
+    const bActive = b.name === activeWorkstreamName ? 1 : 0;
+    if (aActive !== bActive) {
+      return bActive - aActive;
+    }
+    return a.name.localeCompare(b.name);
+  });
+}
+
 function inspectWorkstream(cwd, name, options = {}) {
   const wsDir = path.join(workstreamsRoot(cwd), name);
   if (!fs.existsSync(wsDir)) return null;
@@ -107,11 +118,13 @@ function listWorkstreamInventories(cwd) {
     if (inventory) workstreams.push(inventory);
   }
 
+  const ordered = sortWorkstreamInventories(workstreams, active);
+
   return {
     mode: 'workstream',
     active,
-    workstreams,
-    count: workstreams.length,
+    workstreams: ordered,
+    count: ordered.length,
   };
 }
 
@@ -128,5 +141,6 @@ module.exports = {
   inspectWorkstream,
   isCompletedInventory,
   listWorkstreamInventories,
+  sortWorkstreamInventories,
   workstreamsRoot,
 };

--- a/tests/workstream.test.cjs
+++ b/tests/workstream.test.cjs
@@ -451,18 +451,18 @@ describe('workstream list', () => {
       fs.mkdirSync(path.join(wsDir, 'phases'), { recursive: true });
       fs.writeFileSync(path.join(wsDir, 'STATE.md'), `# State\n**Status:** Working on ${ws}\n**Current Phase:** 1\n`);
     }
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'active-workstream'), 'beta\n');
   });
 
   after(() => cleanup(tmpDir));
 
-  test('lists all workstreams', () => {
+  test('lists all workstreams with active first, then lexical name', () => {
     const result = runGsdTools(['workstream', 'list', '--raw'], tmpDir);
     assert.ok(result.success, `list failed: ${result.error}`);
     const data = JSON.parse(result.output);
     assert.strictEqual(data.mode, 'workstream');
     assert.strictEqual(data.count, 2);
-    const names = data.workstreams.map(w => w.name).sort();
-    assert.deepStrictEqual(names, ['alpha', 'beta']);
+    assert.deepStrictEqual(data.workstreams.map(w => w.name), ['beta', 'alpha']);
   });
 
   describe('flat mode', () => {
@@ -645,6 +645,11 @@ describe('workstream progress', () => {
 
   before(() => {
     tmpDir = createFixture();
+    const alphaDir = path.join(tmpDir, '.planning', 'workstreams', 'alpha');
+    fs.mkdirSync(path.join(alphaDir, 'phases'), { recursive: true });
+    fs.writeFileSync(path.join(alphaDir, 'STATE.md'), '# State\n**Status:** In progress\n');
+    fs.writeFileSync(path.join(alphaDir, 'ROADMAP.md'), '## Roadmap\n');
+
     const wsDir = path.join(tmpDir, '.planning', 'workstreams', 'feature');
     fs.mkdirSync(path.join(wsDir, 'phases', '01-init'), { recursive: true });
     fs.writeFileSync(path.join(wsDir, 'phases', '01-init', 'PLAN.md'), '# Plan\n');
@@ -656,12 +661,13 @@ describe('workstream progress', () => {
 
   after(() => cleanup(tmpDir));
 
-  test('returns progress summary', () => {
+  test('returns progress summary in deterministic order', () => {
     const result = runGsdTools(['workstream', 'progress', '--raw'], tmpDir);
     assert.ok(result.success, `progress failed: ${result.error}`);
     const data = JSON.parse(result.output);
     assert.strictEqual(data.mode, 'workstream');
-    assert.strictEqual(data.count, 1);
+    assert.strictEqual(data.count, 2);
+    assert.deepStrictEqual(data.workstreams.map(w => w.name), ['feature', 'alpha']);
     assert.strictEqual(data.workstreams[0].name, 'feature');
     assert.strictEqual(data.workstreams[0].active, true);
     assert.strictEqual(data.workstreams[0].progress_percent, 50);


### PR DESCRIPTION
## Enhancement PR

> **Using the wrong template?**
> — Bug fix: use [fix.md](?template=fix.md)
> — New feature: use [feature.md](?template=feature.md)

---

## Linked Issue

Closes #293

---

## What this enhancement improves

Improves the workstream progress projection seam so workstream ordering is deterministic for `workstream list` and `workstream progress`.

## Before / After

**Before:**
- Workstream ordering depended on filesystem enumeration order.
- Output ordering could differ across environments.

**After:**
- Workstreams are ordered canonically: active workstream first, then lexical name.
- `workstream list` and `workstream progress` now emit stable ordering.

## How it was implemented

- Added inventory ordering policy in `get-shit-done/bin/lib/workstream-inventory.cjs`.
- Applied ordering centrally in `listWorkstreamInventories`, so all callers reuse it.
- Extended tests in `tests/workstream.test.cjs` to verify deterministic ordering for list/progress.

## Testing

### How I verified the enhancement works

- `node --test tests/workstream.test.cjs`
- `npm run lint:tests`

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue — no additions or removals
- [x] If scope changed during implementation, I updated the issue and got re-approval before continuing

---

## Documentation

- [ ] Updated the relevant file(s) under `docs/` to reflect this change
- [x] All `docs/` content added in this PR is written in English
- [x] If genuinely no user-facing docs impact (infrastructure / internal refactor / test-only),
      apply the `no-docs` label **or** add `<!-- docs-exempt: <reason> -->` inside each
      triggering changeset fragment and leave a comment explaining why.

## Checklist

- [x] Issue linked above with `Closes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `approved-enhancement` label — **PR will be closed if missing**
- [x] Changes are scoped to the approved enhancement — nothing extra included
- [ ] All existing tests pass (`npm test`)
- [x] New or updated tests cover the enhanced behavior
- [x] `.changeset/` fragment added (`npm run changeset -- --type Changed --pr <NNN> --body "..."`) — or `no-changelog` label applied if not user-facing
- [x] No unnecessary dependencies added

## Breaking changes

None
