### PR TITLE
fix: replace removed gsd-sdk prompt references

### DIFF
--- a/.changeset/nimble-wolves-dart.md
+++ b/.changeset/nimble-wolves-dart.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 355
+---
+Replace shipped gsd-sdk query prompt references with the supported gsd-tools query binary.

--- a/agents/gsd-code-fixer.md
+++ b/agents/gsd-code-fixer.md
@@ -454,9 +454,9 @@ For each finding in sorted order:
 
 **If verification passed:**
 
-Use `gsd-sdk query commit` with conventional format (message first, then every staged file path):
+Use `gsd-tools query commit` with conventional format (message first, then every staged file path):
 ```bash
-gsd-sdk query commit \
+gsd-tools query commit \
   "fix({padded_phase}): {finding_id} {short_description}" \
   --files \
   {all_modified_files}
@@ -468,7 +468,7 @@ Examples:
 
 **Multiple files:** List ALL modified files after the message (space-separated):
 ```bash
-gsd-sdk query commit "fix(02): CR-01 ..." --files \
+gsd-tools query commit "fix(02): CR-01 ..." --files \
   src/api/auth.ts src/types/user.ts tests/auth.test.ts
 ```
 

--- a/agents/gsd-debug-session-manager.md
+++ b/agents/gsd-debug-session-manager.md
@@ -93,7 +93,7 @@ Agent(
 
 Resolve the debugger model before spawning:
 ```bash
-debugger_model=$(gsd-sdk query resolve-model gsd-debugger 2>/dev/null | jq -r '.model' 2>/dev/null || true)
+debugger_model=$(gsd-tools query resolve-model gsd-debugger 2>/dev/null | jq -r '.model' 2>/dev/null || true)
 ```
 
 ## Step 3: Handle Agent Return

--- a/agents/gsd-debugger.md
+++ b/agents/gsd-debugger.md
@@ -1150,7 +1150,7 @@ mv .planning/debug/{slug}.md .planning/debug/resolved/
 **Check planning config using state load (commit_docs is available from the output):**
 
 ```bash
-INIT=$(gsd-sdk query state.load)
+INIT=$(gsd-tools query state.load)
 if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
 # commit_docs is in the JSON output
 ```
@@ -1168,7 +1168,7 @@ Root cause: {root_cause}"
 
 Then commit planning docs via CLI (respects `commit_docs` config automatically):
 ```bash
-gsd-sdk query commit "docs: resolve debug {slug}" --files .planning/debug/resolved/{slug}.md
+gsd-tools query commit "docs: resolve debug {slug}" --files .planning/debug/resolved/{slug}.md
 ```
 
 **Append to knowledge base:**
@@ -1199,7 +1199,7 @@ Then append the entry:
 
 Commit the knowledge base update alongside the resolved session:
 ```bash
-gsd-sdk query commit "docs: update debug knowledge base with {slug}" --files .planning/debug/knowledge-base.md
+gsd-tools query commit "docs: update debug knowledge base with {slug}" --files .planning/debug/knowledge-base.md
 ```
 
 Report completion and offer next steps.

--- a/agents/gsd-executor.md
+++ b/agents/gsd-executor.md
@@ -73,7 +73,7 @@ Before executing, discover project context:
 Load execution context:
 
 ```bash
-INIT=$(gsd-sdk query init.execute-phase "${PHASE}")
+INIT=$(gsd-tools query init.execute-phase "${PHASE}")
 if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
 ```
 
@@ -81,10 +81,8 @@ Extract from init JSON: `executor_model`, `commit_docs`, `sub_repos`, `phase_dir
 
 Also load planning state (position, decisions, blockers) via the SDK — **use `node` to invoke the CLI** (not `npx`):
 ```bash
-gsd-sdk query state.load 2>/dev/null
+gsd-tools query state.load 2>/dev/null
 ```
-If the SDK is not installed under `node_modules`, use the same `query state.load` argv with your local `gsd-sdk` CLI on `PATH`.
-
 If STATE.md missing but .planning/ exists: offer to reconstruct or continue without.
 If .planning/ missing: Error — project not initialized.
 </step>
@@ -273,8 +271,8 @@ Do NOT continue reading. Analysis without action is a stuck signal.
 Check if auto mode is active at executor start (chain flag or user preference):
 
 ```bash
-AUTO_CHAIN=$(gsd-sdk query config-get workflow._auto_chain_active 2>/dev/null || echo "false")
-AUTO_CFG=$(gsd-sdk query config-get workflow.auto_advance 2>/dev/null || echo "false")
+AUTO_CHAIN=$(gsd-tools query config-get workflow._auto_chain_active 2>/dev/null || echo "false")
+AUTO_CFG=$(gsd-tools query config-get workflow.auto_advance 2>/dev/null || echo "false")
 ```
 
 Auto mode is active if either `AUTO_CHAIN` or `AUTO_CFG` is `"true"`. Store the result for checkpoint handling below.
@@ -399,7 +397,7 @@ If RED or GREEN gate commits are missing, add a warning to SUMMARY.md under a `#
 **Behavior-Adding Task detection** (the gate only fires when this predicate returns true): apply via the centralized verb instead of inlining the three checks:
 
 ```bash
-IS_BEHAVIOR_ADDING=$(gsd-sdk query task.is-behavior-adding "$TASK_FILE" --pick is_behavior_adding)
+IS_BEHAVIOR_ADDING=$(gsd-tools query task.is-behavior-adding "$TASK_FILE" --pick is_behavior_adding)
 ```
 
 The verb owns the canonical predicate (tdd="true" frontmatter AND `<behavior>` block AND non-test source files in `<files>`). Pure doc-only / config-only / test-only tasks return `false` and are exempt. Full result also exposes per-check breakdown (`checks.tdd_true`, `checks.has_behavior_block`, `checks.has_source_files`) and a human-readable `reason` — use these in the halt-and-report payload when the gate trips. See `references/execute-mvp-tdd.md` for halt protocol.
@@ -499,7 +497,7 @@ git add src/types/user.ts
 
 **If `sub_repos` is configured (non-empty array from init context):** Use `commit-to-subrepo` to route files to their correct sub-repo:
 ```bash
