### PR TITLE
feat(#759): non-destructive CHANGELOG preview in the rc release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -370,6 +370,29 @@ jobs:
           node scripts/check-npm-integrity.cjs
           npm run test:coverage:unit
 
+      - name: Preview CHANGELOG (non-destructive)
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          # Non-destructive CHANGELOG preview for the version under test (#759):
+          # renders the curated section finalize will promote, without writing
+          # CHANGELOG.md or consuming .changeset fragments. Surfaced in the job
+          # summary so RC testers see the upcoming release notes.
+          #
+          # Render to a file as a standalone command so a non-zero exit (e.g. a
+          # malformed fragment) fails the step. The default GitHub Linux shell
+          # is `bash -e` without pipefail, so a `node | tee` pipeline would mask
+          # a node failure behind tee's exit 0.
+          PREVIEW_FILE="${RUNNER_TEMP:-/tmp}/changelog-preview.md"
+          node scripts/changeset/cli.cjs render \
+            --version "$VERSION" --date "$(date -u +%F)" --preview > "$PREVIEW_FILE"
+          {
+            echo "### CHANGELOG preview for v${VERSION} (not yet promoted)"
+            echo ''
+            cat "$PREVIEW_FILE"
+          } >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
+          cat "$PREVIEW_FILE"
+
       - name: Commit pre-release version bump
         env:
           PRE_VERSION: ${{ steps.prerelease.outputs.pre_version }}

--- a/docs/branching.md
+++ b/docs/branching.md
@@ -167,6 +167,7 @@ When `next` has accumulated enough work to ship a new minor/major.
    - Each fix should also be PR'd to `next` so the next release has it too
      (or wait for the auto-back-merge after finalize)
    - Trigger `rc` action to publish RC builds: 1.28.0-rc.1, rc.2, ...
+   - Each `rc` run also prints a non-destructive preview of the curated `## [X.Y.0]` CHANGELOG section in the Actions job summary — rendered from the `.changeset/` fragments without consuming them — so you can review the upcoming release notes during RC testing.
 
 4. When stable: trigger `finalize`.
    - Publishes to npm @latest

--- a/scripts/changeset/cli.cjs
+++ b/scripts/changeset/cli.cjs
@@ -42,6 +42,7 @@ function parseArgs(argv) {
     installCommand: `npx ${packageName}@latest`,
     json: false,
     allowEmpty: false,
+    preview: false,
   };
   if (argv.length === 0) return { ok: true, opts };
   opts.cmd = argv[0];
@@ -62,6 +63,7 @@ function parseArgs(argv) {
     const a = argv[i];
     if (a === '--json') { opts.json = true; continue; }
     if (a === '--allow-empty') { opts.allowEmpty = true; continue; }
+    if (a === '--preview') { opts.preview = true; continue; }
     if (
       a === '--repo' ||
       a === '--version' ||
@@ -133,6 +135,19 @@ function assembleChangelog(lead, releaseBlock) {
   ].join('\n');
 }
 
+// Insert a "_No notable changes._" placeholder after the dated release heading
+// of an otherwise-empty release block. serializeChangelog with no sections
+// yields just "## [v] - d\n"; we expand the trailing newline into a blank line
+// + placeholder + blank line so parseChangelog still sees the dated heading
+// first and the output is human-readable. Shared by the --allow-empty and
+// --preview zero-fragment paths so they can never drift.
+function injectEmptyPlaceholder(headerOnlyBlock) {
+  return headerOnlyBlock.replace(
+    /^(##\s+\[[^\]]+\][^\n]*)\n+/,
+    '$1\n\n_No notable changes._\n\n',
+  );
+}
+
 function cmdRender(opts) {
   const repo = path.resolve(opts.repo);
   const changesetDir = path.join(repo, '.changeset');
@@ -155,6 +170,38 @@ function cmdRender(opts) {
 
   // 2. Read priorText once; reuse in all subsequent branches.
   const priorText = fs.existsSync(changelogPath) ? fs.readFileSync(changelogPath, 'utf8') : '';
+
+  // Preview mode (#759): render the dated release section WITHOUT writing
+  // CHANGELOG.md and WITHOUT consuming .changeset fragments. Used by the rc
+  // release job to surface the curated notes for the version under test while
+  // leaving the fragment set intact for the eventual finalize render.
+  if (opts.preview) {
+    // priorChangelog is intentionally null: a preview shows ONLY the new dated
+    // section for the version under test, not the full file history.
+    // serializeChangelog appends priorChangelog verbatim, so passing the prior
+    // text here would dump every past release into the rc job summary.
+    const ir = renderChangelog({
+      fragments,
+      version: opts.version,
+      date: opts.date,
+      priorChangelog: null,
+    });
+    let releaseBlock = serializeChangelog(ir);
+    if (fragments.length === 0) {
+      // Mirror --allow-empty: a no-fragment release still shows a dated heading
+      // with a placeholder rather than an empty block.
+      releaseBlock = injectEmptyPlaceholder(releaseBlock);
+    }
+    return {
+      exitCode: 0,
+      report: {
+        consumed: 0,
+        failures: [],
+        preview: releaseBlock,
+        fragmentCount: fragments.length,
+      },
+    };
+  }
 
   // 3. FIX 1: idempotency guard — if the version is already promoted (a dated
   //    release heading for this version already exists in CHANGELOG), split on
@@ -201,15 +248,7 @@ function cmdRender(opts) {
       priorChangelog: prior || null,
     });
     const headerOnlyBlock = serializeChangelog(ir);
-    // Insert placeholder after the release header line.
-    // serializeChangelog with no sections yields just "## [v] - d\n" (single
-    // trailing newline, no blank line).  We replace that trailing newline with
-    // a blank line + placeholder + blank line so parseChangelog still sees the
-    // dated heading first and the file is human-readable.
-    const releaseBlock = headerOnlyBlock.replace(
-      /^(##\s+\[[^\]]+\][^\n]*)\n+/,
-      '$1\n\n_No notable changes._\n\n',
-    );
+    const releaseBlock = injectEmptyPlaceholder(headerOnlyBlock);
     // FIX 2: use shared assembleChangelog helper.
     const out = assembleChangelog(lead, releaseBlock);
     fs.writeFileSync(changelogPath, out);
@@ -460,7 +499,8 @@ function cmdGithubReleaseNotes(opts) {
 function usage() {
   return [
     'usage:',
-    '  changeset/cli.cjs render --repo <dir> --version V --date D [--allow-empty] [--json]',
+    '  changeset/cli.cjs render --repo <dir> --version V --date D [--allow-empty] [--preview] [--json]',
+    '    --preview renders the dated section to stdout without writing CHANGELOG.md or consuming fragments.',
     '  changeset/cli.cjs github-release-notes --repo <dir> --from REF --to REF [--output FILE] [--repo-slug OWNER/REPO] [--install-command CMD] [--json]',
     '  changeset/cli.cjs extract --from VERSION --to VERSION [--changelog FILE] [--repo <dir>] [--json]',
     '    Extracts changelog entries strictly after --from (exclusive) and up to',
@@ -525,6 +565,9 @@ function main() {
   const { exitCode, report } = opts.cmd === 'render' ? cmdRender(opts) : cmdGithubReleaseNotes(opts);
   if (opts.json) {
     process.stdout.write(JSON.stringify(report, null, 2) + '\n');
+  } else if (opts.cmd === 'render' && opts.preview) {
+    // render --preview: emit the rendered section verbatim (no mutation occurred).
+    process.stdout.write(report.preview);
   } else if (opts.cmd === 'github-release-notes' && report.body) {
     process.stdout.write(report.body);
   } else {

--- a/tests/changeset-cli.test.cjs
+++ b/tests/changeset-cli.test.cjs
@@ -1,7 +1,7 @@
 'use strict';
 process.env.GSD_TEST_MODE = '1';
 
-const { test, describe, before, after } = require('node:test');
+const { test, describe, before, after, beforeEach } = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const os = require('node:os');
@@ -34,6 +34,11 @@ function runRender(args = []) {
     report: r.stdout && r.stdout.length ? JSON.parse(r.stdout) : null,
     stderr: r.stderr || '',
   };
+}
+
+function runRenderRaw(args = []) {
+  const r = cp.spawnSync(process.execPath, [SCRIPT, 'render', '--repo', tmp, ...args], { encoding: 'utf8' });
+  return { status: r.status, stdout: r.stdout || '', stderr: r.stderr || '' };
 }
 
 before(() => { tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-changeset-')); });
@@ -926,5 +931,109 @@ describe('changeset cli render --allow-empty', () => {
     } finally {
       cleanup(dir);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GROUP D — render --preview (#759)
+// ---------------------------------------------------------------------------
+
+describe('changeset cli render --preview (#759)', () => {
+  // Helper: reset the shared tmp dir to a clean state for preview tests.
+  function resetTmp() {
+    // Remove CHANGELOG.md if present.
+    const changelogPath = path.join(tmp, 'CHANGELOG.md');
+    if (fs.existsSync(changelogPath)) {
+      fs.unlinkSync(changelogPath);
+    }
+    // Remove any leftover .changeset/*.md fragments.
+    const changesetDir = path.join(tmp, '.changeset');
+    if (fs.existsSync(changesetDir)) {
+      for (const f of fs.readdirSync(changesetDir)) {
+        if (f.endsWith('.md') && f !== 'README.md') {
+          fs.unlinkSync(path.join(changesetDir, f));
+        }
+      }
+    }
+  }
+
+  // Reset state before each preview test so a new test added to this group
+  // can never inherit a CHANGELOG.md or fragments left by the previous one.
+  beforeEach(resetTmp);
+
+  test('render --preview prints the section to stdout and mutates nothing', () => {
+    writeFragment('preview-frag-one', 'Added', 900, 'preview-added-feature');
+
+    const fragmentPath = path.join(tmp, '.changeset', 'preview-frag-one.md');
+    const r = runRenderRaw(['--version', '9.9.0', '--date', '2026-01-02', '--preview']);
+
+    assert.equal(r.status, 0, `expected exit 0; stderr=${r.stderr}`);
+    assert.ok(r.stdout.includes('## [9.9.0]'), `stdout must contain ## [9.9.0]; got: ${r.stdout}`);
+    assert.ok(r.stdout.includes('### Added'), `stdout must contain ### Added; got: ${r.stdout}`);
+    assert.ok(r.stdout.includes('preview-added-feature'), `stdout must contain fragment body; got: ${r.stdout}`);
+
+    // CHANGELOG.md must NOT have been created.
+    assert.ok(!fs.existsSync(path.join(tmp, 'CHANGELOG.md')), 'CHANGELOG.md must NOT be created by --preview');
+
+    // Fragment file must still exist.
+    assert.ok(fs.existsSync(fragmentPath), 'fragment file must still exist after --preview');
+  });
+
+  test('render --preview with zero fragments emits the placeholder and writes nothing', () => {
+    // No fragments written — zero-fragment scenario.
+
+    const r = runRenderRaw(['--version', '9.9.0', '--date', '2026-01-02', '--preview']);
+
+    assert.equal(r.status, 0, `expected exit 0; stderr=${r.stderr}`);
+    assert.ok(r.stdout.includes('## ['), `stdout must contain a release heading; got: ${r.stdout}`);
+    assert.ok(r.stdout.includes('_No notable changes._'), `stdout must contain placeholder; got: ${r.stdout}`);
+
+    // CHANGELOG.md must NOT have been created.
+    assert.ok(!fs.existsSync(path.join(tmp, 'CHANGELOG.md')), 'CHANGELOG.md must NOT be created by zero-fragment --preview');
+  });
+
+  test('render --preview --json returns preview text in report with consumed 0', () => {
+    writeFragment('preview-frag-two', 'Fixed', 901, 'preview-fixed-bug');
+
+    const fragmentPath = path.join(tmp, '.changeset', 'preview-frag-two.md');
+    // runRender appends --json automatically.
+    const r = runRender(['--version', '9.9.0', '--date', '2026-01-02', '--preview']);
+
+    assert.equal(r.status, 0, `expected exit 0; stderr=${r.stderr}`);
+    assert.ok(r.report, 'report must be parseable JSON');
+    assert.strictEqual(r.report.consumed, 0, 'consumed must be 0 for preview');
+    assert.strictEqual(r.report.fragmentCount, 1, 'fragmentCount must be 1');
+    assert.ok(typeof r.report.preview === 'string', 'report.preview must be a string');
+    assert.ok(r.report.preview.includes('## [9.9.0]'), `report.preview must contain ## [9.9.0]; got: ${r.report.preview}`);
+
+    // Fragment file must still exist.
+    assert.ok(fs.existsSync(fragmentPath), 'fragment file must still exist after --preview --json');
+  });
+
+  test('render --preview with an existing CHANGELOG.md leaves it byte-identical and shows only the new section', () => {
+    // Seed an existing CHANGELOG with a prior dated release.
+    const changelogPath = path.join(tmp, 'CHANGELOG.md');
+    const existing =
+      '# Changelog\n\n## [1.0.0] - 2020-01-01\n\n### Added\n\n- old prior feature (#1)\n';
+    fs.writeFileSync(changelogPath, existing);
+    writeFragment('preview-frag-three', 'Added', 902, 'brand-new-thing');
+    const before = fs.readFileSync(changelogPath, 'utf8');
+
+    const r = runRenderRaw(['--version', '9.9.0', '--date', '2026-01-02', '--preview']);
+
+    assert.equal(r.status, 0, `expected exit 0; stderr=${r.stderr}`);
+    // Output shows the new section...
+    assert.ok(r.stdout.includes('## [9.9.0]'), `stdout must contain new heading; got: ${r.stdout}`);
+    assert.ok(r.stdout.includes('brand-new-thing'), `stdout must contain new fragment body; got: ${r.stdout}`);
+    // ...and NOT the prior release history (preview is the new section only).
+    assert.ok(!r.stdout.includes('## [1.0.0]'), `preview must NOT include prior releases; got: ${r.stdout}`);
+    assert.ok(!r.stdout.includes('old prior feature'), `preview must NOT include prior bullets; got: ${r.stdout}`);
+
+    // Existing CHANGELOG.md must be byte-identical — preview mutates nothing.
+    assert.strictEqual(
+      fs.readFileSync(changelogPath, 'utf8'),
+      before,
+      'CHANGELOG.md must be byte-identical after --preview',
+    );
   });
 });


### PR DESCRIPTION
## Enhancement PR

## Linked Issue

Closes #759

The linked issue carries the `approved-enhancement` label.

## What this enhancement improves

The `rc` action of `.github/workflows/release.yml` publishes a release candidate to npm under the `@next` dist-tag for testing — but it never surfaces the curated `CHANGELOG.md` section for the version under test. The only place changeset fragments are folded into a dated `## [X.Y.0]` heading is the `finalize` job (`render --allow-empty`, wired in by #715), which runs *after* the RC window closes. And `render` is strictly destructive (always writes `CHANGELOG.md` and `fs.unlinkSync`s every consumed fragment), so there was no safe way to render the section during an RC.

This PR adds a **non-destructive `--preview` mode** to the changeset render CLI and wires it into the `rc` job so each RC run prints the upcoming `## [X.Y.0]` section into the Actions job summary — rendered from `.changeset/` fragments, mutating nothing.

## Before / After

**Before:** `rc` run → publishes `@next`, GitHub pre-release notes from `--generate-notes`. The curated CHANGELOG section is invisible until `finalize`.

**After:** `rc` run → same publish, **plus** a "Preview CHANGELOG (non-destructive)" step that renders the dated section for `inputs.version` and writes it to `$GITHUB_STEP_SUMMARY`. Fragments and `CHANGELOG.md` are left untouched, so the eventual `finalize` render consumes them exactly as before.

## How it was implemented

- **`scripts/changeset/cli.cjs`**
  - New `--preview` boolean flag (parsed alongside `--allow-empty`/`--json`).
  - `cmdRender` gains an early, non-mutating branch: it renders the dated section via the existing `renderChangelog`/`serializeChangelog` pipeline with `priorChangelog: null` (so only the *new* section is emitted, not the full file history), applies the same `_No notable changes._` placeholder as `--allow-empty` for a zero-fragment release, and returns `{ consumed: 0, preview: <text>, fragmentCount }` **without writing `CHANGELOG.md` or deleting any fragment**.
  - The zero-fragment placeholder logic is now a shared `injectEmptyPlaceholder()` helper used by both the `--allow-empty` and `--preview` paths, so they can't drift.
  - `main` routes `render --preview` (without `--json`) to emit the rendered section verbatim to stdout; `--preview --json` still emits the full structured report.
  - `usage()` documents `--preview`.
- **`.github/workflows/release.yml`** — new "Preview CHANGELOG (non-destructive)" step in the `rc` job (after "Install and test"). It renders to a file as a *standalone* command — so a non-zero exit (e.g. a malformed fragment) fails the step — then `cat`s it to the job summary and the log. (The default GitHub Linux shell is `bash -e` without `pipefail`, so a `node | tee` pipeline would have masked a node failure behind `tee`'s exit 0.)
- **`docs/branching.md`** — documents the RC preview in the minor/major release flow.

## Testing

### How I verified the enhancement works

- Added 4 CLI-level tests in `tests/changeset-cli.test.cjs` (`render --preview` group): stdout content + no mutation with fragments; zero-fragment placeholder + no mutation; `--preview --json` report shape (`consumed: 0`, `fragmentCount`, `preview` string); and an existing-`CHANGELOG.md` case proving the file is left **byte-identical** and the output contains only the new section (not prior releases). A `beforeEach` resets shared-tmp state so future tests can't inherit stale state.
- Manual sanity run against a temp repo with an existing CHANGELOG + one fragment: preview printed only `## [1.4.0]`, left `CHANGELOG.md` byte-identical, and retained the fragment.
- Independent reviews run pre-PR: Codex adversarial review (found + fixed the pipefail masking and the prior-history-in-preview issues), `/code-review high` (applied: flag-based output routing, shared placeholder helper, `beforeEach`), `/security-review` (no findings), `npm run lint` (clean).

### Platforms tested

- macOS (local)
- Linux (Docker, via `gsd-test`)

### Runtimes tested

- Node.js (repo default; `node --test` unit suite + full `gsd-test` matrix)

## Scope confirmation

Changes are scoped to the approved enhancement (#759): the `--preview` flag, its wiring into the `rc` job, tests, and docs. The default destructive `render`, plus `verify`/`finalize`/`create`/`extract`/`github-release-notes`, are unchanged.

## Documentation

`docs/branching.md` updated (minor/major release flow now describes the RC CHANGELOG preview).

## Checklist

- [x] Issue linked above with `Closes #759`
- [x] Linked issue has the `approved-enhancement` label
- [x] Changes are scoped to the approved enhancement — nothing extra included
- [x] All existing tests pass
- [x] New or updated tests cover the enhanced behavior
- [x] No user-facing package change → `no-changelog` label applied (the `--preview` flag and rc preview are release-tooling/CI only; end users of the package never invoke them)
- [x] No unnecessary dependencies added

## Breaking changes

None. `--preview` is a new opt-in flag; all existing behavior is unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/763"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783432343&installation_id=134682257&pr_number=763&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F763&signature=9b7225fecf6d0e494d50bd7b6aa167d7a55241859f4a48edaceedf34e07b386e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->