### PR TITLE
fix(#622): make graph.html copy optional in /gsd-graphify build chain

### DIFF
--- a/.changeset/rapid-voles-hop.md
+++ b/.changeset/rapid-voles-hop.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 634
+---
+**`/gsd-graphify build` no longer fails when the graph is too large for an HTML visualization** — when a graph exceeds graphify's HTML viz node limit (default 5000) the `graph.html` artifact is intentionally skipped; the build pipeline now tolerates its absence instead of aborting, so `graph.json`, `GRAPH_REPORT.md`, the diff snapshot, and the status report all still complete.

--- a/commands/gsd/graphify.md
+++ b/commands/gsd/graphify.md
@@ -158,7 +158,7 @@ Run the build, copy artifacts, write the diff snapshot, and report the summary i
 ```bash
 graphify update . \
   && cp graphify-out/graph.json .planning/graphs/graph.json \
-  && cp graphify-out/graph.html .planning/graphs/graph.html \
+  && { [ -f graphify-out/graph.html ] && cp graphify-out/graph.html .planning/graphs/graph.html || true; } \
   && cp graphify-out/GRAPH_REPORT.md .planning/graphs/GRAPH_REPORT.md \
   && node "$HOME/.claude/gsd-core/bin/gsd-tools.cjs" graphify build snapshot \
   && node "$HOME/.claude/gsd-core/bin/gsd-tools.cjs" graphify status

--- a/scripts/lint-test-file-count.allowlist.json
+++ b/scripts/lint-test-file-count.allowlist.json
@@ -25,12 +25,13 @@
     },
     "graphify": {
       "files": [
+        "bug-622-graphify-optional-graph-html.test.cjs",
         "graphify-auto-update.test.cjs",
         "graphify-query.test.cjs",
         "graphify-visualization.test.cjs",
         "graphify.test.cjs"
       ],
-      "issue": "TBD"
+      "issue": "622"
     },
     "intel": {
       "files": [

--- a/tests/bug-622-graphify-optional-graph-html.test.cjs
+++ b/tests/bug-622-graphify-optional-graph-html.test.cjs
@@ -42,7 +42,7 @@ const GRAPHIFY_MD = path.join(__dirname, '..', 'commands', 'gsd', 'graphify.md')
 function extractStep3Block() {
   const content = fs.readFileSync(GRAPHIFY_MD, 'utf-8');
   // Capture from the `graphify update .` line through the next closing ``` fence.
-  const match = content.match(/```bash\n(graphify update \.[^\0]*?)```/);
+  const match = content.match(/```bash\r?\n(graphify update \.[^\0]*?)```/);
   return match ? match[1].trim() : null;
 }
 