-gsd-sdk query commit-to-subrepo "{type}({phase}-{plan}): {concise task description}" --files file1 file2 ...
+gsd-tools query commit-to-subrepo "{type}({phase}-{plan}): {concise task description}" --files file1 file2 ...
 ```
 Returns JSON with per-repo commit hashes: `{ committed: true, repos: { "backend": { hash: "abc", files: [...] }, ... } }`. Record all hashes for SUMMARY.
 
@@ -659,36 +657,36 @@ Do NOT skip. Do NOT proceed to state updates if self-check fails.
 </self_check>
 
 <state_updates>
-After SUMMARY.md, update STATE.md using `gsd-sdk query` state handlers (positional args; see `sdk/src/query/QUERY-HANDLERS.md`):
+After SUMMARY.md, update STATE.md using `gsd-tools query` state handlers (positional args; see `sdk/src/query/QUERY-HANDLERS.md`):
 
 ```bash
 # Advance plan counter (handles edge cases automatically)
-gsd-sdk query state.advance-plan
+gsd-tools query state.advance-plan
 
 # Recalculate progress bar from disk state
-gsd-sdk query state.update-progress
+gsd-tools query state.update-progress
 
 # Record execution metrics (phase, plan, duration, tasks, files)
-gsd-sdk query state.record-metric \
+gsd-tools query state.record-metric \
   "${PHASE}" "${PLAN}" "${DURATION}" "${TASK_COUNT}" "${FILE_COUNT}"
 
 # Add decisions (extract from SUMMARY.md key-decisions)
 for decision in "${DECISIONS[@]}"; do
-  gsd-sdk query state.add-decision "${decision}"
+  gsd-tools query state.add-decision "${decision}"
 done
 
 # Update session info (timestamp, stopped-at, resume-file)
-gsd-sdk query state.record-session \
+gsd-tools query state.record-session \
   "" "Completed ${PHASE}-${PLAN}-PLAN.md" "None"
 ```
 
 ```bash
 # Update ROADMAP.md progress for this phase (plan counts, status)
-gsd-sdk query roadmap.update-plan-progress "${PHASE_NUMBER}"
+gsd-tools query roadmap.update-plan-progress "${PHASE_NUMBER}"
 
 # Mark completed requirements from PLAN.md frontmatter
 # Extract the `requirements` array from the plan's frontmatter, then mark each complete
-gsd-sdk query requirements.mark-complete ${REQ_IDS}
+gsd-tools query requirements.mark-complete ${REQ_IDS}
 ```
 
 **Requirement IDs:** Extract from the PLAN.md frontmatter `requirements:` field (e.g., `requirements: [AUTH-01, AUTH-02]`). Pass all IDs to `requirements mark-complete`. If the plan has no requirements field, skip this step.
@@ -706,19 +704,19 @@ gsd-sdk query requirements.mark-complete ${REQ_IDS}
 
 **For blockers found during execution:**
 ```bash
-gsd-sdk query state.add-blocker "Blocker description"
+gsd-tools query state.add-blocker "Blocker description"
 ```
 </state_updates>
 
 <final_commit>
 ```bash
-gsd-sdk query commit "docs({phase}-{plan}): complete [plan-name] plan" --files \
+gsd-tools query commit "docs({phase}-{plan}): complete [plan-name] plan" --files \
   .planning/phases/XX-name/{phase}-{plan}-SUMMARY.md .planning/STATE.md .planning/ROADMAP.md .planning/REQUIREMENTS.md
 ```
 
 Separate from per-task commits — captures execution results only.
 
-**Handling the SDK return envelope (#3678):** `gsd-sdk query commit` returns
+**Handling the SDK return envelope (#3678):** `gsd-tools query commit` returns
 one of three shapes:
 
 - `{committed: true, hash, reason: 'committed'}` — commit succeeded; record

--- a/agents/gsd-phase-researcher.md
+++ b/agents/gsd-phase-researcher.md
@@ -163,7 +163,7 @@ When researching "best library for X": find what the ecosystem actually uses, do
 Check `brave_search` from init context. If `true`, use Brave Search for higher quality results:
 
 ```bash
-gsd-sdk query websearch "your query" --limit 10
+gsd-tools query websearch "your query" --limit 10
 ```
 
 **Options:**
@@ -595,7 +595,7 @@ Orchestrator provides: phase number/name, description/goal, requirements, constr
 
 Load phase context using init command:
 ```bash
-INIT=$(gsd-sdk query init.phase-op "${PHASE}")
+INIT=$(gsd-tools query init.phase-op "${PHASE}")
 if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
 ```
 
@@ -842,7 +842,7 @@ Write to: `$PHASE_DIR/$PADDED_PHASE-RESEARCH.md`
 ## Step 7: Commit Research (optional)
 
 ```bash
-gsd-sdk query commit "docs($PHASE): research phase domain" --files "$PHASE_DIR/$PADDED_PHASE-RESEARCH.md"
+gsd-tools query commit "docs($PHASE): research phase domain" --files "$PHASE_DIR/$PADDED_PHASE-RESEARCH.md"
 ```
 
 ## Step 8: Return Structured Result

--- a/agents/gsd-plan-checker.md
+++ b/agents/gsd-plan-checker.md
@@ -646,7 +646,7 @@ issue:
 
 Load phase operation context:
 ```bash
