### PR TITLE
perf(#311): index subrepo routing by first path segment

### DIFF
--- a/.changeset/311-subrepo-routing-index.md
+++ b/.changeset/311-subrepo-routing-index.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 311
+---
+Route changed files to sub-repos via a first-segment bucket index instead of an O(files*repos) linear scan (#311).

--- a/get-shit-done/bin/lib/commands.cjs
+++ b/get-shit-done/bin/lib/commands.cjs
@@ -366,6 +366,43 @@ function cmdCommit(cwd, message, files, raw, amend, noVerify) {
   output(result, raw, hash || 'committed');
 }
 
+/**
+ * Route a list of changed files to their sub-repo prefixes.
+ *
+ * Bucket sub-repos by their first path segment. Any file that matches a
+ * sub-repo prefix must share that sub-repo's first segment, so we only scan
+ * the (small) bucket for the file's first segment instead of all sub-repos
+ * — O(F + R) expected vs the prior O(F*R) find-in-loop. Candidates stay in
+ * sub-repo array order, preserving the original first-match semantics
+ * (incl. multi-segment sub-repos like "vendor/pkg", which resolve via the
+ * inner startsWith). (#311)
+ *
+ * @param {string[]} files    - changed file paths (relative to project root)
+ * @param {string[]} subRepos - sub-repo path prefixes from config.sub_repos
+ * @returns {{ grouped: Object<string,string[]>, unmatched: string[] }}
+ */
+function groupFilesBySubrepo(files, subRepos) {
+  const reposByFirstSeg = new Map();
+  for (const repo of subRepos) {
+    const firstSeg = String(repo).split('/')[0];
+    let bucket = reposByFirstSeg.get(firstSeg);
+    if (!bucket) { bucket = []; reposByFirstSeg.set(firstSeg, bucket); }
+    bucket.push(repo);
+  }
+  const grouped = {};
+  const unmatched = [];
+  for (const file of files) {
+    const candidates = reposByFirstSeg.get(file.split('/')[0]);
+    const match = candidates ? candidates.find(repo => file.startsWith(repo + '/')) : undefined;
+    if (match) {
+      (grouped[match] ||= []).push(file);
+    } else {
+      unmatched.push(file);
+    }
+  }
+  return { grouped, unmatched };
+}
+
 function cmdCommitToSubrepo(cwd, message, files, raw) {
   if (!message) {
     error('commit message required');
@@ -383,17 +420,7 @@ function cmdCommitToSubrepo(cwd, message, files, raw) {
   }
 
   // Group files by sub-repo prefix
-  const grouped = {};
-  const unmatched = [];
-  for (const file of files) {
-    const match = subRepos.find(repo => file.startsWith(repo + '/'));
-    if (match) {
-      if (!grouped[match]) grouped[match] = [];
-      grouped[match].push(file);
-    } else {
-      unmatched.push(file);
-    }
-  }
+  const { grouped, unmatched } = groupFilesBySubrepo(files, subRepos);
 
   if (unmatched.length > 0) {
     process.stderr.write(`Warning: ${unmatched.length} file(s) did not match any sub-repo prefix: ${unmatched.join(', ')}\n`);
@@ -1015,6 +1042,7 @@ function cmdCheckCommit(cwd, raw) {
 }
 
 module.exports = {
+  groupFilesBySubrepo,
   determinePhaseStatus,
   cmdGenerateSlug,
   cmdCurrentTimestamp,

--- a/tests/commands.test.cjs
+++ b/tests/commands.test.cjs
@@ -1389,6 +1389,76 @@ describe('commit command', () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
+// groupFilesBySubrepo tests (#311)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('groupFilesBySubrepo (#311)', () => {
+  const { groupFilesBySubrepo } = require('../get-shit-done/bin/lib/commands.cjs');
+
+  test('single-segment subrepos route files correctly and unmatched collected', () => {
+    const result = groupFilesBySubrepo(
+      ['packages/a.js', 'docs/x.md', 'README.md'],
+      ['packages', 'docs']
+    );
+    assert.deepStrictEqual(result.grouped, { packages: ['packages/a.js'], docs: ['docs/x.md'] });
+    assert.deepStrictEqual(result.unmatched, ['README.md']);
+  });
+
+  test('multi-segment subrepo matches deep files, not shallow sibling', () => {
+    const result = groupFilesBySubrepo(
+      ['vendor/pkg/x.js', 'vendor/other.js', 'vendor/pkg/y.js'],
+      ['vendor/pkg']
+    );
+    assert.deepStrictEqual(result.grouped, { 'vendor/pkg': ['vendor/pkg/x.js', 'vendor/pkg/y.js'] });
+    assert.deepStrictEqual(result.unmatched, ['vendor/other.js']);
+  });
+
+  test('first-match-in-array-order wins (not longest-prefix)', () => {
+    // 'app' comes before 'app/sub' in subRepos array; 'app/sub/f.js' matches 'app' first
+    const result = groupFilesBySubrepo(
+      ['app/sub/f.js'],
+      ['app', 'app/sub']
+    );
+    assert.deepStrictEqual(result.grouped, { app: ['app/sub/f.js'] });
+    assert.deepStrictEqual(result.unmatched, []);
+  });
+
+  test('file with no slash does not match a same-name subrepo', () => {
+    const result = groupFilesBySubrepo(['top'], ['top']);
+    assert.deepStrictEqual(result.grouped, {});
+    assert.deepStrictEqual(result.unmatched, ['top']);
+  });
+
+  test('file with slash after prefix routes correctly', () => {
+    const result = groupFilesBySubrepo(['top/a'], ['top']);
+    assert.deepStrictEqual(result.grouped, { top: ['top/a'] });
+    assert.deepStrictEqual(result.unmatched, []);
+  });
+
+  test('empty files list returns empty grouped and unmatched', () => {
+    const result = groupFilesBySubrepo([], ['a']);
+    assert.deepStrictEqual(result.grouped, {});
+    assert.deepStrictEqual(result.unmatched, []);
+  });
+
+  test('empty subRepos list puts all files in unmatched', () => {
+    const result = groupFilesBySubrepo(['a/b'], []);
+    assert.deepStrictEqual(result.grouped, {});
+    assert.deepStrictEqual(result.unmatched, ['a/b']);
+  });
+
+  test('non-string subRepos entry does not throw and string entries still route (#311)', () => {
+    // Old inline code coerced non-string repos via `repo + '/'` and never threw.
+    let result;
+    assert.doesNotThrow(() => {
+      result = groupFilesBySubrepo(['a/b', 'README.md'], [null, 'a']);
+    });
+    assert.deepStrictEqual(result.grouped, { a: ['a/b'] });
+    assert.deepStrictEqual(result.unmatched, ['README.md']);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
 // cmdWebsearch tests (CMD-05)
 // ─────────────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #311

## What was broken

`cmdCommitToSubrepo` in `get-shit-done/bin/lib/commands.cjs` routed each changed file to its sub-repo with `subRepos.find(repo => file.startsWith(repo + '/'))` inside the per-file loop — an O(files × repos) linear prefix scan that scales poorly as either the changed-file list or the configured `sub_repos` list grows.

## What this fix does

Extracts a pure, exported `groupFilesBySubrepo(files, subRepos)` that buckets the sub-repos by their first path segment (a `Map`), then for each file scans only the (small) bucket for that file's first segment. Any file that matches a sub-repo prefix necessarily shares that sub-repo's first segment, so the bucket contains exactly the candidates the original full scan would have considered — in the same array order. Complexity drops from O(files × repos) to expected O(files + repos).

Behavior is identical: same `startsWith(repo + '/')` predicate, same first-match-in-array-order semantics (including multi-segment sub-repos like `vendor/pkg`), and the same `{ grouped, unmatched }` shape and insertion order. Non-string `sub_repos` entries are coerced with `String()` so the helper never throws where the original `repo + '/'` concatenation silently tolerated them.

## Root cause

The routing rebuilt a linear search over all sub-repos for every file. Bucketing the sub-repos once by first path segment removes the repeated full scan without changing the match semantics.

## Testing

### How I verified the fix

- Added the first behavior-lock tests for the routing path: single-segment routing + unmatched collection, multi-segment sub-repo (`vendor/pkg`) resolution, first-match-wins (`['app','app/sub']` + `app/sub/f.js` → grouped under `app`, **not** longest-prefix), no-slash file non-match, and empty-input cases — all asserted with `deepStrictEqual` on `{ grouped, unmatched }`.
- Added a regression test that a non-string `sub_repos` entry does not throw and string entries still route (red before the `String()` coercion — `TypeError` — green after).
- `gsd-test-summary --both -base next` (full suite, branch merged onto `next`): `Mac: 0 failed`, `Docker: 0 failed` (exit 0).

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why: <!-- e.g., environment-specific, non-deterministic -->

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

<!-- Does this fix change any existing behavior, output format, or API that users might depend on?
     If yes, describe. Write "None" if not applicable. -->

None. Routing results are identical (first-match semantics, grouped/unmatched shape, and order all preserved); only the internal algorithm changed from O(files × repos) to O(files + repos).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/get-shit-done-redux/pr/390"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782498064&installation_id=134682257&pr_number=390&repository=open-gsd%2Fget-shit-done-redux&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fget-shit-done-redux%2Fpull%2F390&signature=deb8d62229b62af6ee4821ccf2f2809ed9a62166680781f88575ace76b60fd3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->