### PR TITLE
perf(#315): memoize subrepo detection within loadConfig (3 scans → 1)

### DIFF
--- a/.changeset/315-subrepo-detect-memo.md
+++ b/.changeset/315-subrepo-detect-memo.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 315
+---
+`loadConfig` now memoizes `detectSubRepos(cwd)` per call, collapsing up to 3 redundant directory scans into 1 when migrations and filesystem re-sync both trigger.

--- a/get-shit-done/bin/lib/core.cjs
+++ b/get-shit-done/bin/lib/core.cjs
@@ -287,6 +287,17 @@ function loadConfig(cwd, options = {}) {
   // can inherit from it. This prevents users from duplicating model_overrides,
   // workflow.*, etc. across every workstream config (#2714).
   const ws = activeWorkstream;
+  // #315 — per-call lazy memo: all three detection sites inside this loadConfig
+  // call operate on the same cwd and the subrepo set cannot change mid-call, so
+  // a single scan is sufficient. The memo is scoped to THIS call (not module-level)
+  // so separate loadConfig invocations each get a fresh scan.
+  let cachedSubRepos;
+  const getDetectedSubRepos = () => {
+    if (cachedSubRepos === undefined) cachedSubRepos = detectSubRepos(cwd);
+    // Return a copy: original detectSubRepos returned a fresh array per call,
+    // so each site must keep an independent array (avoid cross-site aliasing).
+    return cachedSubRepos.slice();
+  };
   let rootParsed = null;
   if (ws) {
     const rootConfigPath = path.join(planningRoot(cwd), 'config.json');
@@ -302,7 +313,7 @@ function loadConfig(cwd, options = {}) {
         // Resolve filesystem-dependent normalizations (multiRepo → planning.sub_repos)
         for (const norm of rootNorms) {
           if (norm.requiresFilesystem && !rootNormalized.planning?.sub_repos) {
-            const detected = detectSubRepos(cwd);
+            const detected = getDetectedSubRepos();
             if (detected.length > 0) {
               if (!rootNormalized.planning) rootNormalized.planning = {};
               rootNormalized.planning.sub_repos = detected;
@@ -350,7 +361,7 @@ function loadConfig(cwd, options = {}) {
         // AND the original file didn't have sub_repos already (preserve existing intent).
         for (const norm of normalizations) {
           if (norm.requiresFilesystem && !fileData.planning?.sub_repos) {
-            const detected = detectSubRepos(cwd);
+            const detected = getDetectedSubRepos();
             if (detected.length > 0) {
               if (!fileData.planning) fileData.planning = {};
               fileData.planning.sub_repos = detected;
@@ -364,7 +375,7 @@ function loadConfig(cwd, options = {}) {
     // Keep planning.sub_repos in sync with actual filesystem
     const currentSubRepos = fileData.planning?.sub_repos || [];
     if (Array.isArray(currentSubRepos) && currentSubRepos.length > 0) {
-      const detected = detectSubRepos(cwd);
+      const detected = getDetectedSubRepos();
       if (detected.length > 0) {
         const sorted = [...currentSubRepos].sort();
         if (JSON.stringify(sorted) !== JSON.stringify(detected)) {

--- a/tests/perf-315-loadconfig-subrepo-scan.test.cjs
+++ b/tests/perf-315-loadconfig-subrepo-scan.test.cjs
@@ -1,0 +1,118 @@
+'use strict';
+
+/**
+ * Regression test for #315 — perf: repeated subrepo detection in loadConfig.
+ *
+ * Before the fix, loadConfig called detectSubRepos(cwd) up to 3 times per
+ * invocation (all with the same cwd):
+ *   Site 1 (~line 305): root-config requiresFilesystem migration (workstream path)
+ *   Site 2 (~line 353): workstream-config requiresFilesystem migration
+ *   Site 3 (~line 367): planning.sub_repos filesystem re-sync
+ *
+ * After the fix, a per-call lazy memo ensures detectSubRepos(cwd) is called
+ * EXACTLY once regardless of how many sites trigger.
+ *
+ * Fixture triggers:
+ *   - options.workstream set → loads root config (site 1 candidate)
+ *   - root config has `multiRepo: true` → requiresFilesystem → site 1 fires
+ *   - workstream config has `planning.sub_repos: [...]` → site 3 fires
+ *   - workstream config also has `multiRepo: true` → requiresFilesystem → site 2 fires
+ *   Combined: 3 distinct call sites attempted; memo should collapse to 1 scan.
+ */
+
+const { describe, test, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+// Import loadConfig directly (sync, no CLI subprocess needed)
+const { loadConfig } = require('../get-shit-done/bin/lib/core.cjs');
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+function createProjectWithSubRepo(prefix = 'gsd-315-test-') {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+
+  // Create a child dir that looks like a subrepo
+  const subRepoDir = path.join(tmpDir, 'sub-service');
+  fs.mkdirSync(path.join(subRepoDir, '.git'), { recursive: true });
+
+  // Create .planning root layout
+  fs.mkdirSync(path.join(tmpDir, '.planning', 'phases'), { recursive: true });
+
+  return tmpDir;
+}
+
+function writeRootConfig(tmpDir, obj) {
+  const configPath = path.join(tmpDir, '.planning', 'config.json');
+  fs.writeFileSync(configPath, JSON.stringify(obj, null, 2), 'utf-8');
+}
+
+function writeWorkstreamConfig(tmpDir, wsName, obj) {
+  const wsDir = path.join(tmpDir, '.planning', 'workstreams', wsName, 'phases');
+  fs.mkdirSync(wsDir, { recursive: true });
+  const configPath = path.join(tmpDir, '.planning', 'workstreams', wsName, 'config.json');
+  fs.writeFileSync(configPath, JSON.stringify(obj, null, 2), 'utf-8');
+}
+
+// ─── test ─────────────────────────────────────────────────────────────────────
+
+describe('perf-315 — loadConfig calls detectSubRepos at most once per invocation', () => {
+  let tmpDir;
+
+  afterEach(() => {
+    if (tmpDir) {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+      tmpDir = null;
+    }
+  });
+
+  test('detectSubRepos scan count is exactly 1 regardless of how many sites trigger', () => {
+    tmpDir = createProjectWithSubRepo();
+
+    const wsName = 'test-ws';
+
+    // Root config: multiRepo: true triggers requiresFilesystem at site 1
+    writeRootConfig(tmpDir, { multiRepo: true, model_profile: 'balanced' });
+
+    // Workstream config:
+    //   - planning.sub_repos set  → triggers site 3 (fs-resync)
+    //   - multiRepo: true         → triggers site 2 (requiresFilesystem normalization)
+    writeWorkstreamConfig(tmpDir, wsName, {
+      multiRepo: true,
+      planning: { sub_repos: ['sub-service'] },
+      model_profile: 'balanced',
+    });
+
+    // Spy on fs.readdirSync — count only calls that match detectSubRepos' signature
+    // (first arg === tmpDir, options object containing withFileTypes: true)
+    let scanCount = 0;
+    const originalReaddirSync = fs.readdirSync;
+    fs.readdirSync = function spyReaddirSync(dirPath, opts) {
+      if (dirPath === tmpDir && opts && opts.withFileTypes === true) {
+        scanCount += 1;
+      }
+      return originalReaddirSync.call(this, dirPath, opts);
+    };
+
+    try {
+      // Load config with workstream option so all three sites can be reached
+      const config = loadConfig(tmpDir, { workstream: wsName });
+
+      // Behavior lock: sub_repos is correctly resolved
+      assert.ok(
+        Array.isArray(config.sub_repos) || Array.isArray(config.planning?.sub_repos),
+        'sub_repos should be an array in the returned config'
+      );
+
+      // Performance assertion: only one scan regardless of how many sites triggered
+      assert.strictEqual(
+        scanCount, 1,
+        `Expected detectSubRepos to scan cwd exactly once, but fs.readdirSync was called ${scanCount} time(s) with the cwd + {withFileTypes:true} signature`
+      );
+    } finally {
+      fs.readdirSync = originalReaddirSync;
+    }
+  });
+});


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #315

## What was broken

`loadConfig()` in `get-shit-done/bin/lib/core.cjs` called `detectSubRepos(cwd)` at up to three sites per invocation (root-config migration, workstream-config migration, and the `planning.sub_repos` filesystem re-sync) — each call re-running a `readdirSync` + per-child `existsSync` scan of the same `cwd`. Every CLI command that loads config paid this repeated directory scan.

## What this fix does

Adds a per-`loadConfig`-call lazy memo: `detectSubRepos(cwd)` runs at most once per config load, and each site receives a fresh copy of the result (`.slice()`), preserving the original "independent array per call" semantics. Disk is scanned once instead of up to three times.

## Root cause

The detection was invoked inline at each site instead of computed once. The result is invariant within a single load (same `cwd`, no subrepo dirs created/removed mid-call), so the repeated scans were pure overhead.

## Testing

### How I verified the fix

- Added `tests/perf-315-loadconfig-subrepo-scan.test.cjs`: spies `fs.readdirSync` and counts cwd-scans during a `loadConfig` that triggers multiple detection sites. Fails before the fix (2 scans) and passes after (exactly 1 scan).
- Existing `tests/core.test.cjs` and `tests/config.test.cjs` pass unchanged — behavior preserved.
- Full gate via `gsd-test-summary --both -base next`: **Docker: 0 failed** and **Mac: 0 failed**.

### Regression test added?

- [x] Yes — added a test that would have caught this bug

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux

### Runtimes tested

- [x] N/A (not runtime-specific)

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass (full Docker + Mac gate: 0 failed)
- [x] `.changeset/` fragment added (type Fixed, pr 315)
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/get-shit-done-redux/pr/398"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782504749&installation_id=134682257&pr_number=398&repository=open-gsd%2Fget-shit-done-redux&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fget-shit-done-redux%2Fpull%2F398&signature=e57c19a25be5cca8f429f02133b4955b81eabdce613200d5fd0c06b549720399"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->