### PR TITLE
fix(#621): resolve gap-analysis via gsd_run launcher in plan-phase post-planning-gaps

### DIFF
--- a/.changeset/gentle-ravens-purr.md
+++ b/.changeset/gentle-ravens-purr.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 636
+---
+**`/gsd-plan-phase` post-planning gap analysis now runs on global installs** — the §13e gap-analysis step resolves `gsd-tools` via the runtime launcher instead of a hardcoded `$HOME` path, so it no longer falsely reports the tool as "not found" (and silently skips the gap report) when only a global/shim install is present.

--- a/gsd-core/workflows/plan-phase.md
+++ b/gsd-core/workflows/plan-phase.md
@@ -1628,7 +1628,7 @@ one place before execution begins.
 POST_PLANNING_GAPS=$(gsd_run query config-get workflow.post_planning_gaps --default true 2>/dev/null || echo true)
 if [ "$POST_PLANNING_GAPS" = "true" ]; then
   # Scope to this phase's mapped REQ-IDs (#447); null/TBD skips the requirements comparison (CONTEXT.md decisions still reported), mirroring §13.
-  node "$HOME/.claude/gsd-core/bin/gsd-tools.cjs" gap-analysis --phase-dir "${PHASE_DIR}" --phase-req-ids "$(node "$HOME/.claude/gsd-core/bin/gsd-tools.cjs" query init.plan-phase "$PHASE" --pick phase_req_ids 2>/dev/null || echo TBD)"
+  gsd_run gap-analysis --phase-dir "${PHASE_DIR}" --phase-req-ids "$(gsd_run query init.plan-phase "$PHASE" --pick phase_req_ids 2>/dev/null || echo TBD)"
 fi
 ```
 

--- a/tests/bug-2851-workflow-bare-gsd-tools.test.cjs
+++ b/tests/bug-2851-workflow-bare-gsd-tools.test.cjs
@@ -138,12 +138,16 @@ describe('bug-2851: workflow files must not call bare `gsd-tools` (#2245 sweep r
       violations,
       [],
       'Bare `gsd-tools` invocations found in workflow shell blocks. ' +
-        'Use a resolver snippet or `node "$HOME/.claude/gsd-core/bin/gsd-tools.cjs" <subcommand>` instead.\n' +
+        'Use the `gsd_run` resolver (defined once in the canonical launcher preamble) instead.\n' +
         violations.join('\n'),
     );
   });
 
-  test('plan-phase.md §13e gap-analysis uses canonical absolute-path invocation', () => {
+  // #621: the gap-analysis call previously used a hardcoded
+  // `node "$HOME/.claude/gsd-core/bin/gsd-tools.cjs"` path, which misses a working
+  // global install when no project-local runtime exists. It must now go through the
+  // resolved `gsd_run` launcher like every other invocation in the file.
+  test('plan-phase.md gap-analysis is invoked via the gsd_run resolver (#621)', () => {
     const planPhase = fs.readFileSync(path.join(WORKFLOWS_DIR, 'plan-phase.md'), 'utf-8');
     const blocks = extractShellBlocks(planPhase);
     let foundGapAnalysisCall = false;
@@ -153,8 +157,8 @@ describe('bug-2851: workflow files must not call bare `gsd-tools` (#2245 sweep r
           foundGapAnalysisCall = true;
           assert.match(
             line,
-            /\bnode\s+["']?\$HOME\/\.claude\/gsd-core\/bin\/gsd-tools\.cjs["']?\s+gap-analysis\b/,
-            `gap-analysis call must use canonical absolute-path invocation, got: ${line.trim()}`,
+            /\bgsd_run\s+gap-analysis\b/,
+            `gap-analysis must use the resolved gsd_run launcher (#621), not a hardcoded path, got: ${line.trim()}`,
           );
         }
       }

