### PR TITLE
test: add cross-platform test run module

### DIFF
--- a/scripts/run-cross-platform-tests.cjs
+++ b/scripts/run-cross-platform-tests.cjs
@@ -1,0 +1,63 @@
+'use strict';
+
+const { spawnSync } = require('child_process');
+
+const CROSS_PLATFORM_TEST_REASON = Object.freeze({
+  PASS: 'pass',
+  TEST_FAILURE: 'test_failure',
+  INFRA_FAILURE: 'infra_failure',
+  UNKNOWN_FAILURE: 'unknown_failure',
+});
+
+function classify(exitCode, output) {
+  if (exitCode === 0) return CROSS_PLATFORM_TEST_REASON.PASS;
+  if (exitCode === 2 || /infrastructure failure|worktree\.Construct/i.test(output)) {
+    return CROSS_PLATFORM_TEST_REASON.INFRA_FAILURE;
+  }
+  if (/\bFAIL\b|\d+\s+failures?\)/i.test(output)) {
+    return CROSS_PLATFORM_TEST_REASON.TEST_FAILURE;
+  }
+  return CROSS_PLATFORM_TEST_REASON.UNKNOWN_FAILURE;
+}
+
+function runCrossPlatformTests(options = {}, deps = {}) {
+  const {
+    base = 'next',
+    head = 'HEAD',
+    source = '.',
+    targets = 'linux,macos',
+    cwd = process.cwd(),
+  } = options;
+  const runner = deps.spawnSync || spawnSync;
+
+  const args = ['--targets', targets, '--base', base, '--head', head, '--source', source];
+  const result = runner('gsd-test', args, { cwd, encoding: 'utf8' });
+
+  const stdout = result.stdout || '';
+  const stderr = result.stderr || '';
+  const output = `${stdout}\n${stderr}`;
+  const exitCode = Number(result.status ?? 1);
+  const reason = classify(exitCode, output);
+
+  return {
+    ok: exitCode === 0,
+    reason,
+    exitCode,
+    command: ['gsd-test', ...args].join(' '),
+    stdout,
+    stderr,
+  };
+}
+
+if (require.main === module) {
+  const result = runCrossPlatformTests();
+  const line = `[cross-platform-tests] reason=${result.reason} exit=${result.exitCode}`;
+  if (result.ok) {
+    process.stdout.write(`${line}\n`);
+    process.exit(0);
+  }
+  process.stderr.write(`${line}\n`);
+  process.exit(result.exitCode);
+}
+
+module.exports = { CROSS_PLATFORM_TEST_REASON, runCrossPlatformTests };

--- a/tests/run-cross-platform-tests.test.cjs
+++ b/tests/run-cross-platform-tests.test.cjs
@@ -1,0 +1,46 @@
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { CROSS_PLATFORM_TEST_REASON, runCrossPlatformTests } = require('../scripts/run-cross-platform-tests.cjs');
+
+describe('run cross-platform tests module', () => {
+  test('returns pass reason on zero exit', () => {
+    const out = runCrossPlatformTests({}, {
+      spawnSync: () => ({ status: 0, stdout: 'ok', stderr: '' }),
+    });
+    assert.strictEqual(out.ok, true);
+    assert.strictEqual(out.reason, CROSS_PLATFORM_TEST_REASON.PASS);
+    assert.ok(out.command.includes('--base next'));
+  });
+
+  test('classifies infrastructure failure', () => {
+    const out = runCrossPlatformTests({}, {
+      spawnSync: () => ({ status: 2, stdout: '', stderr: 'infrastructure failure' }),
+    });
+    assert.strictEqual(out.ok, false);
+    assert.strictEqual(out.reason, CROSS_PLATFORM_TEST_REASON.INFRA_FAILURE);
+  });
+
+  test('classifies test failure from FAIL marker', () => {
+    const out = runCrossPlatformTests({}, {
+      spawnSync: () => ({ status: 1, stdout: 'linux FAIL 1/2 tests (1 failures)', stderr: '' }),
+    });
+    assert.strictEqual(out.ok, false);
+    assert.strictEqual(out.reason, CROSS_PLATFORM_TEST_REASON.TEST_FAILURE);
+  });
+
+  test('passes options through to command args', () => {
+    let cmd = null;
+    let args = null;
+    runCrossPlatformTests({ base: 'main', head: 'abc123', source: '/tmp/x', targets: 'linux' }, {
+      spawnSync: (c, a) => {
+        cmd = c;
+        args = a;
+        return { status: 0, stdout: '', stderr: '' };
+      },
+    });
+
+    assert.strictEqual(cmd, 'gsd-test');
+    assert.deepStrictEqual(args, ['--targets', 'linux', '--base', 'main', '--head', 'abc123', '--source', '/tmp/x']);
+  });
+});


### PR DESCRIPTION
## Enhancement PR

## Linked Issue

Closes #334

## What this enhancement improves

Adds a Cross-Platform Test Run Module that standardizes `gsd-test` invocation and returns typed gate semantics for reliability-oriented automation.

## Before / After

**Before:**
- Cross-platform run invocation shape and interpretation were ad hoc.

**After:**
- Added `scripts/run-cross-platform-tests.cjs` with:
  - stable command contract (`--targets`, `--base`, `--head`, `--source`)
  - typed reason classification (`pass`, `test_failure`, `infra_failure`, `unknown_failure`)
- Added unit tests for pass-through args and reason mapping.

## How it was implemented

- New module: `scripts/run-cross-platform-tests.cjs`
- New tests: `tests/run-cross-platform-tests.test.cjs`

## Testing

### How I verified the enhancement works

- `npm run lint:tests`
- `node --test tests/run-cross-platform-tests.test.cjs`
- `gsd-test --targets linux,macos --base next --head HEAD --source .`
  - linux: PASS 11274/11274
  - macos: PASS 11274/11274

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [x] N/A (not runtime-specific)

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue — no additions or removals

## Documentation

- [x] No user-facing docs impact (internal reliability infrastructure)

## Checklist

- [x] Issue linked above with `Closes #NNN`
- [x] Linked issue has the `approved-enhancement` label
- [x] All existing tests pass
- [x] New tests cover enhanced behavior
- [x] `no-changelog` label applied

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/get-shit-done-redux/pr/335"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782400101&installation_id=134682257&pr_number=335&repository=open-gsd%2Fget-shit-done-redux&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fget-shit-done-redux%2Fpull%2F335&signature=294575ff597aae99da561f4e82562b20cd0a493da690d50cead91bcb53af1c07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->