--- a/tests/bug-622-graphify-optional-graph-html.test.cjs
+++ b/tests/bug-622-graphify-optional-graph-html.test.cjs
@@ -1,0 +1,216 @@
+// allow-test-rule: source-text-is-the-product
+// This test extracts the deployed Step 3 shell block from commands/gsd/graphify.md
+// and executes it to prove that a skipped graph.html (due to the graphify HTML viz
+// node limit) does not abort the chain (#622). The deployed markdown text IS the
+// product surface — the block the runtime executes — so asserting on its execution
+// behavior requires reading the source text.
+
+'use strict';
+
+/**
+ * Regression test for bug #622.
+ *
+ * The `/gsd-graphify build` Step 3 shell chain in commands/gsd/graphify.md
+ * aborted when `graph.html` was intentionally skipped (graph exceeds the HTML
+ * viz node limit, default 5000). The unconditional `cp graphify-out/graph.html`
+ * failed with "cannot stat", and the `&&` chain aborted before the
+ * GRAPH_REPORT.md copy, snapshot, and status steps ran.
+ *
+ * Fix: guard the graph.html copy with
+ *   `{ [ -f graphify-out/graph.html ] && cp … || true; }`
+ * so the chain continues when the file is absent.
+ */
+
+const { describe, test, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const { createTempDir, cleanup } = require('./helpers.cjs');
+
+// Path to the command doc (relative to repo root)
+const GRAPHIFY_MD = path.join(__dirname, '..', 'commands', 'gsd', 'graphify.md');
+
+/**
+ * Extract the Step 3 fenced bash block from graphify.md.
+ * The block starts with the line `graphify update .` and ends at the next
+ * closing ``` fence.
+ *
+ * Returns the bash source text (without the fence lines themselves).
+ */
+function extractStep3Block() {
+  const content = fs.readFileSync(GRAPHIFY_MD, 'utf-8');
+  // Capture from the `graphify update .` line through the next closing ``` fence.
+  const match = content.match(/```bash\n(graphify update \.[^\0]*?)```/);
+  return match ? match[1].trim() : null;
+}
+
+// ─── shared sandbox dirs ──────────────────────────────────────────────────────
+
+let sandbox;
+let fakeBin;
+let fakeHome;
+
+before(() => {
+  sandbox = createTempDir('gsd-622-sandbox-');
+  fakeBin = createTempDir('gsd-622-fakebin-');
+  fakeHome = createTempDir('gsd-622-fakehome-');
+});
+
+after(() => {
+  cleanup(sandbox);
+  cleanup(fakeBin);
+  cleanup(fakeHome);
+});
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Write a minimal fake `graphify` executable into fakeBin.
+ * It just exits 0 so the `graphify update .` step succeeds.
+ */
+function writeFakeGraphify() {
+  const exe = path.join(fakeBin, 'graphify');
+  fs.writeFileSync(exe, ['#!/bin/sh', 'exit 0'].join('\n'), { mode: 0o755 });
+}
+
+/**
+ * Write a minimal gsd-tools.cjs stub into fakeHome that exits 0 for any
+ * invocation (covers the `graphify build snapshot` and `graphify status` steps).
+ */
+function writeFakeGsdTools() {
+  const binDir = path.join(fakeHome, '.claude', 'gsd-core', 'bin');
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(binDir, 'gsd-tools.cjs'),
+    ['#!/usr/bin/env node', 'process.exit(0);'].join('\n'),
+    { mode: 0o755 },
+  );
+}
+
+/**
+ * Populate the sandbox with the minimal directory structure and output files
+ * that a real `graphify update .` would produce. `includeHtml` controls
+ * whether graphify-out/graph.html is created (simulating the node-limit skip
+ * when false).
+ */
+function populateSandbox(includeHtml) {
+  // graphify-out/ — simulates graphify CLI output directory
+  const outDir = path.join(sandbox, 'graphify-out');
+  fs.mkdirSync(outDir, { recursive: true });
+  fs.writeFileSync(path.join(outDir, 'graph.json'), '{}');
+  fs.writeFileSync(path.join(outDir, 'GRAPH_REPORT.md'), '# report');
+  if (includeHtml) {
+    fs.writeFileSync(path.join(outDir, 'graph.html'), '<html/>');
+  }
+
+  // .planning/graphs/ — destination directory
+  const graphsDir = path.join(sandbox, '.planning', 'graphs');
+  fs.mkdirSync(graphsDir, { recursive: true });
+}
+
+/**
+ * Execute the extracted Step 3 block in the sandbox.
+ */
+function runBlock(block) {
+  return spawnSync('bash', ['-c', block], {
+    cwd: sandbox,
+    env: {
+      ...process.env,
+      PATH: fakeBin + ':' + process.env.PATH,
+      HOME: fakeHome,
+    },
+    encoding: 'utf8',
+  });
+}
+
+// ─── tests ───────────────────────────────────────────────────────────────────
+
+describe('bug #622: graph.html absence must not abort the Step 3 shell chain', () => {
+  let block;
+
+  before(() => {
+    block = extractStep3Block();
+  });
+
+  test('Step 3 bash block is present in graphify.md (sanity gate)', () => {
+    assert.ok(block !== null, 'Step 3 bash block starting with "graphify update ." was not found in commands/gsd/graphify.md');
+    assert.ok(block.length > 0, 'Extracted bash block must not be empty');
+  });
+
+  test('graph.html absent: chain exits 0 and all other artifacts are copied (#622 regression)', (t) => {
+    // Use t.after for per-test cleanup so sandbox is fresh for each test
+    t.after(() => {
+      // Remove and recreate sandbox so the next test starts with an empty dir
+      cleanup(sandbox);
+      fs.mkdirSync(sandbox, { recursive: true });
+    });
+
+    writeFakeGraphify();
+    writeFakeGsdTools();
+    populateSandbox(false); // no graph.html — simulates node-limit skip
+
+    const result = runBlock(block);
+
+    // Chain must not abort
+    assert.equal(result.status, 0, [
+      'Expected exit 0 but got ' + result.status,
+      'stderr: ' + result.stderr,
+      'stdout: ' + result.stdout,
+    ].join('\n'));
+
+    // graph.json was copied (step before the guarded line)
+    assert.ok(
+      fs.existsSync(path.join(sandbox, '.planning', 'graphs', 'graph.json')),
+      '.planning/graphs/graph.json must be copied even when graph.html is absent',
+    );
+
+    // GRAPH_REPORT.md was copied (step AFTER the guarded line — key regression assertion)
+    assert.ok(
+      fs.existsSync(path.join(sandbox, '.planning', 'graphs', 'GRAPH_REPORT.md')),
+      '.planning/graphs/GRAPH_REPORT.md must be copied (the chain must not abort at graph.html)',
+    );
+
+    // graph.html must NOT exist in the destination (correctly skipped)
+    assert.ok(
+      !fs.existsSync(path.join(sandbox, '.planning', 'graphs', 'graph.html')),
+      '.planning/graphs/graph.html must NOT be created when source is absent',
+    );
+  });
+
+  test('graph.html present: chain exits 0 and graph.html is copied (happy path)', (t) => {
+    t.after(() => {
+      cleanup(sandbox);
+      fs.mkdirSync(sandbox, { recursive: true });
+    });
+
+    writeFakeGraphify();
+    writeFakeGsdTools();
+    populateSandbox(true); // include graph.html
+
+    const result = runBlock(block);
+
+    assert.equal(result.status, 0, [
+      'Expected exit 0 but got ' + result.status,
+      'stderr: ' + result.stderr,
+      'stdout: ' + result.stdout,
+    ].join('\n'));
+
+    // graph.html must exist in the destination (normal copy)
+    assert.ok(
+      fs.existsSync(path.join(sandbox, '.planning', 'graphs', 'graph.html')),
+      '.planning/graphs/graph.html must be copied when the source file is present',
+    );
+
+    // Other artifacts also copied
+    assert.ok(
+      fs.existsSync(path.join(sandbox, '.planning', 'graphs', 'graph.json')),
+      '.planning/graphs/graph.json must be copied',
+    );
+    assert.ok(
+      fs.existsSync(path.join(sandbox, '.planning', 'graphs', 'GRAPH_REPORT.md')),
+      '.planning/graphs/GRAPH_REPORT.md must be copied',
+    );
+  });
+});


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #622

