### PR TITLE
test: add generator freshness reliability module

### DIFF
--- a/scripts/generator-freshness-contract.cjs
+++ b/scripts/generator-freshness-contract.cjs
@@ -1,0 +1,31 @@
+'use strict';
+
+const GENERATOR_FRESHNESS_REASON = Object.freeze({
+  FRESH: 'fresh',
+  STALE: 'stale',
+  MISSING_SOURCE: 'missing_source',
+  MISSING_GENERATED: 'missing_generated',
+});
+
+/**
+ * Compare source and generated artifacts by content hash-equivalence contract.
+ * @param {{source?:string, generated?:string}} input
+ * @returns {{ok:boolean, reason:string}}
+ */
+function evaluateGeneratorFreshness(input) {
+  const source = input?.source;
+  const generated = input?.generated;
+
+  if (typeof source !== 'string') {
+    return { ok: false, reason: GENERATOR_FRESHNESS_REASON.MISSING_SOURCE };
+  }
+  if (typeof generated !== 'string') {
+    return { ok: false, reason: GENERATOR_FRESHNESS_REASON.MISSING_GENERATED };
+  }
+  if (source === generated) {
+    return { ok: true, reason: GENERATOR_FRESHNESS_REASON.FRESH };
+  }
+  return { ok: false, reason: GENERATOR_FRESHNESS_REASON.STALE };
+}
+
+module.exports = { GENERATOR_FRESHNESS_REASON, evaluateGeneratorFreshness };

--- a/tests/generator-freshness-contract.test.cjs
+++ b/tests/generator-freshness-contract.test.cjs
@@ -1,0 +1,29 @@
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  GENERATOR_FRESHNESS_REASON,
+  evaluateGeneratorFreshness,
+} = require('../scripts/generator-freshness-contract.cjs');
+
+describe('generator freshness contract module', () => {
+  test('fresh when source and generated match exactly', () => {
+    const out = evaluateGeneratorFreshness({ source: 'abc', generated: 'abc' });
+    assert.deepStrictEqual(out, { ok: true, reason: GENERATOR_FRESHNESS_REASON.FRESH });
+  });
+
+  test('stale when source and generated differ', () => {
+    const out = evaluateGeneratorFreshness({ source: 'abc', generated: 'abd' });
+    assert.deepStrictEqual(out, { ok: false, reason: GENERATOR_FRESHNESS_REASON.STALE });
+  });
+
+  test('missing_source when source omitted', () => {
+    const out = evaluateGeneratorFreshness({ generated: 'abc' });
+    assert.deepStrictEqual(out, { ok: false, reason: GENERATOR_FRESHNESS_REASON.MISSING_SOURCE });
+  });
+
+  test('missing_generated when generated omitted', () => {
+    const out = evaluateGeneratorFreshness({ source: 'abc' });
+    assert.deepStrictEqual(out, { ok: false, reason: GENERATOR_FRESHNESS_REASON.MISSING_GENERATED });
+  });
+});


### PR DESCRIPTION
## Enhancement PR

## Linked Issue

Closes #336

## What this enhancement improves

Adds a shared Generator Freshness Reliability Module so freshness semantics are centralized and reusable.

## Before / After

**Before:**
- Freshness semantics were repeated ad hoc in per-test assertions.

**After:**
- Added `scripts/generator-freshness-contract.cjs` with typed reasons:
  - `fresh`, `stale`, `missing_source`, `missing_generated`
- Added contract tests in `tests/generator-freshness-contract.test.cjs`.

## How it was implemented

- New module: `scripts/generator-freshness-contract.cjs`
- New tests: `tests/generator-freshness-contract.test.cjs`

## Testing

### How I verified the enhancement works

- `npm run lint:tests`
- `node --test tests/generator-freshness-contract.test.cjs`
- `gsd-test --targets linux,macos --base next --head HEAD --source .`
  - linux: PASS 11274/11274
  - macos: PASS 11274/11274

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [x] N/A (not runtime-specific)

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue — no additions or removals

## Documentation

- [x] No user-facing docs impact (internal reliability infrastructure)

## Checklist

- [x] Issue linked above with `Closes #NNN`
- [x] Linked issue has the `approved-enhancement` label
- [x] All existing tests pass
- [x] New tests cover enhanced behavior
- [x] `no-changelog` label applied

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/get-shit-done-redux/pr/337"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782400280&installation_id=134682257&pr_number=337&repository=open-gsd%2Fget-shit-done-redux&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fget-shit-done-redux%2Fpull%2F337&signature=8041654fdc4e4984b7c7bca9fdd29f7c5c81692327d06e96bac58adc50a9ca03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->