### PR TITLE
fix(#492): manifest effort.agent_overrides and effort.default now fall back correctly

### DIFF
--- a/.changeset/plucky-yaks-forage.md
+++ b/.changeset/plucky-yaks-forage.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 577
+---
+effort.agent_overrides and effort.default in config-defaults.manifest.json now fall back correctly when no project-level effort config exists

--- a/get-shit-done/bin/lib/core.cjs
+++ b/get-shit-done/bin/lib/core.cjs
@@ -1855,6 +1855,12 @@ function resolveEffortInternal(cwd, agentType, opts) {
       const v = ao[agentType];
       if (typeof v === 'string' && EFFORT_SET.has(v)) return v;
     }
+  } else {
+    const mao = CANONICAL_CONFIG_DEFAULTS.effort && CANONICAL_CONFIG_DEFAULTS.effort.agent_overrides;
+    if (mao && typeof mao === 'object' && !Array.isArray(mao)) {
+      const v = mao[agentType];
+      if (typeof v === 'string' && EFFORT_SET.has(v)) return v;
+    }
   }
 
   // Step 3: routing_tier_defaults by agent's default tier.
@@ -1885,6 +1891,9 @@ function resolveEffortInternal(cwd, agentType, opts) {
   // Step 4: effort.default
   if (effortCfg) {
     const d = effortCfg.default;
+    if (typeof d === 'string' && EFFORT_SET.has(d)) return d;
+  } else {
+    const d = CANONICAL_CONFIG_DEFAULTS.effort && CANONICAL_CONFIG_DEFAULTS.effort.default;
     if (typeof d === 'string' && EFFORT_SET.has(d)) return d;
   }
 

--- a/tests/bug-492-effort-manifest-fallback.test.cjs
+++ b/tests/bug-492-effort-manifest-fallback.test.cjs
@@ -1,0 +1,50 @@
+'use strict';
+
+process.env.GSD_TEST_MODE = "1";
+
+const { describe, test, beforeEach, afterEach } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("path");
+const { createTempProject, cleanup } = require("./helpers.cjs");
+const { resolveEffortInternal, CONFIG_DEFAULTS } = require("../get-shit-done/bin/lib/core.cjs");
+const { CONFIG_DEFAULTS: CANONICAL_CONFIG_DEFAULTS } = require("../get-shit-done/bin/lib/configuration.cjs");
+
+describe("#492 manifest effort fallback", () => {
+  let tmpDir;
+  beforeEach(() => { tmpDir = createTempProject(); });
+  afterEach(() => { cleanup(tmpDir); });
+
+  test("routing_tier_defaults manifest fallback still works", () => {
+    assert.strictEqual(resolveEffortInternal(tmpDir, "gsd-planner"), "xhigh");
+  });
+
+  test("manifest effort.agent_overrides wins over routing_tier_defaults when no project config", () => {
+    const original = CANONICAL_CONFIG_DEFAULTS.effort.agent_overrides;
+    try {
+      CANONICAL_CONFIG_DEFAULTS.effort.agent_overrides = { "gsd-planner": "max" };
+      assert.strictEqual(resolveEffortInternal(tmpDir, "gsd-planner"), "max");
+    } finally {
+      CANONICAL_CONFIG_DEFAULTS.effort.agent_overrides = original;
+    }
+  });
+
+  test("manifest effort.default consulted for unknown agent with no project config", () => {
+    const original = CANONICAL_CONFIG_DEFAULTS.effort.default;
+    try {
+      CANONICAL_CONFIG_DEFAULTS.effort.default = "max";
+      assert.strictEqual(resolveEffortInternal(tmpDir, "fictional-agent-xyz-492"), "max");
+    } finally {
+      CANONICAL_CONFIG_DEFAULTS.effort.default = original;
+    }
+  });
+
+  test("manifest agent_overrides takes precedence over manifest routing_tier_defaults", () => {
+    const originalAgentOverrides = CANONICAL_CONFIG_DEFAULTS.effort.agent_overrides;
+    try {
+      CANONICAL_CONFIG_DEFAULTS.effort.agent_overrides = { "gsd-planner": "minimal" };
+      assert.strictEqual(resolveEffortInternal(tmpDir, "gsd-planner"), "minimal");
+    } finally {
+      CANONICAL_CONFIG_DEFAULTS.effort.agent_overrides = originalAgentOverrides;
+    }
+  });
+});


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

> **Required.** This PR will be auto-closed if no valid issue link is found.

Fixes #492

> The linked issue must have the `confirmed-bug` label. If it doesn't, ask a maintainer to confirm the bug before continuing.

---

## What was broken

`effort.agent_overrides` and `effort.default` in `config-defaults.manifest.json` were silently ignored when no project-level effort config existed. Only `routing_tier_defaults` had a manifest-fallback path in `resolveEffortInternal`; the effort fields fell through to `undefined` instead of reading from `CANONICAL_CONFIG_DEFAULTS.effort`.

## What this fix does

Adds `else` branches in Step 2 and Step 4 of `resolveEffortInternal` that consult `CANONICAL_CONFIG_DEFAULTS.effort` when `effortCfg` is null (no project config), mirroring the existing Step 3 pattern for `routing_tier_defaults`.

## Root cause

`resolveEffortInternal` had three steps that each checked `effortCfg` (the project-level effort config object). Step 3 already had a manifest-fallback `else` branch for `routing_tier_defaults`, but Steps 2 and 4 (covering `agent_overrides` and `default`) lacked equivalent branches, leaving those fields unreachable from the manifest.

## Testing

### How I verified the fix

New regression test `tests/bug-492-effort-manifest-fallback.test.cjs` — 4 tests, 3 of which reproduced the bug before the fix (agent_overrides fallback, default fallback, and combined fallback with no project config).

### Regression test added?

- [x] Yes — added a test that would have caught this bug

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [x] N/A (not platform-specific)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/577"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782912880&installation_id=134682257&pr_number=577&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F577&signature=e14c1ebfad2deee027037daa953a6e4efefdf8474569d880d8f745cfc767da0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->