### PR TITLE
fix(#751): recognise config-set prototype-pollution guard in CodeQL + test dynamic-key vectors

### DIFF
--- a/.changeset/751-config-prototype-pollution-codeql-alert-26.md
+++ b/.changeset/751-config-prototype-pollution-codeql-alert-26.md
@@ -1,0 +1,5 @@
+---
+type: Security
+pr: 752
+---
+**`gsd-tools config-set` prototype-pollution guard hardened and regression-tested.** The guard that blocks `__proto__`, `prototype`, and `constructor` segments in dotted config keys now uses inline literal comparisons at each property-write site (instead of a pre-loop `Set` check), so CodeQL's `js/prototype-pollution-utility` analysis recognises it as a sanitising barrier and code-scanning alert #26 clears. Runtime behaviour is unchanged from #663. Added regression tests that drive schema-valid dynamic-prefix keys (`agent_skills.__proto__`, `agent_skills.constructor`, `features.__proto__`, `review.models.constructor`) all the way to the guard — these reach `setConfigValue` past the schema gate and were previously the guard's only untested attack surface. (#751)

--- a/src/config.cts
+++ b/src/config.cts
@@ -429,22 +429,31 @@ function setConfigValue(cwd: string, keyPath: string, parsedValue: unknown): Set
       error('Failed to read config.json: ' + (err as Error).message, ERROR_REASON.CONFIG_PARSE_FAILED);
     }
 
-    // Set nested value using dot notation (e.g., "workflow.research")
+    // Set nested value using dot notation (e.g., "workflow.research").
+    // Prototype-pollution guard: reject dangerous segments via inline literal
+    // comparisons on the exact key used to index `current`, immediately before
+    // each write. The inline comparison is the barrier CodeQL's
+    // js/prototype-pollution-utility query recognises — the previous Set-based
+    // pre-loop check was functionally correct but not traced through, so
+    // code-scanning alert #26 kept firing. Behaviour is unchanged from #663.
     const keys = keyPath.split('.');
-    const FORBIDDEN_KEYS = new Set(['__proto__', 'prototype', 'constructor']);
-    if (keys.some((k) => FORBIDDEN_KEYS.has(k))) {
-      error('Invalid config key (prototype pollution guard): ' + keyPath, ERROR_REASON.CONFIG_PARSE_FAILED);
-    }
     let current: Record<string, unknown> = config;
     for (let i = 0; i < keys.length - 1; i++) {
       const key = keys[i];
+      if (key === '__proto__' || key === 'prototype' || key === 'constructor') {
+        error('Invalid config key (prototype pollution guard): ' + keyPath, ERROR_REASON.CONFIG_PARSE_FAILED);
+      }
       if (current[key] === undefined || typeof current[key] !== 'object') {
         current[key] = {};
       }
       current = current[key] as Record<string, unknown>;
     }
-    const previousValue = current[keys[keys.length - 1]]; // Capture previous value before overwriting
-    current[keys[keys.length - 1]] = parsedValue;
+    const lastKey = keys[keys.length - 1];
+    if (lastKey === '__proto__' || lastKey === 'prototype' || lastKey === 'constructor') {
+      error('Invalid config key (prototype pollution guard): ' + keyPath, ERROR_REASON.CONFIG_PARSE_FAILED);
+    }
+    const previousValue = current[lastKey]; // Capture previous value before overwriting
+    current[lastKey] = parsedValue;
 
     // Write back
     try {

--- a/tests/config.test.cjs
+++ b/tests/config.test.cjs
@@ -1158,6 +1158,127 @@ describe('config-set prototype-pollution guard (#663)', () => {
   });
 });
 
