### PR TITLE
feat(#761): scheduled base-context sweep to close SHA-branch-evading draft PRs

### DIFF
--- a/.github/workflows/close-draft-prs-sweep.yml
+++ b/.github/workflows/close-draft-prs-sweep.yml
@@ -1,0 +1,112 @@
+name: Close Draft PRs (sweep)
+
+# Companion to close-draft-prs.yml. That workflow runs per-PR on
+# pull_request_target and is the fast path. GitHub does NOT dispatch
+# pull_request_target for fork branches whose names look like a Git SHA, so a
+# fork draft PR on a SHA-named branch can never be closed by any PR-triggered
+# event (a pull_request run from a fork gets a read-only token). This scheduled
+# sweep runs in the base-repo context with a write-capable token and enforces
+# the identical policy on a timer, catching that evasion. See issue #761.
+
+on:
+  schedule:
+    - cron: '0 */6 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: close-draft-prs-sweep
+  cancel-in-progress: false
+
+permissions:
+  pull-requests: write
+
+jobs:
+  sweep-draft-prs:
+    name: Sweep open draft PRs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close non-maintainer draft PRs
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            // Maintainers may use draft PRs for internal coordination — same
+            // carve-out as close-draft-prs.yml. A scheduled run has no
+            // github.event.pull_request, so the carve-out is applied here as a
+            // Set membership test over author_association.
+            const MAINTAINER_ASSOCIATIONS = new Set(['OWNER', 'MEMBER', 'COLLABORATOR']);
+            const repoUrl = context.repo.owner + '/' + context.repo.repo;
+
+            const commentBody = [
+              '## Draft PRs are not accepted',
+              '',
+              'This project only accepts completed pull requests. Draft PRs are automatically closed.',
+              '',
+              '**Why?** GSD requires all PRs to be ready for review when opened \u2014 with tests passing, the correct PR template used, and a linked approved issue. Draft PRs bypass these quality gates and create review overhead.',
+              '',
+              '### What to do instead',
+              '',
+              '1. Finish your implementation locally',
+              '2. Run `npm run test:coverage` and confirm all tests pass',
+              '3. Open a **non-draft** PR using the [correct template](https://github.com/' + repoUrl + '/blob/main/CONTRIBUTING.md#pull-request-guidelines)',
+              '',
+              'See [CONTRIBUTING.md](https://github.com/' + repoUrl + '/blob/main/CONTRIBUTING.md) for the full process.',
+            ].join('\n');
+
+            const isEnforceableDraft = (pr) =>
+              !!pr && pr.state === 'open' && pr.draft === true &&
+              !MAINTAINER_ASSOCIATIONS.has(pr.author_association);
+
+            const openPulls = await github.paginate(github.rest.pulls.list, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100,
+            });
+
+            const candidates = openPulls.filter(isEnforceableDraft);
+            core.info('Sweep found ' + candidates.length + ' non-maintainer draft PR(s) of ' + openPulls.length + ' open.');
+
+            const failures = [];
+
+            for (const candidate of candidates) {
+              try {
+                // Re-fetch immediately before mutating: the contributor may have
+                // marked the PR ready (or it may have closed) since pagination.
+                const { data: pr } = await github.rest.pulls.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: candidate.number,
+                });
+
+                if (!isEnforceableDraft(pr)) {
+                  core.info('Skipping PR #' + candidate.number + ' — no longer an open non-maintainer draft.');
+                  continue;
+                }
+
+                // Close FIRST so enforcement (the primary action) is never gated
+                // on the explanatory comment. A closed PR is never revisited by a
+                // later sweep, so this also prevents duplicate comments.
+                await github.rest.pulls.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: pr.number,
+                  state: 'closed'
+                });
+
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  body: commentBody
+                });
+
+                core.info('Closed draft PR #' + pr.number + ': ' + pr.title);
+              } catch (err) {
+                failures.push(candidate.number);
+                core.warning('Failed to process draft PR #' + candidate.number + ': ' + err.message);
+              }
+            }
+
+            if (failures.length > 0) {
+              core.setFailed('Sweep encountered errors on ' + failures.length + ' draft PR(s): ' + failures.join(', '));
+            }

--- a/tests/workflow-maintainer-skip.test.cjs
+++ b/tests/workflow-maintainer-skip.test.cjs
@@ -34,4 +34,36 @@ describe('PR policy workflow maintainer carve-outs', () => {
 
     assertMaintainerSkip(workflow);
   });
+
+  test('draft PR sweep enforces the same policy as the event-driven close', () => {
+    const workflow = readWorkflow('.github/workflows/close-draft-prs-sweep.yml');
+
+    // Timer-driven in base-repo context, plus a manual dispatch for testing.
+    // It must NOT be a fork-triggered event (no pull_request / pull_request_target trigger).
+    assert.match(workflow, /schedule:/);
+    assert.match(workflow, /cron:\s*'0 \*\/6 \* \* \*'/);
+    assert.match(workflow, /workflow_dispatch:/);
+    assert.doesNotMatch(workflow, /^\s*pull_request(_target)?:/m);
+
+    // Write-capable token (needed to close PRs from base context). Tolerant of
+    // intervening blank lines or additional permission keys.
+    assert.match(workflow, /permissions:\s+pull-requests:\s*write/);
+
+    // Identical maintainer carve-out to close-draft-prs.yml — a Set membership
+    // test over author_association, negated (no github.event.pull_request in a
+    // scheduled run).
+    assert.match(workflow, /new Set\(\['OWNER', 'MEMBER', 'COLLABORATOR'\]\)/);
+    assert.match(workflow, /!MAINTAINER_ASSOCIATIONS\.has\([^)]*\.author_association\)/);
+
+    // Paginates over open PRs and filters to drafts.
+    assert.match(workflow, /github\.paginate\(github\.rest\.pulls\.list/);
+    assert.match(workflow, /state:\s*'open'/);
+    assert.match(workflow, /pr\.draft === true/);
+
+    // Same user-facing policy message as close-draft-prs.yml (locks the core
+    // content so the sweep cannot silently drift to a weaker message).
+    assert.match(workflow, /## Draft PRs are not accepted/);
+    assert.match(workflow, /npm run test:coverage/);
+    assert.match(workflow, /CONTRIBUTING\.md#pull-request-guidelines/);
+  });
 });


