### PR TITLE
ci(#534): skip maintainer PR policy gates

### DIFF
--- a/.github/workflows/close-draft-prs.yml
+++ b/.github/workflows/close-draft-prs.yml
@@ -14,7 +14,10 @@ permissions:
 jobs:
   close-if-draft:
     name: Reject draft PRs
-    if: github.event.pull_request.draft == true
+    # Maintainers may use draft PRs for internal coordination.
+    if: >-
+      github.event.pull_request.draft == true &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association) == false
     runs-on: ubuntu-latest
     steps:
       - name: Comment and close draft PR

--- a/.github/workflows/pr-target-validator.yml
+++ b/.github/workflows/pr-target-validator.yml
@@ -22,6 +22,9 @@ permissions:
 
 jobs:
   validate-target:
+    # Maintainers may open internal release/backport coordination PRs against main.
+    if: >-
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association) == false
     runs-on: ubuntu-latest
     timeout-minutes: 2
     env:

--- a/tests/workflow-maintainer-skip.test.cjs
+++ b/tests/workflow-maintainer-skip.test.cjs
@@ -1,0 +1,37 @@
+// allow-test-rule: source-text-is-the-product
+// These workflow files are deployed policy; the tests lock the maintainer
+// carve-out so future edits do not accidentally re-enable enforcement.
+'use strict';
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const MAINTAINER_SKIP_EXPR = 'contains(fromJSON(\'["OWNER","MEMBER","COLLABORATOR"]\'), github.event.pull_request.author_association) == false';
+
+function readWorkflow(relativePath) {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), 'utf8');
+}
+
+function assertMaintainerSkip(source) {
+  assert.ok(
+    source.includes(MAINTAINER_SKIP_EXPR),
+    `Expected workflow to include maintainer skip expression: ${MAINTAINER_SKIP_EXPR}`
+  );
+}
+
+describe('PR policy workflow maintainer carve-outs', () => {
+  test('draft PR auto-close does not run for maintainer-authored PRs', () => {
+    const workflow = readWorkflow('.github/workflows/close-draft-prs.yml');
+
+    assert.match(workflow, /github\.event\.pull_request\.draft == true/);
+    assertMaintainerSkip(workflow);
+  });
+
+  test('PR target validator does not run for maintainer-authored PRs', () => {
+    const workflow = readWorkflow('.github/workflows/pr-target-validator.yml');
+
+    assertMaintainerSkip(workflow);
+  });
+});


### PR DESCRIPTION
<!-- pr-template-exempt: CI policy change with a focused workflow regression test. -->

Closes #534

## Summary

- Skip the draft PR auto-close job for PRs authored by owners, members, or collaborators.
- Skip the PR target validator job for the same maintainer author associations.
- Add a source-policy regression test that locks both maintainer carve-outs.

## Why

The existing gates are useful contributor guardrails, but they also block maintainer-owned coordination flows such as draft internal PRs and main-target release/backport work.

## Validation

- `node --test tests/workflow-maintainer-skip.test.cjs`
- `node --test tests/workflow-shell-pinning.test.cjs`
- `npm run lint:test-file-count`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/535"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782823653&installation_id=134682257&pr_number=535&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F535&signature=3d4bf2aafeebea88b0113e6f05bafb9a96a45d5b8c0b8aa1e824ff9a1210face"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only GitHub Actions job `if` conditions and a workflow source-text test; contributor enforcement behavior is unchanged for non-maintainers.
> 
> **Overview**
> Contributor-facing PR policy automation now **skips owners, members, and collaborators** while still applying to everyone else.
> 
> **Draft auto-close** only runs when the PR is a draft **and** `author_association` is not `OWNER`, `MEMBER`, or `COLLABORATOR`, so maintainers can keep draft PRs for internal coordination. **PR target validation** uses the same association check at the job level, so maintainer release/backport PRs targeting `main` are not blocked.
> 
> A new regression test (`tests/workflow-maintainer-skip.test.cjs`) asserts both workflows still embed the shared `contains(fromJSON(...), author_association) == false` expression so the carve-out is not removed by accident.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c835e208d19df496d771522613c69dc00259176. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->