The linked issue carries the `confirmed-bug` label.

---

## What was broken

`/gsd-graphify build` (Step 3 in `commands/gsd/graphify.md`) chained its steps with `&&` and copied `graphify-out/graph.html` unconditionally. When a graph exceeds graphify's HTML viz node limit (default 5000), `graphify update .` intentionally does **not** emit `graph.html`, so the `cp` failed with `cannot stat … No such file or directory`, aborting the chain before the `GRAPH_REPORT.md` copy, the diff-snapshot write, and the status report. `.planning/graphs/` was left inconsistent and the build reported `GRAPHIFY BUILD FAILED` even though the graph data rebuilt successfully.

## What this fix does

Guards the `graph.html` copy with `{ [ -f graphify-out/graph.html ] && cp graphify-out/graph.html .planning/graphs/graph.html || true; }`, so a skipped optional HTML artifact can no longer abort the chain. The remaining steps (report copy, snapshot, status) now always run. This mirrors the already-correct tolerant copy in `hooks/lib/gsd-graphify-rebuild.sh`.

## Root cause

The auto-update rebuild hook already tolerated a missing `graph.html` (`… || true`); the slash-command Step 3 pipeline was never given the equivalent guard, so the optional artifact's absence was treated as a hard failure.

## Testing

### How I verified the fix

Added `tests/bug-622-graphify-optional-graph-html.test.cjs` — a behavioral regression test that extracts the deployed Step 3 shell block from `commands/gsd/graphify.md` and **executes** it in a sandbox with a fake `graphify` (emits `graph.json` + `GRAPH_REPORT.md` but no `graph.html`) and a stubbed `gsd-tools.cjs`:
- **Regression case:** `graph.html` absent → chain exits 0, `graph.json` and `GRAPH_REPORT.md` are still copied, `graph.html` correctly absent from the destination. (Fails against the old hard-`&&` form with the exact `cp: … No such file or directory` / exit 1.)
- **Happy path:** `graph.html` present → all three artifacts copied, exit 0.

`node --test tests/bug-622-graphify-optional-graph-html.test.cjs` → 3/3 pass. `eslint` clean.

### Regression test added?

- [x] Yes — added a test that would have caught this bug

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added (follow-up commit references the PR number)
- [x] No unnecessary dependencies added

## Breaking changes

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/634"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783045745&installation_id=134682257&pr_number=634&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F634&signature=5eb8adc2110f152001c7922fa4d0a5c360c4943afd3cd3a87d374e1e847a2f84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->