### PR TITLE
refactor(#596): drop dead projection metadata in state-command-router

### DIFF
--- a/src/cjs-command-router-adapter.cts
+++ b/src/cjs-command-router-adapter.cts
@@ -135,19 +135,7 @@ function routeHubCommandFamily({
   error((result as { message: string }).message);
 }
 
-/**
- * Projection helper for family routers that still declare SDK registry metadata
- * but execute the CJS fallback path at this seam.
- *
- * Accepts variable argument shapes so routers can pass legacy projection tuples
- * (`registryCommand`, `registryArgs`, `legacyArgs`, optional `rawFormatter`, `cjsFallback`).
- */
-function cjsFallbackHandler(...projectionArgs: unknown[]): unknown {
-  return projectionArgs[projectionArgs.length - 1];
-}
-
 export = {
   routeCjsCommandFamily,
   routeHubCommandFamily,
-  cjsFallbackHandler,
 };

--- a/src/state-command-router.cts
+++ b/src/state-command-router.cts
@@ -17,18 +17,10 @@
 import { STATE_SUBCOMMANDS } from './command-aliases.cjs';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import cjsCommandRouterAdapter = require('./cjs-command-router-adapter.cjs');
-const { routeHubCommandFamily, cjsFallbackHandler } = cjsCommandRouterAdapter;
+const { routeHubCommandFamily } = cjsCommandRouterAdapter;
 import { parseNamedArgs } from './command-arg-projection.cjs';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
-
-// Handler type matching cjs-command-router-adapter's internal Handler type.
-type Handler = () => unknown;
-
-// Helper: cast cjsFallbackHandler result (always the last arg, a Handler) to Handler.
-function fallback(...projectionArgs: unknown[]): Handler {
-  return cjsFallbackHandler(...projectionArgs) as Handler;
-}
 
 // Helper: extract string-only named arg value (value flags never return boolean).
 function strArg(opts: Record<string, string | boolean | null>, key: string): string | null | undefined {
@@ -94,226 +86,106 @@ function routeStateCommand({ state, args, cwd, raw, error }: RouteStateCommandOp
     raw,
     unknownMessage: (subcommand: string, available: string[]) => `Unknown state subcommand: "${subcommand}". Available: ${available.join(', ')}`,
     handlers: {
-      load: fallback(
-        'state.load',
-        [],
-        args.slice(1),
-        null,
-        () => state.cmdStateLoad(cwd, raw),
-      ),
-      json: fallback(
-        'state.json',
-        [],
-        args.slice(1),
-        null,
-        () => state.cmdStateJson(cwd, raw),
-      ),
-      get: fallback(
-        'state.get',
-        args.slice(2),
-        args.slice(1),
-        null,
-        () => state.cmdStateGet(cwd, args[2], raw),
-      ),
-      update: fallback(
-        'state.update',
-        args.slice(2),
-        args.slice(1),
-        null,
-        () => state.cmdStateUpdate(cwd, args[2], args[3]),
-      ),
-      patch: fallback(
-        'state.patch',
-        args.slice(2),
-        args.slice(1),
-        null,
-        () => {
-          const patches: Record<string, string> = {};
-          if (args.length === 3 && typeof args[2] === 'string' && args[2].trim().startsWith('{')) {
-            let parsed: unknown;
-            try {
-              parsed = JSON.parse(args[2]);
-            } catch (err) {
-              error(`state patch: invalid JSON object: ${(err as Error).message}`);
-              return;
-            }
-            if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-              error('state patch: JSON input must be an object of field/value pairs.');
-              return;
-            }
-            for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
-              if (key && value !== undefined) {
-                // eslint-disable-next-line @typescript-eslint/no-base-to-string
-                patches[key] = String(value);
-              }
-            }
-          } else {
-            for (let i = 2; i < args.length; i += 2) {
-              const key = args[i].replace(/^--/, '');
-              const value = args[i + 1];
-              if (key && value !== undefined) {
-                patches[key] = value;
-              }
+      load: () => state.cmdStateLoad(cwd, raw),
+      json: () => state.cmdStateJson(cwd, raw),
+      get: () => state.cmdStateGet(cwd, args[2], raw),
+      update: () => state.cmdStateUpdate(cwd, args[2], args[3]),
+      patch: () => {
+        const patches: Record<string, string> = {};
+        if (args.length === 3 && typeof args[2] === 'string' && args[2].trim().startsWith('{')) {
+          let parsed: unknown;
+          try {
+            parsed = JSON.parse(args[2]);
+          } catch (err) {
+            error(`state patch: invalid JSON object: ${(err as Error).message}`);
+            return;
+          }
+          if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+            error('state patch: JSON input must be an object of field/value pairs.');
+            return;
+          }
+          for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+            if (key && value !== undefined) {
+              // eslint-disable-next-line @typescript-eslint/no-base-to-string
+              patches[key] = String(value);
             }
           }
-          state.cmdStatePatch(cwd, patches, raw);
-        },
-      ),
-      'advance-plan': fallback(
-        'state.advance-plan',
-        [],
-        args.slice(1),
-        null,
-        () => state.cmdStateAdvancePlan(cwd, raw),
-      ),
-      'record-metric': fallback(
-        'state.record-metric',
-        args.slice(2),
-        args.slice(1),
-        null,
-        () => {
-          const a = parseNamedArgs(args, ['phase', 'plan', 'duration', 'tasks', 'files']);
-          state.cmdStateRecordMetric(cwd, {
-            phase: strArg(a, 'phase'),
-            plan: strArg(a, 'plan'),
-            duration: strArg(a, 'duration'),
-            tasks: strArg(a, 'tasks'),
-            files: strArg(a, 'files'),
-          }, raw);
-        },
-      ),
-      'update-progress': fallback(
-        'state.update-progress',
-        [],
-        args.slice(1),
-        null,
-        () => state.cmdStateUpdateProgress(cwd, raw),
-      ),
-      'add-decision': fallback(
-        'state.add-decision',
-        args.slice(2),
-        args.slice(1),
-        null,
-        () => {
-          const a = parseNamedArgs(args, ['phase', 'summary', 'summary-file', 'rationale', 'rationale-file']);
-          state.cmdStateAddDecision(cwd, {
-            phase: strArg(a, 'phase'),
-            summary: strArg(a, 'summary'),
-            summary_file: strArg(a, 'summary-file'),
-            rationale: strArg(a, 'rationale') || '',
-            rationale_file: strArg(a, 'rationale-file'),
-          }, raw);
-        },
-      ),
-      'add-blocker': fallback(
-        'state.add-blocker',
-        args.slice(2),
-        args.slice(1),
-        null,
-        () => {
-          const a = parseNamedArgs(args, ['text', 'text-file']);
-          state.cmdStateAddBlocker(cwd, { text: strArg(a, 'text'), text_file: strArg(a, 'text-file') }, raw);
-        },
-      ),
-      'resolve-blocker': fallback(
-        'state.resolve-blocker',
-        args.slice(2),
-        args.slice(1),
-        null,
-        () => state.cmdStateResolveBlocker(cwd, strArg(parseNamedArgs(args, ['text']), 'text'), raw),
-      ),
-      'record-session': fallback(
-        'state.record-session',
-        args.slice(2),
-        args.slice(1),
-        null,
-        () => {
-          const a = parseNamedArgs(args, ['stopped-at', 'resume-file']);
-          // Pass resume_file as-is (undefined when --resume-file was not provided) so
-          // cmdStateRecordSession can distinguish "caller explicitly passed a value" from
-          // "option was not supplied" and apply the template-default-only replacement guard.
-          state.cmdStateRecordSession(cwd, { stopped_at: strArg(a, 'stopped-at'), resume_file: strArg(a, 'resume-file') }, raw);
-        },
-      ),
-      'begin-phase': fallback(
-        'state.begin-phase',
-        args.slice(2),
-        args.slice(1),
-        null,
-        () => {
-          const a = parseNamedArgs(args, ['phase', 'name', 'plans']);
-          state.cmdStateBeginPhase(cwd, strArg(a, 'phase'), strArg(a, 'name'), parsePlans(strArg(a, 'plans')), raw);
-        },
-      ),
-      'signal-waiting': fallback(
-        'state.signal-waiting',
-        args.slice(2),
-        args.slice(1),
-        null,
-        () => {
-          const a = parseNamedArgs(args, ['type', 'question', 'options', 'phase']);
-          state.cmdSignalWaiting(cwd, strArg(a, 'type'), strArg(a, 'question'), strArg(a, 'options'), strArg(a, 'phase'), raw);
-        },
-      ),
-      'signal-resume': fallback(
-        'state.signal-resume',
-        [],
-        args.slice(1),
-        null,
-        () => state.cmdSignalResume(cwd, raw),
-      ),
-      'planned-phase': fallback(
-        'state.planned-phase',
-        args.slice(2),
-        args.slice(1),
-        null,
-        () => {
-          const a = parseNamedArgs(args, ['phase', 'name', 'plans']);
-          state.cmdStatePlannedPhase(cwd, strArg(a, 'phase'), parsePlans(strArg(a, 'plans')), raw);
-        },
-      ),
-      validate: fallback(
-        'state.validate',
-        [],
-        args.slice(1),
-        null,
-        () => state.cmdStateValidate(cwd, raw),
-      ),
-      sync: fallback(
-        'state.sync',
-        args.slice(2),
-        args.slice(1),
-        null,
-        () => {
-          const a = parseNamedArgs(args, [], ['verify']);
-          state.cmdStateSync(cwd, { verify: a['verify'] }, raw);
-        },
-      ),
-      prune: fallback(
-        'state.prune',
-        args.slice(2),
-        args.slice(1),
-        null,
-        () => {
-          const a = parseNamedArgs(args, ['keep-recent'], ['dry-run']);
-          state.cmdStatePrune(cwd, { keepRecent: strArg(a, 'keep-recent') || '3', dryRun: a['dry-run'] === true }, raw);
-        },
-      ),
+        } else {
+          for (let i = 2; i < args.length; i += 2) {
+            const key = args[i].replace(/^--/, '');
+            const value = args[i + 1];
+            if (key && value !== undefined) {
+              patches[key] = value;
+            }
+          }
+        }
+        state.cmdStatePatch(cwd, patches, raw);
+      },
+      'advance-plan': () => state.cmdStateAdvancePlan(cwd, raw),
+      'record-metric': () => {
+        const a = parseNamedArgs(args, ['phase', 'plan', 'duration', 'tasks', 'files']);
+        state.cmdStateRecordMetric(cwd, {
+          phase: strArg(a, 'phase'),
+          plan: strArg(a, 'plan'),
+          duration: strArg(a, 'duration'),
+          tasks: strArg(a, 'tasks'),
+          files: strArg(a, 'files'),
+        }, raw);
+      },
+      'update-progress': () => state.cmdStateUpdateProgress(cwd, raw),
+      'add-decision': () => {
+        const a = parseNamedArgs(args, ['phase', 'summary', 'summary-file', 'rationale', 'rationale-file']);
+        state.cmdStateAddDecision(cwd, {
+          phase: strArg(a, 'phase'),
+          summary: strArg(a, 'summary'),
+          summary_file: strArg(a, 'summary-file'),
+          rationale: strArg(a, 'rationale') || '',
+          rationale_file: strArg(a, 'rationale-file'),
+        }, raw);
+      },
+      'add-blocker': () => {
+        const a = parseNamedArgs(args, ['text', 'text-file']);
+        state.cmdStateAddBlocker(cwd, { text: strArg(a, 'text'), text_file: strArg(a, 'text-file') }, raw);
+      },
+      'resolve-blocker': () => state.cmdStateResolveBlocker(cwd, strArg(parseNamedArgs(args, ['text']), 'text'), raw),
+      'record-session': () => {
+        const a = parseNamedArgs(args, ['stopped-at', 'resume-file']);
+        // Pass resume_file as-is (undefined when --resume-file was not provided) so
+        // cmdStateRecordSession can distinguish "caller explicitly passed a value" from
+        // "option was not supplied" and apply the template-default-only replacement guard.
+        state.cmdStateRecordSession(cwd, { stopped_at: strArg(a, 'stopped-at'), resume_file: strArg(a, 'resume-file') }, raw);
+      },
+      'begin-phase': () => {
+        const a = parseNamedArgs(args, ['phase', 'name', 'plans']);
+        state.cmdStateBeginPhase(cwd, strArg(a, 'phase'), strArg(a, 'name'), parsePlans(strArg(a, 'plans')), raw);
+      },
+      'signal-waiting': () => {
+        const a = parseNamedArgs(args, ['type', 'question', 'options', 'phase']);
+        state.cmdSignalWaiting(cwd, strArg(a, 'type'), strArg(a, 'question'), strArg(a, 'options'), strArg(a, 'phase'), raw);
+      },
+      'signal-resume': () => state.cmdSignalResume(cwd, raw),
+      'planned-phase': () => {
+        const a = parseNamedArgs(args, ['phase', 'name', 'plans']);
+        state.cmdStatePlannedPhase(cwd, strArg(a, 'phase'), parsePlans(strArg(a, 'plans')), raw);
+      },
+      validate: () => state.cmdStateValidate(cwd, raw),
+      sync: () => {
+        const a = parseNamedArgs(args, [], ['verify']);
+        state.cmdStateSync(cwd, { verify: a['verify'] }, raw);
+      },
+      prune: () => {
+        const a = parseNamedArgs(args, ['keep-recent'], ['dry-run']);
+        state.cmdStatePrune(cwd, { keepRecent: strArg(a, 'keep-recent') || '3', dryRun: a['dry-run'] === true }, raw);
+      },
       // complete-phase: CJS-only — no SDK counterpart.
       'complete-phase': () => {
         const a = parseNamedArgs(args, ['phase']);
         state.cmdStateCompletePhase(cwd, raw, strArg(a, 'phase') || args[2]);
       },
-      'milestone-switch': fallback(
-        'state.milestone-switch',
-        args.slice(2),
-        args.slice(1),
-        null,
-        () => {
-          const a = parseNamedArgs(args, ['milestone', 'name']);
-          state.cmdStateMilestoneSwitch(cwd, strArg(a, 'milestone'), strArg(a, 'name'), raw);
-        },
-      ),
+      'milestone-switch': () => {
+        const a = parseNamedArgs(args, ['milestone', 'name']);
+        state.cmdStateMilestoneSwitch(cwd, strArg(a, 'milestone'), strArg(a, 'name'), raw);
+      },
     },
   });
 }


