### PR TITLE
fix(#490): restore bounded Windows EBUSY cleanup retry in bug-1974 afterEach

### DIFF
--- a/tests/bug-1974-context-exhaustion-record.test.cjs
+++ b/tests/bug-1974-context-exhaustion-record.test.cjs
@@ -31,6 +31,22 @@ const { cleanup } = require('./helpers.cjs');
 const HOOK_PATH = path.resolve(__dirname, '..', 'hooks', 'gsd-context-monitor.js');
 const GSD_TOOLS = path.resolve(__dirname, '..', 'get-shit-done', 'bin', 'gsd-tools.cjs');
 
+// Windows can hold a transient handle on the temp dir after a spawnSync child
+// exits (AV scanner / handle-release lag), so cleanup()'s internal rmSync retry
+// (~5s) occasionally still throws EBUSY/EPERM/ENOTEMPTY under CI load. Restore a
+// bounded outer retry with async backoff (NOT Atomics.wait — lint no-magic-sleep).
+// Re-adds the guard removed in #482. Refs #490.
+async function cleanupWithRetry(dir, attempts = 8) {
+  for (let i = 0; i < attempts; i += 1) {
+    try { cleanup(dir); return; }
+    catch (err) {
+      const transient = err && (err.code === 'EBUSY' || err.code === 'EPERM' || err.code === 'ENOTEMPTY');
+      if (!transient || i === attempts - 1) throw err;
+      await new Promise((resolve) => setTimeout(resolve, 100 * (i + 1)));
+    }
+  }
+}
+
 /**
  * Run the hook with a given session id and context percentage.
  * Writes a bridge metrics file first, then pipes the hook input via stdin.
@@ -125,10 +141,11 @@ describe('#1974 context exhaustion auto-record', () => {
     sessionId = `test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
   });
 
-  afterEach(() => {
-    // cleanup() uses fs.rmSync with maxRetries:20/retryDelay:250ms internally,
-    // which handles transient EBUSY/ENOTEMPTY on Windows. No outer sleep needed.
-    cleanup(tmpDir);
+  afterEach(async () => {
+    // cleanupWithRetry wraps cleanup() with a bounded outer retry (async setTimeout
+    // backoff, no Atomics.wait) to handle cases where windows-2022 CI load keeps
+    // the temp dir EBUSY beyond rmSync's internal ~5s retry window. Refs #490.
+    await cleanupWithRetry(tmpDir);
     // Clean up bridge files
     try {
       const warnPath = path.join(os.tmpdir(), `claude-ctx-${sessionId}-warned.json`);


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

> **Required.** This PR will be auto-closed if no valid issue link is found.

Fixes #490

> The linked issue must have the `confirmed-bug` label. If it doesn't, ask a maintainer to confirm the bug before continuing.

---

## What was broken

`tests/bug-1974-context-exhaustion-record.test.cjs` intermittently failed on `full test (windows-latest, 22)`, turning `next` red:

```
tests/bug-1974-context-exhaustion-record.test.cjs:141 / :179 — hookFailed
EBUSY: resource busy or locked, rmdir 'C:\...\Temp\gsd-1974-XXXX'
```

The `afterEach` `cleanup(tmpDir)` could not remove the temp dir because Windows briefly holds a handle after the test's `spawnSync` child exits (AV scanner / handle-release lag).

## What this fix does

Restores a bounded outer retry around `cleanup()` in the `afterEach`, using an async `setTimeout` backoff (no `Atomics.wait`, per `no-magic-sleep-in-tests`). Transient `EBUSY`/`EPERM`/`ENOTEMPTY` are retried up to 8 times with escalating delay; a persistent or non-transient error still surfaces.

## Root cause

#482 (commit 668708762) removed the afterEach outer retry guard, assuming `rmSync`'s internal `maxRetries:20`/`retryDelay:250` (~5s) was sufficient. Under windows-2022 CI load it is not, so the bare `cleanup()` threw and the hook failed. #482's PR CI used affected-test scoping that skipped the full Windows matrix, so the regression only surfaced on `next`'s full-matrix push.

## Testing

### How I verified the fix

- `gsd-test-summary --both -base next` (binary v1.3.2, branch rebased onto current `next`): **Docker: 0 failed**, **Mac: 0 failed** — confirms no Linux/macOS regression.
- `node --check` on the modified file — syntax valid.
- The Windows-22 `EBUSY` path cannot be reproduced on macOS/Linux and the scoped PR CI does not run the `windows-latest, 22` leg, so the actual fix is verified by `next`'s **full-matrix push after merge** (this scoped-PR/full-matrix blind spot is tracked as a separate follow-up).

### Regression test added?

- [ ] Yes — added a test that would have caught this bug
- [x] No — explain why: the failure is environment-specific (Windows-2022 transient filesystem `EBUSY` under CI load) and not deterministically reproducible cross-platform; the existing bug-1974 tests exercise the hardened `afterEach`.

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [ ] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/493"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782684751&installation_id=134682257&pr_number=493&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F493&signature=7c58549a09e691adcb4c65c6fb477eb831e74765e1e85a0fbadccb884c1d7ebb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->