### PR TITLE
fix(#341): restore next-based test gate regressions

### DIFF
--- a/.changeset/fix-next-gate-regressions.md
+++ b/.changeset/fix-next-gate-regressions.md
@@ -1,5 +1,5 @@
 ---
-"@opengsd/get-shit-done-redux": patch
+type: Fixed
+pr: 342
 ---
-
-Fix next-branch test-gate regressions by wiring the active workstream resolver correctly, exposing `verify codebase-drift` alias routing, and syncing inventory documentation/manifests.
+Restore next-branch gate stability by wiring `gsd-tools` to the exported active-workstream resolver, exposing `verify codebase-drift` via command aliases, and syncing inventory docs/manifests to shipped CLI surfaces.

--- a/.changeset/fix-next-gate-regressions.md
+++ b/.changeset/fix-next-gate-regressions.md
@@ -1,0 +1,5 @@
+---
+"@opengsd/get-shit-done-redux": patch
+---
+
+Fix next-branch test-gate regressions by wiring the active workstream resolver correctly, exposing `verify codebase-drift` alias routing, and syncing inventory documentation/manifests.

--- a/docs/INVENTORY-MANIFEST.json
+++ b/docs/INVENTORY-MANIFEST.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-05-25",
+  "generated": "2026-05-26",
   "families": {
     "agents": [
       "gsd-advisor-researcher",
@@ -268,6 +268,7 @@
       "clusters.cjs",
       "code-review-flags.cjs",
       "command-aliases.cjs",
+      "command-arg-projection.cjs",
       "command-routing-hub.cjs",
       "commands.cjs",
       "config-schema.cjs",

--- a/docs/INVENTORY.md
+++ b/docs/INVENTORY.md
@@ -362,7 +362,7 @@ The `gsd-planner` agent is decomposed into a core agent plus reference modules t
 
 ---
 
-## CLI Modules (71 shipped)
+## CLI Modules (72 shipped)
 
 Full listing: `get-shit-done/bin/lib/*.cjs`.
 
@@ -376,6 +376,7 @@ Full listing: `get-shit-done/bin/lib/*.cjs`.
 | `clusters.cjs` | Skill cluster definitions for the runtime surface module (ADR-0011 Phase 2) |
 | `code-review-flags.cjs` | Typed flag parser for `/gsd:code-review`; exports `parseCodeReviewFlags(argv)` (→ `{ fix, all, auto, depth, files }`) and `resolveCodeReviewWorkflow(flags)` (→ `'code-review.md' \| 'code-review-fix.md'`); canonical dispatch seam for `--fix`/`--all`/`--auto` routing |
 | `command-aliases.cjs` | Alias/subcommand metadata for manifest-backed family routers |
+| `command-arg-projection.cjs` | Typed flag and positional argument projection helpers shared across command-family routers |
 | `command-routing-hub.cjs` | Pure-result dispatch hub that centralizes mode decision (SDK vs CJS), error taxonomy, and no-throw contract for all command-family routers (#3788) |
 | `commands.cjs` | Misc CLI commands (slug, timestamp, todos, scaffolding, stats) |
 | `config-schema.cjs` | Single source of truth for `VALID_CONFIG_KEYS` and dynamic key patterns; imported by both the validator and the config-schema-docs parity test |

--- a/get-shit-done/bin/gsd-tools.cjs
+++ b/get-shit-done/bin/gsd-tools.cjs
@@ -170,7 +170,7 @@ const path = require('path');
 const core = require('./lib/core.cjs');
 const { error, findProjectRoot, ERROR_REASON } = core;
 const { getActiveWorkstream } = require('./lib/planning-workspace.cjs');
-const { resolveActiveWorkstreamContext, applyResolvedWorkstreamEnv } = require('./lib/active-workstream-store.cjs');
+const { resolveActiveWorkstream, applyResolvedWorkstreamEnv } = require('./lib/active-workstream-store.cjs');
 const state = require('./lib/state.cjs');
 const phase = require('./lib/phase.cjs');
 const roadmap = require('./lib/roadmap.cjs');
@@ -290,7 +290,7 @@ async function main() {
   let ws = null;
   let workstreamContext = null;
   try {
-    workstreamContext = resolveActiveWorkstreamContext(cwd, args, process.env, {
+    workstreamContext = resolveActiveWorkstream(cwd, args, process.env, {
       getStored: getActiveWorkstream,
     });
     ws = workstreamContext.ws;

--- a/get-shit-done/bin/lib/command-aliases.cjs
+++ b/get-shit-done/bin/lib/command-aliases.cjs
@@ -230,6 +230,14 @@ const VERIFY_COMMAND_ALIASES = [
     ],
     "subcommand": "schema-drift",
     "mutation": false
+  },
+  {
+    "canonical": "verify.codebase-drift",
+    "aliases": [
+      "verify codebase-drift"
+    ],
+    "subcommand": "codebase-drift",
+    "mutation": false
   }
 ];
 


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

> **Required.** This PR will be auto-closed if no valid issue link is found.

Fixes #341

> The linked issue must have the `confirmed-bug` label. If it doesn't, ask a maintainer to confirm the bug before continuing.

---

## What was broken

`gsd-test-summary --both --base next` failed with broad command-surface regressions, including a runtime function-name mismatch in `gsd-tools`, missing `verify codebase-drift` alias routing, and inventory docs/manifest drift.

## What this fix does

- Switches `gsd-tools` to the exported active workstream resolver (`resolveActiveWorkstream`).
- Exposes `verify codebase-drift` through `VERIFY_COMMAND_ALIASES` so router dispatch works.
- Updates `docs/INVENTORY.md` and regenerates `docs/INVENTORY-MANIFEST.json` to match shipped surfaces.

## Root cause

Three independent drifts accumulated on `next`:
1. Interface drift between `gsd-tools.cjs` and `active-workstream-store.cjs` (`resolveActiveWorkstreamContext` vs exported `resolveActiveWorkstream`).
2. Command-surface drift where implementation existed (`verify codebase-drift`) but alias registry omitted it.
3. Documentation/manifests not regenerated after CLI surface changes.

## Testing

### How I verified the fix

```bash
node --test tests/agent-install-validation.test.cjs tests/bug-1736-local-install-commands.test.cjs tests/4-phase-complete-cjs-regression.test.cjs
node --test tests/drift-detection.test.cjs tests/inventory-counts.test.cjs tests/inventory-manifest-sync.test.cjs
gsd-test-summary --both --base next
```

`gsd-test-summary --both --base next` result:

- Docker: **0 failed**
- Mac: **0 failed**

### Regression test added?

- [x] Yes — existing regression suites for alias routing and inventory parity now pass against `next`:
  - `tests/drift-detection.test.cjs` (`verify codebase-drift` CLI coverage)
  - `tests/inventory-counts.test.cjs`
  - `tests/inventory-manifest-sync.test.cjs`
- [ ] No — explain why:

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/get-shit-done-redux/pr/342"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782409516&installation_id=134682257&pr_number=342&repository=open-gsd%2Fget-shit-done-redux&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fget-shit-done-redux%2Fpull%2F342&signature=8367e3b046f3da651aac03a48aa7b892671d150a02fc07d70e381a23d315e2de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->