### PR TITLE
chore(lint): justify intentional no-control-regex (ANSI strip) + ratchet to error

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -222,7 +222,7 @@ export default tseslint.config(
       // Downgraded from recommended error → warn (pre-existing violations; follow-up to fix)
       'no-useless-escape': 'warn',
       'no-regex-spaces': 'warn',
-      'no-control-regex': 'warn',
+      'no-control-regex': 'error',
       'no-irregular-whitespace': 'warn',
     },
   },

--- a/tests/bug-2957-claude-global-postinstall-message.test.cjs
+++ b/tests/bug-2957-claude-global-postinstall-message.test.cjs
@@ -39,6 +39,7 @@ function captureFinishInstallOutput(runtime, isGlobal) {
     console.log = original;
   }
   // Strip ANSI color escapes so message-content assertions don't couple to colors.
+  // eslint-disable-next-line no-control-regex -- \x1b (ESC) is the required leading byte of ANSI SGR color sequences; matching it is the purpose of stripping ANSI codes from captured CLI/console output
   return lines.join('\n').replace(/\x1B\[[0-9;]*m/g, '');
 }
 

--- a/tests/bug-3582-codex-skills-materialized.test.cjs
+++ b/tests/bug-3582-codex-skills-materialized.test.cjs
@@ -54,6 +54,7 @@ const COMMANDS_DIR = path.join(ROOT, 'commands', 'gsd');
 
 // Strip ANSI color codes so log assertions don't depend on TTY detection.
 function stripAnsi(s) {
+  // eslint-disable-next-line no-control-regex -- \x1b (ESC) is the required leading byte of ANSI SGR color sequences; matching it is the purpose of stripping ANSI codes from captured CLI/console output
   return s.replace(/\x1b\[[0-9;]*m/g, '');
 }
 

--- a/tests/feat-2795-update-banner.test.cjs
+++ b/tests/feat-2795-update-banner.test.cjs
@@ -317,6 +317,7 @@ describe('install.js update-banner wiring', () => {
     // Strip ANSI color escapes before structural assertions — the choice
     // digits are wrapped in color codes so word-boundary regex against the
     // raw text would miss them.
+    // eslint-disable-next-line no-control-regex -- \x1b (ESC) is the required leading byte of ANSI SGR color sequences; matching it is the purpose of stripping ANSI codes from captured CLI/console output
     const stripped = text.replace(/\x1b\[[0-9;]*m/g, '');
     // Prompt must offer at least two choices (default + opt-in).
     assert.match(stripped, /\b1\b/);

--- a/tests/gsd-statusline.test.cjs
+++ b/tests/gsd-statusline.test.cjs
@@ -334,6 +334,7 @@ describe('context meter respects CLAUDE_CODE_AUTO_COMPACT_WINDOW (#2219)', () =>
 
     // Parse normalized used% from the statusline bar output (e.g. "60%")
     // Strip ANSI escape codes then extract the percentage digit(s) before "%"
+    // eslint-disable-next-line no-control-regex -- \x1b (ESC) is the required leading byte of ANSI SGR color sequences; matching it is the purpose of stripping ANSI codes from captured CLI/console output
     const clean = stdout.replace(/\x1b\[[0-9;]*m/g, '');
     const match = clean.match(/(\d+)%/);
     const normalizedUsed = match ? parseInt(match[1], 10) : null;

--- a/tests/installer-migration-install-integration.test.cjs
+++ b/tests/installer-migration-install-integration.test.cjs
@@ -133,6 +133,7 @@ function withSdkDistPresent(fn) {
 }
 
 function stripAnsi(value) {
+  // eslint-disable-next-line no-control-regex -- \x1b (ESC) is the required leading byte of ANSI SGR color sequences; matching it is the purpose of stripping ANSI codes from captured CLI/console output
   return value.replace(/\x1b\[[0-9;]*m/g, '');
 }
 


### PR DESCRIPTION
<!-- pr-template-exempt: internal test/lint change — comments + one lint severity flip, no runtime change -->

## What & why

Category 3 of 3 of the deferred ESLint warning cleanup. Resolves the **5 `no-control-regex` warnings** and **ratchets the rule from `warn` to `error`** so it can't regrow.

Closes #736.

## Finding

All 5 warnings are the **same intentional ANSI-color-strip pattern** `/\x1b\[[0-9;]*m/g` (one site uses uppercase `\x1B`), spread across 5 test files:

| File | Line | Use |
|---|---|---|
| `bug-2957-claude-global-postinstall-message.test.cjs` | 42 | strip ANSI before message assertions |
| `bug-3582-codex-skills-materialized.test.cjs` | 57 | `stripAnsi` helper for log assertions |
| `feat-2795-update-banner.test.cjs` | 320 | strip ANSI before choice-digit assertions |
| `gsd-statusline.test.cjs` | 337 | strip ANSI to extract usage `%` |
| `installer-migration-install-integration.test.cjs` | 136 | `stripAnsi` helper for CLI output |

The `\x1b` (ESC) control char is the **required leading byte** of an ANSI SGR escape sequence — matching it is the entire purpose of stripping color codes from captured CLI/console output. These are intentional and essential, **not** accidental metacharacters.

## Approach (maintainer-decided)

Per the decision for this category: intentional control-char matches get an inline `// eslint-disable-next-line no-control-regex` with a justifying comment; refactor only if the control char is accidental. None here are accidental, so each site gets a justified disable (same justification text), then the rule flips to `error`.

## Verification

- `npm run lint`: **0 errors**, zero remaining `no-control-regex` (345 → 340, exactly the 5 resolved); full `eslint --no-cache .` repo-wide is 0 errors (rule is scoped to `tests/**/*.test.cjs`).
- `node --test` on all 5 files: pass (112 tests, 0 fail).
- Codex adversarial review: no findings (confirmed each disable targets the correct line; justification accurate; no other undisabled control-regex would now error).
- `/security-review`: no surface (comments + lint-config only).
- `gsd-test-both` (Mac + Linux Docker): 125/125, 0 failures, 0 platform-specific.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/737"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783352834&installation_id=134682257&pr_number=737&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F737&signature=88763460f4973d52cbf118e27a1fcbfb5548f7c0f310369237812a3f906bcf24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->