-INIT=$(gsd-sdk query init.phase-op "${PHASE_ARG}")
+INIT=$(gsd-tools query init.phase-op "${PHASE_ARG}")
 if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
 ```
 
@@ -655,23 +655,23 @@ Extract from init JSON: `phase_dir`, `phase_number`, `has_plans`, `plan_count`.
 Orchestrator provides CONTEXT.md content in the verification prompt. If provided, parse for locked decisions, discretion areas, deferred ideas.
 
 ```bash
-gsd-sdk query phase.list-plans "$phase_number"
+gsd-tools query phase.list-plans "$phase_number"
 # Research / brief artifacts (deterministic listing)
-gsd-sdk query phase.list-artifacts "$phase_number" --type research
-gsd-sdk query roadmap.get-phase "$phase_number"
-gsd-sdk query phase.list-artifacts "$phase_number" --type summary
+gsd-tools query phase.list-artifacts "$phase_number" --type research
+gsd-tools query roadmap.get-phase "$phase_number"
+gsd-tools query phase.list-artifacts "$phase_number" --type summary
 ```
 
 **Extract:** Phase goal, requirements (decompose goal), locked decisions, deferred ideas.
 
 ## Step 2: Load All Plans
 
-Use `gsd-sdk query` to validate plan structure:
+Use `gsd-tools query` to validate plan structure:
 
 ```bash
 for plan in "$PHASE_DIR"/*-PLAN.md; do
   echo "=== $plan ==="
-  PLAN_STRUCTURE=$(gsd-sdk query verify.plan-structure "$plan")
+  PLAN_STRUCTURE=$(gsd-tools query verify.plan-structure "$plan")
   echo "$PLAN_STRUCTURE"
 done
 ```
@@ -686,10 +686,10 @@ Map errors/warnings to verification dimensions:
 
 ## Step 3: Parse must_haves
 
-Extract must_haves from each plan using `gsd-sdk query`:
+Extract must_haves from each plan using `gsd-tools query`:
 
 ```bash
-MUST_HAVES=$(gsd-sdk query frontmatter.get "$PLAN_PATH" must_haves)
+MUST_HAVES=$(gsd-tools query frontmatter.get "$PLAN_PATH" must_haves)
 ```
 
 Returns JSON: `{ truths: [...], artifacts: [...], key_links: [...] }`
@@ -734,7 +734,7 @@ For each requirement: find covering task(s), verify action is specific, flag gap
 Use `verify.plan-structure` (already run in Step 2):
 
 ```bash
-PLAN_STRUCTURE=$(gsd-sdk query verify.plan-structure "$PLAN_PATH")
+PLAN_STRUCTURE=$(gsd-tools query verify.plan-structure "$PLAN_PATH")
 ```
 
 The `tasks` array in the result shows each task's completeness:
@@ -747,7 +747,7 @@ The `tasks` array in the result shows each task's completeness:
 
 **For manual validation of specificity** (`verify.plan-structure` checks structure, not content quality), use structured extraction instead of grepping raw XML:
 ```bash
-gsd-sdk query plan.task-structure "$PLAN_PATH"
+gsd-tools query plan.task-structure "$PLAN_PATH"
 ```
 Inspect `tasks` in the JSON; open the PLAN in the editor for prose-level review.
 
@@ -774,8 +774,8 @@ Missing: No mention of fetch/API call → Issue: Key link not planned
 ## Step 8: Assess Scope
 
 ```bash
-gsd-sdk query plan.task-structure "$PHASE_DIR/$PHASE-01-PLAN.md"
-gsd-sdk query frontmatter.get "$PHASE_DIR/$PHASE-01-PLAN.md" files_modified
+gsd-tools query plan.task-structure "$PHASE_DIR/$PHASE-01-PLAN.md"
+gsd-tools query frontmatter.get "$PHASE_DIR/$PHASE-01-PLAN.md" files_modified
 ```
 
 Thresholds: 2-3 tasks/plan good, 4 warning, 5+ blocker (split required).

--- a/agents/gsd-planner.md
+++ b/agents/gsd-planner.md
@@ -771,7 +771,7 @@ start of execution when `--reviews` flag is present or reviews mode is active.
 Load planning context:
 
 ```bash
-INIT=$(gsd-sdk query init.plan-phase "${PHASE}")
+INIT=$(gsd-tools query init.plan-phase "${PHASE}")
 if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
 ```
 
@@ -779,10 +779,8 @@ Extract from init JSON: `planner_model`, `researcher_model`, `checker_model`, `c
 
 Also load planning state (position, decisions, blockers) via the SDK — **use `node` to invoke the CLI** (not `npx`):
 ```bash
-gsd-sdk query state.load 2>/dev/null
+gsd-tools query state.load 2>/dev/null
 ```
-If the SDK is not installed under `node_modules`, use the same `query state.load` argv with your local `gsd-sdk` CLI on `PATH`.
-
 If STATE.md missing but .planning/ exists, offer to reconstruct or continue without.
 </step>
 
@@ -840,7 +838,7 @@ Query the graph for phase-relevant dependency context (single query per D-06):
 node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" graphify query "<phase-goal-keyword>" --budget 2000
 ```
 
-(graphify is not exposed on `gsd-sdk query` yet; use `gsd-tools.cjs` for graphify only.)
+(graphify is not exposed on `gsd-tools query` yet; use `gsd-tools.cjs` for graphify only.)
 
 Use the keyword that best captures the phase goal. Examples:
 - Phase "User Authentication" -> query term "auth"
@@ -877,7 +875,7 @@ Apply discovery level protocol (see discovery_levels section).
 
 **Step 1 — Generate digest index:**
 ```bash
-gsd-sdk query history-digest
+gsd-tools query history-digest
 ```
 
 **Step 2 — Select relevant phases (typically 2-4):**
@@ -922,7 +920,7 @@ Read the most recent milestone retrospective and cross-milestone trends. Extract
 </step>
 
 <step name="inject_global_learnings">
-If `features.global_learnings` is `true`: run `gsd-sdk query learnings.query --tag <tag> --limit 5` once per tag from PLAN.md frontmatter `tags` (or use the single most specific keyword). The handler matches one `--tag` at a time. Prefix matches with `[Prior learning from <project>]` as weak priors. Project-local decisions take precedence. Skip silently if disabled or no matches.
+If `features.global_learnings` is `true`: run `gsd-tools query learnings.query --tag <tag> --limit 5` once per tag from PLAN.md frontmatter `tags` (or use the single most specific keyword). The handler matches one `--tag` at a time. Prefix matches with `[Prior learning from <project>]` as weak priors. Project-local decisions take precedence. Skip silently if disabled or no matches.
 </step>
 
 <step name="gather_phase_context">
@@ -1048,10 +1046,10 @@ Include all frontmatter fields.
 </step>
 
 <step name="validate_plan">
-Validate each created PLAN.md using `gsd-sdk query`:
+Validate each created PLAN.md using `gsd-tools query`:
 
 ```bash
-VALID=$(gsd-sdk query frontmatter.validate "$PLAN_PATH" --schema plan)
+VALID=$(gsd-tools query frontmatter.validate "$PLAN_PATH" --schema plan)
 ```
 
 Returns JSON: `{ valid, missing, present, schema }`
@@ -1064,7 +1062,7 @@ Required plan frontmatter fields:
 Also validate plan structure:
 
 ```bash
-STRUCTURE=$(gsd-sdk query verify.plan-structure "$PLAN_PATH")
+STRUCTURE=$(gsd-tools query verify.plan-structure "$PLAN_PATH")
 ```
 
 Returns JSON: `{ valid, errors, warnings, task_count, tasks }`
@@ -1101,7 +1099,7 @@ Plans:
 
 <step name="git_commit">
 ```bash
-gsd-sdk query commit "docs($PHASE): create phase plan" --files \
+gsd-tools query commit "docs($PHASE): create phase plan" --files \
   .planning/phases/$PHASE-*/$PHASE-*-PLAN.md .planning/ROADMAP.md
 ```
 </step>

--- a/agents/gsd-project-researcher.md
+++ b/agents/gsd-project-researcher.md
@@ -128,7 +128,7 @@ Use multiple query variations. Mark WebSearch-only findings as LOW confidence. D
 Check `brave_search` from orchestrator context. If `true`, use Brave Search for higher quality results:
 
 ```bash
