### PR TITLE
enhancement(#609): parallelize mutation gate via dynamic per-module matrix

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -1,10 +1,11 @@
 name: Mutation Testing
 
 # PR-GATING: runs on every pull_request targeting `next` or `main`.
-# Computes changed core lib files via git diff and passes them to --mutate,
-# so only mutants in CHANGED files are tested — keeps the job bounded.
-# If no core lib files changed, the gate passes trivially (skip+exit 0).
-# Full-repo mutation runs are reserved for local exploration (npm run test:mutation).
+# scripts/mutation-matrix.cjs is the single source of truth for which modules
+# are "covered" (have meaningful test coverage for mutation). It computes
+# changed modules from git diff and emits a GitHub Actions matrix so each
+# changed module gets its own Stryker shard running in parallel.
+# If no covered modules changed the gate passes trivially (has_work: false).
 
 on:
   pull_request:
@@ -12,10 +13,15 @@ on:
       - next
       - main
     paths:
-      # Only run when lib source or property tests change
+      # Only run when lib source, property/unit tests, or mutation config change
+      - 'src/**/*.cts'
       - 'get-shit-done/bin/lib/**/*.cjs'
       - 'tests/**/*.property.test.cjs'
+      - 'tests/**/*.unit.test.cjs'
+      - 'tests/adr-parser.test.cjs'
+      - 'tests/active-workstream-store.test.cjs'
       - 'stryker.config.mjs'
+      - 'scripts/mutation-matrix.cjs'
   workflow_dispatch:
 
 concurrency:
@@ -26,10 +32,60 @@ permissions:
   contents: read
 
 jobs:
-  mutation:
-    name: Stryker mutation score (changed files only)
+  # ── Job 1: detect ─────────────────────────────────────────────────────────
+  # Computes which covered modules changed and emits a matrix for the mutate job.
+  # Intentionally does NOT run npm ci — it only needs git + Node builtins.
+  detect:
+    name: Detect changed covered modules
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    outputs:
+      has_work: ${{ steps.matrix.outputs.has_work }}
+      matrix: ${{ steps.matrix.outputs.matrix }}
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Fetch base ref for diff
+        # Ensure the base branch tip is available for the git diff below.
+        # fetch-depth: 0 above gets all history, but the remote ref name must exist.
+        # For workflow_dispatch (no base_ref) we fall back to `next`.
+        run: git fetch origin ${{ github.base_ref || 'next' }} --depth=1
+
+      - name: Compute mutation matrix
+        id: matrix
+        run: |
+          BASE_REF="origin/${{ github.base_ref || 'next' }}"
+          # Run the matrix script; capture the JSON output.
+          JSON=$(node scripts/mutation-matrix.cjs --base "${BASE_REF}")
+
+          # Extract has_work and the compact matrix string for GITHUB_OUTPUT.
+          HAS_WORK=$(node -e "process.stdout.write(JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')).has_work)" <<< "${JSON}")
+          MATRIX=$(node -e "process.stdout.write(JSON.stringify(JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')).matrix))" <<< "${JSON}")
+
+          echo "has_work=${HAS_WORK}" >> "${GITHUB_OUTPUT}"
+          echo "matrix=${MATRIX}" >> "${GITHUB_OUTPUT}"
+
+          # Human-readable summary for the step log.
+          echo "has_work=${HAS_WORK}"
+          echo "${JSON}"
+
+  # ── Job 2: mutate ──────────────────────────────────────────────────────────
+  # One shard per changed covered module, each running only that module's tests.
+  # Skipped entirely when detect reports no covered files changed.
+  mutate:
+    name: Stryker (${{ matrix.name }})
+    needs: detect
+    if: needs.detect.outputs.has_work == 'true'
+    # TODO: can switch runs-on to blacksmith-4vcpu-ubuntu-2404 for faster shards
+    # once org-level runner label is confirmed available — do NOT change in this PR.
+    runs-on: ubuntu-latest
+    timeout-minutes: 15  # per-shard; lower than the old 30-min serial budget
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.detect.outputs.matrix) }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -43,63 +99,66 @@ jobs:
           node-version-file: .nvmrc
           cache: npm
 
-      - name: Install dependencies
+      - name: Install dependencies (builds .cjs via prepare)
         run: npm ci
 
