### PR TITLE
fix(#494): ci-test-scope selects the checks a diff can break (tests→full matrix, docs→docs-parity)

### DIFF
--- a/scripts/ci-test-scope.cjs
+++ b/scripts/ci-test-scope.cjs
@@ -105,6 +105,7 @@ const RULES = [
       'tests/command-contract.test.cjs',
       'tests/command-routing-hub.test.cjs',
       'tests/commands.test.cjs',
+      'tests/docs-parity-live-registry.test.cjs',
       'tests/phase-command-router.test.cjs',
       'tests/roadmap-command-router.test.cjs',
     ],
@@ -129,6 +130,15 @@ const RULES = [
       'tests/agent-skills.test.cjs',
       'tests/agent-skills-awareness.test.cjs',
       'tests/agent-required-reading-consistency.test.cjs',
+      'tests/docs-parity-live-registry.test.cjs',
+    ],
+  },
+  {
+    name: 'docs content',
+    match: path => path.startsWith('docs/'),
+    fullMatrix: false,
+    tests: [
+      'tests/docs-parity-live-registry.test.cjs',
     ],
   },
   {
@@ -219,7 +229,7 @@ function classify(files) {
   let fullMatrix = false;
 
   for (const file of files) {
-    if (/^(bin|get-shit-done|agents|commands|hooks|tests|scripts)\//.test(file) ||
+    if (/^(bin|get-shit-done|agents|commands|docs|hooks|tests|scripts)\//.test(file) ||
       /^package(-lock)?\.json$/.test(file) ||
       /^tsconfig.*\.json$/.test(file) ||
       file.startsWith('.github/workflows/') ||
@@ -229,6 +239,7 @@ function classify(files) {
 
     if (file.startsWith('tests/') && file.endsWith('.test.cjs')) {
       targeted.add(file);
+      fullMatrix = true;
       if (/windows|path|shell|workflow|install|hook/i.test(file)) {
         windows.add(file);
       }

--- a/tests/ci-test-scope.test.cjs
+++ b/tests/ci-test-scope.test.cjs
@@ -18,12 +18,14 @@ function scopeFor(files) {
 }
 
 describe('ci-test-scope.cjs', () => {
-  test('docs-only changes do not request code matrix work', () => {
+  test('docs-only changes mark code_changed and select docs-parity (new correct contract)', () => {
     const result = scopeFor(['docs/usage.md']);
-    assert.strictEqual(result.code_changed, false);
+    assert.strictEqual(result.code_changed, true);
     assert.strictEqual(result.full_matrix, false);
-    assert.deepStrictEqual(result.targeted_tests, []);
-    assert.deepStrictEqual(result.windows_tests, []);
+    assert.ok(
+      result.targeted_tests.some(t => t.includes('docs-parity-live-registry')),
+      `expected docs-parity-live-registry in targeted_tests, got: ${JSON.stringify(result.targeted_tests)}`,
+    );
   });
 
   test('workflow changes request full matrix and workflow contract tests', () => {
@@ -101,5 +103,49 @@ describe('ci-test-scope.cjs', () => {
     // allow-test-rule: the unit-fallback contract is the exact subject of bug #408.
     assert.deepStrictEqual(result.targeted_tests, ['unit'],
       'targeted_tests must be [\'unit\'] when code changed but no rule matched');
+  });
+});
+
+describe('ci-test-scope superset invariant (#494)', () => {
+  // Facet A: any tests/** change → full_matrix === true
+  test('A1: a specific changed test file forces full_matrix', () => {
+    const result = scopeFor(['tests/bug-1974-context-exhaustion-record.test.cjs']);
+    assert.strictEqual(result.full_matrix, true,
+      `expected full_matrix=true for tests/** change, got: ${JSON.stringify(result)}`);
+  });
+
+  test('A2: any tests/** path forces full_matrix', () => {
+    const result = scopeFor(['tests/some-new.test.cjs']);
+    assert.strictEqual(result.full_matrix, true,
+      `expected full_matrix=true for tests/** change, got: ${JSON.stringify(result)}`);
+  });
+
+  // Facet B: docs/**, commands/**, agents/** → code_changed AND docs-parity selected
+  test('B1: docs/adr change marks code_changed and selects docs-parity-live-registry', () => {
+    const result = scopeFor(['docs/adr/22-plan-drift-guard.md']);
+    assert.strictEqual(result.code_changed, true,
+      `expected code_changed=true for docs/** change, got: ${JSON.stringify(result)}`);
+    assert.ok(
+      result.targeted_tests.some(t => t.includes('docs-parity-live-registry')),
+      `expected docs-parity-live-registry in targeted_tests, got: ${JSON.stringify(result.targeted_tests)}`,
+    );
+  });
+
+  test('B2: docs locale dir change marks code_changed and selects docs-parity-live-registry', () => {
+    const result = scopeFor(['docs/ja-JP/USAGE.md']);
+    assert.strictEqual(result.code_changed, true,
+      `expected code_changed=true for docs/ja-JP/** change, got: ${JSON.stringify(result)}`);
+    assert.ok(
+      result.targeted_tests.some(t => t.includes('docs-parity-live-registry')),
+      `expected docs-parity-live-registry in targeted_tests, got: ${JSON.stringify(result.targeted_tests)}`,
+    );
+  });
+
+  test('B3: commands/** change selects docs-parity-live-registry', () => {
+    const result = scopeFor(['commands/gsd/plan-phase.md']);
+    assert.ok(
+      result.targeted_tests.some(t => t.includes('docs-parity-live-registry')),
+      `expected docs-parity-live-registry in targeted_tests for commands/** change, got: ${JSON.stringify(result.targeted_tests)}`,
+    );
   });
 });


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

> **Required.** This PR will be auto-closed if no valid issue link is found.

Fixes #494

> The linked issue must have the `confirmed-bug` label. If it doesn't, ask a maintainer to confirm the bug before continuing.

---

## What was broken

`scripts/ci-test-scope.cjs` `classify()` under-selected CI checks for scoped PRs, so a PR could pass green while skipping the exact check its diff would break — which then failed on `next`'s unconditional full-matrix push. Two real escapes this session:

- **#484** (docs-only `docs/adr/*.md`) → `code_changed=false` → no test job ran → `docs-parity-live-registry` (reads `docs/**` at runtime) never executed → broke `next`.
- **#482** (test-only `tests/bug-1974*.test.cjs`) → `full_matrix=false` → `test-full` (windows-22 + macOS) skipped → the Windows-22 `EBUSY` never ran → broke `next`.

## What this fix does

Restores the selector's safety invariant — **the checks a PR runs ⊇ the checks `next`'s push would run that the diff can break** — via two fail-safe widenings in `classify()`:

1. Any `tests/**` change → `full_matrix=true` (a changed test can fail OS/version-specifically; it must run on every matrix leg `next` would run it on).
2. Any `docs/**` (incl. locale dirs), `commands/**`, or `agents/**` change → `code_changed=true` and `tests/docs-parity-live-registry.test.cjs` is selected (those are docs-parity's runtime inputs). `full_matrix` stays `false` for docs-only changes since docs-parity is platform-independent.

## Root cause

`classify()` keyed its scope decision on a RULES table + a `code_changed` regex that (a) omitted `docs/` and (b) had no rule forcing the full OS matrix for `tests/**` changes — and the underlying selectors only model static `require()` edges, never the runtime `fs.readdirSync('docs/')` dependency that `docs-parity-live-registry` has. So both classes of breakable check were invisible to the PR-time scope.

## Testing

### How I verified the fix

- TDD: added 5 behavioral tests (A1/A2 full-matrix-on-test-change, B1/B2/B3 docs-parity-on-content-change) to `tests/ci-test-scope.test.cjs` and updated the existing docs-only case that asserted the old (buggy) contract. Confirmed **RED** (6 failing) before the fix, **GREEN** (13/13) after. Assertions are on `scopeFor()`'s structured JSON output (`full_matrix`, `code_changed`, `targeted_tests`), not source text.
- `gsd-test-summary --both -base next` (binary v1.3.2): **Docker: 0 failed**, **Mac: 0 failed** — full suite green on Linux and macOS.
- This PR dog-foods the fix: it touches a `tests/**` file, so its own CI runs the full matrix (incl. Windows-22) under the new rule.

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why: <!-- e.g., environment-specific, non-deterministic -->

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [ ] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/495"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782686967&installation_id=134682257&pr_number=495&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F495&signature=902f2d2bcaf972cd80c9e7282ac32991a1abb3718fb856a41adfe0a5c41fb4af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->