-gsd-sdk query websearch "your query" --limit 10
+gsd-tools query websearch "your query" --limit 10
 ```
 
 **Options:**

--- a/agents/gsd-research-synthesizer.md
+++ b/agents/gsd-research-synthesizer.md
@@ -58,7 +58,7 @@ cat .planning/research/FEATURES.md
 cat .planning/research/ARCHITECTURE.md
 cat .planning/research/PITFALLS.md
 
-# Planning config loaded via gsd-sdk query (or gsd-tools.cjs) in commit step
+# Planning config loaded via gsd-tools query (or gsd-tools.cjs) in commit step
 ```
 
 Parse each file to extract:
@@ -147,7 +147,7 @@ Write to `.planning/research/SUMMARY.md`.
 The 4 parallel researcher agents write files but do NOT commit. You commit everything together.
 
 ```bash
-gsd-sdk query commit "docs: complete project research" --files .planning/research/
+gsd-tools query commit "docs: complete project research" --files .planning/research/
 ```
 
 ## Step 8: Return Summary

--- a/agents/gsd-roadmapper.md
+++ b/agents/gsd-roadmapper.md
@@ -560,7 +560,7 @@ When files are written and returning to orchestrator:
 
 ### Files Ready for Review
 
-User can review actual files in the editor or via SDK queries (e.g. `gsd-sdk query roadmap.analyze` and `gsd-sdk query state.load`) instead of ad-hoc shell `cat`.
+User can review actual files in the editor or via SDK queries (e.g. `gsd-tools query roadmap.analyze` and `gsd-tools query state.load`) instead of ad-hoc shell `cat`.
 
 {If gaps found during creation:}
 

--- a/agents/gsd-ui-researcher.md
+++ b/agents/gsd-ui-researcher.md
@@ -292,7 +292,7 @@ Fill all sections. Write to `$PHASE_DIR/$PADDED_PHASE-UI-SPEC.md`.
 ## Step 6: Commit (optional)
 
 ```bash
-gsd-sdk query commit "docs($PHASE): UI design contract" --files "$PHASE_DIR/$PADDED_PHASE-UI-SPEC.md"
+gsd-tools query commit "docs($PHASE): UI design contract" --files "$PHASE_DIR/$PADDED_PHASE-UI-SPEC.md"
 ```
 
 ## Step 7: Return Structured Result

--- a/agents/gsd-verifier.md
+++ b/agents/gsd-verifier.md
@@ -101,7 +101,7 @@ Set `is_re_verification = false`, proceed with Step 1.
 ```bash
 ls "$PHASE_DIR"/*-PLAN.md 2>/dev/null
 ls "$PHASE_DIR"/*-SUMMARY.md 2>/dev/null
-gsd-sdk query roadmap.get-phase "$PHASE_NUM"
+gsd-tools query roadmap.get-phase "$PHASE_NUM"
 grep -E "^| $PHASE_NUM" .planning/REQUIREMENTS.md 2>/dev/null
 ```
 
