### PR TITLE
test: add typed failure classification module

### DIFF
--- a/scripts/test-failure-reasons.cjs
+++ b/scripts/test-failure-reasons.cjs
@@ -1,0 +1,34 @@
+'use strict';
+
+const TEST_GATE_REASON = Object.freeze({
+  PASS: 'pass',
+  TEST_FAILURE: 'test_failure',
+  INFRA_FAILURE: 'infra_failure',
+  UNKNOWN_FAILURE: 'unknown_failure',
+});
+
+/**
+ * Classify gsd-test style output + exit code into a typed reason.
+ * @param {{exitCode:number, output?:string}} input
+ * @returns {{ok:boolean, reason:string}}
+ */
+function classifyTestGateResult(input) {
+  const exitCode = Number(input?.exitCode ?? 0);
+  const output = String(input?.output ?? '');
+
+  if (exitCode === 0) return { ok: true, reason: TEST_GATE_REASON.PASS };
+
+  // gsd-test/gsd-test-summary infrastructure class (exit 2)
+  if (exitCode === 2 || /infrastructure failure|worktree\.Construct/i.test(output)) {
+    return { ok: false, reason: TEST_GATE_REASON.INFRA_FAILURE };
+  }
+
+  // test failures (non-zero plus explicit FAIL lines)
+  if (/\bFAIL\b|\d+\s+failures?\)|failed\)/i.test(output)) {
+    return { ok: false, reason: TEST_GATE_REASON.TEST_FAILURE };
+  }
+
+  return { ok: false, reason: TEST_GATE_REASON.UNKNOWN_FAILURE };
+}
+
+module.exports = { TEST_GATE_REASON, classifyTestGateResult };

--- a/tests/test-failure-reasons.test.cjs
+++ b/tests/test-failure-reasons.test.cjs
@@ -1,0 +1,37 @@
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { TEST_GATE_REASON, classifyTestGateResult } = require('../scripts/test-failure-reasons.cjs');
+
+describe('test failure reason classification', () => {
+  test('classifies pass on exitCode 0', () => {
+    const out = classifyTestGateResult({ exitCode: 0, output: 'all good' });
+    assert.deepStrictEqual(out, { ok: true, reason: TEST_GATE_REASON.PASS });
+  });
+
+  test('classifies infrastructure failure via exitCode 2', () => {
+    const out = classifyTestGateResult({ exitCode: 2, output: 'ERROR: infrastructure failure' });
+    assert.deepStrictEqual(out, { ok: false, reason: TEST_GATE_REASON.INFRA_FAILURE });
+  });
+
+  test('classifies infrastructure failure via known worktree construct signature', () => {
+    const out = classifyTestGateResult({
+      exitCode: 1,
+      output: 'worktree.Construct: worktree construction failed at merge',
+    });
+    assert.deepStrictEqual(out, { ok: false, reason: TEST_GATE_REASON.INFRA_FAILURE });
+  });
+
+  test('classifies test failure via FAIL markers', () => {
+    const out = classifyTestGateResult({
+      exitCode: 1,
+      output: 'linux      FAIL  11274/11277 tests (3 failures)',
+    });
+    assert.deepStrictEqual(out, { ok: false, reason: TEST_GATE_REASON.TEST_FAILURE });
+  });
+
+  test('classifies unknown failure when non-zero without known signatures', () => {
+    const out = classifyTestGateResult({ exitCode: 1, output: 'nonzero but unknown format' });
+    assert.deepStrictEqual(out, { ok: false, reason: TEST_GATE_REASON.UNKNOWN_FAILURE });
+  });
+});


### PR DESCRIPTION
## Enhancement PR

## Linked Issue

Closes #332

## What this enhancement improves

Adds a typed Failure Classification Module for test-gate outcomes so automation can distinguish pass, test failure, and infrastructure failure without brittle prose parsing.

## Before / After

**Before:**
- Test-gate interpretation depended on mixed prose and exit handling in ad hoc call sites.

**After:**
- Added `scripts/test-failure-reasons.cjs` with:
  - `TEST_GATE_REASON` enum-like constants
  - `classifyTestGateResult({ exitCode, output })`
- Added contract tests in `tests/test-failure-reasons.test.cjs`.

## How it was implemented

- New module: `scripts/test-failure-reasons.cjs`
- New tests: `tests/test-failure-reasons.test.cjs`

## Testing

### How I verified the enhancement works

- `npm run lint:tests`
- `node --test tests/test-failure-reasons.test.cjs`
- `gsd-test --targets linux,macos --base next --head HEAD --source .`
  - linux: PASS 11274/11274
  - macos: PASS 11274/11274

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [x] N/A (not runtime-specific)

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue — no additions or removals

## Documentation

- [x] No user-facing docs impact (internal reliability infrastructure)

## Checklist

- [x] Issue linked above with `Closes #NNN`
- [x] Linked issue has the `approved-enhancement` label
- [x] All existing tests pass
- [x] New tests cover enhanced behavior
- [x] `no-changelog` label applied

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/get-shit-done-redux/pr/333"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782399953&installation_id=134682257&pr_number=333&repository=open-gsd%2Fget-shit-done-redux&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fget-shit-done-redux%2Fpull%2F333&signature=3b78e9e725c3dcc28e3e19407117c7f6fef21ee5b2e7f88123f89fe7383144b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->