### PR TITLE
docs(#627): ADR — unified .gsd/ root with platform sub-namespaces

### DIFF
--- a/docs/adr/627-unified-gsd-root-namespacing.md
+++ b/docs/adr/627-unified-gsd-root-namespacing.md
@@ -1,0 +1,79 @@
+# Unified `.gsd/` root with platform sub-namespaces for cross-platform compatibility
+
+- **Status:** Proposed
+- **Date:** 2026-06-02
+- **Issue:** open-gsd/gsd-core#627
+- **Related:** ADR-0006 (planning-path-projection-module), ADR-0008 (installer-migration-module), ADR-3660 (runtime-artifact-layout-module), #260 (worktree absolute-path guard)
+- **Sibling decision:** open-gsd/gsd-pi#430 (mirrored enhancement)
+
+## Context
+
+gsd-core and gsd-pi are sibling platforms in the GSD family. Each persists its runtime state in a different top-level directory at the repo root:
+
+- gsd-core → `.planning/` — **gitignored, local-only** (`.gitignore:33`; `git ls-files .planning` returns 0 tracked files), resolved through a single projection seam (`planningDir`/`planningRoot` in `get-shit-done/bin/lib/planning-workspace.cjs`, established by ADR-0006).
+- gsd-pi → `.gsd/`.
+
+These roots are conceptually parallel — both hold "the agent's long-horizon working memory" — but they share no convention. A repository cannot cleanly host both, and a user who wants to migrate from one platform to the other has no defined path. Both platforms market autonomous, long-running operation, which makes a durable, predictable on-disk home for state (and for the worktrees agents run in) a shared concern rather than an incidental one.
+
+Separately, agent worktree storage is inconsistent within gsd-core: parallel executors use `.claude/worktrees/agent-<id>`, while `gsd-code-fixer` uses `mktemp -d /tmp/sv-...`. The `/tmp` location is not reboot-durable and may sit on a different filesystem than the repo.
+
+## Decision
+
+Adopt a **single `.gsd/` root at the repo root, partitioned by platform**:
+
+```
+.gsd/
+├── gsd-core/                 # gsd-core runtime state (formerly .planning/)
+├── gsd-pi/                   # gsd-pi runtime state
+└── gsd-worktree/             # shared, gitignored, ephemeral agent worktrees
+    ├── gsd-core/agent-<id>/  # per-platform leaf
+    └── gsd-pi/agent-<id>/
+```
+
+1. **gsd-core relocates its projection root** from `.planning/` to `.gsd/gsd-core/`, behind the existing ADR-0006 projection seam. The `GSD_PROJECT`/`GSD_WORKSTREAM` segments continue to nest below the platform namespace. The duplicated literals in `observability/logger.cjs` (`PLANNING_DIR`) and `intel.cjs` (`INTEL_DIR`) are refactored to read from the seam rather than re-deriving the string.
+2. **gsd-pi mirrors the convention**, keeping its state under `.gsd/gsd-pi/` (filed as a sibling enhancement, open-gsd/gsd-pi#430).
+3. **Agent worktrees move to a per-platform leaf `.gsd/gsd-worktree/<platform>/`** — gitignored, co-located on the repo filesystem, platform-neutral — replacing `/tmp` and, over time, `.claude/worktrees/`. The #260 absolute-path guard extends to this location.
+4. **Migration** (ADR-0008 precedent): since `.planning/` is gitignored/local-only, migration is a local `fs.rename('.planning' → '.gsd/gsd-core')` on first run — atomic on a single filesystem, idempotent, once per working copy, with a one-time notice. If `.gsd/gsd-core/` already exists it is canonical: warn and leave any stray `.planning/`, never silently merge. The `/gsd-pr-branch` command's `.planning/`-commit filter moves to `.gsd/gsd-core/` (or `.gsd/`) in lockstep.
+
+### Worktree location — options evaluated
+
+| Option | Pros | Cons |
+|---|---|---|
+| **`/tmp` / `$TMPDIR`** (status quo for code-fixer) | OS auto-cleanup; never git-tracked; no gitignore needed | Lost on reboot (kills resumable long runs); may be a different filesystem; not co-located/visible; not a portable cross-platform concept |
+| **`.claude/worktrees/`** (status quo for executors) | Co-located, same filesystem; already covered by #260 path-guard | Claude-Code-specific namespace; not portable to gsd-pi's harness; couples worktree location to one tool |
+| **Single shared `.gsd/gsd-worktree/` pool** | Co-located; one directory | One platform's GC can reap the other's live worktree |
+| **`.gsd/gsd-worktree/<platform>/`** (chosen) | Co-located & same filesystem (fast adds, no cross-device edge cases); unified under the shared `.gsd` root; platform-neutral; per-platform leaf so GC never crosses platforms; gitignorable; reboot-durable so paused runs resume; visible for debugging; #260 guard extends naturally | Must be gitignored or it pollutes `git status`; nested-worktree-in-repo needs care (already handled for `.claude/worktrees/`); not OS-cleaned — needs explicit lock/heartbeat GC |
+
+**Chosen: `.gsd/gsd-worktree/<platform>/`.** It is the only option that is simultaneously co-located (same filesystem as the repo), reboot-durable, and platform-neutral. The leaf is **namespaced per platform** so each platform's GC operates only on its own worktrees and can never reap a concurrent platform's live worktree.
+
+### Worktree garbage collection — lock/heartbeat
+
+The OS gave `/tmp` free liveness (reboot wipes it); a repo-local directory does not, so GC needs an explicit liveness signal to avoid deleting a worktree a concurrent run is using:
+
+- The owning agent writes a **lock/heartbeat file** into its worktree directory for the duration of its run.
+- A **GC sweep runs at the start of any worktree-creating command**, scoped to the current platform's leaf only. It removes an `agent-<id>/` directory only when **both**: (a) its owning branch is merged or absent, **and** (b) its lock is stale/dead.
+- **mtime-TTL is a crash backstop** for locks orphaned by a hard kill — not the primary signal.
+
+This was chosen over branch-state-only (cannot distinguish a live-but-unmerged run from an abandoned one) and TTL-only (reaps a long quiet run mid-flight).
+
+## Consequences
+
+- **Positive.** One on-disk contract both platforms honor; a real migration path between them; reboot-durable worktrees on a guaranteed-local filesystem; "where state lives" knowledge concentrated behind one seam; one worktree convention instead of two; per-platform GC isolation.
+- **Negative / cost.** A one-time local relocation of `.planning/` (no committed-history break since it is gitignored; mitigated by automatic migration); `.gitignore` and `docs/ARCHITECTURE.md` updates land with the implementation; the `/gsd-pr-branch` filter literal must move in lockstep; new lock/heartbeat GC responsibility for the non-OS-cleaned worktree directory; external references to `.planning/` must be updated.
+- **Coordination.** The two platforms must keep the `.gsd/<platform>/` convention in lockstep; this ADR and its gsd-pi sibling (open-gsd/gsd-pi#430) are the coordination record.
+
+## Alternatives considered
+
+- **Keep `.planning/` and `.gsd/` separate (status quo).** Zero migration cost, but permanently forecloses cross-platform interop and leaves no migration path — the core motivation.
+- **gsd-core adopts a bare `.gsd/` root (no platform sub-namespace).** Collides head-on with gsd-pi's `.gsd/` and makes dual-hosting impossible. The `gsd-core/`/`gsd-pi/` sub-namespace is what prevents collision.
+- **Dual-read or symlink `.planning/` → `.gsd/gsd-core/`** instead of a move. These solve *cross-clone propagation* of a committed path — a problem that does not exist for gitignored local-only state — at the cost of two code paths or cross-platform symlink fragility (Windows, archives, CI). Rejected; a hard local `fs.rename` is strictly simpler.
+- **Single shared worktree pool (not per-platform leaf).** Rejected — a shared directory with per-platform GC rules lets one platform's sweep delete the other's live worktree.
+- **Worktree GC by branch-state-only or mtime-TTL-only.** Branch-state-only cannot distinguish a live-unmerged run from an abandoned one; TTL-only can reap a long quiet run mid-flight. Rejected as primary signals in favor of lock/heartbeat (TTL kept as a crash backstop).
+
+## References
+
+- ADR-0006 — planning-path-projection-module (the seam this builds on)
+- ADR-0008 — installer-migration-module (migration precedent)
+- ADR-3660 — runtime-artifact-layout-module
+- #260 — worktree absolute-path guard hook
+- Sibling enhancement — open-gsd/gsd-pi#430

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -53,6 +53,7 @@ See **[CONTRIBUTING.md — "Proposing an ADR or PRD"](../../CONTRIBUTING.md#prop
 | [452-eslint-lint-harness.md](452-eslint-lint-harness.md) | Adopt standard ESLint flat-config lint harness; retire homegrown regex scanners | Accepted |
 | [456-test-rigor-architecture.md](456-test-rigor-architecture.md) | Test-rigor architecture — deterministic scheduling, antagonistic tier, typed-surface mandate, delete-bad-tests policy | Accepted |
 | [457-generated-cjs-single-source.md](457-generated-cjs-single-source.md) | Collapse hand-written CJS to generated single-source | Proposed |
+| [627-unified-gsd-root-namespacing.md](627-unified-gsd-root-namespacing.md) | Unified .gsd/ root with platform sub-namespaces for cross-platform compatibility | Proposed |
 
 ## Seam map
 


### PR DESCRIPTION
## Enhancement PR

## Linked Issue

Closes #627

> The linked issue has the `approved-enhancement` label.

---

## What this enhancement improves

The runtime artifact layout. This PR adds the decision record (ADR, **Status: Proposed**) for converging gsd-core and our sibling platform gsd-pi onto a single, platform-namespaced `.gsd/` root, and for moving agent worktrees off `/tmp` to a per-platform `.gsd/gsd-worktree/<platform>/` leaf.

This is a **decision-record-only PR** — no runtime behavior changes. gsd-core still writes `.planning/` today; the relocation, migration, and worktree changes land in a follow-up implementation PR so this stays "one issue = one ADR = one PR" per CONTRIBUTING.

## Before / After

**Before:**
gsd-core persists state under `.planning/` (gitignored, local-only); gsd-pi persists under `.gsd/`. The two roots share no convention, so a repo cannot host both and there is no migration path. Worktrees are split between `.claude/worktrees/agent-<id>` (executors) and `/tmp/sv-...` (`gsd-code-fixer`).

**After (decision recorded):**
```
.gsd/
├── gsd-core/                 # gsd-core state (formerly .planning/)
├── gsd-pi/                   # gsd-pi state
└── gsd-worktree/
    ├── gsd-core/agent-<id>/  # per-platform leaf, GC-isolated
    └── gsd-pi/agent-<id>/
```
Migration is a local `fs.rename('.planning' → '.gsd/gsd-core')` (no git op — state is gitignored). Worktree GC uses a lock/heartbeat signal (branch-merged AND dead-lock), mtime-TTL backstop, scoped per platform.

## How it was implemented

- Added `docs/adr/627-unified-gsd-root-namespacing.md` (Status: Proposed).
- Added the index row to `docs/adr/README.md`.

Builds on ADR-0006 (planning-path-projection seam), ADR-0008 (installer-migration precedent), and #260 (worktree path guard). Sibling decision mirrored on open-gsd/gsd-pi#430.

## Testing

### How I verified the enhancement works

Docs-only. Verified the ADR follows the `<issue#>-<slug>.md` naming convention and is linked from the index.

### Platforms tested

- [x] N/A (not platform-specific)

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue — no additions or removals
- [x] If scope changed during implementation, I updated the issue and got re-approval before continuing

---

## Documentation

- [x] Updated the relevant file(s) under `docs/` to reflect this change
  - Architectural change → `docs/adr/`
- [x] All `docs/` content added in this PR is written in English
- [x] Docs-only decision record — `no-changelog` label applied; no user-facing behavior changes yet (implementation lands separately).

## Checklist

- [x] Issue linked above with `Closes #627`
- [x] Linked issue has the `approved-enhancement` label
- [x] Changes are scoped to the approved enhancement — nothing extra included
- [x] All existing tests pass (`npm test`) — docs-only, no code touched
- [ ] New or updated tests cover the enhanced behavior — N/A (decision record only)
- [x] `no-changelog` label applied (docs-only; opts out of changeset requirement)
- [x] No unnecessary dependencies added

## Breaking changes

None in this PR (decision record only). The recorded decision does describe a future one-time relocation of `.planning/` → `.gsd/gsd-core/`, mitigated by automatic local migration; that ships in the implementation PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/629"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783039635&installation_id=134682257&pr_number=629&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F629&signature=2e7e06f7ec1f0d522b6994f4356450443f044d3291561731a8f2fb30f2dff2e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->