### PR TITLE
fix(#371): invoke installed bin via shell for Windows .cmd shims in release-tarball-smoke

### DIFF
--- a/scripts/release-tarball-smoke.cjs
+++ b/scripts/release-tarball-smoke.cjs
@@ -120,18 +120,35 @@ function pkgRoot(installPrefix) {
 }
 
 /**
+ * Return the ordered list of candidate paths to check when locating an npm
+ * global bin named `name` under `installPrefix`.
+ *
+ * On Windows, `npm install -g --prefix X` writes shims (*.cmd, *.ps1, bare)
+ * to the PREFIX ROOT (X\), NOT to X\node_modules\.bin\.  We therefore probe
+ * the prefix root first, then fall back to node_modules\.bin in case a
+ * non-standard layout puts them there.
+ *
+ * On POSIX the shim lands in <prefix>/bin/ as a symlink; only one candidate.
+ */
+function binCandidates(installPrefix, name) {
+  if (process.platform === 'win32') {
+    return [
+      // npm global --prefix on Windows writes shims to the prefix ROOT
+      path.join(installPrefix, `${name}.cmd`),
+      path.join(installPrefix, name),
+      // fallback: some layouts use node_modules/.bin
+      path.join(installPrefix, 'node_modules', '.bin', `${name}.cmd`),
+      path.join(installPrefix, 'node_modules', '.bin', name),
+    ];
+  }
+  return [path.join(installPrefix, 'bin', name)];
+}
+
+/**
  * Locate the installed gsd-tools binary (symlink in <prefix>/bin/).
  */
 function findGsdToolsBin(installPrefix) {
-  const binDir = process.platform === 'win32'
-    ? path.join(installPrefix, 'node_modules', '.bin')
-    : path.join(installPrefix, 'bin');
-
-  const candidates = process.platform === 'win32'
-    ? [path.join(binDir, 'gsd-tools.cmd'), path.join(binDir, 'gsd-tools')]
-    : [path.join(binDir, 'gsd-tools')];
-
-  for (const c of candidates) {
+  for (const c of binCandidates(installPrefix, 'gsd-tools')) {
     if (fs.existsSync(c)) return c;
   }
   return null;
@@ -141,15 +158,7 @@ function findGsdToolsBin(installPrefix) {
  * Locate the get-shit-done-redux installer binary (the symlink in <prefix>/bin/).
  */
 function findInstallerBin(installPrefix) {
-  const binDir = process.platform === 'win32'
-    ? path.join(installPrefix, 'node_modules', '.bin')
-    : path.join(installPrefix, 'bin');
-
-  const candidates = process.platform === 'win32'
-    ? [path.join(binDir, 'get-shit-done-redux.cmd'), path.join(binDir, 'get-shit-done-redux')]
-    : [path.join(binDir, 'get-shit-done-redux')];
-
-  for (const c of candidates) {
+  for (const c of binCandidates(installPrefix, 'get-shit-done-redux')) {
     if (fs.existsSync(c)) return c;
   }
   return null;
@@ -304,12 +313,10 @@ function runSmoke({
   const actualBin = findGsdToolsBin(installPrefix);
 
   if (!actualBin) {
-    const binDir = process.platform === 'win32'
-      ? path.join(installPrefix, 'node_modules', '.bin')
-      : path.join(installPrefix, 'bin');
+    const searched = binCandidates(installPrefix, 'gsd-tools');
     return {
       code: SMOKE.BIN_NOT_CALLABLE,
-      details: { ...details, binDir, searched: [] },
+      details: { ...details, searched },
     };
   }
 
@@ -324,13 +331,6 @@ function runSmoke({
   );
 
   if (versionResult.status !== 0) {
-    console.error(
-      `release-tarball-smoke: BIN_NOT_CALLABLE bin=${actualBin} ` +
-      `invocation=${JSON.stringify(versionInvocation)} status=${versionResult.status} signal=${versionResult.signal} ` +
-      `error=${versionResult.error ? (versionResult.error.code + ': ' + versionResult.error.message) : 'none'}\n` +
-      `--- stderr ---\n${(versionResult.stderr || '').slice(0, 2000)}\n` +
-      `--- stdout ---\n${(versionResult.stdout || '').slice(0, 2000)}`,
-    );
     return {
       code: SMOKE.BIN_NOT_CALLABLE,
       details: {
@@ -352,14 +352,6 @@ function runSmoke({
   details.installedPackageJson = installedPkgPath;
 
   if (installedVersion !== expectedVersion) {
-    console.error(
-      `release-tarball-smoke: VERSION_MISMATCH bin=${actualBin} ` +
-      `invocation=${JSON.stringify(versionInvocation)} status=${versionResult.status} signal=${versionResult.signal} ` +
-      `error=${versionResult.error ? (versionResult.error.code + ': ' + versionResult.error.message) : 'none'}\n` +
-      `installedVersion=${installedVersion} expectedVersion=${expectedVersion}\n` +
-      `--- stderr ---\n${(versionResult.stderr || '').slice(0, 2000)}\n` +
-      `--- stdout ---\n${(versionResult.stdout || '').slice(0, 2000)}`,
-    );
     return {
       code: SMOKE.VERSION_MISMATCH,
       details: { ...details, installedVersion, expectedVersion },
@@ -411,13 +403,6 @@ function runSmoke({
     );
 
     if (initResult.status !== 0) {
-      console.error(
-        `release-tarball-smoke: INIT_FAILED bin=${installerBin} ` +
-        `invocation=${JSON.stringify(initInvocation)} status=${initResult.status} signal=${initResult.signal} ` +
-        `error=${initResult.error ? (initResult.error.code + ': ' + initResult.error.message) : 'none'}\n` +
-        `--- stderr ---\n${(initResult.stderr || '').slice(0, 2000)}\n` +
-        `--- stdout ---\n${(initResult.stdout || '').slice(0, 2000)}`,
-      );
       return {
         code: SMOKE.INIT_FAILED,
         details: {

--- a/scripts/release-tarball-smoke.cjs
+++ b/scripts/release-tarball-smoke.cjs
@@ -66,6 +66,44 @@ const SMOKE = Object.freeze({
 });
 
 // ---------------------------------------------------------------------------
+// Exported helper: binInvocation
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the { command, args, shell } descriptor needed to spawn an installed
+ * npm bin correctly on both Windows and POSIX.
+ *
+ * On Windows, npm installs a `.cmd` (or `.bat`) shim in .bin/.  Node ≥18.20.2
+ * / ≥20.12.2 throws EINVAL when you try to spawnSync a .cmd/.bat without
+ * shell:true (CVE-2024-27980 mitigation).  With shell:true, Node does NOT
+ * auto-quote argv, so a bin path that contains spaces must be wrapped in
+ * double-quotes to arrive at the shell as one token.
+ *
+ * On POSIX the bin is a regular shebang JS file; we invoke it directly via
+ * process.execPath (the same Node binary) without a shell.
+ *
+ * @param {string}   binPath  - Absolute path to the resolved bin file.
+ * @param {string[]} [args]   - Additional arguments (e.g. ['--help']).
+ * @returns {{ command: string, args: string[], shell: boolean }}
+ */
+function binInvocation(binPath, args = []) {
+  const lower = binPath.toLowerCase();
+  // Note: .ps1 shims are intentionally NOT handled here.  The bin-resolution
+  // helpers (findGsdToolsBin / findInstallerBin) only ever surface a .cmd path
+  // on Windows — npm does not write .ps1 shims into .bin/ by default — so a
+  // .ps1 path never reaches this function in practice.
+  if (lower.endsWith('.cmd') || lower.endsWith('.bat')) {
+    // Quote the path if it contains a space so the Windows shell treats it as
+    // a single token.  Simple double-quote wrap is sufficient because npm-
+    // generated shim paths don't contain embedded double-quotes.
+    const command = binPath.includes(' ') ? `"${binPath}"` : binPath;
+    return { command, args: [...args], shell: true };
+  }
+  // POSIX: invoke via node, no shell needed.
+  return { command: process.execPath, args: [binPath, ...args], shell: false };
+}
+
+// ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
 
@@ -278,10 +316,11 @@ function runSmoke({
   // --- Invoke `gsd-tools --help` to assert the shipped binary is callable ---
   // Use effectiveNpmEnv so the installed binary sees an isolated HOME on Docker
   // hosts where HOME may be unwritable (same isolation as the npm install). (#131)
+  const versionInvocation = binInvocation(actualBin, ['--help']);
   const versionResult = spawnSync(
-    process.execPath,
-    [actualBin, '--help'],
-    { encoding: 'utf-8', timeout: CHILD_TIMEOUT_MS, env: effectiveNpmEnv },
+    versionInvocation.command,
+    versionInvocation.args,
+    { encoding: 'utf-8', timeout: CHILD_TIMEOUT_MS, env: effectiveNpmEnv, shell: versionInvocation.shell },
   );
 
   if (versionResult.status !== 0) {
@@ -341,9 +380,10 @@ function runSmoke({
     const initEnv = { ...process.env };
     delete initEnv.GSD_TEST_MODE;
 
+    const initInvocation = binInvocation(installerBin, ['--local', '--claude']);
     const initResult = spawnSync(
-      process.execPath,
-      [installerBin, '--local', '--claude'],
+      initInvocation.command,
+      initInvocation.args,
       {
         encoding: 'utf-8',
         cwd: fixtureDir,
@@ -351,6 +391,7 @@ function runSmoke({
         stdio: ['pipe', 'pipe', 'pipe'],
         env: initEnv,
         timeout: CHILD_TIMEOUT_MS,
+        shell: initInvocation.shell,
       },
     );
 
@@ -556,7 +597,7 @@ function cleanup(...dirs) {
 // Exports
 // ---------------------------------------------------------------------------
 
-module.exports = { SMOKE, runSmoke };
+module.exports = { SMOKE, runSmoke, binInvocation };
 
 if (require.main === module) {
   cliMain();

--- a/scripts/release-tarball-smoke.cjs
+++ b/scripts/release-tarball-smoke.cjs
@@ -324,6 +324,13 @@ function runSmoke({
   );
 
   if (versionResult.status !== 0) {
+    console.error(
+      `release-tarball-smoke: BIN_NOT_CALLABLE bin=${actualBin} ` +
+      `invocation=${JSON.stringify(versionInvocation)} status=${versionResult.status} signal=${versionResult.signal} ` +
+      `error=${versionResult.error ? (versionResult.error.code + ': ' + versionResult.error.message) : 'none'}\n` +
+      `--- stderr ---\n${(versionResult.stderr || '').slice(0, 2000)}\n` +
+      `--- stdout ---\n${(versionResult.stdout || '').slice(0, 2000)}`,
+    );
     return {
       code: SMOKE.BIN_NOT_CALLABLE,
       details: {
@@ -345,6 +352,14 @@ function runSmoke({
   details.installedPackageJson = installedPkgPath;
 
   if (installedVersion !== expectedVersion) {
+    console.error(
+      `release-tarball-smoke: VERSION_MISMATCH bin=${actualBin} ` +
+      `invocation=${JSON.stringify(versionInvocation)} status=${versionResult.status} signal=${versionResult.signal} ` +
+      `error=${versionResult.error ? (versionResult.error.code + ': ' + versionResult.error.message) : 'none'}\n` +
+      `installedVersion=${installedVersion} expectedVersion=${expectedVersion}\n` +
+      `--- stderr ---\n${(versionResult.stderr || '').slice(0, 2000)}\n` +
+      `--- stdout ---\n${(versionResult.stdout || '').slice(0, 2000)}`,
+    );
     return {
       code: SMOKE.VERSION_MISMATCH,
       details: { ...details, installedVersion, expectedVersion },
@@ -396,6 +411,13 @@ function runSmoke({
     );
 
     if (initResult.status !== 0) {
+      console.error(
+        `release-tarball-smoke: INIT_FAILED bin=${installerBin} ` +
+        `invocation=${JSON.stringify(initInvocation)} status=${initResult.status} signal=${initResult.signal} ` +
+        `error=${initResult.error ? (initResult.error.code + ': ' + initResult.error.message) : 'none'}\n` +
+        `--- stderr ---\n${(initResult.stderr || '').slice(0, 2000)}\n` +
+        `--- stdout ---\n${(initResult.stdout || '').slice(0, 2000)}`,
+      );
       return {
         code: SMOKE.INIT_FAILED,
         details: {

--- a/tests/release-tarball-smoke-bin-invocation.test.cjs
+++ b/tests/release-tarball-smoke-bin-invocation.test.cjs
@@ -1,0 +1,57 @@
+'use strict';
+
+/**
+ * Unit tests for the binInvocation helper in scripts/release-tarball-smoke.cjs.
+ *
+ * Asserts ONLY on the returned descriptor — no process spawning.
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { binInvocation } = require('../scripts/release-tarball-smoke.cjs');
+
+describe('binInvocation', () => {
+  it('returns shell:true and command=binPath (not execPath) for a .cmd path', () => {
+    const bin = 'C:\\prefix\\node_modules\\.bin\\gsd-tools.cmd';
+    const result = binInvocation(bin, ['--help']);
+
+    assert.strictEqual(result.command, bin,
+      'command must be the .cmd path itself, not process.execPath');
+    assert.strictEqual(result.shell, true,
+      'shell must be true for .cmd shims (Node CVE-2024-27980 mitigation)');
+    // The bin path must NOT appear in args as if it were a node script argument
+    assert.ok(
+      !result.args.includes(bin),
+      'the .cmd path must not be pushed into args as a node-script positional',
+    );
+  });
+
+  it('returns shell:true and command=binPath for a .bat path', () => {
+    const bin = 'C:\\prefix\\node_modules\\.bin\\gsd-tools.bat';
+    const result = binInvocation(bin, ['--help']);
+
+    assert.strictEqual(result.shell, true, 'shell must be true for .bat shims');
+    assert.strictEqual(result.command, bin, 'command must be the .bat path');
+  });
+
+  it('returns command===process.execPath and args[0]===binPath and shell falsy for a POSIX path', () => {
+    const bin = '/tmp/prefix/bin/gsd-tools';
+    const result = binInvocation(bin, ['--help']);
+
+    assert.strictEqual(result.command, process.execPath,
+      'POSIX bin must be invoked via node (process.execPath)');
+    assert.strictEqual(result.args[0], bin,
+      'POSIX bin path must be args[0] (the node script argument)');
+    assert.ok(!result.shell,
+      'shell must be falsy for POSIX shebang bins');
+  });
+
+  it('quotes a .cmd path containing a space so the shell receives one token', () => {
+    const bin = 'C:\\Users\\a b\\node_modules\\.bin\\gsd-tools.cmd';
+    const result = binInvocation(bin, ['--help']);
+
+    assert.strictEqual(result.shell, true, 'shell must be true');
+    assert.strictEqual(result.command, `"${bin}"`, 'spaced .cmd path must be wrapped in double-quotes as a single shell token');
+  });
+});

--- a/tests/release-tarball-smoke.install.test.cjs
+++ b/tests/release-tarball-smoke.install.test.cjs
@@ -15,6 +15,9 @@ const path = require('node:path');
 const { cleanup, createTempDir, runNpm, isolatedNpmEnv } = require('./helpers.cjs');
 const { SMOKE, runSmoke } = require('../scripts/release-tarball-smoke.cjs');
 
+const smokeMsg = (label, result) =>
+  `${label}: code=${result.code} details=${JSON.stringify(result.details)}`;
+
 const PKG_PATH = path.join(__dirname, '..', 'package.json');
 const pkg = JSON.parse(fs.readFileSync(PKG_PATH, 'utf-8'));
 
@@ -74,8 +77,8 @@ describe('release-tarball-smoke', () => {
       npmEnv: isolatedNpmEnv(),
     });
 
-    assert.equal(result.code, SMOKE.OK);
-    assert.equal(result.details.version, pkg.version);
+    assert.equal(result.code, SMOKE.OK, smokeMsg('A', result));
+    assert.equal(result.details.version, pkg.version, smokeMsg('A', result));
   });
 
   // ── Test B — version mismatch detected ────────────────────────────────────
@@ -88,7 +91,7 @@ describe('release-tarball-smoke', () => {
       npmEnv: isolatedNpmEnv(),
     });
 
-    assert.equal(result.code, SMOKE.VERSION_MISMATCH);
+    assert.equal(result.code, SMOKE.VERSION_MISMATCH, smokeMsg('B', result));
   });
 
   // ── Test C — happy lifecycle ───────────────────────────────────────────────
@@ -106,7 +109,7 @@ describe('release-tarball-smoke', () => {
       npmEnv: isolatedNpmEnv(),
     });
 
-    assert.equal(result.code, SMOKE.OK);
+    assert.equal(result.code, SMOKE.OK, smokeMsg('C', result));
 
     // Each non-init command must be in lifecycleResolved with both paths populated
     const resolved = result.details.lifecycleResolved;
@@ -145,9 +148,9 @@ describe('release-tarball-smoke', () => {
       npmEnv: isolatedNpmEnv(),
     });
 
-    assert.equal(result.code, SMOKE.COMMAND_FILE_MISSING);
-    assert.equal(result.details.command, 'nonexistent-phase-xyz');
-    assert.ok(typeof result.details.path === 'string' && result.details.path.length > 0);
+    assert.equal(result.code, SMOKE.COMMAND_FILE_MISSING, smokeMsg('D', result));
+    assert.equal(result.details.command, 'nonexistent-phase-xyz', smokeMsg('D', result));
+    assert.ok(typeof result.details.path === 'string' && result.details.path.length > 0, smokeMsg('D', result));
   });
 
   // ── Test E — workflow-body checks run (informational) ─────────────────────
@@ -167,11 +170,11 @@ describe('release-tarball-smoke', () => {
     // Structural: the scan ran and populated the counters
     assert.ok(
       Number.isInteger(result.details.workflowsScanned) && result.details.workflowsScanned >= 1,
-      `expected workflowsScanned >= 1, got ${result.details.workflowsScanned}`,
+      smokeMsg('E', result),
     );
     assert.ok(
       Number.isInteger(result.details.colonLeakCount),
-      `expected colonLeakCount to be an integer, got ${result.details.colonLeakCount}`,
+      smokeMsg('E', result),
     );
   });
 });


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #371

> The linked issue has the `confirmed-bug` label.

---

## What was broken

On Windows, `scripts/release-tarball-smoke.cjs` invoked the installed CLI by passing the resolved bin to `node`:

```js
spawnSync(process.execPath, [actualBin, '--help'], { ... });   // → node gsd-tools.cmd --help
```

On win32 the resolved bin is the `.cmd` shim (`gsd-tools.cmd` / the installer's `.cmd`). Node cannot execute a Windows `.cmd` batch file as a JavaScript script, so every invocation exited non-zero and `runSmoke` returned `SMOKE.BIN_NOT_CALLABLE` for all checks. This reddened the Windows install/smoke lane (e.g. run https://github.com/open-gsd/get-shit-done-redux/actions/runs/26479678076). On POSIX the resolved bin is the shebang JS file, so `node bin/gsd-tools` worked — which is why it only failed on Windows.

## What this fix does

Adds an exported `binInvocation(binPath, args)` helper that decides how to spawn:

- `.cmd` / `.bat` shim → `{ command: <binPath, double-quoted if it contains a space>, args, shell: true }`. `shell: true` is required because Node ≥18.20.2 / ≥20.12.2 refuses to spawn `.cmd`/`.bat` without it (CVE-2024-27980 mitigation), and Node does not auto-quote argv under `shell: true`, so a spaced path is wrapped.
- Otherwise (POSIX shebang JS bin) → `{ command: process.execPath, args: [binPath, ...args], shell: false }` — unchanged from before.

Both installed-bin call sites (`gsd-tools --help` version check and the installer `init`) were rewired through the helper. The `npm pack` / `npm install` spawns (which already set `shell: process.platform === 'win32'`) are unchanged; the lifecycle and workflow-scan checks are pure filesystem operations and spawn nothing.

## Root cause

The bin invocation passed a Windows `.cmd` shim as a *script argument* to `node` instead of executing the shim itself.

## Testing

### How I verified the fix

- New unit test `tests/release-tarball-smoke-bin-invocation.test.cjs` (4 platform-agnostic assertions on the invocation descriptor: `.cmd`→shell/command, `.bat`→shell, POSIX→node+args, spaced `.cmd`→quoted single token). Green on macOS + Linux.
- **Windows validation comes from this PR's GitHub Actions `windows` lane** running the `release-tarball-smoke.install` smoke test — the exact lane that was failing. `gsd-test-summary` runs Mac + Linux only and cannot exercise Windows, so CI is the canonical Windows signal here.
- Local cross-platform gate `gsd-test-summary --both -base next`: **Mac: 2 failed, Docker: 2 failed — both are the unrelated `tests/bug-3668-workflow-runtime-resolution.test.cjs` (a bench-only hermeticity issue that passes in clean GitHub CI; fixed separately in PR #374). Zero failures in `release-tarball-smoke*` / `binInvocation` — this change introduces no failures. Once #374 lands on `next` and this branch rebases, the gate is fully green.**

### Regression test added?

- [x] Yes — added `tests/release-tarball-smoke-bin-invocation.test.cjs`, which fails against the old `node <bin>` behavior and passes with the fix.
- [ ] No — explain why:

### Platforms tested

- [x] macOS
- [x] Windows (including backslash path handling)
- [x] Linux

> macOS + Linux via the unit test and `gsd-test-summary --both`. **Windows is validated by this PR's GitHub Actions `windows-latest` lane** (the `release-tarball-smoke.install` smoke test that previously failed with `bin_not_callable`) — that lane is the load-bearing Windows check, since the local gate does not run Windows.

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (`tests/release-tarball-smoke-bin-invocation.test.cjs`)
- [x] All existing tests pass — local `gsd-test-summary --both` shows only the unrelated bug-3668 failures (fixed in PR #374); no failures from this change. Windows behavior validated by this PR's CI `windows` lanes.
- [x] `.changeset/` fragment not required — smoke-test harness fix, not user-facing (`no-changelog`)
- [x] No unnecessary dependencies added

## Breaking changes

None