### PR DESCRIPTION
## Enhancement PR

## Linked Issue

Closes #596

The issue carries the `approved-enhancement` label (maintainer-verified diagnosis in the issue thread).

---

## What this enhancement improves

`state-command-router` — removes the dead projection-metadata plumbing that wrapped every state subcommand handler.

## Before / After

**Before:** Every one of the 20 state handlers was wrapped in a 5-argument projection tuple via `cjsFallbackHandler`:

```ts
load: fallback(
  'state.load',   // registryCommand — discarded
  [],             // registryArgs    — discarded
  args.slice(1),  // legacyArgs      — discarded
  null,           // rawFormatter    — discarded (null at 100% of sites)
  () => state.cmdStateLoad(cwd, raw),  // the only arg actually used
),
```

`cjsFallbackHandler` is a no-op pass-through (`return projectionArgs[projectionArgs.length - 1]`), and `state-command-router` was its only consumer. The SDK-dispatch path the metadata was nominally for is a retired shim.

**After:** Plain inline thunks, matching the post-#298 convention already used by the `verify` / `roadmap` / `phases` routers (and by `complete-phase` in this same file):

```ts
load: () => state.cmdStateLoad(cwd, raw),
```

## How it was implemented

- `src/state-command-router.cts` — collapsed all 20 handlers to `() => state.cmd*(...)` thunks; removed the local `fallback()` helper, the now-unused `Handler` type, and the `cjsFallbackHandler` import.
- `src/cjs-command-router-adapter.cts` — dropped `cjsFallbackHandler` from exports (no remaining consumers).

