### PR TITLE
fix(#520): register package-identity.cjs in inventory (regression from #516)

### DIFF
--- a/docs/INVENTORY-MANIFEST.json
+++ b/docs/INVENTORY-MANIFEST.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-05-29",
+  "generated": "2026-05-30",
   "families": {
     "agents": [
       "gsd-advisor-researcher",
@@ -298,6 +298,7 @@
       "milestone.cjs",
       "model-catalog.cjs",
       "model-profiles.cjs",
+      "package-identity.cjs",
       "phase-command-router.cjs",
       "phase-lifecycle.cjs",
       "phase.cjs",

--- a/docs/INVENTORY.md
+++ b/docs/INVENTORY.md
@@ -362,7 +362,7 @@ The `gsd-planner` agent is decomposed into a core agent plus reference modules t
 
 ---
 
-## CLI Modules (76 shipped)
+## CLI Modules (77 shipped)
 
 Full listing: `get-shit-done/bin/lib/*.cjs`.
 
@@ -406,6 +406,7 @@ Full listing: `get-shit-done/bin/lib/*.cjs`.
 | `milestone.cjs` | Milestone archival, requirements marking |
 | `model-catalog.cjs` | CJS adapter over the shared model catalog JSON; exports canonical runtime tier defaults, agent profile maps, alias maps, and routing metadata for all CLI consumers |
 | `model-profiles.cjs` | Backward-compatible profile helpers derived from `model-catalog.cjs`; no longer owns its own model table |
+| `package-identity.cjs` | Single source of truth for the package's own identity — exports `PACKAGE_NAME` derived from `package.json` `name` so a rename is a one-line change (#516) |
 | `phase-command-router.cjs` | Thin CJS subcommand router adapter for `gsd-tools phase` |
 | `phase-lifecycle.cjs` | Pure-computation phase lifecycle helpers extracted from the phase-lifecycle SDK handler |
 | `phase.cjs` | Phase directory operations, decimal numbering, plan indexing |


### PR DESCRIPTION
<!-- pr-template-exempt: docs-only inventory sync, regression fix (#520) -->

## Fix — inventory out of sync after #516

Closes #520

#516 added `get-shit-done/bin/lib/package-identity.cjs` but I did not regenerate the inventory, breaking two tests on `next` (they read repo files → fail in CI):
- `inventory-manifest-sync` — `cli_modules/package-identity.cjs` missing from `docs/INVENTORY-MANIFEST.json`.
- `inventory-counts` — `docs/INVENTORY.md` headline "76 shipped" vs filesystem 77.

Verified green at `3b4f2938` (pre-#516), red after — this is my regression, now fixed.

### Change (docs-only)
- `docs/INVENTORY-MANIFEST.json` regenerated via `node scripts/gen-inventory-manifest.cjs --write`.
- `docs/INVENTORY.md`: CLI Modules 76 → 77 + `package-identity.cjs` row.

### Verification
- `inventory-counts` + `inventory-manifest-sync`: **pass**.
- Full unit suite: the only remaining failures are `code-review` (×4), which read `~/.claude/get-shit-done/` — a stale local install on this machine; they **skip in CI** (no `~/.claude`) and are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/521"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782758059&installation_id=134682257&pr_number=521&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F521&signature=4be1463fde5e6bb509a9bc85e22c5dc5cd0de341446408fb0e321516ab960f2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->