### PR TITLE
fix(#690): backfill CHANGELOG 1.3.x on main for /gsd:update preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.3.1](https://www.npmjs.com/package/@opengsd/gsd-core/v/1.3.1) - 2026-06-04
+
+### Security
+
+- **Bumped `hono` to clear a moderate npm advisory** carried transitively in the dependency tree. (#670)
+
+### Fixed
+
+- **Installer-migration checksum drift no longer blocks upgrades** — the updater now self-heals when a shipped migration's recorded checksum has drifted, reconciling the stored checksum instead of aborting. Restores upgrades across all OSes after shipped migration bodies were edited in a prior release. (#670)
+
+## [1.3.0](https://www.npmjs.com/package/@opengsd/gsd-core/v/1.3.0) - 2026-06-04
+
 ### Added
 
 - **Vertical MVP Slice mode** — `--mvp` flag on `/gsd-plan-phase` switches the planner from horizontal layer decomposition to vertical feature-slice decomposition (UI→API→DB in one task sequence). On Phase 1 of a new project with no prior phase summaries, also emits `SKELETON.md` via Walking Skeleton mode. Composable with `--tdd`: `--mvp --tdd` produces vertical slices where every behavior-adding task starts with a failing test. Phase-level persistence via `**Mode:** mvp` in ROADMAP.md applies `--mvp` automatically without the flag. (#78)


### PR DESCRIPTION
## Fix PR (CHANGELOG fast-track to `main`)

## Linked Issue

Fixes #690

> `#690` carries `confirmed-bug`. The full fix merged to `next` in #694; this PR fast-tracks **only the CHANGELOG backfill** to `main`.

---

## What was broken

`/gsd:update` fetches **`main`**'s `CHANGELOG.md` for its "What's New" preview. `main` only had `## [Unreleased]` + `## [1.2.0]`, so `extract --to 1.3.1` returned exit 2 and the preview showed the empty message. #694 fixed this on `next`, but there is **no `next → main` automation** — `next` reaches `main` only at release — so the live symptom persists on `main` until then.

## What this fix does

Backfills `main`'s `CHANGELOG.md` with the dated `## [1.3.0]` / `## [1.3.1]` sections — **byte-identical** to the content merged to `next` in #694 (CHANGELOG content hash `913a58ac`). This restores the live `/gsd:update` preview immediately.

## Root cause

CHANGELOG promotion is a manual release step that was skipped for the 1.3.0/1.3.1 tags. See #690 / #694 for the full analysis and the new `verify` release gate that prevents recurrence (that code-side prevention reaches `main` on the next release).

## Scope

- **CHANGELOG.md only** — 12-line insertion, no code. `git diff` is exactly the `[1.3.0]`/`[1.3.1]` promotion.
- Uses the `fix/critical-*` lane: the sanctioned `main`-target branch pattern, which also triggers the `Auto Back-Merge main → next` workflow (validating the now-PAT-enabled backmerge end-to-end; the back-merge is a clean no-op since `next` already holds this exact content).

## Testing

### How I verified the fix

- `main`'s pre-change CHANGELOG hash (`6f25bcfe`) is identical to the pre-fix base of #694, so the backfilled CHANGELOG (`913a58ac`) applies with no other deltas.
- The identical CHANGELOG content was already fully gated in #694: `/adversarial-review`, `/code-review`, `/security-review`, lint, and the full cross-platform CI matrix (macOS/Linux/Windows · Node 22/24) — all green.
- This is a docs/CHANGELOG-only change (no code, no tests affected); CI on this PR re-runs the relevant lints.

### Regression test added?

- [x] N/A — the regression test landed with the code fix in #694; this PR carries only the `main` CHANGELOG content.

### Platforms tested

- [x] N/A (CHANGELOG content only)

---

## Checklist

- [x] Issue linked with `Fixes #690` (has `confirmed-bug`)
- [x] Scoped to the CHANGELOG backfill — no unrelated changes
- [x] Content identical to the reviewed/merged #694 CHANGELOG
- [x] `fix/critical-*` lane (allowed `main` target; auto-back-merges to `next`)

## Breaking changes

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/696"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783220323&installation_id=134682257&pr_number=696&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F696&signature=e17cae4e68482075409edd8877f7120525d405aeb61473f5ef27c01a4bec60f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->