### PR TITLE
fix(#570): scope Codex leak scanner to manifest + replace bare ~/.claude refs

### DIFF
--- a/.changeset/sunny-lynx-rally.md
+++ b/.changeset/sunny-lynx-rally.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 570
+---
+Codex leak scanner now reads gsd-file-manifest.json to scope path checks to GSD-owned files only; bare ~/.claude (no trailing slash) is now replaced in converted Codex markdown; writeManifest now records agents/gsd-*.toml so the manifest-scoped scanner covers them

--- a/bin/install.js
+++ b/bin/install.js
@@ -2812,6 +2812,9 @@ function convertClaudeToCodexMarkdown(content) {
   converted = converted.replace(/\$HOME\/\.claude\//g, '$HOME/.codex/');
   converted = converted.replace(/~\/\.claude\//g, '~/.codex/');
   converted = converted.replace(/\.\/\.claude\//g, './.codex/');
+  // Bare ~/.claude without trailing slash (e.g. configDir = ~/.claude)
+  converted = converted.replace(/\$HOME\/\.claude\b/g, '$HOME/.codex');
+  converted = converted.replace(/~\/\.claude\b/g, '~/.codex');
   // Bare/project-relative .claude/... references (#2639). Covers strings like
   // "check `.claude/skills/`" where there is no ~/, $HOME/, or ./ anchor.
   // Negative lookbehind prevents double-replacing already-anchored forms and
@@ -7853,7 +7856,7 @@ function writeManifest(configDir, runtime = 'claude', options = {}) {
   }
   if (fs.existsSync(agentsDir)) {
     for (const file of fs.readdirSync(agentsDir)) {
-      if (file.startsWith('gsd-') && file.endsWith('.md')) {
+      if (file.startsWith('gsd-') && (file.endsWith('.md') || file.endsWith('.toml'))) {
         manifest.files['agents/' + file] = fileHash(path.join(agentsDir, file));
       }
     }
@@ -9104,42 +9107,48 @@ function install(isGlobal, runtime = 'claude', options = {}) {
   // Report any backed-up local patches
   reportLocalPatches(targetDir, runtime);
 
-  // Verify no leaked .claude paths in non-Claude runtimes
+  // Verify no leaked .claude paths in non-Claude runtimes (manifest-scoped)
   if (runtime !== 'claude') {
     const leakedPaths = [];
-    function scanForLeakedPaths(dir) {
-      if (!fs.existsSync(dir)) return;
-      let entries;
-      try {
-        entries = fs.readdirSync(dir, { withFileTypes: true });
-      } catch (err) {
-        if (err.code === 'EPERM' || err.code === 'EACCES') {
-          return; // skip inaccessible directories
+    // Only scan files that were written by this install (manifest-tracked).
+    // Scanning the entire targetDir can match user-authored content that
+    // legitimately references ~/.claude (e.g. personal notes), producing
+    // false-positive warnings. Restricting to the manifest avoids that.
+    let manifestFiles = null;
+    try {
+      const manifestPath = path.join(targetDir, MANIFEST_NAME);
+      if (fs.existsSync(manifestPath)) {
+        const manifestData = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+        if (manifestData && typeof manifestData.files === 'object') {
+          manifestFiles = Object.keys(manifestData.files);
         }
-        throw err;
       }
-      for (const entry of entries) {
-        const fullPath = path.join(dir, entry.name);
-        if (entry.isDirectory()) {
-          scanForLeakedPaths(fullPath);
-        } else if ((entry.name.endsWith('.md') || entry.name.endsWith('.toml')) && entry.name !== 'CHANGELOG.md') {
-          let content;
-          try {
-            content = fs.readFileSync(fullPath, 'utf8');
-          } catch (err) {
-            if (err.code === 'EPERM' || err.code === 'EACCES') {
-              continue; // skip inaccessible files
-            }
-            throw err;
+    } catch (_manifestParseErr) {
+      // If we cannot read/parse the manifest, skip the scan entirely to
+      // avoid false positives rather than falling back to a full directory walk.
+      manifestFiles = null;
+    }
+    if (manifestFiles !== null) {
+      for (const relPath of manifestFiles) {
+        const fileName = path.basename(relPath);
+        if (!(fileName.endsWith('.md') || fileName.endsWith('.toml'))) continue;
+        if (fileName === 'CHANGELOG.md') continue;
+        const fullPath = path.join(targetDir, relPath);
+        let content;
+        try {
+          content = fs.readFileSync(fullPath, 'utf8');
+        } catch (err) {
+          if (err.code === 'EPERM' || err.code === 'EACCES' || err.code === 'ENOENT') {
+            continue; // skip inaccessible or missing files
           }
-          const matches = content.match(/(?:~|\$HOME)\/\.claude\b/g);
-          if (matches) {
-            leakedPaths.push({ file: fullPath.replace(targetDir + '/', ''), count: matches.length });
-          }
+          throw err;
+        }
+        const matches = content.match(/(?:~|\$HOME)\/\.claude\b/g);
+        if (matches) {
+          leakedPaths.push({ file: relPath, count: matches.length });
         }
       }
     }
-    scanForLeakedPaths(targetDir);
     if (leakedPaths.length > 0) {
       const totalLeaks = leakedPaths.reduce((sum, l) => sum + l.count, 0);
       console.warn(`\n  ${yellow}⚠${reset}  Found ${totalLeaks} unreplaced .claude path reference(s) in ${leakedPaths.length} file(s):`);
@@ -9343,6 +9352,10 @@ function install(isGlobal, runtime = 'claude', options = {}) {
       }
       console.log(`  ${green}✓${reset} Generated config.toml with ${agentCount} agent roles`);
       console.log(`  ${green}✓${reset} Generated ${agentCount} agent .toml config files`);
+      // Re-write the manifest now that .toml agent files exist on disk.
+      // The initial writeManifest call (before Codex config generation) could
+      // not include agents/gsd-*.toml because those files did not yet exist.
+      writeManifest(targetDir, runtime, { mode: _effectiveInstallMode });
     } else {
       console.log(`  ${dim}↳${reset} Skipping Codex agent config generation (minimal install)`);
     }

--- a/tests/bug-570-codex-leak-scanner.test.cjs
+++ b/tests/bug-570-codex-leak-scanner.test.cjs
@@ -1,0 +1,141 @@
+// allow-test-rule: source-text-is-the-product
+'use strict';
+
+process.env.GSD_TEST_MODE = '1';
+
+/**
+ * Regression tests for issue #570 — three related sub-bugs in the Codex leak
+ * scanner and supporting infrastructure.
+ *
+ * SUB-BUG A: scanForLeakedPaths recursively scans the entire targetDir,
+ *   including pre-existing unrelated files that contain ~/.claude references.
+ *   Fix: scan only files listed in gsd-file-manifest.json.
+ *
+ * SUB-BUG B: convertClaudeToCodexMarkdown replaces "~/.claude/" (with trailing
+ *   slash) but NOT bare "~/.claude" (no slash). The scanner regex
+ *   /(?:~|\$HOME)\/\.claude\b/ matches without trailing slash.
+ *   Fix: add bare word-boundary replacement.
+ *
+ * SUB-BUG C: writeManifest checks file.endsWith('.md') for the agents/
+ *   directory. Codex installs .toml agent files, so they are invisible to the
+ *   manifest and thus to any manifest-based scan fix.
+ *   Fix: also check .toml.
+ */
+
+const { describe, test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+const {
+  install,
+  writeManifest,
+  convertClaudeCommandToCodexSkill,
+} = require('../bin/install.js');
+const { createTempDir, cleanup, captureConsole } = require('./helpers.cjs');
+
+const HOOKS_DIST = path.join(__dirname, '..', 'hooks', 'dist');
+const BUILD_HOOKS_SCRIPT = path.join(__dirname, '..', 'scripts', 'build-hooks.js');
+
+function withCodexHome(codexHome, fn) {
+  const prev = process.env.CODEX_HOME;
+  process.env.CODEX_HOME = codexHome;
+  try {
+    return fn();
+  } finally {
+    if (prev == null) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = prev;
+  }
+}
+
+describe('#570 — Codex leak scanner sub-bugs', { concurrency: false }, () => {
+  let tmpRoot;
+  let codexHome;
+
+  beforeEach(() => {
+    if (!fs.existsSync(HOOKS_DIST) || fs.readdirSync(HOOKS_DIST).length === 0) {
+      execFileSync(process.execPath, [BUILD_HOOKS_SCRIPT], { stdio: 'pipe' });
+    }
+    tmpRoot = createTempDir('gsd-570-');
+    codexHome = path.join(tmpRoot, '.codex');
+    fs.mkdirSync(codexHome, { recursive: true });
+  });
+
+  afterEach(() => {
+    cleanup(tmpRoot);
+  });
+
+  // SUB-BUG B
+  test('convertClaudeToCodexMarkdown replaces bare ~/.claude (no trailing slash)', () => {
+    // convertClaudeToCodexMarkdown is not exported directly; exercise it via
+    // convertClaudeCommandToCodexSkill which calls it internally.
+    const input = 'configDir = ~/.claude\npath = ~/.claude/hooks/\ndir = $HOME/.claude';
+    const out = convertClaudeCommandToCodexSkill(input, 'gsd-test');
+
+    assert.ok(
+      !/(?:~|\$HOME)\/\.claude\b/.test(out),
+      `Expected no leaked ~/.claude reference after conversion, got:\n${out}`,
+    );
+  });
+
+  // SUB-BUG C
+  test('writeManifest includes .toml agent files for Codex', () => {
+    withCodexHome(codexHome, () => install(true, 'codex'));
+
+    const agentsDir = path.join(codexHome, 'agents');
+    // Confirm that Codex actually wrote .toml agent files — if none exist the
+    // test is vacuous and we should fail loudly.
+    const tomlFiles = fs.existsSync(agentsDir)
+      ? fs.readdirSync(agentsDir).filter((f) => f.startsWith('gsd-') && f.endsWith('.toml'))
+      : [];
+    assert.ok(
+      tomlFiles.length > 0,
+      `Precondition: Codex install must write at least one gsd-*.toml in agents/; found none in ${agentsDir}`,
+    );
+
+    const manifestPath = path.join(codexHome, 'gsd-file-manifest.json');
+    assert.ok(
+      fs.existsSync(manifestPath),
+      `gsd-file-manifest.json must exist after install; not found at ${manifestPath}`,
+    );
+
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+    const manifestKeys = Object.keys(manifest.files || {});
+
+    const tomlManifestKeys = manifestKeys.filter(
+      (k) => k.startsWith('agents/gsd-') && k.endsWith('.toml'),
+    );
+    assert.ok(
+      tomlManifestKeys.length > 0,
+      `Expected at least one 'agents/gsd-*.toml' key in manifest.files, but found none.\n` +
+        `agents/ toml files on disk: ${tomlFiles.join(', ')}\n` +
+        `All manifest keys (agents/): ${manifestKeys.filter((k) => k.startsWith('agents/')).join(', ')}`,
+    );
+  });
+
+  // SUB-BUG A
+  test('scanForLeakedPaths does not warn for pre-existing unrelated files in ~/.codex', () => {
+    // Write a pre-existing file with ~/.claude references BEFORE install.
+    const memoriesDir = path.join(codexHome, 'memories');
+    fs.mkdirSync(memoriesDir, { recursive: true });
+    const preExistingFile = path.join(memoriesDir, 'raw_memories.md');
+    fs.writeFileSync(
+      preExistingFile,
+      '# Old memories\nI used to work in ~/.claude and $HOME/.claude regularly.\n',
+    );
+
+    let captured;
+    withCodexHome(codexHome, () => {
+      captured = captureConsole(() => install(true, 'codex'));
+    });
+
+    const combinedOutput = captured.stderr;
+
+    assert.ok(
+      !combinedOutput.includes('memories/raw_memories.md'),
+      `scanForLeakedPaths must not warn about pre-existing unrelated file memories/raw_memories.md.\n` +
+        `Actual warnings:\n${combinedOutput}`,
+    );
+  });
+});


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

> **Required.** This PR will be auto-closed if no valid issue link is found.

Fixes #570

> The linked issue must have the `confirmed-bug` label. If it doesn't, ask a maintainer to confirm the bug before continuing.

---

## What was broken

The Codex post-install leak scanner walked the entire `~/.codex` tree, which caused it to flag pre-existing user files (e.g. `memories/raw_memories.md`) that legitimately contained `~/.claude` references. Additionally, `convertClaudeToCodexMarkdown` only replaced `~/.claude/` (with trailing slash) but not bare `~/.claude` (no trailing slash), so some installed files (`gsd-debugger.toml`, `gsd-surface/SKILL.md` examples) slipped through. A third sub-bug: `writeManifest` only recorded `agents/gsd-*.md` files, so `.toml` agent files were invisible to the manifest — and thus invisible to any manifest-scoped scan fix.

## What this fix does

Three targeted fixes:

1. **Scoped scanner** — `scanForLeakedPaths` now reads `gsd-file-manifest.json` and only checks files that GSD itself wrote. Pre-existing user content is never scanned.
2. **Bare `~/.claude` replacement** — `convertClaudeToCodexMarkdown` gains word-boundary replacements for `~/.claude` and `$HOME/.claude` without a trailing slash.
3. **Manifest covers `.toml` agents** — the manifest was written before `installCodexConfig` generated the `.toml` files. A second `writeManifest` call after `installCodexConfig` ensures the manifest reflects all installed artifacts.

## Root cause

- Scanner used a recursive directory walk instead of the manifest, making it impossible to distinguish GSD-written files from user-authored content.
- The slash-only regex in `convertClaudeToCodexMarkdown` was too narrow; the scanner uses a word-boundary pattern (`~/.claude\b`) that the converter did not mirror.
- `writeManifest` was called at the end of the common install path, but Codex `.toml` agent generation happens in a later Codex-specific block — so the manifest was always snapshotted before the `.toml` files existed on disk.

## Testing

### How I verified the fix

Three regression tests added in `tests/bug-570-codex-leak-scanner.test.cjs`:

- **Sub-bug A**: installs with a pre-existing `memories/raw_memories.md` containing `~/.claude` refs; asserts the scanner emits no warning for that file.
- **Sub-bug B**: calls `convertClaudeCommandToCodexSkill` with bare `~/.claude` input; asserts the output contains no `~/.claude` reference.
- **Sub-bug C**: runs a full Codex install and asserts the manifest contains at least one `agents/gsd-*.toml` key.

All three tests pass along with the full test suite (114 tests, 0 failures).

### Regression test added?

- [x] Yes — added a test that would have caught this bug

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [x] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [x] Other: Codex
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [ ] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added (`npm run changeset -- --type Fixed --pr 570 --body "..."`)
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/574"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782912290&installation_id=134682257&pr_number=574&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F574&signature=308403197d4f780317a0d93951f6f470ee326363e5023c179b09ba902c4f3f2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->