### PR TITLE
fix(#669): /gsd-review --cursor actually invokes cursor-agent

### DIFF
--- a/.changeset/669-gsd-review-cursor-agent.md
+++ b/.changeset/669-gsd-review-cursor-agent.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 683
+pr: 686
 ---
 `/gsd-review --cursor` now actually invokes the Cursor agent. Detection probes the `cursor-agent` headless binary instead of the `cursor` IDE launcher, the invocation calls the single `cursor-agent` binary in print mode (not the two-token `cursor agent`, which the IDE treats as a file path), and the review prompt is passed as a file-path argument rather than piped to stdin (which `cursor-agent -p` ignores). On failure the captured stderr is surfaced instead of a silent empty result.

--- a/.changeset/669-gsd-review-cursor-agent.md
+++ b/.changeset/669-gsd-review-cursor-agent.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 683
+---
+`/gsd-review --cursor` now actually invokes the Cursor agent. Detection probes the `cursor-agent` headless binary instead of the `cursor` IDE launcher, the invocation calls the single `cursor-agent` binary in print mode (not the two-token `cursor agent`, which the IDE treats as a file path), and the review prompt is passed as a file-path argument rather than piped to stdin (which `cursor-agent -p` ignores). On failure the captured stderr is surfaced instead of a silent empty result.

--- a/gsd-core/workflows/review.md
+++ b/gsd-core/workflows/review.md
@@ -22,7 +22,7 @@ command -v codex >/dev/null 2>&1 && echo "codex:available" || echo "codex:missin
 command -v coderabbit >/dev/null 2>&1 && echo "coderabbit:available" || echo "coderabbit:missing"
 command -v opencode >/dev/null 2>&1 && echo "opencode:available" || echo "opencode:missing"
 command -v qwen >/dev/null 2>&1 && echo "qwen:available" || echo "qwen:missing"
-command -v cursor >/dev/null 2>&1 && echo "cursor:available" || echo "cursor:missing"
+command -v cursor-agent >/dev/null 2>&1 && echo "cursor:available" || echo "cursor:missing"
 command -v agy >/dev/null 2>&1 && echo "antigravity:available" || echo "antigravity:missing"
 
 # Check local model servers (OpenAI-compatible HTTP API — no CLI binary required)
@@ -284,9 +284,15 @@ fi
 
 **Cursor:**
 ```bash
-cat /tmp/gsd-review-prompt-{phase}.md | cursor agent -p --mode ask --trust 2>/dev/null > /tmp/gsd-review-cursor-{phase}.md
+# cursor-agent is a SEPARATE binary from the `cursor` IDE launcher; print mode (-p) takes the
+# prompt as an ARGUMENT, not stdin. A full review prompt can exceed the OS argument limit, so
+# reference the prompt file by path rather than inlining it. Capture stderr so a failure is
+# diagnosable instead of a silent empty result.
+CURSOR_PROMPT_ARG="Read the file at /tmp/gsd-review-prompt-{phase}.md in full and carry out the review request it contains. Output only the resulting markdown review. Do not edit any files."
+cursor-agent -p --mode ask --trust --output-format text "$CURSOR_PROMPT_ARG" 2>/tmp/gsd-review-cursor-{phase}.err > /tmp/gsd-review-cursor-{phase}.md
 if [ ! -s /tmp/gsd-review-cursor-{phase}.md ]; then
-  echo "Cursor review failed or returned empty output." > /tmp/gsd-review-cursor-{phase}.md
+  echo "Cursor review failed or returned empty output. stderr:" > /tmp/gsd-review-cursor-{phase}.md
+  cat /tmp/gsd-review-cursor-{phase}.err >> /tmp/gsd-review-cursor-{phase}.md
 fi
 ```
 

--- a/tests/cursor-reviewer.test.cjs
+++ b/tests/cursor-reviewer.test.cjs
@@ -36,11 +36,11 @@ describe('Cursor CLI reviewer in /gsd-review (#1960)', () => {
       content = fs.readFileSync(reviewPath, 'utf-8');
     });
 
-    test('contains cursor CLI detection via command -v', () => {
+    test('contains cursor CLI detection via command -v cursor-agent', () => {
       const c = fs.readFileSync(reviewPath, 'utf-8');
       assert.ok(
-        c.includes('command -v cursor'),
-        'review.md should detect cursor CLI via "command -v cursor"'
+        c.includes('command -v cursor-agent'),
+        'review.md should detect cursor CLI via "command -v cursor-agent" (not the cursor IDE launcher)'
       );
     });
 
@@ -60,11 +60,47 @@ describe('Cursor CLI reviewer in /gsd-review (#1960)', () => {
       );
     });
 
-    test('contains cursor agent invocation command', () => {
+    test('invocation uses cursor-agent single binary with -p flag', () => {
       const c = fs.readFileSync(reviewPath, 'utf-8');
       assert.ok(
-        c.includes('cursor agent -p --mode ask --trust'),
-        'review.md should invoke cursor via "cursor agent -p --mode ask --trust"'
+        c.includes('cursor-agent -p'),
+        'review.md should invoke cursor via "cursor-agent -p" (single binary, not two-token "cursor agent")'
+      );
+    });
+
+    test('invocation includes --output-format text', () => {
+      const c = fs.readFileSync(reviewPath, 'utf-8');
+      assert.ok(
+        c.includes('--output-format text'),
+        'review.md cursor-agent invocation should include "--output-format text"'
+      );
+    });
+
+    test('invocation passes prompt as a file-path argument (not via stdin pipe)', () => {
+      const c = fs.readFileSync(reviewPath, 'utf-8');
+      assert.ok(
+        c.includes('Read the file at /tmp/gsd-review-prompt-'),
+        'review.md cursor-agent invocation should pass prompt by referencing the file path as an argument'
+      );
+    });
+
+    test('does NOT use broken two-token "cursor agent " form', () => {
+      const c = fs.readFileSync(reviewPath, 'utf-8');
+      // Must not match "cursor agent " (cursor + space + agent + space)
+      // The hyphenated "cursor-agent" must NOT trip this check — the regex uses a space, not a hyphen.
+      assert.ok(
+        !/cursor agent /.test(c),
+        'review.md must NOT contain the broken two-token form "cursor agent " (use "cursor-agent" instead)'
+      );
+    });
+
+    test('does NOT pipe the prompt into a cursor command via stdin', () => {
+      const c = fs.readFileSync(reviewPath, 'utf-8');
+      // Must not match a pipe feeding into a cursor command (e.g. "| cursor" or "|cursor")
+      // "cursor-agent" (hyphenated) must NOT trip this — the regex anchors on "cursor" not followed by "-agent"
+      assert.ok(
+        !/\| *cursor(?!-agent)/.test(c),
+        'review.md must NOT pipe the prompt to a cursor command via stdin'
       );
     });
 


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #669

> Linked issue #669 carries the `confirmed-bug` label.

---

## What was broken

`/gsd-review --cursor` could never produce a review: the Cursor reviewer branch in `gsd-core/workflows/review.md` detected the wrong binary, invoked the wrong command, and fed the prompt the wrong way — so even with a working, authenticated `cursor-agent` it wrote a 0-byte file and fell into the generic "Cursor review failed or returned empty output." branch after burning the full timeout.

## What this fix does

Probes the `cursor-agent` headless binary (not the `cursor` IDE launcher), invokes the single `cursor-agent` binary in print mode with the prompt passed as a command-line argument that references the prompt file by path, and captures stderr so a failure is diagnosable instead of silently empty. The `cursor` detection slug and all downstream parsing/output-file naming are unchanged.

## Root cause

Three coupled defects, all absent from the sibling `agy` reviewer branch which already did it right:
- **Detection (L25):** `command -v cursor` matches the IDE launcher, not the separate `cursor-agent` headless binary.
- **Binary (L287):** `cursor agent` is two tokens — the IDE treats `agent` as a file-path argument, so the agent never runs. The binary is the single token `cursor-agent`.
- **Input (L287):** the prompt was piped via stdin, but `cursor-agent -p` (print mode) reads the prompt from a command-line **argument**; `2>/dev/null` then hid the empty result.

Verified against the [Cursor CLI parameters reference](https://cursor.com/docs/cli/reference/parameters): `-p`/`--print`, `--mode ask`, `--trust` ("trust the workspace without prompting — headless mode only"), and `--output-format text` are all documented flags. The prompt is referenced by file path rather than inlined because a full review prompt can exceed the OS argument-length limit.

## Testing

### How I verified the fix

TDD: inverted `tests/cursor-reviewer.test.cjs` to assert the corrected contract first (6 assertions RED against the broken workflow), then fixed the workflow (23/23 GREEN). Full local suite `npm test` → **5825 pass / 0 fail**; `npm run lint` → **0 errors**. The end-to-end `cursor-agent` invocation itself can't run in CI; the workflow text is the runtime contract, so the test asserts on its content (with `// allow-test-rule: source-text-is-the-product`).

### Regression test added?

- [x] Yes — added assertions that would have caught this bug (correct binary/flags + negative guards against the two-token form and the stdin pipe)

### Platforms tested

- [x] N/A (not platform-specific — workflow-text + content-assertion change; the POSIX-vs-PowerShell `cursor-agent` path nuance noted in #669 is intentionally out of scope, one-concern-per-PR)

### Runtimes tested

- [x] Claude Code

---

## Checklist

- [x] Issue linked above with `Fixes #669`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added (`669-gsd-review-cursor-agent.md`)
- [x] No unnecessary dependencies added

## Breaking changes

None — the `cursor:available`/`cursor:missing` detection slug and the `/tmp/gsd-review-cursor-{phase}.md` output naming are unchanged; only the failure-path message gains a captured-stderr suffix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/686"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783198086&installation_id=134682257&pr_number=686&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F686&signature=9c000fdb58278b9f61e3b11a9a8299cc3a9041e4d3fe9999ca04a6bc37610423"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->