### PR TITLE
feat(#25): scope gsd-verifier Step 7b to enumerate-or-single-test; forbid full-suite re-runs

### DIFF
--- a/.changeset/gentle-orcas-click.md
+++ b/.changeset/gentle-orcas-click.md
@@ -1,0 +1,5 @@
+---
+type: Changed
+pr: 753
+---
+The `gsd-verifier` agent no longer re-runs the full workspace test suite once per must-have during Step 7b spot-checks — it enumerates tests to prove existence and runs a single named test to prove a pass, invoking the full suite at most once per verification.

--- a/agents/gsd-verifier.md
+++ b/agents/gsd-verifier.md
@@ -466,8 +466,11 @@ ls $BUILD_OUTPUT_DIR/*.{js,css} 2>/dev/null | wc -l
 # Module exports expected functions
 node -e "const m = require('$MODULE_PATH'); console.log(typeof m.$FUNCTION_NAME)" 2>/dev/null | grep -q "function"
 
-# Test suite passes (if tests exist for this phase's code)
-npm test -- --grep "$PHASE_TEST_PATTERN" 2>&1 | grep -q "passing"
+# A test EXISTS (existence proof — enumerate, do NOT run the suite)
+cargo test -- --list 2>/dev/null | grep -q "$PHASE_TEST_PATTERN"   # pytest --collect-only -q · npx vitest list · go test -list '.*'
+
+# A specific test PASSES (run ONE named test, never the whole suite)
+cargo test "$TEST_NAME" -- --exact   # pytest -k "$TEST_NAME" · npx vitest run -t "$TEST_NAME"
 ```
 
 2. **Run each check** and record pass/fail:
@@ -487,6 +490,7 @@ npm test -- --grep "$PHASE_TEST_PATTERN" 2>&1 | grep -q "passing"
 - Each check must complete in under 10 seconds
 - Do not start servers or services — only test what's already runnable
 - Do not modify state (no writes, no mutations, no side effects)
+- **Run the full workspace test command at most once per verification.** Never filter a full run per must-have (`<full-suite> 2>&1 | grep X` repeated per truth) — it re-runs everything and yields no new evidence. Prove a test exists by enumeration (`--list` / `--collect-only`); prove one passes via a single named test. If a full run is genuinely required, run it once and `grep` the saved output.
 - If the project has no runnable entry points yet, skip with: "Step 7b: SKIPPED (no runnable entry points)"
 
 ## Step 7c: Probe Execution

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -292,6 +292,7 @@ GSD uses a multi-agent architecture where thin orchestrators (workflow files) sp
 - Logs issues for `/gsd-verify-work` to address
 - Milestone scope filtering: gaps addressed in later phases are marked as "deferred", not reported as failures (v1.32)
 - **Test quality audit** (v1.32): verifies that tests prove what they claim by checking for disabled/skipped tests on requirements, circular test patterns (system generating its own expected values), assertion strength (existence vs. value vs. behavioral), and expected value provenance. Blockers from test quality audit override an otherwise passing verification
+- Runs the full workspace test suite at most once per verification — proves a test *exists* by enumeration and that it *passes* via a single named test, never re-running the whole suite per must-have.
 
 ---
 

--- a/tests/verifier-spotcheck-test-discipline.test.cjs
+++ b/tests/verifier-spotcheck-test-discipline.test.cjs
@@ -1,0 +1,57 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+// Issue #25: gsd-verifier Step 7b must not present the runner-specific
+// full-suite "| grep" anti-pattern, and must steer toward
+// enumerate-for-existence / single-named-test-for-pass.
+const verifierPath = path.join(__dirname, '..', 'agents', 'gsd-verifier.md');
+const content = fs.readFileSync(verifierPath, 'utf8');
+
+// Scope assertions to the Step 7b section so the guard tracks the right place.
+const start = content.indexOf('## Step 7b');
+const end = content.indexOf('## Step 7c', start);
+assert.ok(start !== -1 && end !== -1 && end > start, 'Step 7b section not found');
+const step7b = content.slice(start, end);
+
+test('Step 7b drops the misleading full-suite grep example', () => {
+  assert.ok(
+    !step7b.includes('npm test -- --grep "$PHASE_TEST_PATTERN" 2>&1 | grep -q "passing"'),
+    'the runner-specific `npm test --grep` example should be removed (it mis-generalizes to `<full-suite> | grep`)'
+  );
+});
+
+test('Step 7b steers existence proofs to test enumeration', () => {
+  assert.ok(
+    /cargo test -- --list/.test(step7b),
+    'Step 7b should show the correct `cargo test -- --list` enumeration form'
+  );
+  assert.ok(
+    /pytest --collect-only/.test(step7b) &&
+      /vitest list/.test(step7b) &&
+      /go test -list/.test(step7b),
+    'Step 7b should list cross-ecosystem enumeration commands (pytest/vitest/go)'
+  );
+});
+
+test('Step 7b steers pass-checks to a single named test', () => {
+  assert.ok(
+    /-- --exact/.test(step7b) &&
+      /pytest -k/.test(step7b) &&
+      /vitest run -t/.test(step7b),
+    'Step 7b should show single-named-test commands across ecosystems'
+  );
+});
+
+test('Step 7b forbids re-running the full suite per must-have', () => {
+  assert.ok(
+    /at most once per verification/i.test(step7b),
+    'Step 7b should forbid invoking the full workspace test command more than once per verification'
+  );
+  assert.ok(
+    /grep/i.test(step7b) && /per must-have|per truth/i.test(step7b),
+    'Step 7b should explicitly call out the per-must-have full-suite grep anti-pattern'
+  );
+});


### PR DESCRIPTION
## Enhancement PR

## Linked Issue

Closes #25

The linked issue carries the `approved-enhancement` label. This PR implements the **trimmed scope** the maintainer specified in the issue decision comment (fold into Step 7b; no new top-level Step 7a; no `VERIFICATION.md` label changes).

## What this enhancement improves

`agents/gsd-verifier.md` — **Step 7b: Behavioral Spot-Checks**, the only step in the verifier that runs the project's test suite.

## Before / After

**Before:**

Step 7b's lone test-running example was runner-specific:

```bash
# Test suite passes (if tests exist for this phase's code)
npm test -- --grep "$PHASE_TEST_PATTERN" 2>&1 | grep -q "passing"
```

In mocha/vitest/jest, `--grep` filters which tests **execute**. Reading this as a general template, a model re-expresses it for other ecosystems as `cargo test --workspace 2>&1 | grep X` — which runs the **entire** suite and filters only the **output** — then repeats it once per must-have. On a 60+ binary Rust workspace that added minutes per verification and produced no new evidence after the first run. The prompt never *forbade* the pattern.

**After:**

The example is replaced with two language-agnostic intents, and a constraint makes the discipline explicit:

```bash
# A test EXISTS (existence proof — enumerate, do NOT run the suite)
cargo test -- --list 2>/dev/null | grep -q "$PHASE_TEST_PATTERN"   # pytest --collect-only -q · npx vitest list · go test -list '.*'

# A specific test PASSES (run ONE named test, never the whole suite)
cargo test "$TEST_NAME" -- --exact   # pytest -k "$TEST_NAME" · npx vitest run -t "$TEST_NAME"
```

New Spot-check constraint:

> **Run the full workspace test command at most once per verification.** Never filter a full run per must-have (`<full-suite> 2>&1 | grep X` repeated per truth) — it re-runs everything and yields no new evidence. Prove a test exists by enumeration (`--list` / `--collect-only`); prove one passes via a single named test. If a full run is genuinely required, run it once and `grep` the saved output.

## How it was implemented

A scoped prompt-engineering change, plus a content-assertion test:

- **`agents/gsd-verifier.md`** — replaced the misleading example (existence-via-enumeration + pass-via-single-named-test) and added one forbidden-pattern bullet to the Step 7b "Spot-check constraints" list.
- **`docs/AGENTS.md`** — one-line entry in the gsd-verifier "Key behaviors" list.
- **`tests/verifier-spotcheck-test-discipline.test.cjs`** — new; asserts (scoped to the `## Step 7b` … `## Step 7c` slice) that the misleading example is gone, that enumeration + single-named-test commands are present across cargo/pytest/vitest/go, and that the full-suite-per-must-have anti-pattern is forbidden.

The `cargo test -- --list` form (libtest flag after `--`) was corrected following an adversarial review that caught an earlier `cargo test --list`.

## Testing

### How I verified the enhancement works

- TDD: the new test was written first and failed (4/4), then passed after the edit (4/4).
- Sibling verifier content tests: `verifier-mvp-section`, `verifier-deferred-items`, `verification-overrides` — 50/50 pass.
- Full local unit suite (`npm test`): 3880/3881 pass (1 pre-existing skip), 0 fail.
- Full cross-platform run (`gsd-test-both`): Mac local 13874 pass; Docker/Linux 12004 pass, 0 fail. (Windows leg not run locally — no host configured; the test is `path.join`-based and matches single-line substrings, so it is path/EOL-agnostic, and CI runs Windows.)
- `npm run lint`, `lint:test-file-count`: clean. Independent Codex adversarial review + `/code-review` + `/security-review`: no outstanding findings.

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific — agent-prompt guidance shared across runtimes)

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue — no additions or removals
- [x] If scope changed during implementation, I updated the issue and got re-approval before continuing

## Documentation

- [x] Updated the relevant file(s) under `docs/` to reflect this change (`docs/AGENTS.md` — agent change)
- [x] All `docs/` content added in this PR is written in English
- [ ] If genuinely no user-facing docs impact, apply `no-docs` / `docs-exempt`

## Checklist

- [x] Issue linked above with `Closes #25`
- [x] Linked issue has the `approved-enhancement` label
- [x] Changes are scoped to the approved enhancement — nothing extra included
- [x] All existing tests pass (`npm test`)
- [x] New or updated tests cover the enhanced behavior
- [x] `.changeset/` fragment added (`type: Changed`, added with the PR number in the follow-up push)
- [x] No unnecessary dependencies added

## Breaking changes

None. The change constrains how often the verifier re-invokes the workspace test command; it does not alter any input/output contract or the `VERIFICATION.md` format.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/753"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783398793&installation_id=134682257&pr_number=753&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F753&signature=f75a17eade5227920854ff4a0ea88035b0a37288e3ed37a0d429f4e11730c765"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->