### PR TITLE
refactor(#712): replace Codex slash-command denylist lookbehind with positive-boundary match

### DIFF
--- a/.changeset/vivid-badgers-zip.md
+++ b/.changeset/vivid-badgers-zip.md
@@ -1,0 +1,7 @@
+---
+type: Changed
+pr: 747
+---
+**Codex slash-command conversion no longer corrupts inline-wrapped `/gsd-…` file paths** — the install-time converter now identifies a real `/gsd-<command>` mention by positive boundaries (opening delimiter + no path continuation) instead of an unbounded preceding-character denylist, closing the path-corruption class (#637 → #704) by construction while still converting legitimate backtick-wrapped mentions.
+
+<!-- docs-exempt: internal Codex install-time converter; no command, flag, output, or user-doc surface to update -->

--- a/bin/install.js
+++ b/bin/install.js
@@ -2797,17 +2797,22 @@ function convertClaudeAgentToClineAgent(content) {
 // ── End Cline converters ─────────────────────────────────────────────────────
 
 function convertSlashCommandsToCodexSkillMentions(content) {
-  // Convert colon-style skill invocations to Codex $ prefix
+  // Colon-style /gsd: never appears as a filesystem path segment, so no boundary guard is needed (unlike the hyphen-style below).
   let converted = content.replace(/\/gsd:([a-z0-9-]+)/gi, (_, commandName) => {
     return `$gsd-${String(commandName).toLowerCase()}`;
   });
   // Convert hyphen-style command references (workflow output) to Codex $ prefix.
-  // Negative lookbehind excludes shell path contexts where `/gsd-` is a path
-  // segment, not a slash-command mention:
-  //   - word chars / dot / slash: `bin/gsd-tools.cjs`, `.claude/gsd-core/`
-  //   - `}`: shell variable expressions `${VAR}/gsd-core/` (#704)
-  //   - `)`: command-substitution paths `$(cmd)/gsd-local-patches` (#704)
-  converted = converted.replace(/(?<![a-zA-Z0-9./})])\/gsd-([a-z0-9-]+)/gi, (_, commandName) => {
+  // A real /gsd-<cmd> MENTION is defined positively by two boundaries, so any
+  // in-path occurrence is excluded by construction (no denylist of preceding
+  // chars to maintain — see #712, supersedes the #637/#704 lookbehind treadmill):
+  //   1. Left boundary: opens at start-of-string, whitespace, or an inline-prose
+  //      delimiter (backtick/quote/paren/bracket) — e.g. `/gsd-execute-phase`.
+  //   2. Right boundary: the command token is NOT followed by a path separator
+  //      `/` (a path continues: `/gsd-core/bin/...`; a command does not). The
+  //      `(?![a-z0-9/-])` also blocks regex backtracking to a shorter command.
+  // This converts backtick-wrapped MENTIONS (`/gsd-foo`) while leaving backtick-
+  // wrapped PATHS (`/gsd-core/workflows/update.md`) untouched (#712).
+  converted = converted.replace(/(?<=^|[\s`"'([])\/gsd-([a-z0-9-]+)(?![a-z0-9/-])/gi, (_, commandName) => {
     return `$gsd-${String(commandName).toLowerCase()}`;
   });
   return converted;
@@ -10948,6 +10953,7 @@ module.exports = {
     install,
     installAllRuntimes,
     uninstall,
+    convertSlashCommandsToCodexSkillMentions,
     convertClaudeCommandToCodexSkill,
     convertClaudeToOpencodeFrontmatter,
     convertClaudeToKiloFrontmatter,

--- a/tests/bug-704-codex-launcher-path-corruption.test.cjs
+++ b/tests/bug-704-codex-launcher-path-corruption.test.cjs
@@ -23,7 +23,10 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
 
-const { convertClaudeCommandToCodexSkill } = require('../bin/install.js');
+const {
+  convertClaudeCommandToCodexSkill,
+  convertSlashCommandsToCodexSkillMentions,
+} = require('../bin/install.js');
 
 // The canonical launcher snippet path that was being corrupted
 const RUNTIME_ROOT_PATH = '${_GSD_RUNTIME_ROOT}/gsd-core/bin/${_GSD_SHIM_NAME}';
@@ -148,11 +151,10 @@ describe('#704 — Codex global install launcher path corruption', () => {
     // Walk gsd-core/workflows/ and assert that no file produces $gsd-core
     // inside a shell variable expansion context after Codex conversion.
     //
-    // NOTE: The regex `/(?<![a-zA-Z0-9./}])\/gsd-/` still converts backtick-
-    // wrapped prose paths like `\`/gsd-core/workflows/update.md\`` (a pre-existing
-    // issue separate from #704 — update.md's backtick is not in the lookbehind
-    // set). That prose-path case is intentionally excluded from this assertion
-    // (tracked separately; the primary #704 bug is the shell-variable expansion).
+    // NOTE: The backtick-wrapped prose-path case (`/gsd-core/workflows/update.md`)
+    // was a pre-existing gap with the #704 lookbehind fix and is now addressed by
+    // the positive-boundary regex introduced in #712. That case is covered by the
+    // "#712" describe block below.
     //
     // We probe for the specific shell-context pattern from the issue report:
     //   BAD:  ${_GSD_RUNTIME_ROOT}$gsd-core/bin/
@@ -232,6 +234,185 @@ describe('#704 — Codex global install launcher path corruption', () => {
       [],
       `Found shell-context path corruption ([})]$gsd-*) in Codex-converted command files (#704):\n` +
         offending.map((o) => `  ${o.file}: ...${o.context}...`).join('\n'),
+    );
+  });
+});
+
+describe('#712: positive-boundary slash-command conversion', () => {
+  // Tests call convertSlashCommandsToCodexSkillMentions directly so the regex
+  // is exercised in isolation — no frontmatter wrapping, no ADAPTER_CLOSE
+  // stripping, no .claude→.codex rewrite masking the result.
+
+  // ── MUST-NOT-CONVERT (negative) cases ─────────────────────────────────────
+  // These inputs must be returned UNCHANGED — no $gsd-* substitution.
+
+  test('backtick-wrapped path: `/gsd-core/workflows/update.md` is NOT converted (THE new fix)', () => {
+    const input = 'See `/gsd-core/workflows/update.md` for details.';
+    const result = convertSlashCommandsToCodexSkillMentions(input);
+    assert.strictEqual(
+      result,
+      input,
+      `Expected backtick-wrapped path to be unchanged. Got: ${result}`,
+    );
+  });
+
+  test('backtick-wrapped path deeper: `/gsd-pi/bin/foo.cjs` is NOT converted', () => {
+    const input = 'Run `/gsd-pi/bin/foo.cjs` directly.';
+    const result = convertSlashCommandsToCodexSkillMentions(input);
+    assert.strictEqual(
+      result,
+      input,
+      `Expected deep backtick-wrapped path to be unchanged. Got: ${result}`,
+    );
+  });
+
+  test('shell var expansion: ${_GSD_RUNTIME_ROOT}/gsd-core/bin/x is NOT converted (regression guard)', () => {
+    const input = 'PATH="${_GSD_RUNTIME_ROOT}/gsd-core/bin/x"';
+    const result = convertSlashCommandsToCodexSkillMentions(input);
+    assert.ok(
+      !result.includes('$gsd-core'),
+      `Expected no $gsd-core substitution in shell var path. Got: ${result}`,
+    );
+    assert.ok(
+      result.includes('/gsd-core/bin/x'),
+      `Expected original path to be preserved. Got: ${result}`,
+    );
+  });
+
+  test('command substitution: $(expand_home ~/.claude)/gsd-local-patches is NOT converted (regression guard)', () => {
+    const input = 'candidate="$(expand_home ~/.claude)/gsd-local-patches"';
+    const result = convertSlashCommandsToCodexSkillMentions(input);
+    assert.ok(
+      !result.includes(')$gsd-local'),
+      `Expected no )$gsd-local substitution. Got: ${result}`,
+    );
+    assert.ok(
+      result.includes(')/gsd-local-patches'),
+      `Expected original path to be preserved. Got: ${result}`,
+    );
+  });
+
+  test('plain path segment: bin/gsd-tools.cjs is NOT converted', () => {
+    const input = 'node bin/gsd-tools.cjs --help';
+    const result = convertSlashCommandsToCodexSkillMentions(input);
+    assert.strictEqual(
+      result,
+      input,
+      `Expected plain path segment to be unchanged. Got: ${result}`,
+    );
+  });
+
+  test('plain path segment: .claude/gsd-core/agents — /gsd-core portion is NOT slash-command converted', () => {
+    // Tests the regex in isolation: the .claude→.codex path rewrite that happens
+    // inside convertClaudeToCodexMarkdown does NOT run here. We assert directly
+    // that the slash-command regex leaves /gsd-core after the slash intact —
+    // i.e. the `e` in `/gsd-core` is NOT treated as a command boundary.
+    const input = 'Look in .claude/gsd-core/agents for the agent files.';
+    const result = convertSlashCommandsToCodexSkillMentions(input);
+    assert.ok(
+      !result.includes('$gsd-core'),
+      `Expected no $gsd-core substitution in .claude/gsd-core path. Got: ${result}`,
+    );
+    assert.ok(
+      result.includes('/gsd-core/agents'),
+      `Expected /gsd-core/agents to remain as a path segment. Got: ${result}`,
+    );
+  });
+
+  // ── MUST-CONVERT (positive) cases ─────────────────────────────────────────
+  // These inputs contain legitimate /gsd-<cmd> mentions that MUST be converted.
+
+  test('space-preceded prose: Use /gsd-discuss-phase to start. → $gsd-discuss-phase', () => {
+    const input = 'Use /gsd-discuss-phase to start.';
+    const result = convertSlashCommandsToCodexSkillMentions(input);
+    assert.ok(
+      result.includes('$gsd-discuss-phase'),
+      `Expected /gsd-discuss-phase to be converted. Got: ${result}`,
+    );
+    assert.ok(
+      !result.includes('/gsd-discuss-phase'),
+      `Expected original /gsd-discuss-phase to be replaced. Got: ${result}`,
+    );
+  });
+
+  test('backtick-WRAPPED MENTION (single segment): Run `/gsd-execute-phase` now → `$gsd-execute-phase`', () => {
+    // A backtick-wrapped COMMAND (single segment, no path continuation) MUST
+    // still be converted — this guards against a naive whitespace-only fix.
+    const input = 'Run `/gsd-execute-phase` now.';
+    const result = convertSlashCommandsToCodexSkillMentions(input);
+    assert.ok(
+      result.includes('`$gsd-execute-phase`'),
+      `Expected backtick-wrapped command to be converted to \`$gsd-execute-phase\`. Got: ${result}`,
+    );
+    assert.ok(
+      !result.includes('`/gsd-execute-phase`'),
+      `Expected original \`/gsd-execute-phase\` to be replaced. Got: ${result}`,
+    );
+  });
+
+  test('parenthetical/backtick list like CONTEXT.md:59: (`/gsd-plan-phase`, `/gsd-progress`) → converted', () => {
+    const input = 'Available commands: (`/gsd-plan-phase`, `/gsd-progress`) — pick one.';
+    const result = convertSlashCommandsToCodexSkillMentions(input);
+    assert.ok(
+      result.includes('`$gsd-plan-phase`'),
+      `Expected /gsd-plan-phase to be converted. Got: ${result}`,
+    );
+    assert.ok(
+      result.includes('`$gsd-progress`'),
+      `Expected /gsd-progress to be converted. Got: ${result}`,
+    );
+  });
+
+  test('start-of-string: /gsd-manager runs → $gsd-manager runs (exercises the ^ branch of lookbehind)', () => {
+    // This case is IMPOSSIBLE to test through the frontmatter-wrapping pipeline
+    // (the body always has preceding chars). Direct call exercises the ^ branch.
+    const input = '/gsd-manager runs the pipeline.';
+    const result = convertSlashCommandsToCodexSkillMentions(input);
+    assert.ok(
+      result.includes('$gsd-manager'),
+      `Expected /gsd-manager to be converted. Got: ${result}`,
+    );
+    assert.ok(
+      !result.includes('/gsd-manager'),
+      `Expected original /gsd-manager to be replaced. Got: ${result}`,
+    );
+  });
+
+  test('double-quote wrapped: "/gsd-resume" → "$gsd-resume"', () => {
+    const input = 'Call "/gsd-resume" to continue.';
+    const result = convertSlashCommandsToCodexSkillMentions(input);
+    assert.ok(
+      result.includes('"$gsd-resume"'),
+      `Expected "/gsd-resume" to be converted to "$gsd-resume". Got: ${result}`,
+    );
+    assert.ok(
+      !result.includes('"/gsd-resume"'),
+      `Expected original "/gsd-resume" to be replaced. Got: ${result}`,
+    );
+  });
+
+  // ── End-to-end: headline #712 bug through the real install pipeline ────────
+
+  test('end-to-end: backtick-wrapped path `/gsd-core/workflows/update.md` survives full Codex install pipeline', () => {
+    // Uses convertClaudeCommandToCodexSkill (same pattern as #704 tests above)
+    // to prove the real install path does not corrupt prose references to repo paths.
+    const input = [
+      '---',
+      'description: Test',
+      '---',
+      '',
+      'See `/gsd-core/workflows/update.md` for the update workflow.',
+    ].join('\n');
+
+    const output = convertClaudeCommandToCodexSkill(input, 'gsd-test-712-e2e');
+
+    assert.ok(
+      !output.includes('$gsd-core'),
+      `Expected no $gsd-core in converted output. Got:\n${output}`,
+    );
+    assert.ok(
+      output.includes('/gsd-core/workflows/update.md'),
+      `Expected backtick-wrapped path to survive conversion. Got:\n${output}`,
     );
   });
 });


### PR DESCRIPTION
## Linked Issue

Closes #712

> Linked issue carries the `approved-enhancement` label.

---

## What this enhancement improves

The hyphen-style `/gsd-<cmd>` → `$gsd-<cmd>` conversion in `convertSlashCommandsToCodexSkillMentions` (`bin/install.js`), used when installing GSD command/workflow/agent content for the **OpenAI Codex** runtime. It hardens the converter so filesystem/shell path segments containing `/gsd-` are never corrupted into a literal `$gsd-…` token.

## Before / After

**Before:** The conversion used a negative-lookbehind **denylist** that enumerated the characters which must *not* precede a real mention:

```js
/(?<![a-zA-Z0-9./})])\/gsd-([a-z0-9-]+)/gi
```

This is an unbounded treadmill — `#637 → #704` each added a newly-discovered preceding char (`/`, `.`, word-chars, then `}`, `)`). A backtick-wrapped **path** still leaked through and was corrupted:

```
`/gsd-core/workflows/update.md`   →   `$gsd-core/workflows/update.md`   ❌
```

(The #704 regression test documented this exact case as a known pre-existing gap.)

**After:** A **positive, two-boundary** definition of a mention — no preceding-char denylist to maintain:

```js
/(?<=^|[\s`"'([])\/gsd-([a-z0-9-]+)(?![a-z0-9/-])/gi
```

1. **Left boundary** — opens at start-of-string, whitespace, or an inline-prose delimiter (backtick/quote/paren/bracket).
2. **Right boundary** — the command token is *not* followed by a path separator `/` (a path continues, `/gsd-core/bin/…`; a command does not). The `(?![a-z0-9/-])` lookahead also blocks regex backtracking to a shorter command.

Result:

```
`/gsd-core/workflows/update.md`   →   `/gsd-core/workflows/update.md`   ✅ (unchanged — path)
`/gsd-execute-phase`              →   `$gsd-execute-phase`              ✅ (converted — mention)
Use /gsd-discuss-phase            →   Use $gsd-discuss-phase           ✅ (converted — mention)
```

This closes the whole bug class by construction and fixes the backtick-wrapped-path corruption, **while preserving** conversion of legitimate backtick-wrapped mentions (e.g. CONTEXT.md's parenthetical `` `/gsd-execute-phase` `` lists).

## How it was implemented

- `bin/install.js` — replaced the second `.replace()` regex in `convertSlashCommandsToCodexSkillMentions` with the positive-boundary version + a two-condition explanatory comment; added a one-line note that the colon-style `/gsd:` replace is intentionally unguarded (it never appears as a path segment); exported the function for direct testing.
- `tests/bug-704-codex-launcher-path-corruption.test.cjs` — added a `#712` matrix that calls the converter **directly** (6 don't-convert path forms incl. the backtick-wrapped path, 5 convert mention forms incl. backtick-wrapped, parenthetical-list, and true start-of-string), plus one end-to-end pipeline assertion for the headline backtick-path case. Removed the stale "pre-existing gap" note.

## Testing

### How I verified the enhancement works

- TDD: the two backtick-wrapped-path assertions failed against the old regex (RED), pass after the change (GREEN).
- `node --test tests/bug-704-codex-launcher-path-corruption.test.cjs` — all pass.
- `node --test tests/codex-config.test.cjs` — 111 pass (the existing `convertSlashCommandsToCodexSkillMentions` suite is unaffected).
- Full suite on Mac + Linux Docker via the bench runner: **Both passed: 13867, Both failed: 0, platform-specific: 0**.
- `npm run lint` — clean. Independent Codex adversarial review + empirical content scan confirmed **no real conversion regression** in any shipped Codex-converted content.

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

> Change is platform-agnostic (pure string regex; `\s` covers LF/CRLF line starts). Windows lane covered by CI.

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [x] Other: OpenAI Codex (converter exercised by automated tests)
- [ ] N/A (not runtime-specific)

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue — no additions or removals
- [x] If scope changed during implementation, I updated the issue and got re-approval before continuing — N/A (no scope change)

---

## Documentation

- [ ] Updated the relevant file(s) under `docs/`
- [x] All `docs/` content added in this PR is written in English — N/A (no docs added)
- [x] No user-facing docs impact (internal install-time converter, no command/flag/output surface): the triggering changeset fragment carries a `<!-- docs-exempt: … -->` marker.

## Checklist

- [x] Issue linked above with `Closes #712`
- [x] Linked issue has the `approved-enhancement` label
- [x] Changes are scoped to the approved enhancement — nothing extra included
- [x] All existing tests pass (`npm test`)
- [x] New or updated tests cover the enhanced behavior
- [x] `.changeset/` fragment added (follow-up push with `--pr`)
- [x] No unnecessary dependencies added

## Breaking changes

None. Every previously-correct conversion still converts identically; the only behavioral change is that backtick-wrapped (and other inline-prose-wrapped) **paths** are no longer corrupted. Verified by an empirical scan of all shipped Codex-converted content — zero legitimate mentions relied on the dropped denylist preceding-characters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/747"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783379797&installation_id=134682257&pr_number=747&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F747&signature=437377ad0ba7a0ec0bc93ec633e7a9be95e998d6dca06501ff4d0ac7098137ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->