### PR TITLE
perf(#314): index roadmap plan lookups by id (O(lines×plans) → O(lines+plans))

### DIFF
--- a/.changeset/314-roadmap-plan-id-map.md
+++ b/.changeset/314-roadmap-plan-id-map.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 314
+---
+`roadmap annotate-dependencies` now indexes plan data by ID in a Map before the checklist loop, reducing plan lookup from O(lines×plans) to O(lines+plans).

--- a/get-shit-done/bin/lib/roadmap.cjs
+++ b/get-shit-done/bin/lib/roadmap.cjs
@@ -572,6 +572,14 @@ function cmdRoadmapAnnotateDependencies(cwd, phaseNum, raw) {
 
     if (listLines.length === 0) return;
 
+    // #314 perf: build a first-wins Map so per-line lookup is O(1) instead of O(plans).
+    // First-wins mirrors .find() semantics: if the same planId appears more than once
+    // in planData, the earlier entry wins — identical to what .find() returned before.
+    const planById = new Map();
+    for (const p of planData) {
+      if (!planById.has(p.planId)) planById.set(p.planId, p);
+    }
+
     // Build wave-annotated plan list
     const linesByWave = new Map();
     for (const line of listLines) {
@@ -586,7 +594,7 @@ function cmdRoadmapAnnotateDependencies(cwd, phaseNum, raw) {
       // (e.g. `.invalid-PLAN.md`) would silently default to wave 1 — defensively
       // skip the line instead so corrupted ROADMAP entries don't corrupt wave layout.
       if (planId && !/^\w[\w.-]*$/.test(planId)) continue;
-      const planEntry = planId ? planData.find(p => p.planId === planId) : null;
+      const planEntry = planId ? (planById.get(planId) || null) : null;
       const wave = planEntry ? planEntry.wave : 1;
       if (!linesByWave.has(wave)) linesByWave.set(wave, []);
       linesByWave.get(wave).push(line);

--- a/tests/enh-2447-roadmap-wave-deps.test.cjs
+++ b/tests/enh-2447-roadmap-wave-deps.test.cjs
@@ -217,6 +217,46 @@ Plans:
     assert.ok(typeof out.updated === 'boolean', 'should return a valid result object');
   });
 
+  test('#314 map-lookup: found-path uses plan wave, miss-path defaults to wave 1', () => {
+    // Behavior lock for the O(1) Map swap: asserts BOTH branches of the lookup.
+    // - 01-01-PLAN.md is in planData (wave 2) → checklist line must land under Wave 2.
+    // - 01-99-PLAN.md is NOT in planData → null-on-miss → defaults to wave 1.
+    tmpDir = makePlanProject({
+      '.planning/ROADMAP.md': `# Roadmap
+
+### Phase 1: Foundation
+**Goal:** Set up project
+**Plans:** 2 plans
+
+Plans:
+- [ ] 01-01-PLAN.md — Known plan
+- [ ] 01-99-PLAN.md — Unknown plan (no PLAN.md)
+`,
+      '.planning/phases/01-foundation/01-01-PLAN.md': PLAN_TEMPLATE(2),
+      // 01-99-PLAN.md intentionally absent — simulates a checklist entry with no backing plan file
+    });
+
+    const result = runGsdTools('roadmap annotate-dependencies 1', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const roadmap = fs.readFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), 'utf-8');
+
+    // Both waves must be present (wave 1 from the miss, wave 2 from the found entry)
+    assert.ok(roadmap.includes('**Wave 1**'), 'Wave 1 header present (miss-path default)');
+    assert.ok(roadmap.includes('**Wave 2**'), 'Wave 2 header present (found-path)');
+
+    // Known plan (wave 2) must appear AFTER Wave 2 header
+    const wave2Idx = roadmap.indexOf('**Wave 2**');
+    const knownLineIdx = roadmap.indexOf('01-01-PLAN.md');
+    assert.ok(knownLineIdx > wave2Idx, 'known plan line grouped under Wave 2');
+
+    // Unknown plan (wave 1 default) must appear AFTER Wave 1 header and BEFORE Wave 2 header
+    const wave1Idx = roadmap.indexOf('**Wave 1**');
+    const unknownLineIdx = roadmap.indexOf('01-99-PLAN.md');
+    assert.ok(unknownLineIdx > wave1Idx, 'unknown plan line grouped under Wave 1');
+    assert.ok(unknownLineIdx < wave2Idx, 'unknown plan line appears before Wave 2 section');
+  });
+
   test('plan-phase.md documents annotate-dependencies step', () => {
     const planPhase = fs.readFileSync(
       path.join(__dirname, '../get-shit-done/workflows/plan-phase.md'), 'utf-8'


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #314

## What was broken

`cmdRoadmapAnnotateDependencies` in `get-shit-done/bin/lib/roadmap.cjs` looked up each checklist line's plan with `planData.find(p => p.planId === planId)` inside the per-line loop — O(lines × plans). For a phase with many plans and a long checklist this rescans the plan array on every line.

## What this fix does

Builds a `planById` Map once before the loop (first-wins, to exactly preserve `.find`'s first-match semantics) and does an O(1) `planById.get(planId)` per line. Net: O(lines × plans) → O(lines + plans). Output is unchanged, including the null-on-miss → wave 1 default.

## Root cause

The lookup was written as a linear scan inside the hot loop instead of an indexed lookup.

## Testing

### How I verified the fix

- Added a behavior-lock test in `tests/enh-2447-roadmap-wave-deps.test.cjs` covering both branches the swap touches: a checklist line referencing an existing planId groups under that plan's wave, and a line referencing an unknown planId defaults to wave 1.
- Existing `roadmap annotate-dependencies` + `roadmap` suites: 40 → 41 tests, all passing before and after the swap (behavior preserved).
- Full gate via `gsd-test-summary --both -base next`: **Docker: 0 failed** and **Mac: 0 failed**.

### Regression test added?

- [x] Yes — added a test that would have caught this bug

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux

### Runtimes tested

- [x] N/A (not runtime-specific)

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass (full Docker + Mac gate: 0 failed)
- [x] `.changeset/` fragment added (type Fixed, pr 314)
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/get-shit-done-redux/pr/396"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782503765&installation_id=134682257&pr_number=396&repository=open-gsd%2Fget-shit-done-redux&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fget-shit-done-redux%2Fpull%2F396&signature=96e6d4cf956b0354985cd8ababe2576a6551a3a063409df01736729f72d00eb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->