### PR DESCRIPTION
## Enhancement PR

## Linked Issue

Closes #761

> The linked issue carries the `approved-enhancement` label.

---

## What this enhancement improves

The `Close Draft PRs` enforcement policy (`.github/workflows/close-draft-prs.yml`) — auto-comment + close on draft PRs whose `author_association` is not `OWNER`/`MEMBER`/`COLLABORATOR`. This PR closes the one documented residual bypass so the *same policy* holds for 100% of fork draft PRs.

## Before / After

**Before:**
After #760, `close-draft-prs.yml` triggers on `pull_request_target`, so fork draft PRs get a write-capable base-repo token and are correctly closed — **except** for fork branches whose names look like a Git SHA. GitHub [deliberately does not dispatch `pull_request_target`](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request_target) for SHA-like head branches, and a `pull_request` run from a fork gets a read-only token. So a contributor can keep a non-compliant draft PR open indefinitely by naming their head branch like a 40-hex commit hash — no PR-triggered event can close it.

**After:**
A new scheduled sweep (`.github/workflows/close-draft-prs-sweep.yml`) runs every 6 hours (plus `workflow_dispatch`) in the base-repo context with `pull-requests: write`, enumerates open draft PRs (paginated), filters to non-maintainer authors, and closes + comments them with the **identical** policy and message. Branch-name evasion is caught within one cron interval; the event-driven workflow remains the near-instant fast path for the common case.

## How it was implemented

`.github/workflows/close-draft-prs-sweep.yml` uses the same pinned `actions/github-script` SHA as the sibling, the same `["OWNER","MEMBER","COLLABORATOR"]` carve-out (as a `Set` membership test, since a scheduled run has no `github.event.pull_request`), and the byte-identical comment body. Robustness hardening from review:
- **Re-fetch before mutate** — each candidate is re-fetched immediately before closing and re-checked (`isEnforceableDraft`), so a PR marked ready (or already closed) between pagination and the close is not wrongly closed (TOCTOU guard).
- **Close before comment** — enforcement (the primary action) is never gated on the explanatory comment; a closed PR is never revisited, so there are no duplicate comments.
- **Failure visibility** — per-PR errors are collected and `core.setFailed(...)` marks the run failed so transient API failures surface in the Actions UI.
- **`cancel-in-progress: false`** — a whole-repo enforcement sweep is idempotent and should run to completion rather than be cancelled mid-loop.

Key files:
- `.github/workflows/close-draft-prs-sweep.yml` (new)
- `tests/workflow-maintainer-skip.test.cjs` (structural guards)

> **Dependency note:** the "fast path" framing assumes #760 (which switches `close-draft-prs.yml` to `pull_request_target`) is merged. This PR does **not** touch that file (one concern per PR). If #760 has not merged yet, the sweep simply becomes the primary enforcement for all fork drafts until it does — it works correctly either way.
>
> **Deferred follow-up:** the comment body / carve-out are duplicated across the two workflows. The clean de-duplication (a shared composite action) would touch `close-draft-prs.yml` and is out of scope here; the new test locks the message content so the two cannot silently drift in the meantime.

## Testing

### How I verified the enhancement works

- Added structural regression guards in `tests/workflow-maintainer-skip.test.cjs` asserting: `schedule` + `cron: '0 */6 * * *'` + `workflow_dispatch` triggers, **no** `pull_request`/`pull_request_target` trigger, `pull-requests: write`, the exact `Set(['OWNER','MEMBER','COLLABORATOR'])` carve-out negated over `author_association`, pagination over open PRs, the draft filter, and the policy message content.
- `npm test` — full unit suite green.
- gsd-test on Mac (local) + Linux (Docker): **14032 passed, 0 failed**, no platform-specific deltas.
- `npm run lint` — clean.
- Independent Codex adversarial review + `/code-review` + `/security-review` run; actionable findings addressed (no security findings).

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue — no additions or removals
- [x] If scope changed during implementation, I updated the issue and got re-approval before continuing

## Documentation

- [ ] Updated the relevant file(s) under `docs/` to reflect this change
- [x] All `docs/` content added in this PR is written in English
- [x] If genuinely no user-facing docs impact (infrastructure / internal refactor / test-only), apply the `no-docs` label — this is a CI/repo-governance workflow with no user-facing runtime or doc impact; `no-docs` applied.

## Checklist

- [x] Issue linked above with `Closes #761`
- [x] Linked issue has the `approved-enhancement` label
- [x] Changes are scoped to the approved enhancement — nothing extra included
- [x] All existing tests pass (`npm test`)
- [x] New or updated tests cover the enhanced behavior
- [x] `.changeset/` fragment added — or `no-changelog` label applied if not user-facing (CI-workflow/test-only change, no user-facing impact; `no-changelog` applied)
- [x] No unnecessary dependencies added

## Breaking changes

None. Net effect is strictly more enforcement of an already-stated policy; maintainer-authored drafts remain exempt via the same `author_association` carve-out.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/765"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783432734&installation_id=134682257&pr_number=765&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F765&signature=f3a8404d937f9b743d253c2756d5cabd6a9eb3f5b28ba0e2a81a338d11909796"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->