### PR TITLE
ci(#660): scoped GSD_BOT_PR_TOKEN for backmerge & release merge-back PR creation

### DIFF
--- a/.github/workflows/auto-backmerge.yml
+++ b/.github/workflows/auto-backmerge.yml
@@ -56,7 +56,7 @@ jobs:
         if: steps.check.outputs.next_exists == 'true'
         id: branch
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.GSD_BOT_PR_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           SHORT_SHA=$(git rev-parse --short HEAD)
@@ -108,7 +108,7 @@ jobs:
       - name: Open or update PR
         if: steps.check.outputs.next_exists == 'true' && steps.branch.outputs.reused != 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.GSD_BOT_PR_TOKEN || secrets.GITHUB_TOKEN }}
           BR: ${{ steps.branch.outputs.branch }}
         run: |
           set -euo pipefail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -326,7 +326,7 @@ jobs:
         if: ${{ !inputs.dry_run }}
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.GSD_BOT_PR_TOKEN || secrets.GITHUB_TOKEN }}
           BRANCH: ${{ needs.validate-version.outputs.branch }}
           VERSION: ${{ inputs.version }}
         run: |


### PR DESCRIPTION
The `open-gsd` org blocks the Actions `GITHUB_TOKEN` from creating PRs, so the auto-backmerge PR steps and the release `finalize` merge-back PR step can't open their PRs (currently created manually). Points those three steps' `GH_TOKEN` at a scoped secret with a safe fallback:

`GH_TOKEN: ${{ secrets.GSD_BOT_PR_TOKEN || secrets.GITHUB_TOKEN }}`

Behavior is unchanged until the secret exists (falls back to the default token). **Action required to activate:** create a fine-grained PAT/App token scoped to this repo with `pull-requests:write` + `contents:write`, and add it as repo secret `GSD_BOT_PR_TOKEN`. After that, back-merges and release merge-backs self-create their PRs.

`git push` in the backmerge step is unaffected (it uses the checkout-persisted credential, not `GH_TOKEN`). YAML validated.

Refs #660

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/673"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783170902&installation_id=134682257&pr_number=673&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F673&signature=ae88131d012629827e2ad24c0306d148b9269e58f14b8b204a870707f60b4b8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->