### PR TITLE
fix(#130): skip opencode permission config under GSD_TEST_MODE

### DIFF
--- a/.changeset/130-finishinstall-testmode-guard.md
+++ b/.changeset/130-finishinstall-testmode-guard.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 130
+---
+Test-mode installs no longer write the opencode config file — `finishInstall` now skips `configureOpencodePermissions` when `GSD_TEST_MODE=1`.

--- a/bin/install.js
+++ b/bin/install.js
@@ -9798,7 +9798,7 @@ function finishInstall(settingsPath, settings, statuslineCommand, shouldInstallS
   }
 
   // Configure OpenCode permissions
-  if (isOpencode) {
+  if (isOpencode && !process.env.GSD_TEST_MODE) {
     configureOpencodePermissions(isGlobal, configDir);
   }
 

--- a/tests/bug-130-finishinstall-opencode-testmode.test.cjs
+++ b/tests/bug-130-finishinstall-opencode-testmode.test.cjs
@@ -1,0 +1,75 @@
+'use strict';
+
+process.env.GSD_TEST_MODE = '1';
+
+/**
+ * Bug #130: finishInstall calls configureOpencodePermissions unconditionally,
+ * violating the GSD_TEST_MODE side-effect-free contract.
+ *
+ * configureOpencodePermissions does fs.mkdirSync + fs.writeFileSync, which
+ * must NOT run under GSD_TEST_MODE='1'. This test asserts that the opencode
+ * config file (opencode.json) is NOT created when GSD_TEST_MODE is set.
+ */
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const os = require('node:os');
+const fs = require('node:fs');
+
+const ROOT = path.join(__dirname, '..');
+
+// Point HOME at a temp dir so configureOpencodePermissions can't write to
+// the real ~/.config/opencode/ even if the guard is missing.
+const FAKE_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-130-test-'));
+process.env.HOME = FAKE_HOME;
+
+// The opencode config dir that configureOpencodePermissions would use for a
+// global install when configDir=null: <HOME>/.config/opencode/
+// The file it writes is opencode.json (or opencode.jsonc if pre-existing).
+const OPENCODE_CONFIG_DIR = path.join(FAKE_HOME, '.config', 'opencode');
+const OPENCODE_CONFIG_FILE = path.join(OPENCODE_CONFIG_DIR, 'opencode.json');
+
+// configDir is passed explicitly so the function targets our FAKE_HOME dir
+// regardless of how getGlobalDir resolves.
+const installModule = require(path.join(ROOT, 'bin', 'install.js'));
+
+const SETTINGS_PATH = path.join(FAKE_HOME, `gsd-test-settings-${process.pid}.json`);
+
+function callFinishInstall() {
+  const original = console.log;
+  console.log = () => {};
+  try {
+    installModule.finishInstall(
+      SETTINGS_PATH,
+      {},
+      null,
+      false,
+      'opencode',
+      true,
+      OPENCODE_CONFIG_DIR, // pass explicit configDir pointing at our temp dir
+    );
+  } finally {
+    console.log = original;
+  }
+}
+
+describe('Bug #130: finishInstall opencode + GSD_TEST_MODE side-effect guard', () => {
+  test('configureOpencodePermissions does NOT write opencode.json under GSD_TEST_MODE', () => {
+    // Confirm the file does not exist before the call
+    assert.equal(
+      fs.existsSync(OPENCODE_CONFIG_FILE),
+      false,
+      'opencode.json should not exist before finishInstall call',
+    );
+
+    callFinishInstall();
+
+    // Assert the file was NOT created — the side-effect must be suppressed
+    assert.equal(
+      fs.existsSync(OPENCODE_CONFIG_FILE),
+      false,
+      `opencode.json must NOT be created under GSD_TEST_MODE; found at ${OPENCODE_CONFIG_FILE}`,
+    );
+  });
+});


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #130

## What was broken

`finishInstall` in `bin/install.js` called `configureOpencodePermissions(isGlobal, configDir)` unconditionally for the OpenCode runtime. That function does `fs.mkdirSync` + `fs.writeFileSync` (writes `<configDir>/.config/opencode/opencode.json`), so an install run under `GSD_TEST_MODE=1` performed real filesystem writes — violating the GSD_TEST_MODE side-effect-free contract (and failing with EPERM where the config dir isn't writable).

## What this fix does

Guards the `configureOpencodePermissions` call with the canonical `!process.env.GSD_TEST_MODE` check (matching the existing pattern at `install.js:5077` and `:11437`), so test-mode installs no longer touch the filesystem for OpenCode permission config.

## Root cause

The OpenCode permission-config call was added to `finishInstall` without the GSD_TEST_MODE guard that other side-effecting steps use.

## Testing

### How I verified the fix

- Added `tests/bug-130-finishinstall-opencode-testmode.test.cjs`: under `GSD_TEST_MODE=1` with a temp HOME, calls `finishInstall` for the OpenCode runtime and asserts `opencode.json` is NOT created. Fails before the fix (file written) and passes after (file absent).
- Existing `tests/bug-2957-claude-global-postinstall-message.test.cjs` still passes (no regression).
- Full gate via `gsd-test-summary --both -base next`: **Docker: 0 failed** and **Mac: 0 failed**.

### Regression test added?

- [x] Yes — added a test that would have caught this bug

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux

### Runtimes tested

- [x] OpenCode

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass (full Docker + Mac gate: 0 failed)
- [x] `.changeset/` fragment added (type Fixed, pr 130)
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/get-shit-done-redux/pr/404"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782508776&installation_id=134682257&pr_number=404&repository=open-gsd%2Fget-shit-done-redux&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fget-shit-done-redux%2Fpull%2F404&signature=801cf2b9779ff6763f4ffb212dbdce0582cb4346d6bd8acf16e3b8cc0808f108"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->