### PR TITLE
feat: deepen runtime name policy seam

### DIFF
--- a/get-shit-done/bin/lib/profile-output.cjs
+++ b/get-shit-done/bin/lib/profile-output.cjs
@@ -16,6 +16,7 @@ const { output, error, loadConfig } = require('./core.cjs');
 const { platformReadSync: safeReadFile, platformWriteSync, platformEnsureDir } = require('./shell-command-projection.cjs');
 const { getGlobalSkillDir } = require('./runtime-homes.cjs');
 const { formatGsdSlash, resolveRuntime } = require('./runtime-slash.cjs');
+const { resolveRuntimeNameFromCandidates } = require('./runtime-name-policy.cjs');
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -811,9 +812,16 @@ function cmdGenerateDevPreferences(cwd, options, raw) {
     let effectiveRuntime = 'claude';
     try {
       const config = loadConfig(cwd);
-      effectiveRuntime = process.env.GSD_RUNTIME || config.runtime || 'claude';
+      effectiveRuntime = resolveRuntimeNameFromCandidates(
+        process.env.GSD_RUNTIME,
+        config.runtime,
+        'claude'
+      ) || 'claude';
     } catch {
-      effectiveRuntime = process.env.GSD_RUNTIME || 'claude';
+      effectiveRuntime = resolveRuntimeNameFromCandidates(
+        process.env.GSD_RUNTIME,
+        'claude'
+      ) || 'claude';
     }
     const skillDir = getGlobalSkillDir(effectiveRuntime, 'gsd-dev-preferences');
     if (!skillDir) {
@@ -1003,7 +1011,10 @@ function cmdGenerateClaudeMd(cwd, options, raw) {
     // #3163: When runtime is codex, override the output target to AGENTS.md
     // regardless of claude_md_path, so Codex projects never write to CLAUDE.md.
     // GSD_RUNTIME env var takes precedence over config.runtime, mirroring detectRuntime().
-    const effectiveRuntime = process.env.GSD_RUNTIME || config.runtime || null;
+    const effectiveRuntime = resolveRuntimeNameFromCandidates(
+      process.env.GSD_RUNTIME,
+      config.runtime
+    );
     if (!options.output && effectiveRuntime === 'codex') {
       configClaudeMdPath = './AGENTS.md';
     }

--- a/get-shit-done/bin/lib/runtime-name-policy.cjs
+++ b/get-shit-done/bin/lib/runtime-name-policy.cjs
@@ -57,6 +57,27 @@ function canonicalizeRuntimeName(value) {
   return aliasToCanonical.get(normalizeRuntimeToken(value)) || null;
 }
 
+/**
+ * Resolve runtime from a precedence list of candidate values.
+ *
+ * - First non-empty string candidate wins.
+ * - Known aliases are canonicalized (codex-cli -> codex).
+ * - Unknown values are normalized and returned (future-runtime tolerance).
+ *
+ * @param {...string} candidates
+ * @returns {string|null}
+ */
+function resolveRuntimeNameFromCandidates(...candidates) {
+  for (const candidate of candidates) {
+    if (typeof candidate !== 'string') continue;
+    const normalized = normalizeRuntimeToken(candidate);
+    if (!normalized) continue;
+    return canonicalizeRuntimeName(normalized) || normalized;
+  }
+  return null;
+}
+
 module.exports = {
   canonicalizeRuntimeName,
+  resolveRuntimeNameFromCandidates,
 };

--- a/get-shit-done/bin/lib/runtime-slash.cjs
+++ b/get-shit-done/bin/lib/runtime-slash.cjs
@@ -1,6 +1,6 @@
 'use strict';
 
-const { canonicalizeRuntimeName } = require('./runtime-name-policy.cjs');
+const { canonicalizeRuntimeName, resolveRuntimeNameFromCandidates } = require('./runtime-name-policy.cjs');
 
 /**
  * runtime-slash.cjs — single source of truth for emitting GSD slash-command
@@ -69,10 +69,8 @@ function formatGsdSlash(commandName, runtime) {
  * @returns {string}
  */
 function resolveRuntime(projectDir) {
-  if (process.env.GSD_RUNTIME) {
-    const rawRuntime = String(process.env.GSD_RUNTIME).toLowerCase();
-    return canonicalizeRuntimeName(rawRuntime) || rawRuntime;
-  }
+  const envRuntime = resolveRuntimeNameFromCandidates(process.env.GSD_RUNTIME);
+  if (envRuntime) return envRuntime;
   if (projectDir) {
     try {
       // Read config.json directly (not via loadConfig). loadConfig has a side
@@ -87,8 +85,8 @@ function resolveRuntime(projectDir) {
         const raw = fs.readFileSync(configPath, 'utf-8');
         const parsed = JSON.parse(raw);
         if (parsed && typeof parsed === 'object' && parsed.runtime) {
-          const rawRuntime = String(parsed.runtime).toLowerCase();
-          return canonicalizeRuntimeName(rawRuntime) || rawRuntime;
+          const configRuntime = resolveRuntimeNameFromCandidates(parsed.runtime);
+          if (configRuntime) return configRuntime;
         }
       }
     } catch {

--- a/tests/profile-output.test.cjs
+++ b/tests/profile-output.test.cjs
@@ -174,6 +174,16 @@ describe('generate-claude-md command', () => {
     assert.ok(content.includes('.codex/skills/'));
     assert.ok(!content.includes('get-shit-done/skills'));
   });
+
+  test('codex runtime aliases default output to AGENTS.md', () => {
+    const result = runGsdTools(
+      ['generate-claude-md', '--auto', '--raw'],
+      tmpDir,
+      { GSD_RUNTIME: 'codex-cli' }
+    );
+    assert.ok(result.success, `Failed: ${result.error}`);
+    assert.ok(fs.existsSync(path.join(tmpDir, 'AGENTS.md')), 'AGENTS.md should be generated for codex aliases');
+  });
 });
 
 // ─── generate-dev-preferences ─────────────────────────────────────────────────
@@ -236,6 +246,27 @@ describe('generate-dev-preferences command', () => {
     const out = JSON.parse(result.output);
     assert.strictEqual(out.command_path, path.join(codexHome, 'skills', 'gsd-dev-preferences', 'SKILL.md'));
     assert.ok(fs.existsSync(out.command_path), 'runtime-aware output should be written');
+  });
+
+  test('canonicalizes codex runtime aliases for skills output path', () => {
+    const analysis = {
+      profile_version: '1.0',
+      dimensions: {
+        communication_style: { rating: 'terse-direct', confidence: 'HIGH' },
+      },
+    };
+    const analysisPath = path.join(tmpDir, 'analysis.json');
+    const codexHome = path.join(tmpDir, 'codex-home');
+    fs.writeFileSync(analysisPath, JSON.stringify(analysis));
+
+    const result = runGsdTools(
+      ['generate-dev-preferences', '--analysis', analysisPath, '--raw'],
+      tmpDir,
+      { CODEX_HOME: codexHome, GSD_RUNTIME: 'codex-app' }
+    );
+    assert.ok(result.success, `Failed: ${result.error}`);
+    const out = JSON.parse(result.output);
+    assert.strictEqual(out.command_path, path.join(codexHome, 'skills', 'gsd-dev-preferences', 'SKILL.md'));
   });
 
   test('errors for cline unless --output is supplied', () => {


### PR DESCRIPTION
## Enhancement PR

> **Using the wrong template?**
> — Bug fix: use [fix.md](?template=fix.md)
> — New feature: use [feature.md](?template=feature.md)

---

## Linked Issue

Closes #295

---

## What this enhancement improves

Deepens the **Runtime Name Policy Module** seam so runtime precedence and alias canonicalization are resolved through one shared interface instead of ad-hoc call-site checks.

## Before / After

**Before:**
- `profile-output.cjs` had inline runtime precedence checks (`GSD_RUNTIME || config.runtime`) in paths that bypassed canonical alias handling.
- Runtime aliases (for example `codex-cli`, `codex-app`) could miss codex-specific behavior in those paths.

**After:**
- Runtime canonicalization and precedence selection are centralized through a new runtime-name policy helper.
- `runtime-slash` and `profile-output` both consume the same canonical runtime-resolution seam.
- Codex alias behavior is consistent for `generate-claude-md` and `generate-dev-preferences` output paths.

## How it was implemented

- Added `resolveRuntimeNameFromCandidates(...)` to `get-shit-done/bin/lib/runtime-name-policy.cjs`.
- Updated `get-shit-done/bin/lib/runtime-slash.cjs` to use that helper for env/config precedence.
- Updated `get-shit-done/bin/lib/profile-output.cjs` to consume the same helper in runtime-sensitive paths.
- Added alias regressions in `tests/profile-output.test.cjs`.

## Testing

### How I verified the enhancement works

- `node --test tests/bug-3584-runtime-slash-formatter.test.cjs`
- `node --test tests/profile-output.test.cjs`
- `npm run lint:tests`

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue — no additions or removals
- [x] If scope changed during implementation, I updated the issue and got re-approval before continuing

---

## Documentation

- [ ] Updated the relevant file(s) under `docs/` to reflect this change
- [x] All `docs/` content added in this PR is written in English
- [x] If genuinely no user-facing docs impact (infrastructure / internal refactor / test-only),
      apply the `no-docs` label **or** add `<!-- docs-exempt: <reason> -->` inside each
      triggering changeset fragment and leave a comment explaining why.

## Checklist

- [x] Issue linked above with `Closes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `approved-enhancement` label — **PR will be closed if missing**
- [x] Changes are scoped to the approved enhancement — nothing extra included
- [ ] All existing tests pass (`npm test`)
- [x] New or updated tests cover the enhanced behavior
- [x] `.changeset/` fragment added (`npm run changeset -- --type Changed --pr <NNN> --body "..."`) — or `no-changelog` label applied if not user-facing
- [x] No unnecessary dependencies added

## Breaking changes

None
