### PR TITLE
refactor(#720): lazy-load MVP-only reference bodies on non-MVP runs

### DIFF
--- a/.changeset/lazy-mvp-bodies-progressive-disclosure.md
+++ b/.changeset/lazy-mvp-bodies-progressive-disclosure.md
@@ -1,0 +1,5 @@
+---
+type: Changed
+pr: 746
+---
+**`/gsd:plan-phase` and `/gsd:execute-phase` no longer eagerly load MVP-only guidance on non-MVP runs** — the MVP planner rules, user-story template, Walking-Skeleton template, and MVP+TDD halt-report reference are now Read lazily by the planner/executor only when MVP / Walking-Skeleton / MVP+TDD mode is active, in both the workflow files and the `gsd-planner`/`gsd-executor` agent definitions, instead of being `@`-imported into every run. Behaviour is unchanged; non-MVP planning/execution simply carries less context. (#720)

--- a/agents/gsd-executor.md
+++ b/agents/gsd-executor.md
@@ -385,7 +385,7 @@ If RED or GREEN gate commits are missing, add a warning to SUMMARY.md under a `#
 
 ## MVP+TDD Gate
 
-**When the orchestrator passes both `MVP_MODE=true` and `TDD_MODE=true`:** Before running the implementation step of any task with `tdd="true"`, run the runtime gate from `@~/.claude/gsd-core/references/execute-mvp-tdd.md`. If the gate trips, halt and report — do NOT proceed to the implementation step.
+**When the orchestrator passes both `MVP_MODE=true` and `TDD_MODE=true`:** Before running the implementation step of any task with `tdd="true"`, run the runtime gate from `~/.claude/gsd-core/references/execute-mvp-tdd.md` (Read it). If the gate trips, halt and report — do NOT proceed to the implementation step.
 
 **Halt-and-report protocol:**
 

--- a/agents/gsd-planner.md
+++ b/agents/gsd-planner.md
@@ -309,7 +309,7 @@ Exceptions where `tdd="true"` is not needed: `type="checkpoint:*"` tasks, config
 
 ## MVP Mode Detection
 
-**When `MVP_MODE` is enabled (passed by the plan-phase orchestrator):** Decompose tasks as **vertical feature slices**, not horizontal layers. Required reading: `@~/.claude/gsd-core/references/planner-mvp-mode.md` (loaded conditionally by the orchestrator).
+**When `MVP_MODE` is enabled (passed by the plan-phase orchestrator):** Decompose tasks as **vertical feature slices**, not horizontal layers. Required reading: Read `~/.claude/gsd-core/references/planner-mvp-mode.md` for the vertical-slice rules (lazy — only on MVP runs).
 
 **Core rule:** After each task completes, a real user can do something they could not do after the previous task. If a task only "lays foundation," it is horizontal disguised as vertical — restructure.
 
@@ -323,7 +323,7 @@ Exceptions where `tdd="true"` is not needed: `type="checkpoint:*"` tasks, config
    **As a** [user role], **I want to** [capability], **so that** [outcome].
    ```
 
-   Format rules from `@~/.claude/gsd-core/references/user-story-template.md`:
+   Format rules (Read `~/.claude/gsd-core/references/user-story-template.md`):
    - All three slots required. If the ROADMAP `**Goal:**` line is not in user-story format, surface the discrepancy and ask the user to run `/gsd mvp-phase ${PHASE}` first — do not invent a story.
    - Bold the three keywords (`**As a**`, `**I want to**`, `**so that**`) when emitting to PLAN.md. The ROADMAP form does not use bolded keywords; the PLAN form does.
 2. First task: failing end-to-end test for the happy path.
@@ -332,7 +332,7 @@ Exceptions where `tdd="true"` is not needed: `type="checkpoint:*"` tasks, config
 
 **Mode is all-or-nothing per phase** (PRD decision Q1). Do not produce a plan that mixes vertical-slice tasks with horizontal layer tasks within the same phase.
 
-**Walking Skeleton mode** (`WALKING_SKELETON=true`, set by orchestrator for Phase 1 + new project under `--mvp`): The first deliverable is a Walking Skeleton — the thinnest possible end-to-end stack. In addition to `PLAN.md`, produce `SKELETON.md` using the template at `@~/.claude/gsd-core/references/skeleton-template.md`. `SKELETON.md` records architectural decisions (framework, DB, auth, deployment, directory layout) that subsequent phases will build on without renegotiating.
+**Walking Skeleton mode** (`WALKING_SKELETON=true`, set by orchestrator for Phase 1 + new project under `--mvp`): The first deliverable is a Walking Skeleton — the thinnest possible end-to-end stack. In addition to `PLAN.md`, produce `SKELETON.md` using the template at `~/.claude/gsd-core/references/skeleton-template.md` (Read it now). `SKELETON.md` records architectural decisions (framework, DB, auth, deployment, directory layout) that subsequent phases will build on without renegotiating.
 
 **Compatibility with TDD detection:** When both `MVP_MODE=true` and `workflow.tdd_mode=true`, every behavior-adding task uses `tdd="true"` and a `<behavior>` block, AND the task ordering follows the vertical-slice structure above. The first task is always a failing end-to-end test.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -193,6 +193,16 @@ parent dispatches, modes/ holds per-flag behavior (`power.md`, `all.md`,
 checkpoint.json schemas that are read only when the corresponding output
 file is being written.
 
+`workflows/plan-phase.md`, `workflows/execute-phase.md`, and the
+`gsd-planner` / `gsd-executor` agent definitions apply the same discipline
+to their MVP-only reference bodies — `planner-mvp-mode.md`,
+`user-story-template.md`, `skeleton-template.md`, and `execute-mvp-tdd.md`
+are referenced for the planner/executor to Read only on MVP,
+Walking-Skeleton, or MVP+TDD paths, rather than eagerly `@`-imported, so
+non-MVP runs do not pay their context cost (guards against the "`@`-import
+behind a conditional still loads eagerly" leak; see #720). The dedicated
+`mvp-phase` workflow keeps its eager imports, since it is always MVP.
+
 ### Agents (`agents/*.md`)
 
 Specialized agent definitions with frontmatter specifying:

--- a/gsd-core/workflows/execute-phase.md
+++ b/gsd-core/workflows/execute-phase.md
@@ -188,7 +188,7 @@ if [ "$MVP_MODE" = "true" ] && [ "$TDD_MODE" = "true" ]; then
   fi
 fi
 ```
-Pure doc-only / config-only / test-only tasks return `is_behavior_adding=false` and are exempt. See `execute-mvp-tdd.md` for the halt report format.
+Pure doc-only / config-only / test-only tasks return `is_behavior_adding=false` and are exempt. When the gate trips, Read `~/.claude/gsd-core/references/execute-mvp-tdd.md` for the exact halt report format.
 </step>
 
 <step name="check_blocking_antipatterns" priority="first">

--- a/gsd-core/workflows/plan-phase.md
+++ b/gsd-core/workflows/plan-phase.md
@@ -143,7 +143,7 @@ fi
 ```
 
 When `WALKING_SKELETON=true`:
-- Planner is instructed to produce `SKELETON.md` in the phase directory alongside `PLAN.md`. The template lives at `@~/.claude/gsd-core/references/skeleton-template.md`.
+- Planner is instructed to produce `SKELETON.md` in the phase directory alongside `PLAN.md`. The template lives at `~/.claude/gsd-core/references/skeleton-template.md` — the planner reads it when producing SKELETON.md (lazy; not loaded on non-skeleton runs).
 - The plan must scaffold project + routing + one real DB read/write + one real UI interaction + dev deployment — the thinnest possible end-to-end working slice.
 
 **Interaction with `--prd <filepath>`.** `--mvp` and `--prd` compose. The PRD express path (Step 3.5) creates `CONTEXT.md` from the PRD file and continues to research; the Walking Skeleton gate fires independently from the conditions above. When both are active on Phase 1 of a new project, the planner receives `WALKING_SKELETON=true` and PRD-derived context simultaneously — the PRD informs *what the skeleton should prove*. No precedence is needed; the two signals are orthogonal. See [`references/mvp-concepts.md`](../references/mvp-concepts.md) for the broader interaction map.
@@ -933,12 +933,12 @@ Each TDD plan gets one feature with RED/GREEN/REFACTOR gate sequence.
 </tdd_mode_active>
 ` : ''}
 
-**MVP_MODE:** ${MVP_MODE} (when true, follow vertical-slice rules from `@~/.claude/gsd-core/references/planner-mvp-mode.md`; when false, ignore MVP guidance entirely.)
-**WALKING_SKELETON:** ${WALKING_SKELETON} (when true, the first deliverable must be a Walking Skeleton — produce SKELETON.md alongside PLAN.md.)
+**MVP_MODE:** ${MVP_MODE} (when true, follow vertical-slice rules from `~/.claude/gsd-core/references/planner-mvp-mode.md`; when false, ignore MVP guidance entirely.)
+**WALKING_SKELETON:** ${WALKING_SKELETON} (when true, the first deliverable must be a Walking Skeleton — Read the template at `~/.claude/gsd-core/references/skeleton-template.md` and produce SKELETON.md alongside PLAN.md.)
 
 ${MVP_MODE === 'true' ? `
 <mvp_mode_active>
-**MVP Mode is ENABLED.** Follow vertical-slice planning rules from @~/.claude/gsd-core/references/planner-mvp-mode.md. Each plan must deliver a complete vertical slice — thin end-to-end functionality rather than horizontal layers.
+**MVP Mode is ENABLED.** Read `~/.claude/gsd-core/references/planner-mvp-mode.md` now and follow its vertical-slice planning rules. Each plan must deliver a complete vertical slice — thin end-to-end functionality rather than horizontal layers.
 </mvp_mode_active>
 ` : ''}
 </planning_context>

--- a/tests/workflow-size-budget.test.cjs
+++ b/tests/workflow-size-budget.test.cjs
@@ -402,3 +402,150 @@ describe('SIZE: discuss-phase progressive disclosure (issue #2551)', () => {
     );
   });
 });
+
+const AGENTS_DIR = path.join(__dirname, '..', 'agents');
+
+describe('workflow progressive disclosure — MVP bodies lazy-loaded (#720)', () => {
+  // MVP-only reference bodies (planner-mvp-mode.md, skeleton-template.md,
+  // execute-mvp-tdd.md) must NOT be eagerly @-imported at the top level of the
+  // always-loaded workflow files or agent definitions. An @-prefixed path is
+  // expanded into context the moment the file loads — regardless of whether
+  // MVP_MODE is true — inflating every session's token cost. Use a plain
+  // backtick path or a conditional "Read ..." instruction instead. See issue #720.
+
+  test('plan-phase.md does not eagerly @-import planner-mvp-mode.md', () => {
+    const planPhaseContent = fs.readFileSync(path.join(WORKFLOWS_DIR, 'plan-phase.md'), 'utf-8');
+    assert.ok(
+      !/@[~./\w-]*planner-mvp-mode\.md/.test(planPhaseContent),
+      'plan-phase.md contains an eager @-import of planner-mvp-mode.md — ' +
+      'this loads the MVP body into context for every session, even when MVP_MODE is false. ' +
+      'Replace with a conditional Read instruction or a plain backtick path. See #720.'
+    );
+  });
+
+  test('plan-phase.md does not eagerly @-import skeleton-template.md', () => {
+    const planPhaseContent = fs.readFileSync(path.join(WORKFLOWS_DIR, 'plan-phase.md'), 'utf-8');
+    assert.ok(
+      !/@[~./\w-]*skeleton-template\.md/.test(planPhaseContent),
+      'plan-phase.md contains an eager @-import of skeleton-template.md — ' +
+      'this loads the template into context on every plan-phase invocation. ' +
+      'Replace with a conditional Read instruction or a plain backtick path. See #720.'
+    );
+  });
+
+  test('plan-phase.md still references both MVP bodies (lazy reference preserved)', () => {
+    const planPhaseContent = fs.readFileSync(path.join(WORKFLOWS_DIR, 'plan-phase.md'), 'utf-8');
+    assert.ok(
+      /planner-mvp-mode\.md/.test(planPhaseContent) && /skeleton-template\.md/.test(planPhaseContent),
+      'plan-phase.md must still reference planner-mvp-mode.md and skeleton-template.md ' +
+      '(as lazy backtick paths or Read instructions) so agents know where to find them. ' +
+      'Do not delete the references — only remove the leading @ sigil. See #720.'
+    );
+  });
+
+  test('plan-phase.md does not list MVP bodies in <required_reading>', () => {
+    const planPhaseContent = fs.readFileSync(path.join(WORKFLOWS_DIR, 'plan-phase.md'), 'utf-8');
+    const requiredReadingMatch = planPhaseContent.match(/<required_reading>([\s\S]*?)<\/required_reading>/);
+    if (requiredReadingMatch) {
+      const block = requiredReadingMatch[1];
+      assert.ok(
+        !/planner-mvp-mode\.md/.test(block),
+        'planner-mvp-mode.md must NOT appear in plan-phase.md <required_reading> — ' +
+        'that block is always loaded regardless of MVP_MODE. See #720.'
+      );
+      assert.ok(
+        !/skeleton-template\.md/.test(block),
+        'skeleton-template.md must NOT appear in plan-phase.md <required_reading> — ' +
+        'that block is always loaded regardless of MVP_MODE. See #720.'
+      );
+    }
+  });
+
+  test('execute-phase.md does not eagerly @-import execute-mvp-tdd.md', () => {
+    const executePhaseContent = fs.readFileSync(path.join(WORKFLOWS_DIR, 'execute-phase.md'), 'utf-8');
+    assert.ok(
+      !/@[~./\w-]*execute-mvp-tdd\.md/.test(executePhaseContent),
+      'execute-phase.md contains an eager @-import of execute-mvp-tdd.md — ' +
+      'this loads the MVP TDD body into context for every session. ' +
+      'Replace with a conditional Read instruction or a plain backtick path. See #720.'
+    );
+  });
+
+  test('execute-phase.md still references execute-mvp-tdd.md (lazy reference preserved)', () => {
+    const executePhaseContent = fs.readFileSync(path.join(WORKFLOWS_DIR, 'execute-phase.md'), 'utf-8');
+    assert.ok(
+      /execute-mvp-tdd\.md/.test(executePhaseContent),
+      'execute-phase.md must still reference execute-mvp-tdd.md (as a lazy backtick path ' +
+      'or Read instruction) so agents know where to find it. ' +
+      'Do not delete the reference — only ensure there is no leading @ sigil. See #720.'
+    );
+  });
+
+  test('gsd-planner.md does not eagerly @-import planner-mvp-mode.md', () => {
+    const content = fs.readFileSync(path.join(AGENTS_DIR, 'gsd-planner.md'), 'utf-8');
+    assert.ok(
+      !/@[~./\w-]*planner-mvp-mode\.md/.test(content),
+      'gsd-planner.md contains an eager @-import of planner-mvp-mode.md — ' +
+      'this loads the MVP body into context for every session, even when MVP_MODE is false. ' +
+      'Replace with a conditional Read instruction or a plain backtick path. See #720.'
+    );
+  });
+
+  test('gsd-planner.md does not eagerly @-import skeleton-template.md', () => {
+    const content = fs.readFileSync(path.join(AGENTS_DIR, 'gsd-planner.md'), 'utf-8');
+    assert.ok(
+      !/@[~./\w-]*skeleton-template\.md/.test(content),
+      'gsd-planner.md contains an eager @-import of skeleton-template.md — ' +
+      'this loads the template into context on every planner invocation. ' +
+      'Replace with a conditional Read instruction or a plain backtick path. See #720.'
+    );
+  });
+
+  test('gsd-planner.md does not eagerly @-import user-story-template.md', () => {
+    const content = fs.readFileSync(path.join(AGENTS_DIR, 'gsd-planner.md'), 'utf-8');
+    assert.ok(
+      !/@[~./\w-]*user-story-template\.md/.test(content),
+      'gsd-planner.md contains an eager @-import of user-story-template.md — ' +
+      'this loads the template into context on every planner invocation. ' +
+      'Replace with a conditional Read instruction or a plain backtick path. See #720.'
+    );
+  });
+
+  test('gsd-planner.md still references the three MVP bodies', () => {
+    const content = fs.readFileSync(path.join(AGENTS_DIR, 'gsd-planner.md'), 'utf-8');
+    assert.ok(
+      /planner-mvp-mode\.md/.test(content),
+      'gsd-planner.md must still reference planner-mvp-mode.md (as a lazy path or Read instruction). ' +
+      'Do not delete the reference — only remove the leading @ sigil. See #720.'
+    );
+    assert.ok(
+      /skeleton-template\.md/.test(content),
+      'gsd-planner.md must still reference skeleton-template.md (as a lazy path or Read instruction). ' +
+      'Do not delete the reference — only remove the leading @ sigil. See #720.'
+    );
+    assert.ok(
+      /user-story-template\.md/.test(content),
+      'gsd-planner.md must still reference user-story-template.md (as a lazy path or Read instruction). ' +
+      'Do not delete the reference — only remove the leading @ sigil. See #720.'
+    );
+  });
+
+  test('gsd-executor.md does not eagerly @-import execute-mvp-tdd.md', () => {
+    const content = fs.readFileSync(path.join(AGENTS_DIR, 'gsd-executor.md'), 'utf-8');
+    assert.ok(
+      !/@[~./\w-]*execute-mvp-tdd\.md/.test(content),
+      'gsd-executor.md contains an eager @-import of execute-mvp-tdd.md — ' +
+      'this loads the MVP TDD body into context for every session. ' +
+      'Replace with a conditional Read instruction or a plain backtick path. See #720.'
+    );
+  });
+
+  test('gsd-executor.md still references execute-mvp-tdd.md', () => {
+    const content = fs.readFileSync(path.join(AGENTS_DIR, 'gsd-executor.md'), 'utf-8');
+    assert.ok(
+      /execute-mvp-tdd\.md/.test(content),
+      'gsd-executor.md must still reference execute-mvp-tdd.md (as a lazy path or Read instruction). ' +
+      'Do not delete the reference — only remove the leading @ sigil. See #720.'
+    );
+  });
+});


### PR DESCRIPTION
## Enhancement PR

## Linked Issue

Closes #720

## What this enhancement improves

`/gsd:plan-phase` and `/gsd:execute-phase` (and the `gsd-planner` / `gsd-executor` agents they spawn) no longer eagerly load **MVP-only** reference bodies into context on **non-MVP** runs. The MVP planner rules, user-story template, Walking-Skeleton template, and MVP+TDD halt-report reference are now Read lazily only when `MVP_MODE` / `WALKING_SKELETON` / `MVP+TDD` is active.

This re-scopes the deferred ex-#3182 work honestly (per #717's deferral note): MVP mode is a cross-cutting concern, so the naïve "extract a single `modes/mvp.md`" split does **not** map. The real, bounded win is converting the eager `@`-imports of the already-extracted reference bodies into lazy, mode-gated Reads — a *loaded-context* reduction, not a byte-proxy one (so no XL-ceiling claim, no #597 ratchet interaction).

## Before / After

In gsd-core, a path written `@~/.claude/gsd-core/references/foo.md` is **eagerly** expanded into context when the containing workflow/agent `.md` loads — even when it sits inside a `${MVP_MODE === 'true' ? … }` ternary or under a "When MVP_MODE is enabled" heading. This is the exact "`@`-import behind a conditional still loads eagerly" leak documented in `docs/ARCHITECTURE.md` (the #717 Goodhart caveat).

**Before:** every `plan-phase` / `execute-phase` run — and every `gsd-planner` / `gsd-executor` spawn — eagerly pulled `planner-mvp-mode.md`, `skeleton-template.md`, `user-story-template.md`, and `execute-mvp-tdd.md` into context, regardless of mode. `agents/gsd-planner.md:312` even carried the comment *"(loaded conditionally by the orchestrator)"* while using `@` — i.e. it *intended* to defer but loaded eagerly.

**After:** those references are plain `Read` instructions (no leading `@`), reached only on the MVP / Walking-Skeleton / MVP+TDD paths that need them. Non-MVP planning and execution carry less context; MVP runs read the same bodies exactly as before.

## How it was implemented

Stripped the leading `@` from each MVP-body reference and phrased it as an explicit lazy `Read` under the existing conditional framing. Key files:

- `gsd-core/workflows/plan-phase.md` — `:146` (skeleton-template, orchestrator gate), `:936` (descriptive mention), `:937` (explicit Walking-Skeleton template Read), `:941` (MVP `<mvp_mode_active>` → "Read `planner-mvp-mode.md` now").
- `gsd-core/workflows/execute-phase.md` — `:191` halt-report Read, now gated "When the gate trips".
- `agents/gsd-planner.md` — `planner-mvp-mode.md` (`:312`), `user-story-template.md` (`:326`), `skeleton-template.md` (`:335`).
- `agents/gsd-executor.md` — `execute-mvp-tdd.md` (`:388`).

The dedicated **always-MVP** `mvp-phase.md` / `commands/gsd/mvp-phase.md` keep their eager imports — correct, since those paths are unconditionally MVP. `references/planner-mvp-mode.md:41`'s nested reference is left intact for the same reason.

## Testing

### How I verified the enhancement works

- Added a regression guard in `tests/workflow-size-budget.test.cjs` mirroring the existing `discuss-phase` lazy-load test: asserts the four MVP bodies are **not** eagerly `@`-imported in the two workflow files **or** the two agent files (regex `/@[~./\w-]*<file>\.md/`), are **not** in `<required_reading>`, yet are **still referenced** (lazy). Written test-first (RED: 6 failing assertions), then implemented to GREEN.
- Full MVP / Walking-Skeleton / MVP+TDD regression suite stays green (`planner-mvp-mode`, `executor-mvp-tdd-section`, `execute-mvp-tdd-gate`, `verifier-mvp-section`, `new-project-mvp-prompt`, `mvp-phase-*`).
- `agent-size-budget` and `workflow-size-budget` suites green; full `npm test` = **3512 pass / 0 fail**.
- Cross-platform `gsd-test-both`: **13826/13826 on Mac + Linux Docker, 0 failures**.
- Independent adversarial (Codex) review surfaced that the agent definitions shared the same eager imports; that finding is now fixed and re-verified clean.

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [x] N/A (not platform-specific) — change is markdown prompt text; no path/OS-specific logic

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue — no additions or removals
- [x] If scope changed during implementation, I updated the issue and got re-approval before continuing — the agent-file extension was surfaced from the adversarial review and explicitly approved by the maintainer before landing

## Documentation

- [x] Updated the relevant file(s) under `docs/` to reflect this change — `docs/ARCHITECTURE.md` (Architecture → lazy-load discipline), Explanation register, cross-referencing #720
- [x] All `docs/` content added in this PR is written in English

## Checklist

- [x] Issue linked above with `Closes #720`
- [x] Linked issue has the `approved-enhancement` label
- [x] Changes are scoped to the approved enhancement
- [x] All existing tests pass (`npm test`) — 3512 pass / 0 fail
- [x] New or updated tests cover the enhanced behavior
- [x] `.changeset/` fragment added (`type: Changed`) — added in the immediate follow-up push (the fragment requires the real PR number; two-push pattern)
- [x] No unnecessary dependencies added

## Breaking changes

None. Behaviour on MVP / Walking-Skeleton / MVP+TDD paths is identical — the same reference bodies are loaded, just lazily at the step that needs them rather than eagerly on every run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/746"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783375423&installation_id=134682257&pr_number=746&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F746&signature=431527a2eb443f8c8e9e9cacb7e81a3e50198157b2a1d427e14b626c21f458e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->