### PR TITLE
ci(#310): scope release and hotfix gates to unit coverage

### DIFF
--- a/.github/workflows/hotfix.yml
+++ b/.github/workflows/hotfix.yml
@@ -320,7 +320,7 @@ jobs:
       - name: Install and test
         run: |
           npm ci
-          npm run test:coverage
+          npm run test:coverage:unit
 
 
       - name: Dry-run publish validation

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,7 +191,7 @@ jobs:
           npm ci
           chmod +x scripts/check-npm-integrity.sh
           scripts/check-npm-integrity.sh
-          npm run test:coverage
+          npm run test:coverage:unit
 
       - name: Commit pre-release version bump
         env:
@@ -324,7 +324,7 @@ jobs:
           npm ci
           chmod +x scripts/check-npm-integrity.sh
           scripts/check-npm-integrity.sh
-          npm run test:coverage
+          npm run test:coverage:unit
 
       - name: Ensure npm supports trusted publishing
         run: npm install -g npm@latest

--- a/tests/release-coverage-scope.test.cjs
+++ b/tests/release-coverage-scope.test.cjs
@@ -1,0 +1,35 @@
+// allow-test-rule: source-text-is-the-product
+// .github/workflows/{release,hotfix}.yml are the deployed CI contract; asserting
+// the release-gate test command is only expressible against the workflow text.
+
+'use strict';
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const RELEASE_WORKFLOW = path.join(__dirname, '..', '.github', 'workflows', 'release.yml');
+const HOTFIX_WORKFLOW  = path.join(__dirname, '..', '.github', 'workflows', 'hotfix.yml');
+
+describe('release-coverage-scope', () => {
+  test('release.yml uses test:coverage:unit (not full suite) in both rc and finalize gates', () => {
+    const lines = fs.readFileSync(RELEASE_WORKFLOW, 'utf8').split('\n').map(l => l.trim());
+    const bareCount = lines.filter(l => l === 'npm run test:coverage').length;
+    const unitCount = lines.filter(l => l === 'npm run test:coverage:unit').length;
+    assert.strictEqual(bareCount, 0,
+      `release.yml still has ${bareCount} bare 'npm run test:coverage' line(s); expected 0`);
+    assert.strictEqual(unitCount, 2,
+      `release.yml has ${unitCount} 'npm run test:coverage:unit' line(s); expected 2`);
+  });
+
+  test('hotfix.yml uses test:coverage:unit (not full suite) in the finalize gate', () => {
+    const lines = fs.readFileSync(HOTFIX_WORKFLOW, 'utf8').split('\n').map(l => l.trim());
+    const bareCount = lines.filter(l => l === 'npm run test:coverage').length;
+    const unitCount = lines.filter(l => l === 'npm run test:coverage:unit').length;
+    assert.strictEqual(bareCount, 0,
+      `hotfix.yml still has ${bareCount} bare 'npm run test:coverage' line(s); expected 0`);
+    assert.strictEqual(unitCount, 1,
+      `hotfix.yml has ${unitCount} 'npm run test:coverage:unit' line(s); expected 1`);
+  });
+});


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #310

## What was broken

The release and hotfix CI workflows ran the full `npm run test:coverage` suite on the release path — `release.yml` in both the `rc` and `finalize` jobs, and `hotfix.yml` in the `finalize` job. That redundantly re-ran the integration, install, security, and slow suites that had already passed on the PR lanes into `next`, inflating release latency for no added gate value.

## What this fix does

Switches those three release-path steps to `npm run test:coverage:unit` (already defined in `package.json` with the same `c8` config, scoped to the unit suite via `--suite unit`). The integration/install/security/slow suites continue to run on their dedicated PR lanes; the full suite remains available via `npm run test:coverage:all`. Staged gates — unit coverage on the release/hotfix path, full coverage upstream.

## Root cause

The release gate defaulted to the full coverage command, so it duplicated suites already verified on the PRs that composed the release, rather than scoping to what the release gate actually needs.

## Testing

### How I verified the fix

- Added `tests/release-coverage-scope.test.cjs`, a workflow-contract regression test (annotated `// allow-test-rule: source-text-is-the-product`, matching the existing workflow-YAML test pattern). It asserts via **exact trimmed-line** counts (not a substring match, which would vacuously match `:unit`) that `release.yml` and `hotfix.yml` have zero bare `npm run test:coverage` lines and the expected `npm run test:coverage:unit` lines (2 + 1). Red before the fix, green after.
- `gsd-test-summary --both -base next` (full suite, branch merged onto `next`): `Mac: 0 failed`, `Docker: 0 failed` (exit 0).

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why: <!-- e.g., environment-specific, non-deterministic -->

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

<!-- Does this fix change any existing behavior, output format, or API that users might depend on?
     If yes, describe. Write "None" if not applicable. -->

None for users. Internal CI change only: the release/hotfix path now runs unit coverage instead of the full suite. The integration/install/security/slow suites still run on the PR lanes into `next`, and `npm run test:coverage:all` remains for full-suite runs. No product behavior, output, or API changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/get-shit-done-redux/pr/388"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782494832&installation_id=134682257&pr_number=388&repository=open-gsd%2Fget-shit-done-redux&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fget-shit-done-redux%2Fpull%2F388&signature=0856c2e58c331669ed42280df17a8ecd01927effe2f0137abc24cd1c4e95ba88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->