### PR TITLE
fix(#704): exclude } and ) from Codex path-rewrite lookbehind (no literal $gsd-core in installs)

### DIFF
--- a/.changeset/rapid-tigers-dance.md
+++ b/.changeset/rapid-tigers-dance.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 704
+---
+**Codex install no longer corrupts launcher paths** — shell path segments like `${VAR}/gsd-core/` and `$(cmd)/gsd-local-patches` are no longer rewritten into a literal `$gsd-core` token during Codex markdown conversion (#704).

--- a/.changeset/rapid-tigers-dance.md
+++ b/.changeset/rapid-tigers-dance.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 704
+pr: 710
 ---
 **Codex install no longer corrupts launcher paths** — shell path segments like `${VAR}/gsd-core/` and `$(cmd)/gsd-local-patches` are no longer rewritten into a literal `$gsd-core` token during Codex markdown conversion (#704).

--- a/bin/install.js
+++ b/bin/install.js
@@ -2800,9 +2800,12 @@ function convertSlashCommandsToCodexSkillMentions(content) {
     return `$gsd-${String(commandName).toLowerCase()}`;
   });
   // Convert hyphen-style command references (workflow output) to Codex $ prefix.
-  // Negative lookbehind excludes file paths like bin/gsd-tools.cjs where
-  // the slash is preceded by a word char, dot, or another slash.
-  converted = converted.replace(/(?<![a-zA-Z0-9./])\/gsd-([a-z0-9-]+)/gi, (_, commandName) => {
+  // Negative lookbehind excludes shell path contexts where `/gsd-` is a path
+  // segment, not a slash-command mention:
+  //   - word chars / dot / slash: `bin/gsd-tools.cjs`, `.claude/gsd-core/`
+  //   - `}`: shell variable expressions `${VAR}/gsd-core/` (#704)
+  //   - `)`: command-substitution paths `$(cmd)/gsd-local-patches` (#704)
+  converted = converted.replace(/(?<![a-zA-Z0-9./})])\/gsd-([a-z0-9-]+)/gi, (_, commandName) => {
     return `$gsd-${String(commandName).toLowerCase()}`;
   });
   return converted;

--- a/tests/bug-704-codex-launcher-path-corruption.test.cjs
+++ b/tests/bug-704-codex-launcher-path-corruption.test.cjs
@@ -1,0 +1,236 @@
+// allow-test-rule: source-text-is-the-product
+'use strict';
+
+/**
+ * Regression test for issue #704:
+ * "v1.3.1 global install ships literal $gsd-core launcher paths in workflows"
+ *
+ * ROOT CAUSE: `convertSlashCommandsToCodexSkillMentions` had a regex
+ *   /(?<![a-zA-Z0-9./])\/gsd-([a-z0-9-]+)/
+ * The lookbehind did NOT include `}`, so shell variable expressions like
+ *   `${_GSD_RUNTIME_ROOT}/gsd-core/bin/...`
+ * had their `/gsd-core` matched (the char before `/` was `}`, not in the
+ * exclusion set), converting it to `$gsd-core` and breaking all Codex
+ * workflow launcher paths.
+ *
+ * FIX: Add `}` to the lookbehind set so `${VAR}/gsd-core/` is excluded.
+ */
+
+process.env.GSD_TEST_MODE = '1';
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { convertClaudeCommandToCodexSkill } = require('../bin/install.js');
+
+// The canonical launcher snippet path that was being corrupted
+const RUNTIME_ROOT_PATH = '${_GSD_RUNTIME_ROOT}/gsd-core/bin/${_GSD_SHIM_NAME}';
+// The exact bad token reported in issue #704
+const BAD_TOKEN = '$gsd-core';
+
+describe('#704 — Codex global install launcher path corruption', () => {
+  test('convertClaudeCommandToCodexSkill does not corrupt ${VAR}/gsd-core/ or $(cmd)/gsd-* paths', () => {
+    // Minimal fixture with the launcher snippet and command-substitution patterns
+    // that were being corrupted (#704).
+    const input = [
+      '---',
+      'description: Test skill',
+      '---',
+      '',
+      '```bash',
+      '_GSD_SHIM_NAME="gsd-tools.cjs"',
+      '_GSD_RUNTIME_ROOT="${RUNTIME_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"',
+      'GSD_TOOLS="${_GSD_RUNTIME_ROOT}/gsd-core/bin/${_GSD_SHIM_NAME}"',
+      'if [ -f "$GSD_TOOLS" ]; then',
+      '  gsd_run() { node "$GSD_TOOLS" "$@"; }',
+      'elif [ -f "${_GSD_RUNTIME_ROOT}/.claude/gsd-core/bin/${_GSD_SHIM_NAME}" ]; then',
+      '  GSD_TOOLS="${_GSD_RUNTIME_ROOT}/.claude/gsd-core/bin/${_GSD_SHIM_NAME}"',
+      '  gsd_run() { node "$GSD_TOOLS" "$@"; }',
+      'elif [ -f "$HOME/.claude/gsd-core/bin/${_GSD_SHIM_NAME}" ]; then',
+      '  GSD_TOOLS="$HOME/.claude/gsd-core/bin/${_GSD_SHIM_NAME}"',
+      '  gsd_run() { node "$GSD_TOOLS" "$@"; }',
+      'fi',
+      '# Command-substitution path form (reapply-patches pattern)',
+      'candidate="$(expand_home "$KILO_CONFIG_DIR")/gsd-local-patches"',
+      '```',
+    ].join('\n');
+
+    const output = convertClaudeCommandToCodexSkill(input, 'gsd-test-704');
+
+    // Shell-context corruption patterns from issue #704:
+    //   - `}$gsd-*` from shell variable expressions `${VAR}/gsd-*`
+    //   - `)$gsd-*` from command-substitution paths `$(cmd)/gsd-*`
+    const shellCorruptionPatterns = [
+      { pattern: '}' + BAD_TOKEN, description: 'shell-variable }$gsd-core' },
+      { pattern: ')$gsd-local', description: 'command-substitution )$gsd-local-patches' },
+    ];
+    for (const { pattern, description } of shellCorruptionPatterns) {
+      assert.ok(
+        !output.includes(pattern),
+        `Codex skill conversion must not produce "${pattern}" (${description}). ` +
+          `Offending fragment: ${
+            output.includes(pattern)
+              ? output.substring(output.indexOf(pattern) - 50, output.indexOf(pattern) + 80)
+              : '(not found)'
+          }`,
+      );
+    }
+
+    // The correct path forms must be preserved
+    assert.ok(
+      output.includes('}/gsd-core/bin/'),
+      `Expected "${'}' + '/gsd-core/bin/'}" to appear in the converted output. ` +
+        `Got:\n${output.substring(0, 500)}`,
+    );
+    assert.ok(
+      output.includes(')/gsd-local-patches'),
+      `Expected ")/gsd-local-patches" to appear in the converted output. ` +
+        `Got:\n${output.substring(0, 500)}`,
+    );
+  });
+
+  test('convertClaudeCommandToCodexSkill preserves all shell path forms (}, ) closers)', () => {
+    // All these paths appear after a shell-closing character (} or )) and must
+    // NOT be converted to $gsd-* by the Codex slash-command converter.
+    const shellPaths = [
+      // Shell variable expression forms (} closer)
+      { path: '"${_GSD_RUNTIME_ROOT}/gsd-core/bin/${_GSD_SHIM_NAME}"', corruptedForm: '}$gsd-core' },
+      { path: '"${_GSD_RUNTIME_ROOT}/.claude/gsd-core/bin/${_GSD_SHIM_NAME}"', corruptedForm: '}$gsd-core' },
+      { path: '"$HOME/.claude/gsd-core/bin/${_GSD_SHIM_NAME}"', corruptedForm: '}$gsd-core' },
+      // Command-substitution forms () closer) — reapply-patches pattern
+      { path: 'candidate="$(expand_home "$KILO_CONFIG_DIR")/gsd-local-patches"', corruptedForm: ')$gsd-local' },
+      { path: 'candidate="$(dirname "$(expand_home "$OPENCODE_CONFIG")")/gsd-local-patches"', corruptedForm: ')$gsd-local' },
+    ];
+
+    for (const { path: p, corruptedForm } of shellPaths) {
+      const input = `---\ndescription: Test\n---\n\n\`\`\`bash\n${p}\n\`\`\``;
+      const output = convertClaudeCommandToCodexSkill(input, 'gsd-test-704-paths');
+      assert.ok(
+        !output.includes(corruptedForm),
+        `Path "${p}" was corrupted to contain "${corruptedForm}" after Codex conversion.\n` +
+          `Got:\n${output}`,
+      );
+    }
+  });
+
+  test('convertClaudeCommandToCodexSkill still converts legitimate /gsd-<cmd> slash mentions', () => {
+    // Slash-command mentions (not preceded by }) should still be converted
+    const input = [
+      '---',
+      'description: Test',
+      '---',
+      '',
+      'Use /gsd-discuss-phase to start a discussion.',
+      'Or use /gsd-plan-phase for planning.',
+      'Also: /gsd:capture --backlog adds items.',
+    ].join('\n');
+
+    const output = convertClaudeCommandToCodexSkill(input, 'gsd-test-704-cmds');
+
+    assert.ok(
+      output.includes('$gsd-discuss-phase'),
+      'Expected /gsd-discuss-phase to be converted to $gsd-discuss-phase',
+    );
+    assert.ok(
+      output.includes('$gsd-plan-phase'),
+      'Expected /gsd-plan-phase to be converted to $gsd-plan-phase',
+    );
+    assert.ok(
+      output.includes('$gsd-capture'),
+      'Expected /gsd:capture to be converted to $gsd-capture',
+    );
+  });
+
+  test('actual shipped workflow files: shell-variable launcher paths contain no $gsd-core', () => {
+    // Walk gsd-core/workflows/ and assert that no file produces $gsd-core
+    // inside a shell variable expansion context after Codex conversion.
+    //
+    // NOTE: The regex `/(?<![a-zA-Z0-9./}])\/gsd-/` still converts backtick-
+    // wrapped prose paths like `\`/gsd-core/workflows/update.md\`` (a pre-existing
+    // issue separate from #704 — update.md's backtick is not in the lookbehind
+    // set). That prose-path case is intentionally excluded from this assertion
+    // (tracked separately; the primary #704 bug is the shell-variable expansion).
+    //
+    // We probe for the specific shell-context pattern from the issue report:
+    //   BAD:  ${_GSD_RUNTIME_ROOT}$gsd-core/bin/
+    //   GOOD: ${_GSD_RUNTIME_ROOT}/gsd-core/bin/
+    const workflowsDir = path.join(__dirname, '..', 'gsd-core', 'workflows');
+    if (!fs.existsSync(workflowsDir)) {
+      // If the directory doesn't exist, skip gracefully (non-standard layout)
+      return;
+    }
+
+    const files = fs.readdirSync(workflowsDir)
+      .filter((f) => f.endsWith('.md'))
+      .map((f) => path.join(workflowsDir, f));
+
+    assert.ok(files.length > 0, 'Expected at least one workflow .md file');
+
+    // Shell-context corruption patterns from issue #704:
+    //   - `}$gsd-*`: closing brace from `${VAR}/gsd-*` shell variable expressions
+    //   - `)$gsd-*`: closing paren from `$(cmd)/gsd-*` command substitutions
+    const SHELL_CORRUPTION_RE = /[})](\$gsd-[a-z])/;
+
+    const offending = [];
+    for (const file of files) {
+      const content = fs.readFileSync(file, 'utf8');
+      const skillName = `gsd-${path.basename(file, '.md')}`;
+      const converted = convertClaudeCommandToCodexSkill(content, skillName);
+      const match = converted.match(SHELL_CORRUPTION_RE);
+      if (match) {
+        const idx = converted.indexOf(match[0]);
+        offending.push({
+          file: path.relative(workflowsDir, file),
+          context: converted.substring(Math.max(0, idx - 40), idx + 80),
+        });
+      }
+    }
+
+    assert.deepStrictEqual(
+      offending,
+      [],
+      `Found shell-context path corruption ([})]$gsd-*) in Codex-converted workflow files (#704):\n` +
+        offending.map((o) => `  ${o.file}: ...${o.context}...`).join('\n'),
+    );
+  });
+
+  test('commands/gsd/*.md: shell-variable launcher paths contain no $gsd-core', () => {
+    // Walk commands/gsd/ and assert that no command file produces the shell-context
+    // }$gsd-core corruption — since commands also go through
+    // convertClaudeCommandToCodexSkill when installed globally for Codex.
+    const commandsDir = path.join(__dirname, '..', 'commands', 'gsd');
+    if (!fs.existsSync(commandsDir)) return;
+
+    const files = fs.readdirSync(commandsDir)
+      .filter((f) => f.endsWith('.md'))
+      .map((f) => path.join(commandsDir, f));
+
+    assert.ok(files.length > 0, 'Expected at least one command .md file');
+
+    const SHELL_CORRUPTION_RE = /[})](\$gsd-[a-z])/;
+
+    const offending = [];
+    for (const file of files) {
+      const content = fs.readFileSync(file, 'utf8');
+      const skillName = `gsd-${path.basename(file, '.md')}`;
+      const converted = convertClaudeCommandToCodexSkill(content, skillName);
+      const match = converted.match(SHELL_CORRUPTION_RE);
+      if (match) {
+        const idx = converted.indexOf(match[0]);
+        offending.push({
+          file: path.relative(commandsDir, file),
+          context: converted.substring(Math.max(0, idx - 40), idx + 80),
+        });
+      }
+    }
+
+    assert.deepStrictEqual(
+      offending,
+      [],
+      `Found shell-context path corruption ([})]$gsd-*) in Codex-converted command files (#704):\n` +
+        offending.map((o) => `  ${o.file}: ...${o.context}...`).join('\n'),
+    );
+  });
+});

