### PR TITLE
fix(#378): poll scoped package name in update check

### DIFF
--- a/.changeset/378-update-check-scoped-name.md
+++ b/.changeset/378-update-check-scoped-name.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 378
+---
+Update check now polls the correct scoped package name (@opengsd/get-shit-done-redux) so update_available works.

--- a/hooks/gsd-check-update-worker.js
+++ b/hooks/gsd-check-update-worker.js
@@ -13,6 +13,9 @@ const fs = require('fs');
 const path = require('path');
 const { execFileSync } = require('child_process');
 const { isSemverNewer } = require('../get-shit-done/bin/lib/semver-compare.cjs');
+// Derive the published package name from package.json so this survives
+// future renames and always matches the actual registry entry (#378).
+const PACKAGE_NAME = require('../package.json').name;
 
 const cacheFile = process.env.GSD_CACHE_FILE;
 const projectVersionFile = process.env.GSD_PROJECT_VERSION_FILE;
@@ -79,7 +82,7 @@ if (configDir) {
 
 let latest = null;
 try {
-  latest = execFileSync('npm', ['view', 'get-shit-done-redux', 'version'], {
+  latest = execFileSync('npm', ['view', PACKAGE_NAME, 'version'], {
     encoding: 'utf8',
     timeout: 10000,
     windowsHide: true,

--- a/tests/bug-378-update-check-scoped-name.test.cjs
+++ b/tests/bug-378-update-check-scoped-name.test.cjs
@@ -1,0 +1,98 @@
+/**
+ * Regression test for #378: gsd-check-update-worker.js must query
+ * the SCOPED package name (@opengsd/get-shit-done-redux) when calling
+ * `npm view <name> version`.
+ *
+ * Background: the worker previously hardcoded the unscoped string
+ * 'get-shit-done-redux', which returns E404 from the npm registry because
+ * the published package is scoped. This caused `latest` to stay null and
+ * `update_available` to be permanently false — users never saw update
+ * notifications.
+ *
+ * The fix derives the name from package.json (most robust — survives
+ * future renames). This test locks the contract in two ways:
+ *
+ * 1. Structural: the worker must NOT contain the bare unscoped literal
+ *    'get-shit-done-redux' as a standalone npm view argument.
+ * 2. Derived: the worker must read the package name from package.json
+ *    and the package.json name MUST be the scoped string
+ *    '@opengsd/get-shit-done-redux'.
+ *
+ * Source-grep policy: this test reads hook source via readFileSync.
+ * The repo's lint-no-source-grep rule targets bin/lib/get-shit-done — hooks/
+ * is out of scope. The shape we need to lock (which string is passed as the
+ * npm view argument) only manifests at runtime against the live registry;
+ * a structural assertion is the minimum-cost contract.
+ */
+
+// allow-test-rule: structural assertion on hook npm-view argument; the
+// behavior being tested (correct package name → no E404) only manifests at
+// runtime against the live npm registry, which CI does not call.
+
+'use strict';
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const WORKER_PATH = path.join(__dirname, '..', 'hooks', 'gsd-check-update-worker.js');
+const PKG_PATH = path.join(__dirname, '..', 'package.json');
+
+describe('bug #378: update-check worker uses scoped package name', () => {
+  test('worker file exists', () => {
+    assert.ok(fs.existsSync(WORKER_PATH), `worker not found at ${WORKER_PATH}`);
+  });
+
+  test('package.json name is the scoped @opengsd/get-shit-done-redux', () => {
+    const pkg = JSON.parse(fs.readFileSync(PKG_PATH, 'utf8'));
+    assert.equal(
+      pkg.name,
+      '@opengsd/get-shit-done-redux',
+      'package.json must declare the scoped name — this is what npm view must query',
+    );
+  });
+
+  test('worker does NOT hardcode the unscoped get-shit-done-redux as an npm view argument', () => {
+    const src = fs.readFileSync(WORKER_PATH, 'utf8');
+
+    // Strip comments so doc-prose mentions don't trigger the check.
+    const codeOnly = src
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+
+    // The unscoped bare string as a string literal used in code.
+    // A match here means the bug is present: npm view 'get-shit-done-redux'
+    // → E404 → update_available permanently false.
+    const unscopedLiteral = /['"]get-shit-done-redux['"]/;
+
+    assert.doesNotMatch(
+      codeOnly,
+      unscopedLiteral,
+      [
+        "Worker must not pass the unscoped 'get-shit-done-redux' to `npm view`.",
+        'That name returns E404, leaving update_available permanently false.',
+        'Use the scoped name from package.json: @opengsd/get-shit-done-redux.',
+      ].join(' '),
+    );
+  });
+
+  test('worker derives package name from package.json (require + .name)', () => {
+    const src = fs.readFileSync(WORKER_PATH, 'utf8');
+
+    // Structural check: worker must load package.json and read .name from it.
+    // This is the robust form — survives future renames without code edits.
+    const requiresPkgJson = /require\s*\(\s*['"][^'"]*package\.json['"]\s*\)\.name/;
+
+    assert.match(
+      src,
+      requiresPkgJson,
+      [
+        'Worker must derive the npm view package name via',
+        "`require('../package.json').name` (or similar).",
+        'Hardcoding the scoped literal is less robust: a future rename',
+        'would silently break update checks again.',
+      ].join(' '),
+    );
+  });
+});


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #378

## What was broken

The update-check worker (`hooks/gsd-check-update-worker.js`) hardcoded the **unscoped** package name `'get-shit-done-redux'` in its `npm view … version` call. The published package is **scoped** (`@opengsd/get-shit-done-redux`), so `npm view get-shit-done-redux version` returns **E404**. The error was swallowed by the surrounding `catch`, leaving `latest = null`, so `update_available` (`latest && isNewer(...)`) was **always false** — users never saw update notifications.

## What this fix does

Derives the package name from `package.json` at runtime and uses it in the `npm view` call:

```js
// hooks/gsd-check-update-worker.js
const PACKAGE_NAME = require('../package.json').name; // @opengsd/get-shit-done-redux
…
latest = execFileSync('npm', ['view', PACKAGE_NAME, 'version'], { … });
```

This always matches the actual published registry entry and survives future renames.

## Root cause

Leftover from the `@opengsd` scope rebrand (#126): the worker was never updated to the scoped name, and the swallowed E404 hid the failure so `update_available` could never become true.

## Testing

### How I verified the fix

`gsd-test-summary --both` (full suite, Mac + Linux/Docker):

```
Mac: 0 failed
Docker: 0 failed
```

The new regression test passes 4/4 locally.

### Regression test added?

- [x] Yes — added a test that would have caught this bug: `tests/bug-378-update-check-scoped-name.test.cjs` asserts the worker derives its name via `require('../package.json').name`, that `package.json.name` is the scoped `@opengsd/get-shit-done-redux`, and that no unscoped literal is hardcoded.
- [ ] No — explain why:

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

> The fix is platform-agnostic (npm package-name resolution — no path handling); the unscoped name E404s on every platform. The CI `windows-latest` matrix exercises Windows.

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [ ] N/A (not runtime-specific)

> The worker is a shared hook; the fix is runtime-agnostic.

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes (3 files: worker, regression test, changeset)
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`gsd-test-summary --both`: Mac 0 failed, Docker 0 failed)
- [x] `.changeset/` fragment added if this is a user-facing fix (`type: Fixed`, present) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/get-shit-done-redux/pr/414"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782522585&installation_id=134682257&pr_number=414&repository=open-gsd%2Fget-shit-done-redux&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fget-shit-done-redux%2Fpull%2F414&signature=6763304ab622a29c221a4c967d7c43eda86cf3190f3aa5c52ec2c2392876f2b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->