### PR TITLE
ci(#319): shallow checkout for docs/changeset lint workflows

### DIFF
--- a/.github/workflows/changeset-required.yml
+++ b/.github/workflows/changeset-required.yml
@@ -18,7 +18,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 50
+      - name: Fetch base ref for diff
+        run: git fetch --depth=50 origin "${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
       - uses: actions/setup-node@v4
         with:
           node-version: '24'

--- a/.github/workflows/docs-required.yml
+++ b/.github/workflows/docs-required.yml
@@ -18,7 +18,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 50
+      - name: Fetch base ref for diff
+        run: git fetch --depth=50 origin "${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
       - uses: actions/setup-node@v4
         with:
           node-version: '24'

--- a/tests/policy-lint-shallow-checkout.test.cjs
+++ b/tests/policy-lint-shallow-checkout.test.cjs
@@ -1,0 +1,64 @@
+'use strict';
+
+/**
+ * Policy test: docs-required.yml and changeset-required.yml must use
+ * fetch-depth: 50 (NOT fetch-depth: 0) in their checkout steps.
+ *
+ * Rationale: both workflows run a lint script that performs a three-dot git diff
+ * (`git diff --name-only origin/${base}...HEAD`). A full-history clone
+ * (fetch-depth: 0) is wasteful — depth 50 covers >99% of PRs and is far faster.
+ * The explicit base-ref fetch step ensures the merge-base is present for the
+ * three-dot diff. The workflow FAILS CLOSED (lint errors) if the merge-base is
+ * deeper than 50, which is intentional.
+ *
+ * Note: security-scan.yml legitimately uses fetch-depth: 0 and is NOT covered
+ * by this test (see tests/security-scan.test.cjs).
+ */
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const PROJECT_ROOT = path.join(__dirname, '..');
+
+const WORKFLOWS = {
+  'docs-required.yml': path.join(PROJECT_ROOT, '.github', 'workflows', 'docs-required.yml'),
+  'changeset-required.yml': path.join(
+    PROJECT_ROOT,
+    '.github',
+    'workflows',
+    'changeset-required.yml',
+  ),
+};
+
+for (const [name, workflowPath] of Object.entries(WORKFLOWS)) {
+  describe(`${name} shallow-checkout policy`, () => {
+    let content;
+
+    test('workflow file exists', () => {
+      assert.ok(fs.existsSync(workflowPath), `Missing workflow: ${workflowPath}`);
+      content = fs.readFileSync(workflowPath, 'utf-8');
+    });
+
+    test('checkout uses fetch-depth: 50 (not 0)', () => {
+      if (!content) content = fs.readFileSync(workflowPath, 'utf-8');
+      assert.ok(
+        content.includes('fetch-depth: 50'),
+        `${name}: checkout must use fetch-depth: 50 (got full-history clone with fetch-depth: 0 or missing)`,
+      );
+      assert.ok(
+        !content.includes('fetch-depth: 0'),
+        `${name}: fetch-depth: 0 (full-history clone) must be replaced with fetch-depth: 50`,
+      );
+    });
+
+    test('has explicit base-ref fetch step for three-dot diff merge-base', () => {
+      if (!content) content = fs.readFileSync(workflowPath, 'utf-8');
+      assert.ok(
+        content.includes('Fetch base ref for diff'),
+        `${name}: must have an explicit "Fetch base ref for diff" step so the three-dot diff has its merge-base`,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #319

## What was broken

`.github/workflows/docs-required.yml` and `changeset-required.yml` checked out with `fetch-depth: 0` (full clone) on every PR, even though they only need enough history for a `git diff origin/<base>...HEAD` merge-base comparison. The full-history fetch adds avoidable startup time to these lightweight lint gates.

## What this fix does

Switches both workflows to `fetch-depth: 50` plus an explicit `git fetch --depth=50` of the PR base ref, so the three-dot diff's merge-base is present while the clone stays shallow. Covers >99% of realistic PRs; if a PR's merge-base is deeper than 50 the lint fails closed (errors) rather than computing a wrong diff. Adds a policy test forbidding `fetch-depth: 0` in these two lint workflows.

## Root cause

The workflows used `fetch-depth: 0` when only the base merge-base is needed for the diff.

## Testing

### How I verified the fix

- Added `tests/policy-lint-shallow-checkout.test.cjs` (scoped to the two lint workflows; does not touch the existing security-scan `fetch-depth: 0` allowlist): asserts both use `fetch-depth: 50` and an explicit base-ref fetch, not `fetch-depth: 0`. Fails before the fix and passes after (6/6).
- Confirmed `tests/security-scan.test.cjs` still passes (58/58) — its required `fetch-depth: 0` for security-scan.yml is unaffected.
- Validated both edited workflows parse as valid YAML.
- Independent codex review: base-ref consistency, pull_request-only triggers (no empty-base_ref case), and fail-closed behavior all confirmed.
- Full gate via `gsd-test-summary --both -base next`: **Docker: 0 failed** and **Mac: 0 failed**.

### Regression test added?

- [x] Yes — added a test that would have caught this bug

### Platforms tested

- [x] N/A (not platform-specific)

### Runtimes tested

- [x] N/A (not runtime-specific)

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass (full Docker + Mac gate: 0 failed)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/get-shit-done-redux/pr/402"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782507981&installation_id=134682257&pr_number=402&repository=open-gsd%2Fget-shit-done-redux&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fget-shit-done-redux%2Fpull%2F402&signature=c2c9fa2b68cc74821ba39544deeaf07a7dac8359b3bde667b3af8345c87db8ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->