### PR TITLE
fix(#581): add Edit to six writer agents' tools so Edit-only discipline is enforceable

### DIFF
--- a/.changeset/edit-tool-writer-agents.md
+++ b/.changeset/edit-tool-writer-agents.md
@@ -1,5 +1,0 @@
----
-type: Fixed
-pr: 582
----
-Six writer agents (`gsd-eval-planner`, `gsd-ai-researcher`, `gsd-domain-researcher`, `gsd-phase-researcher`, `gsd-ui-researcher`, `gsd-debug-session-manager`) now carry `Edit` alongside `Write` in their `tools:` frontmatter. Their spawn prompts instruct surgical in-place section edits on existing/shared files (notably the `AI-SPEC.md` trio writing disjoint sections of the same file), but without `Edit` they fell back to whole-file `Write` and silently clobbered sibling sections. Same bug class as #571 (fixed for `gsd-doc-writer` in #575). See #581.

--- a/.changeset/edit-tool-writer-agents.md
+++ b/.changeset/edit-tool-writer-agents.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 582
+---
+Six writer agents (`gsd-eval-planner`, `gsd-ai-researcher`, `gsd-domain-researcher`, `gsd-phase-researcher`, `gsd-ui-researcher`, `gsd-debug-session-manager`) now carry `Edit` alongside `Write` in their `tools:` frontmatter. Their spawn prompts instruct surgical in-place section edits on existing/shared files (notably the `AI-SPEC.md` trio writing disjoint sections of the same file), but without `Edit` they fell back to whole-file `Write` and silently clobbered sibling sections. Same bug class as #571 (fixed for `gsd-doc-writer` in #575). See #581.

--- a/.changeset/wise-hawks-bark.md
+++ b/.changeset/wise-hawks-bark.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 582
+---
+Six writer agents (`gsd-eval-planner`, `gsd-ai-researcher`, `gsd-domain-researcher`, `gsd-phase-researcher`, `gsd-ui-researcher`, `gsd-debug-session-manager`) now carry `Edit` alongside `Write` in their `tools:` frontmatter, so the Edit-only discipline in their spawn prompts is enforceable. Previously, without `Edit`, they fell back to whole-file `Write` and silently clobbered sibling sections of shared files such as `AI-SPEC.md`. Same bug class as #571 (fixed for `gsd-doc-writer` in #575). See #581.

--- a/agents/gsd-ai-researcher.md
+++ b/agents/gsd-ai-researcher.md
@@ -1,7 +1,7 @@
 ---
 name: gsd-ai-researcher
 description: Researches a chosen AI framework's official docs to produce implementation-ready guidance — best practices, syntax, core patterns, and pitfalls distilled for the specific use case. Writes the Framework Quick Reference and Implementation Guidance sections of AI-SPEC.md. Spawned by /gsd:ai-integration-phase orchestrator.
-tools: Read, Write, Bash, Grep, Glob, WebFetch, WebSearch, mcp__context7__*
+tools: Read, Write, Edit, Bash, Grep, Glob, WebFetch, WebSearch, mcp__context7__*
 color: "#34D399"
 # hooks:
 #   PostToolUse:

--- a/agents/gsd-debug-session-manager.md
+++ b/agents/gsd-debug-session-manager.md
@@ -1,7 +1,7 @@
 ---
 name: gsd-debug-session-manager
 description: Manages multi-cycle /gsd:debug checkpoint and continuation loop in isolated context. Spawns gsd-debugger agents, handles checkpoints via AskUserQuestion, dispatches specialist skills, applies fixes. Returns compact summary to main context. Spawned by /gsd:debug command.
-tools: Read, Write, Bash, Grep, Glob, Agent, AskUserQuestion
+tools: Read, Write, Edit, Bash, Grep, Glob, Agent, AskUserQuestion
 color: orange
 # hooks:
 #   PostToolUse:

--- a/agents/gsd-domain-researcher.md
+++ b/agents/gsd-domain-researcher.md
@@ -1,7 +1,7 @@
 ---
 name: gsd-domain-researcher
 description: Researches the business domain and real-world application context of the AI system being built. Surfaces domain expert evaluation criteria, industry-specific failure modes, regulatory context, and what "good" looks like for practitioners in this field — before the eval-planner turns it into measurable rubrics. Spawned by /gsd:ai-integration-phase orchestrator.
-tools: Read, Write, Bash, Grep, Glob, WebSearch, WebFetch, mcp__context7__*
+tools: Read, Write, Edit, Bash, Grep, Glob, WebSearch, WebFetch, mcp__context7__*
 color: "#A78BFA"
 # hooks:
 #   PostToolUse:

--- a/agents/gsd-eval-planner.md
+++ b/agents/gsd-eval-planner.md
@@ -1,7 +1,7 @@
 ---
 name: gsd-eval-planner
 description: Designs a structured evaluation strategy for an AI phase. Identifies critical failure modes, selects eval dimensions with rubrics, recommends tooling, and specifies the reference dataset. Writes the Evaluation Strategy, Guardrails, and Production Monitoring sections of AI-SPEC.md. Spawned by /gsd:ai-integration-phase orchestrator.
-tools: Read, Write, Bash, Grep, Glob, AskUserQuestion
+tools: Read, Write, Edit, Bash, Grep, Glob, AskUserQuestion
 color: "#F59E0B"
 # hooks:
 #   PostToolUse:

--- a/agents/gsd-phase-researcher.md
+++ b/agents/gsd-phase-researcher.md
@@ -1,7 +1,7 @@
 ---
 name: gsd-phase-researcher
 description: Researches how to implement a phase before planning. Produces RESEARCH.md consumed by gsd-planner. Spawned by /gsd:plan-phase orchestrator.
-tools: Read, Write, Bash, Grep, Glob, WebSearch, WebFetch, mcp__context7__*, mcp__firecrawl__*, mcp__exa__*
+tools: Read, Write, Edit, Bash, Grep, Glob, WebSearch, WebFetch, mcp__context7__*, mcp__firecrawl__*, mcp__exa__*
 color: cyan
 # hooks:
 #   PostToolUse:

--- a/agents/gsd-ui-researcher.md
+++ b/agents/gsd-ui-researcher.md
@@ -1,7 +1,7 @@
 ---
 name: gsd-ui-researcher
 description: Produces UI-SPEC.md design contract for frontend phases. Reads upstream artifacts, detects design system state, asks only unanswered questions. Spawned by /gsd:ui-phase orchestrator.
-tools: Read, Write, Bash, Grep, Glob, WebSearch, WebFetch, mcp__context7__*, mcp__firecrawl__*, mcp__exa__*
+tools: Read, Write, Edit, Bash, Grep, Glob, WebSearch, WebFetch, mcp__context7__*, mcp__firecrawl__*, mcp__exa__*
 color: "#E879F9"
 # hooks:
 #   PostToolUse:

--- a/tests/agent-frontmatter.test.cjs
+++ b/tests/agent-frontmatter.test.cjs
@@ -397,6 +397,41 @@ describe('DISCUSS: discussion log generation', () => {
   });
 });
 
