### PR TITLE
fix(#631): correct stale code references in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -534,7 +534,7 @@ Generator tests should run in temp fixtures and assert atomic output behavior. D
 ```javascript
 // BAD — source-grep theater
 const configSrc = fs.readFileSync(
-  path.join(GSD_ROOT, 'bin', 'lib', 'config-schema.cjs'), 'utf-8'
+  path.join(GSD_ROOT, 'gsd-core', 'bin', 'lib', 'config-schema.cjs'), 'utf-8'
 );
 assert.ok(
   configSrc.includes("'workflow.plan_bounce'"),
@@ -565,7 +565,7 @@ This single test covers key registration in `VALID_CONFIG_KEYS`, the key's names
 
 **Why this pattern broke at scale:** Commit `990c3e64` in this repo updated 5 source-grep tests in one pass when `VALID_CONFIG_KEYS` moved between files. Zero of those tests were testing behavior. If they had been behavioral tests, the migration would have been invisible.
 
-**CI enforcement:** A linter (`scripts/lint-no-source-grep.cjs`, run as `npm run lint:tests`) detects violations. Any test file that calls `readFileSync` on a `.cjs` path in a source directory without the exemption annotation below will fail the `lint-tests` CI job.
+**CI enforcement:** The `local/no-source-grep` ESLint rule (`eslint-rules/no-source-grep.cjs`, wired in `eslint.config.mjs`) detects violations. Any test file that calls `readFileSync` on a `.cjs` path in a source directory without the exemption annotation below is flagged by `npx eslint .` (the `Lint — ESLint` CI step).
 
 ### Exception: `allow-test-rule: <reason>`
 
@@ -636,11 +636,9 @@ Concretely: for any system-under-test that produces text output (a file renderer
 | Error / status / reason | A frozen enum (`Object.freeze({ FAIL_X: 'fail_x', ... })`) | `assert.equal(result.reason, REASON.FAIL_X)` |
 | File presence after a write | `fs.statSync().isFile()`, `.size > 0`, `.mtimeMs` advances | Filesystem facts; never read the file content back |
 
-#### Concrete examples from this repo
+#### Concrete example from this repo
 
-`buildWindowsShimTriple(shimSrc)` in `bin/install.js` is the canonical IR pattern: pure function, no I/O, returns `{ invocation, eol, fileNames, render }`. `trySelfLinkGsdSdkWindows` calls it and writes `triple.render[kind]()` to disk. Tests assert on `triple.invocation.target`, `triple.eol.cmd`, `Object.keys(triple).sort()` — never on the rendered text. Filesystem-level tests assert `fs.statSync(target).size === Buffer.byteLength(triple.render.cmd())` to prove the writer writes what the renderer produces, **without comparing content**.
-
-`scripts/verify-reapply-patches.cjs` exposes a frozen `REASON` enum and emits it through `--json`. Tests assert `report.results[0].reason === REASON.FAIL_USER_LINES_MISSING`. The human formatter exists for operator console output only — tests must not depend on its prose. Adding a new reason code requires updating the `REASON` enum, the `--json` output, AND the test that locks `Object.keys(REASON).sort()` — three coordinated changes that prevent the code surface from drifting from the test surface.
+`gsd-core/bin/verify-reapply-patches.cjs` exposes a frozen `REASON` enum and emits it through `--json`. Tests assert `report.results[0].reason === REASON.FAIL_USER_LINES_MISSING` rather than regex-matching the human-readable prose. The human formatter exists for operator console output only — tests must not depend on it. Adding a new reason code requires updating the `REASON` enum, the `--json` output, AND the test that locks `Object.keys(REASON).sort()` — three coordinated changes that keep the code surface from drifting from the test surface. A pure builder that returns the IR (no I/O) and a writer that consumes it — `fs.statSync(target).size === Buffer.byteLength(render())` to prove the writer writes what the renderer produces, **without comparing content** — is the same pattern applied to rendered files.
 
 #### Hiding grep behind a function is still grep
 
@@ -655,7 +653,7 @@ There are exactly two cases where text content is the legitimate object of a tes
 
 For everything else, if a test reaches for `.includes()` / `.startsWith()` / `assert.match(text, /…/)`, the production code is missing a typed surface. **Add the typed surface; do not work around it.**
 
-**CI enforcement:** `scripts/lint-no-source-grep.cjs` is being extended (see issue tracker for the latest scope) to flag `String#includes`/`String#startsWith`/`String#endsWith`/`assert.match` on `readFileSync` results and on `cp.spawnSync` stdout/stderr in test files, with the same `// allow-test-rule:` exemption mechanism.
+**CI enforcement:** the `local/no-source-grep` ESLint rule (`eslint-rules/no-source-grep.cjs`) is being extended (see issue tracker for the latest scope) to flag `String#includes`/`String#startsWith`/`String#endsWith`/`assert.match` on `readFileSync` results and on `cp.spawnSync` stdout/stderr in test files, with the same `// allow-test-rule:` exemption mechanism.
 
 ### Node.js Version Compatibility
 
@@ -791,11 +789,9 @@ The following checks run on every PR in addition to the test suite:
 
 | Job | What it checks | How to pass |
 |-----|----------------|-------------|
-| `lint-tests` | No source-grep tests (see above) | Replace with `runGsdTools()` behavioral tests, or add `// allow-test-rule: <reason>` |
+| `Lint — ESLint` | No source-grep tests (see above), via the `local/no-source-grep` rule | Replace with `runGsdTools()` behavioral tests, or add `// allow-test-rule: <reason>` |
 
-Run locally before pushing: `npm run lint:tests`
-
-### Test Requirements by Contribution Type
+Run locally before pushing: `npm run lint` (or `npx eslint .`)
 
 ### Architecture-Aware Testing Requirements
 
@@ -804,6 +800,8 @@ When work touches architecture, routing, policy, registry assembly, or command s
 - Prefer invariant/contract tests that protect ADR-backed behavior and `CONTEXT.md` terminology.
 - Ensure tests validate canonical behavior through the defined seam (for example: structured result contracts, canonical command metadata, and adapter parity), not source-text coupling.
 - If ADRs define expected behavior, tests should assert those expectations directly.
+
+### Test Requirements by Contribution Type
 
 The required tests differ depending on what you are contributing:
 


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #631

The linked issue carries the `confirmed` label (maintainer-verified). Note: the issue is labeled `confirmed` rather than `confirmed-bug`; both are treated identically by repo automation, and `confirmed` is the maintainer's verification of this documentation defect.

---

## What was broken

`CONTRIBUTING.md` contained four stale code-facing references left behind by three already-merged changes (#452, #604, and the gsd-sdk shim removal). Each pointed contributors at a command, file, or symbol that no longer exists or moved, so following the doc fails.

## What this fix does

Corrects all four references to match the current codebase, and fixes one malformed (empty) section heading.

## Root cause

- **#452** migrated source-grep enforcement to the `local/no-source-grep` ESLint rule but the doc still told contributors to run `npm run lint:tests` (no such script) and described a `lint-tests` CI job.
- **#604** renamed `get-shit-done/` → `gsd-core/` but left stale `bin/lib/…` and `scripts/verify-reapply-patches.cjs` paths in the doc.
- The **gsd-sdk shim removal** deleted `buildWindowsShimTriple`, which the doc still cited as the "canonical IR pattern."

## Testing

### How I verified the fix

Documentation-only change. Verified each corrected reference against the live tree:
- `eslint.config.mjs:12,176` — `local/no-source-grep` is the live rule; `npm run lint` runs ESLint (no `lint:tests` script in `package.json`).
- `gsd-core/bin/verify-reapply-patches.cjs` — correct path; `REASON` enum present.
- `tests/bug-3442-shim-projection-drift-guard.test.cjs:23` — confirms `buildWindowsShimTriple` was removed.
- `gsd-core/bin/lib/` — correct prefix per ADR-457.

### Regression test added?

- [ ] Yes
- [x] No — explain why: this is a prose documentation correction with no runtime surface; the references are now verified against the live tree. A doc-link linter would be the right guard but is out of scope for this fix.

### Platforms tested

- [x] N/A (not platform-specific)

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #631`
- [x] Linked issue has the `confirmed` label (see note above re: `confirmed` vs `confirmed-bug`)
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not — see above)
- [x] All existing tests pass (no code changed)
- [x] `.changeset/` fragment — not required: `CONTRIBUTING.md` is not a changeset-trigger path and the change is docs-only
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/638"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783047078&installation_id=134682257&pr_number=638&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F638&signature=2c2426c0e7b68de6ad08a36ddd199c13528a45db9a5bb681bbe8b5e06c58ee65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->