--- a/tests/bug-621-plan-phase-sdk-resolution.test.cjs
+++ b/tests/bug-621-plan-phase-sdk-resolution.test.cjs
@@ -1,0 +1,47 @@
+// allow-test-rule: source-text-is-the-product
+// plan-phase.md workflow text IS what the runtime loads and the agent executes,
+// so asserting on its bash invocations tests the deployed contract directly.
+// Regression guard for #621: the §13e post-planning-gaps gap-analysis step must
+// invoke gsd-tools through the resolved `gsd_run` launcher (defined once in the
+// canonical preamble), NOT a hardcoded "$HOME/.claude/.../gsd-tools.cjs" path —
+// which misses a working global install when no project-local runtime exists.
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const PLAN_PHASE = path.join(__dirname, '..', 'gsd-core', 'workflows', 'plan-phase.md');
+
+// The #621 bug form: a direct `node "$HOME/.../gsd-tools.cjs" <cmd>` invocation.
+// This is deliberately distinct from the canonical launcher preamble, which
+// references $HOME only inside a `[ -f "$HOME/..." ]` probe / `GSD_TOOLS=` assignment
+// and always invokes the tool as `node "$GSD_TOOLS"` (the resolved variable) — so the
+// preamble never matches this pattern and is not a false positive.
+const HARDCODED_HOME_INVOCATION = /node\s+"\$HOME\/[^"]*gsd-tools\.cjs"/;
+
+describe('bug #621: plan-phase post-planning-gaps SDK resolution', () => {
+  const content = fs.readFileSync(PLAN_PHASE, 'utf8');
+
+  test('no hardcoded "node \\"$HOME/.../gsd-tools.cjs\\"" invocation survives anywhere in plan-phase.md', () => {
+    const offending = content
+      .split(/\r?\n/)
+      .map((line, i) => ({ line, n: i + 1 }))
+      .filter(({ line }) => HARDCODED_HOME_INVOCATION.test(line))
+      .map((o) => o.n);
+    assert.deepEqual(
+      offending,
+      [],
+      `plan-phase.md must invoke gsd-tools via the resolved gsd_run launcher, not a hardcoded $HOME path. Offending line(s): ${offending.join(', ') || '(none)'}`,
+    );
+  });
+
+  test('post-planning-gaps gap-analysis is invoked via the gsd_run launcher', () => {
+    const gapLine = content
+      .split(/\r?\n/)
+      .find((line) => /\bgap-analysis --phase-dir\b/.test(line));
+    assert.ok(gapLine, 'expected a gap-analysis --phase-dir invocation in plan-phase.md');
+    assert.match(gapLine, /gsd_run gap-analysis --phase-dir/, 'gap-analysis must be invoked via the resolved gsd_run launcher');
+    assert.doesNotMatch(gapLine, HARDCODED_HOME_INVOCATION, 'gap-analysis line must not hardcode a $HOME gsd-tools path');
+  });
+});


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #621

The linked issue carries the `confirmed-bug` label.

---

## What was broken

`plan-phase.md`'s §13e post-planning-gaps step invoked the gap-analysis tool via a hardcoded `node "$HOME/.claude/gsd-core/bin/gsd-tools.cjs"` path. On a global/shim-only install with no project-local runtime, that path can miss a working install — so the assistant reports the gap-analysis tool "not found" and silently falls back to a frontmatter-only coverage check, even though a valid SDK is present.

## What this fix does

Routes the gap-analysis call (and its nested `init.plan-phase` query) through the resolved `gsd_run` launcher — the same resolver the line directly above it already used, and the one every other invocation in the file uses.

## Root cause

#3668 introduced the runtime-launcher resolution pattern and migrated the early sections of `plan-phase.md`, but the §13e gap-analysis invocation was missed in that pass. The result was an in-block inconsistency: line 1628 used `gsd_run`, line 1631 hardcoded `$HOME`. The `runtime-launcher-parity` test guards against retired `$GSD_SDK` / bare `/gsd-tools` tokens but not against the hardcoded `node "$HOME/...gsd-tools.cjs"` invocation form, so it slipped through.

## Testing

### How I verified the fix

- Added `tests/bug-621-plan-phase-sdk-resolution.test.cjs` — verified it **fails on the pre-fix file** (2/2 fail when the `$HOME` line is restored via `git stash`) and **passes after** (2/2).
- `tests/runtime-launcher-parity.test.cjs` — 7/7 (preamble invariant intact; the file still defines `gsd_run` exactly once before first use).
- Full unit suite (`npm run test:unit`) — **3458 pass / 0 fail** (3 pre-existing environment skips).

### Regression test added?

- [x] Yes — added a test that would have caught this bug

### Platforms tested

- [x] Windows (including backslash path handling)
- [ ] macOS
- [ ] Linux
- [ ] N/A (not platform-specific)

> Note: the fix is a workflow `.md` shell-invocation change; the bug reproduces on macOS/Linux global installs per the issue. The regression guard is platform-agnostic (asserts on workflow source text).

### Runtimes tested

- [x] N/A (not runtime-specific — workflow launcher resolution)

---

## Checklist

- [x] Issue linked above with `Fixes #621`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass (full unit suite green)
- [x] `.changeset/` fragment added (user-facing `Fixed`) — added in a follow-up commit with the assigned PR number
- [x] No unnecessary dependencies added

### Scope note

Per the approved issue this PR is scoped to `plan-phase.md`. The repo-wide sweep the issue suggested found the same hardcoded form in `ingest-docs.md`, `plan-review-convergence.md`, and `spec-phase.md` — these are **out of scope** here and will be raised as a separate follow-up issue rather than expanding this PR.

The `tests/bug-2851` §13e assertion was updated (not added): it previously pinned gap-analysis to the absolute-path form, which predates the `gsd_run` launcher migration and directly contradicts this fix. Flipping it to assert `gsd_run` is the mandatory behavior-change test update, and is consistent with bug-2851's own "no bare `gsd-tools`" intent.

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/636"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783046673&installation_id=134682257&pr_number=636&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F636&signature=a48f897d559b6218837f95643125cde375a020d4d46fecdcb19903155a93ca7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->