Source-only diff: `gsd-core/bin/lib/*.cjs` are built-at-publish from these `.cts` sources per ADR-457.

## Testing

### How I verified the enhancement works

Behavior-preserving — each thunk body is byte-for-behaviour identical; only the dead wrapper was removed. No test referenced `cjsFallbackHandler`.

- `npm run build:lib` → clean
- `npx eslint` on both changed sources → clean
- `tests/cjs-command-router-adapter.test.cjs` → 8/8
- State-routing behavioral suite (write-routing, update-progress, begin-phase, milestone-switch, dollar-backreference, executor-preserve) → 36/36
- Full unit suite (`npm run test:unit`) → **3435 pass / 0 fail** (3 pre-existing environment skips)

### Platforms tested

- [x] Windows (including backslash path handling)
- [ ] macOS
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [x] N/A (not runtime-specific — internal CJS router refactor)

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue — no additions or removals
- [x] If scope changed during implementation, I updated the issue and got re-approval before continuing

Implements the issue's option (1) exactly. The issue's third scope bullet (`tests/cjs-command-router-adapter.test.cjs`) was conditional on `cjsFallbackHandler` having a test to remove — it has none, so no test change was needed.

---

## Documentation

- [x] If genuinely no user-facing docs impact (infrastructure / internal refactor / test-only), apply the `no-docs` label

Pure internal refactor — no user-visible behavior, output, config, or API change. No `docs/` impact.

## Checklist

- [x] Issue linked above with `Closes #596`
- [x] Linked issue has the `approved-enhancement` label
- [x] Changes are scoped to the approved enhancement — nothing extra included
- [x] All existing tests pass (full unit suite green)
- [x] No new test added — this is a behavior-preserving refactor (each handler thunk is unchanged), so there is no new behavior to cover. The preserved behavior is already locked by `tests/cjs-command-router-adapter.test.cjs` (8/8) and the state-routing suite (36/36), both green against this change.
- [x] No `.changeset/` fragment — diff touches only root `src/` (not a changeset-trigger path) and the change is not user-facing; `no-changelog` applies if CI flags it
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/633"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783044037&installation_id=134682257&pr_number=633&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F633&signature=c770484f2958abfb5f94d6d53aa97262d80a7dc46c1a08c77c50f053658638dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