@@ -114,7 +114,7 @@ In re-verification mode, must-haves come from Step 0.
 **Step 2a: Always load ROADMAP Success Criteria**
 
 ```bash
-PHASE_DATA=$(gsd-sdk query roadmap.get-phase "$PHASE_NUM" --raw)
+PHASE_DATA=$(gsd-tools query roadmap.get-phase "$PHASE_NUM" --raw)
 ```
 
 Parse the `success_criteria` array from the JSON output. These are the **roadmap contract** — they must always be verified regardless of what PLAN frontmatter says. Store them as `roadmap_truths`.
@@ -216,10 +216,10 @@ overrides:
 
 ## Step 4: Verify Artifacts (Three Levels)
 
-Use `gsd-sdk query` for artifact verification against must_haves in PLAN frontmatter:
+Use `gsd-tools query` for artifact verification against must_haves in PLAN frontmatter:
 
 ```bash
-ARTIFACT_RESULT=$(gsd-sdk query verify.artifacts "$PLAN_PATH")
+ARTIFACT_RESULT=$(gsd-tools query verify.artifacts "$PLAN_PATH")
 ```
 
 Parse JSON result: `{ all_passed, passed, total, artifacts: [{path, exists, issues, passed}] }`
@@ -322,10 +322,10 @@ grep -r -A 3 "<${COMPONENT_NAME}" "${search_path:-src/}" --include="*.tsx" 2>/de
 
 Key links are critical connections. If broken, the goal fails even with all artifacts present.
 
-Use `gsd-sdk query` for key link verification against must_haves in PLAN frontmatter:
+Use `gsd-tools query` for key link verification against must_haves in PLAN frontmatter:
 
 ```bash
-LINKS_RESULT=$(gsd-sdk query verify.key-links "$PLAN_PATH")
+LINKS_RESULT=$(gsd-tools query verify.key-links "$PLAN_PATH")
 ```
 
 Parse JSON result: `{ all_verified, verified, total, links: [{from, to, via, verified, detail}] }`
@@ -407,12 +407,12 @@ Identify files modified in this phase from SUMMARY.md key-files section, or extr
 
 ```bash
 # Option 1: Extract from SUMMARY frontmatter
-SUMMARY_FILES=$(gsd-sdk query summary-extract "$PHASE_DIR"/*-SUMMARY.md --fields key-files)
+SUMMARY_FILES=$(gsd-tools query summary-extract "$PHASE_DIR"/*-SUMMARY.md --fields key-files)
 
 # Option 2: Verify commits exist (if commit hashes documented)
 COMMIT_HASHES=$(grep -oE "[a-f0-9]{7,40}" "$PHASE_DIR"/*-SUMMARY.md | head -10)
 if [ -n "$COMMIT_HASHES" ]; then
-  COMMITS_VALID=$(gsd-sdk query verify.commits $COMMIT_HASHES)
+  COMMITS_VALID=$(gsd-tools query verify.commits $COMMIT_HASHES)
 fi
 
 # Fallback: grep for files
@@ -581,7 +581,7 @@ Before reporting gaps, check if any identified gaps are explicitly addressed in 
 **Load the full milestone roadmap:**
 
 ```bash
-ROADMAP_DATA=$(gsd-sdk query roadmap.analyze --raw)
+ROADMAP_DATA=$(gsd-tools query roadmap.analyze --raw)
 ```
 
 Parse the JSON to extract all phases. Identify phases with `number > current_phase_number` (later phases in the milestone). For each later phase, extract its `goal` and `success_criteria`.
@@ -656,7 +656,7 @@ Deferred items are informational only — they do not require closure plans.
 **User Story format guard:** Apply via the centralized verb instead of inlining the regex:
 
 ```bash
