### PR TITLE
ci(#318): drop runtime npm self-upgrade from release lanes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -200,8 +200,7 @@ jobs:
           git add package.json package-lock.json
           git commit -m "chore: bump to ${PRE_VERSION}"
 
-      - name: Ensure npm supports trusted publishing
-        run: npm install -g npm@latest
+      # npm bundled with Node 24 (pinned via setup-node) already supports trusted publishing (#318)
 
       - name: Dry-run publish validation
         run: npm publish --dry-run --tag next
@@ -326,8 +325,7 @@ jobs:
           scripts/check-npm-integrity.sh
           npm run test:coverage
 
-      - name: Ensure npm supports trusted publishing
-        run: npm install -g npm@latest
+      # npm bundled with Node 24 (pinned via setup-node) already supports trusted publishing (#318)
 
       - name: Dry-run publish validation
         run: npm publish --dry-run

--- a/tests/policy-release-no-npm-self-upgrade.test.cjs
+++ b/tests/policy-release-no-npm-self-upgrade.test.cjs
@@ -1,0 +1,67 @@
+'use strict';
+
+// allow-test-rule: source-text-is-the-product
+// Workflow YAML is a runtime contract; these assertions verify that the
+// anti-pattern of runtime global npm self-upgrade never re-enters release lanes.
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const REPO_ROOT = path.join(__dirname, '..');
+const WORKFLOWS_DIR = path.join(REPO_ROOT, '.github', 'workflows');
+
+// Matches: npm install -g npm@..., npm i -g npm, npm install --global npm@11, etc.
+// Does NOT match: npm ci, npm install (no -g / --global followed by npm)
+const NPM_SELF_UPGRADE_RE = /\bnpm\s+(install|i)\s+(-g|--global)\b[^\n]*\bnpm(@|\b)/;
+
+describe('policy: no runtime npm self-upgrade in release lanes (#318)', () => {
+  const releaseFile = path.join(WORKFLOWS_DIR, 'release.yml');
+  const hotfixFile = path.join(WORKFLOWS_DIR, 'hotfix.yml');
+
+  test('release.yml must not contain a runtime global npm self-upgrade step', () => {
+    const content = fs.readFileSync(releaseFile, 'utf8');
+    const lines = content.split('\n');
+    const violations = lines
+      .map((line, idx) => ({ line, lineNo: idx + 1 }))
+      .filter(({ line }) => NPM_SELF_UPGRADE_RE.test(line));
+
+    assert.strictEqual(
+      violations.length,
+      0,
+      `release.yml contains ${violations.length} runtime npm self-upgrade line(s) — ` +
+        `remove them and rely on Node 24 bundled npm (pinned via setup-node). ` +
+        `Violations: ${violations.map(({ lineNo, line }) => `line ${lineNo}: ${line.trim()}`).join('; ')}`
+    );
+  });
+
+  test('hotfix.yml must not contain a runtime global npm self-upgrade step', () => {
+    const content = fs.readFileSync(hotfixFile, 'utf8');
+    const lines = content.split('\n');
+    const violations = lines
+      .map((line, idx) => ({ line, lineNo: idx + 1 }))
+      .filter(({ line }) => NPM_SELF_UPGRADE_RE.test(line));
+
+    assert.strictEqual(
+      violations.length,
+      0,
+      `hotfix.yml contains ${violations.length} runtime npm self-upgrade line(s) — ` +
+        `Violations: ${violations.map(({ lineNo, line }) => `line ${lineNo}: ${line.trim()}`).join('; ')}`
+    );
+  });
+
+  test('NPM_SELF_UPGRADE_RE correctly matches the antipattern', () => {
+    // Positive cases — must match
+    assert.ok(NPM_SELF_UPGRADE_RE.test('npm install -g npm@latest'), 'should match npm install -g npm@latest');
+    assert.ok(NPM_SELF_UPGRADE_RE.test('npm i -g npm'), 'should match npm i -g npm');
+    assert.ok(NPM_SELF_UPGRADE_RE.test('npm install --global npm@11'), 'should match npm install --global npm@11');
+    assert.ok(NPM_SELF_UPGRADE_RE.test('  run: npm install -g npm@latest'), 'should match indented run step');
+
+    // Negative cases — must NOT match
+    assert.ok(!NPM_SELF_UPGRADE_RE.test('npm ci'), 'should not match npm ci');
+    assert.ok(!NPM_SELF_UPGRADE_RE.test('npm install'), 'should not match plain npm install');
+    assert.ok(!NPM_SELF_UPGRADE_RE.test('npm install -g some-other-tool'), 'should not match -g some-other-tool');
+    assert.ok(!NPM_SELF_UPGRADE_RE.test('npm run build'), 'should not match npm run');
+  });
+});


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #318

## What was broken

The release workflow ran `npm install -g npm@latest` during execution (jobs `rc` and `finalize`, `.github/workflows/release.yml`), adding install time and version-drift / registry-flake risk on every release.

## What this fix does

Removes both runtime npm self-upgrade steps and relies on the npm bundled with Node 24 (already pinned via `actions/setup-node`), which supports trusted publishing. Adds a policy test forbidding reintroduction of a runtime global npm self-upgrade in release lanes.

## Root cause

A `npm install -g npm@latest` step was added to each release job; the runner's pinned Node 24 already ships a trusted-publishing-capable npm, making the global upgrade unnecessary.

## Testing

### How I verified the fix

- Added `tests/policy-release-no-npm-self-upgrade.test.cjs`: asserts neither `release.yml` nor `hotfix.yml` performs a runtime global npm self-upgrade. Fails before the fix (2 violations at the removed steps) and passes after.
- Validated the edited `release.yml` parses as valid YAML.
- Full gate via `gsd-test-summary --both -base next`: **Docker: 0 failed** and **Mac: 0 failed**.

### Regression test added?

- [x] Yes — added a test that would have caught this bug

### Platforms tested

- [x] N/A (not platform-specific)

### Runtimes tested

- [x] N/A (not runtime-specific)

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass (full Docker + Mac gate: 0 failed)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/get-shit-done-redux/pr/401"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782507546&installation_id=134682257&pr_number=401&repository=open-gsd%2Fget-shit-done-redux&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fget-shit-done-redux%2Fpull%2F401&signature=49a38ab332f9e5afd29bd4bdb0461ea5b62d88bc5d0270d2f6cc0f5abc5b2eb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->