### PR TITLE
test: add process-state isolation module for reliability

### DIFF
--- a/tests/bug-3441-path-action-projection.test.cjs
+++ b/tests/bug-3441-path-action-projection.test.cjs
@@ -17,6 +17,7 @@ const projection = require(path.join(
   'shell-command-projection.cjs',
 ));
 const install = require(path.join(__dirname, '..', 'bin', 'install.js'));
+const { withIsolatedProcessState } = require('./helpers.cjs');
 
 function createTempHome() {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-home-3441-'));
@@ -88,38 +89,37 @@ describe('bug #3441: PATH guidance is projected from typed shell action IR', () 
 
   test('maybeSuggestPathExport renders commands projected by path-action seam', () => {
     const home = createTempHome();
-    const originalPath = process.env.PATH;
     try {
-      const globalBin = path.join(home, '.npm-global', 'bin');
-      fs.mkdirSync(globalBin, { recursive: true });
-      fs.writeFileSync(path.join(home, '.zshrc'), 'export PATH="$HOME/.cargo/bin:$PATH"\n');
-      process.env.PATH = '';
+      withIsolatedProcessState(() => {
+        const globalBin = path.join(home, '.npm-global', 'bin');
+        fs.mkdirSync(globalBin, { recursive: true });
+        fs.writeFileSync(path.join(home, '.zshrc'), 'export PATH="$HOME/.cargo/bin:$PATH"\n');
+        process.env.PATH = '';
 
-      const expected = projection.projectPathActionProjection({
-        mode: 'persist',
-        targetDir: globalBin,
-        platform: process.platform,
+        const expected = projection.projectPathActionProjection({
+          mode: 'persist',
+          targetDir: globalBin,
+          platform: process.platform,
+        });
+
+        const logs = [];
+        const originalLog = console.log;
+        console.log = (...args) => logs.push(args.join(' '));
+        try {
+          install.maybeSuggestPathExport(globalBin, home);
+        } finally {
+          console.log = originalLog;
+        }
+
+        const joined = logs.join('\n');
+        for (const action of expected.shellActions) {
+          assert.ok(
+            joined.includes(action.command),
+            `expected installer output to include projected command: ${action.command}\nOutput:\n${joined}`,
+          );
+        }
       });
-
-      const logs = [];
-      const originalLog = console.log;
-      console.log = (...args) => logs.push(args.join(' '));
-      try {
-        install.maybeSuggestPathExport(globalBin, home);
-      } finally {
-        console.log = originalLog;
-      }
-
-      const joined = logs.join('\n');
-      for (const action of expected.shellActions) {
-        assert.ok(
-          joined.includes(action.command),
-          `expected installer output to include projected command: ${action.command}\nOutput:\n${joined}`,
-        );
-      }
     } finally {
-      if (originalPath == null) delete process.env.PATH;
-      else process.env.PATH = originalPath;
       cleanup(home);
     }
   });

--- a/tests/helpers-process-isolation.test.cjs
+++ b/tests/helpers-process-isolation.test.cjs
@@ -1,0 +1,41 @@
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const { withIsolatedProcessState } = require('./helpers.cjs');
+
+describe('withIsolatedProcessState', () => {
+  test('restores env, cwd, and exitCode after callback', () => {
+    const originalCwd = process.cwd();
+    const originalExitCode = process.exitCode;
+    const originalMarker = process.env.GSD_TEST_ISOLATION_MARKER;
+
+    const tempCwd = path.dirname(originalCwd);
+
+    withIsolatedProcessState(() => {
+      process.env.GSD_TEST_ISOLATION_MARKER = 'changed';
+      process.exitCode = 73;
+      process.chdir(tempCwd);
+    });
+
+    assert.strictEqual(process.cwd(), originalCwd);
+    assert.strictEqual(process.exitCode, originalExitCode);
+    assert.strictEqual(process.env.GSD_TEST_ISOLATION_MARKER, originalMarker);
+  });
+
+  test('restores state even when callback throws', () => {
+    const originalCwd = process.cwd();
+    const originalPath = process.env.PATH;
+
+    assert.throws(() => {
+      withIsolatedProcessState(() => {
+        process.env.PATH = '';
+        process.chdir(path.dirname(originalCwd));
+        throw new Error('boom');
+      });
+    }, /boom/);
+
+    assert.strictEqual(process.cwd(), originalCwd);
+    assert.strictEqual(process.env.PATH, originalPath);
+  });
+});

--- a/tests/helpers.cjs
+++ b/tests/helpers.cjs
@@ -315,4 +315,34 @@ function isolatedNpmEnv() {
   };
 }
 
-module.exports = { runGsdTools, createTempDir, createTempProject, createTempGitProject, cleanup, parseFrontmatter, isUsageOutput, captureConsole, toPosixPath, runNpm, isolatedNpmEnv, TOOLS_PATH };
+/**
+ * Run a callback with process-level state isolation.
+ * Restores cwd, exitCode, and process.env after callback returns or throws.
+ *
+ * @template T
+ * @param {() => T} fn
+ * @returns {T}
+ */
+function withIsolatedProcessState(fn) {
+  const originalCwd = process.cwd();
+  const originalExitCode = process.exitCode;
+  const originalEnv = { ...process.env };
+
+  try {
+    return fn();
+  } finally {
+    if (process.cwd() !== originalCwd) {
+      process.chdir(originalCwd);
+    }
+    process.exitCode = originalExitCode;
+
+    for (const key of Object.keys(process.env)) {
+      if (!(key in originalEnv)) delete process.env[key];
+    }
+    for (const [key, value] of Object.entries(originalEnv)) {
+      process.env[key] = value;
+    }
+  }
+}
+
+module.exports = { runGsdTools, createTempDir, createTempProject, createTempGitProject, cleanup, parseFrontmatter, isUsageOutput, captureConsole, toPosixPath, runNpm, isolatedNpmEnv, withIsolatedProcessState, TOOLS_PATH };


### PR DESCRIPTION
## Enhancement PR

## Linked Issue

Closes #330

## What this enhancement improves

Introduces a Test Isolation Module seam for process-level state (`process.env`, `cwd`, `process.exitCode`) to reduce order-dependent test failures.

## Before / After

**Before:**
- Suites manually saved/restored process globals ad hoc.
- Restoration logic was duplicated and easy to drift.

**After:**
- Added `withIsolatedProcessState(fn)` in `tests/helpers.cjs`.
- Added focused reliability tests for restoration invariants.
- Adopted helper in `bug-3441` seam test to remove ad hoc env restoration.

## How it was implemented

- `tests/helpers.cjs`: new process-state isolation helper
- `tests/helpers-process-isolation.test.cjs`: contract tests
- `tests/bug-3441-path-action-projection.test.cjs`: adopted helper

## Testing

### How I verified the enhancement works

- `npm run lint:tests`
- `node --test tests/helpers-process-isolation.test.cjs tests/bug-3441-path-action-projection.test.cjs`
- `gsd-test --targets linux,macos --base next --head HEAD --source .`
  - linux: PASS 11277/11277
  - macos: PASS 11277/11277

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue — no additions or removals
- [x] If scope changed during implementation, I updated the issue and got re-approval before continuing

## Documentation

- [ ] Updated the relevant file(s) under `docs/` to reflect this change
- [x] All `docs/` content added in this PR is written in English
- [x] No user-facing docs impact (internal test infrastructure refactor)

## Checklist

- [x] Issue linked above with `Closes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `approved-enhancement` label — **PR will be closed if missing**
- [x] Changes are scoped to the approved enhancement — nothing extra included
- [x] All existing tests pass (`npm test`)
- [x] New or updated tests cover the enhanced behavior
- [x] `.changeset/` fragment added (`npm run changeset -- --type Changed --pr <NNN> --body "..."`) — or `no-changelog` label applied if not user-facing
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/get-shit-done-redux/pr/331"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782399652&installation_id=134682257&pr_number=331&repository=open-gsd%2Fget-shit-done-redux&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fget-shit-done-redux%2Fpull%2F331&signature=f203c476fae15574fde0bc45609c20e50b807e41d84a6295f2bf5f69bc067303"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->