### PR TITLE
chore(#504): remove dead sdk/ references from eslint & stryker config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,8 +3,7 @@ import tseslint from 'typescript-eslint';
 import globals from 'globals';
 import pluginN from 'eslint-plugin-n';
 import noOnlyTests from 'eslint-plugin-no-only-tests';
-import { existsSync } from 'fs';
-import { join, dirname } from 'path';
+import { dirname } from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -22,15 +21,12 @@ const localPlugin = {
   },
 };
 
-const sdkSrcExists = existsSync(join(__dirname, 'sdk', 'src'));
-
 export default tseslint.config(
   // ── Global ignores ─────────────────────────────────────────────────────────
   {
     ignores: [
       'node_modules/**',
       '**/dist/**',
-      'sdk/dist/**',
       '.worktrees/**',
       '.claude/**',
       'coverage/**',

--- a/stryker.config.mjs
+++ b/stryker.config.mjs
@@ -23,7 +23,6 @@
 
 // Generated files that must NEVER be mutated
 const GENERATED_FILES = [
-  '!get-shit-done/bin/lib/configuration.cjs',   // GENERATED — sdk/src/config/index.ts
   '!get-shit-done/bin/lib/command-aliases.cjs',  // GENERATED
   '!get-shit-done/bin/lib/commands.cjs',         // GENERATED
   '!get-shit-done/bin/lib/core.cjs',             // GENERATED


### PR DESCRIPTION
<!-- pr-template-exempt: chore — removing dead config references, no user-facing behavior change, auto-detected tooling paths do not cover root .mjs config files -->

Closes #504

## What changed

**`eslint.config.mjs`**
- Removed `existsSync` and `join` from imports — only used by the dead `sdkSrcExists` guard
- Removed `const sdkSrcExists = existsSync(join(__dirname, 'sdk', 'src'))` — unreachable since ADR-0174 retired `@opengsd/gsd-sdk`
- Removed `'sdk/dist/**'` from the global ignores — dead path; already covered by the broader `'**/dist/**'` glob anyway

**`stryker.config.mjs`**
- Removed `'!get-shit-done/bin/lib/configuration.cjs' // GENERATED — sdk/src/config/index.ts` from `GENERATED_FILES` — the file is hand-authored, not generated; the exclusion has been wrong since `30c572e5` (refactor(#189): retire generated cjs artifacts from bin/lib) and the `Source: sdk/src` banner was removed from the file itself in `00082442` (#510). Stryker will now mutate `configuration.cjs`, which is the correct behavior.

## Verification

- `npm run lint` exits 0 — 0 errors, same 361 pre-existing warnings, no newly-linted or newly-ignored files
- `grep -n sdk eslint.config.mjs stryker.config.mjs` → no matches
- Codex adversarial review conducted; C-finding (configuration.cjs exclusion removal is a real behavioral change) resolved by git history confirming hand-authored status since PR #510

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/567"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782877272&installation_id=134682257&pr_number=567&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F567&signature=dd7fa0df67227c884d29fd3bd4c52ed671128b1fc6ea29454a6ce10b28bb533a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->