### PR TITLE
fix(#586): make ship PHASE_VERIFICATION_INCOMPLETE actionable, drop dead `pass` status branch

### DIFF
--- a/.changeset/ship-verification-actionable.md
+++ b/.changeset/ship-verification-actionable.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 650
 ---
 **ship now tells you how to clear a blocked verification** — the `PHASE_VERIFICATION_INCOMPLETE` block names the exact next action per status (`gaps_found`, `human_needed`, or missing), and the dead `pass` status arm is gone. (#586)

--- a/.changeset/ship-verification-actionable.md
+++ b/.changeset/ship-verification-actionable.md
@@ -2,4 +2,4 @@
 type: Fixed
 pr: 650
 ---
-**ship now tells you how to clear a blocked verification** — the `PHASE_VERIFICATION_INCOMPLETE` block names the exact next action per status (`gaps_found`, `human_needed`, or missing), and the dead `pass` status arm is gone. (#586)
+**ship now tells you how to clear a blocked verification** — the `PHASE_VERIFICATION_INCOMPLETE` block names the exact next action per status (`gaps_found`, `human_needed`, or missing), and the dead `pass` status arm is gone.

--- a/.changeset/ship-verification-actionable.md
+++ b/.changeset/ship-verification-actionable.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**ship now tells you how to clear a blocked verification** — the `PHASE_VERIFICATION_INCOMPLETE` block names the exact next action per status (`gaps_found`, `human_needed`, or missing), and the dead `pass` status arm is gone. (#586)

--- a/gsd-core/workflows/ship.md
+++ b/gsd-core/workflows/ship.md
@@ -41,10 +41,15 @@ Verify the work is ready to ship:
 
 1. **Verification passed?**
    ```bash
-   VERIFICATION=$(cat ${PHASE_DIR}/*-VERIFICATION.md 2>/dev/null)
+   VERIFICATION_FILE=$(ls ${PHASE_DIR}/*-VERIFICATION.md 2>/dev/null | head -1)
+   STATUS=$(grep "^status:" "${VERIFICATION_FILE}" 2>/dev/null | cut -d: -f2 | tr -d ' ')
    ```
-   Check for `status: pass` or `status: passed`.
-   If no VERIFICATION.md or status is anything other than `pass` / `passed` (including `human_needed` / `gaps_found`): block with `PHASE_VERIFICATION_INCOMPLETE`; complete or formally re-run verification before shipping.
+   The verifier emits exactly `passed`, `gaps_found`, or `human_needed` (see the status table in `execute-phase.md`); only `passed` may ship. Route on `${STATUS}` — on any non-`passed` value, block with `PHASE_VERIFICATION_INCOMPLETE` and state the matching next action:
+   - `passed` → verification complete; continue to the next preflight check.
+   - `gaps_found` → run `/gsd:plan-phase ${PHASE_NUMBER} --gaps` to plan the fixes, then re-run `/gsd:execute-phase` before shipping.
+   - `human_needed` → complete the manual tests in `${PHASE_DIR}/*-UAT.md`, then re-run the verify step until status is `passed`.
+   - empty (no `*-VERIFICATION.md`) → the verify step never completed; re-run `/gsd:execute-phase`.
+   - any other value → unexpected status `${STATUS}`; re-run `/gsd:execute-phase` verification.
 
 2. **Clean working tree?**
    ```bash

--- a/gsd-core/workflows/ship.md
+++ b/gsd-core/workflows/ship.md
@@ -42,7 +42,7 @@ Verify the work is ready to ship:
 1. **Verification passed?**
    ```bash
    VERIFICATION_FILE=$(ls ${PHASE_DIR}/*-VERIFICATION.md 2>/dev/null | head -1)
-   STATUS=$(grep "^status:" "${VERIFICATION_FILE}" 2>/dev/null | cut -d: -f2 | tr -d ' ')
+   STATUS=$(sed -n '/^---$/,/^---$/p' "${VERIFICATION_FILE}" 2>/dev/null | grep -m1 "^status:" | cut -d: -f2 | tr -d ' ')
    ```
    The verifier emits exactly `passed`, `gaps_found`, or `human_needed` (see the status table in `execute-phase.md`); only `passed` may ship. Route on `${STATUS}` — on any non-`passed` value, block with `PHASE_VERIFICATION_INCOMPLETE` and state the matching next action:
    - `passed` → verification complete; continue to the next preflight check.

--- a/tests/ship-586-verification-routing.test.cjs
+++ b/tests/ship-586-verification-routing.test.cjs
@@ -3,23 +3,33 @@
 // The ship.md verification gate is LLM-executed prose; its routing message text
 // IS the user-facing product surface (RULESET.TESTS.no-source-grep.exemption:
 // "reserved for tests where the file content IS the product surface ... agent .md").
+// The behavioral tests below additionally EXECUTE the gate's own bash extraction
+// pipeline (parsed out of ship.md) against fixture reports, so the extraction
+// contract is verified, not just asserted as text.
 const test = require('node:test');
 const assert = require('node:assert');
 const fs = require('node:fs');
+const os = require('node:os');
 const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+const helpers = require('./helpers.cjs');
 
 const SHIP_MD = path.join(__dirname, '..', 'gsd-core', 'workflows', 'ship.md');
 const ship = fs.readFileSync(SHIP_MD, 'utf8');
 
-// Narrow to the preflight verification gate so we don't match the PR-body
-// template lower in the file that also mentions VERIFICATION.md.
 const start = ship.indexOf('**Verification passed?**');
 const end = ship.indexOf('**Clean working tree?**');
 assert.ok(start !== -1 && end !== -1 && end > start, 'could not locate the verification gate block');
 const gate = ship.slice(start, end);
 
-test('gate captures the status value (capture-then-route, not membership check)', () => {
-  assert.match(gate, /grep\s+"\^status:"/, 'gate must extract the status via grep "^status:"');
+// ---- content assertions (the routing message IS the product surface) ----
+
+test('gate captures the status value with a single first-match grep', () => {
+  assert.match(gate, /grep -m1 "\^status:"/, 'gate must extract status via grep -m1 "^status:"');
+});
+
+test('gate scopes status extraction to the YAML frontmatter only', () => {
+  assert.match(gate, /sed -n '\/\^---\$\/,\/\^---\$\/p'/, 'gate must restrict extraction to the frontmatter block');
 });
 
 test('gate routes gaps_found to /gsd:plan-phase --gaps', () => {
@@ -44,4 +54,52 @@ test('the dead `pass` status arm is gone — only `passed` is accepted', () => {
   assert.doesNotMatch(gate, /status:\s*pass(?!ed)/i, 'no bare `status: pass` arm may remain');
   assert.doesNotMatch(gate, /`pass`\s*\/\s*`passed`/, 'the `pass` / `passed` either-arm must be removed');
   assert.match(gate, /passed/);
+});
+
+// ---- behavioral tests: run the gate's OWN bash pipeline against fixtures ----
+
+const bashBlock = (() => {
+  const m = gate.match(/```bash\n([\s\S]*?)```/);
+  assert.ok(m, 'gate must contain a bash block');
+  return m[1];
+})();
+
+const hasBash = (() => {
+  try { execFileSync('bash', ['-c', 'true'], { stdio: 'ignore' }); return true; }
+  catch { return false; }
+})();
+
+function runGateExtraction(verificationContents) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ship586-'));
+  try {
+    if (verificationContents !== null) {
+      fs.writeFileSync(path.join(dir, '01-VERIFICATION.md'), verificationContents);
+    }
+    const script = `PHASE_DIR='${dir}'\n${bashBlock}\nprintf '%s' "$STATUS"`;
+    return execFileSync('bash', ['-c', script], { encoding: 'utf8' });
+  } finally {
+    helpers.cleanup(dir);
+  }
+}
+
+const FM = (status) =>
+  `---\nphase: 01-demo\nverified: 2026-01-01T00:00:00Z\nstatus: ${status}\nscore: 3/3 must-haves verified\n---\n\n# Verification\n`;
+
+test('extraction yields passed for a passing frontmatter', { skip: !hasBash && 'bash unavailable' }, () => {
+  assert.strictEqual(runGateExtraction(FM('passed')), 'passed');
+});
+
+test('extraction yields gaps_found / human_needed verbatim', { skip: !hasBash && 'bash unavailable' }, () => {
+  assert.strictEqual(runGateExtraction(FM('gaps_found')), 'gaps_found');
+  assert.strictEqual(runGateExtraction(FM('human_needed')), 'human_needed');
+});
+
+test('REGRESSION: a body `status:` line does not corrupt a passing report (Codex PR #650 finding)', { skip: !hasBash && 'bash unavailable' }, () => {
+  const withBodyStatus = FM('passed') +
+    '\n## Example\n\n```yaml\nstatus: gaps_found\n```\n\nstatus: human_needed\n';
+  assert.strictEqual(runGateExtraction(withBodyStatus), 'passed');
+});
+
+test('extraction yields empty when no VERIFICATION.md exists', { skip: !hasBash && 'bash unavailable' }, () => {
+  assert.strictEqual(runGateExtraction(null), '');
 });

--- a/tests/ship-586-verification-routing.test.cjs
+++ b/tests/ship-586-verification-routing.test.cjs
@@ -71,6 +71,11 @@ const hasBash = (() => {
   catch { return false; }
 })();
 
+// The extraction logic is platform-independent; the bash *pipeline* is executed
+// only where the gate's shell actually runs (POSIX). On Windows, git-bash exists
+// but receives Windows-style tmpdir paths it cannot glob, so skip execution there.
+const skipBashPipeline = (process.platform === 'win32' || !hasBash) && 'bash pipeline runs on POSIX only';
+
 function runGateExtraction(verificationContents) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ship586-'));
   try {
@@ -87,21 +92,21 @@ function runGateExtraction(verificationContents) {
 const FM = (status) =>
   `---\nphase: 01-demo\nverified: 2026-01-01T00:00:00Z\nstatus: ${status}\nscore: 3/3 must-haves verified\n---\n\n# Verification\n`;
 
-test('extraction yields passed for a passing frontmatter', { skip: !hasBash && 'bash unavailable' }, () => {
+test('extraction yields passed for a passing frontmatter', { skip: skipBashPipeline }, () => {
   assert.strictEqual(runGateExtraction(FM('passed')), 'passed');
 });
 
-test('extraction yields gaps_found / human_needed verbatim', { skip: !hasBash && 'bash unavailable' }, () => {
+test('extraction yields gaps_found / human_needed verbatim', { skip: skipBashPipeline }, () => {
   assert.strictEqual(runGateExtraction(FM('gaps_found')), 'gaps_found');
   assert.strictEqual(runGateExtraction(FM('human_needed')), 'human_needed');
 });
 
-test('REGRESSION: a body `status:` line does not corrupt a passing report (Codex PR #650 finding)', { skip: !hasBash && 'bash unavailable' }, () => {
+test('REGRESSION: a body `status:` line does not corrupt a passing report (Codex PR #650 finding)', { skip: skipBashPipeline }, () => {
   const withBodyStatus = FM('passed') +
     '\n## Example\n\n```yaml\nstatus: gaps_found\n```\n\nstatus: human_needed\n';
   assert.strictEqual(runGateExtraction(withBodyStatus), 'passed');
 });
 
-test('extraction yields empty when no VERIFICATION.md exists', { skip: !hasBash && 'bash unavailable' }, () => {
+test('extraction yields empty when no VERIFICATION.md exists', { skip: skipBashPipeline }, () => {
   assert.strictEqual(runGateExtraction(null), '');
 });

--- a/tests/ship-586-verification-routing.test.cjs
+++ b/tests/ship-586-verification-routing.test.cjs
@@ -1,0 +1,47 @@
+'use strict';
+// allow-test-rule: runtime-contract-is-the-product
+// The ship.md verification gate is LLM-executed prose; its routing message text
+// IS the user-facing product surface (RULESET.TESTS.no-source-grep.exemption:
+// "reserved for tests where the file content IS the product surface ... agent .md").
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const SHIP_MD = path.join(__dirname, '..', 'gsd-core', 'workflows', 'ship.md');
+const ship = fs.readFileSync(SHIP_MD, 'utf8');
+
+// Narrow to the preflight verification gate so we don't match the PR-body
+// template lower in the file that also mentions VERIFICATION.md.
+const start = ship.indexOf('**Verification passed?**');
+const end = ship.indexOf('**Clean working tree?**');
+assert.ok(start !== -1 && end !== -1 && end > start, 'could not locate the verification gate block');
+const gate = ship.slice(start, end);
+
+test('gate captures the status value (capture-then-route, not membership check)', () => {
+  assert.match(gate, /grep\s+"\^status:"/, 'gate must extract the status via grep "^status:"');
+});
+
+test('gate routes gaps_found to /gsd:plan-phase --gaps', () => {
+  assert.match(gate, /gaps_found/);
+  assert.match(gate, /\/gsd:plan-phase[^\n]*--gaps/);
+});
+
+test('gate routes human_needed to the UAT manual-test step', () => {
+  assert.match(gate, /human_needed/);
+  assert.match(gate, /UAT\.md/);
+});
+
+test('gate routes a missing VERIFICATION.md to re-running execute-phase', () => {
+  assert.match(gate, /\/gsd:execute-phase/);
+});
+
+test('gate still blocks with PHASE_VERIFICATION_INCOMPLETE', () => {
+  assert.match(gate, /PHASE_VERIFICATION_INCOMPLETE/);
+});
+
+test('the dead `pass` status arm is gone — only `passed` is accepted', () => {
+  assert.doesNotMatch(gate, /status:\s*pass(?!ed)/i, 'no bare `status: pass` arm may remain');
+  assert.doesNotMatch(gate, /`pass`\s*\/\s*`passed`/, 'the `pass` / `passed` either-arm must be removed');
+  assert.match(gate, /passed/);
+});

--- a/tests/ship-586-verification-routing.test.cjs
+++ b/tests/ship-586-verification-routing.test.cjs
@@ -59,9 +59,11 @@ test('the dead `pass` status arm is gone — only `passed` is accepted', () => {
 // ---- behavioral tests: run the gate's OWN bash pipeline against fixtures ----
 
 const bashBlock = (() => {
-  const m = gate.match(/```bash\n([\s\S]*?)```/);
+  // `\r?\n` (not a literal `\n`) so the fence matches on Windows CRLF checkouts;
+  // normalize the captured block to LF before handing it to bash.
+  const m = gate.match(/```bash\r?\n([\s\S]*?)```/);
   assert.ok(m, 'gate must contain a bash block');
-  return m[1];
+  return m[1].replace(/\r\n/g, '\n');
 })();
 
 const hasBash = (() => {


### PR DESCRIPTION
## Enhancement PR

## Linked Issue

Closes #586

> The linked issue has the `approved-enhancement` + `ready-for-agent` labels.

---

## What this enhancement improves

The `ship` workflow's verification preflight gate (`gsd-core/workflows/ship.md`). When a phase is not yet verified, the gate blocked with `PHASE_VERIFICATION_INCOMPLETE` but named **no next action** — and `*-VERIFICATION.md` is produced automatically by `gsd-verifier` inside `/gsd:execute-phase`, so a blocked user had no obvious route forward. This makes the block **actionable per status** and removes a dead status arm.

## Before / After

**Before** — the gate `cat`'d the file and did a membership check, throwing away the one value that tells the user what to do:

```bash
VERIFICATION=$(cat ${PHASE_DIR}/*-VERIFICATION.md 2>/dev/null)
# "Check for status: pass or passed"
# missing OR not-pass/passed -> block PHASE_VERIFICATION_INCOMPLETE  (no next action named)
```

The `pass` arm was **dead**: the verifier (`gsd-verifier.md`) only ever emits `passed`, `gaps_found`, or `human_needed`.

**After** — capture the status (mirroring the extraction already in `execute-phase.md`) and route per value:

```bash
VERIFICATION_FILE=$(ls ${PHASE_DIR}/*-VERIFICATION.md 2>/dev/null | head -1)
STATUS=$(grep "^status:" "${VERIFICATION_FILE}" 2>/dev/null | cut -d: -f2 | tr -d ' ')
```

| `${STATUS}` | Next action the block now names |
|---|---|
| `passed` | verification complete — continue shipping |
| `gaps_found` | run `/gsd:plan-phase ${PHASE_NUMBER} --gaps`, then re-run `/gsd:execute-phase` |
| `human_needed` | complete the manual tests in `${PHASE_DIR}/*-UAT.md`, then re-run the verify step until `passed` |
| empty / missing | the verify step never completed — re-run `/gsd:execute-phase` |

Only `passed` may ship; the `pass` arm is gone.

## How it was implemented

Single-file change to `gsd-core/workflows/ship.md`. The routing it mirrors already lives in `execute-phase.md`'s status table, so no new knowledge is invented — the gate simply reads the status the same way and states the matching next step. Reuses the existing `${PHASE_DIR}` / `${PHASE_NUMBER}` shell vars (the verified-dead `VERIFICATION` capture variable was unused downstream). No version bump, no breaking change, no command rename (the #44 rename is explicitly **not** revived).

> Architectural note: the dead `pass` arm was a symptom of the verification-status vocabulary having no single home (three prose surfaces re-derive it — `DEFECT.GENERATIVE-FIX`). Consolidating that into one queryable seam is deliberately left out of this one-file PR and will be filed as a separate follow-up enhancement.

## Testing

### How I verified the enhancement works

- Added regression test `tests/ship-586-verification-routing.test.cjs` (written **first**): demonstrated RED (5 of 6 assertions fail against the old gate), then GREEN (6/6) after the fix.
- Full ship-related suite — `code-review-command`, `enh-2790-skill-consolidation`, `feat-3167-ship-pr-body-sections`, `feat-41-ship-tdd-audit-gate-status`, and the new test — **95 pass, 0 fail**.
- Cross-platform (`gsd-test-both`, Mac local + Linux Docker): **109 both-passed, 0 failed, 0 platform-specific**.

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling) — runner not configured; change is markdown prose + a `path.join`-based test, not platform-specific
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific) — the change is workflow prose consumed identically by every runtime

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue — no additions or removals
- [x] If scope changed during implementation, I updated the issue and got re-approval before continuing — *(scope unchanged; the regression test + changeset are standard PR artifacts, not scope expansion)*

---

## Documentation

- [ ] Updated the relevant file(s) under `docs/` to reflect this change
- [x] All `docs/` content added in this PR is written in English — *(no docs changed)*
- [x] If genuinely no user-facing docs impact, apply the `no-docs` label **or** add `<!-- docs-exempt -->` — *(the changeset is typed **`Fixed`**, which `lint:docs` already exempts; the only user-visible surface is the block message itself, which this PR changes. No separate docs page documents this internal preflight message, consistent with the issue's explicit one-file scope.)*

## Checklist

- [x] Issue linked above with `Closes #NNN`
- [x] Linked issue has the `approved-enhancement` label
- [x] Changes are scoped to the approved enhancement — nothing extra included
- [x] All existing tests pass (`npm test`) — ran the relevant suite + full cross-platform
- [x] New or updated tests cover the enhanced behavior
- [x] `.changeset/` fragment added — typed **`Fixed`** (symptom-led: a blocked user had no next step) rather than `Changed`, which keeps the PR docs-exempt and to the single file the issue scopes
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/650"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783105146&installation_id=134682257&pr_number=650&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F650&signature=22ccc0c7268ada95b062f2756192f70ad4d6a872f818efbbafa83f02934e38eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->