### PR TITLE
fix(#322): normalize surface manifest input shapes

### DIFF
--- a/.changeset/eager-koalas-zip.md
+++ b/.changeset/eager-koalas-zip.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 322
+---
+**`/gsd-surface` now accepts parsed manifest JSON input safely** — surface resolution normalizes manifest inputs before profile closure and list/apply operations so list/status/enable/disable no longer crash with `manifest.get is not a function`.

--- a/get-shit-done/bin/lib/surface.cjs
+++ b/get-shit-done/bin/lib/surface.cjs
@@ -109,6 +109,43 @@ function clustersToSkills(clusterNames, clusterMap) {
 }
 
 /**
+ * Normalize manifest inputs to the skill-dependency Map shape expected by
+ * resolveProfile/computeClosure.
+ *
+ * Supports:
+ *  - canonical Map<string, string[]>
+ *  - legacy plain object map: { [stem]: string[] }
+ *  - parsed gsd-file-manifest.json object ({ files: { ... } }) by rebuilding
+ *    the dependency manifest from the install source tree
+ *
+ * @param {string} runtimeConfigDir
+ * @param {Map<string, string[]>|Object} manifest
+ * @returns {Map<string, string[]>}
+ */
+function normalizeSkillManifest(runtimeConfigDir, manifest) {
+  if (manifest instanceof Map) {
+    return manifest;
+  }
+  if (!manifest || typeof manifest !== 'object') {
+    return new Map();
+  }
+
+  // Legacy/ad-hoc object map: stem -> requires[]
+  const arrayEntries = Object.entries(manifest).filter(([, value]) => Array.isArray(value));
+  if (arrayEntries.length > 0) {
+    return new Map(arrayEntries.map(([stem, deps]) => [stem, deps]));
+  }
+
+  // Parsed gsd-file-manifest.json shape: rebuild the dependency map from source.
+  if (manifest.files && typeof manifest.files === 'object') {
+    const srcCommandsDir = findInstallSourceRoot(runtimeConfigDir);
+    return loadSkillsManifest(srcCommandsDir);
+  }
+
+  return new Map();
+}
+
+/**
  * Resolve the effective surface to a typed profile-like object.
  * Shape: { name, skills: Set<string>|'*', agents: Set<string> }
  *
@@ -125,6 +162,7 @@ function clustersToSkills(clusterNames, clusterMap) {
  */
 function resolveSurface(runtimeConfigDir, manifest, clusterMap) {
   const cm = clusterMap || CLUSTERS;
+  const skillManifest = normalizeSkillManifest(runtimeConfigDir, manifest);
   const surface = readSurface(runtimeConfigDir);
 
   // Determine base profile name: from surface state or from .gsd-profile marker
@@ -135,7 +173,7 @@ function resolveSurface(runtimeConfigDir, manifest, clusterMap) {
   // Resolve base profile
   const baseResolved = resolveProfile({
     modes: baseProfileName.split(',').map(s => s.trim()),
-    manifest,
+    manifest: skillManifest,
   });
 
   // If full, we need to enumerate all skills from the manifest
@@ -143,7 +181,7 @@ function resolveSurface(runtimeConfigDir, manifest, clusterMap) {
   if (baseResolved.skills === '*') {
     // Materialize all skill stems from manifest
     skills = new Set();
-    for (const [key] of manifest) {
+    for (const [key] of skillManifest) {
       if (!key.startsWith('_calls_agents_')) skills.add(key);
     }
   } else {
@@ -163,7 +201,7 @@ function resolveSurface(runtimeConfigDir, manifest, clusterMap) {
       const visited = new Set(addSet);
       while (queue.length > 0) {
         const stem = queue.pop();
-        const deps = manifest.get(stem) || [];
+        const deps = skillManifest.get(stem) || [];
         for (const dep of deps) {
           if (!visited.has(dep)) {
             visited.add(dep);
@@ -183,7 +221,7 @@ function resolveSurface(runtimeConfigDir, manifest, clusterMap) {
   // Derive agents from skills
   const agents = new Set();
   for (const skillStem of skills) {
-    const agentRefs = manifest.get(`_calls_agents_${skillStem}`) || [];
+    const agentRefs = skillManifest.get(`_calls_agents_${skillStem}`) || [];
     for (const agentStem of agentRefs) agents.add(agentStem);
   }
 
@@ -208,11 +246,12 @@ function applySurface(runtimeConfigDir, layout, manifest, clusterMap) {
   if (path.resolve(runtimeConfigDir) !== path.resolve(layout.configDir)) {
     throw new TypeError('applySurface runtimeConfigDir must match layout.configDir');
   }
-  const resolved = resolveSurface(layout.configDir, manifest, clusterMap);
+  const skillManifest = normalizeSkillManifest(layout.configDir, manifest);
+  const resolved = resolveSurface(layout.configDir, skillManifest, clusterMap);
   for (const kind of layout.kinds) {
     const staged = kind.stage(resolved);
     const dest = path.join(layout.configDir, kind.destSubpath);
-    _syncGsdDir(staged, dest, kind, manifest);
+    _syncGsdDir(staged, dest, kind, skillManifest);
   }
   return resolved;
 }
@@ -384,11 +423,12 @@ function _syncGsdDir(stagedDir, destDir, kind, manifest) {
  * @returns {{ enabled: string[], disabled: string[], tokenCost: number }}
  */
 function listSurface(runtimeConfigDir, manifest, clusterMap) {
-  const resolved = resolveSurface(runtimeConfigDir, manifest, clusterMap);
+  const skillManifest = normalizeSkillManifest(runtimeConfigDir, manifest);
+  const resolved = resolveSurface(runtimeConfigDir, skillManifest, clusterMap);
 
   // All known stems from manifest (exclude _calls_agents_ meta keys)
   const allStems = [];
-  for (const [key] of manifest) {
+  for (const [key] of skillManifest) {
     if (!key.startsWith('_calls_agents_')) allStems.push(key);
   }
 

--- a/tests/runtime-artifact-layout-surface.test.cjs
+++ b/tests/runtime-artifact-layout-surface.test.cjs
@@ -703,6 +703,27 @@ describe('CLUSTERS data structure', () => {
 // ─── listSurface ─────────────────────────────────────────────────────────────
 
 describe('listSurface', () => {
+  test('accepts parsed gsd-file-manifest JSON objects without crashing (#322)', () => {
+    const dir = tmpDir('gsd-surface-list-');
+    try {
+      fs.writeFileSync(path.join(dir, '.gsd-source'), REAL_COMMANDS_DIR, 'utf8');
+      writeActiveProfile(dir, 'core');
+      const diskManifestShape = {
+        version: '1.0.0',
+        timestamp: new Date().toISOString(),
+        mode: 'core',
+        files: {},
+      };
+      const result = listSurface(dir, diskManifestShape, CLUSTERS);
+
+      assert.ok(Array.isArray(result.enabled), 'enabled must be array');
+      assert.ok(Array.isArray(result.disabled), 'disabled must be array');
+      assert.ok(typeof result.tokenCost === 'number', 'tokenCost must be number');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   test('returns { enabled, disabled, tokenCost } structure', () => {
     const dir = tmpDir('gsd-surface-list-');
     try {


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #322

## What was broken

`/gsd-surface` operations crashed with `TypeError: manifest.get is not a function` when callers passed parsed JSON manifest objects instead of the `Map` shape expected by profile closure code.

## What this fix does

Adds manifest-shape normalization in `surface.cjs` so `resolveSurface`, `listSurface`, and `applySurface` always operate on a dependency `Map`. Parsed `gsd-file-manifest.json` objects now auto-rebuild the skill manifest from the install source.

## Root cause

The surface module accepted a loosely-typed `manifest` parameter but forwarded it directly into `resolveProfile`/`computeClosure`, where `.get()` is required. That implicit contract mismatch caused immediate runtime failure.

## Testing

### How I verified the fix

- `node --test tests/runtime-artifact-layout-surface.test.cjs`
- `node --test tests/runtime-artifact-layout-install-profiles.test.cjs`
- `node --test tests/bug-3735-profiles-core-includes-surface.test.cjs`

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [ ] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/get-shit-done-redux/pr/325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782391460&installation_id=134682257&pr_number=325&repository=open-gsd%2Fget-shit-done-redux&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fget-shit-done-redux%2Fpull%2F325&signature=d7150aba8df65c52e2b11e9a3e3ee0d94d87d254d82e9ac9f00e5ab13e47719d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->