### PR TITLE
perf(#305): single-pass max-by-mtime for statusline todo lookup

### DIFF
--- a/.changeset/swift-otter-hum.md
+++ b/.changeset/swift-otter-hum.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 305
+---
+Use a single-pass max-by-mtime scan for statusline todo lookup, dropping the per-render O(n log n) sort (#305).

--- a/hooks/gsd-statusline.js
+++ b/hooks/gsd-statusline.js
@@ -368,14 +368,20 @@ function runStatusline() {
     const todosDir = path.join(claudeDir, 'todos');
     if (session && fs.existsSync(todosDir)) {
       try {
-        const files = fs.readdirSync(todosDir)
-          .filter(f => f.startsWith(session) && f.includes('-agent-') && f.endsWith('.json'))
-          .map(f => ({ name: f, mtime: fs.statSync(path.join(todosDir, f)).mtime }))
-          .sort((a, b) => b.mtime - a.mtime);
+        // Single-pass max-by-mtime scan: only the newest matching todos file
+        // is needed, so the O(n log n) sort and the intermediate array from the
+        // prior `.filter().map(statSync).sort()` chain are unnecessary. Identical
+        // I/O (one statSync per match) and identical result. (#305)
+        let latest = null;
+        for (const entry of fs.readdirSync(todosDir)) {
+          if (!entry.startsWith(session) || !entry.includes('-agent-') || !entry.endsWith('.json')) continue;
+          const mtime = fs.statSync(path.join(todosDir, entry)).mtime;
+          if (!latest || mtime > latest.mtime) latest = { name: entry, mtime };
+        }
 
-        if (files.length > 0) {
+        if (latest) {
           try {
-            const todos = JSON.parse(fs.readFileSync(path.join(todosDir, files[0].name), 'utf8'));
+            const todos = JSON.parse(fs.readFileSync(path.join(todosDir, latest.name), 'utf8'));
             const inProgress = todos.find(t => t.status === 'in_progress');
             if (inProgress) task = inProgress.activeForm || '';
           } catch (e) {}

--- a/tests/gsd-statusline.test.cjs
+++ b/tests/gsd-statusline.test.cjs
@@ -386,3 +386,83 @@ describe('context meter respects CLAUDE_CODE_AUTO_COMPACT_WINDOW (#2219)', () =>
       'bridge used_pct must be raw (100-50=50) regardless of CLAUDE_CODE_AUTO_COMPACT_WINDOW');
   });
 });
+
+// ─── todo-resolution path (#305) ────────────────────────────────────────────
+
+describe('todo-resolution: resolves in_progress task from the newest matching todos file (#305)', () => {
+  const { execFileSync } = require('node:child_process');
+  const hookPath = path.join(__dirname, '..', 'hooks', 'gsd-statusline.js');
+
+  test('resolves in_progress task from the newest matching todos file (#305)', (t) => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-305-'));
+    t.after(() => {
+      try { fs.rmSync(tempDir, { recursive: true, force: true }); } catch {}
+    });
+
+    const todosDir = path.join(tempDir, 'todos');
+    fs.mkdirSync(todosDir, { recursive: true });
+
+    const session = `sess-305-${Math.random().toString(36).slice(2)}`;
+    const now = Date.now() / 1000; // seconds for utimesSync
+
+    // Older matching file — should NOT be selected
+    const olderPath = path.join(todosDir, `${session}-agent-A.json`);
+    fs.writeFileSync(olderPath, JSON.stringify([
+      { content: 'old task', status: 'in_progress', activeForm: 'OLDER TASK 305' },
+    ]));
+    const olderTime = now - 10000;
+    fs.utimesSync(olderPath, olderTime, olderTime);
+
+    // Newer matching file — should be selected
+    const newerPath = path.join(todosDir, `${session}-agent-B.json`);
+    fs.writeFileSync(newerPath, JSON.stringify([
+      { content: 'new task', status: 'in_progress', activeForm: 'NEWER TASK 305' },
+    ]));
+    const newerTime = now - 1000;
+    fs.utimesSync(newerPath, newerTime, newerTime);
+
+    // Distractor: different session prefix — must be ignored even with very-new mtime
+    const wrongSessPath = path.join(todosDir, 'other-sess-agent-Z.json');
+    fs.writeFileSync(wrongSessPath, JSON.stringify([
+      { content: 'wrong session', status: 'in_progress', activeForm: 'WRONG SESSION 305' },
+    ]));
+    fs.utimesSync(wrongSessPath, now, now);
+
+    // Distractor: matches session + .json but lacks -agent- — must be ignored
+    const notAgentPath = path.join(todosDir, `${session}-notagent.json`);
+    fs.writeFileSync(notAgentPath, JSON.stringify([
+      { content: 'not agent', status: 'in_progress', activeForm: 'NOT AGENT 305' },
+    ]));
+    fs.utimesSync(notAgentPath, now, now);
+
+    const payload = JSON.stringify({
+      model: { display_name: 'Claude' },
+      workspace: { current_dir: os.tmpdir() },
+      session_id: session,
+      context_window: { remaining_percentage: 80, total_tokens: 1_000_000 },
+    });
+
+    const env = { ...process.env, CLAUDE_CONFIG_DIR: tempDir };
+
+    let stdout = '';
+    try {
+      stdout = execFileSync(process.execPath, [hookPath], {
+        input: payload,
+        env,
+        encoding: 'utf8',
+        timeout: 4000,
+      });
+    } catch (e) {
+      stdout = e.stdout || '';
+    }
+
+    assert.ok(stdout.includes('NEWER TASK 305'),
+      `expected stdout to contain "NEWER TASK 305", got: ${stdout}`);
+    assert.ok(!stdout.includes('OLDER TASK 305'),
+      `stdout must NOT contain "OLDER TASK 305", got: ${stdout}`);
+    assert.ok(!stdout.includes('WRONG SESSION 305'),
+      `stdout must NOT contain "WRONG SESSION 305", got: ${stdout}`);
+    assert.ok(!stdout.includes('NOT AGENT 305'),
+      `stdout must NOT contain "NOT AGENT 305", got: ${stdout}`);
+  });
+});


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #305

## What was broken

`hooks/gsd-statusline.js` resolved the active session's current todo on every statusline render by scanning the whole `~/.claude/todos` directory with `readdirSync().filter().map(statSync).sort()` — an O(n log n) sort plus a throwaway intermediate array — when only the single newest matching file is ever used. Render latency grew with the todo-file count.

## What this fix does

Replaces the `.filter().map(statSync).sort()` chain with a single-pass max-by-mtime loop that keeps only the newest matching entry. The I/O shape is unchanged (one `readdirSync`, one `statSync` per matching file) and the resolved file is identical; only the unnecessary sort and intermediate array are dropped, lowering the per-render cost from O(n log n) to O(n).

## Root cause

The lookup materialized and fully sorted every matching todo file just to read element `[0]`. A sort is unnecessary when only the maximum is needed — a linear scan tracking the running max suffices.

## Testing

### How I verified the fix

- Added the first behavior-lock test for this path: it writes older/newer matching `-agent-*.json` files with explicit `utimesSync` mtimes plus two distractors (wrong session prefix, missing `-agent-`) and asserts the in_progress task resolves from the newest matching file while the distractors are excluded. Deterministic — no timing/ratio assertions (those are flaky on contended CI).
- `gsd-test-summary --both -base next` (full suite, branch merged onto `next`): `Mac: 0 failed`, `Docker: 0 failed` (exit 0).

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why: <!-- e.g., environment-specific, non-deterministic -->

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

<!-- Does this fix change any existing behavior, output format, or API that users might depend on?
     If yes, describe. Write "None" if not applicable. -->

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/get-shit-done-redux/pr/385"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782488911&installation_id=134682257&pr_number=385&repository=open-gsd%2Fget-shit-done-redux&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fget-shit-done-redux%2Fpull%2F385&signature=7a537cab04c40dc69886040303c163c71084ba5a5cbf44ef0d484928e5378531"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->