### PR TITLE
fix(#445): upgrade Windows checkout v4→v5.0.1 + audit other @v4 floats (silence Node 20 deprecation warnings)

### DIFF
--- a/.github/workflows/changeset-required.yml
+++ b/.github/workflows/changeset-required.yml
@@ -16,14 +16,14 @@ jobs:
   changeset-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
         with:
           fetch-depth: 50
       - name: Fetch base ref for diff
         run: git fetch --depth=50 origin "${BASE_REF}:refs/remotes/origin/${BASE_REF}"
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5.0.0
         with:
           node-version: '24'
       - name: Run changeset lint

--- a/.github/workflows/docs-required.yml
+++ b/.github/workflows/docs-required.yml
@@ -16,14 +16,14 @@ jobs:
   docs-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
         with:
           fetch-depth: 50
       - name: Fetch base ref for diff
         run: git fetch --depth=50 origin "${BASE_REF}:refs/remotes/origin/${BASE_REF}"
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5.0.0
         with:
           node-version: '24'
       - name: Run docs-required lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,10 +132,10 @@ jobs:
             scope: windows
 
     steps:
-      # actions/checkout@v6 uses includeIf.gitdir: to inject auth on Windows.
-      # On Windows git 2.54, the gitdir path comparison is unreliable, so use
-      # v4 on Windows and v6 elsewhere.
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2 (Windows)
+      # Windows lane on checkout v5.0.1 (drops includeIf; no auth flake, uses Node 24 natively).
+      # v6 uses includeIf.gitdir: for auth injection; on Windows git 2.54 the path comparison is
+      # unreliable (https://github.com/actions/checkout/pull/2425). v5 never used includeIf.
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1 (Windows)
         if: runner.os == 'Windows'
         with:
           fetch-depth: 0
@@ -231,7 +231,7 @@ jobs:
             shell: 'zsh {0}'
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2 (Windows)
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1 (Windows)
         if: runner.os == 'Windows'
         with:
           fetch-depth: 0


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

> **Required.** This PR will be auto-closed if no valid issue link is found.

Fixes #445

> The linked issue must have the `confirmed-bug` label. If it doesn't, ask a maintainer to confirm the bug before continuing.

---

## What was broken

GitHub Actions emitted Node 20 deprecation warnings on every CI run despite PR #350 setting `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` in test.yml. Per [actions/runner src/Runner.Worker/JobExtension.cs](https://github.com/actions/runner/blob/main/src/Runner.Worker/JobExtension.cs), that env var doesn't silence the warning — it changes which warning fires (from 'running on Node.js 20' to 'target Node.js 20 but being forced to run on Node.js 24'). Both call `context.Warning()`. The only mechanism that fully silences is the action's own `action.yml` declaring `using: node24`.

## What this fix does

- test.yml Windows checkout: SHA `11bd71901bbe5b1630ceea73d27597364c9af683` (v4.2.2) → `93cb6efe18208431cddfb8368fd83d5badbf9bfd` (v5.0.1). Per [v5 action.yml](https://raw.githubusercontent.com/actions/checkout/v5/action.yml), v5 declares `using: node24`. Per upstream PR #2425, v5 does NOT use `includeIf` — auth-bug-free.
- test.yml comment lines 135-137 updated to reflect the v5 rationale.
- changeset-required.yml + docs-required.yml: `@v4` → SHA-pinned v5.0.1 (checkout) and v5.0.0 (setup-node SHA `a0853c24544627f65ddf259abe73b1d18a591444`).
- Note: `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` was already absent from `origin/next`'s test.yml (only existed on `main`), so no env var removal was needed. Worth investigating why #350 didn't land cleanly — surfaced as separate concern.

## Root cause

Three workflow files referenced `@v4` actions whose `action.yml` declares `using: node20`:
- `.github/workflows/test.yml:138 + :234` (Windows lane in `test` job + `test-full` job) — pinned `actions/checkout@v4.2.2` (SHA `11bd71901bbe5b1630ceea73d27597364c9af683`). Per commit `925e8d953` (PR #162) + issue #161 rationale: 'v6 uses `includeIf.gitdir:` to inject the auth token, but on Windows git 2.54 the gitdir path comparison fails non-deterministically, leaving the fetch unauthenticated.' Upstream confirms: [actions/checkout#2425](https://github.com/actions/checkout/pull/2425) — 'This was introduced in v6 with the move to credential isolation via `includeIf` (#2286). v5 did not use `includeIf` so it was never an issue.'
- `.github/workflows/changeset-required.yml:19,22` — floating `actions/checkout@v4` + `actions/setup-node@v4`.
- `.github/workflows/docs-required.yml:19,22` — same.

## Testing

### How I verified the fix

- `actionlint` on all three workflow files: exit 0.
- `gsd-test-summary --both -base next` against commit `cbbd9fe0`: Mac 0 failed, Docker 0 failed.
- Policy linter (workflow-policy.cjs): 13/13 pass.
- **CI on this PR is the authoritative Windows verification** for the v5 auth-bug claim — only real CI can prove v5 doesn't reintroduce the issue #161 flake.

### Regression test added?

- [ ] Yes — added a test that would have caught this bug
- [x] No — explain why: CI workflow YAML changes; the actionlint + policy linter pass is the automated gate; a unit test cannot simulate GitHub Actions runner Node version selection.

### Platforms tested

- [x] macOS — gsd-test-summary --both -base next against commit cbbd9fe0: Mac: 0 failed
- [ ] Windows (including backslash path handling)
- [x] Linux — same: Docker: 0 failed
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [ ] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None

---

## References

- #161, PR #162 (original v4 pin)
- #350 (partial FORCE env var fix)
- Upstream [actions/checkout#2425](https://github.com/actions/checkout/pull/2425)
- [actions/runner FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 implementation](https://github.com/actions/runner/blob/main/src/Runner.Common/Util/NodeUtil.cs)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/get-shit-done-redux/pr/446"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782599338&installation_id=134682257&pr_number=446&repository=open-gsd%2Fget-shit-done-redux&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fget-shit-done-redux%2Fpull%2F446&signature=6a82fbe1df8061bade7ba4f3b7faf1db00aeea5a33c9be2f82459a9f6d9cd992"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->