### PR TITLE
fix(#408): align ci-test-scope smoke handling with #395 changeset (drop unconditional injection; unit fallback)

### DIFF
--- a/.changeset/408-ci-test-scope-smoke-alignment.md
+++ b/.changeset/408-ci-test-scope-smoke-alignment.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 408
+---
+`ci-test-scope.cjs` now matches the #370/#395 changeset: drops the unconditional `DEFAULT_SMOKE_TESTS` injection on code-change, and falls back to the `unit` suite when the affected selection is empty.

--- a/scripts/ci-test-scope.cjs
+++ b/scripts/ci-test-scope.cjs
@@ -5,20 +5,6 @@ const { execFileSync } = require('child_process');
 const { existsSync, readdirSync, appendFileSync } = require('fs');
 const { join } = require('path');
 
-const DEFAULT_SMOKE_TESTS = [
-  'tests/command-contract.test.cjs',
-  'tests/commands.test.cjs',
-  'tests/core.test.cjs',
-  'tests/package-manifest.test.cjs',
-];
-
-const WINDOWS_SMOKE_TESTS = [
-  'tests/hardcoded-paths.test.cjs',
-  'tests/windows-robustness.test.cjs',
-  'tests/windows-test-parity-guard.test.cjs',
-  'tests/workflow-shell-pinning.test.cjs',
-];
-
 const RULES = [
   {
     name: 'workflow automation',
@@ -257,12 +243,14 @@ function classify(files) {
     }
   }
 
-  if (codeChanged) {
-    addAll(targeted, DEFAULT_SMOKE_TESTS);
-    addAll(windows, WINDOWS_SMOKE_TESTS);
+  const targetedTests = existingTests([...targeted].sort());
+
+  // When code changed but no rule matched any changed file, fall back to the
+  // unit suite so the targeted lane always runs something meaningful (#408).
+  if (codeChanged && targetedTests.length === 0) {
+    targetedTests.push('unit');
   }
 
-  const targetedTests = existingTests([...targeted].sort());
   const windowsTests = existingTests([...new Set([...windows, ...targetedTests.filter(t => /windows|path|shell|workflow|install|hook/i.test(t))])].sort());
 
   return {

--- a/tests/ci-test-scope.test.cjs
+++ b/tests/ci-test-scope.test.cjs
@@ -68,4 +68,38 @@ describe('ci-test-scope.cjs', () => {
     // allow-test-rule: CLI usage banner presence is a user-facing contract.
     assert.match(r.stderr, /Usage:/);
   });
+
+  // bug-408: unconditional DEFAULT_SMOKE_TESTS injection removed; unit fallback added
+  test('bug-408: code change with matched rules produces exactly the rule-selected tests (no smoke list appended)', () => {
+    // commands/ matches the "command definitions" rule only — no smoke list should be added
+    const result = scopeFor(['commands/gsd/plan-phase.md']);
+    assert.strictEqual(result.code_changed, true);
+    const expectedTests = [
+      'tests/command-contract.test.cjs',
+      'tests/command-routing-hub.test.cjs',
+      'tests/commands.test.cjs',
+      'tests/phase-command-router.test.cjs',
+      'tests/roadmap-command-router.test.cjs',
+    ];
+    // Every expected test must be present
+    for (const t of expectedTests) {
+      assert.ok(result.targeted_tests.includes(t), `expected ${t} in targeted_tests`);
+    }
+    // No DEFAULT_SMOKE_TESTS files should be injected beyond what the rule selects.
+    // The former smoke list contained package-manifest.test.cjs and core.test.cjs —
+    // neither is in the "command definitions" rule, so they must not appear.
+    assert.ok(!result.targeted_tests.includes('tests/core.test.cjs'),
+      'tests/core.test.cjs must NOT be unconditionally injected for command changes');
+    assert.ok(!result.targeted_tests.includes('tests/package-manifest.test.cjs'),
+      'tests/package-manifest.test.cjs must NOT be unconditionally injected for command changes');
+  });
+
+  test('bug-408: code change with no rule match falls back to unit suite token', () => {
+    // A plain source file that matches no RULES entry but is under get-shit-done/ (code path)
+    const result = scopeFor(['get-shit-done/src/some-util.js']);
+    assert.strictEqual(result.code_changed, true);
+    // allow-test-rule: the unit-fallback contract is the exact subject of bug #408.
+    assert.deepStrictEqual(result.targeted_tests, ['unit'],
+      'targeted_tests must be [\'unit\'] when code changed but no rule matched');
+  });
 });


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #408

## What was broken

`scripts/ci-test-scope.cjs` unconditionally injected `DEFAULT_SMOKE_TESTS` (and `WINDOWS_SMOKE_TESTS`) whenever code changed — contradicting PR #395's changeset, which stated that injection was removed and an empty selection now falls back to the `unit` suite. Affected-test scoping ran broader than the changelog described, and the documented "empty → unit" fallback never fired.

## What this fix does

Removes the unconditional `DEFAULT_SMOKE_TESTS` / `WINDOWS_SMOKE_TESTS` injection in the `codeChanged` branch. Adds the empty-selection-falls-back-to-`unit` behavior. Drops the now-dead `DEFAULT_SMOKE_TESTS` and `WINDOWS_SMOKE_TESTS` constant declarations.

## Root cause

PR #395 shipped a changeset describing two behavior changes that were not actually present in the merged code. This PR aligns shipped behavior with the changeset.

## Testing

### How I verified the fix

`gsd-test-summary --both` (full suite, Mac + Linux/Docker):

```
Mac: 0 failed
Docker: 0 failed
```

Two new `bug-408` cases added to `tests/ci-test-scope.test.cjs`: (1) code change with matched rules returns only the rule-selected tests, no smoke list; (2) code change with no rule match returns `['unit']` via the new fallback. Existing tests in the file still pass (8/8).

### Regression test added?

- [x] Yes — extended `tests/ci-test-scope.test.cjs` with 2 bug-408 cases

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped — `ci-test-scope.cjs` + its existing test file
- [x] Regression test added
- [x] All existing tests pass
- [x] `.changeset/` fragment added
- [x] No unnecessary dependencies added

## Breaking changes

None for users. CI-internal: PRs that previously got the hardcoded smoke list appended now get only the rule-selected affected tests (matches the documented #395 behavior). One follow-up out of scope: `.github/workflows/test.yml` has its own shell-level empty-selection fallback hardcoded to the old smoke list — now a dead branch (the script will emit `['unit']` instead of empty). Worth cleaning up separately.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/get-shit-done-redux/pr/420"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782529160&installation_id=134682257&pr_number=420&repository=open-gsd%2Fget-shit-done-redux&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fget-shit-done-redux%2Fpull%2F420&signature=c562f84c8dc1e656cbe7e9a294474d60b5772f6d5328ab4d7af19803d856f6ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->