### PR TITLE
test(#382): make graphify-auto-update hook tests deterministic on Docker

### DIFF
--- a/tests/graphify-auto-update.test.cjs
+++ b/tests/graphify-auto-update.test.cjs
@@ -272,6 +272,26 @@ describe('auto-update', () => {
     Atomics.wait(_sleepSai, 0, 0, ms);
   }
 
+  // Wait until the detached rebuild writes a terminal status, with a generous
+  // deadline. The detached subprocess can be slow under contended Docker; all
+  // assertions here are outcome-based, so we wait for the real terminal state
+  // rather than guessing a tight wall-clock budget (#382).
+  function waitForBuildStatus(statusPath, terminal /* e.g. new Set(['ok']) */, { deadlineMs = 30000, stepMs = 25 } = {}) {
+    const deadline = Date.now() + deadlineMs;
+    let status;
+    while (Date.now() < deadline) {
+      if (fs.existsSync(statusPath)) {
+        try {
+          const parsed = JSON.parse(fs.readFileSync(statusPath, 'utf8'));
+          status = parsed;
+          if (parsed && terminal.has(parsed.status)) return parsed;
+        } catch { /* detached writer can briefly expose a partial JSON write */ }
+      }
+      atomicSleep(stepMs);
+    }
+    return status; // last seen (may be undefined / non-terminal) — assertions below will report
+  }
+
   function cleanupHookRepo(tmpDir) {
     // The hook detaches a graphify-rebuild subprocess that may still be writing
     // into tmpDir when the test body returns. Wait for the rebuild PID to exit
@@ -279,11 +299,11 @@ describe('auto-update', () => {
     // absorb any remaining transient ENOTEMPTY race.
     //
     // Uses Atomics.wait instead of execFileSync('sleep', ...) so we yield the
-    // CPU without spawning an external process per iteration.  Budget: 4 s —
-    // the mock graphify binary completes in well under 1 s; if we hit the
-    // ceiling something else is broken.
+    // CPU without spawning an external process per iteration.  Budget: 15 s —
+    // bumped from 4 s to give the detached child more time to exit under
+    // contended Docker before we attempt removal (#382).
     const lockPath = path.join(tmpDir, '.planning/graphs/.rebuild.lock');
-    const lockDeadline = Date.now() + 4000;
+    const lockDeadline = Date.now() + 15000;
     while (Date.now() < lockDeadline) {
       if (!fs.existsSync(lockPath)) break;
       try {
@@ -295,7 +315,9 @@ describe('auto-update', () => {
       }
       atomicSleep(50); // yield 50 ms, then re-check (replaces execFileSync('sleep'))
     }
-    fs.rmSync(tmpDir, { recursive: true, force: true, maxRetries: 8, retryDelay: 100 });
+    try {
+      fs.rmSync(tmpDir, { recursive: true, force: true, maxRetries: 8, retryDelay: 100 });
+    } catch { /* best-effort teardown: a residual temp dir is harmless; never fail the test (#382) */ }
   }
 
   describe('hook — bail paths (no side effects)',
@@ -438,32 +460,11 @@ describe('auto-update', () => {
       );
 
       // Wait for the detached rebuild process to write the final status file.
-      // The detached process exits after writing; we poll until the status
-      // transitions from "running" to a terminal value.
-      //
-      // Behavior-anchored wait (fix for #3803): the poll budget is derived from
-      // the mock's known sleepMs (200 ms) rather than a wall-clock constant.
-      // waitBudget = sleepMs + 2000 ms: the 2 s buffer covers two bash process
-      // startups (the hook script + the detached rebuild subprocess) plus
-      // filesystem write latency.  Mac bash startup: ~100-300 ms; Docker adds
-      // more.  2 s keeps the test honest under load without guessing an absolute
-      // wall-clock ceiling.  See PR #3793 for the reference fix pattern.
+      // Uses waitForBuildStatus with a generous 30 s deadline so contended
+      // Docker is never racing a tight budget (#382). All assertions are
+      // outcome-based; the deadline is deterministic, not a timing assertion.
       const statusPath = path.join(tmpDir, '.planning/graphs/.last-build-status.json');
-      const _sleepMs_ok = 200; // mirrors makeMockGraphifyBin sleepMs above
-      const _waitBudget_ok = _sleepMs_ok + 2000; // 2 s: two bash spawn overheads
-      const _maxIter_ok = Math.ceil(_waitBudget_ok / 100); // 100 ms poll step
-      let status;
-      for (let i = 0; i < _maxIter_ok; i++) {
-        if (fs.existsSync(statusPath)) {
-          try {
-            status = JSON.parse(fs.readFileSync(statusPath, 'utf8'));
-            if (status.status === 'ok') break;
-          } catch {
-            // Detached writer can briefly expose a partial JSON write.
-          }
-        }
-        atomicSleep(100); // yield 100 ms, then re-check
-      }
+      const status = waitForBuildStatus(statusPath, new Set(['ok']));
       assert.ok(status, 'status file must exist after dispatch');
       assert.strictEqual(status.status, 'ok', 'mock graphify exit=0 → status ok');
       assert.strictEqual(status.exit_code, 0);
@@ -484,28 +485,11 @@ describe('auto-update', () => {
       );
 
       // Wait for the detached rebuild process to write the final status file.
-      //
-      // Behavior-anchored wait (fix for #3803): same pattern as the status=ok
-      // variant above.  Budget derived from mock sleepMs (100 ms) + 2 s overhead
-      // buffer (two bash spawns: hook script + detached rebuild subprocess).
-      // The 2 s absorbs startup latency without anchoring to an absolute
-      // wall-clock ceiling.
+      // Uses waitForBuildStatus with a generous 30 s deadline so contended
+      // Docker is never racing a tight budget (#382). All assertions are
+      // outcome-based; the deadline is deterministic, not a timing assertion.
       const statusPath = path.join(tmpDir, '.planning/graphs/.last-build-status.json');
-      const _sleepMs_fail = 100; // mirrors makeMockGraphifyBin sleepMs above
-      const _waitBudget_fail = _sleepMs_fail + 2000; // 2 s: two bash spawn overheads
-      const _maxIter_fail = Math.ceil(_waitBudget_fail / 100); // 100 ms poll step
-      let status;
-      for (let i = 0; i < _maxIter_fail; i++) {
-        if (fs.existsSync(statusPath)) {
-          try {
-            status = JSON.parse(fs.readFileSync(statusPath, 'utf8'));
-            if (status.status === 'failed') break;
-          } catch {
-            // Detached writer can briefly expose a partial JSON write.
-          }
-        }
-        atomicSleep(100); // yield 100 ms, then re-check
-      }
+      const status = waitForBuildStatus(statusPath, new Set(['failed']));
       assert.ok(status, 'status file must exist after dispatch');
       assert.strictEqual(status.status, 'failed', 'mock graphify exit=1 → status failed');
       assert.strictEqual(status.exit_code, 1);
@@ -605,12 +589,9 @@ describe('auto-update', () => {
           { pathPrepend: mockBin },
         );
         const statusPath = path.join(tmpDir, '.planning/graphs/.last-build-status.json');
-        const waitBudgetMs = 2500; // 100 ms mock sleep + hook/detached bash startup slack
-        const maxIter = Math.ceil(waitBudgetMs / 100);
-        for (let i = 0; i < maxIter; i++) {
-          if (fs.existsSync(statusPath)) break;
-          atomicSleep(100);
-        }
+        // Wait for any terminal status; we only assert the file exists,
+        // not which terminal value it holds (#382: generous deadline).
+        waitForBuildStatus(statusPath, new Set(['ok', 'failed']));
         assert.ok(
           fs.existsSync(statusPath),
           `must dispatch for HEAD-advancing op: ${cmd}`,


### PR DESCRIPTION
<!-- pr-template-exempt: test-only flaky-test stabilization chore (#382); no production/hook code or user-facing change, so none of the fix/enhancement/feature typed templates apply -->

## Test stabilization (chore)

Fixes #382

## What was flaky

`tests/graphify-auto-update.test.cjs` flaked on the Docker (Linux) leg of the `gsd-test-summary --both` gate — it blocked unrelated PRs (#308, #310 each lost a gate run to it) with two intermittent signatures:

- **`"1 subtest failed"`** — the dispatch tests poll the detached rebuild's status file with a tight `sleepMs + 2000ms` (~2.2 s) budget. Under contended Docker, the detached `graphify-rebuild` subprocess writes its terminal status later than 2.2 s, so the poll loop exits before observing `ok`/`failed` and the assertion fails.
- **`"failed running after hook"`** — `cleanupHookRepo`'s `fs.rmSync` could throw `EBUSY`/`ENOTEMPTY` while the detached child was still writing into the temp dir, throwing **in the `after` hook** and failing an otherwise-passing test.

Both are pure timing races against the hook's detached background rebuild; the Mac leg always passed.

## Root cause

The tests encoded **wall-clock budgets** for asynchronous background work whose latency varies with host load. The hook (`hooks/gsd-graphify-update.sh`) writes the final status (`ok`/`failed`) before its child's EXIT trap removes the lock, so a terminal status is a deterministic completion signal — but the tests guessed a tight upper bound instead of waiting for it.

## The fix (test-only — no production/hook code changed)

- Replaced all three ad-hoc poll loops with a shared `waitForBuildStatus(statusPath, terminalSet, { deadlineMs: 30000 })` that waits for the real terminal status under a generous deadline. All assertions are outcome-based (`status === 'ok'`/`'failed'`, `exit_code`, `duration_ms >= 0`) — none assert a time bound — so waiting longer is deterministic, not a timing assertion. The loop still exits the instant the status is terminal (fast in practice).
- Made `cleanupHookRepo` teardown best-effort: extended the lock-wait deadline (4 s → 15 s) and wrapped the final `rmSync` so it can never throw. A residual temp dir under `os.tmpdir()` is harmless; a throwing `after` hook must never fail a passing test.

No assertion was weakened or removed; coverage is unchanged.

## Verification

- **Reproduced** the flake in a Linux container (`node:22`) under CPU contention + parallelism: **4/72 runs failed (5.6%)** on the pre-fix tree, with the two signatures above.
- **Post-fix: 0/144 runs failed** under the same load (if the 5.6% rate had persisted, 0/144 would occur ~0.02% of the time — strong evidence the races are closed, and that all poll sites were migrated).
- `gsd-test-summary --both -base next` (full suite): `Mac: 0 failed`, `Docker: 0 failed`.

## Notes

- Test-only change; no files under `bin/` `get-shit-done/` `agents/` `commands/` `hooks/` `sdk/src/` touched, so the changeset lint does not apply — `no-changelog` label applied.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/get-shit-done-redux/pr/389"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782496449&installation_id=134682257&pr_number=389&repository=open-gsd%2Fget-shit-done-redux&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fget-shit-done-redux%2Fpull%2F389&signature=1dba3678bccf75eab8c16b594c57ba5269859ff814ace9807ee2483e2cbcb6df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->