### PR TITLE
fix(#260): enforce worktree absolute-path safety via PreToolUse hook

### DIFF
--- a/.changeset/plucky-cats-purr.md
+++ b/.changeset/plucky-cats-purr.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 579
+---
+Worktree executor agents no longer leak writes to the main checkout: a new PreToolUse hook (gsd-worktree-path-guard.js) hard-blocks Edit/Write/MultiEdit calls whose absolute path resolves outside the active worktree root.

--- a/bin/install.js
+++ b/bin/install.js
@@ -9931,6 +9931,33 @@ function install(isGlobal, runtime = 'claude', options = {}) {
       console.warn(`  ${yellow}⚠${reset}  Skipped workflow guard hook — gsd-workflow-guard.js not found at target`);
     }
 
+    // Configure PreToolUse hook for worktree absolute-path safety (#260)
+    // Hard-blocks Edit/Write tool calls with absolute paths that resolve
+    // outside the current worktree root. Prevents executor agents from
+    // accidentally writing to the main checkout when running in isolation="worktree".
+    const worktreePathGuardCommand = isGlobal
+      ? buildHookCommand(targetDir, 'gsd-worktree-path-guard.js', hookOpts)
+      : localCmd('gsd-worktree-path-guard.js');
+    const hasWorktreePathGuardHook = settings.hooks[preToolEvent].some(entry =>
+      entry.hooks && entry.hooks.some(h => h.command && h.command.includes('gsd-worktree-path-guard'))
+    );
+    const worktreePathGuardFile = path.join(targetDir, 'hooks', 'gsd-worktree-path-guard.js');
+    if (!hasWorktreePathGuardHook && fs.existsSync(worktreePathGuardFile) && worktreePathGuardCommand) {
+      settings.hooks[preToolEvent].push({
+        matcher: 'Write|Edit',
+        hooks: [
+          {
+            type: 'command',
+            command: worktreePathGuardCommand,
+            timeout: 5
+          }
+        ]
+      });
+      console.log(`  ${green}✓${reset} Configured worktree path guard hook`);
+    } else if (!hasWorktreePathGuardHook && !fs.existsSync(worktreePathGuardFile)) {
+      console.warn(`  ${yellow}⚠${reset}  Skipped worktree path guard hook — gsd-worktree-path-guard.js not found at target`);
+    }
+
     // Configure commit validation hook (Conventional Commits enforcement, opt-in)
     const validateCommitCommand = isGlobal
       ? buildHookCommand(targetDir, 'gsd-validate-commit.sh', hookOpts)

--- a/bin/install.js
+++ b/bin/install.js
@@ -9932,7 +9932,7 @@ function install(isGlobal, runtime = 'claude', options = {}) {
     }
 
     // Configure PreToolUse hook for worktree absolute-path safety (#260)
-    // Hard-blocks Edit/Write tool calls with absolute paths that resolve
+    // Hard-blocks Edit/Write/MultiEdit tool calls with absolute paths that resolve
     // outside the current worktree root. Prevents executor agents from
     // accidentally writing to the main checkout when running in isolation="worktree".
     const worktreePathGuardCommand = isGlobal
@@ -9944,7 +9944,7 @@ function install(isGlobal, runtime = 'claude', options = {}) {
     const worktreePathGuardFile = path.join(targetDir, 'hooks', 'gsd-worktree-path-guard.js');
     if (!hasWorktreePathGuardHook && fs.existsSync(worktreePathGuardFile) && worktreePathGuardCommand) {
       settings.hooks[preToolEvent].push({
-        matcher: 'Write|Edit',
+        matcher: 'Write|Edit|MultiEdit',
         hooks: [
           {
             type: 'command',

--- a/docs/INVENTORY-MANIFEST.json
+++ b/docs/INVENTORY-MANIFEST.json
@@ -355,7 +355,8 @@
       "gsd-statusline.js",
       "gsd-update-banner.js",
       "gsd-validate-commit.sh",
-      "gsd-workflow-guard.js"
+      "gsd-workflow-guard.js",
+      "gsd-worktree-path-guard.js"
     ]
   }
 }

--- a/docs/INVENTORY.md
+++ b/docs/INVENTORY.md
@@ -454,7 +454,7 @@ Full listing: `get-shit-done/bin/lib/*.cjs`.
 
 ---
 
-## Hooks (13 shipped)
+## Hooks (14 shipped)
 
 Full listing: `hooks/`.
 
@@ -469,6 +469,7 @@ Full listing: `hooks/`.
 | `gsd-workflow-guard.js` | `PreToolUse` | Detects file edits outside GSD workflow context (advisory, opt-in) |
 | `gsd-read-guard.js` | `PreToolUse` | Advisory guard preventing Edit/Write on unread files |
 | `gsd-read-injection-scanner.js` | `PostToolUse` | Scans tool Read results for prompt-injection patterns (v1.36+, PR #2201) |
+| `gsd-worktree-path-guard.js` | `PreToolUse` | Hard-blocks Edit/Write/MultiEdit with absolute paths outside the worktree root (PR #579, #260) |
 | `gsd-session-state.sh` | `PostToolUse` | Session-state tracking for shell-based runtimes |
 | `gsd-validate-commit.sh` | `PostToolUse` | Commit validation for conventional-commit enforcement |
 | `gsd-phase-boundary.sh` | `PostToolUse` | Phase-boundary detection for workflow transitions |

--- a/get-shit-done/bin/lib/installer-migration-report.cjs
+++ b/get-shit-done/bin/lib/installer-migration-report.cjs
@@ -122,6 +122,7 @@ const BUNDLED_GSD_HOOK_FILES = Object.freeze(new Set([
   'hooks/gsd-update-banner.js',
   'hooks/gsd-validate-commit.sh',
   'hooks/gsd-workflow-guard.js',
+  'hooks/gsd-worktree-path-guard.js',
 ]));
 
 // Classify a blocked prompt-user action into one of the safe-default

--- a/hooks/gsd-worktree-path-guard.js
+++ b/hooks/gsd-worktree-path-guard.js
@@ -24,6 +24,19 @@ function git(args, cwd) {
   return spawnSync('git', args, { ...SPAWNOPT, cwd });
 }
 
+// Walk up from `start` to find the nearest existing directory.
+// Returns null if we reach the filesystem root without finding one.
+function nearestExistingDir(start) {
+  let dir = start;
+  let prev;
+  do {
+    prev = dir;
+    try { fs.accessSync(dir, fs.constants.F_OK); return dir; } catch { /* keep walking */ }
+    dir = path.dirname(dir);
+  } while (dir !== prev);
+  return null;
+}
+
 let input = '';
 const stdinTimeout = setTimeout(() => process.exit(0), 3000);
 process.stdin.setEncoding('utf8');
@@ -43,8 +56,8 @@ process.stdin.on('end', () => {
 
     // Detect whether CWD is inside a linked git worktree by inspecting
     // the git-dir path. In a linked worktree, git rev-parse --git-dir
-    // returns a path ending with .git/worktrees/<id>. In the main repo
-    // or a submodule it returns .git (or a path without /worktrees/).
+    // returns a path containing .git/worktrees/ as a component.
+    // In the main repo or a submodule it returns .git (or a path without /worktrees/).
     // This approach works even when cwd is a subdirectory of the worktree.
     const gitDirResult = git(['rev-parse', '--git-dir'], cwd);
     if (gitDirResult.status !== 0 || !gitDirResult.stdout) {
@@ -58,50 +71,92 @@ process.stdin.on('end', () => {
       process.exit(0); // main repo, submodule, or separate-git-dir — no-op
     }
 
-    // Get the worktree root (canonical, resolves symlinks on the worktree side)
-    const toplevelResult = git(['rev-parse', '--show-toplevel'], cwd);
-    if (toplevelResult.status !== 0 || !toplevelResult.stdout) {
+    // Get the raw --show-toplevel output for the worktree (cwd).
+    // We keep it raw (not path.resolve'd) to compare directly with the
+    // file's toplevel — same git binary, same format, no normalization needed.
+    const wtTopResult = git(['rev-parse', '--show-toplevel'], cwd);
+    if (wtTopResult.status !== 0 || !wtTopResult.stdout) {
       process.exit(0); // can't determine root — fail open
     }
-
-    // path.resolve() normalises git's forward-slash output (C:/repo) to the
-    // platform separator (C:\repo on Windows) and collapses any .. segments.
-    // We intentionally do NOT call realpathSync here: on Windows, realpathSync
-    // returns the filesystem's canonical case (e.g. C:\Users\Runner) which may
-    // differ from the case used in the file_path argument, causing false blocks.
-    const wtRoot = path.resolve(toplevelResult.stdout.trim());
+    const wtTopRaw = wtTopResult.stdout.trim();
 
     const rawFilePath = data.tool_input?.file_path || '';
     if (!rawFilePath) {
       process.exit(0);
     }
 
-    // Relative paths are always safe — they resolve relative to CWD which is inside the worktree
+    // Relative paths are always safe — they resolve relative to CWD inside the worktree
     if (!path.isAbsolute(rawFilePath)) {
       process.exit(0);
     }
 
-    // Normalise the target path to collapse any `..` traversal sequences.
-    // We do NOT call realpathSync here because the file may not exist yet
-    // (Write creates new files). path.resolve with the raw value is sufficient
-    // to eliminate traversal while leaving non-existent paths representable.
+    // Normalise .. traversal so /worktree/src/../../../main/file
+    // resolves to its true location before we check containment.
     const filePath = path.resolve(rawFilePath);
 
-    // Containment check: filePath must equal wtRoot or be a strict descendant.
-    // Using path.sep instead of '/' ensures correctness on Windows.
-    if (filePath === wtRoot || filePath.startsWith(wtRoot + path.sep)) {
+    // Find the nearest existing ancestor of filePath so we can ask git
+    // for its toplevel. The file itself may not exist yet (Write creates
+    // new files), but at least one ancestor directory must exist.
+    // We check the file itself first in case it already exists.
+    const checkDir = nearestExistingDir(
+      (() => {
+        try {
+          return fs.statSync(filePath).isDirectory() ? filePath : path.dirname(filePath);
+        } catch {
+          return path.dirname(filePath);
+        }
+      })()
+    );
+
+    if (!checkDir) {
+      // Walked to root without finding any directory — path is synthetic.
+      // Block conservatively.
+      const output = {
+        decision: 'block',
+        reason:
+          `Worktree path guard: '${filePath}' has no existing ancestor directory — ` +
+          `cannot verify it is inside the worktree '${wtTopRaw}'. Use a relative path instead.`,
+      };
+      process.stdout.write(JSON.stringify(output));
+      process.exit(2);
+    }
+
+    // Ask git for the toplevel of the file's location.
+    // Comparing two raw git --show-toplevel outputs avoids every
+    // platform-specific path normalisation pitfall (Windows 8.3 short names,
+    // case differences between realpathSync and path.resolve, forward- vs
+    // back-slash inconsistencies) — both values come from the same git binary
+    // in the same format by definition.
+    const fileTopResult = git(['rev-parse', '--show-toplevel'], checkDir);
+
+    if (fileTopResult.status !== 0 || !fileTopResult.stdout) {
+      // checkDir is not inside any git repo → cannot be inside the worktree.
+      const output = {
+        decision: 'block',
+        reason:
+          `Worktree path guard: '${filePath}' is not inside any git repository — ` +
+          `it cannot be inside the worktree at '${wtTopRaw}'. Use a relative path instead.`,
+      };
+      process.stdout.write(JSON.stringify(output));
+      process.exit(2);
+    }
+
+    const fileTopRaw = fileTopResult.stdout.trim();
+
+    // Same git toplevel → file is inside the worktree → allow
+    if (fileTopRaw === wtTopRaw) {
       process.exit(0);
     }
 
-    // BLOCK: absolute path is outside the worktree root
+    // BLOCK: file resolves to a different git root than the active worktree
     const output = {
       decision: 'block',
       reason:
-        `Worktree path guard: attempted to write to '${filePath}' which is outside the ` +
-        `worktree root '${wtRoot}'. This likely means an absolute path was derived from the ` +
-        `orchestrator's main repository instead of the active worktree. ` +
-        `To fix: use a relative path, or re-derive the base directory with ` +
-        '`git rev-parse --show-toplevel` from within the worktree ' +
+        `Worktree path guard: '${filePath}' resolves to git root '${fileTopRaw}' which ` +
+        `differs from the active worktree root '${wtTopRaw}'. This likely means an ` +
+        `absolute path was derived from the orchestrator's main repository instead of ` +
+        `the active worktree. To fix: use a relative path, or re-derive the base ` +
+        `directory with \`git rev-parse --show-toplevel\` from within the worktree ` +
         `(hook cwd: '${cwd}').`,
     };
 

--- a/hooks/gsd-worktree-path-guard.js
+++ b/hooks/gsd-worktree-path-guard.js
@@ -64,8 +64,9 @@ process.stdin.on('end', () => {
       process.exit(0); // can't determine root — fail open
     }
 
-    let wtRoot = toplevelResult.stdout.trim();
-    // Resolve symlinks on the worktree root so the anchor is canonical
+    // path.resolve() normalises git's forward-slash output (C:/repo) to the
+    // platform separator (C:\repo on Windows) before realpathSync runs.
+    let wtRoot = path.resolve(toplevelResult.stdout.trim());
     try { wtRoot = fs.realpathSync(wtRoot); } catch { /* fail open */ }
 
     const rawFilePath = data.tool_input?.file_path || '';

--- a/hooks/gsd-worktree-path-guard.js
+++ b/hooks/gsd-worktree-path-guard.js
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+// gsd-hook-version: {{GSD_VERSION}}
+// GSD Worktree Path Guard — PreToolUse hook
+// Blocks Edit/Write tool calls that target absolute paths outside the worktree root.
+//
+// Problem: gsd-executor agents spawned with isolation="worktree" sometimes issue
+// Edit/Write calls with absolute paths rooted at the MAIN repository instead of
+// the worktree (issue #260). The prose guard in agents/gsd-executor.md step 0b
+// is never enforced because the model under load skips it.
+//
+// This hook enforces the constraint at the tooling layer, making it HARD-BLOCKING.
+//
+// Triggers on: Edit and Write tool calls
+// Action: BLOCK (exit 2) if file_path is absolute and outside the worktree root
+// No-op: relative paths, non-worktree CWDs, hook errors (silent fail)
+
+const fs = require('fs');
+const { spawnSync } = require('child_process');
+
+let input = '';
+const stdinTimeout = setTimeout(() => process.exit(0), 3000);
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', chunk => input += chunk);
+process.stdin.on('end', () => {
+  clearTimeout(stdinTimeout);
+  try {
+    const data = JSON.parse(input);
+    const toolName = data.tool_name;
+
+    // Only guard Edit and Write tool calls
+    if (toolName !== 'Edit' && toolName !== 'Write') {
+      process.exit(0);
+    }
+
+    const cwd = data.cwd || process.cwd();
+
+    // Detect if CWD is inside a git worktree by checking if .git is a FILE (not a directory).
+    // In the main repo, .git is a directory. In a worktree, .git is a file containing a gitdir pointer.
+    const gitPath = require('path').join(cwd, '.git');
+    let gitStat;
+    try {
+      gitStat = fs.statSync(gitPath);
+    } catch {
+      // No .git at all — not a git repo or .git is elsewhere; exit silently
+      process.exit(0);
+    }
+
+    if (!gitStat.isFile()) {
+      // .git is a directory → this is the main repo, not a worktree. No-op.
+      process.exit(0);
+    }
+
+    // Get the worktree root via git
+    const gitResult = spawnSync('git', ['rev-parse', '--show-toplevel'], {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+
+    if (gitResult.status !== 0 || !gitResult.stdout) {
+      // Can't determine worktree root — fail open
+      process.exit(0);
+    }
+
+    const wtRoot = gitResult.stdout.trim();
+
+    const filePath = data.tool_input?.file_path || '';
+
+    // Relative paths are always safe — they resolve relative to CWD which is inside the worktree
+    if (!filePath.startsWith('/')) {
+      process.exit(0);
+    }
+
+    // Check containment: file_path must equal wtRoot or be a descendant of it
+    if (filePath === wtRoot || filePath.startsWith(wtRoot + '/')) {
+      process.exit(0);
+    }
+
+    // BLOCK: absolute path is outside the worktree root
+    const output = {
+      decision: 'block',
+      reason:
+        `Path guard violation: attempted to write to '${filePath}' which is outside the ` +
+        `worktree root '${wtRoot}'. This likely means an absolute path was derived from the ` +
+        `main repository instead of the active worktree. To fix: use a relative path, or ` +
+        `re-derive the base directory with \`git rev-parse --show-toplevel\` from within the ` +
+        `worktree (cwd: '${cwd}').`,
+    };
+
+    process.stdout.write(JSON.stringify(output));
+    process.exit(2);
+  } catch {
+    // Silent fail — never block valid tool calls due to hook errors
+    process.exit(0);
+  }
+});

--- a/hooks/gsd-worktree-path-guard.js
+++ b/hooks/gsd-worktree-path-guard.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // gsd-hook-version: {{GSD_VERSION}}
 // GSD Worktree Path Guard — PreToolUse hook
-// Blocks Edit/Write tool calls that target absolute paths outside the worktree root.
+// Blocks Edit/Write/MultiEdit tool calls that target absolute paths outside the worktree root.
 //
 // Problem: gsd-executor agents spawned with isolation="worktree" sometimes issue
 // Edit/Write calls with absolute paths rooted at the MAIN repository instead of
@@ -10,12 +10,19 @@
 //
 // This hook enforces the constraint at the tooling layer, making it HARD-BLOCKING.
 //
-// Triggers on: Edit and Write tool calls
+// Triggers on: Edit, Write, and MultiEdit tool calls
 // Action: BLOCK (exit 2) if file_path is absolute and outside the worktree root
 // No-op: relative paths, non-worktree CWDs, hook errors (silent fail)
 
 const fs = require('fs');
+const path = require('path');
 const { spawnSync } = require('child_process');
+
+const SPAWNOPT = { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 2000 };
+
+function git(args, cwd) {
+  return spawnSync('git', args, { ...SPAWNOPT, cwd });
+}
 
 let input = '';
 const stdinTimeout = setTimeout(() => process.exit(0), 3000);
@@ -27,52 +34,59 @@ process.stdin.on('end', () => {
     const data = JSON.parse(input);
     const toolName = data.tool_name;
 
-    // Only guard Edit and Write tool calls
-    if (toolName !== 'Edit' && toolName !== 'Write') {
+    // Only guard Edit, Write, and MultiEdit tool calls
+    if (toolName !== 'Edit' && toolName !== 'Write' && toolName !== 'MultiEdit') {
       process.exit(0);
     }
 
     const cwd = data.cwd || process.cwd();
 
-    // Detect if CWD is inside a git worktree by checking if .git is a FILE (not a directory).
-    // In the main repo, .git is a directory. In a worktree, .git is a file containing a gitdir pointer.
-    const gitPath = require('path').join(cwd, '.git');
-    let gitStat;
-    try {
-      gitStat = fs.statSync(gitPath);
-    } catch {
-      // No .git at all — not a git repo or .git is elsewhere; exit silently
-      process.exit(0);
+    // Detect whether CWD is inside a linked git worktree by inspecting
+    // the git-dir path. In a linked worktree, git rev-parse --git-dir
+    // returns a path ending with .git/worktrees/<id>. In the main repo
+    // or a submodule it returns .git (or a path without /worktrees/).
+    // This approach works even when cwd is a subdirectory of the worktree.
+    const gitDirResult = git(['rev-parse', '--git-dir'], cwd);
+    if (gitDirResult.status !== 0 || !gitDirResult.stdout) {
+      process.exit(0); // not a git repo — pass through
     }
 
-    if (!gitStat.isFile()) {
-      // .git is a directory → this is the main repo, not a worktree. No-op.
-      process.exit(0);
+    const gitDir = gitDirResult.stdout.trim();
+    // A linked worktree's --git-dir contains .git/worktrees/ as a path component
+    const isLinkedWorktree = /[/\\]\.git[/\\]worktrees[/\\]/.test(gitDir);
+    if (!isLinkedWorktree) {
+      process.exit(0); // main repo, submodule, or separate-git-dir — no-op
     }
 
-    // Get the worktree root via git
-    const gitResult = spawnSync('git', ['rev-parse', '--show-toplevel'], {
-      cwd,
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'ignore'],
-    });
-
-    if (gitResult.status !== 0 || !gitResult.stdout) {
-      // Can't determine worktree root — fail open
-      process.exit(0);
+    // Get the worktree root (canonical, resolves symlinks on the worktree side)
+    const toplevelResult = git(['rev-parse', '--show-toplevel'], cwd);
+    if (toplevelResult.status !== 0 || !toplevelResult.stdout) {
+      process.exit(0); // can't determine root — fail open
     }
 
-    const wtRoot = gitResult.stdout.trim();
+    let wtRoot = toplevelResult.stdout.trim();
+    // Resolve symlinks on the worktree root so the anchor is canonical
+    try { wtRoot = fs.realpathSync(wtRoot); } catch { /* fail open */ }
 
-    const filePath = data.tool_input?.file_path || '';
+    const rawFilePath = data.tool_input?.file_path || '';
+    if (!rawFilePath) {
+      process.exit(0);
+    }
 
     // Relative paths are always safe — they resolve relative to CWD which is inside the worktree
-    if (!filePath.startsWith('/')) {
+    if (!path.isAbsolute(rawFilePath)) {
       process.exit(0);
     }
 
-    // Check containment: file_path must equal wtRoot or be a descendant of it
-    if (filePath === wtRoot || filePath.startsWith(wtRoot + '/')) {
+    // Normalise the target path to collapse any `..` traversal sequences.
+    // We do NOT call realpathSync here because the file may not exist yet
+    // (Write creates new files). path.resolve with the raw value is sufficient
+    // to eliminate traversal while leaving non-existent paths representable.
+    const filePath = path.resolve(rawFilePath);
+
+    // Containment check: filePath must equal wtRoot or be a strict descendant.
+    // Using path.sep instead of '/' ensures correctness on Windows.
+    if (filePath === wtRoot || filePath.startsWith(wtRoot + path.sep)) {
       process.exit(0);
     }
 
@@ -80,11 +94,12 @@ process.stdin.on('end', () => {
     const output = {
       decision: 'block',
       reason:
-        `Path guard violation: attempted to write to '${filePath}' which is outside the ` +
+        `Worktree path guard: attempted to write to '${filePath}' which is outside the ` +
         `worktree root '${wtRoot}'. This likely means an absolute path was derived from the ` +
-        `main repository instead of the active worktree. To fix: use a relative path, or ` +
-        `re-derive the base directory with \`git rev-parse --show-toplevel\` from within the ` +
-        `worktree (cwd: '${cwd}').`,
+        `orchestrator's main repository instead of the active worktree. ` +
+        `To fix: use a relative path, or re-derive the base directory with ` +
+        '`git rev-parse --show-toplevel` from within the worktree ' +
+        `(hook cwd: '${cwd}').`,
     };
 
     process.stdout.write(JSON.stringify(output));

--- a/hooks/gsd-worktree-path-guard.js
+++ b/hooks/gsd-worktree-path-guard.js
@@ -65,9 +65,11 @@ process.stdin.on('end', () => {
     }
 
     // path.resolve() normalises git's forward-slash output (C:/repo) to the
-    // platform separator (C:\repo on Windows) before realpathSync runs.
-    let wtRoot = path.resolve(toplevelResult.stdout.trim());
-    try { wtRoot = fs.realpathSync(wtRoot); } catch { /* fail open */ }
+    // platform separator (C:\repo on Windows) and collapses any .. segments.
+    // We intentionally do NOT call realpathSync here: on Windows, realpathSync
+    // returns the filesystem's canonical case (e.g. C:\Users\Runner) which may
+    // differ from the case used in the file_path argument, causing false blocks.
+    const wtRoot = path.resolve(toplevelResult.stdout.trim());
 
     const rawFilePath = data.tool_input?.file_path || '';
     if (!rawFilePath) {

--- a/hooks/managed-hooks-registry.cjs
+++ b/hooks/managed-hooks-registry.cjs
@@ -29,6 +29,7 @@ const MANAGED_HOOKS = [
   'gsd-update-banner.js',
   'gsd-validate-commit.sh',
   'gsd-workflow-guard.js',
+  'gsd-worktree-path-guard.js',
 ];
 
 module.exports = { MANAGED_HOOKS };

--- a/scripts/build-hooks.js
+++ b/scripts/build-hooks.js
@@ -33,6 +33,7 @@ const HOOKS_TO_COPY = [
   'gsd-statusline.js',
   'gsd-update-banner.js',
   'gsd-workflow-guard.js',
+  'gsd-worktree-path-guard.js',
   // Community hooks (bash, opt-in via .planning/config.json hooks.community)
   'gsd-session-state.sh',
   'gsd-validate-commit.sh',

--- a/tests/bug-1754-js-hook-guard.test.cjs
+++ b/tests/bug-1754-js-hook-guard.test.cjs
@@ -27,6 +27,7 @@ const JS_HOOKS = [
   { name: 'gsd-prompt-guard.js',      registrationAnchor: 'hasPromptGuardHook' },
   { name: 'gsd-read-guard.js',        registrationAnchor: 'hasReadGuardHook' },
   { name: 'gsd-workflow-guard.js',    registrationAnchor: 'hasWorkflowGuardHook' },
+  { name: 'gsd-worktree-path-guard.js', registrationAnchor: 'hasWorktreePathGuardHook' },
 ];
 
 describe('bug #1754: .js hook registration guards', () => {

--- a/tests/bug-260-worktree-path-guard.test.cjs
+++ b/tests/bug-260-worktree-path-guard.test.cjs
@@ -1,0 +1,330 @@
+/**
+ * Regression tests for bug #260 — gsd-worktree-path-guard.js
+ *
+ * Executor agents spawned with isolation="worktree" sometimes issue Edit/Write
+ * calls with absolute paths rooted at the MAIN repository instead of the
+ * worktree. The prose guard in gsd-executor.md step 0b is skipped under load,
+ * so we enforce the constraint at the tooling layer with a PreToolUse hook.
+ *
+ * This file verifies all guard behaviours:
+ *   1. No-op in the main repo (.git is a directory)
+ *   2. Relative path always passes
+ *   3. Non-Edit/Write tools always pass
+ *   4. Absolute path inside worktree root passes
+ *   5. Absolute path outside worktree root is BLOCKED (exit 2)
+ *   6. Sibling path that merely shares a prefix is BLOCKED (/ boundary check)
+ *   7. install.js has an fs.existsSync guard for gsd-worktree-path-guard.js
+ */
+
+'use strict';
+
+const { describe, test, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync, execFileSync } = require('node:child_process');
+
+const HOOK_PATH = path.join(__dirname, '..', 'hooks', 'gsd-worktree-path-guard.js');
+const INSTALL_SRC = path.join(__dirname, '..', 'bin', 'install.js');
+
+/**
+ * Resolve symlinks in a path so that we compare the same canonical form
+ * that `git rev-parse --show-toplevel` returns. On macOS /tmp is a symlink
+ * to /private/tmp, which causes path prefix checks to fail without this.
+ */
+function realp(p) {
+  try { return fs.realpathSync(p); } catch { return p; }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function git(cwd, args) {
+  return execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+}
+
+/**
+ * Create a plain git repo (main repo — .git is a directory).
+ */
+function makeMainRepo() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-260-main-'));
+  git(dir, ['init', '-q']);
+  git(dir, ['config', 'user.email', 'test@example.com']);
+  git(dir, ['config', 'user.name', 'Test User']);
+  git(dir, ['config', 'commit.gpgsign', 'false']);
+  fs.writeFileSync(path.join(dir, 'README.md'), '# test\n');
+  git(dir, ['add', 'README.md']);
+  git(dir, ['commit', '-q', '-m', 'chore: init']);
+  return dir;
+}
+
+/**
+ * Create a worktree off mainRepo and return its path.
+ * In the worktree, .git is a FILE (the gitdir pointer).
+ */
+function makeWorktree(mainRepo) {
+  const wtDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-260-wt-'));
+  fs.rmdirSync(wtDir); // git worktree add creates the dir itself
+  git(mainRepo, ['worktree', 'add', '-q', '-b', 'wt-test-branch', wtDir]);
+  return wtDir;
+}
+
+/**
+ * Run the hook with a given payload, returning the spawnSync result.
+ */
+function runHook(cwd, payload) {
+  return spawnSync(process.execPath, [HOOK_PATH], {
+    cwd,
+    input: JSON.stringify(payload),
+    encoding: 'utf8',
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Fixture lifecycle
+// ---------------------------------------------------------------------------
+
+let mainRepo;
+let worktreeDir;
+
+before(() => {
+  mainRepo = realp(makeMainRepo());
+  worktreeDir = realp(makeWorktree(mainRepo));
+});
+
+after(() => {
+  // Remove worktree registration before deleting the directory
+  try { git(mainRepo, ['worktree', 'remove', '--force', worktreeDir]); } catch { /* ignore */ }
+  try { fs.rmSync(mainRepo, { recursive: true, force: true }); } catch { /* ignore */ }
+  try { fs.rmSync(worktreeDir, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('bug #260: gsd-worktree-path-guard.js', () => {
+
+  // 1. No-op in main repo
+  describe('no-op in main repo', () => {
+    test('Edit call in main repo (.git is a directory) exits 0', () => {
+      const payload = {
+        cwd: mainRepo,
+        tool_name: 'Edit',
+        tool_input: { file_path: path.join(mainRepo, 'src', 'foo.ts') },
+      };
+      const result = runHook(mainRepo, payload);
+      assert.strictEqual(result.status, 0, `Expected exit 0 in main repo, got ${result.status}. stderr: ${result.stderr}`);
+      assert.strictEqual(result.stdout, '', 'Expected no stdout in main repo no-op');
+    });
+
+    test('Write call in main repo exits 0', () => {
+      const payload = {
+        cwd: mainRepo,
+        tool_name: 'Write',
+        tool_input: { file_path: path.join(mainRepo, 'out.txt') },
+      };
+      const result = runHook(mainRepo, payload);
+      assert.strictEqual(result.status, 0);
+      assert.strictEqual(result.stdout, '');
+    });
+  });
+
+  // 2. Relative path always passes
+  describe('relative path', () => {
+    test('Edit with relative file_path exits 0 even in worktree', () => {
+      const payload = {
+        cwd: worktreeDir,
+        tool_name: 'Edit',
+        tool_input: { file_path: 'src/foo.ts' },
+      };
+      const result = runHook(worktreeDir, payload);
+      assert.strictEqual(result.status, 0, `Relative path should always pass. stderr: ${result.stderr}`);
+      assert.strictEqual(result.stdout, '');
+    });
+
+    test('Write with relative file_path exits 0 in worktree', () => {
+      const payload = {
+        cwd: worktreeDir,
+        tool_name: 'Write',
+        tool_input: { file_path: 'dist/bundle.js' },
+      };
+      const result = runHook(worktreeDir, payload);
+      assert.strictEqual(result.status, 0);
+      assert.strictEqual(result.stdout, '');
+    });
+  });
+
+  // 3. Non-Edit/Write tools always pass
+  describe('non-Edit/Write tools', () => {
+    test('Bash tool exits 0', () => {
+      const payload = {
+        cwd: worktreeDir,
+        tool_name: 'Bash',
+        tool_input: { command: 'ls' },
+      };
+      const result = runHook(worktreeDir, payload);
+      assert.strictEqual(result.status, 0);
+    });
+
+    test('Read tool exits 0', () => {
+      const payload = {
+        cwd: worktreeDir,
+        tool_name: 'Read',
+        tool_input: { file_path: path.join(mainRepo, 'README.md') },
+      };
+      const result = runHook(worktreeDir, payload);
+      assert.strictEqual(result.status, 0);
+    });
+
+    test('Grep tool exits 0', () => {
+      const payload = {
+        cwd: worktreeDir,
+        tool_name: 'Grep',
+        tool_input: { pattern: 'foo', path: mainRepo },
+      };
+      const result = runHook(worktreeDir, payload);
+      assert.strictEqual(result.status, 0);
+    });
+  });
+
+  // 4. Absolute path inside worktree passes
+  describe('path inside worktree', () => {
+    test('Edit with absolute path inside worktree root exits 0', () => {
+      const payload = {
+        cwd: worktreeDir,
+        tool_name: 'Edit',
+        tool_input: { file_path: path.join(worktreeDir, 'src', 'foo.ts') },
+      };
+      const result = runHook(worktreeDir, payload);
+      assert.strictEqual(result.status, 0, `Path inside worktree should pass. stderr: ${result.stderr}`);
+      assert.strictEqual(result.stdout, '');
+    });
+
+    test('Edit targeting exactly the worktree root exits 0', () => {
+      const payload = {
+        cwd: worktreeDir,
+        tool_name: 'Edit',
+        tool_input: { file_path: worktreeDir },
+      };
+      const result = runHook(worktreeDir, payload);
+      assert.strictEqual(result.status, 0);
+    });
+  });
+
+  // 5. Absolute path outside worktree is BLOCKED
+  describe('path outside worktree is blocked', () => {
+    test('Edit targeting main repo root exits 2 with block decision', () => {
+      const payload = {
+        cwd: worktreeDir,
+        tool_name: 'Edit',
+        tool_input: { file_path: path.join(mainRepo, 'src', 'index.ts') },
+      };
+      const result = runHook(worktreeDir, payload);
+      assert.strictEqual(result.status, 2, `Expected exit 2 (block), got ${result.status}. stderr: ${result.stderr}`);
+      let parsed;
+      assert.doesNotThrow(() => { parsed = JSON.parse(result.stdout); }, 'stdout must be valid JSON');
+      assert.strictEqual(parsed.decision, 'block', 'Expected decision:"block" in output');
+    });
+
+    test('Write targeting main repo root exits 2 with block decision', () => {
+      const payload = {
+        cwd: worktreeDir,
+        tool_name: 'Write',
+        tool_input: { file_path: path.join(mainRepo, 'out.txt') },
+      };
+      const result = runHook(worktreeDir, payload);
+      assert.strictEqual(result.status, 2);
+      const parsed = JSON.parse(result.stdout);
+      assert.strictEqual(parsed.decision, 'block');
+    });
+
+    test('block output includes the offending path in reason', () => {
+      const offendingPath = path.join(mainRepo, 'src', 'leak.ts');
+      const payload = {
+        cwd: worktreeDir,
+        tool_name: 'Edit',
+        tool_input: { file_path: offendingPath },
+      };
+      const result = runHook(worktreeDir, payload);
+      assert.strictEqual(result.status, 2);
+      const parsed = JSON.parse(result.stdout);
+      assert.ok(
+        parsed.reason && parsed.reason.includes(offendingPath),
+        `block reason should include the offending path. Got: ${parsed.reason}`
+      );
+    });
+  });
+
+  // 6. Sibling directory path is BLOCKED (validates the '/' boundary check)
+  describe('sibling path is blocked', () => {
+    test('path that shares prefix with worktree root but is a sibling exits 2', () => {
+      // e.g. worktreeDir = /tmp/gsd-260-wt-XXXXX
+      // sibling       = /tmp/gsd-260-wt-XXXXXsibling/file.ts
+      // This would pass a naive startsWith(wtRoot) check without the '/' suffix.
+      const siblingPath = worktreeDir + '-sibling/file.ts';
+      const payload = {
+        cwd: worktreeDir,
+        tool_name: 'Edit',
+        tool_input: { file_path: siblingPath },
+      };
+      const result = runHook(worktreeDir, payload);
+      assert.strictEqual(result.status, 2,
+        `Sibling path "${siblingPath}" must be blocked (exit 2), got ${result.status}. ` +
+        `This validates the '/' boundary check in startsWith(wtRoot + '/'). stderr: ${result.stderr}`
+      );
+      const parsed = JSON.parse(result.stdout);
+      assert.strictEqual(parsed.decision, 'block');
+    });
+  });
+
+});
+
+// ---------------------------------------------------------------------------
+// Static analysis: install.js guard
+// ---------------------------------------------------------------------------
+
+describe('install.js guard for gsd-worktree-path-guard.js', () => {
+  let src;
+
+  before(() => {
+    src = fs.readFileSync(INSTALL_SRC, 'utf-8');
+  });
+
+  test('install.js has hasWorktreePathGuardHook variable', () => {
+    assert.ok(
+      src.includes('hasWorktreePathGuardHook'),
+      'hasWorktreePathGuardHook variable not found in install.js'
+    );
+  });
+
+  test('install.js checks fs.existsSync before registering gsd-worktree-path-guard.js', () => {
+    const anchorIdx = src.indexOf('hasWorktreePathGuardHook');
+    assert.ok(anchorIdx !== -1, 'hasWorktreePathGuardHook not found in install.js');
+
+    const blockStart = anchorIdx;
+    const blockEnd = Math.min(src.length, anchorIdx + 1200);
+    const block = src.slice(blockStart, blockEnd);
+
+    assert.ok(
+      block.includes('fs.existsSync') || block.includes('existsSync'),
+      'install.js must call fs.existsSync on the target path before registering ' +
+      'gsd-worktree-path-guard.js in settings.json. Without this guard, the hook ' +
+      'is registered even when the .js file was never copied (root cause of #1754).'
+    );
+  });
+
+  test('install.js emits a skip warning when gsd-worktree-path-guard.js is missing', () => {
+    const anchorIdx = src.indexOf('hasWorktreePathGuardHook');
+    assert.ok(anchorIdx !== -1, 'hasWorktreePathGuardHook not found in install.js');
+
+    const block = src.slice(anchorIdx, Math.min(src.length, anchorIdx + 1200));
+
+    assert.ok(
+      block.includes('Skipped') && block.includes('gsd-worktree-path-guard'),
+      'install.js must emit a skip warning mentioning gsd-worktree-path-guard when the file is not found'
+    );
+  });
+});

--- a/tests/bug-260-worktree-path-guard.test.cjs
+++ b/tests/bug-260-worktree-path-guard.test.cjs
@@ -280,6 +280,99 @@ describe('bug #260: gsd-worktree-path-guard.js', () => {
     });
   });
 
+  // 7. Adversarial: subdirectory cwd still guards correctly (Codex finding #2)
+  describe('subdirectory cwd', () => {
+    test('hook fires when cwd is a subdirectory of the worktree, not just its root', () => {
+      // The orchestrator may set cwd to a subdirectory. The hook must still
+      // detect the worktree context via git rev-parse --git-dir and block.
+      const subDir = path.join(worktreeDir, 'src');
+      fs.mkdirSync(subDir, { recursive: true });
+      const payload = {
+        cwd: subDir,
+        tool_name: 'Edit',
+        tool_input: { file_path: path.join(mainRepo, 'src', 'index.ts') },
+      };
+      const result = runHook(subDir, payload);
+      assert.strictEqual(result.status, 2,
+        `Hook must block even when cwd is a subdirectory of the worktree. ` +
+        `Got exit ${result.status}. stderr: ${result.stderr}`
+      );
+      const parsed = JSON.parse(result.stdout);
+      assert.strictEqual(parsed.decision, 'block');
+    });
+
+    test('path inside worktree passes even when cwd is a subdirectory', () => {
+      const subDir = path.join(worktreeDir, 'src');
+      fs.mkdirSync(subDir, { recursive: true });
+      const payload = {
+        cwd: subDir,
+        tool_name: 'Edit',
+        tool_input: { file_path: path.join(worktreeDir, 'src', 'foo.ts') },
+      };
+      const result = runHook(subDir, payload);
+      assert.strictEqual(result.status, 0,
+        `Absolute path inside worktree should pass regardless of cwd. ` +
+        `Got exit ${result.status}. stderr: ${result.stderr}`
+      );
+    });
+  });
+
+  // 8. Adversarial: `..` traversal is normalised before the containment check (Codex finding #1)
+  describe('dot-dot traversal is blocked', () => {
+    test('path with .. that escapes the worktree is blocked', () => {
+      // /worktree/src/../../../main-repo/file.ts resolves outside the worktree
+      const traversalPath = path.join(worktreeDir, 'src', '..', '..', '..', mainRepo.replace(/^\//, ''), 'file.ts');
+      const payload = {
+        cwd: worktreeDir,
+        tool_name: 'Edit',
+        tool_input: { file_path: traversalPath },
+      };
+      const result = runHook(worktreeDir, payload);
+      // After path.resolve, the path should equal something outside the worktree
+      const resolved = path.resolve(traversalPath);
+      if (resolved.startsWith(worktreeDir + path.sep) || resolved === worktreeDir) {
+        // The traversal happened to stay inside — skip this assertion
+        assert.ok(true, 'traversal resolved inside worktree (environment-dependent)');
+      } else {
+        assert.strictEqual(result.status, 2,
+          `Traversal path "${traversalPath}" resolves to "${resolved}" which is outside the worktree. ` +
+          `Must be blocked. Got exit ${result.status}. stderr: ${result.stderr}`
+        );
+        const parsed = JSON.parse(result.stdout);
+        assert.strictEqual(parsed.decision, 'block');
+      }
+    });
+  });
+
+  // 9. MultiEdit is also guarded (Codex finding #5)
+  describe('MultiEdit tool is guarded', () => {
+    test('MultiEdit with outside absolute path is blocked', () => {
+      const payload = {
+        cwd: worktreeDir,
+        tool_name: 'MultiEdit',
+        tool_input: { file_path: path.join(mainRepo, 'src', 'index.ts') },
+      };
+      const result = runHook(worktreeDir, payload);
+      assert.strictEqual(result.status, 2,
+        `MultiEdit targeting outside path must be blocked. Got ${result.status}. stderr: ${result.stderr}`
+      );
+      const parsed = JSON.parse(result.stdout);
+      assert.strictEqual(parsed.decision, 'block');
+    });
+
+    test('MultiEdit with inside absolute path passes', () => {
+      const payload = {
+        cwd: worktreeDir,
+        tool_name: 'MultiEdit',
+        tool_input: { file_path: path.join(worktreeDir, 'src', 'foo.ts') },
+      };
+      const result = runHook(worktreeDir, payload);
+      assert.strictEqual(result.status, 0,
+        `MultiEdit inside worktree should pass. Got ${result.status}. stderr: ${result.stderr}`
+      );
+    });
+  });
+
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

> **Required.** This PR will be auto-closed if no valid issue link is found.

Fixes #260

> The linked issue must have the `confirmed-bug` label. If it doesn't, ask a maintainer to confirm the bug before continuing.

---

## What was broken

The `gsd-executor` agent, when spawned with `isolation="worktree"`, sometimes issued `Edit`/`Write` calls with absolute paths rooted at the **main repository** instead of the worktree. Writes landed in the wrong directory. Self-checks passed because the worktree's corrected final version was committed — but the leaked intermediate write in the main checkout blocked the orchestrator's ff-merge with "local changes would be overwritten."

## What this fix does

Moves the step-0b path guard from prose instructions (model memory, easily skipped under load) to a **harness-enforced `PreToolUse` hook** (`gsd-worktree-path-guard.js`). The hook hard-blocks (`exit 2`, `decision: block`) any `Edit`/`Write`/`MultiEdit` call whose absolute `file_path` resolves outside the active worktree root. Relative paths and non-worktree contexts pass through silently.

The hook uses `git rev-parse --git-dir` to detect linked worktrees (not the `.git`-file heuristic, which breaks in subdirectories and false-positives in submodules). Paths are normalised with `path.resolve()` before comparison to close the `..`-traversal bypass. `path.isAbsolute()` / `path.sep` are used for cross-platform correctness.

## Root cause

`agents/gsd-executor.md` step 0b documented the guard as a prose checklist item the model was supposed to `Bash`-execute before every absolute-path tool call. Under load the model skipped the pre-flight — a documentation-level contract with no enforcement layer.

## Testing

### How I verified the fix

21 regression tests in `tests/bug-260-worktree-path-guard.test.cjs` using real `git worktree add` fixtures, covering:
- No-op in main repo
- Relative paths always pass
- Non-Edit/Write/MultiEdit tools pass
- Absolute path inside worktree passes
- Absolute path outside worktree blocked (exit 2 + `decision: block`)
- Sibling-prefix boundary check (`wtRoot + '/'`)
- Subdirectory `cwd` (Codex adversarial finding #2)
- `..` traversal normalisation (Codex adversarial finding #1)
- `MultiEdit` coverage (Codex adversarial finding #5)

All 21 pass. `tests/bug-1754-js-hook-guard.test.cjs` extended (13/13 pass).

### Regression test added?

- [x] Yes — added a test that would have caught this bug

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [ ] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/579"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782913478&installation_id=134682257&pr_number=579&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F579&signature=11d2e566fd572606c961fe42c64e7dc8561f5378449852fa3903e51f3c883462"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->