### PR TITLE
fix(#687): cap agy -p with a hard wall-clock timeout (no indefinite hang)

### DIFF
--- a/.changeset/687-agy-print-timeout.md
+++ b/.changeset/687-agy-print-timeout.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 689
+---
+**`/gsd-review --agy` no longer hangs the whole review on large prompts.** On a big, file-path-rich prompt Antigravity's `agy -p` agentic Cascade can loop on its `code_search`/grep steps and never converge. The invocation now passes agy's own `--print-timeout` flag (its native print-mode cap) so a stalled run self-terminates through the tool's own mechanism; on a non-zero exit any partial output is discarded so the existing transcript fallback / "review failed" stub take over.

--- a/gsd-core/workflows/review.md
+++ b/gsd-core/workflows/review.md
@@ -350,8 +350,19 @@ if [ -f "$_AGY_CACHE" ]; then
   fi
 fi
 
-# Step 1 — primary invocation: stdout works on macOS, Linux, and WSL
-agy -p "$(cat /tmp/gsd-review-prompt-{phase}.md)" 2>/dev/null > /tmp/gsd-review-antigravity-{phase}.md
+# Step 1 — primary invocation: stdout works on macOS, Linux, and WSL.
+# Bound the run with agy's OWN `--print-timeout` (issue #687). On a large,
+# file-path-rich prompt agy's agentic Cascade can loop on its code_search/grep
+# steps and never converge; `--print-timeout` is agy's native cap for print mode
+# (defaults to 5m — see maintainer note above), so we pass it explicitly to let a
+# stalled run self-terminate through the tool's own mechanism. A non-zero exit
+# (timeout or crash) discards any partial output so the Step 2 transcript fallback
+# / Step 3 stub take over.
+agy --print-timeout 300s -p "$(cat /tmp/gsd-review-prompt-{phase}.md)" 2>/dev/null > /tmp/gsd-review-antigravity-{phase}.md
+_AGY_RC=$?
+if [ "$_AGY_RC" -ne 0 ]; then
+  : > /tmp/gsd-review-antigravity-{phase}.md
+fi
 
 # Step 2 — transcript fallback: catches Windows agy -p stdout bug (and any future stdout-silent edge cases).
 # Reads only lines appended AFTER the pre-flight watermark. If agy failed before writing a new response,

--- a/tests/bug-687-agy-timeout.test.cjs
+++ b/tests/bug-687-agy-timeout.test.cjs
@@ -1,0 +1,45 @@
+// allow-test-rule: source-text-is-the-product
+// review.md is a workflow file whose deployed text IS the runtime contract; the
+// agy -p invocation cannot be run in CI, so we assert on its content (issue #687).
+'use strict';
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const reviewPath = path.resolve(__dirname, '..', 'gsd-core', 'workflows', 'review.md');
+const read = () => fs.readFileSync(reviewPath, 'utf-8');
+
+describe('bug #687: agy print mode must be bounded via its native --print-timeout', () => {
+  test('invokes agy with its own --print-timeout flag (not an external killer)', () => {
+    assert.match(read(), /agy --print-timeout \d+s? -p "\$\(cat/,
+      'review.md must cap agy through `agy --print-timeout <N> -p …` (the tool\'s own mechanism)');
+  });
+
+  test('discards partial output on non-zero exit so the fallback fires', () => {
+    const c = read();
+    assert.match(c, /_AGY_RC.*-ne 0/, 'review.md must check the agy exit code');
+    assert.match(c, /: > \/tmp\/gsd-review-antigravity-/,
+      'review.md must truncate the output file when agy timed out / failed');
+  });
+
+  test('agy is bounded only by its own --print-timeout, not an external process killer', () => {
+    const c = read();
+    // Print-mode reviewers invoke the tool directly; agy must self-terminate via
+    // --print-timeout, never via an external SIGKILL/timeout binary wrapped around it.
+    assert.doesNotMatch(c, /-s KILL/, 'must not SIGKILL agy from the outside');
+    // Any external timeout binary wrapping agy — `timeout 300s agy …`,
+    // `gtimeout 300 agy …`, `timeout -s KILL 300 agy …`. The lookbehind keeps
+    // agy's own `--print-timeout` flag from tripping it.
+    assert.doesNotMatch(c, /(?<!print-)\bg?timeout[ \t]+[^\n]*\bagy\b/,
+      'must not wrap agy in an external timeout binary — use its --print-timeout flag');
+    assert.doesNotMatch(c, /kill -9 "\$_AGY/, 'must not use a kill -9 watchdog on agy');
+  });
+
+  test('no unguarded bare "agy -p" invocation remains at line start', () => {
+    // A bare `agy -p "$(cat …)"` with no cap was the original hang.
+    assert.doesNotMatch(read(), /^agy -p "\$\(cat/m,
+      'review.md must not invoke agy -p without --print-timeout');
+  });
+});


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #687

> Linked issue #687 carries the `confirmed-bug` label.

---

## What was broken

On a non-trivial `/gsd-review --agy` (or `--all`), Antigravity's `agy -p` hung indefinitely and blocked the entire review. On a large, file-path-rich prompt agy's agentic Cascade launches its `code_search`/grep tool against the workspace and never converges; the workflow's transcript fallback only runs *after* agy exits, so it couldn't recover a run that never exits.

## What this fix does

Bounds the run with agy's own `--print-timeout` flag — its native print-mode cap — so a stalled run self-terminates through the tool's own mechanism. On a non-zero exit any partial output is discarded so the existing Step 2 transcript fallback / Step 3 "review failed" stub take over.

```bash
agy --print-timeout 300s -p "$(cat /tmp/gsd-review-prompt-{phase}.md)" 2>/dev/null > …
_AGY_RC=$?
[ "$_AGY_RC" -ne 0 ] && : > …   # discard partial output → fallback fires
```

## Root cause

The `agy -p` invocation had no cap, and agy's print mode runs the full tool-enabled agent. Per the published Antigravity API ([SDK](https://github.com/google-antigravity/antigravity-sdk-python)), the clean control would be denying the `code_search` tool (`policy.deny_all()` / `CapabilitiesConfig(BuiltinTools.read_only())`) — but that lives in the **Python SDK**, not the `agy` CLI. The CLI's native lever for print mode is `--print-timeout` (default 5m), so the fix expresses the cap through the tool itself.

**Known limitation:** if a given agy version does not enforce `--print-timeout`, a run could still stall — partially covered by the existing empty-output fallback. agy's CHANGELOG shows timeout handling being actively fixed.

## Testing

### How I verified the fix

TDD: `tests/bug-687-agy-timeout.test.cjs` asserts the native `--print-timeout` cap, the partial-output discard, that agy is bounded only by its own flag (not an external process-killer), and that no unguarded bare `agy -p` remains. Full local suite `npm test` → **5833 pass / 0 fail**; `npm run lint` → **0 errors**; `gsd-test-both` (Mac + Linux Docker) → exit 0, 5/5. Codex adversarial → SOUND.

### Regression test added?

- [x] Yes — binds the native flag and the empty-output fallback contract

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling) — **not tested** (no Windows runner available). The change is a POSIX-shell flag + exit-code check that runs on every platform; agy's Windows-specific `-p` stdout path is already handled by the existing transcript fallback.
- [x] Linux

### Runtimes tested

- [x] Claude Code

---

## Checklist

- [x] Issue linked above with `Fixes #687`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug (the hang)
- [x] Regression test added
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added (`687-agy-print-timeout.md`)
- [x] No unnecessary dependencies added

## Breaking changes

None — adds agy's own `--print-timeout` to an existing invocation; a non-hung agy completes exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
