### PR TITLE
chore(#552): lint hand-written bin/lib/*.cjs and remove surfaced dead code

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -22,22 +22,6 @@ const localPlugin = {
   },
 };
 
-// Generated bin/lib files — never lint
-const GENERATED_CJS_IGNORES = [
-  'get-shit-done/bin/lib/command-aliases.cjs',
-  'get-shit-done/bin/lib/configuration.cjs',
-  'get-shit-done/bin/lib/decisions.cjs',
-  'get-shit-done/bin/lib/phase-lifecycle.cjs',
-  'get-shit-done/bin/lib/plan-scan.cjs',
-  'get-shit-done/bin/lib/project-root.cjs',
-  'get-shit-done/bin/lib/schema-detect.cjs',
-  'get-shit-done/bin/lib/secrets.cjs',
-  'get-shit-done/bin/lib/state-document.cjs',
-  'get-shit-done/bin/lib/validate.cjs',
-  'get-shit-done/bin/lib/workstream-inventory-builder.cjs',
-  'get-shit-done/bin/lib/workstream-name-policy.cjs',
-];
-
 const sdkSrcExists = existsSync(join(__dirname, 'sdk', 'src'));
 
 export default tseslint.config(
@@ -53,7 +37,6 @@ export default tseslint.config(
       '**/*.generated.cjs',
       // ADR-457: tsc-generated runtime artifact — lint the src/*.cts source, not the emitted .cjs.
       'get-shit-done/bin/lib/semver-compare.cjs',
-      ...GENERATED_CJS_IGNORES,
     ],
   },
 

--- a/get-shit-done/bin/lib/phase-lifecycle.cjs
+++ b/get-shit-done/bin/lib/phase-lifecycle.cjs
@@ -55,7 +55,6 @@ function deriveProgressFromRoadmap(roadmapContent) {
     let totalPlansSum = 0;
     const planCellPattern = /\|\s*\d+[^|]*\|\s*(\d+)\/(\d+)\s*\|/gi;
     let pm;
-    // eslint-disable-next-line no-cond-assign
     while ((pm = planCellPattern.exec(roadmapContent)) !== null) {
       totalPlansSum += parseInt(pm[2], 10);
     }

--- a/get-shit-done/bin/lib/state-document.cjs
+++ b/get-shit-done/bin/lib/state-document.cjs
@@ -238,10 +238,6 @@ function isStateTemplateDefault(field, value) {
 function stateReplaceFieldIfTemplate(content, field, knownDefaults, newValue) {
     if (newValue === null || newValue === undefined) return content;
     const existing = stateExtractField(content, field);
-    // Build a temporary KNOWN_TEMPLATE_DEFAULTS-compatible lookup so we can reuse
-    // the isStateTemplateDefault logic for the provided knownDefaults array.
-    const tempField = '__tmp__';
-    const tempDefaults = { [tempField]: knownDefaults || [] };
     // Inline check: absent/blank → always write; in list → write; else → skip.
     if (existing === null || existing === undefined || existing.trim() === '') {
         return stateReplaceField(content, field, newValue) || content;


### PR DESCRIPTION
<!-- pr-template-exempt: Internal chore (lint-config + dead-code cleanup). No fix/enhancement/feature typed template applies; see CONTRIBUTING.md chore process. -->

## Summary

`eslint.config.mjs` listed 12 **hand-written** `get-shit-done/bin/lib/*.cjs` modules in a `GENERATED_CJS_IGNORES` array (commented "Generated bin/lib files — never lint") and excluded them from ESLint. They are source, not generated output — genuinely-generated artifacts are already covered by the `**/*.generated.cjs` glob and the ADR-457 `semver-compare.cjs` entry. The array only created a lint-coverage gap across core library code.

This PR removes the array (and its spread) so all 12 modules are linted under the existing `get-shit-done/bin/**/*.cjs` ruleset, then fixes the two dormant dead-code findings that linting surfaces.

## Changes

- **`eslint.config.mjs`** — remove the `GENERATED_CJS_IGNORES` array and its `...spread` from the global `ignores`.
- **`bin/lib/phase-lifecycle.cjs`** — remove a stale `// eslint-disable-next-line no-cond-assign` directive. The `while ((pm = planCellPattern.exec(...)) !== null)` already uses the parenthesized-assignment form that `no-cond-assign` (default `except-parens`) permits, so the directive suppressed nothing.
- **`bin/lib/state-document.cjs`** — remove vestigial `tempField`/`tempDefaults` locals and their comment, left over from a refactor to an inline `.some(...)` check against `knownDefaults`; never referenced.

22 deletions, 0 additions of behavior. Pure dead-code / lint-config cleanup — no user-facing change, hence the `no-changelog` label (per CONTRIBUTING.md, lint-config and non-user-facing refactors opt out of the changeset requirement).

## Testing

- `npm run lint` → **0 errors**, 363 pre-existing warnings (test files); the two target modules are now linted and clean. Verified all 12 newly-linted modules produce 0 errors / 0 warnings.
- `npm run test:unit` → **1923 passing, 0 failing**.

Closes #552

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/554"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782848852&installation_id=134682257&pr_number=554&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F554&signature=fea1c5e1f7c8688adad1d953925471e1149c838d81f18c29d6520c59ceab64cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->