### PR TITLE
fix: sync lockfile bin metadata

### DIFF
--- a/.changeset/tidy-moles-rest.md
+++ b/.changeset/tidy-moles-rest.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 357
+---
+Sync package-lock bin metadata with the retired SDK package surface.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,7 @@
       },
       "bin": {
         "get-shit-done-redux": "bin/install.js",
-        "gsd-sdk": "bin/gsd-sdk.js",
-        "gsd-tools": "bin/gsd-sdk.js"
+        "gsd-tools": "get-shit-done/bin/gsd-tools.cjs"
       },
       "devDependencies": {
         "c8": "^11.0.0"


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #364

## What was broken

`package.json` removed the `gsd-sdk` binary and points `gsd-tools` at `get-shit-done/bin/gsd-tools.cjs`, but `package-lock.json` still advertised `gsd-sdk` and mapped `gsd-tools` to deleted `bin/gsd-sdk.js`.

## What this fix does

Updates the root package-lock bin metadata to match package.json: only `get-shit-done-redux` and `gsd-tools` are exposed, and `gsd-tools` points at the CJS runtime file.

## Root cause

The SDK removal changed package.json without refreshing the corresponding lockfile root package metadata.

## Testing

### How I verified the fix

- `node -e "const p=require('./package-lock.json'); const b=p.packages['']; if (b.bin['gsd-sdk']) throw new Error('gsd-sdk bin still present'); if (b.bin['gsd-tools'] !== 'get-shit-done/bin/gsd-tools.cjs') throw new Error('bad gsd-tools bin')"`
- `node --test tests/bugs-1656-1657.test.cjs tests/release-tarball-smoke.install.test.cjs`
- `git diff --check`

### Regression test added?

- [ ] No - metadata-only lockfile sync; existing SDK retirement and tarball smoke tests cover package publication behavior.

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (package metadata only)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug - no unrelated changes included
- [x] Regression test added (or explained why not)
- [ ] All existing tests pass (`npm test`) - not run; focused SDK/package smoke tests passed
- [x] `.changeset/` fragment added if this is a user-facing fix
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/get-shit-done-redux/pr/357"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782421703&installation_id=134682257&pr_number=357&repository=open-gsd%2Fget-shit-done-redux&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fget-shit-done-redux%2Fpull%2F357&signature=166294adafcf40c6f98b0597e86650cec4d411e779912ae466d5e9b7102e594b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
