### PR TITLE
feat(#159): auto-use existing RESEARCH.md in /gsd:plan-phase --research-phase

### DIFF
--- a/.changeset/159-research-phase-auto-use-existing.md
+++ b/.changeset/159-research-phase-auto-use-existing.md
@@ -1,5 +1,5 @@
 ---
 type: Changed
-pr: 159
+pr: 718
 ---
 `/gsd:plan-phase --research-phase <N>` now auto-uses an existing `RESEARCH.md` instead of prompting update/view/skip. When research already exists and neither `--research` nor `--view` is passed, it emits a one-line notice and exits cleanly, matching the promptless behavior of standard `/gsd:plan-phase <N>`. Pass `--research` to force-refresh or `--view` to print the existing research. (#159)

--- a/.changeset/159-research-phase-auto-use-existing.md
+++ b/.changeset/159-research-phase-auto-use-existing.md
@@ -1,0 +1,5 @@
+---
+type: Changed
+pr: 159
+---
+`/gsd:plan-phase --research-phase <N>` now auto-uses an existing `RESEARCH.md` instead of prompting update/view/skip. When research already exists and neither `--research` nor `--view` is passed, it emits a one-line notice and exits cleanly, matching the promptless behavior of standard `/gsd:plan-phase <N>`. Pass `--research` to force-refresh or `--view` to print the existing research. (#159)

--- a/commands/gsd/plan-phase.md
+++ b/commands/gsd/plan-phase.md
@@ -22,8 +22,8 @@ Create executable phase prompts (PLAN.md files) for a roadmap phase with integra
 **Research-only mode (`--research-phase <N>`):** Spawn `gsd-phase-researcher` for phase `N`, write `RESEARCH.md`, then exit before the planner runs. Useful for cross-phase research, doc review before committing to a planning approach, and correction-without-replanning loops where iterating on research alone is dramatically cheaper than re-spawning the planner. Replaces the deleted research-phase command (#3042).
 
 **Research-only modifiers:**
-- **No flag** — when `RESEARCH.md` already exists, prompt the user to choose `update / view / skip`.
-- **`--research`** — force-refresh: re-spawn the researcher unconditionally, no prompt. Skips the existing-RESEARCH.md menu.
+- **No flag** — when `RESEARCH.md` already exists, auto-use it: emit a one-line notice and exit cleanly (no prompt). Pass `--research` to refresh or `--view` to print.
+- **`--research`** — force-refresh: re-spawn the researcher unconditionally, no prompt. Bypasses the existing-RESEARCH.md auto-use path.
 - **`--view`** — view-only: print existing `RESEARCH.md` to stdout. Does not spawn the researcher. Cheapest mode for the correction-without-replanning loop. If no `RESEARCH.md` exists yet, errors with a hint to drop `--view`.
 
 **Orchestrator role:** Parse arguments, validate phase, research domain (unless skipped), spawn gsd-planner, verify with gsd-plan-checker, iterate until pass or max iterations, present results.

--- a/commands/gsd/plan-phase.md
+++ b/commands/gsd/plan-phase.md
@@ -22,7 +22,7 @@ Create executable phase prompts (PLAN.md files) for a roadmap phase with integra
 **Research-only mode (`--research-phase <N>`):** Spawn `gsd-phase-researcher` for phase `N`, write `RESEARCH.md`, then exit before the planner runs. Useful for cross-phase research, doc review before committing to a planning approach, and correction-without-replanning loops where iterating on research alone is dramatically cheaper than re-spawning the planner. Replaces the deleted research-phase command (#3042).
 
 **Research-only modifiers:**
-- **No flag** — when `RESEARCH.md` already exists, auto-use it: emit a one-line notice and exit cleanly (no prompt). Pass `--research` to refresh or `--view` to print.
+- **No flag** — when `RESEARCH.md` already exists, auto-uses it: emits a one-line notice and exits cleanly, no prompt.
 - **`--research`** — force-refresh: re-spawn the researcher unconditionally, no prompt. Bypasses the existing-RESEARCH.md auto-use path.
 - **`--view`** — view-only: print existing `RESEARCH.md` to stdout. Does not spawn the researcher. Cheapest mode for the correction-without-replanning loop. If no `RESEARCH.md` exists yet, errors with a hint to drop `--view`.
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -162,7 +162,7 @@ Research, plan, and verify a phase.
 **Produces:** `{phase}-RESEARCH.md`, `{phase}-{N}-PLAN.md`, `{phase}-VALIDATION.md`; `{phase}/SKELETON.md` when Walking Skeleton mode fires
 
 **Research-only mode (`--research-phase <N>`):**
-- No modifier: when RESEARCH.md already exists, auto-use it — emit a one-line notice and exit cleanly (no prompt). Pass `--research` to refresh or `--view` to print.
+- No modifier: when RESEARCH.md already exists, auto-uses it — emits a one-line notice and exits, no prompt.
 - With `--research`: force-refresh — re-spawn researcher unconditionally, no prompt.
 - With `--view`: print existing RESEARCH.md to stdout, no spawn. Errors if RESEARCH.md missing.
 
@@ -185,7 +185,7 @@ See [Package Legitimacy Gate in the User Guide](USER-GUIDE.md#package-legitimacy
 /gsd-plan-phase 1 --bounce                     # Plan + external bounce validation
 /gsd-plan-phase 2 --ingest docs/adr/0010.md   # ADR express path for context synthesis
 /gsd-plan-phase 2 --ingest 'docs/adr/00*.md' --ingest-format auto
-/gsd-plan-phase --research-phase 4             # Research only on phase 4 (auto-uses existing RESEARCH.md; --research to refresh)
+/gsd-plan-phase --research-phase 4             # Research only on phase 4 (auto-uses existing RESEARCH.md, no prompt)
 /gsd-plan-phase --research-phase 4 --view      # Print existing RESEARCH.md, no spawn
 /gsd-plan-phase --research-phase 4 --research  # Force-refresh research, no prompt
 /gsd-plan-phase 1 --mvp                        # Vertical-slice plan for phase 1

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -162,7 +162,7 @@ Research, plan, and verify a phase.
 **Produces:** `{phase}-RESEARCH.md`, `{phase}-{N}-PLAN.md`, `{phase}-VALIDATION.md`; `{phase}/SKELETON.md` when Walking Skeleton mode fires
 
 **Research-only mode (`--research-phase <N>`):**
-- No modifier: prompts `update / view / skip` if RESEARCH.md already exists.
+- No modifier: when RESEARCH.md already exists, auto-use it — emit a one-line notice and exit cleanly (no prompt). Pass `--research` to refresh or `--view` to print.
 - With `--research`: force-refresh — re-spawn researcher unconditionally, no prompt.
 - With `--view`: print existing RESEARCH.md to stdout, no spawn. Errors if RESEARCH.md missing.
 
@@ -185,7 +185,7 @@ See [Package Legitimacy Gate in the User Guide](USER-GUIDE.md#package-legitimacy
 /gsd-plan-phase 1 --bounce                     # Plan + external bounce validation
 /gsd-plan-phase 2 --ingest docs/adr/0010.md   # ADR express path for context synthesis
 /gsd-plan-phase 2 --ingest 'docs/adr/00*.md' --ingest-format auto
-/gsd-plan-phase --research-phase 4             # Research only on phase 4 (prompts if RESEARCH.md exists)
+/gsd-plan-phase --research-phase 4             # Research only on phase 4 (auto-uses existing RESEARCH.md; --research to refresh)
 /gsd-plan-phase --research-phase 4 --view      # Print existing RESEARCH.md, no spawn
 /gsd-plan-phase --research-phase 4 --research  # Force-refresh research, no prompt
 /gsd-plan-phase 1 --mvp                        # Vertical-slice plan for phase 1

--- a/gsd-core/workflows/help/modes/full.md
+++ b/gsd-core/workflows/help/modes/full.md
@@ -86,7 +86,7 @@ Create detailed execution plan for a specific phase.
 
 - `--skip-research` — bypass the research subagent
 - `--research-phase <N>` — research-only mode. Spawns the research agent for phase `<N>`, writes `RESEARCH.md`, then exits before the planner runs. Useful for cross-phase research, doc review before committing to a planning approach, and correction-without-replanning loops. Replaces the deleted `gsd-research-phase` standalone command (#3042).
-  - Modifiers: `--research` forces refresh (re-spawn researcher, no prompt). `--view` prints existing `RESEARCH.md` to stdout without spawning. With neither, prompts `update / view / skip` if `RESEARCH.md` already exists.
+  - Modifiers: `--research` forces refresh (re-spawn researcher). `--view` prints existing `RESEARCH.md` to stdout without spawning. With neither, auto-uses an existing `RESEARCH.md` (one-line notice + clean exit; pass `--research` to refresh or `--view` to print).
 - `--gaps` — focus only on closing gaps from a prior plan-check
 - `--skip-verify` — skip the post-plan verifier loop
 - `--ingest <path-or-glob>` — pre-ingest external ADRs/PRDs/SPECs before planning (see *PRD Express Path* below)
@@ -100,7 +100,7 @@ Create detailed execution plan for a specific phase.
 - Multiple plans per phase supported (XX-01, XX-02, etc.)
 
 Usage: `/gsd:plan-phase 1`
-Usage: `/gsd:plan-phase --research-phase 2` — research only on phase 2 (prompts if `RESEARCH.md` exists)
+Usage: `/gsd:plan-phase --research-phase 2` — research only on phase 2 (auto-uses existing `RESEARCH.md`; pass `--research` to refresh)
 Usage: `/gsd:plan-phase --research-phase 2 --view` — print existing `RESEARCH.md`, no spawn
 Usage: `/gsd:plan-phase --research-phase 2 --research` — force-refresh, no prompt
 Result: Creates `.planning/phases/01-foundation/01-01-PLAN.md`

--- a/gsd-core/workflows/help/modes/full.md
+++ b/gsd-core/workflows/help/modes/full.md
@@ -86,7 +86,7 @@ Create detailed execution plan for a specific phase.
 
 - `--skip-research` — bypass the research subagent
 - `--research-phase <N>` — research-only mode. Spawns the research agent for phase `<N>`, writes `RESEARCH.md`, then exits before the planner runs. Useful for cross-phase research, doc review before committing to a planning approach, and correction-without-replanning loops. Replaces the deleted `gsd-research-phase` standalone command (#3042).
-  - Modifiers: `--research` forces refresh (re-spawn researcher). `--view` prints existing `RESEARCH.md` to stdout without spawning. With neither, auto-uses an existing `RESEARCH.md` (one-line notice + clean exit; pass `--research` to refresh or `--view` to print).
+  - Modifiers: `--research` forces refresh (re-spawn researcher). `--view` prints existing `RESEARCH.md` to stdout without spawning. With neither, auto-uses an existing `RESEARCH.md` (one-line notice, then clean exit).
 - `--gaps` — focus only on closing gaps from a prior plan-check
 - `--skip-verify` — skip the post-plan verifier loop
 - `--ingest <path-or-glob>` — pre-ingest external ADRs/PRDs/SPECs before planning (see *PRD Express Path* below)
@@ -100,7 +100,7 @@ Create detailed execution plan for a specific phase.
 - Multiple plans per phase supported (XX-01, XX-02, etc.)
 
 Usage: `/gsd:plan-phase 1`
-Usage: `/gsd:plan-phase --research-phase 2` — research only on phase 2 (auto-uses existing `RESEARCH.md`; pass `--research` to refresh)
+Usage: `/gsd:plan-phase --research-phase 2` — research only on phase 2 (auto-uses existing `RESEARCH.md`, no prompt)
 Usage: `/gsd:plan-phase --research-phase 2 --view` — print existing `RESEARCH.md`, no spawn
 Usage: `/gsd:plan-phase --research-phase 2 --research` — force-refresh, no prompt
 Result: Creates `.planning/phases/01-foundation/01-01-PLAN.md`

--- a/gsd-core/workflows/plan-phase.md
+++ b/gsd-core/workflows/plan-phase.md
@@ -417,15 +417,15 @@ Pass `ai_spec_path` and `framework_line` to planner in step 7 so it can referenc
 
 **Skip if:** `--gaps` flag or `--skip-research` flag or `--reviews` flag.
 
-### 5.0. Research-Only Modifiers (`--view`, `--research`, prompt)
+### 5.0. Research-Only Modifiers (`--view`, `--research`)
 
 **Skip if:** `RESEARCH_ONLY` is `false`.
 
 Three branches in research-only mode (`--research-phase <N>`):
 
-1. **`--view`** (or user picks "View" in the prompt below): print `RESEARCH.md` to stdout, no spawn, exit. If `RESEARCH.md` is missing, error with: `--view requires an existing RESEARCH.md; drop --view to spawn the researcher.`
+1. **`--view`**: print `RESEARCH.md` to stdout, no spawn, exit. If `RESEARCH.md` is missing, error with: `--view requires an existing RESEARCH.md; drop --view to spawn the researcher.`
 2. **`--research`** (force-refresh): re-spawn researcher unconditionally — fall through to "Spawn gsd-phase-researcher" below.
-3. **Neither flag AND `has_research=true`:** emit `RESEARCH.md already exists for Phase ${PHASE}.` and prompt the user with three choices: `1. Update — re-spawn researcher and refresh RESEARCH.md`, `2. View — print existing RESEARCH.md and exit (no spawn)`, `3. Skip — exit without spawning or printing`. Map "Update" → fall through to spawn, "View" → set `VIEW_ONLY=true` and emit RESEARCH.md as in (1), "Skip" → exit cleanly. Mirrors the deleted `/gsd-research-phase` standalone's existing-artifact menu (#3042 parity).
+3. **Neither flag AND `has_research=true`:** auto-use the existing research and exit cleanly — do not prompt, do not re-spawn. Emit `RESEARCH.md already exists for Phase ${PHASE}, using it. To force-refresh, re-invoke with --research; to print, re-invoke with --view. Path: ${research_path}` then exit. The explicit-flag escape hatches cover any deviation; this matches §5.1's promptless auto-use of existing research, removing the §5.0/§5.1 inconsistency (#159).
 
 ```bash
 if [[ "$VIEW_ONLY" == "true" ]]; then

--- a/tests/skill-frontmatter-contract.test.cjs
+++ b/tests/skill-frontmatter-contract.test.cjs
@@ -172,29 +172,42 @@ describe('skill frontmatter: /gsd-plan-phase --research-phase flag absorbs the s
     );
   });
 
-  test('workflow has an existing-RESEARCH.md prompt path (update/view/skip) within proximity', () => {
+  test('research-only mode auto-uses existing RESEARCH.md (no update/view/skip prompt)', () => {
     const content = read('gsd-core/workflows/plan-phase.md');
-    // CR #3045 finding: the previous version of this test asserted
-    // `update`, `view`, `skip` appeared anywhere in the file, which was
-    // tautological — those words occur all over the workflow for
-    // unrelated reasons (--skip-research, --view flag declarations,
-    // etc.). Tighten to a proximity check: all three choice tokens
-    // must occur in a window of ~400 chars surrounding "RESEARCH.md
-    // already exists" / "Update — re-spawn" / equivalent prompt prose,
-    // proving the prompt section is genuinely present.
+    // #159: the §5.0 existing-RESEARCH.md path no longer prompts
+    // update/view/skip. When RESEARCH.md exists and neither --research nor
+    // --view is set, the workflow emits a brief "using it" notice naming
+    // the two escape-hatch flags and exits cleanly — matching the
+    // promptless auto-use behavior of §5.1 standard mode.
     const idx = content.indexOf('RESEARCH.md already exists');
     assert.ok(
       idx >= 0,
-      'plan-phase workflow must contain the literal "RESEARCH.md already exists" prompt header in the research-only existing-artifact section'
+      'plan-phase workflow must contain the literal "RESEARCH.md already exists" notice in the research-only existing-artifact section'
     );
     const window = content.slice(idx, idx + 600);
-    const hasUpdate = /\b(?:update|refresh|re-spawn)\b/i.test(window);
-    const hasView = /\bview\b/i.test(window);
-    const hasSkip = /\bskip\b/i.test(window);
+    // Positive contract: an auto-use notice that names both recovery flags.
     assert.ok(
-      hasUpdate && hasView && hasSkip,
-      'prompt section near "RESEARCH.md already exists" must mention all three choices (update/refresh/re-spawn, view, skip); ' +
-        'got update=' + hasUpdate + ' view=' + hasView + ' skip=' + hasSkip
+      /using it/i.test(window),
+      'existing-RESEARCH.md notice must state the existing research is being used (e.g. "using it")'
+    );
+    assert.ok(
+      /--research\b/.test(window),
+      'notice must name --research as the force-refresh escape hatch'
+    );
+    assert.ok(
+      /--view\b/.test(window),
+      'notice must name --view as the print-existing escape hatch'
+    );
+    // Negative contract: the interactive three-choice prompt must be gone.
+    // Guard against reintroduction via prose, an AskUserQuestion call, or a
+    // lingering "skip" choice token. (The §5.1 "skip to step 6" text is ~805
+    // chars past the anchor, outside this 600-char window.)
+    assert.ok(
+      !/prompt the user/i.test(window) &&
+        !/three choices/i.test(window) &&
+        !/AskUserQuestion/i.test(window) &&
+        !/\bskip\b/i.test(window),
+      'existing-RESEARCH.md path must no longer present an interactive update/view/skip prompt'
     );
   });
 });


### PR DESCRIPTION
## Enhancement PR

## Linked Issue

Closes #159

The linked issue carries the `approved-enhancement` label.

---

## What this enhancement improves

`/gsd:plan-phase --research-phase <N>` (research-only mode) — specifically the §5.0 "Research-Only Modifiers" path in `gsd-core/workflows/plan-phase.md` that handles the case where `RESEARCH.md` already exists.

## Before / After

**Before:**
When `RESEARCH.md` already existed and neither `--research` nor `--view` was passed, the workflow emitted `RESEARCH.md already exists for Phase <N>.` and then fired an interactive `AskUserQuestion` prompt with three options (Update / View / Skip). The caller had to answer before anything could proceed — even though Update is already reachable via `--research`, View via `--view`, and Skip is just "do nothing".

**After:**
The same case now auto-uses the existing research and exits cleanly with a one-line notice, no prompt:

```
RESEARCH.md already exists for Phase <N>, using it. To force-refresh, re-invoke with --research; to print, re-invoke with --view. Path: <research_path>
```

This matches the promptless auto-use already in standard `/gsd:plan-phase <N>` (§5.1) and makes AI-agent / CLI invocations non-interactive in the common case (research exists, caller wants to proceed).

## How it was implemented

Workflow-content change only — no SDK/CJS code touched. Key files:

- `gsd-core/workflows/plan-phase.md` §5.0 — branch 3 (neither flag, `has_research=true`) now states auto-use + clean exit; the section heading and branch 1 lost their now-stale references to the removed prompt.
- `gsd-core/workflows/help/modes/full.md` and `docs/COMMANDS.md` — modifier description + usage examples updated to describe auto-use instead of a prompt.
- `commands/gsd/plan-phase.md` — the `--research`/no-flag modifier bullets updated.
- `tests/skill-frontmatter-contract.test.cjs` — the existing contract test was flipped from asserting the old update/view/skip prompt to asserting the new auto-use notice (positive: `using it`, `--research`, `--view`; negative: no `prompt the user` / `three choices` / `AskUserQuestion` / lone `skip` choice within the notice window).

The new branch-3 prose was kept to a single line so `plan-phase.md` stays at its existing XL size-budget ceiling (1810 lines) — no budget ratchet bump.

## Testing

### How I verified the enhancement works

- TDD: rewrote the contract test to the new behavior first (confirmed red), then implemented the workflow change to green.
- `node --test tests/skill-frontmatter-contract.test.cjs` → 9/9 pass.
- `node --test tests/workflow-size-budget.test.cjs` → 110/110 pass (XL-tier `plan-phase` regression avoided; file held at 1810).
- Full unit suite (`npm run test:unit`) → 3438 pass, 0 fail, 1 skipped.
- `npm run lint` → 0 errors. `lint:changeset` and `lint:docs` (base `next`) → ok.
- Independent Codex adversarial review + a security review pass; findings (a stale "menu" reference in `commands/gsd/plan-phase.md`, a stale `prompts update/view/skip` line + example comment in `docs/COMMANDS.md`, and a strengthened negative test assertion) were applied.

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [x] N/A (not platform-specific — workflow/doc content + test)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [ ] N/A (not runtime-specific)

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue — no additions or removals
- [x] If scope changed during implementation, I updated the issue and got re-approval before continuing

> Note: issue comment #2 proposed broadening this to other artifacts (UI-SPEC.md, AI-SPEC.md, etc.). Per the triage note that this belongs in separate enhancements, this PR is deliberately scoped to the RESEARCH.md path only.

## Documentation

- [x] Updated the relevant file(s) under `docs/` to reflect this change (`docs/COMMANDS.md` — modifier description + usage example)
- [x] All `docs/` content added in this PR is written in English
- [ ] If genuinely no user-facing docs impact — N/A (docs were updated)

## Checklist

- [x] Issue linked above with `Closes #159`
- [x] Linked issue has the `approved-enhancement` label
- [x] Changes are scoped to the approved enhancement — nothing extra included
- [x] All existing tests pass (`npm test` unit suite green)
- [x] New or updated tests cover the enhanced behavior
- [x] `.changeset/` fragment added (type `Changed`)
- [x] No unnecessary dependencies added

## Breaking changes

Minor, documented behavior change: a caller who ran `/gsd:plan-phase --research-phase <N>` expecting the Update/View/Skip prompt no longer sees it when research exists. Recovery is in-band and one-shot — the notice names `--research` (refresh) and `--view` (print). The Skip option is removed because clean auto-exit is now the default; operationally nothing changes (the workflow exits cleanly either way). Captured as a `Changed` changeset entry.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/718"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783291263&installation_id=134682257&pr_number=718&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F718&signature=1d57bd230d7e8db30063117fdced47cc8c24c5733d1c8501b0c0b881dadd889f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->