### PR TITLE
ci(#676): use OIDC trusted publishing in hotfix.yml

### DIFF
--- a/.github/workflows/hotfix.yml
+++ b/.github/workflows/hotfix.yml
@@ -324,8 +324,7 @@ jobs:
 
 
       - name: Dry-run publish validation
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GETSHITDONEREDUXNPMTOKEN }}
+        # OIDC trusted publishing (id-token: write); no NODE_AUTH_TOKEN — matches release.yml (#318)
         run: npm publish --dry-run --tag latest
 
       - name: Tag and push
@@ -348,17 +347,16 @@ jobs:
 
       - name: Publish to npm (latest)
         if: ${{ !inputs.dry_run && steps.prior_publish.outputs.skip_publish != 'true' }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GETSHITDONEREDUXNPMTOKEN }}
+        # --provenance is automatic under OIDC trusted publishing; no NODE_AUTH_TOKEN (#318)
         run: npm publish --provenance --access public --tag latest
 
       - name: Re-point next dist-tag at this hotfix
         if: ${{ !inputs.dry_run }}
         env:
           VERSION: ${{ inputs.version }}
-          NODE_AUTH_TOKEN: ${{ secrets.GETSHITDONEREDUXNPMTOKEN }}
         run: |
-          npm dist-tag add "@opengsd/gsd-core@${VERSION}" next
+          # Best-effort under OIDC (publish-scoped token); matches release.yml's @next re-point.
+          npm dist-tag add "@opengsd/gsd-core@${VERSION}" next 2>/dev/null || true
           echo "✅ next dist-tag re-pointed to v${VERSION} (matches latest)"
 
       - name: Create GitHub Release (idempotent)


### PR DESCRIPTION
## Linked Issue

Fixes #676

## What was broken

The `v1.3.1` hotfix `finalize` failed at **Publish to npm (latest)** with `npm error code ENEEDAUTH`. The `v1.3.1` tag was pushed but nothing published (npm `latest` still `1.3.0`).

## What this fix does

Removes the three `NODE_AUTH_TOKEN` env blocks from `hotfix.yml`'s publish/dist-tag steps so npm **OIDC trusted publishing** engages, exactly as `release.yml` already does. The finalize job already has `id-token: write` and `environment: npm-publish` — the empty-token env was forcing the legacy token path. Also makes the `@next` dist-tag re-point best-effort (`|| true`), matching `release.yml` (OIDC tokens are publish-scoped).

## Root cause

`hotfix.yml` was never converted to OIDC trusted publishing (the repo moved to it per #318). Its publish steps set `NODE_AUTH_TOKEN: ${{ secrets.GETSHITDONEREDUXNPMTOKEN }}` — a secret that is empty post-migration — so npm took the token path and died with ENEEDAUTH. The finalize **dry-run** passed because `npm publish --dry-run` does not authenticate, so it never exercised the publish auth path.

## Testing

### How I verified the fix

- Diffed against `release.yml`'s working OIDC pattern (no `NODE_AUTH_TOKEN`; `--provenance` automatic under OIDC). hotfix.yml now matches.
- Confirmed no `NODE_AUTH_TOKEN` remains in `hotfix.yml`; `id-token: write` + `environment: npm-publish` retained.
- Independent adversarial review (correctness + security) + security review: change is correct and security-positive (drops long-lived token).
- lint 0 errors; full cross-platform suite green (`gsd-test-both`: 13467 both-passed, 0 fail) — no code paths changed.

### Regression test added?

- [ ] Yes
- [x] No — CI workflow change; not unit-testable in-repo. Validated by the subsequent `finalize` re-run publishing successfully.

### Platforms tested

- [x] N/A (not platform-specific) — GitHub Actions workflow.

### Runtimes tested

- [x] N/A (not runtime-specific).

---

## Checklist

- [x] Issue linked above with `Fixes #676`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if user-facing — N/A (CI-only change; `.github/` is not a changeset-watched path)
- [x] No unnecessary dependencies added

## Breaking changes

None. Internal CI/release infrastructure only. Requires the npm Trusted Publisher to authorize `hotfix.yml` (same npm-publish environment as `release.yml`).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/677"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783189073&installation_id=134682257&pr_number=677&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F677&signature=f03aa9db3e5d93a1d8fed008f89d1486aff9de5379f9423c5734efc93dfe957b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->