### PR TITLE
fix(#758): trigger draft-PR auto-close on pull_request_target

### DIFF
--- a/.github/workflows/close-draft-prs.yml
+++ b/.github/workflows/close-draft-prs.yml
@@ -1,7 +1,18 @@
 name: Close Draft PRs
 
+# pull_request_target (not pull_request) so the job runs in the base-repo
+# context with a write-capable token even for PRs from forks. Without this,
+# fork PRs from first-time/external contributors get a read-only GITHUB_TOKEN
+# and the close/comment API calls 403 — letting them bypass the auto-close.
+# Safe because this job only reads event metadata and never checks out or
+# executes PR-supplied code.
+# Residual platform limitation: GitHub deliberately does NOT trigger
+# pull_request_target for fork branches whose names look like a Git SHA, so a
+# contributor could still evade this by naming their head branch like a commit
+# hash. Fully closing that gap needs a scheduled base-context sweep (separate
+# concern); a draft PR that evades this still cannot merge and still fails the other gates.
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, converted_to_draft]
 
 concurrency:

--- a/tests/workflow-maintainer-skip.test.cjs
+++ b/tests/workflow-maintainer-skip.test.cjs
@@ -29,6 +29,18 @@ describe('PR policy workflow maintainer carve-outs', () => {
     assertMaintainerSkip(workflow);
   });
 
+  test('draft PR auto-close triggers on pull_request_target so fork PRs cannot bypass it', () => {
+    const workflow = readWorkflow('.github/workflows/close-draft-prs.yml');
+
+    // A bare `pull_request` trigger hands fork PRs (how first-time/external
+    // contributors contribute) a read-only GITHUB_TOKEN, so the close/comment
+    // API calls 403 and the draft PR survives — bypassing the auto-close.
+    // `pull_request_target` runs in the base-repo context with a write-capable
+    // token. Guard against a regression back to the bypassable trigger.
+    assert.match(workflow, /^\s*pull_request_target:/m);
+    assert.doesNotMatch(workflow, /^\s*pull_request:\s*$/m);
+  });
+
   test('PR target validator does not run for maintainer-authored PRs', () => {
     const workflow = readWorkflow('.github/workflows/pr-target-validator.yml');
 


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #758

> The linked issue carries the `confirmed-bug` label.

---

## What was broken

The `Close Draft PRs` workflow auto-closes draft PRs from non-maintainers, but a first-time or external contributor could bypass it entirely — their draft PR was never closed.

## What this fix does

Switches the workflow trigger from `on: pull_request` to `on: pull_request_target`, so the job runs in the base-repo context with a write-capable token even for PRs opened from forks. The close + comment now succeed against fork PRs.

## Root cause

`on: pull_request` workflows triggered by PRs **from forks** receive a read-only `GITHUB_TOKEN`, regardless of the `permissions:` block. Both API calls in the job — `issues.createComment(...)` and `pulls.update({ state: 'closed' })` — therefore returned HTTP 403, leaving the draft PR open. The exact population the job targets (non-`OWNER`/`MEMBER`/`COLLABORATOR`, i.e. first-time/external contributors) is precisely the one whose fork-PR token could not close anything.

`pull_request_target` is safe here because the job never checks out or executes PR-supplied code — it only reads event metadata (`context.payload.pull_request`) and calls the GitHub API. The minimal `permissions: pull-requests: write` block continues to constrain the elevated token.

**Known residual (documented in the workflow, out of scope for this fix):** GitHub deliberately does not trigger `pull_request_target` for fork branches whose names look like a Git SHA, so a contributor could still evade the auto-close by naming their head branch like a commit hash. Closing that gap requires a separate base-context scheduled sweep (tracked as a follow-up); a draft PR that evades this still cannot merge and still fails the other gates.

## Testing

### How I verified the fix

Added a regression test in `tests/workflow-maintainer-skip.test.cjs` that asserts the workflow triggers on `pull_request_target` and **not** on bare `pull_request`. The negative assertion (`assert.doesNotMatch(workflow, /^\s*pull_request:\s*$/m)`) fails against the old trigger and passes after the fix, so it genuinely guards the regression. Full unit suite green (`npm test`: 3762 pass, 0 fail).

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [x] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix — or `no-changelog` label applied (CI-workflow/test-only change, no user-facing impact; `no-changelog` label applied)
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/760"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783430985&installation_id=134682257&pr_number=760&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F760&signature=5e6cccf4e102312581fe10b42ab74bfa06ffa7e20da1c2eea97f10ed823a0707"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->