### PR TITLE
fix(#478): delete wall-clock elapsed-time assertions per ADR 456 (keep correctness invariants)

### DIFF
--- a/tests/bug-3670-cursor-local-install-migration-lock.test.cjs
+++ b/tests/bug-3670-cursor-local-install-migration-lock.test.cjs
@@ -301,7 +301,6 @@ test('T5: unreclaimable same-PID lock throws bounded error (reclaim-unlink failu
     return originalUnlinkSync.call(fs, targetPath);
   });
 
-  const startMs = Date.now();
   assert.throws(
     () => runInstallerMigrations({
       configDir,
@@ -314,10 +313,4 @@ test('T5: unreclaimable same-PID lock throws bounded error (reclaim-unlink failu
     },
     'must throw "installer migration lock is held" when reclaim-unlink fails — not spin indefinitely'
   );
-  const elapsedMs = Date.now() - startMs;
-
-  // Must resolve within a generous but finite window (fix + timeout overhead).
-  // If it spins (deadlock regression), the process-level test timeout fires instead.
-  t.diagnostic(`T5 elapsed: ${elapsedMs}ms (expected ≤500ms for lockTimeoutMs:200 + overhead)`);
-  assert.ok(elapsedMs < 500, `T5 must resolve within 500ms; actual ${elapsedMs}ms — possible spin-loop regression`);
 });

--- a/tests/feat-3594-parser-adversarial-frontmatter.test.cjs
+++ b/tests/feat-3594-parser-adversarial-frontmatter.test.cjs
@@ -114,14 +114,9 @@ describe('feat-3594: frontmatter parser handles null bytes without truncation', 
 });
 
 describe('feat-3594: frontmatter parser handles bounded-large inputs in reasonable time', () => {
-  test('64KB frontmatter with 2000 array items parses under 2 seconds and returns the right shape', () => {
+  test('64KB frontmatter with 2000 array items parses and returns the right shape', () => {
     const content = loadFixture('huge-bounded.md');
-    const startedAt = Date.now();
     const fm = extractFrontmatter(content);
-    const elapsedMs = Date.now() - startedAt;
-    // Time bound is generous — a parser regression that makes this O(n^2)
-    // would blow well past 2s on this fixture.
-    assert.ok(elapsedMs < 2000, `parse took ${elapsedMs}ms — should be < 2000ms`);
     assert.equal(fm.phase, '06');
     assert.ok(Array.isArray(fm.plans), 'plans must be parsed as an array');
     assert.equal(fm.plans.length, 2000, 'all 2000 array items must be captured');

--- a/tests/health-validation.test.cjs
+++ b/tests/health-validation.test.cjs
@@ -374,13 +374,9 @@ describe('stateReplaceFieldWithFallback field-miss warning', () => {
       }
     }
 
-    const { performance } = require('perf_hooks');
-    const start = performance.now();
     const result = runGsdTools('validate health', tmpDir);
-    const elapsed = performance.now() - start;
 
     assert.ok(result.success, `validate health should succeed: ${result.error}`);
-    assert.ok(elapsed < 3000, `Should complete in under 3000ms, took ${elapsed.toFixed(0)}ms`);
 
     const output = JSON.parse(result.output);
     assert.ok(typeof output.status === 'string', 'Should return a status string');

--- a/tests/read-injection-scanner.test.cjs
+++ b/tests/read-injection-scanner.test.cjs
@@ -104,11 +104,9 @@ describe('gsd-read-injection-scanner: advisory output', () => {
     assert.ok(out.hookSpecificOutput.additionalContext.includes('/home/user/project/README.md'));
   });
 
-  test('SCAN-07: hook completes within 5s on large content', () => {
+  test('SCAN-07: hook exits cleanly on large content', () => {
     const bigContent = 'x'.repeat(500_000); // 500KB of benign content
-    const start = Date.now();
     const r = runHook(readPayload('/tmp/large.ts', bigContent), 6000);
-    assert.ok(Date.now() - start < 5000, 'hook should complete within 5s');
     assert.equal(r.exitCode, 0);
     assert.equal(r.stdout, '');
   });


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

> **Required.** This PR will be auto-closed if no valid issue link is found.

Fixes #478

> The linked issue must have the `confirmed-bug` label. If it doesn't, ask a maintainer to confirm the bug before continuing.

---

## What was broken

Several tests asserted on wall-clock elapsed time (`assert.ok(elapsed < N)`), which gates on CI-runner load rather than behavior — the documented perf-flake class (perf-316/407).

## What this fix does

Deletes the elapsed-time assertions in `health-validation.test.cjs`, `bug-3670-cursor-local-install-migration-lock.test.cjs`, `read-injection-scanner.test.cjs`, and `feat-3594-parser-adversarial-frontmatter.test.cjs`, per ADR 456's delete-bad-tests policy. Every correctness assertion in each test is retained (success, throws, output shape, parsed result). The three `concurrency-safety.test.cjs` perf sites were already removed under #453.

## Root cause

Wall-clock `assert(elapsed < N)` tests the host machine, not the SUT, and flakes on loaded CI runners. ADR 456 mandates removal; they lingered only because `local/no-elapsed-assertion` is at `warn`.

## Testing

### How I verified the fix

Each touched test file passes individually after the deletions and still asserts real behavior. Adversarial review confirmed no vacuous tests, no accidental correctness-assertion removal, and no dangling imports. `gsd-test-summary --both -base next`: `Docker: 0 failed`, `Mac: 0 failed`.

### Regression test added?

- [ ] Yes — added a test that would have caught this bug
- [x] No — explain why: this removes flaky assertions; each behavior remains covered by the retained correctness assertions in the same test

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

<!-- Does this fix change any existing behavior, output format, or API that users might depend on?
     If yes, describe. Write "None" if not applicable. -->

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/480"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782675368&installation_id=134682257&pr_number=480&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F480&signature=c2269445907ad20f77bc98002099acd2a7604d310a8e02719b225671650a2530"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->