-USER_STORY_VALID=$(gsd-sdk query user-story.validate --story "$PHASE_GOAL" --pick valid)
+USER_STORY_VALID=$(gsd-tools query user-story.validate --story "$PHASE_GOAL" --pick valid)
 ```
 
 If `valid != true`, refuse to verify. Surface the discrepancy and ask the user to run `/gsd mvp-phase ${PHASE}` to set a proper User Story goal. The verb owns the canonical regex `/^As a .+, I want to .+, so that .+\.$/` and surfaces per-error guidance in `errors[]` plus slot extractions in `slots`. Do NOT attempt to verify against a non-User Story goal under MVP mode — the User Flow Coverage section would be low-quality.

--- a/commands/gsd/autonomous.md
+++ b/commands/gsd/autonomous.md
@@ -37,7 +37,7 @@ Optional flags:
 - `--only N` — execute only phase N (single-phase mode).
 - `--interactive` — run discuss inline with questions (not auto-answered), then dispatch plan→execute as background agents. Keeps the main context lean while preserving user input on decisions.
 
-Project context, phase list, and state are resolved inside the workflow using init commands (`gsd-sdk query init.milestone-op`, `gsd-sdk query roadmap.analyze`). No upfront context loading needed.
+Project context, phase list, and state are resolved inside the workflow using init commands (`gsd-tools query init.milestone-op`, `gsd-tools query roadmap.analyze`). No upfront context loading needed.
 </context>
 
 <process>

--- a/commands/gsd/code-review.md
+++ b/commands/gsd/code-review.md
@@ -41,7 +41,7 @@ Optional flags parsed from $ARGUMENTS:
 - `--depth=VALUE` — Depth override (quick|standard|deep). If provided, overrides workflow.code_review_depth config.
 - `--files=file1,file2,...` — Explicit file list override. Has highest precedence for file scoping per D-08. When provided, workflow skips SUMMARY.md extraction and git diff fallback entirely.
 
-Context files (CLAUDE.md, SUMMARY.md, phase state) are resolved inside the workflow via `gsd-sdk query init.phase-op` and delegated to agent via `<files_to_read>` blocks.
+Context files (CLAUDE.md, SUMMARY.md, phase state) are resolved inside the workflow via `gsd-tools query init.phase-op` and delegated to agent via `<files_to_read>` blocks.
 </context>
 
 <process>

--- a/commands/gsd/config.md
+++ b/commands/gsd/config.md
@@ -27,7 +27,7 @@ Mode routing:
 | (none) | Interactive 5-question common-case config prompt | settings |
 | --advanced | Power-user knobs: planning, execution, discussion, cross-AI, git, runtime | settings-advanced |
 | --integrations | API keys (Brave/Firecrawl/Exa), review CLI routing, agent skills | settings-integrations |
-| --profile &lt;name&gt; | Switch model profile without interactive prompt | gsd-sdk config-set-model-profile |
+| --profile &lt;name&gt; | Switch model profile without interactive prompt | gsd-tools query config-set-model-profile |
 
 </routing>
 
@@ -44,10 +44,8 @@ Parse the first token of $ARGUMENTS:
 - If it is `--advanced`: strip the flag, execute settings-advanced workflow
 - If it is `--integrations`: strip the flag, execute settings-integrations workflow
 - If it starts with `--profile`: extract the profile name (remainder after `--profile`), then:
-  1. **Pre-flight check (#2439):** verify `gsd-sdk` is on PATH via `command -v gsd-sdk`.
-     If absent, emit the install hint `Install GSD via 'npm i -g get-shit-done'` and stop —
-     do NOT invoke `gsd-sdk` directly (avoids the opaque `command not found: gsd-sdk` failure).
-  2. Run: `gsd-sdk query config-set-model-profile <profile-name> --raw` and display the output verbatim.
+  1. Verify `gsd-tools` is on PATH via `command -v gsd-tools`; if absent, emit the install hint `Install GSD via 'npm i -g @opengsd/get-shit-done-redux'` and stop.
+  2. Run: `gsd-tools query config-set-model-profile <profile-name> --raw` and display the output verbatim.
 - Otherwise: execute settings workflow (no argument needed)
 </context>
 

--- a/commands/gsd/discuss-phase.md
+++ b/commands/gsd/discuss-phase.md
@@ -47,7 +47,7 @@ Context files are resolved in-workflow using `init phase-op` and roadmap/state t
 <process>
 **Mode routing:**
 ```bash
-DISCUSS_MODE=$(gsd-sdk query config-get workflow.discuss_mode 2>/dev/null || echo "discuss")
+DISCUSS_MODE=$(gsd-tools query config-get workflow.discuss_mode 2>/dev/null || echo "discuss")
 ```
 
 If `--assumptions` is in $ARGUMENTS:

--- a/commands/gsd/execute-phase.md
+++ b/commands/gsd/execute-phase.md
@@ -55,7 +55,7 @@ Phase: $ARGUMENTS
 - If none of these tokens appear, run the standard full-phase execution flow with no flag-specific filtering
 - Do not infer that a flag is active just because it is documented in this prompt
 
-Context files are resolved inside the workflow via `gsd-sdk query init.execute-phase` and per-subagent `<files_to_read>` blocks.
+Context files are resolved inside the workflow via `gsd-tools query init.execute-phase` and per-subagent `<files_to_read>` blocks.
 </context>
 
 <process>

--- a/commands/gsd/graphify.md
+++ b/commands/gsd/graphify.md
@@ -10,7 +10,7 @@ requires: [config, fast, phase, update]
 
 **STOP -- DO NOT READ THIS FILE. You are already reading it. This prompt was injected into your context by Claude Code's command system. Using the Read tool on this file wastes tokens. Begin executing Step 0 immediately.**
 
-**CJS-only (graphify):** `graphify` subcommands are not registered on `gsd-sdk query`. Use `node $HOME/.claude/get-shit-done/bin/gsd-tools.cjs graphify …` as documented in this command and in `docs/CLI-TOOLS.md`. Other tooling may still use `gsd-sdk query` where a handler exists.
+**CJS-only (graphify):** `graphify` subcommands are not registered on `gsd-tools query`. Use `node $HOME/.claude/get-shit-done/bin/gsd-tools.cjs graphify …` as documented in this command and in `docs/CLI-TOOLS.md`. Other tooling may still use `gsd-tools query` where a handler exists.
 
 ## Step 0 -- Banner
 
@@ -179,7 +179,7 @@ If the chain succeeds:
 
 ## MVP-Mode Node Rendering
 
-**MVP-mode rendering.** When a phase has `**Mode:** mvp` in ROADMAP.md (resolved via `gsd-sdk query roadmap.get-phase --pick mode`), render its graph node with two distinct visual signals:
+**MVP-mode rendering.** When a phase has `**Mode:** mvp` in ROADMAP.md (resolved via `gsd-tools query roadmap.get-phase --pick mode`), render its graph node with two distinct visual signals:
 
 1. **Distinct fill color.** Use `#22c55e` (green) for MVP-mode phase nodes. Standard phases keep the default fill color. Two-channel signaling (color + label) handles color-blind and grayscale renders.
 2. **`MVP` label suffix.** Append ` (MVP)` to the node's label text. Example: a phase originally labeled `Phase 1: User Auth` renders as `Phase 1: User Auth (MVP)`.

--- a/commands/gsd/health.md
+++ b/commands/gsd/health.md
@@ -12,7 +12,7 @@ requires: [thread]
 <objective>
 Validate `.planning/` directory integrity and report actionable issues. Checks for missing files, invalid configurations, inconsistent state, and orphaned plans.
 
