### PR TITLE
fix(#481): remove residual dead silent-expiry poll helper + Atomics.wait in bug-1974

### DIFF
--- a/tests/bug-1974-context-exhaustion-record.test.cjs
+++ b/tests/bug-1974-context-exhaustion-record.test.cjs
@@ -82,20 +82,6 @@ function runRecordSession(cwd, stoppedAt) {
   };
 }
 
-function sleep(ms) {
-  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
-}
-
-function waitForStateMatch(statePath, regex, timeoutMs = 45000) {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    const content = fs.readFileSync(statePath, 'utf-8');
-    if (regex.test(content)) return content;
-    sleep(100);
-  }
-  return fs.readFileSync(statePath, 'utf-8');
-}
-
 /**
  * Read and parse the warn sentinel file for a session.
  * Returns the parsed object, or null if the file does not exist.
@@ -140,17 +126,9 @@ describe('#1974 context exhaustion auto-record', () => {
   });
 
   afterEach(() => {
-    for (let attempt = 0; attempt < 5; attempt += 1) {
-      try {
-        cleanup(tmpDir);
-        break;
-      } catch (err) {
-        const code = err && err.code;
-        const transient = code === 'EPERM' || code === 'EBUSY' || code === 'ENOTEMPTY';
-        if (!transient || attempt === 4) throw err;
-        sleep(250 * (attempt + 1));
-      }
-    }
+    // cleanup() uses fs.rmSync with maxRetries:20/retryDelay:250ms internally,
+    // which handles transient EBUSY/ENOTEMPTY on Windows. No outer sleep needed.
+    cleanup(tmpDir);
     // Clean up bridge files
     try {
       const warnPath = path.join(os.tmpdir(), `claude-ctx-${sessionId}-warned.json`);


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

> **Required.** This PR will be auto-closed if no valid issue link is found.

Fixes #481

> The linked issue must have the `confirmed-bug` label. If it doesn't, ask a maintainer to confirm the bug before continuing.

---

## What was broken

`tests/bug-1974-context-exhaustion-record.test.cjs` carried residual dead code after #453 removed the racy 45 s poll caller: a definition-only `waitForStateMatch` helper embodying the silent-expiry anti-pattern (returns stale file content on timeout instead of throwing — silently passes if ever reused), plus an `Atomics.wait`-based `afterEach` retry loop. The `Atomics.wait` is a `no-magic-sleep-in-tests` violation, and the retry was redundant with `cleanup()`'s built-in `fs.rmSync(..., { maxRetries: 20, retryDelay: 250 })`.

## What this fix does

Deletes the dead `waitForStateMatch` helper and the redundant `Atomics.wait` retry, leaving `afterEach` as a single `cleanup(tmpDir)` plus the existing bridge-file cleanup. Net deletion (−25 lines). The genuine, already-deterministic tests (which use `spawnSync` + the `criticalRecorded` sentinel) are untouched.

## Root cause

#453 removed the racy poll's caller but left its helper definition and the `afterEach` retry/sleep behind. The leftover silent-expiry helper is a latent bug and the `Atomics.wait` is a lint violation; neither belongs in the suite.

## Testing

### How I verified the fix

`tests/bug-1974-context-exhaustion-record.test.cjs` passes 5/5 across repeated runs; no live `waitForStateMatch`/`Atomics.wait` remain (one historical comment only). Adversarial review confirmed no live caller dangles and the `afterEach` retry was redundant with `cleanup()`'s `maxRetries`. `gsd-test-summary --both -base next`: `Docker: 0 failed`, `Mac: 0 failed`.

### Regression test added?

- [ ] Yes — added a test that would have caught this bug
- [x] No — explain why: this is a net deletion of dead test code; the file's genuine tests already pass deterministically and are unchanged

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

<!-- Does this fix change any existing behavior, output format, or API that users might depend on?
     If yes, describe. Write "None" if not applicable. -->

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/482"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782676408&installation_id=134682257&pr_number=482&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F482&signature=fa2301338b944be10b214b7dcf675e73fc3166788d6ab4b1ff6d457b52805436"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->