### PR TITLE
chore(#653): set npm package author to OpenGSD

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "codex",
     "codex-cli"
   ],
-  "author": "TÂCHES",
+  "author": "OpenGSD",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!-- pr-template-exempt: metadata-only package.json author rebrand (single root file, no behavior change) -->

## What

Set the npm package `author` from the legacy personal credit `TÂCHES` to the org name `OpenGSD`, matching the `@opengsd` scope / `open-gsd` org. npm renders this field on the package page, so it was the last in-repo "by TÂCHES" branding.

Closes #653

## Context

Issue #653 reported off branding on the package's web surfaces. Investigation:

- **Installer banner** ("…CodeBuddy by TÂCHES") — already removed in the #523 rebrand; the change is committed at HEAD and ships on the next publish (the reporter's screenshot is from the published `@latest`).
- **`package.json` author** (`TÂCHES`) — fixed here. It was the only remaining `TÂCHES` literal in the repo.
- **The landing page** showing the legacy `@opengsd/get-shit-done-redux` npx command (issue screenshot 1) is a **separate web property**, not this repo — the maintainer is handling it externally. This repo's own README/docs already use `@opengsd/gsd-core`.

## Scope

One line in `package.json` (metadata only). No behavior change. No changeset (`changeset-lint` → `ok_no_user_facing_changes`; root `package.json` is not a watched dir). No docs impact. The 5 package-identity test files pass unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/654"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783127333&installation_id=134682257&pr_number=654&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F654&signature=d181f2b27909bc7ac199298bda124b08b6843ca41302ccf19352b87f34c7667d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->