### PR TITLE
fix(#321): replace JSON config default clone with structuredClone

### DIFF
--- a/.changeset/eager-elks-romp.md
+++ b/.changeset/eager-elks-romp.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 321
+---
+**`loadConfig` now clones config defaults with `structuredClone`** — avoids JSON round-trip fragility in defaults merging used by config loads and related tooling.

--- a/get-shit-done/bin/lib/configuration.cjs
+++ b/get-shit-done/bin/lib/configuration.cjs
@@ -158,7 +158,7 @@ function normalizeLegacyKeys(parsed) {
 
 function mergeDefaults(parsed) {
     // Start with a deep clone of defaults, then overlay parsed
-    const defaults = JSON.parse(JSON.stringify(CONFIG_DEFAULTS));
+    const defaults = structuredClone(CONFIG_DEFAULTS);
     return deepMergeConfig(defaults, parsed);
 }
 

--- a/tests/bug-321-config-defaults-clone-strategy.test.cjs
+++ b/tests/bug-321-config-defaults-clone-strategy.test.cjs
@@ -1,0 +1,23 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const configuration = require('../get-shit-done/bin/lib/configuration.cjs');
+
+test('mergeDefaults clones defaults without JSON serialization fragility (#321)', () => {
+  const sentinelKey = '__bug321_bigint_sentinel__';
+  const sentinelValue = BigInt('9007199254740993001');
+
+  configuration.CONFIG_DEFAULTS[sentinelKey] = sentinelValue;
+  try {
+    const merged = configuration.mergeDefaults({});
+    assert.equal(
+      merged[sentinelKey],
+      sentinelValue,
+      'mergeDefaults must preserve non-JSON scalar defaults when cloning'
+    );
+  }
+  finally {
+    delete configuration.CONFIG_DEFAULTS[sentinelKey];
+  }
+});


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #321

## What was broken

`mergeDefaults()` cloned `CONFIG_DEFAULTS` with `JSON.parse(JSON.stringify(...))`, which is slow in repeated config-load paths and fragile for non-JSON scalar values.

## What this fix does

Switches defaults cloning to `structuredClone(CONFIG_DEFAULTS)` and adds a regression test that proves clone behavior no longer depends on JSON serialization.

## Root cause

The clone strategy encoded a JSON-serialization assumption into config defaults merging. That assumption is unnecessary on Node 22+ and introduces avoidable allocation overhead and type fragility.

## Testing

### How I verified the fix

- `node --test tests/bug-321-config-defaults-clone-strategy.test.cjs`
- `node --test tests/bug-3523-cjs-loadconfig-branching-strategy-warning.test.cjs`
- `node --test tests/configuration-migrate-config.test.cjs`

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [ ] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/get-shit-done-redux/pr/324"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782391298&installation_id=134682257&pr_number=324&repository=open-gsd%2Fget-shit-done-redux&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fget-shit-done-redux%2Fpull%2F324&signature=993eb8e34822bba0cda8298818da69216027d99b9f8eab11e4b49096cc2e015b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->