### PR TITLE
fix(#410): guard ~/.gsd/defaults.json write with GSD_TEST_MODE (#130 sibling)

### DIFF
--- a/.changeset/410-install-defaults-test-mode-guard.md
+++ b/.changeset/410-install-defaults-test-mode-guard.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 410
+---
+`installAllRuntimes` no longer writes `~/.gsd/defaults.json` under `GSD_TEST_MODE` — matches the #130-class guard already applied to the opencode permission-config write.

--- a/bin/install.js
+++ b/bin/install.js
@@ -9810,8 +9810,8 @@ function finishInstall(settingsPath, settings, statuslineCommand, shouldInstallS
   // For non-Claude runtimes, set resolve_model_ids: "omit" in ~/.gsd/defaults.json
   // so resolveModelInternal() returns '' instead of Claude aliases (opus/sonnet/haiku)
   // that the runtime can't resolve. Users can still use model_overrides for explicit IDs.
-  // See #1156.
-  if (runtime !== 'claude') {
+  // See #1156. Guard matches the #130-class pattern on configureOpencodePermissions above.
+  if (runtime !== 'claude' && !process.env.GSD_TEST_MODE) {
     const gsdDir = path.join(os.homedir(), '.gsd');
     const defaultsPath = path.join(gsdDir, 'defaults.json');
     try {

--- a/tests/bug-410-install-defaults-test-mode-guard.test.cjs
+++ b/tests/bug-410-install-defaults-test-mode-guard.test.cjs
@@ -1,0 +1,112 @@
+'use strict';
+
+/**
+ * Bug #410: finishInstall writes ~/.gsd/defaults.json for non-Claude runtimes
+ * without a GSD_TEST_MODE guard, polluting the real developer home directory
+ * during test runs.
+ *
+ * The opencode permission-config write a few lines above already carries the
+ * GSD_TEST_MODE guard (added for #130) — this test covers the un-fixed sibling
+ * (the resolve_model_ids: "omit" write).
+ */
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const os = require('node:os');
+const fs = require('node:fs');
+
+const ROOT = path.join(__dirname, '..');
+
+// Point HOME at a temp dir so the defaults.json write can't reach the real
+// ~/.gsd/ even if the guard is missing.
+const FAKE_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-410-test-'));
+process.env.HOME = FAKE_HOME;
+
+// The path that finishInstall would write to for a non-Claude runtime.
+const GSD_DIR = path.join(FAKE_HOME, '.gsd');
+const DEFAULTS_PATH = path.join(GSD_DIR, 'defaults.json');
+
+// Set GSD_TEST_MODE before requiring install.js so any module-level guards
+// also see the flag.
+process.env.GSD_TEST_MODE = '1';
+
+const installModule = require(path.join(ROOT, 'bin', 'install.js'));
+
+// A synthetic settingsPath that won't exist — finishInstall should cope.
+const SETTINGS_PATH = path.join(FAKE_HOME, `gsd-test-settings-${process.pid}.json`);
+
+function callFinishInstallForRuntime(runtime) {
+  const original = console.log;
+  console.log = () => {};
+  try {
+    installModule.finishInstall(
+      SETTINGS_PATH,
+      {},       // empty settings
+      null,     // statuslineCommand
+      false,    // shouldInstallStatusline
+      runtime,
+      true,     // isGlobal
+      null,     // configDir
+    );
+  } finally {
+    console.log = original;
+  }
+}
+
+describe('Bug #410: finishInstall non-Claude runtime + GSD_TEST_MODE side-effect guard', () => {
+  test('defaults.json is NOT written for opencode runtime under GSD_TEST_MODE', () => {
+    assert.equal(
+      fs.existsSync(DEFAULTS_PATH),
+      false,
+      'defaults.json should not exist before finishInstall call',
+    );
+
+    callFinishInstallForRuntime('opencode');
+
+    assert.equal(
+      fs.existsSync(DEFAULTS_PATH),
+      false,
+      `defaults.json must NOT be created under GSD_TEST_MODE; found at ${DEFAULTS_PATH}`,
+    );
+  });
+
+  test('defaults.json is NOT written for gemini runtime under GSD_TEST_MODE', () => {
+    // Reset in case previous test left artifacts (it shouldn't).
+    assert.equal(
+      fs.existsSync(DEFAULTS_PATH),
+      false,
+      'defaults.json should not exist before gemini test',
+    );
+
+    callFinishInstallForRuntime('gemini');
+
+    assert.equal(
+      fs.existsSync(DEFAULTS_PATH),
+      false,
+      `defaults.json must NOT be created under GSD_TEST_MODE for gemini; found at ${DEFAULTS_PATH}`,
+    );
+  });
+
+  test('defaults.json IS written for opencode runtime when GSD_TEST_MODE is unset', () => {
+    // Temporarily unset GSD_TEST_MODE to verify the user-facing path still works.
+    const saved = process.env.GSD_TEST_MODE;
+    delete process.env.GSD_TEST_MODE;
+    try {
+      callFinishInstallForRuntime('opencode');
+      assert.equal(
+        fs.existsSync(DEFAULTS_PATH),
+        true,
+        `defaults.json must be written for non-Claude runtime when GSD_TEST_MODE is unset`,
+      );
+      // Verify the written content is correct.
+      const contents = JSON.parse(fs.readFileSync(DEFAULTS_PATH, 'utf8'));
+      assert.equal(contents.resolve_model_ids, 'omit', 'resolve_model_ids must be "omit"');
+    } finally {
+      // Restore GSD_TEST_MODE and clean up the written file.
+      process.env.GSD_TEST_MODE = saved;
+      try { fs.rmSync(DEFAULTS_PATH); } catch { /* already gone */ }
+      try { fs.rmdirSync(GSD_DIR); } catch { /* not empty or already gone */ }
+    }
+  });
+});


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #410

## What was broken

The installer's `finishInstall` (in `bin/install.js`, where the brief mis-described it as `installAllRuntimes`) writes `~/.gsd/defaults.json` for non-Claude runtimes guarded only by `runtime !== 'claude'` — with no `GSD_TEST_MODE` check. The module-level `GSD_TEST_MODE` guard wraps `main()` only; tests that exercise `finishInstall` directly bypass it, so test runs mutated the developer's real `~/.gsd/defaults.json`. Same #130-class shape as the opencode-permission config write a few lines above (which already carries the guard).

## What this fix does

Adds `&& !process.env.GSD_TEST_MODE` to the guard, matching the #130 sibling pattern.

## Root cause

When #130's opencode-permission fix landed, the analogous defaults.json write site was not updated.

## Testing

### How I verified the fix

`gsd-test-summary --both` (full suite, Mac + Linux/Docker):

```
Mac: 0 failed
Docker: 0 failed
```

New `tests/bug-410-install-defaults-test-mode-guard.test.cjs` covers 3 cases (GSD_TEST_MODE=1 suppresses write for opencode and gemini; absence of flag allows write). `tests/bug-130-finishinstall-opencode-testmode.test.cjs` still passes (no regression on the sibling).

### Regression test added?

- [x] Yes — `tests/bug-410-install-defaults-test-mode-guard.test.cjs`

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped — single guard addition in `bin/install.js`
- [x] Regression test added
- [x] All existing tests pass
- [x] `.changeset/` fragment added
- [x] No unnecessary dependencies added

## Breaking changes

None — only changes behavior under `GSD_TEST_MODE`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/get-shit-done-redux/pr/421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782529270&installation_id=134682257&pr_number=421&repository=open-gsd%2Fget-shit-done-redux&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fget-shit-done-redux%2Fpull%2F421&signature=0971a24535d9871e90dd421e10aa04e8475a002f1a244f1789b8eb1d71f2e0d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->