### PR TITLE
fix: accept json input for state patch

### DIFF
--- a/.changeset/sturdy-geese-roam.md
+++ b/.changeset/sturdy-geese-roam.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 356
+---
+Accept JSON object input for state.patch so workflow state updates survive SDK retirement.

--- a/get-shit-done/bin/lib/state-command-router.cjs
+++ b/get-shit-done/bin/lib/state-command-router.cjs
@@ -73,11 +73,28 @@ function routeStateCommand({ state, args, cwd, raw, error }) {
         null,
         () => {
           const patches = {};
-          for (let i = 2; i < args.length; i += 2) {
-            const key = args[i].replace(/^--/, '');
-            const value = args[i + 1];
-            if (key && value !== undefined) {
-              patches[key] = value;
+          if (args.length === 3 && typeof args[2] === 'string' && args[2].trim().startsWith('{')) {
+            let parsed;
+            try {
+              parsed = JSON.parse(args[2]);
+            } catch (err) {
+              error(`state patch: invalid JSON object: ${err.message}`);
+            }
+            if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+              error('state patch: JSON input must be an object of field/value pairs.');
+            }
+            for (const [key, value] of Object.entries(parsed)) {
+              if (key && value !== undefined) {
+                patches[key] = String(value);
+              }
+            }
+          } else {
+            for (let i = 2; i < args.length; i += 2) {
+              const key = args[i].replace(/^--/, '');
+              const value = args[i + 1];
+              if (key && value !== undefined) {
+                patches[key] = value;
+              }
             }
           }
           state.cmdStatePatch(cwd, patches, raw);

--- a/tests/state.test.cjs
+++ b/tests/state.test.cjs
@@ -922,6 +922,27 @@ describe('cmdStatePatch and cmdStateUpdate (state patch, state update)', () => {
     assert.ok(updated.includes('**Last Activity:** 2024-01-15'), 'Last Activity should be unchanged');
   });
 
+  test('state patch accepts JSON object input from workflows', () => {
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'STATE.md'), stateMd);
+
+    const result = runGsdTools([
+      'query',
+      'state.patch',
+      JSON.stringify({
+        Status: 'Complete',
+        'Current Phase': '04',
+      }),
+    ], tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.deepEqual(output.updated.sort(), ['Current Phase', 'Status'].sort());
+
+    const updated = fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
+    assert.ok(updated.includes('**Status:** Complete'), 'Status should be updated to Complete');
+    assert.ok(updated.includes('**Current Phase:** 04'), 'Current Phase should be updated to 04');
+  });
+
   test('state patch reports failed fields that do not exist', () => {
     fs.writeFileSync(path.join(tmpDir, '.planning', 'STATE.md'), stateMd);
 


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #363

## What was broken

`insert-phase` calls `state.patch` with a JSON object, but the CJS `state.patch` router only parsed `--field value` pairs. The command could not apply the intended phase pointer updates from that workflow input shape.

## What this fix does

Adds JSON-object input support to `state.patch` while preserving the existing flag-pair behavior. JSON values are converted to strings before reaching the existing state mutation path.

## Root cause

The SDK handler accepted the workflow's JSON object shape, but the CJS fallback after SDK retirement only implemented the flag-pair parser.

## Testing

### How I verified the fix

- `node --test tests/state.test.cjs tests/cjs-command-router-adapter.test.cjs`
- `git diff --check`

### Regression test added?

- [x] Yes - added a state test that calls `query state.patch '{...}'` through real `gsd-tools` and verifies `STATE.md` updates.

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [x] Other: direct `gsd-tools` subprocess tests
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug - no unrelated changes included
- [x] Regression test added (or explained why not)
- [ ] All existing tests pass (`npm test`) - not run; full state/router focused tests passed
- [x] `.changeset/` fragment added if this is a user-facing fix
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/get-shit-done-redux/pr/356"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782421687&installation_id=134682257&pr_number=356&repository=open-gsd%2Fget-shit-done-redux&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fget-shit-done-redux%2Fpull%2F356&signature=d9d9a6f1525d07483ed42d9af54c759a71cc8c37f6881996814593b60d96af2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