-      - name: Fetch base ref for diff
-        # Ensure the base branch tip is available for the git diff below.
-        # fetch-depth: 0 above gets all history, but the remote ref name must exist.
-        run: git fetch origin ${{ github.base_ref }} --depth=1
-
-      - name: Compute changed core lib files
-        id: changed
-        run: |
-          BASE_REF="origin/${{ github.base_ref }}"
-          # ADR-457 build-at-publish: bin/lib/*.cjs are generated from src/*.cts,
-          # so Stryker mutates the TS SOURCES. The mutation gate is only
-          # meaningful for modules that the stryker.config.mjs command actually
-          # exercises (its property/unit test set) — mutating an uncovered module
-          # can only ever produce survived mutants. Scope to those covered modules.
-          # grep-based (not a git pathspec): `src/**/*.cts` pathspec only matches
-          # nested dirs, missing the top-level src/*.cts covered modules.
-          # Stryker mutates the BUILT artifact, so map the changed src/*.cts to
-          # its emitted get-shit-done/bin/lib/*.cjs path.
-          COVERED='^src/(context-utilization|prompt-budget|frontmatter|adr-parser|config-schema|active-workstream-store)\.cts$'
-          CHANGED=$(git diff --name-only "${BASE_REF}...HEAD" \
-            | grep -E '^src/.*\.cts$' \
-            | grep -vE '\.d\.cts$' \
-            | grep -E "$COVERED" \
-            | sed -E 's#^src/#get-shit-done/bin/lib/#; s#\.cts$#.cjs#' \
-            || true)
-          if [ -z "$CHANGED" ]; then
-            echo "changed=" >> "$GITHUB_OUTPUT"
-          else
-            # Join with commas for --mutate
-            MUTATE_LIST=$(echo "$CHANGED" | paste -sd, -)
-            echo "changed=${MUTATE_LIST}" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Skip mutation gate (no core lib files changed)
-        if: steps.changed.outputs.changed == ''
-        run: echo "No core lib files changed; skipping mutation gate"
-
-      - name: Run Stryker (incremental, changed files only)
-        if: steps.changed.outputs.changed != ''
-        # --mutate scopes mutation to only the changed production files.
+      - name: Run Stryker — ${{ matrix.name }}
+        # MUTATION_TEST_CMD scopes the command runner to only this module's tests.
+        # --mutate scopes mutation to only the changed module's built artifact.
         # --incremental reuses cached results for unchanged mutants.
-        # The break threshold (50) is read from stryker.config.mjs and causes
-        # Stryker to exit non-zero when mutation score < 50%, failing the PR check.
+        # The break threshold (50) is read from stryker.config.mjs.
         env:
           NODE_OPTIONS: '--max-old-space-size=4096'
+          MUTATION_TEST_CMD: node --test ${{ matrix.tests }}
         run: |
-          MUTATE_LIST="${{ steps.changed.outputs.changed }}"
-          echo "Running Stryker --mutate '${MUTATE_LIST}'"
-          npx stryker run --incremental --mutate "${MUTATE_LIST}"
+          echo "Module:  ${{ matrix.name }}"
+          echo "Mutate:  ${{ matrix.mutate }}"
+          echo "Tests:   ${{ matrix.tests }}"
+          npx stryker run --incremental --mutate "${{ matrix.mutate }}"
 
