### PR TITLE
fix(#245): surface worktree.cleanup-wave SUMMARY rescue copy failure

### DIFF
--- a/.changeset/245-summary-rescue-copy-failure.md
+++ b/.changeset/245-summary-rescue-copy-failure.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`worktree.cleanup-wave` no longer silently loses a SUMMARY.md when the rescue copy fails** — a failed `*SUMMARY.md` rescue now blocks cleanup with `summary_rescue_failed` instead of merging and removing the worktree, preventing silent data loss.

--- a/.changeset/245-summary-rescue-copy-failure.md
+++ b/.changeset/245-summary-rescue-copy-failure.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 616
 ---
 **`worktree.cleanup-wave` no longer silently loses a SUMMARY.md when the rescue copy fails** — a failed `*SUMMARY.md` rescue now blocks cleanup with `summary_rescue_failed` instead of merging and removing the worktree, preventing silent data loss.

--- a/src/worktree-safety.cts
+++ b/src/worktree-safety.cts
@@ -546,12 +546,20 @@ function defaultFindSummaryFiles(worktreePath: string): string[] {
  *   - destination = <repoRoot>/<relPath>
  *   - copy when dest is absent or content differs
  *
- * Returns a Set of worktree-relative paths (e.g. ".planning/q1-SUMMARY.md")
- * that were eligible for rescue (regardless of whether a copy was needed).
- * These paths are filtered out of the git-status porcelain output so a
- * SUMMARY-only dirty worktree does not block cleanup.
+ * Returns `{ rescuedRelPaths, failures }`:
+ *   - `rescuedRelPaths`: Set of worktree-relative paths that were successfully rescued
+ *     (copy not needed because dest already matches, or copy succeeded).  Only paths
+ *     where the rescue genuinely succeeded are included so the dirty-block filter does
+ *     not suppress paths that were silently lost.
+ *   - `failures`: array of `{ relPath, error }` for any path where mkdirSync or
+ *     copyFileSync threw.  A read failure during content comparison is NOT a rescue
+ *     failure — it sets needsCopy=true and the copy is attempted normally.
  */
-function rescueSummaryArtifacts(worktreePath: string, repoRoot: string, deps: WorktreeDeps): Set<string> {
+function rescueSummaryArtifacts(
+  worktreePath: string,
+  repoRoot: string,
+  deps: WorktreeDeps,
+): { rescuedRelPaths: Set<string>; failures: Array<{ relPath: string; error: string }> } {
   const findSummaryFiles = deps.findSummaryFiles || defaultFindSummaryFiles;
   const existsSync = deps.existsSync || fs.existsSync;
   const readFileSync = deps.readFileSync || ((p: string) => fs.readFileSync(p, 'utf8'));
@@ -560,13 +568,13 @@ function rescueSummaryArtifacts(worktreePath: string, repoRoot: string, deps: Wo
 
   const summaryPaths = findSummaryFiles(worktreePath);
   const rescuedRelPaths = new Set<string>();
+  const failures: Array<{ relPath: string; error: string }> = [];
 
   for (const absPath of summaryPaths) {
     // relPath is the path relative to the worktree root (e.g. ".planning/q1-SUMMARY.md")
     // Normalize to forward slashes so the Set comparison against `git status --porcelain`
     // output works on Windows too (git always emits forward slashes in porcelain output).
     const relPath = absPath.slice(worktreePath.length).replace(/^[/\\]/, '').replace(/\\/g, '/');
-    rescuedRelPaths.add(relPath);
 
     const dest = path.join(repoRoot, relPath);
     let needsCopy = !existsSync(dest);
@@ -576,6 +584,7 @@ function rescueSummaryArtifacts(worktreePath: string, repoRoot: string, deps: Wo
         const destContent = readFileSync(dest);
         needsCopy = srcContent !== destContent;
       } catch {
+        // Read failure during comparison is not a rescue failure — force a copy attempt.
         needsCopy = true;
       }
     }
@@ -583,13 +592,20 @@ function rescueSummaryArtifacts(worktreePath: string, repoRoot: string, deps: Wo
       try {
         mkdirSync(path.dirname(dest), { recursive: true });
         copyFileSync(absPath, dest);
-      } catch {
-        // Best-effort rescue — if it fails the dirty check below will decide fate
+        // Copy succeeded — the SUMMARY is now safe in the main tree.
+        rescuedRelPaths.add(relPath);
+      } catch (err) {
+        // Write failure: the SUMMARY was NOT rescued.  Record it so the caller can
+        // block cleanup instead of silently losing data.
+        failures.push({ relPath, error: (err as Error).message });
       }
+    } else {
+      // dest already exists with identical content — SUMMARY is already safe.
+      rescuedRelPaths.add(relPath);
     }
   }
 
-  return rescuedRelPaths;
+  return { rescuedRelPaths, failures };
 }
 
 interface WaveCleanupEntryResult extends CleanupManifestEntry {
@@ -677,7 +693,16 @@ function executeWorktreeWaveCleanupPlan(plan: WaveCleanupPlan | null, deps: Work
     // Safety net: rescue uncommitted SUMMARY.md artifacts before the dirty check.
     // The executor leaves <quick_id>-SUMMARY.md uncommitted by contract — the
     // orchestrator commits it.  Mirrors quick.md shell fallback (#2296, #2070, #2838, #3804).
-    const rescuedRelPaths = rescueSummaryArtifacts(entry.worktree_path, plan.repoRoot, deps);
+    const { rescuedRelPaths, failures: rescueFailures } = rescueSummaryArtifacts(entry.worktree_path, plan.repoRoot, deps);
+    if (rescueFailures.length > 0) {
+      result.status = 'blocked';
+      result.reason = 'summary_rescue_failed';
+      result.stderr = rescueFailures.map((f) => `${f.relPath}: ${f.error}`).join('; ');
+      results.push(result);
+      pending.push(...entries.slice(i + 1));
+      ok = false;
+      break;
+    }
 
     const worktreeStatus = execGit(['-C', entry.worktree_path, 'status', '--porcelain', '--untracked-files=all'], { cwd: plan.repoRoot });
     if (!gitResultOk(worktreeStatus)) {

--- a/tests/worktree-safety.test.cjs
+++ b/tests/worktree-safety.test.cjs
@@ -772,6 +772,70 @@ describe('executeWorktreeWaveCleanupPlan', () => {
     assert.equal(result.entries[0].reason, 'worktree_dirty');
   });
 
+  test('#245: blocks with summary_rescue_failed when copyFileSync throws during rescue', () => {
+    // Fixture: the only dirty file is .planning/q1-SUMMARY.md, but copyFileSync throws
+    // (simulating ENOSPC / permission error).  The path must NOT be added to rescuedRelPaths,
+    // so the entry must be blocked with status='blocked', reason='summary_rescue_failed',
+    // and the worktree must NOT be merged or removed.
+    const calls = [];
+    const plan = {
+      ok: true,
+      repoRoot: '/repo/main',
+      action: 'cleanup_wave',
+      discovery: 'manifest',
+      entries: [{
+        agent_id: 'a1',
+        worktree_path: '/repo/.claude/worktrees/agent-a1',
+        branch: 'worktree-agent-a1',
+        expected_base: 'abc123',
+      }],
+    };
+    const result = executeWorktreeWaveCleanupPlan(plan, {
+      execGit: (args) => {
+        calls.push(args.join(' '));
+        const key = args.join(' ');
+        if (key === '-C /repo/.claude/worktrees/agent-a1 rev-parse --abbrev-ref HEAD') {
+          return { exitCode: 0, stdout: 'worktree-agent-a1', stderr: '' };
+        }
+        if (key === 'merge-base HEAD worktree-agent-a1') {
+          return { exitCode: 0, stdout: 'abc123', stderr: '' };
+        }
+        if (key === 'diff --diff-filter=D --name-only HEAD...worktree-agent-a1') {
+          return { exitCode: 0, stdout: '', stderr: '' };
+        }
+        if (key === '-C /repo/.claude/worktrees/agent-a1 status --porcelain --untracked-files=all') {
+          // Only the SUMMARY is dirty
+          return { exitCode: 0, stdout: '?? .planning/q1-SUMMARY.md', stderr: '' };
+        }
+        // Any merge or worktree-remove call proves we failed to block — throw to surface it
+        if (key.startsWith('merge worktree-agent-a1') || key.startsWith('worktree remove')) {
+          throw new Error(`worktree was not blocked before merge/remove: ${key}`);
+        }
+        return { exitCode: 0, stdout: '', stderr: '' };
+      },
+      findSummaryFiles: (worktreePath) => {
+        if (worktreePath === '/repo/.claude/worktrees/agent-a1') {
+          return ['/repo/.claude/worktrees/agent-a1/.planning/q1-SUMMARY.md'];
+        }
+        return [];
+      },
+      readFileSync: (p) => {
+        if (p === '/repo/.claude/worktrees/agent-a1/.planning/q1-SUMMARY.md') return 'summary content';
+        return '';
+      },
+      existsSync: () => false,
+      mkdirSync: () => {},
+      copyFileSync: () => { throw new Error('ENOSPC: no space left on device'); },
+    });
+
+    assert.equal(result.ok, false, 'result.ok must be false when rescue copy fails');
+    assert.equal(result.entries[0].status, 'blocked', 'entry status must be blocked');
+    assert.equal(result.entries[0].reason, 'summary_rescue_failed', 'entry reason must be summary_rescue_failed');
+    // Verify no merge or worktree-remove call was made (the execGit throw above would have surfaced it)
+    const mergeCalls = calls.filter((c) => c.startsWith('merge worktree-agent-a1') || c.startsWith('worktree remove'));
+    assert.equal(mergeCalls.length, 0, 'no merge or worktree-remove git call must have been made');
+  });
+
   test('blocks dirty worktrees before merge/remove/delete', () => {
     const calls = [];
     const plan = {


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #245

## What was broken

`worktree.cleanup-wave` could silently lose an uncommitted `*SUMMARY.md`: if the rescue `copyFileSync` threw (full disk / read-only / permission denied) the error was swallowed, yet the path had already been recorded as "rescued", so the dirty-block filter skipped it and the worktree was merged and removed with the SUMMARY never written.

## What this fix does

A path is recorded in the rescued set only **after** the copy actually succeeds (or the destination is verified identical). A write failure is now surfaced as a `blocked` entry with `reason: 'summary_rescue_failed'`, failing closed — the worktree is left intact instead of being merged/removed.

## Root cause

In `rescueSummaryArtifacts` (`src/worktree-safety.cts`), `rescuedRelPaths.add(relPath)` ran before the `copyFileSync` attempt, and the `catch` was a no-op ("best-effort"). The comment claimed "the dirty check below will decide fate", but the path was already in the rescued set, so the dirty-block filter in `executeWorktreeWaveCleanupPlan` excluded it — a failed rescue was indistinguishable from a successful one.

## Testing

### How I verified the fix

Added a regression test that injects a throwing `copyFileSync` through the existing dependency-injection seam, with an `execGit` that throws if any merge/remove call is reached. It fails against the unmodified code (worktree gets merged) and passes after the fix (entry is `blocked` / `summary_rescue_failed`, no merge/remove). Full file: 36 pass / 0 fail. Source-grep linters clean.

### Regression test added?

- [x] Yes — added a test that would have caught this bug

### Platforms tested

- [x] N/A (not platform-specific — logic-level, deps fully injected)

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass (`npm test` — worktree-safety suite green; see note)
- [x] `.changeset/` fragment added (`Fixed`)
- [x] No unnecessary dependencies added

## Breaking changes

None — only the previously-silent failure path changes (now fails closed instead of losing data).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/616"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783019744&installation_id=134682257&pr_number=616&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F616&signature=dc44d713ae2dffea43606d909ab9ea02c4f85ed32e56e8fb90adbf1a230384dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->