### PR TITLE
fix(#411): restore gsd_run launcher in next.md and align policy-160 test

### DIFF
--- a/get-shit-done/workflows/next.md
+++ b/get-shit-done/workflows/next.md
@@ -95,7 +95,7 @@ This catches the common failure mode where a session died mid-execution (hang, t
 
 **Why Route 0 runs here (after Gates 1-3, before the prior-phase defer prompt):** This step is a hard invariant independent of `current_phase`'s value — it must run before any routing rule that reads `current_phase`. Gates 1-3 are cheap repo/state validity checks that must always run — skipping them on the resume path would risk advancing into a broken-state project. The prior-phase completeness-scan DEFER PROMPT, however, must NOT run in the default (no-flag) case when Route 0 is about to resume the phase automatically: that would force a double-decision (prompt first, then resume anyway), overriding the user's choice. Route 0 placed here means: default = resume silently (no defer prompt); `--no-resume` = skip Route 0 and fall through to the prior-phase defer prompt in `prior_phase_completeness`; `--force` = jump straight to `determine_next_action` at `safety_gates` (never reaches Route 0 or `prior_phase_completeness` at all).
 
-Scan ALL phases in ROADMAP order (lowest-numbered to highest) for incomplete-execution state. Use `$GSD_SDK query roadmap.analyze` to get the phase list, then for each phase number `N` query `$GSD_SDK query find-phase <N>` JSON and inspect its `plans` and `summaries` arrays. A phase is **incomplete-execution** when `plans.length > summaries.length` (at least one PLAN.md has no matching SUMMARY.md).
+Scan ALL phases in ROADMAP order (lowest-numbered to highest) for incomplete-execution state. Use `gsd_run query roadmap.analyze` to get the phase list, then for each phase number `N` query `gsd_run query find-phase <N>` JSON and inspect its `plans` and `summaries` arrays. A phase is **incomplete-execution** when `plans.length > summaries.length` (at least one PLAN.md has no matching SUMMARY.md).
 
 Stop at the first such phase. Record its phase number as `INCOMPLETE_PHASE`. This is the lowest-numbered phase that needs continued execution.
 
@@ -103,7 +103,7 @@ Illustrative bash:
 
 ```bash
 INCOMPLETE_PHASE=""
-ROADMAP_JSON=$($GSD_SDK query roadmap.analyze)
+ROADMAP_JSON=$(gsd_run query roadmap.analyze)
 if [ $? -ne 0 ] || [ -z "$ROADMAP_JSON" ]; then
   echo "⚠ WARNING: resume-incomplete-phase scan could not run (roadmap.analyze failed)." >&2
   echo "  The incomplete-phase invariant (#160) could not be verified." >&2
@@ -111,7 +111,7 @@ if [ $? -ne 0 ] || [ -z "$ROADMAP_JSON" ]; then
   # Fall through to prior_phase_completeness rather than silently skipping
 else
   for PHASE_NUM in $(echo "$ROADMAP_JSON" | jq -r '.phases[] | (.number // .phase_number // empty)'); do
-    PHASE_JSON=$($GSD_SDK query find-phase "$PHASE_NUM")
+    PHASE_JSON=$(gsd_run query find-phase "$PHASE_NUM")
     if [ $? -ne 0 ] || [ -z "$PHASE_JSON" ]; then
       echo "⚠ WARNING: Could not query phase $PHASE_NUM — skipping in resume scan." >&2
       continue
@@ -143,7 +143,7 @@ Then invoke via SlashCommand. Do not continue to subsequent steps.
 **Prior-phase completeness scan (runs when `--no-resume` was passed and Route 0 was skipped, or when Route 0 found no incomplete-execution phases in the default case). NOT reached under `--force` — that flag jumps directly to `determine_next_action` at `safety_gates`.**
 
 **Prior-phase completeness scan:**
-Scan all phases that precede the current phase in ROADMAP.md order for incomplete work. For each prior phase number `N`, use `$GSD_SDK query find-phase <N>` JSON (plans, summaries, incomplete_plans, etc.) to inspect that phase.
+Scan all phases that precede the current phase in ROADMAP.md order for incomplete work. For each prior phase number `N`, use `gsd_run query find-phase <N>` JSON (plans, summaries, incomplete_plans, etc.) to inspect that phase.
 
 Detect three categories of incomplete work:
 1. **Plans without summaries** — a PLAN.md exists in a prior phase directory but no matching SUMMARY.md exists (execution started but not completed).
@@ -291,7 +291,7 @@ Resume with: `/gsd:progress --next --auto` once resolved.
 - [ ] Default (no flag): Route 0 resumes incomplete phase silently, exits — user never sees the prior-phase defer prompt
 - [ ] `--no-resume`: Route 0 skipped, prior_phase_completeness defer prompt runs as before
 - [ ] `--force`: everything skipped (Gates, Route 0, prior_phase_completeness) → straight to `determine_next_action`
-- [ ] Scan uses `$GSD_SDK` (canonical resolver form); errors are surfaced rather than suppressed
+- [ ] Scan uses `gsd_run` (canonical resolver form); errors are surfaced rather than suppressed
 - [ ] Predicate is plans-without-summaries (`plans.length > summaries.length`) — consistent with `determine_next_action` Route 4
 - [ ] Next action correctly determined from routing rules
 - [ ] Command invoked immediately without user confirmation

--- a/tests/policy-160-route0-resume.test.cjs
+++ b/tests/policy-160-route0-resume.test.cjs
@@ -241,21 +241,21 @@ describe('Route 0: resume_incomplete_phase invariant (#160)', () => {
 
     // ── SHOULD-FIX 2: SDK form and fail-closed error surfacing ──
 
-    test('scan uses $GSD_SDK (canonical resolver form, not bare gsd-sdk)', () => {
+    test('scan uses gsd_run (canonical resolver form, not bare gsd-sdk)', () => {
       const content = fs.readFileSync(nextMdPath, 'utf8');
       const route0Start = content.indexOf('name="resume_incomplete_phase"');
       const route0End = content.indexOf('</step>', route0Start);
       const route0Block = content.slice(route0Start, route0End);
-      // Must use $GSD_SDK, not bare gsd-sdk
+      // Must use gsd_run, not bare gsd-sdk
       assert.ok(
-        route0Block.includes('$GSD_SDK'),
-        'Route 0 scan must use $GSD_SDK (canonical resolver), not bare gsd-sdk'
+        route0Block.includes('gsd_run'),
+        'Route 0 scan must use gsd_run (canonical resolver), not bare gsd-sdk'
       );
       // Must NOT use bare gsd-sdk (without $)
       const bareGsdSdkPattern = /(?<!\$)gsd-sdk/;
       assert.ok(
         !bareGsdSdkPattern.test(route0Block),
-        'Route 0 must not use bare gsd-sdk — use $GSD_SDK to match the file convention'
+        'Route 0 must not use bare gsd-sdk — use gsd_run to match the file convention'
       );
     });
 


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #411

## What was broken

`get-shit-done/workflows/next.md` still contained the retired `$GSD_SDK` token (5 occurrences), failing `runtime-launcher-parity (#373)` on **both Mac and Docker** — `next` was red on every PR gate. A stale companion assertion in `tests/policy-160-route0-resume.test.cjs` also still required `$GSD_SDK` to be present.

## What this fix does

Runs the canonical propagator (`scripts/sync-runtime-launcher.cjs`) to convert `next.md` to the `gsd_run` launcher, and updates the `policy-160` Route-0 assertion to expect `gsd_run` (the canonical resolver since #379). Both `runtime-launcher-parity` and `policy-160-route0-resume` now pass.

## Root cause

PR #406 (`fix(#160)`) was branched before PR #379 renamed `$GSD_SDK` → `gsd_run` and added the parity test. #406 edited a different region of `next.md`, so it merged after #379 with **no textual conflict** — silently re-introducing the retired token in `next.md` and leaving its companion test asserting the old name. (Sibling to the textual conflict already resolved in #405.)

## Testing

### How I verified the fix

`gsd-test-summary --both` (full suite, Mac + Linux/Docker):

```
Mac: 0 failed
Docker: 0 failed
```

Locally: `node --test tests/runtime-launcher-parity.test.cjs` → 6/6 pass; `node --test tests/policy-160-route0-resume.test.cjs` → 32/0 pass.

### Regression test added?

- [ ] Yes — added a test that would have caught this bug
- [x] No — the existing `runtime-launcher-parity` test already catches any `$GSD_SDK` token in workflow `.md` files (it is what surfaced this regression); `policy-160` now asserts the `gsd_run` canonical form.

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included (only `next.md` + its `policy-160` test)
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`gsd-test-summary --both`: Mac 0 failed, Docker 0 failed)
- [x] `.changeset/` fragment added if this is a user-facing fix — or `no-changelog` label applied → **`no-changelog` applied** (re-applies #379's already-logged `$GSD_SDK`→`gsd_run` rename to the one workflow file a concurrent merge missed; not a new user-facing change)
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/get-shit-done-redux/pr/412"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782522170&installation_id=134682257&pr_number=412&repository=open-gsd%2Fget-shit-done-redux&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fget-shit-done-redux%2Fpull%2F412&signature=116d0ff1197620379ce4ccb7931e9f0b37b8e0250d8f26b08078b257e449551a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->