-      - name: Upload mutation HTML report
+      - name: Upload mutation report — ${{ matrix.name }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         if: always()  # upload even on failure so the score is visible
         with:
-          name: mutation-report-${{ github.run_number }}
+          name: mutation-report-${{ matrix.name }}-${{ github.run_number }}
           path: reports/mutation/mutation.html
           retention-days: 14
+
+  # ── Job 3: mutation-gate ───────────────────────────────────────────────────
+  # Stable required-check name for branch protection. Passes when:
+  #   • has_work is false (nothing to mutate — trivial pass), OR
+  #   • all mutate shards succeeded.
+  # Fails when any shard failed.
+  mutation-gate:
+    name: Mutation gate
+    needs: [detect, mutate]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Evaluate gate
+        run: |
+          DETECT="${{ needs.detect.result }}"
+          MUTATE="${{ needs.mutate.result }}"
+          HAS_WORK="${{ needs.detect.outputs.has_work }}"
+
+          echo "detect result : ${DETECT}"
+          echo "mutate result : ${MUTATE}"
+          echo "has_work      : ${HAS_WORK}"
+
+          if [ "${DETECT}" != "success" ]; then
+            echo "FAIL: detect job did not succeed (${DETECT})"
+            exit 1
+          fi
+
+          if [ "${HAS_WORK}" = "false" ]; then
+            echo "PASS: no covered modules changed — gate trivially green"
+            exit 0
+          fi
+
+          if [ "${MUTATE}" = "success" ]; then
+            echo "PASS: all mutation shards passed"
+            exit 0
+          fi
+
+          echo "FAIL: one or more mutation shards failed or were cancelled (${MUTATE})"
+          exit 1

--- a/scripts/mutation-matrix.cjs
+++ b/scripts/mutation-matrix.cjs
@@ -1,0 +1,217 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * scripts/mutation-matrix.cjs
+ *
+ * Single source of truth for the ADR-457 Stryker mutation gate dynamic matrix.
+ *
+ * Computes which covered modules changed vs a base ref and emits a GitHub
+ * Actions matrix JSON so CI can run one Stryker shard per changed module in
+ * parallel rather than a single serial run over all modules.
+ *
+ * Usage:
+ *   node scripts/mutation-matrix.cjs --base origin/next
+ *   printf 'src/config-schema.cts\n' | node scripts/mutation-matrix.cjs
+ *   node scripts/mutation-matrix.cjs --base origin/next --print
+ *
+ * Output (stdout, default): JSON object
+ *   {
+ *     "has_work": "true"|"false",
+ *     "matrix": {
+ *       "include": [
+ *         { "name": "<module>", "mutate": "get-shit-done/bin/lib/<module>.cjs", "tests": "<space-joined test files>" },
+ *         ...
+ *       ]
+ *     }
+ *   }
+ *
+ * Exit codes: 0 always (empty matrix is not an error, has_work "false").
+ */
+
+const { execFileSync } = require('child_process');
+const { readFileSync } = require('fs');
+
+// ── Single source of truth: covered modules ───────────────────────────────────
+// Each entry: { cjs: '<built artifact>', tests: ['tests/...', ...] }
+// A module is "covered" iff its tests are wired into the Stryker command runner
+// (stryker.config.mjs commandRunner.command). Mutating an uncovered module can
+// only ever produce survived mutants — so we scope strictly to these 6.
+const COVERED = {
+  'context-utilization': {
+    cjs: 'get-shit-done/bin/lib/context-utilization.cjs',
+    tests: [
+      'tests/context-utilization.property.test.cjs',
+    ],
+  },
+  'prompt-budget': {
+    cjs: 'get-shit-done/bin/lib/prompt-budget.cjs',
+    tests: [
+      'tests/prompt-budget.property.test.cjs',
+      'tests/prompt-budget.unit.test.cjs',
+    ],
+  },
+  frontmatter: {
+    cjs: 'get-shit-done/bin/lib/frontmatter.cjs',
+    tests: [
+      'tests/frontmatter.property.test.cjs',
+    ],
+  },
+  'adr-parser': {
+    cjs: 'get-shit-done/bin/lib/adr-parser.cjs',
+    tests: [
+      'tests/adr-parser.property.test.cjs',
+      'tests/adr-parser.test.cjs',
+      'tests/adr-parser.unit.test.cjs',
+    ],
+  },
+  'config-schema': {
+    cjs: 'get-shit-done/bin/lib/config-schema.cjs',
+    tests: [
+      'tests/config-schema.property.test.cjs',
+    ],
+  },
+  'active-workstream-store': {
+    cjs: 'get-shit-done/bin/lib/active-workstream-store.cjs',
+    tests: [
+      'tests/active-workstream-store.test.cjs',
+    ],
+  },
+};
+
+// ── Files that, when changed, invalidate ALL modules ─────────────────────────
+// Changes to the Stryker config, this script itself, or any covered test file
+// affect all mutation scores and must force a full re-run.
+const GLOBAL_TRIGGERS = new Set([
+  'stryker.config.mjs',
+  'scripts/mutation-matrix.cjs',
+]);
+
+// Also flag all test files that belong to any covered module as global triggers.
+for (const mod of Object.values(COVERED)) {
+  for (const t of mod.tests) {
+    GLOBAL_TRIGGERS.add(t);
+  }
+}
+
+// ── Argument parsing ──────────────────────────────────────────────────────────
+function parseArgs(argv) {
+  const out = { base: null, print: false };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--base') {
+      out.base = argv[++i];
+      if (!out.base || out.base.startsWith('--')) {
+        throw new Error('--base requires a value');
+      }
+    } else if (arg.startsWith('--base=')) {
+      out.base = arg.slice('--base='.length);
+      if (!out.base) throw new Error('--base requires a value');
+    } else if (arg === '--print') {
+      out.print = true;
+    } else if (arg === '--help' || arg === '-h') {
+      console.log([
+        'Usage:',
+        '  node scripts/mutation-matrix.cjs --base <ref> [--print]',
+        '  printf "src/foo.cts\\n" | node scripts/mutation-matrix.cjs [--print]',
+        '',
+        'Options:',
+        '  --base <ref>   Git ref to diff against (default: origin/${GITHUB_BASE_REF:-next})',
+        '  --print        Human-readable output instead of JSON',
+      ].join('\n'));
+      process.exit(0);
+    } else {
+      throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+  return out;
+}
+
+// ── Changed-file resolution ───────────────────────────────────────────────────
+function resolveChangedFiles(args) {
+  // When --base is provided, always use git diff (regardless of stdin).
+  // When --base is absent AND stdin is not a TTY (isTTY is falsy / undefined),
+  // read a newline-delimited file list from stdin.
+  if (!args.base && process.stdin.isTTY !== true) {
+    const raw = readFileSync(process.stdin.fd, 'utf8');
+    return raw.split('\n').map(l => l.trim()).filter(Boolean);
+  }
+
+  // Otherwise (--base given, or stdin is a real TTY), diff against the base ref.
+  const defaultBase = `origin/${process.env.GITHUB_BASE_REF || 'next'}`;
+  const base = args.base || defaultBase;
+  const stdout = execFileSync('git', ['diff', '--name-only', `${base}...HEAD`], {
+    encoding: 'utf8',
+  });
+  return stdout.split('\n').map(l => l.trim()).filter(Boolean);
+}
+
+// ── Module classification ─────────────────────────────────────────────────────
+function computeMatrix(changedFiles) {
+  // Check for global triggers first — if any hit, include every covered module.
+  const allModuleNames = Object.keys(COVERED);
+  for (const f of changedFiles) {
+    if (GLOBAL_TRIGGERS.has(f)) {
+      return allModuleNames;
+    }
+  }
+
+  // Otherwise find which modules have their src/*.cts changed.
+  const changed = new Set();
+  for (const f of changedFiles) {
+    // Match src/<module>.cts (top-level src/, not nested)
+    const m = f.match(/^src\/([^/]+)\.cts$/);
+    if (m && COVERED[m[1]]) {
+      changed.add(m[1]);
+    }
+  }
+  return [...changed];
+}
+
+// ── Output formatting ─────────────────────────────────────────────────────────
+function buildResult(moduleNames) {
+  const include = moduleNames.map(name => ({
+    name,
+    mutate: COVERED[name].cjs,
+    tests: COVERED[name].tests.join(' '),
+  }));
+
+  return {
+    has_work: include.length > 0 ? 'true' : 'false',
+    matrix: { include },
+  };
+}
+
+function printHuman(result, changedFiles) {
+  console.log(`Changed files (${changedFiles.length}):`);
+  for (const f of changedFiles) console.log(`  ${f}`);
+  console.log('');
+  console.log(`has_work: ${result.has_work}`);
+  console.log(`Shards (${result.matrix.include.length}):`);
+  for (const shard of result.matrix.include) {
+    console.log(`  [${shard.name}]`);
+    console.log(`    mutate: ${shard.mutate}`);
+    console.log(`    tests:  ${shard.tests}`);
+  }
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+function main() {
+  try {
+    const args = parseArgs(process.argv.slice(2));
+    const changedFiles = resolveChangedFiles(args);
+    const moduleNames = computeMatrix(changedFiles);
+    const result = buildResult(moduleNames);
+
+    if (args.print) {
+      printHuman(result, changedFiles);
+    } else {
+      console.log(JSON.stringify(result, null, 2));
+    }
+  } catch (err) {
+    console.error(`mutation-matrix: ${err.message}`);
+    process.exit(2);
+  }
+}
+
+main();

--- a/stryker.config.mjs
+++ b/stryker.config.mjs
@@ -44,6 +44,10 @@ const UNMUTATED = [
   '!get-shit-done/bin/lib/gsd2-import.cjs',
 ];
 
+// Full test command used by local runs and as the fallback when CI does not
+// inject a per-shard command via MUTATION_TEST_CMD.
+const DEFAULT_TEST_CMD = 'node --test tests/context-utilization.property.test.cjs tests/prompt-budget.property.test.cjs tests/frontmatter.property.test.cjs tests/adr-parser.property.test.cjs tests/config-schema.property.test.cjs tests/adr-parser.test.cjs tests/active-workstream-store.test.cjs tests/prompt-budget.unit.test.cjs tests/adr-parser.unit.test.cjs';
+
 /** @type {import('@stryker-mutator/core').PartialStrykerOptions} */
 export default {
   // ── Test runner ──────────────────────────────────────────────────────────────
@@ -52,7 +56,8 @@ export default {
     // Run property + unit tests over lib only (avoids the slow integration
     // suite). NO build step here: Stryker mutates the already-built .cjs and the
     // tests load it directly — adding a build would rebuild over the mutation.
-    command: 'node --test tests/context-utilization.property.test.cjs tests/prompt-budget.property.test.cjs tests/frontmatter.property.test.cjs tests/adr-parser.property.test.cjs tests/config-schema.property.test.cjs tests/adr-parser.test.cjs tests/active-workstream-store.test.cjs tests/prompt-budget.unit.test.cjs tests/adr-parser.unit.test.cjs',
+    // In CI each matrix shard injects MUTATION_TEST_CMD with only its own tests.
+    command: process.env.MUTATION_TEST_CMD || DEFAULT_TEST_CMD,
   },
 
   // ── Files to mutate ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Enhancement PR

## Linked Issue

Closes #609

> **Stacked on #602** (base is the #602 branch so the diff is just the 3 CI files). Before merge: land #602 first, then retarget this PR's base to `next`. If #602 squash-merges and deletes its branch, GitHub may auto-close this — just reopen against `next`; the change is self-contained.

## What this enhancement improves

The `Mutation Testing` workflow. After #602 the gate already scopes to changed covered modules and skips when none changed, but it ran them in **one serial Stryker invocation** (~22 min, near the 30-min cap), with the `command` runner re-running all ~300 tests per mutant.

## Before / After

**Before:** one job, one `stryker run --mutate <all changed covered modules>`, every mutant re-runs the full 8-file test command.

**After:** `detect` job emits a dynamic matrix → **one parallel shard per changed covered module**, each scoped (via `MUTATION_TEST_CMD`) to **only that module's tests**, enforcing `break:50` per module. A stable `Mutation gate` summary job is the required check.
- 1 module changed → 1 fast shard
- 0 covered modules changed → gate trivially green (skipped)
- all 6 (e.g. the migration) → 6 parallel shards; wall-clock = slowest module, not the ~22-min sum

## How it was implemented

- **`scripts/mutation-matrix.cjs`** — single source of truth for the covered-module → test-file map; computes changed modules from `git diff`/stdin → `{has_work, matrix.include[]}` JSON. A change to `stryker.config.mjs`, the script, or any covered test file forces all modules.
- **`.github/workflows/mutation.yml`** — `detect` → `mutate` (dynamic `matrix: fromJSON(...)`, `fail-fast:false`, 15-min/shard, per-shard HTML artifact) → `mutation-gate` (stable required check).
- **`stryker.config.mjs`** — `commandRunner.command` reads `MUTATION_TEST_CMD` (falls back to the full command for local runs).

## Testing

### How I verified the enhancement works

- `node scripts/mutation-matrix.cjs --base origin/next` → `has_work:true`, all 6 modules. `printf 'src/config-schema.cts' | node scripts/mutation-matrix.cjs` → single-module matrix.
- Confirmed `MUTATION_TEST_CMD=... npx stryker run --mutate <module.cjs>` honors the scoped command.
- `npx eslint scripts/mutation-matrix.cjs stryker.config.mjs` → 0 errors. YAML parses.
- Full end-to-end runs in this PR's own CI (it changes `stryker.config.mjs` → all 6 shards exercise the new matrix).

### Platforms tested
- [x] N/A (CI workflow / Linux runners)

### Runtimes tested
- [x] N/A (CI tooling)

## Scope confirmation

- [x] Implementation matches the approved issue (#609)
- [x] No scope changes

## Documentation

- [ ] Updated `docs/`
- [x] No user-facing docs impact (CI tooling only; recorded via `no-docs`/exempt as needed — no changeset fragment added since this is CI-only with no shipped behavior change).

## Checklist

- [x] Issue linked (`Closes #609`, `approved-enhancement`)
- [x] Scoped to the approved enhancement
- [x] Lint clean
- [x] No unnecessary dependencies

## Breaking changes

**CI-only:** the required status check is renamed to **`Mutation gate`** (from `Stryker mutation score (changed files only)`). Branch protection must be updated to require `Mutation gate` when this merges. No runtime/package behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/610"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782999751&installation_id=134682257&pr_number=610&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F610&signature=7abc9094a7d1813454bb348476c9571de658ae81764a79e1e4440246ed06175c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->