### PR TITLE
[codex] Remove README continuity section

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,18 +52,6 @@ npx @opengsd/gsd-core@latest
 
 ---
 
-## Why We Continue Building GSD Core
-
-GSD Core exists to help solo builders and small teams ship reliably with AI: clear specs, controlled context, and verification before release.
-
-In May 2026, maintainers published a continuity announcement and migrated active development to `open-gsd/gsd-core` after trust and ownership concerns around the former upstream, including a meme-coin rug-pull incident publicly associated with that ecosystem.
-
-The former creator and legacy lineage are no longer part of this program. This repository is the maintained continuation under open-gsd governance.
-
-The current team continues release operations, triage, and security hardening in public. Audit status and follow-up security work are documented in Discussion #119 and linked issues.
-
----
-
 ## How It Works
 
 The loop is six commands. Each one does exactly one thing.


### PR DESCRIPTION
## Summary

- Remove the `## Why We Continue Building GSD Core` continuity/history section from the root README.
- Leave the rest of the README product and workflow content unchanged.

## Validation

- `npm run lint:docs`
- `git diff --check`
- grep check confirms the requested continuity/history phrases are gone from `README.md`.

Closes #532

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/533"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782823333&installation_id=134682257&pr_number=533&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F533&signature=70e1690ef1cc80bc871b91aa6d56576005126a7a9aac226a10b444f7f6d36d7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README edit with no runtime, security, or data-handling impact.
> 
> **Overview**
> Removes the **`## Why We Continue Building GSD Core`** section from the root `README.md`, including continuity messaging about the May 2026 migration, upstream trust concerns, and links to Discussion #119.
> 
> The **Returning to GSD Core?** callout and everything from **`## How It Works`** onward are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7eaa14f48f7e060b3c70152e6da3483deb833b8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->