### PR TITLE
fix(#628): read snake_case requirements_completed in summary-extract

### DIFF
--- a/.changeset/clever-deer-wander.md
+++ b/.changeset/clever-deer-wander.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 640
+---
+**`gsd-tools query summary-extract` no longer drops snake_case `requirements_completed`** — the reader now accepts both the kebab `requirements-completed` and the snake `requirements_completed` key forms (the snake form is what the tool's own JSON output and the milestone audit `--pick` emit), so a round-tripped requirements field is no longer silently read back as empty.

--- a/src/commands.cts
+++ b/src/commands.cts
@@ -750,7 +750,11 @@ function cmdSummaryExtract(cwd: string, summaryPath: string | undefined, fields:
     tech_added: (techStack && techStack['added']) || [],
     patterns: fm['patterns-established'] || [],
     decisions: parseDecisions(fm['key-decisions']),
-    requirements_completed: fm['requirements-completed'] || [],
+    // Tolerate both key forms: the template/reader use kebab `requirements-completed`,
+    // but the tool's own JSON output and the milestone audit `--pick` use snake
+    // `requirements_completed`. Reading both prevents a snake-keyed SUMMARY (the form the
+    // tool emits) from being silently dropped to []. See #628.
+    requirements_completed: fm['requirements-completed'] ?? fm['requirements_completed'] ?? [],
   };
 
   // If fields specified, filter to only those fields

--- a/tests/commands.test.cjs
+++ b/tests/commands.test.cjs
@@ -424,6 +424,61 @@ one-liner: Minimal summary
     assert.deepStrictEqual(output.requirements_completed, [], 'requirements_completed defaults to empty');
   });
 
+  test('reads requirements in snake_case form the tool itself emits (#628)', () => {
+    // Regression: the tool's JSON output key and the milestone-audit `--pick` both use the
+    // snake form `requirements_completed`, so operators naturally write that into SUMMARY
+    // frontmatter. The reader must accept it, not silently drop it to [].
+    const phaseDir = path.join(tmpDir, '.planning', 'phases', '01-foundation');
+    fs.mkdirSync(phaseDir, { recursive: true });
+
+    fs.writeFileSync(
+      path.join(phaseDir, '01-01-SUMMARY.md'),
+      `---
+one-liner: Snake-keyed summary
+requirements_completed:
+  - REQ-1
+  - REQ-2
+---
+
+# Summary
+`
+    );
+
+    const result = runGsdTools('summary-extract .planning/phases/01-foundation/01-01-SUMMARY.md', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.deepStrictEqual(output.requirements_completed, ['REQ-1', 'REQ-2'],
+      'snake-case requirements_completed should be read, not dropped to []');
+  });
+
+  test('prefers kebab requirements-completed when both key forms are present (#628)', () => {
+    // kebab is the documented template form and must win the tolerance fallback.
+    const phaseDir = path.join(tmpDir, '.planning', 'phases', '01-foundation');
+    fs.mkdirSync(phaseDir, { recursive: true });
+
+    fs.writeFileSync(
+      path.join(phaseDir, '01-01-SUMMARY.md'),
+      `---
+one-liner: Both key forms present
+requirements-completed:
+  - KEBAB-1
+requirements_completed:
+  - SNAKE-1
+---
+
+# Summary
+`
+    );
+
+    const result = runGsdTools('summary-extract .planning/phases/01-foundation/01-01-SUMMARY.md', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.deepStrictEqual(output.requirements_completed, ['KEBAB-1'],
+      'kebab key should take precedence over snake when both are present');
+  });
+
   test('parses key-decisions with rationale', () => {
     const phaseDir = path.join(tmpDir, '.planning', 'phases', '01-foundation');
     fs.mkdirSync(phaseDir, { recursive: true });


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #628

> The linked issue carries the `confirmed` label (bug verified to exist).

---

## What was broken

`gsd-tools query summary-extract` read only the **kebab** frontmatter key `requirements-completed`, but the tool's own JSON output key and the `audit-milestone` `--pick` both use the **snake** form `requirements_completed`. A SUMMARY whose frontmatter used the snake form — the exact form the tool emits and the audit picks — was read back as `[]` with no error, silently losing milestone requirement traceability.

## What this fix does

Makes the reader tolerant of both key forms at `src/commands.cts:753`:

```js
requirements_completed: fm['requirements-completed'] ?? fm['requirements_completed'] ?? [],
```

Kebab (the documented template form) takes precedence; the snake form the tool emits is now also accepted. Byte-identical behavior for existing kebab SUMMARYs.

## Root cause

`extractFrontmatter` stores keys verbatim with no hyphen↔underscore normalization, so `fm['requirements_completed']` and `fm['requirements-completed']` are distinct keys. The reader looked up only the kebab key while the tool's output/audit conventions point operators at the snake key — a key-form asymmetry that shipped because tests covered only the kebab form.

## Testing

### How I verified the fix

Added two regression tests in `tests/commands.test.cjs` and confirmed red→green (kebab-only source fails the snake fixture; the fix makes it pass). Full unit suite: 2956 passing. `npm run lint`: 0 errors.

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [x] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed` label (bug verified to exist)
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass (`npm test` — unit suite 2956 passing)
- [x] `.changeset/` fragment added (added after PR number assigned)
- [x] No unnecessary dependencies added

## Breaking changes

None — kebab SUMMARYs and the documented template are unchanged; the fix only additionally accepts the snake key the tool already emits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/640"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783050407&installation_id=134682257&pr_number=640&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F640&signature=baa8989e47514c26e9ee22cf4e3a0302f4ef61c76484b4c7cd6472dcc2f7d107"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->