### PR TITLE
feat(#323): fish-shell support in post-install PATH suggestion and rc-coverage detection

### DIFF
--- a/.changeset/curious-ravens-zip.md
+++ b/.changeset/curious-ravens-zip.md
@@ -1,0 +1,5 @@
+---
+type: Changed
+pr: 323
+---
+**The installer now speaks fish** — the post-install "not on your PATH" guidance includes a copy-paste-correct `fish_add_path` line, and the warning is suppressed when fish already covers the directory via `fish_user_paths` or `config.fish`. Previously fish users were handed inert `export PATH=…` commands and a false-positive warning on every install (#323).

--- a/.changeset/curious-ravens-zip.md
+++ b/.changeset/curious-ravens-zip.md
@@ -1,5 +1,5 @@
 ---
 type: Changed
-pr: 323
+pr: 721
 ---
 **The installer now speaks fish** — the post-install "not on your PATH" guidance includes a copy-paste-correct `fish_add_path` line, and the warning is suppressed when fish already covers the directory via `fish_user_paths` or `config.fish`. Previously fish users were handed inert `export PATH=…` commands and a false-positive warning on every install (#323).

--- a/bin/install.js
+++ b/bin/install.js
@@ -10659,6 +10659,115 @@ function homePathCoveredByRc(globalBin, homeDir, rcFileNames) {
 }
 
 /**
+ * Detect whether fish shell already adds globalBin to PATH (#323). fish does
+ * not use the POSIX rc files scanned by homePathCoveredByRc(); it persists PATH
+ * additions through the `fish_user_paths` universal variable and through
+ * `fish_add_path` / `set -gx PATH` lines in ~/.config/fish/config.fish. Without
+ * this check the installer fires a false-positive "not on your PATH" warning on
+ * every reinstall for fish users whose PATH is already fine.
+ *
+ * Two detection routes:
+ *   1. ~/.config/fish/fish_variables — a `SETUVAR … fish_user_paths:…` line whose
+ *      \x1e (record-separator) delimited entries include globalBin. fish stores
+ *      these values fully expanded (HOME is not represented as ~ or $HOME here).
+ *   2. ~/.config/fish/config.fish — a `fish_add_path …`, `set … PATH …`, or
+ *      `set … fish_user_paths …` line referencing globalBin after HOME expansion.
+ *
+ * Exported for tests.
+ *
+ * @param {string} globalBin  Absolute path to npm's global bin directory.
+ * @param {string} homeDir    Absolute HOME path used to expand ~ / $HOME.
+ * @returns {boolean}         true iff fish config already covers globalBin.
+ */
+function homePathCoveredByFishConfig(globalBin, homeDir) {
+  if (!globalBin || !homeDir) return false;
+  const path = require('path');
+  const fs = require('fs');
+
+  const normalise = (p) => {
+    if (!p) return '';
+    let n = p.replace(/[\\/]+$/g, '');
+    if (n === '') n = p.startsWith('/') ? '/' : p;
+    return n;
+  };
+
+  const targetAbs = normalise(path.resolve(globalBin));
+  const homeAbs = path.resolve(homeDir);
+  const fishDir = path.join(homeAbs, '.config', 'fish');
+
+  const expandHome = (segment) => {
+    let s = segment;
+    s = s.replace(/\$\{HOME\}/g, homeAbs);
+    s = s.replace(/\$HOME/g, homeAbs);
+    if (s.startsWith('~/') || s === '~') {
+      s = s === '~' ? homeAbs : path.join(homeAbs, s.slice(2));
+    }
+    return s;
+  };
+
+  // Resolve a single path token and compare it to the target. Mirrors the
+  // relative-segment and unresolved-variable guards in homePathCoveredByRc():
+  // a cwd-relative token (e.g. `bin`) is NOT equivalent to `$HOME/bin`, and a
+  // token still carrying `$` after expansion is an unresolved variable.
+  const matchesTarget = (rawSegment) => {
+    if (!rawSegment) return false;
+    let seg = rawSegment.trim();
+    if (!seg) return false;
+    if ((seg.startsWith('"') && seg.endsWith('"')) ||
+        (seg.startsWith("'") && seg.endsWith("'"))) {
+      seg = seg.slice(1, -1);
+    }
+    const expanded = expandHome(seg);
+    if (!expanded || expanded.includes('$')) return false;
+    if (!path.isAbsolute(expanded)) return false;
+    try {
+      return normalise(path.resolve(expanded)) === targetAbs;
+    } catch {
+      return false;
+    }
+  };
+
+  // Route 1: universal variable store. fish_user_paths entries are \x1e
+  // delimited and stored as fully-expanded absolute paths.
+  try {
+    const content = fs.readFileSync(path.join(fishDir, 'fish_variables'), 'utf8');
+    for (const rawLine of content.split(/\r?\n/)) {
+      const m = /^SETUVAR\s+(?:--\S+\s+)*fish_user_paths:(.*)$/.exec(rawLine.replace(/^\s+/, ''));
+      if (!m) continue;
+      for (const entry of m[1].split('\x1e')) {
+        if (matchesTarget(entry)) return true;
+      }
+    }
+  } catch {
+    // missing/unreadable store — fall through to config.fish
+  }
+
+  // Route 2: config.fish — fish_add_path / set -gx PATH / set -Ux fish_user_paths.
+  try {
+    const content = fs.readFileSync(path.join(fishDir, 'config.fish'), 'utf8');
+    for (const rawLine of content.split(/\r?\n/)) {
+      const line = rawLine.replace(/^\s+/, '');
+      if (line.startsWith('#')) continue;
+      const isPathLine =
+        /^fish_add_path\b/.test(line) ||
+        /^set\s+(?:-\S+\s+)*PATH\b/.test(line) ||
+        /^set\s+(?:-\S+\s+)*fish_user_paths\b/.test(line);
+      if (!isPathLine) continue;
+      // Tokenise on whitespace; flags (`-gx`), the var name, and `$PATH`-style
+      // tokens fail matchesTarget()'s absolute/unresolved guards, so only real
+      // path arguments can register coverage. fish_add_path/set accept many.
+      for (const token of line.split(/\s+/)) {
+        if (matchesTarget(token)) return true;
+      }
+    }
+  } catch {
+    // missing/unreadable config — no fish coverage
+  }
+
+  return false;
+}
+
+/**
  * Emit a PATH-export suggestion if globalBin is not already on PATH AND
  * the user's shell rc files do not already cover it via a HOME-relative
  * entry (#2620).
@@ -10696,6 +10805,15 @@ function maybeSuggestPathExport(globalBin, homeDir) {
   if (homePathCoveredByRc(globalBin, homeDir)) {
     console.log('');
     console.log(`  ${yellow}⚠${reset} ${bold}${globalBin}${reset}'s directory is already on your PATH via an rc file entry — try reopening your shell (or ${cyan}source ~/.zshrc${reset}).`);
+    console.log('');
+    return;
+  }
+
+  // fish persists PATH outside the POSIX rc files above (#323) — suppress the
+  // warning when fish_user_paths / config.fish already covers globalBin.
+  if (homePathCoveredByFishConfig(globalBin, homeDir)) {
+    console.log('');
+    console.log(`  ${yellow}⚠${reset} ${bold}${globalBin}${reset}'s directory is already on your PATH via your fish config (${cyan}fish_user_paths${reset}) — try reopening your shell.`);
     console.log('');
     return;
   }
@@ -10996,6 +11114,7 @@ module.exports = {
     USER_OWNED_ARTIFACTS,
     finishInstall,
     homePathCoveredByRc,
+    homePathCoveredByFishConfig,
     maybeSuggestPathExport,
     runtimeMap,
     allRuntimes,

--- a/docs/how-to/recover-and-troubleshoot.md
+++ b/docs/how-to/recover-and-troubleshoot.md
@@ -253,6 +253,21 @@ npx @opengsd/gsd-core@latest --claude --local
 
 For runtime-specific install paths and troubleshooting, see [Install on your runtime](install-on-your-runtime.md).
 
+### If the installer warns the global bin is "not on your PATH"
+
+The installer prints a copy-paste command to add the npm global bin directory to your PATH. Run the line for your shell:
+
+```bash
+# zsh
+echo 'export PATH="/path/to/global/bin:$PATH"' >> ~/.zshrc
+# bash
+echo 'export PATH="/path/to/global/bin:$PATH"' >> ~/.bashrc
+# fish
+fish_add_path /path/to/global/bin
+```
+
+For **fish**, use `fish_add_path` — fish is not POSIX-compatible, so the `export PATH=…` form does not work there. `fish_add_path` persists the entry in fish's universal-variable store (`fish_user_paths`) and is idempotent. Once the directory is covered (via `fish_user_paths` or a `fish_add_path`/`set -gx PATH` line in `~/.config/fish/config.fish`), the installer stops warning on subsequent runs.
+
 ### If an update overwrote your local changes
 
 Since v1.17, the installer backs up locally modified files to `gsd-local-patches/`. Reapply your changes:

--- a/src/shell-command-projection.cts
+++ b/src/shell-command-projection.cts
@@ -357,6 +357,15 @@ export function projectPathActionProjection({
         shell: 'bash',
         command: `echo 'export PATH="${bashTargetDir}:$PATH"' >> ~/.bashrc`,
       },
+      {
+        // fish is not POSIX-compatible: it has no `export` and persists PATH
+        // through the universal-variable store, not an rc file. `fish_add_path`
+        // is the idempotent, deduplicating fish 3.2+ native API (#323). The
+        // value is single-quote-escaped consistently with the bash/zsh siblings.
+        label: 'fish',
+        shell: 'fish',
+        command: `fish_add_path '${bashTargetDir}'`,
+      },
     ];
   } else {
     const posixTargetDir = escapePosixDoubleQuoted(targetDir);

--- a/tests/bug-3441-path-action-projection.test.cjs
+++ b/tests/bug-3441-path-action-projection.test.cjs
@@ -39,11 +39,49 @@ describe('bug #3441: PATH guidance is projected from typed shell action IR', () 
       platform: 'linux',
     });
     assert.ok(Array.isArray(posix.shellActions));
-    assert.equal(posix.shellActions.length, 2);
+    assert.equal(posix.shellActions.length, 3);
     assert.equal(posix.shellActions[0].label, 'zsh');
     assert.equal(posix.shellActions[1].label, 'bash');
+    assert.equal(posix.shellActions[2].label, 'fish');
     assert.ok(posix.shellActions[0].command.includes('~/.zshrc'));
     assert.ok(posix.shellActions[1].command.includes('~/.bashrc'));
+    assert.ok(posix.shellActions[2].command.includes('~/.zshrc') === false);
+    assert.ok(posix.shellActions[2].command.includes('~/.bashrc') === false);
+  });
+
+  // #323: fish is not POSIX — its persist action uses the fish-native
+  // fish_add_path API, never `export`/`echo … >> rc`.
+  test('persist mode projects a fish_add_path action for fish', () => {
+    const projected = projection.projectPathActionProjection({
+      mode: 'persist',
+      targetDir: '/opt/node/bin',
+      platform: 'linux',
+    });
+    const fishAction = projected.shellActions.find((a) => a.shell === 'fish');
+    assert.ok(fishAction, 'expected a fish shell action in persist projection');
+    assert.equal(fishAction.label, 'fish');
+    assert.equal(fishAction.command, "fish_add_path '/opt/node/bin'");
+    assert.ok(!/\bexport\b/.test(fishAction.command), 'fish action must not use POSIX export');
+    assert.ok(!fishAction.command.includes('>>'), 'fish action must not append to an rc file');
+  });
+
+  test('fish persist action escapes single quotes consistently with siblings', () => {
+    const projected = projection.projectPathActionProjection({
+      mode: 'persist',
+      targetDir: "/tmp/O'Neil/bin",
+      platform: 'linux',
+    });
+    const fishAction = projected.shellActions.find((a) => a.shell === 'fish');
+    assert.equal(fishAction.command, "fish_add_path '/tmp/O'\\''Neil/bin'");
+  });
+
+  test('fish action is absent on win32 (PowerShell/cmd/Git-Bash projection)', () => {
+    const projected = projection.projectPathActionProjection({
+      mode: 'persist',
+      targetDir: 'C\\\\Users\\\\dev\\\\bin',
+      platform: 'win32',
+    });
+    assert.equal(projected.shellActions.find((a) => a.shell === 'fish'), undefined);
   });
 
   test('POSIX repair mode escapes double-quoted shell metacharacters', () => {

--- a/tests/install-path-detection.test.cjs
+++ b/tests/install-path-detection.test.cjs
@@ -294,6 +294,164 @@ describe('installer HOME-relative PATH detection (#2620)',
     }
   });
 
+  // ---- #323: fish-shell coverage detection (fish_user_paths / config.fish) ----
+
+  function writeFish(home, name, content) {
+    const dir = path.join(home, '.config', 'fish');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, name), content);
+  }
+
+  test('homePathCoveredByFishConfig is exported', () => {
+    assert.strictEqual(
+      typeof installer.homePathCoveredByFishConfig,
+      'function',
+      'bin/install.js must export homePathCoveredByFishConfig for #323',
+    );
+  });
+
+  test('detects globalBin in fish_variables SETUVAR fish_user_paths', () => {
+    const home = createTempHome();
+    try {
+      const globalBin = path.join(home, '.npm-global', 'bin');
+      // fish stores absolute, fully-expanded paths, \x1e-delimited.
+      writeFish(home, 'fish_variables',
+        `# This file contains fish universal variable definitions.\nSETUVAR --export fish_user_paths:${globalBin}\x1e${path.join(home, '.cargo', 'bin')}\n`,
+      );
+      assert.strictEqual(installer.homePathCoveredByFishConfig(globalBin, home), true);
+    } finally {
+      cleanup(home);
+    }
+  });
+
+  test('detects globalBin via fish_add_path in config.fish', () => {
+    const home = createTempHome();
+    try {
+      const globalBin = path.join(home, '.npm-global', 'bin');
+      writeFish(home, 'config.fish', `fish_add_path ${globalBin}\n`);
+      assert.strictEqual(installer.homePathCoveredByFishConfig(globalBin, home), true);
+    } finally {
+      cleanup(home);
+    }
+  });
+
+  test('detects globalBin via set -gx PATH in config.fish (HOME-expanded)', () => {
+    const home = createTempHome();
+    try {
+      const globalBin = path.join(home, '.npm-global', 'bin');
+      writeFish(home, 'config.fish', 'set -gx PATH $HOME/.npm-global/bin $PATH\n');
+      assert.strictEqual(installer.homePathCoveredByFishConfig(globalBin, home), true);
+    } finally {
+      cleanup(home);
+    }
+  });
+
+  test('returns false when fish config does not cover globalBin', () => {
+    const home = createTempHome();
+    try {
+      const globalBin = path.join(home, '.npm-global', 'bin');
+      writeFish(home, 'fish_variables', `SETUVAR fish_user_paths:${path.join(home, '.cargo', 'bin')}\n`);
+      writeFish(home, 'config.fish', 'fish_add_path $HOME/.cargo/bin\n');
+      assert.strictEqual(installer.homePathCoveredByFishConfig(globalBin, home), false);
+    } finally {
+      cleanup(home);
+    }
+  });
+
+  test('returns false when no fish config exists', () => {
+    const home = createTempHome();
+    try {
+      const globalBin = path.join(home, '.npm-global', 'bin');
+      assert.strictEqual(installer.homePathCoveredByFishConfig(globalBin, home), false);
+    } finally {
+      cleanup(home);
+    }
+  });
+
+  test('ignores commented fish_add_path lines', () => {
+    const home = createTempHome();
+    try {
+      const globalBin = path.join(home, '.npm-global', 'bin');
+      writeFish(home, 'config.fish', `# fish_add_path ${globalBin}\n`);
+      assert.strictEqual(installer.homePathCoveredByFishConfig(globalBin, home), false);
+    } finally {
+      cleanup(home);
+    }
+  });
+
+  test('does not treat bare relative fish path token as HOME-relative', () => {
+    const home = createTempHome();
+    try {
+      const globalBin = path.join(home, 'bin');
+      writeFish(home, 'config.fish', 'fish_add_path bin\n');
+      assert.strictEqual(
+        installer.homePathCoveredByFishConfig(globalBin, home),
+        false,
+        'relative tokens depend on cwd and are not equivalent to $HOME/bin',
+      );
+    } finally {
+      cleanup(home);
+    }
+  });
+
+  test('swallows unreadable fish config without throwing', () => {
+    const home = createTempHome();
+    try {
+      const dir = path.join(home, '.config', 'fish');
+      fs.mkdirSync(dir, { recursive: true });
+      fs.mkdirSync(path.join(dir, 'config.fish')); // directory where a file is expected
+      const globalBin = path.join(home, '.npm-global', 'bin');
+      assert.doesNotThrow(() => installer.homePathCoveredByFishConfig(globalBin, home));
+      assert.strictEqual(installer.homePathCoveredByFishConfig(globalBin, home), false);
+    } finally {
+      cleanup(home);
+    }
+  });
+
+  test('matches fish_user_paths entry regardless of trailing slash', () => {
+    const home = createTempHome();
+    try {
+      const globalBin = path.join(home, '.npm-global', 'bin');
+      writeFish(home, 'fish_variables', `SETUVAR fish_user_paths:${globalBin}/\n`);
+      assert.strictEqual(installer.homePathCoveredByFishConfig(globalBin, home), true);
+    } finally {
+      cleanup(home);
+    }
+  });
+
+  test('maybeSuggestPathExport suppresses suggestion when fish config covers globalBin', () => {
+    const home = createTempHome();
+    try {
+      const globalBin = path.join(home, '.npm-global', 'bin');
+      fs.mkdirSync(globalBin, { recursive: true });
+      writeFish(home, 'fish_variables', `SETUVAR --export fish_user_paths:${globalBin}\n`);
+
+      const logs = [];
+      const origLog = console.log;
+      console.log = (...args) => { logs.push(args.join(' ')); };
+      try {
+        installer.maybeSuggestPathExport(globalBin, home);
+      } finally {
+        console.log = origLog;
+      }
+
+      // Behavioral signal (mirrors the rc-coverage test above): the projected
+      // PATH-fix suggestion command must NOT be emitted when fish already
+      // covers the directory. The fish suggestion command is `fish_add_path …`.
+      const joined = logs.join('\n');
+      const fishSuggestion = projection.projectPersistentPathExportActions({
+        targetDir: globalBin,
+        platform: process.platform,
+      }).shellActions.find((a) => a.shell === 'fish');
+      assert.ok(
+        !joined.includes(fishSuggestion.command),
+        `installer must suppress the PATH suggestion when fish covers it; got:\n${joined}`,
+      );
+    } finally {
+      cleanup(home);
+    }
+  });
+
   test('maybeSuggestPathExport is a no-op when globalBin already on process.env.PATH', () => {
     const home = createTempHome();
     const origPath = process.env.PATH;


### PR DESCRIPTION
## Enhancement PR

## Linked Issue

Closes #323

The linked issue carries the `approved-enhancement` label (approved by @trek-e).

---

## What this enhancement improves

`bin/install.js` post-install PATH guidance — `maybeSuggestPathExport()` and its rc-coverage check — plus the persist-mode shell-action projection in `src/shell-command-projection.cts`. Adds **fish** as a first-class shell alongside zsh/bash.

## Before / After

**Before:** On POSIX, when the npm global bin dir is not on `PATH`, the installer prints only zsh/bash lines, and `homePathCoveredByRc()` only scans `.zshrc`/`.bashrc`/`.bash_profile`/`.profile`:

```
⚠ /home/user/.nvm/.../bin is not on your PATH.
  Add it with one of:
    zsh: echo 'export PATH="…:$PATH"' >> ~/.zshrc
    bash: echo 'export PATH="…:$PATH"' >> ~/.bashrc
```

For fish users both commands are **inert** (fish has no `export`), and because fish persists PATH via its universal-variable store (`fish_user_paths`) rather than an rc file, the warning is a **false positive on every install** even when PATH is already fine.

**After:** A copy-paste-correct fish line is added, and the warning is suppressed when fish already covers the directory:

```
    zsh:  echo 'export PATH="…:$PATH"' >> ~/.zshrc
    bash: echo 'export PATH="…:$PATH"' >> ~/.bashrc
    fish: fish_add_path '…'
```

## How it was implemented

- **`src/shell-command-projection.cts`** (TS source of truth per ADR-457; the `.cjs` under `gsd-core/bin/lib/` is a gitignored build artifact and is **not** committed) — add a `fish` entry to the `persist` branch using `fish_add_path` (idempotent fish 3.2+ native API), single-quote-escaped consistently with the bash/zsh siblings.
- **`bin/install.js`** — new `homePathCoveredByFishConfig()` parses `~/.config/fish/fish_variables` (`SETUVAR fish_user_paths`, `\x1e`-delimited absolute paths) and `~/.config/fish/config.fish` (`fish_add_path` / `set -gx PATH` / `set -Ux fish_user_paths`). Wired into `maybeSuggestPathExport()`. Reuses the same relative-token and unresolved-variable guards as `homePathCoveredByRc()`. Exported for tests.

## Testing

### How I verified the enhancement works

- `node --test tests/install-path-detection.test.cjs tests/bug-3441-path-action-projection.test.cjs` → **34/34 pass**.
- New fish coverage cases (positive + adversarial): `fish_variables` parsing, `fish_add_path`/`set -gx PATH` in `config.fish`, commented lines ignored, bare-relative tokens rejected, unreadable config swallowed, trailing-slash match, and warning-suppression. Projection IR tests assert the typed `shellActions` (no rendered-text matching).
- `npx eslint .` → 0 errors.

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling) — covered by a unit test asserting no fish action is projected on `win32`
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [x] N/A (not runtime-specific — installer PATH guidance)

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue — no additions or removals
- [x] If scope changed during implementation, I updated the issue and got re-approval before continuing

## Documentation

- [x] Updated `docs/how-to/recover-and-troubleshoot.md` with the fish PATH guidance
- [x] All `docs/` content added in this PR is written in English

## Checklist

- [x] Issue linked above with `Closes #323`
- [x] Linked issue has the `approved-enhancement` label
- [x] Changes are scoped to the approved enhancement — nothing extra included
- [x] All existing tests pass (`npm test` — affected suites verified)
- [x] New or updated tests cover the enhanced behavior
- [x] `.changeset/` fragment added (`type: Changed`)
- [x] No unnecessary dependencies added

## Breaking changes

None for bash/zsh/PowerShell/cmd/Git-Bash users — those entries and command strings are unchanged. For fish users, a previously-emitted false-positive warning stops emitting when `fish_user_paths` already covers the global bin (a silent improvement), and the suggestion list gains one fish line.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/721"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783310080&installation_id=134682257&pr_number=721&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F721&signature=c5e81973816c10f1415e1261a6a022eaa55f44f1e5763bcea1198d31b87b44d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->