### PR TITLE
test(#606): regression guard — every same-dir require() target of a shipped hook must itself ship

### DIFF
--- a/.changeset/fierce-finches-munch.md
+++ b/.changeset/fierce-finches-munch.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 613
+---
+**Fresh installs now ship `managed-hooks-registry.cjs` next to `gsd-check-update-worker.js`, so the background update checker no longer crashes silently (#606)** — the worker `require()`s that sibling, but it had been missing from the hooks copy allowlist, so on a clean install the worker threw `Cannot find module` in the background and the update cache was never written. The file is now in the allowlist, and a regression guard asserts that every same-directory `require()` target of a shipped hook is itself shipped. Thanks @baksohyeon for the clean-room reproduction.

--- a/scripts/build-hooks.js
+++ b/scripts/build-hooks.js
@@ -237,4 +237,4 @@ if (require.main === module) {
   build();
 }
 
-module.exports = { HOOKS_TO_COPY };
+module.exports = { HOOKS_TO_COPY, HOOKS_SUBDIRS_TO_COPY };

--- a/tests/orphaned-hooks.test.cjs
+++ b/tests/orphaned-hooks.test.cjs
@@ -26,7 +26,7 @@ const HOOKS_DIR = path.join(__dirname, '..', 'hooks');
 
 // Typed imports — no source-grep needed (#455)
 const { MANAGED_HOOKS } = require(path.join(HOOKS_DIR, 'managed-hooks-registry.cjs'));
-const { HOOKS_TO_COPY } = require(path.join(__dirname, '..', 'scripts', 'build-hooks.js'));
+const { HOOKS_TO_COPY, HOOKS_SUBDIRS_TO_COPY } = require(path.join(__dirname, '..', 'scripts', 'build-hooks.js'));
 
 describe('orphaned hooks stale detection (#1750)', () => {
   test('MANAGED_HOOKS is an array and does not use a broad gsd-* wildcard', () => {
@@ -109,6 +109,48 @@ describe('orphaned hooks stale detection (#1750)', () => {
         !MANAGED_HOOKS.includes(orphan),
         `orphaned hook '${orphan}' must NOT be in MANAGED_HOOKS`
       );
+    }
+  });
+
+  test('every same-dir require() target of a shipped hook is itself shipped (#606)', () => {
+    // Regression guard for #606: gsd-check-update-worker.js does
+    // require('./managed-hooks-registry.cjs'), but that sibling was missing from
+    // HOOKS_TO_COPY, so the installer never placed it next to the worker and the
+    // background worker crashed at runtime with "Cannot find module". The fix added
+    // the file to HOOKS_TO_COPY; this guard fails if any shipped hook ever again
+    // requires a same-directory file that the installer would not ship.
+    //
+    // Scope: only *same-directory* relative requires — require('./x') and
+    // require('./subdir/x'). A require('../...') target reaches out of the hooks/
+    // dir into sibling package dirs (e.g. get-shit-done/) whose shipping is governed
+    // by package.json "files", not by this allowlist, so it is out of scope here.
+    assert.ok(Array.isArray(HOOKS_SUBDIRS_TO_COPY), 'HOOKS_SUBDIRS_TO_COPY must be exported as an array');
+
+    const SAME_DIR_REQUIRE = /require\(\s*['"](\.\/[^'"]+)['"]\s*\)/g;
+    const jsHooks = HOOKS_TO_COPY.filter(h => /\.c?js$/.test(h));
+    assert.ok(jsHooks.length >= 5, `expected at least 5 JS/CJS hooks in HOOKS_TO_COPY, got ${jsHooks.length}`);
+
+    for (const hook of jsHooks) {
+      const source = fs.readFileSync(path.join(HOOKS_DIR, hook), 'utf8');
+      for (const match of source.matchAll(SAME_DIR_REQUIRE)) {
+        const rel = match[1].slice(2); // strip leading './'
+        const slash = rel.indexOf('/');
+        if (slash === -1) {
+          assert.ok(
+            HOOKS_TO_COPY.includes(rel),
+            `${hook} requires './${rel}', but '${rel}' is not in HOOKS_TO_COPY — the installer ` +
+            `would not place it next to ${hook}, so the require would throw at runtime (the #606 class of bug). ` +
+            `Add '${rel}' to HOOKS_TO_COPY in scripts/build-hooks.js.`
+          );
+        } else {
+          const subdir = rel.slice(0, slash);
+          assert.ok(
+            HOOKS_SUBDIRS_TO_COPY.includes(subdir),
+            `${hook} requires './${rel}', but subdirectory '${subdir}' is not in HOOKS_SUBDIRS_TO_COPY — ` +
+            `the installer would not ship it. Add '${subdir}' to HOOKS_SUBDIRS_TO_COPY in scripts/build-hooks.js.`
+          );
+        }
+      }
     }
   });
 });


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #606

> The linked issue carries the `confirmed-bug` + `ready-for-agent` labels.

---

## What was broken

On a fresh install, `gsd-check-update-worker.js` was copied into the runtime `hooks/` dir but its sibling dependency `managed-hooks-registry.cjs` was **not** — it was missing from the `HOOKS_TO_COPY` allowlist in `scripts/build-hooks.js`. The worker does `require('./managed-hooks-registry.cjs')`, so the background update checker crashed silently with `Cannot find module` and the update cache was never written.

## What this fix does

The **behavioral fix already shipped** in #611 (the file is now in `HOOKS_TO_COPY` on `next`). This PR adds the **regression guard** that was the issue's third acceptance criterion — the test that would have caught the omission — plus exports `HOOKS_SUBDIRS_TO_COPY` so the test reads the real subdir allowlist instead of hardcoding it.

The new test (`tests/orphaned-hooks.test.cjs`) scans every JS/CJS hook in `HOOKS_TO_COPY` for **same-directory** relative requires — `require('./x')` and `require('./subdir/x')` — and asserts each target is itself shipped:
- `./x` → must be in `HOOKS_TO_COPY`
- `./subdir/…` → `subdir` must be in `HOOKS_SUBDIRS_TO_COPY` (whole-subdir copy)

`require('../…')` targets that escape the `hooks/` dir (e.g. `../get-shit-done/bin/lib/…`) are intentionally out of scope — their shipping is governed by `package.json` `"files"`, not this allowlist.

## Root cause

#455 added `managed-hooks-registry.cjs` and switched the worker to `require()` it, but did not add the new file to the hooks copy allowlist. There was no test asserting that a shipped hook's relative `require()` targets are themselves shipped, so the omission was invisible until a user (thanks @baksohyeon) reproduced it clean-room.

## Testing

### How I verified the fix

- `node --test tests/orphaned-hooks.test.cjs` → 7/7 pass.
- **Negative proof**: temporarily removed `managed-hooks-registry.cjs` from `HOOKS_TO_COPY` → the new test fails with the `#606`-class message naming the missing file; restored → green again. So the guard genuinely catches the original bug.
- `node scripts/lint-no-source-grep.cjs` → 0 violations (the file carries the existing `// allow-test-rule: structural-regression-guard` annotation, which covers this readFileSync-based wiring check).
- `npm run build:lib` clean, `npm run lint` 0 errors, `npm run lint:changeset` ok, `npm run lint:docs` ok, affected-test suite green.

### Regression test added?

- [x] Yes — added a test that would have caught this bug (verified it fails without the fix)

### Platforms tested

- [x] macOS
- [x] N/A — the test is pure path/string logic (uses `path.join`), behaves identically on all platforms

### Runtimes tested

- [x] N/A (not runtime-specific — it's a build/install allowlist invariant)

---

## Checklist

- [x] Issue linked above with `Fixes #606`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes
- [x] Regression test added (verified red-without-fix, green-with-fix)
- [x] All existing tests pass (affected suite + targeted file green)
- [x] `.changeset/` fragment crediting the #606 fix added (`.changeset/fierce-finches-munch.md`, type `Fixed`, pr 613)
- [x] No unnecessary dependencies added

## Breaking changes

None — adds a test and an additive named export (`HOOKS_SUBDIRS_TO_COPY`) on `scripts/build-hooks.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)