### PR TITLE
refactor: deepen active workstream resolution context

### DIFF
--- a/get-shit-done/bin/gsd-tools.cjs
+++ b/get-shit-done/bin/gsd-tools.cjs
@@ -174,7 +174,7 @@ const path = require('path');
 const core = require('./lib/core.cjs');
 const { error, findProjectRoot, ERROR_REASON } = core;
 const { getActiveWorkstream } = require('./lib/planning-workspace.cjs');
-const { resolveActiveWorkstream, applyResolvedWorkstreamEnv } = require('./lib/active-workstream-store.cjs');
+const { resolveActiveWorkstreamContext, applyResolvedWorkstreamEnv } = require('./lib/active-workstream-store.cjs');
 const state = require('./lib/state.cjs');
 const phase = require('./lib/phase.cjs');
 const roadmap = require('./lib/roadmap.cjs');
@@ -293,14 +293,15 @@ async function main() {
   // Optional workstream override for parallel milestone work.
   // Priority: --ws flag > GSD_WORKSTREAM env var > session/shared pointer > null.
   let ws = null;
+  let workstreamContext = null;
   try {
-    const wsResolution = resolveActiveWorkstream(cwd, args, process.env, {
+    workstreamContext = resolveActiveWorkstreamContext(cwd, args, process.env, {
       getStored: getActiveWorkstream,
     });
-    ws = wsResolution.ws;
-    args = wsResolution.args;
+    ws = workstreamContext.ws;
+    args = workstreamContext.args;
     // Set env var so all modules (planningDir, planningPaths) auto-resolve workstream paths.
-    applyResolvedWorkstreamEnv(wsResolution, process.env);
+    applyResolvedWorkstreamEnv(workstreamContext, process.env);
   } catch (err) {
     error(err.message || String(err));
   }
@@ -431,7 +432,7 @@ async function main() {
   // When --pick is active, capture stdout and extract the requested field.
   if (pickField) {
     const captured = await captureStdoutSyncWrites(async () => {
-      await runCommand(command, args, cwd, raw, defaultValue, originalCommand);
+      await runCommand(command, args, cwd, raw, defaultValue, originalCommand, workstreamContext);
     });
     const resolved = resolveAtFileOutput(captured);
     try {
@@ -451,7 +452,7 @@ async function main() {
   // every workflow to have a bash-specific `if [[ "$INIT" == @file:* ]]` check
   // that breaks on PowerShell and other non-bash shells.
   const captured = await captureStdoutSyncWrites(async () => {
-    await runCommand(command, args, cwd, raw, defaultValue, originalCommand);
+    await runCommand(command, args, cwd, raw, defaultValue, originalCommand, workstreamContext);
   });
   fs.writeSync(1, resolveAtFileOutput(captured));
 }
@@ -518,7 +519,7 @@ function extractField(obj, fieldPath) {
   return current;
 }
 
-async function runCommand(command, args, cwd, raw, defaultValue, originalCommand) {
+async function runCommand(command, args, cwd, raw, defaultValue, originalCommand, workstreamContext = null) {
   switch (command) {
     case 'state': {
       routeStateCommand({
@@ -801,7 +802,7 @@ async function runCommand(command, args, cwd, raw, defaultValue, originalCommand
       // The SDK handler (configPath) also exists but requires a projectDir that
       // is already resolved. Both produce identical output; keeping CJS here is
       // simpler and avoids sync-bridge overhead for a trivial path lookup.
-      config.cmdConfigPath(cwd, raw);
+      config.cmdConfigPath(cwd, raw, workstreamContext);
       break;
     }
 

--- a/get-shit-done/bin/lib/config.cjs
+++ b/get-shit-done/bin/lib/config.cjs
@@ -651,10 +651,12 @@ function getCmdConfigSetModelProfileResultMessage(
  * Print the resolved config.json path (workstream-aware). Used by settings.md
  * so the workflow writes/reads the correct file when a workstream is active (#2282).
  */
-function cmdConfigPath(cwd) {
+function cmdConfigPath(cwd, _raw, workstreamContext = null) {
   // Always emit as plain text — a file path is used via shell substitution,
   // never consumed as JSON. Passing raw=true forces plain-text output.
-  const configPath = path.join(planningDir(cwd), 'config.json');
+  const configPath = workstreamContext && workstreamContext.configPath
+    ? workstreamContext.configPath
+    : path.join(planningDir(cwd), 'config.json');
   output(configPath, true, configPath);
 }
 

--- a/get-shit-done/bin/lib/core.cjs
+++ b/get-shit-done/bin/lib/core.cjs
@@ -280,6 +280,8 @@ function _deepMergeConfig(base, overlay) {
 function loadConfig(cwd, options = {}) {
   const activeWorkstream = Object.prototype.hasOwnProperty.call(options, 'workstream')
     ? options.workstream
+    : (options.workstreamContext && Object.prototype.hasOwnProperty.call(options.workstreamContext, 'ws'))
+      ? options.workstreamContext.ws
     : (process.env.GSD_WORKSTREAM || null);
   // When GSD_WORKSTREAM is set, load root config first so workstream config
   // can inherit from it. This prevents users from duplicating model_overrides,

--- a/tests/core.test.cjs
+++ b/tests/core.test.cjs
@@ -298,6 +298,19 @@ describe('loadConfig workstream config inheritance (#2714)', () => {
     assert.strictEqual(config.model_profile, 'quality');
     assert.strictEqual(process.env.GSD_WORKSTREAM, 'feature-f');
   });
+
+  test('loadConfig accepts workstreamContext.ws without requiring env mutation', () => {
+    writeRootConfig({ model_profile: 'balanced' });
+    writeWorkstreamConfig('feature-g', { model_profile: 'quality' });
+    delete process.env.GSD_WORKSTREAM;
+
+    const config = loadConfig(tmpDir, {
+      workstreamContext: { ws: 'feature-g' },
+    });
+
+    assert.strictEqual(config.model_profile, 'quality');
+    assert.strictEqual(process.env.GSD_WORKSTREAM, undefined);
+  });
 });
 
 // ─── loadConfig commit_docs gitignore auto-detection (#1250) ──────────────────


### PR DESCRIPTION
## Enhancement PR

> **Using the wrong template?**
> — Bug fix: use [fix.md](?template=fix.md)
> — New feature: use [feature.md](?template=feature.md)

---

## Linked Issue

> **Required.** This PR will be auto-closed if no valid issue link is found.
> The linked issue **must** have the `approved-enhancement` label. If it does not, this PR will be closed without review.

Closes #299

> ⛔ **No `approved-enhancement` label on the issue = immediate close.**
> Do not open this PR if a maintainer has not yet approved the enhancement proposal.

---

## What this enhancement improves

Deepens the Active Workstream Resolution Module so callers can consume a single resolved context Interface (`ws`, source, args, planning/config paths) instead of relying on env-only coupling.

## Before / After

**Before:**
- Workstream precedence was resolved, then callers primarily relied on env mutation (`GSD_WORKSTREAM`) and downstream re-resolution.
- `loadConfig()` and `config-path` consumed workstream state implicitly.

**After:**
- `active-workstream-store` exposes a full context resolver (`resolveActiveWorkstreamContext`).
- `gsd-tools` resolves and carries a context object at entry.
- `core.loadConfig()` accepts `workstreamContext.ws` as an explicit input.
- `config-path` can consume `workstreamContext.configPath` directly.

## How it was implemented

- Added context Interface in:
  - `get-shit-done/bin/lib/active-workstream-store.cjs`
- Wired resolver usage in CLI entry path:
  - `get-shit-done/bin/gsd-tools.cjs`
- Extended config consumers to accept explicit context:
  - `get-shit-done/bin/lib/core.cjs`
  - `get-shit-done/bin/lib/config.cjs`
- Added/updated regression coverage:
  - `tests/active-workstream-store.test.cjs`
  - `tests/core.test.cjs`

## Testing

### How I verified the enhancement works

- `node --test tests/active-workstream-store.test.cjs tests/core.test.cjs tests/config.test.cjs`
  - Result: 246 passed, 0 failed
- `gsd-test-summary -base next`
  - Result: `Docker: 0 failed`

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue — no additions or removals
- [x] If scope changed during implementation, I updated the issue and got re-approval before continuing

---

## Documentation

> CI enforces this — `lint:docs` fails any PR with an `Added` / `Changed` / `Deprecated` / `Removed`
> changeset fragment that does not also touch at least one file under `docs/`.
> See [CONTRIBUTING.md → Documentation Updates](../../CONTRIBUTING.md#documentation-updates-update-the-relevant-docs).

- [ ] Updated the relevant file(s) under `docs/` to reflect this change
  - Behavior or output change → `docs/USER-GUIDE.md` and/or `docs/COMMANDS.md`
  - Configuration / schema change → `docs/CONFIGURATION.md`
  - Architectural change → `docs/ARCHITECTURE.md` and/or `docs/adr/`
  - Agent or skill change → `docs/AGENTS.md`
- [x] All `docs/` content added in this PR is written in English
- [x] If genuinely no user-facing docs impact (infrastructure / internal refactor / test-only),
      apply the `no-docs` label **or** add `<!-- docs-exempt: <reason> -->` inside each
      triggering changeset fragment and leave a comment explaining why.

## Checklist

- [x] Issue linked above with `Closes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `approved-enhancement` label — **PR will be closed if missing**
- [x] Changes are scoped to the approved enhancement — nothing extra included
- [x] All existing tests pass (`npm test`)
- [x] New or updated tests cover the enhanced behavior
- [x] `.changeset/` fragment added (`npm run changeset -- --type Changed --pr <NNN> --body "..."`) — or `no-changelog` label applied if not user-facing
- [x] No unnecessary dependencies added

## Breaking changes

None