+// ─── Section-writer agents must carry both Write and Edit (#581) ────────────
+
+describe('EDITWRITE: section-writer agents must have both Write and Edit in tools', () => {
+  // These agents perform in-place section edits on shared/existing files (e.g.
+  // AI-SPEC.md). Without Edit in tools:, the "Edit-only" discipline in their
+  // spawn-prompt is unenforceable — they fall back to whole-file Write and
+  // clobber sibling sections. Same bug class as #571/#575 (fixed gsd-doc-writer).
+  // Issue #581.
+  const SECTION_WRITER_AGENTS = [
+    'gsd-eval-planner',
+    'gsd-ai-researcher',
+    'gsd-domain-researcher',
+    'gsd-phase-researcher',
+    'gsd-ui-researcher',
+    'gsd-debug-session-manager',
+  ];
+
+  for (const agent of SECTION_WRITER_AGENTS) {
+    test(`${agent} has both Write and Edit in tools: (#581)`, () => {
+      const content = fs.readFileSync(path.join(AGENTS_DIR, agent + '.md'), 'utf-8');
+      const toolsMatch = content.match(/^tools:\s*(.+)$/m);
+      assert.ok(toolsMatch, `${agent} missing tools: line in frontmatter`);
+      const tools = toolsMatch[1].split(',').map(t => t.trim());
+      assert.ok(
+        tools.includes('Write'),
+        `${agent} missing Write in tools: — required for file creation`
+      );
+      assert.ok(
+        tools.includes('Edit'),
+        `${agent} missing Edit in tools: — required to enforce Edit-only discipline on shared files (#581)`
+      );
+    });
+  }
+});
+
 // ─── Cross-runtime agent compatibility (#1522) ──────────────────────────────
 
 describe('COMPAT: agents must not use runtime-specific frontmatter keys', () => {


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #581

---

## What was broken

Six writer agents (`gsd-eval-planner`, `gsd-ai-researcher`, `gsd-domain-researcher`, `gsd-phase-researcher`, `gsd-ui-researcher`, `gsd-debug-session-manager`) shipped with `Write` but no `Edit` in their `tools:` frontmatter, so their spawn-prompt "Edit-only — never Write" discipline was unenforceable: they fell back to whole-file `Write` and silently clobbered content (still reporting success). The `gsd-eval-planner`/`gsd-ai-researcher`/`gsd-domain-researcher` trio write disjoint sections of the same `AI-SPEC.md`, so a `Write` finalization is a last-writer-wins overwrite of a sibling agent's sections.

## What this fix does

Adds `Edit` alongside the existing `Write` in the `tools:` line of all six agents (placed adjacent to `Write`, mirroring the already-fixed `gsd-doc-writer`). No prompt-body changes; `Write` retained on each; no other agent definitions touched.

## Root cause

Same bug class as #571 (fixed for `gsd-doc-writer` in #575): the Edit-only instruction was injected into the spawn prompts (originally to fix the ai-integration race) but the agents were never granted the `Edit` tool, so the instruction could not be honored.

## Testing

### How I verified the fix

Added a regression test in `tests/agent-frontmatter.test.cjs` (`EDITWRITE` block) asserting each of the six agents carries both `Write` and `Edit`. Confirmed red before the fix, green after. Full suite, lint, and docs-lint pass locally.

- `npm test`: 4978 pass / 1 pre-existing skip / 0 fail
- `npm run lint`: 0 errors
- `npm run lint:docs`: ok

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [x] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None