+// ─── config-set prototype-pollution guard via dynamic-key prefixes (alert #26) ─
+
+describe('config-set prototype-pollution guard via dynamic-key prefixes (alert #26)', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempProject();
+    // Initialise config so there is a config.json to write to.
+    runGsdTools('config-ensure-section', tmpDir);
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('agent_skills.__proto__ is blocked by setConfigValue guard (not schema gate)', () => {
+    const result = runGsdTools('config-set agent_skills.__proto__ somevalue', tmpDir);
+
+    assert.strictEqual(result.success, false, `Expected failure but got: ${result.output}`);
+
+    // Must be the pollution guard, not the schema gate.
+    assert.ok(
+      result.error.includes('prototype pollution guard'),
+      `Expected "prototype pollution guard" in error, got: ${result.error}`,
+    );
+    // No schema-gate message.
+    assert.ok(
+      !result.error.includes('Unknown config key'),
+      `Should not hit schema gate, got: ${result.error}`,
+    );
+
+    // No prototype pollution occurred.
+    assert.strictEqual(({}).somevalue, undefined, 'agent_skills.__proto__: {}.somevalue should be undefined');
+    assert.strictEqual(Object.prototype.hasOwnProperty.call(Object.prototype, 'somevalue'), false,
+      'agent_skills.__proto__: Object.prototype should not gain "somevalue"');
+  });
+
+  test('agent_skills.constructor is blocked by setConfigValue guard (not schema gate)', () => {
+    const result = runGsdTools('config-set agent_skills.constructor somevalue', tmpDir);
+
+    assert.strictEqual(result.success, false, `Expected failure but got: ${result.output}`);
+
+    assert.ok(
+      result.error.includes('prototype pollution guard'),
+      `Expected "prototype pollution guard" in error, got: ${result.error}`,
+    );
+    assert.ok(
+      !result.error.includes('Unknown config key'),
+      `Should not hit schema gate, got: ${result.error}`,
+    );
+
+    assert.strictEqual(Object.prototype.hasOwnProperty.call(Object.prototype, 'somevalue'), false,
+      'agent_skills.constructor: Object.prototype should not gain "somevalue"');
+  });
+
+  test('agent_skills.prototype is blocked by setConfigValue guard (not schema gate)', () => {
+    const result = runGsdTools('config-set agent_skills.prototype somevalue', tmpDir);
+
+    assert.strictEqual(result.success, false, `Expected failure but got: ${result.output}`);
+
+    assert.ok(
+      result.error.includes('prototype pollution guard'),
+      `Expected "prototype pollution guard" in error, got: ${result.error}`,
+    );
+    assert.ok(
+      !result.error.includes('Unknown config key'),
+      `Should not hit schema gate, got: ${result.error}`,
+    );
+
+    assert.strictEqual(Object.prototype.hasOwnProperty.call(Object.prototype, 'somevalue'), false,
+      'agent_skills.prototype: Object.prototype should not gain "somevalue"');
+  });
+
+  test('features.__proto__ is blocked by setConfigValue guard (not schema gate)', () => {
+    const result = runGsdTools('config-set features.__proto__ somevalue', tmpDir);
+
+    assert.strictEqual(result.success, false, `Expected failure but got: ${result.output}`);
+
+    assert.ok(
+      result.error.includes('prototype pollution guard'),
+      `Expected "prototype pollution guard" in error, got: ${result.error}`,
+    );
+    assert.ok(
+      !result.error.includes('Unknown config key'),
+      `Should not hit schema gate, got: ${result.error}`,
+    );
+
+    assert.strictEqual(({}).somevalue, undefined, 'features.__proto__: {}.somevalue should be undefined');
+    assert.strictEqual(Object.prototype.hasOwnProperty.call(Object.prototype, 'somevalue'), false,
+      'features.__proto__: Object.prototype should not gain "somevalue"');
+  });
+
+  test('review.models.constructor is blocked by setConfigValue guard (not schema gate)', () => {
+    const result = runGsdTools('config-set review.models.constructor somevalue', tmpDir);
+
+    assert.strictEqual(result.success, false, `Expected failure but got: ${result.output}`);
+
+    assert.ok(
+      result.error.includes('prototype pollution guard'),
+      `Expected "prototype pollution guard" in error, got: ${result.error}`,
+    );
+    assert.ok(
+      !result.error.includes('Unknown config key'),
+      `Should not hit schema gate, got: ${result.error}`,
+    );
+
+    assert.strictEqual(Object.prototype.hasOwnProperty.call(Object.prototype, 'somevalue'), false,
+      'review.models.constructor: Object.prototype should not gain "somevalue"');
+  });
+
+  test('positive control: agent_skills.sonnet-coder with valid value succeeds', () => {
+    const result = runGsdTools('config-set agent_skills.sonnet-coder true', tmpDir);
+
+    assert.ok(result.success, `Legitimate agent_skills key rejected unexpectedly: ${result.error}`);
+
+    const config = readConfig(tmpDir);
+    assert.strictEqual(config.agent_skills['sonnet-coder'], true,
+      'agent_skills.sonnet-coder should be written to config.json');
+  });
+});
+
 // ─── plan_review.source_grounding + _authority (#22) ─────────────────────────
 
 describe('plan_review.source_grounding and plan_review.source_grounding_authority (#22)', () => {


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #751

> Linked issue has the `confirmed-bug` + `security` labels.

---

## What was broken

CodeQL code-scanning [alert #26](https://github.com/open-gsd/gsd-core/security/code-scanning/26) (`js/prototype-pollution-utility`, medium) kept firing on `setConfigValue` in `src/config.cts`, and the existing `#663` prototype-pollution tests never actually exercised the guard — leaving the guard's real attack surface untested.

## What this fix does

Restructures the existing guard to use **inline literal comparisons** (`key === '__proto__' || 'prototype' || 'constructor'`) on the exact key used to index `current`, immediately before each write, and adds regression tests that drive schema-valid dynamic-prefix keys through to the guard. Runtime behaviour is unchanged from `#663` (identical forbidden set, error message, and `ERROR_REASON.CONFIG_PARSE_FAILED`); the alert clears because the barrier is now in a shape CodeQL's dataflow recognises.

## Root cause

Two compounding issues:

1. **The alert.** The `#663` guard rejected forbidden segments via a `Set` + pre-loop `keys.some(...)` check. That is functionally correct, but CodeQL does not trace a `Set`-based, pre-loop early-return as a sanitising **barrier** on the write at `src/config.cts:447`, so the alert stayed open.
2. **The test gap.** The `#663` tests used keys (`__proto__.polluted`, `constructor.prototype.x`, bare `prototype`) that are rejected by the schema gate (`isValidConfigKey`) in `cmdConfigSet` **before** `setConfigValue` runs — they produced `Unknown config key`, never reaching the guard. The guard is, however, the *sole* barrier for schema-valid dynamic-prefix keys: the dynamic patterns allow `[a-zA-Z0-9_-]+` final segments, and underscore is in that class, so `agent_skills.__proto__`, `agent_skills.constructor`, `features.__proto__`, and `review.models.constructor` all pass the schema gate and reach the guard. Before `#663`, those inputs would have polluted `Object.prototype`.

## Testing

### How I verified the fix

- Empirically confirmed (via Node) that the dynamic-key regexes match `agent_skills.__proto__` etc., proving those inputs reach the guard.
- Added 5 regression tests (+1 positive control) that run each dynamic-prefix vector through the real CLI and assert the **guard's own** error message fires (`Invalid config key (prototype pollution guard)`), not the schema gate's `Unknown config key`, and that `Object.prototype` is not polluted.
- `node --test tests/config.test.cjs tests/bug-2530-valid-config-keys.test.cjs` → 108/108 pass.
- Full suite on Mac + Linux Docker (`gsd-test-both`) → 13881/13881 pass, 0 failures, 0 platform divergence.
- `npm run lint` clean; independent Codex adversarial review (its one test-gap finding is what these tests close); `/code-review` and `/security-review` surfaced no findings.

### Regression test added?

- [x] Yes — added tests that would have caught this bug (and that prove the guard is load-bearing, not dead code)
- [ ] No — explain why:

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

> Logic is pure string/object handling with no path or platform dependence; Windows runner not configured locally (full suite green on macOS + Linux Docker).

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added (`Security` type)
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/752"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783397261&installation_id=134682257&pr_number=752&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F752&signature=9dfcd99ead7867b3c912f78ff6b34f13fdfca92ab81f1693266880091e432f2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->