-`--context` runs an orthogonal check: the running session's context utilization. The workflow asks for the model's tokensUsed + contextWindow, calls `gsd-sdk query validate.context`, and renders one of three states:
+`--context` runs an orthogonal check: the running session's context utilization. The workflow asks for the model's tokensUsed + contextWindow, calls `gsd-tools query validate.context`, and renders one of three states:
 
 | Utilization | State    | Action                                                |
 |-------------|----------|-------------------------------------------------------|

--- a/commands/gsd/manager.md
+++ b/commands/gsd/manager.md
@@ -33,7 +33,7 @@ Designed for power users who want to parallelize work across phases from one ter
 <context>
 No arguments required. Requires an active milestone with ROADMAP.md and STATE.md.
 
-Project context, phase list, dependencies, and recommendations are resolved inside the workflow using `gsd-sdk query init.manager`. No upfront context loading needed.
+Project context, phase list, dependencies, and recommendations are resolved inside the workflow using `gsd-tools query init.manager`. No upfront context loading needed.
 </context>
 
 <process>

--- a/commands/gsd/quick.md
+++ b/commands/gsd/quick.md
@@ -72,7 +72,7 @@ For each directory found:
 - Check if PLAN.md exists
 - Check if SUMMARY.md exists; if so, read `status` from its frontmatter via:
   ```bash
-  gsd-sdk query frontmatter.get .planning/quick/{dir}/SUMMARY.md status
+  gsd-tools query frontmatter.get .planning/quick/{dir}/SUMMARY.md status
   ```
 - Determine directory creation date: `stat -f "%SB" -t "%Y-%m-%d"` (macOS) or `stat -c "%w"` (Linux); fall back to the date prefix in the directory name (format: `YYYYMMDD-` prefix)
 - Derive display status:
@@ -145,7 +145,7 @@ When SUBCMD=resume and SLUG is set (already sanitized):
 
 5. Load context via:
    ```bash
-   gsd-sdk query init.quick
+   gsd-tools query init.quick
    ```
 
 6. Proceed to execute the quick workflow with resume context, passing the slug and plan directory so the executor picks up where it left off.
