### PR TITLE
fix(#308): bound websearch fetch with timeout and retry

### DIFF
--- a/.changeset/308-websearch-timeout-retry.md
+++ b/.changeset/308-websearch-timeout-retry.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 308
+---
+Add a per-attempt timeout (configurable via GSD_WEBSEARCH_TIMEOUT_MS) and bounded retry with Retry-After handling to the Brave websearch fetch (#308).

--- a/get-shit-done/bin/lib/commands.cjs
+++ b/get-shit-done/bin/lib/commands.cjs
@@ -517,6 +517,30 @@ function cmdSummaryExtract(cwd, summaryPath, fields, raw) {
   output(fullResult, raw);
 }
 
+function _wsSleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function _wsParseRetryAfter(header) {
+  if (!header) return null;
+  const trimmed = header.trim();
+  if (/^\d+$/.test(trimmed)) {
+    return Math.min(Math.max(parseInt(trimmed, 10) * 1000, 0), 60000);
+  }
+  const asDate = Date.parse(trimmed);
+  if (!isNaN(asDate)) {
+    return Math.min(Math.max(asDate - Date.now(), 0), 60000);
+  }
+  return null;
+}
+
+function _wsRetryDelayMs(attempt) {
+  const base = 250;
+  const cap = 2000;
+  const exp = Math.min(base * Math.pow(2, attempt), cap);
+  return exp + Math.floor(Math.random() * 100);
+}
+
 async function cmdWebsearch(query, options, raw) {
   const apiKey = process.env.BRAVE_API_KEY;
 
@@ -543,39 +567,82 @@ async function cmdWebsearch(query, options, raw) {
     params.set('freshness', options.freshness);
   }
 
-  try {
-    const response = await fetch(
-      `https://api.search.brave.com/res/v1/web/search?${params}`,
-      {
-        headers: {
-          'Accept': 'application/json',
-          'X-Subscription-Token': apiKey
-        }
+  const rawTimeout = parseInt(process.env.GSD_WEBSEARCH_TIMEOUT_MS, 10);
+  const timeoutMs = (Number.isInteger(rawTimeout) && rawTimeout > 0) ? rawTimeout : 10000;
+
+  const MAX_RETRIES = 2;
+  let attempt = 0;
+
+  while (true) {
+    try {
+      const ac = new AbortController();
+      const timer = setTimeout(() => ac.abort(new Error('timeout')), timeoutMs);
+      let response;
+      try {
+        response = await fetch(
+          `https://api.search.brave.com/res/v1/web/search?${params}`,
+          {
+            headers: {
+              'Accept': 'application/json',
+              'X-Subscription-Token': apiKey
+            },
+            signal: ac.signal
+          }
+        );
+      } finally {
+        clearTimeout(timer);
       }
-    );
 
-    if (!response.ok) {
-      output({ available: false, error: `API error: ${response.status}` }, raw, '');
-      return;
+      if (response.ok) {
+        const data = await response.json();
+        const results = (data.web?.results || []).map(r => ({
+          title: r.title,
+          url: r.url,
+          description: r.description,
+          age: r.age || null
+        }));
+        output({
+          available: true,
+          query,
+          count: results.length,
+          results
+        }, raw, results.map(r => `${r.title}\n${r.url}\n${r.description}`).join('\n\n'));
+        return;
+      }
+
+      const status = response.status;
+      const isRetryable = status === 429 || status >= 500;
+
+      if (!isRetryable) {
+        // Non-retryable 4xx — fail immediately, no attempts field
+        output({ available: false, error: `API error: ${status}` }, raw, '');
+        return;
+      }
+
+      // Retryable HTTP error
+      attempt++;
+      if (attempt > MAX_RETRIES) {
+        output({ available: false, error: `API error: ${status}`, attempts: attempt }, raw, '');
+        return;
+      }
+
+      let delay;
+      if (status === 429) {
+        const retryAfter = _wsParseRetryAfter(response.headers.get('retry-after'));
+        delay = retryAfter !== null ? retryAfter : _wsRetryDelayMs(attempt - 1);
+      } else {
+        delay = _wsRetryDelayMs(attempt - 1);
+      }
+      await _wsSleep(delay);
+
+    } catch (err) {
+      attempt++;
+      if (attempt > MAX_RETRIES) {
+        output({ available: false, error: err.message, attempts: attempt }, raw, '');
+        return;
+      }
+      await _wsSleep(_wsRetryDelayMs(attempt - 1));
     }
-
-    const data = await response.json();
-
-    const results = (data.web?.results || []).map(r => ({
-      title: r.title,
-      url: r.url,
-      description: r.description,
-      age: r.age || null
-    }));
-
-    output({
-      available: true,
-      query,
-      count: results.length,
-      results
-    }, raw, results.map(r => `${r.title}\n${r.url}\n${r.description}`).join('\n\n'));
-  } catch (err) {
-    output({ available: false, error: err.message }, raw, '');
   }
 }
 
@@ -1060,4 +1127,5 @@ module.exports = {
   cmdScaffold,
   cmdStats,
   cmdCheckCommit,
+  _wsParseRetryAfter,
 };

--- a/tests/commands.test.cjs
+++ b/tests/commands.test.cjs
@@ -1558,14 +1558,15 @@ describe('websearch command', () => {
 
     global.fetch = async () => ({
       ok: false,
-      status: 429,
+      status: 401,
+      headers: { get: () => null },
     });
 
     await cmdWebsearch('test query', {}, false);
 
     const output = JSON.parse(captured);
     assert.strictEqual(output.available, false);
-    assert.ok(output.error.includes('429'), 'error should include status code');
+    assert.ok(output.error.includes('401'), 'error should include status code');
   });
 
   test('handles network failure', async () => {
@@ -1580,6 +1581,113 @@ describe('websearch command', () => {
     const output = JSON.parse(captured);
     assert.strictEqual(output.available, false);
     assert.strictEqual(output.error, 'Network timeout');
+  });
+
+  // ── New retry/timeout tests (A–E) ──────────────────────────────────────────
+
+  test('A. timeout is bounded: AbortSignal fires, resolves with available=false and attempts field', async (t) => {
+    process.env.BRAVE_API_KEY = 'test-key';
+    process.env.GSD_WEBSEARCH_TIMEOUT_MS = '20';
+    t.after(() => { delete process.env.GSD_WEBSEARCH_TIMEOUT_MS; });
+
+    global.fetch = async (_url, init) => new Promise((_resolve, reject) => {
+      init.signal.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')));
+    });
+
+    await cmdWebsearch('q', {}, false);
+
+    const output = JSON.parse(captured);
+    assert.strictEqual(output.available, false, 'should be available=false after timeout exhaustion');
+    assert.ok(typeof output.attempts === 'number', 'should include attempts field');
+  });
+
+  test('B. retry on 503 then success: succeeds on 2nd attempt, fetch called exactly twice', async () => {
+    process.env.BRAVE_API_KEY = 'test-key';
+    let callCount = 0;
+
+    global.fetch = async () => {
+      callCount++;
+      if (callCount === 1) {
+        return { ok: false, status: 503, headers: { get: () => null } };
+      }
+      return {
+        ok: true,
+        json: async () => ({
+          web: { results: [{ title: 'T', url: 'https://example.com', description: 'D' }] },
+        }),
+      };
+    };
+
+    await cmdWebsearch('test query', {}, false);
+
+    const output = JSON.parse(captured);
+    assert.strictEqual(output.available, true, 'should succeed after retry');
+    assert.strictEqual(output.results.length, 1, 'should have one result');
+    assert.strictEqual(callCount, 2, 'fetch should be called exactly twice');
+  });
+
+  test('C. 429 honors Retry-After then succeeds on 2nd call, fetch called exactly twice', async () => {
+    process.env.BRAVE_API_KEY = 'test-key';
+    let callCount = 0;
+
+    global.fetch = async () => {
+      callCount++;
+      if (callCount === 1) {
+        return {
+          ok: false,
+          status: 429,
+          headers: { get: (h) => h.toLowerCase() === 'retry-after' ? '0' : null },
+        };
+      }
+      return {
+        ok: true,
+        json: async () => ({
+          web: { results: [{ title: 'T', url: 'https://example.com', description: 'D' }] },
+        }),
+      };
+    };
+
+    await cmdWebsearch('test query', {}, false);
+
+    const output = JSON.parse(captured);
+    assert.strictEqual(output.available, true, 'should succeed after 429 retry');
+    assert.strictEqual(callCount, 2, 'fetch should be called exactly twice');
+  });
+
+  test('D. no retry on 401: fails immediately, fetch called exactly once', async () => {
+    process.env.BRAVE_API_KEY = 'test-key';
+    let callCount = 0;
+
+    global.fetch = async () => {
+      callCount++;
+      return { ok: false, status: 401, headers: { get: () => null } };
+    };
+
+    await cmdWebsearch('test query', {}, false);
+
+    const output = JSON.parse(captured);
+    assert.strictEqual(output.available, false, 'should be available=false');
+    assert.strictEqual(output.error, 'API error: 401', 'error should be API error: 401');
+    assert.strictEqual(output.attempts, undefined, 'should NOT have attempts field on immediate fail');
+    assert.strictEqual(callCount, 1, 'fetch should be called exactly once');
+  });
+
+  test('E. network error retried then exhausted: attempts=3, fetch called 3 times', async () => {
+    process.env.BRAVE_API_KEY = 'test-key';
+    let callCount = 0;
+
+    global.fetch = async () => {
+      callCount++;
+      throw new Error('boom');
+    };
+
+    await cmdWebsearch('test query', {}, false);
+
+    const output = JSON.parse(captured);
+    assert.strictEqual(output.available, false, 'should be available=false');
+    assert.ok(output.error.includes('boom'), 'error should include boom');
+    assert.strictEqual(output.attempts, 3, 'attempts should be 3');
+    assert.strictEqual(callCount, 3, 'fetch should be called 3 times');
   });
 });
 
@@ -1950,5 +2058,52 @@ describe('check-commit command', () => {
     assert.ok(!result.success, 'should block commit');
     assert.ok(result.error.includes('.planning/'), 'error should mention .planning/ files');
     assert.ok(result.error.includes('unstage'), 'error should suggest unstage command');
+  });
+});
+
+describe('_wsParseRetryAfter (#308)', () => {
+  const { _wsParseRetryAfter } = require('../get-shit-done/bin/lib/commands.cjs');
+
+  test('integer seconds: "120" → 60000 (capped at 60s)', () => {
+    assert.strictEqual(_wsParseRetryAfter('120'), 60000);
+  });
+
+  test('leading zero: "01" → 1000', () => {
+    assert.strictEqual(_wsParseRetryAfter('01'), 1000);
+  });
+
+  test('whitespace: " 5 " → 5000', () => {
+    assert.strictEqual(_wsParseRetryAfter(' 5 '), 5000);
+  });
+
+  test('"0" → 0', () => {
+    assert.strictEqual(_wsParseRetryAfter('0'), 0);
+  });
+
+  test('value > 60s cap: "120000" → 60000', () => {
+    assert.strictEqual(_wsParseRetryAfter('120000'), 60000);
+  });
+
+  test('future HTTP-date → value in (0, 60000]', () => {
+    const futureDate = new Date(Date.now() + 5000).toUTCString();
+    const v = _wsParseRetryAfter(futureDate);
+    assert.ok(typeof v === 'number' && v > 0 && v <= 60000, `expected (0,60000], got ${v}`);
+  });
+
+  test('past HTTP-date → 0', () => {
+    const pastDate = new Date(Date.now() - 5000).toUTCString();
+    assert.strictEqual(_wsParseRetryAfter(pastDate), 0);
+  });
+
+  test('"garbage" → null', () => {
+    assert.strictEqual(_wsParseRetryAfter('garbage'), null);
+  });
+
+  test('"" → null', () => {
+    assert.strictEqual(_wsParseRetryAfter(''), null);
+  });
+
+  test('null → null', () => {
+    assert.strictEqual(_wsParseRetryAfter(null), null);
   });
 });


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #308

## What was broken

`cmdWebsearch` in `get-shit-done/bin/lib/commands.cjs` called global `fetch()` to the Brave Search API with **no timeout and no retry**. A hung or slow connection blocked the command indefinitely, and transient failures (429 rate-limit, 5xx, network errors) were surfaced as a one-shot failure with no recovery.

## What this fix does

Wraps the fetch in a bounded retry loop with a per-attempt timeout:

- **Timeout:** each attempt uses an `AbortController` aborted by a `setTimeout` that is cleared in a `finally` once the request settles, configurable via `GSD_WEBSEARCH_TIMEOUT_MS` (positive integer, default `10000`). Clearing the timer on settle avoids leaving a pending timer alive after a fast response.
- **Bounded retry:** up to 2 retries (3 attempts total) for `429`, `5xx`, and thrown network/timeout errors, with exponential backoff + jitter. The attempt counter strictly increments and is hard-capped, so the loop provably terminates and worst-case time is bounded by `timeout × (1 + retries) + Σ backoff` (no more unbounded waits).
- **Honors `Retry-After` on 429:** parses integer-seconds or HTTP-date, clamped to `[0, 60s]`, falling back to normal backoff when absent/unparseable.
- **No retry on non-429 4xx:** `400/401/403/404` fail immediately with the existing `{ available: false, error: "API error: <status>" }` shape — retrying a guaranteed-failure response only burns rate budget.
- **Transient-vs-permanent:** failures that exhaust retries include an additive `attempts` field so the calling agent can distinguish "retried N times and still failed" from an immediate hard failure. Success and immediate-4xx outputs are unchanged.

## Root cause

The request was a single `await fetch(...)` with no `signal` and no surrounding retry policy. Resilience was never expressed for this network boundary.

## Testing

### How I verified the fix

- Added behavior tests (mocking `global.fetch`): timeout aborts and completes bounded; `503` is retried then succeeds (2 calls); `429` with `Retry-After` is retried then succeeds; `401` fails immediately with **one** fetch call and no `attempts` field; a persistent network error is retried to exhaustion (`attempts: 3`, 3 calls).
- Added deterministic unit tests for the `Retry-After` parser (integer seconds incl. leading-zero, whitespace, HTTP-date, the 60s cap, and invalid/missing → fallback).
- Repurposed the existing non-200 test to a non-retryable `401` (since `429` is now retryable) to keep immediate-fail coverage.
- `gsd-test-summary --both -base next` (full suite, branch merged onto `next`): `Mac: 0 failed`, `Docker: 0 failed` (exit 0).

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why: <!-- e.g., environment-specific, non-deterministic -->

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

<!-- Does this fix change any existing behavior, output format, or API that users might depend on?
     If yes, describe. Write "None" if not applicable. -->

The websearch failure path now retries transient errors before returning, and transient-exhausted failures gain an additive `attempts` field. The success output and immediate-failure (non-429 4xx, missing key, missing query) outputs are unchanged. New optional env var `GSD_WEBSEARCH_TIMEOUT_MS` (default 10000) tunes the per-attempt timeout. No removed or renamed fields.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/get-shit-done-redux/pr/387"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782493839&installation_id=134682257&pr_number=387&repository=open-gsd%2Fget-shit-done-redux&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fget-shit-done-redux%2Fpull%2F387&signature=12eec909e55541ebde7dcb5d7fc32864b6de3d5823f13a38132caf19a61463c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->