### PR TITLE
[codex] Include README assets in next package

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "bin",
     "commands",
     "get-shit-done",
+    "assets",
     "agents",
     "hooks",
     "scripts"


### PR DESCRIPTION
## Summary

- Add `assets/` to the package `files` allowlist so README image references are present in next publish artifacts.
- Keeps the already-updated `assets/terminal.svg` available when consumers view packaged README content.

## Validation

- `npm pack --dry-run --json` now lists `assets/terminal.svg` and the logo assets.
- `node -e "JSON.parse(require('node:fs').readFileSync('package.json','utf8')); console.log('package.json ok')"`
- `git diff --check`

Closes #526

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/527"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782822516&installation_id=134682257&pr_number=527&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F527&signature=7ee0dd40d7a6880ef278279f46c96b9ce058d54cd72405bdab5fffd1ecae5420"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only change to the publish allowlist; no runtime, auth, or application logic is modified.
> 
> **Overview**
> Adds **`assets`** to the npm **`files`** allowlist in `package.json` so published `@opengsd/gsd-core` tarballs include README-linked images (e.g. `assets/terminal.svg` and logo assets). Without this, those paths were omitted from `npm pack` / registry installs even though READMEs reference them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bee1cab7fba00a8c0dec32d286913d36615f5bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->