### PR TITLE
fix(#621): route plan-phase post-planning-gaps through gsd_run launcher

### DIFF
--- a/.changeset/curious-lynx-travel.md
+++ b/.changeset/curious-lynx-travel.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 635
+---
+**`/gsd-plan-phase` gap-analysis no longer reports the tool as "not found" on non-default installs** — the post-planning-gaps step now resolves `gsd-tools` through the workflow's `gsd_run` launcher instead of a hardcoded `$HOME/.claude/...` path, so it works under relocated/global installs and non-Claude runtimes instead of silently falling back to a frontmatter-only coverage check.

--- a/gsd-core/workflows/plan-phase.md
+++ b/gsd-core/workflows/plan-phase.md
@@ -1628,7 +1628,7 @@ one place before execution begins.
 POST_PLANNING_GAPS=$(gsd_run query config-get workflow.post_planning_gaps --default true 2>/dev/null || echo true)
 if [ "$POST_PLANNING_GAPS" = "true" ]; then
   # Scope to this phase's mapped REQ-IDs (#447); null/TBD skips the requirements comparison (CONTEXT.md decisions still reported), mirroring §13.
-  node "$HOME/.claude/gsd-core/bin/gsd-tools.cjs" gap-analysis --phase-dir "${PHASE_DIR}" --phase-req-ids "$(node "$HOME/.claude/gsd-core/bin/gsd-tools.cjs" query init.plan-phase "$PHASE" --pick phase_req_ids 2>/dev/null || echo TBD)"
+  gsd_run gap-analysis --phase-dir "${PHASE_DIR}" --phase-req-ids "$(gsd_run query init.plan-phase "$PHASE" --pick phase_req_ids 2>/dev/null || echo TBD)"
 fi
 ```
 

--- a/tests/bug-2851-workflow-bare-gsd-tools.test.cjs
+++ b/tests/bug-2851-workflow-bare-gsd-tools.test.cjs
@@ -7,6 +7,10 @@
  *
  *   node "$HOME/.claude/gsd-core/bin/gsd-tools.cjs" <subcommand> [args]
  *
+ * As of #621, the §13e gap-analysis call uses the `gsd_run` launcher (the
+ * canonical resolvable form) instead of the absolute-$HOME path above.
+ * Both forms are resolvable; `gsd_run` is now the preferred canonical form.
+ *
  * Some workflow markdown files leaked the bare `gsd-tools <subcommand>` form,
  * which fails with `command not found` at runtime.
  *
@@ -143,7 +147,7 @@ describe('bug-2851: workflow files must not call bare `gsd-tools` (#2245 sweep r
     );
   });
 
-  test('plan-phase.md §13e gap-analysis uses canonical absolute-path invocation', () => {
+  test('plan-phase.md §13e gap-analysis uses the gsd_run launcher (resolvable invocation, #621)', () => {
     const planPhase = fs.readFileSync(path.join(WORKFLOWS_DIR, 'plan-phase.md'), 'utf-8');
     const blocks = extractShellBlocks(planPhase);
     let foundGapAnalysisCall = false;
@@ -153,8 +157,8 @@ describe('bug-2851: workflow files must not call bare `gsd-tools` (#2245 sweep r
           foundGapAnalysisCall = true;
           assert.match(
             line,
-            /\bnode\s+["']?\$HOME\/\.claude\/gsd-core\/bin\/gsd-tools\.cjs["']?\s+gap-analysis\b/,
-            `gap-analysis call must use canonical absolute-path invocation, got: ${line.trim()}`,
+            /\bgsd_run\s+gap-analysis\b/,
+            `gap-analysis must use the gsd_run launcher (not a hardcoded $HOME path), got: ${line.trim()}`,
           );
         }
       }

--- a/tests/bug-621-plan-phase-gap-analysis-gsd-run.test.cjs
+++ b/tests/bug-621-plan-phase-gap-analysis-gsd-run.test.cjs
@@ -1,0 +1,84 @@
+// allow-test-rule: source-text-is-the-product
+// The post-planning-gaps gap-analysis invocation is deployed workflow text the
+// runtime executes; the contract is that it routes through the gsd_run launcher,
+// not a hardcoded $HOME path (#621).
+
+/**
+ * Regression test for #621: plan-phase gap-analysis must route through gsd_run
+ *
+ * Prior to the fix, line 1631 of plan-phase.md hardcoded:
+ *   node "$HOME/.claude/gsd-core/bin/gsd-tools.cjs" gap-analysis ...
+ * twice on the same line, breaking non-default install layouts.
+ *
+ * After the fix, both invocations route through gsd_run (the launcher defined
+ * at line ~34 of the same file that resolves gsd-tools.cjs against
+ * RUNTIME_DIR / git-toplevel / PATH / $HOME in order).
+ */
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const WORKFLOW_PATH = path.join(
+  __dirname,
+  '..',
+  'gsd-core',
+  'workflows',
+  'plan-phase.md'
+);
+
+// ─── Fixture ──────────────────────────────────────────────────────────────────
+
+const workflow = fs.readFileSync(WORKFLOW_PATH, 'utf8');
+
+// ─── #621 regression: gap-analysis routes through gsd_run ────────────────────
+
+describe('plan-phase workflow: post-planning-gaps gap-analysis uses gsd_run launcher (#621)', () => {
+  test('gap-analysis call routes through gsd_run, not hardcoded node path', () => {
+    assert.ok(
+      workflow.includes('gsd_run gap-analysis'),
+      'workflow must invoke gap-analysis via gsd_run, not a hardcoded node path'
+    );
+  });
+
+  test('inner phase_req_ids query also routes through gsd_run', () => {
+    assert.ok(
+      workflow.includes('gsd_run query init.plan-phase'),
+      'workflow must invoke the inner phase_req_ids query via gsd_run launcher'
+    );
+  });
+
+  test('no hardcoded node "$HOME/.claude/gsd-core/bin/gsd-tools.cjs" invocations remain (#621)', () => {
+    const hardcodedCount = (
+      workflow.match(/node "\$HOME\/\.claude\/gsd-core\/bin\/gsd-tools\.cjs"/g) || []
+    ).length;
+    assert.strictEqual(
+      hardcodedCount,
+      0,
+      [
+        '#621 regression: workflow must not contain any hardcoded',
+        'node "$HOME/.claude/gsd-core/bin/gsd-tools.cjs" invocations;',
+        `found ${hardcodedCount}`,
+      ].join(' ')
+    );
+  });
+
+  test('post-planning-gaps block still gates on workflow.post_planning_gaps and preserves required args', () => {
+    const hasGate = workflow.includes('workflow.post_planning_gaps');
+    const hasPhaseDir = workflow.includes('--phase-dir "${PHASE_DIR}"');
+    const hasPickArg = workflow.includes('--pick phase_req_ids');
+    assert.ok(
+      hasGate,
+      'workflow must still gate the gap-analysis step on workflow.post_planning_gaps config key'
+    );
+    assert.ok(
+      hasPhaseDir,
+      'gap-analysis invocation must still pass --phase-dir "${PHASE_DIR}"'
+    );
+    assert.ok(
+      hasPickArg,
+      'inner query must still pass --pick phase_req_ids to extract phase requirement IDs'
+    );
+  });
+});


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #621

The linked issue carries the `confirmed-bug` label.

---

## What was broken

In `gsd-core/workflows/plan-phase.md`, the post-planning-gaps step invoked `gsd-tools` via a hardcoded `node "$HOME/.claude/gsd-core/bin/gsd-tools.cjs"` path — twice on the same line, for the `gap-analysis` call and its nested `query init.plan-phase … --pick phase_req_ids` call. Every other `gsd-tools` invocation in the workflow goes through the `gsd_run()` launcher. On any install/runtime layout where the tool is not at `$HOME/.claude/...` (relocated/global installs, non-Claude runtimes), the hardcoded path does not resolve, so the assistant reported the gap-analysis tool as "not found" and silently fell back to a frontmatter-only coverage check even though a working install was present.

## What this fix does

Routes both invocations in that block through `gsd_run` — the launcher already defined near line 34 of the same file, which resolves `gsd-tools.cjs` against `RUNTIME_DIR` / git-toplevel / `PATH` / `$HOME` in order. The gap-analysis arguments (`--phase-dir`, nested `--pick phase_req_ids`, the `2>/dev/null || echo TBD` fallback) are unchanged. No hardcoded `$HOME` gsd-tools path remains anywhere in `plan-phase.md`.

## Root cause

`#3668` introduced the launcher-based resolution and converted the early section of the workflow, but the post-planning-gaps invocation was missed in that pass and kept its `$HOME`-hardcoded form.

## Testing

### How I verified the fix

Added `tests/bug-621-plan-phase-gap-analysis-gsd-run.test.cjs` — a source-text contract regression test (the workflow `.md` is the deployed product surface the runtime executes, same pattern as the existing `tests/plan-phase-drift-guard.test.cjs`). It asserts: (1) the gap-analysis call uses `gsd_run gap-analysis`; (2) the nested query uses `gsd_run query init.plan-phase`; (3) **negative proof** — zero `node "$HOME/.claude/gsd-core/bin/gsd-tools.cjs"` invocations remain in the file (this assertion fails against the pre-fix text); (4) the block still gates on `workflow.post_planning_gaps` and preserves the `--phase-dir` / `--pick phase_req_ids` arguments.

`node --test tests/bug-621-plan-phase-gap-analysis-gsd-run.test.cjs` → 4/4 pass. `eslint` clean.

### Regression test added?

- [x] Yes — added a test that would have caught this bug

### Platforms tested

- [x] N/A (not platform-specific)

### Runtimes tested

- [x] N/A (the fix specifically restores correct behavior across all runtimes/install layouts; verified via the deployed-text contract test)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included (only line 1631)
- [x] Regression test added
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added (follow-up commit references the PR number)
- [x] No unnecessary dependencies added

## Breaking changes

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/635"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783045939&installation_id=134682257&pr_number=635&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F635&signature=d4827c42f40503b0354a3d7d84a2be06796c2a2f3a10d422fa6f64718a28730c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->