### PR TITLE
fix(#489): stop docs-parity tokenizer matching repo path open-gsd/gsd-core as a command

### DIFF
--- a/tests/docs-parity-live-registry.test.cjs
+++ b/tests/docs-parity-live-registry.test.cjs
@@ -197,9 +197,14 @@ function extractCommandTokens(content) {
     return false;
   }
 
-  const allSlash = (stripped.match(/\/gsd-[a-z0-9][a-z0-9-]*/g) || []);
-  const allColon = (stripped.match(/\/gsd:[a-z0-9][a-z0-9-]*/g) || []);
-  const allDollar = (stripped.match(/\$gsd-[a-z0-9][a-z0-9-]*/g) || []);
+  // Negative lookbehind: only match tokens NOT preceded by a letter, digit,
+  // `/`, `_`, or `-`. This prevents matching the `/gsd-core` substring inside
+  // the org/repo path `open-gsd/gsd-core` (and similar path-embedded segments)
+  // while still matching real invocations preceded by BOL, space, backtick, or
+  // `(`. Fixes false-positive class identified in #489.
+  const allSlash = (stripped.match(/(?<![A-Za-z0-9/_-])\/gsd-[a-z0-9][a-z0-9-]*/g) || []);
+  const allColon = (stripped.match(/(?<![A-Za-z0-9/_-])\/gsd:[a-z0-9][a-z0-9-]*/g) || []);
+  const allDollar = (stripped.match(/(?<![A-Za-z0-9/_-])\$gsd-[a-z0-9][a-z0-9-]*/g) || []);
 
   const slash = new Set(allSlash.filter(t => !isInternal(t)));
   const colon = new Set(allColon.filter(t => !isInternal(t)));
@@ -481,5 +486,46 @@ describe('adversarial: polarity inversion catches drift deny-list misses', () =>
   test('freshly-deleted command /gsd-research-phase is absent from registry', () => {
     const registry = getLiveCommandTokens();
     assert.ok(!registry.has('/gsd-research-phase'), '/gsd-research-phase must not be in the live registry');
+  });
+});
+
+// ─── Tokenizer regression tests (#489) ───────────────────────────────────────
+
+describe('extractCommandTokens() — repo-path false-positive regression (#489)', () => {
+  test('open-gsd/gsd-core#22 repo path does NOT produce a /gsd-core token', () => {
+    // Before the lookbehind fix, /gsd-core inside `open-gsd/gsd-core#22`
+    // would be matched by the slash regex — a false positive.
+    const { slash, colon, dollar } = extractCommandTokens(
+      'see open-gsd/gsd-core#22 for details'
+    );
+    const all = [...slash, ...colon, ...dollar];
+    assert.ok(
+      !all.includes('/gsd-core'),
+      'repo path open-gsd/gsd-core#22 must not produce a /gsd-core token; got: ' + all.join(', ')
+    );
+    assert.strictEqual(all.length, 0, 'expected zero tokens from a bare repo-path string; got: ' + all.join(', '));
+  });
+
+  test('space-preceded /gsd-totally-not-a-real-command is still extracted (real invocation)', () => {
+    // A genuine (but unregistered) command reference after whitespace must be
+    // captured so the live-registry check can flag it as unknown.
+    const { slash } = extractCommandTokens(
+      'run /gsd-totally-not-a-real-command here'
+    );
+    assert.ok(
+      slash.has('/gsd-totally-not-a-real-command'),
+      'invocation after whitespace must be extracted; slash set: ' + [...slash].join(', ')
+    );
+  });
+
+  test('backtick-wrapped `/gsd-plan` is still extracted (real invocation)', () => {
+    // Backtick-wrapped commands (common in markdown) must still be captured.
+    const { slash } = extractCommandTokens(
+      'use `/gsd-plan` to plan'
+    );
+    assert.ok(
+      slash.has('/gsd-plan'),
+      'backtick-wrapped invocation must be extracted; slash set: ' + [...slash].join(', ')
+    );
   });
 });


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

> **Required.** This PR will be auto-closed if no valid issue link is found.

Fixes #489

> The linked issue must have the `confirmed-bug` label. If it doesn't, ask a maintainer to confirm the bug before continuing.

---

## What was broken

`tests/docs-parity-live-registry.test.cjs:377` ("every slash-command token in docs/*.md resolves to a live command") failed on every full-suite CI leg (macOS 22/24, Windows-22, Ubuntu-24), turning `next` red:

```
docs/adr/22-plan-drift-guard.md: unknown command token(s): [/gsd-core]
```

## What this fix does

Hardens `extractCommandTokens()` so a `/gsd-…` / `/gsd:…` / `$gsd-…` token is only treated as a command **invocation**, not when it is embedded in a path or word. The previously-failing parity test now passes, and a regression test locks the behavior.

## Root cause

`extractCommandTokens()` used `/\/gsd-[a-z0-9][a-z0-9-]*/g`, which matched the `/gsd-core` **substring inside the org/repo path** `open-gsd/gsd-core#22` in ADR 22. After the repo was renamed to `gsd-core`, the canonical reference `open-gsd/gsd-core` — used throughout the project — contains the literal `/gsd-core`, so any doc citing the repo path produced a false positive. The fix adds a negative lookbehind `(?<![A-Za-z0-9/_-])` so path/word-embedded segments no longer match, while real invocations (start-of-line, space, backtick, paren) still do.

## Testing

### How I verified the fix

- `node --test tests/docs-parity-live-registry.test.cjs` — the line-377 parity test (and the localized ja/ko/zh/pt parity tests) pass; the new regression block passes.
- `gsd-test-summary --both -base next` (binary v1.3.2): **Docker: 0 failed**, **Mac: 0 failed** — full suite green on Linux and macOS (docs-parity is deterministic and platform-independent).

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why: <!-- e.g., environment-specific, non-deterministic -->

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [ ] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/491"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782684220&installation_id=134682257&pr_number=491&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F491&signature=cfd458dbc52ec5d955dfc695db85ab077d55aa35aad314b26d167484dbb086ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->