--- a/tests/bug-704-codex-launcher-path-corruption.test.cjs
+++ b/tests/bug-704-codex-launcher-path-corruption.test.cjs
@@ -78,10 +78,11 @@ describe('#704 — Codex global install launcher path corruption', () => {
       );
     }
 
-    // The correct path forms must be preserved
+    // The correct path forms must be preserved — the canonical launcher path
+    // (RUNTIME_ROOT_PATH) must survive Codex conversion intact.
     assert.ok(
-      output.includes('}/gsd-core/bin/'),
-      `Expected "${'}' + '/gsd-core/bin/'}" to appear in the converted output. ` +
+      output.includes(RUNTIME_ROOT_PATH),
+      `Expected canonical launcher path "${RUNTIME_ROOT_PATH}" to appear in the converted output. ` +
         `Got:\n${output.substring(0, 500)}`,
     );
     assert.ok(


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #704

The linked issue carries the `confirmed-bug` label.

---

## What was broken

`v1.3.1` global installs for Codex shipped workflow files containing a literal `$gsd-core` token in the launcher path (e.g. `${_GSD_RUNTIME_ROOT}$gsd-core/bin/...`), producing broken launcher invocations.

## What this fix does

Adds `}` and `)` to the negative lookbehind in `convertSlashCommandsToCodexSkillMentions` (`bin/install.js`), so shell path segments like `${VAR}/gsd-core/` and `$(cmd)/gsd-local-patches` are no longer mistaken for `/gsd-<cmd>` slash-command mentions and rewritten into `$gsd-core`.

## Root cause

The hyphen-style conversion regex `(?<![a-zA-Z0-9./])\/gsd-([a-z0-9-]+)` excluded word chars, `.` and `/` from the character immediately before `/gsd-`, but not `}` or `)`. A path segment following a shell variable expansion (`}`) or command substitution (`)`) therefore matched and was corrupted during Codex markdown conversion. Fixed by extending the lookbehind to `(?<![a-zA-Z0-9./})])`.

## Testing

### How I verified the fix

New regression test `tests/bug-704-codex-launcher-path-corruption.test.cjs` (5 cases): the `${VAR}/` and `$(cmd)/` forms survive conversion uncorrupted, all closer chars are covered, legitimate `/gsd-<cmd>` mentions still convert, and a sweep of all 88 `gsd-core/workflows/*.md` and `commands/gsd/*.md` produces no `[})]$gsd-*` corruption. Full `npm test` (3379 pass / 0 fail) and the local docker matrix (macOS + Linux Docker, 13,491 pass / 0 fail / 0 platform-specific) are green. Adversarial (Codex) review caught the `)` closer that a `}`-only fix would have missed.

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No

### Platforms tested

- [x] macOS
- [ ] Windows (no local Windows host configured; CI matrix covers it — fix is a platform-agnostic string transform)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [x] Other: Codex install markdown conversion (the affected surface)
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added (`.changeset/rapid-tigers-dance.md`, type `Fixed`)
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/710"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783268763&installation_id=134682257&pr_number=710&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F710&signature=417625640789bcc75db378aa211ce1e4f8317f40394b89750bba7fbb37818d83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->