@@ -170,5 +170,5 @@ Preserve all workflow gates (validation, task description, planning, execution, 
 - Slugs from $ARGUMENTS are sanitized before use in file paths: only [a-z0-9-] allowed, max 60 chars, reject ".." and "/"
 - File names from readdir/ls are sanitized before display: strip non-printable chars and ANSI sequences
 - Artifact content (plan descriptions, task titles) rendered as plain text only — never executed or passed to agent prompts without DATA_START/DATA_END boundaries
-- Status fields read via `gsd-sdk query frontmatter.get` — never eval'd or shell-expanded
+- Status fields read via `gsd-tools query frontmatter.get` — never eval'd or shell-expanded
 </security_notes>

--- a/commands/gsd/review-backlog.md
+++ b/commands/gsd/review-backlog.md
@@ -35,7 +35,7 @@ milestone sequence or remove stale entries.
    - Find the next sequential phase number in the active milestone
    - Rename the directory from `999.x-slug` to `{new_num}-slug`:
      ```bash
-     NEW_NUM=$(gsd-sdk query phase.add "${DESCRIPTION}" --raw)
+     NEW_NUM=$(gsd-tools query phase.add "${DESCRIPTION}" --raw)
      ```
    - Move accumulated artifacts to the new phase directory
    - Update ROADMAP.md: move the entry from `## Backlog` section to the active phase list
@@ -48,7 +48,7 @@ milestone sequence or remove stale entries.
 
 6. **Commit changes:**
    ```bash
-   gsd-sdk query commit "docs: review backlog — promoted N, removed M" --files .planning/ROADMAP.md
+   gsd-tools query commit "docs: review backlog — promoted N, removed M" --files .planning/ROADMAP.md
    ```
 
 7. **Report summary:**

--- a/commands/gsd/workstreams.md
+++ b/commands/gsd/workstreams.md
@@ -35,30 +35,30 @@ If no subcommand given, default to `list`.
 ## Step 2: Execute Operation
 
 ### list
-Run: `gsd-sdk query workstream.list --raw --cwd "$CWD"`
+Run: `gsd-tools query workstream.list --raw --cwd "$CWD"`
 Display the workstreams in a table format showing name, status, current phase, and progress.
 
 ### create
-Run: `gsd-sdk query workstream.create <name> --raw --cwd "$CWD"`
+Run: `gsd-tools query workstream.create <name> --raw --cwd "$CWD"`
 After creation, display the new workstream path and suggest next steps:
 - `/gsd:new-milestone --ws <name>` to set up the milestone
 
 ### status
-Run: `gsd-sdk query workstream.status <name> --raw --cwd "$CWD"`
+Run: `gsd-tools query workstream.status <name> --raw --cwd "$CWD"`
 Display detailed phase breakdown and state information.
 
 ### switch
-Run: `gsd-sdk query workstream.set <name> --raw --cwd "$CWD"`
+Run: `gsd-tools query workstream.set <name> --raw --cwd "$CWD"`
 Also set `GSD_WORKSTREAM` for the current session when the runtime supports it.
 If the runtime exposes a session identifier, GSD also stores the active workstream
 session-locally so concurrent sessions do not overwrite each other.
 
 ### progress
-Run: `gsd-sdk query workstream.progress --raw --cwd "$CWD"`
+Run: `gsd-tools query workstream.progress --raw --cwd "$CWD"`
 Display a progress overview across all workstreams.
 
 ### complete
-Run: `gsd-sdk query workstream.complete <name> --raw --cwd "$CWD"`
+Run: `gsd-tools query workstream.complete <name> --raw --cwd "$CWD"`
 Archive the workstream to milestones/.
 
 ### resume
@@ -66,5 +66,5 @@ Set the workstream as active and suggest `/gsd:resume-work --ws <name>`.
 
 ## Step 3: Display Results
 
-Format the JSON output from gsd-sdk query into a human-readable display.
+Format the JSON output from gsd-tools query into a human-readable display.
 Include the `${GSD_WS}` flag in any routing suggestions.

--- a/tests/gsd-tools-path-refs.test.cjs
+++ b/tests/gsd-tools-path-refs.test.cjs
@@ -1,10 +1,8 @@
 /**
- * Regression guard for #1766: $GSD_TOOLS env var undefined
+ * Regression guards for shipped prompt references to gsd-tools.cjs.
  *
- * All command files must use the resolved path to gsd-tools.cjs
- * ($HOME/.claude/get-shit-done/bin/gsd-tools.cjs), not the undefined
- * $GSD_TOOLS variable. This test catches any command file that
- * references the undefined variable.
+ * Command and agent prompts must instruct clean installs to use the supported
+ * `gsd-tools query` binary, not the removed standalone `gsd-sdk query` binary.
  */
 
 const { describe, test } = require('node:test');
@@ -13,49 +11,46 @@ const fs = require('fs');
 const path = require('path');
 
 const COMMANDS_DIR = path.join(__dirname, '..', 'commands', 'gsd');
+const AGENTS_DIR = path.join(__dirname, '..', 'agents');
+
+function mdFiles(dir) {
+  return fs.readdirSync(dir)
+    .filter(f => f.endsWith('.md'))
+    .map(f => path.join(dir, f));
+}
+
+function rel(file) {
+  return path.relative(path.join(__dirname, '..'), file);
+}
 
 describe('command files: gsd-tools path references (#1766)', () => {
-  test('no command file references undefined $GSD_TOOLS variable', () => {
-    const files = fs.readdirSync(COMMANDS_DIR).filter(f => f.endsWith('.md'));
+  test('shipped agents and commands do not instruct removed SDK query binaries', () => {
+    const files = [...mdFiles(COMMANDS_DIR), ...mdFiles(AGENTS_DIR)];
     const violations = [];
 
     for (const file of files) {
-      const content = fs.readFileSync(path.join(COMMANDS_DIR, file), 'utf-8');
-      // Match $GSD_TOOLS or "$GSD_TOOLS" or ${GSD_TOOLS} used as a path
-      // (not as a documentation reference)
+      const content = fs.readFileSync(file, 'utf-8');
       const lines = content.split('\n');
       for (let i = 0; i < lines.length; i++) {
-        const line = lines[i];
-        if (/\$GSD_TOOLS\b/.test(line) && /node\s/.test(line)) {
-          violations.push(`${file}:${i + 1}: ${line.trim()}`);
+        if (/\bgsd-sdk\s+query\b|\$GSD_SDK\s+query/.test(lines[i])) {
+          violations.push(`${rel(file)}:${i + 1}: ${lines[i].trim()}`);
         }
       }
     }
 
     assert.strictEqual(violations.length, 0,
-      'Command files must not reference undefined $GSD_TOOLS. ' +
-      'Use $HOME/.claude/get-shit-done/bin/gsd-tools.cjs instead.\n' +
+      'Shipped agent/command prompts must use gsd-tools query, not removed SDK query forms.\n' +
       'Violations:\n' + violations.join('\n'));
   });
 
-  test('workstreams.md documents gsd-sdk query or legacy gsd-tools.cjs', () => {
+  test('workstreams.md documents the supported gsd-tools query binary', () => {
     const content = fs.readFileSync(
       path.join(COMMANDS_DIR, 'workstreams.md'), 'utf-8'
     );
 
     assert.ok(
-      /gsd-sdk\s+query/.test(content) || /gsd-tools\.cjs/.test(content),
-      'workstreams.md should document gsd-sdk query or gsd-tools.cjs'
+      /gsd-tools query workstream\.list/.test(content),
+      'workstreams.md should document gsd-tools query workstream.list'
     );
-
-    const lines = content.split('\n');
-    for (const line of lines) {
-      if (/node\s/.test(line)) {
-        assert.ok(
-          line.includes('gsd-tools.cjs'),
-          'Each node invocation must reference gsd-tools.cjs, got: ' + line.trim()
-        );
-      }
-    }
   });
 });


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #362

## What was broken

The package no longer exposes a `gsd-sdk` binary, but shipped agent and command prompts still instructed fresh installs to run `gsd-sdk query ...`. Clean users would hit `gsd-sdk: command not found` in planner, executor, verifier, and command flows.

## What this fix does

Replaces shipped prompt references with the supported `gsd-tools query` binary and adds a guard test so standalone SDK query instructions do not come back.

## Root cause

SDK retirement updated package bin metadata and workflow runtime code but did not sweep prompt/documented command invocations used by spawned agents.

## Testing

### How I verified the fix

- `node --test tests/gsd-tools-path-refs.test.cjs`
- `rg -n "\\bgsd-sdk\\s+query\\b|\\$GSD_SDK\\s+query" agents commands/gsd || true`
- `git diff --check`

### Regression test added?

- [x] Yes - updated `tests/gsd-tools-path-refs.test.cjs` to scan shipped agents and commands for removed SDK query forms.

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (prompt text only)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug - no unrelated changes included
- [x] Regression test added (or explained why not)
- [ ] All existing tests pass (`npm test`) - not run; focused prompt scan passed
- [x] `.changeset/` fragment added if this is a user-facing fix
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/get-shit-done-redux/pr/355"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782421673&installation_id=134682257&pr_number=355&repository=open-gsd%2Fget-shit-done-redux&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fget-shit-done-redux%2Fpull%2F355&signature=a02b8b4fd2a825d943d51a51db057021c0cc8624395930f00c0ae06517ca5bbe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
