### PR TITLE
fix(#783): resolve Kilo global skills base to ~/.kilo/skills

### DIFF
--- a/.changeset/783-kilo-global-skills-base.md
+++ b/.changeset/783-kilo-global-skills-base.md
@@ -1,6 +1,6 @@
 ---
 type: Fixed
-pr: 783
+pr: 806
 ---
 **`getGlobalSkillsBase('kilo')` now resolves to `~/.kilo/skills`** — where Kilo Code actually discovers global skills — instead of `~/.config/kilo/skills`. Per [Kilo Code docs](https://kilo.ai/docs/customize/skills), global skills live in the `.kilo` directory within HOME (`~/.kilo/skills/`), independent of the XDG-based config dir at `~/.config/kilo`. The kilo.jsonc config dir (`~/.config/kilo`) and the `command/` path used by the installer are correct and unchanged. Blast radius: this corrects the resolved skills-base path used by doctor/status checks and agent-skills-block resolution (`init.cjs`); the installer writes commands (not skills) for Kilo, so no files were previously being written to the wrong location.
 

--- a/.changeset/783-kilo-global-skills-base.md
+++ b/.changeset/783-kilo-global-skills-base.md
@@ -1,0 +1,7 @@
+---
+type: Fixed
+pr: 783
+---
+**`getGlobalSkillsBase('kilo')` now resolves to `~/.kilo/skills`** — where Kilo Code actually discovers global skills — instead of `~/.config/kilo/skills`. Per [Kilo Code docs](https://kilo.ai/docs/customize/skills), global skills live in the `.kilo` directory within HOME (`~/.kilo/skills/`), independent of the XDG-based config dir at `~/.config/kilo`. The kilo.jsonc config dir (`~/.config/kilo`) and the `command/` path used by the installer are correct and unchanged. Blast radius: this corrects the resolved skills-base path used by doctor/status checks and agent-skills-block resolution (`init.cjs`); the installer writes commands (not skills) for Kilo, so no files were previously being written to the wrong location.
+
+<!-- docs-exempt: internal path-resolution correction; no user-facing how-to surface changed -->

--- a/src/runtime-homes.cts
+++ b/src/runtime-homes.cts
@@ -162,8 +162,17 @@ export function getGlobalConfigDir(runtime: string, explicitDir?: string | null)
  */
 export function getGlobalSkillsBase(runtime: string): string | null {
   if (runtime === 'cline') return null;
+  if (runtime === 'hermes') {
+    const configDir = getGlobalConfigDir(runtime);
+    return path.join(configDir, 'skills', 'gsd');
+  }
+  // Kilo Code discovers global skills from ~/.kilo/skills/ (HOME-relative),
+  // independent of the XDG-based config dir (~/.config/kilo) used for commands.
+  // See: https://kilo.ai/docs/customize/skills
+  // "Global skills are located in the `.kilo` directory within your Home
+  //  directory: ~/.kilo/skills/"
+  if (runtime === 'kilo') return path.join(os.homedir(), '.kilo', 'skills');
   const configDir = getGlobalConfigDir(runtime);
-  if (runtime === 'hermes') return path.join(configDir, 'skills', 'gsd');
   return path.join(configDir, 'skills');
 }
 

--- a/tests/bug-783-kilo-global-skills-base.test.cjs
+++ b/tests/bug-783-kilo-global-skills-base.test.cjs
@@ -1,0 +1,105 @@
+'use strict';
+// Regression guard for bug #783.
+//
+// getGlobalSkillsBase('kilo') was returning ~/.config/kilo/skills (the XDG
+// config dir) instead of ~/.kilo/skills — where Kilo Code actually discovers
+// global skills per its docs:
+//   https://kilo.ai/docs/customize/skills
+//   "Global skills are located in the `.kilo` directory within your Home
+//    directory: ~/.kilo/skills/"
+//
+// The fix adds a special case in getGlobalSkillsBase() that resolves kilo's
+// skills dir from HOME (not from the XDG config dir). The config dir at
+// ~/.config/kilo is still CORRECT for commands (command/) and must stay
+// unchanged — this test verifies both roles are separate.
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const os = require('node:os');
+
+const ROOT = path.join(__dirname, '..');
+const {
+  getGlobalConfigDir,
+  getGlobalSkillsBase,
+} = require(path.join(ROOT, 'gsd-core', 'bin', 'lib', 'runtime-homes.cjs'));
+
+// Helper: temporarily override env vars for a test, restoring them afterwards.
+function withEnv(overrides, fn) {
+  const saved = {};
+  for (const [key, value] of Object.entries(overrides)) {
+    saved[key] = process.env[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  try {
+    return fn();
+  } finally {
+    for (const [key] of Object.entries(overrides)) {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key];
+    }
+  }
+}
+
+// Clear all kilo-relevant env vars so tests are hermetic.
+const kiloEnvClears = {
+  KILO_CONFIG_DIR: undefined,
+  XDG_CONFIG_HOME: undefined,
+};
+
+describe('bug #783: kilo global skills dir is ~/.kilo/skills, not ~/.config/kilo/skills', () => {
+  test('getGlobalSkillsBase("kilo") resolves to ~/.kilo/skills', () => {
+    withEnv(kiloEnvClears, () => {
+      assert.strictEqual(
+        getGlobalSkillsBase('kilo'),
+        path.join(os.homedir(), '.kilo', 'skills'),
+      );
+    });
+  });
+
+  test('getGlobalConfigDir("kilo") still resolves to ~/.config/kilo (config dir unchanged)', () => {
+    withEnv(kiloEnvClears, () => {
+      assert.strictEqual(
+        getGlobalConfigDir('kilo'),
+        path.join(os.homedir(), '.config', 'kilo'),
+      );
+    });
+  });
+
+  test('kilo skills dir and config dir are decoupled (not equal, not nested)', () => {
+    withEnv(kiloEnvClears, () => {
+      const skillsBase = getGlobalSkillsBase('kilo');
+      const configDir = getGlobalConfigDir('kilo');
+
+      assert.notStrictEqual(skillsBase, configDir, 'skills dir must differ from config dir');
+      assert.ok(
+        !skillsBase.startsWith(configDir + path.sep),
+        `skills dir (${skillsBase}) must not be nested under config dir (${configDir})`,
+      );
+      assert.ok(
+        !configDir.startsWith(skillsBase + path.sep),
+        `config dir (${configDir}) must not be nested under skills dir (${skillsBase})`,
+      );
+    });
+  });
+
+  test('getGlobalSkillsBase("kilo") is NOT affected by KILO_CONFIG_DIR override', () => {
+    // Skills always live in ~/.kilo/skills regardless of XDG/config-dir overrides.
+    withEnv({ KILO_CONFIG_DIR: '/tmp/custom-kilo-config', XDG_CONFIG_HOME: undefined }, () => {
+      assert.strictEqual(
+        getGlobalSkillsBase('kilo'),
+        path.join(os.homedir(), '.kilo', 'skills'),
+      );
+    });
+  });
+
+  test('getGlobalSkillsBase("kilo") is NOT affected by XDG_CONFIG_HOME override', () => {
+    withEnv({ KILO_CONFIG_DIR: undefined, XDG_CONFIG_HOME: '/tmp/custom-xdg' }, () => {
+      assert.strictEqual(
+        getGlobalSkillsBase('kilo'),
+        path.join(os.homedir(), '.kilo', 'skills'),
+      );
+    });
+  });
+});


### PR DESCRIPTION
# Fix PR

## Linked Issue

Fixes #783

## What was broken

`getGlobalSkillsBase('kilo')` resolved Kilo's global skills directory to `~/.config/kilo/skills` (derived from the XDG config dir). But Kilo Code discovers **global** skills from `~/.kilo/skills/` — the `.kilo` directory in HOME — independent of the `kilo.jsonc` config dir at `~/.config/kilo`. The resolver therefore pointed at a path Kilo never reads.

## What this fix does

Adds a HOME-relative special case so `getGlobalSkillsBase('kilo')` returns `~/.kilo/skills`, decoupled from the XDG config dir. The config dir (`~/.config/kilo`, via `getGlobalConfigDir('kilo')`) and the installer's `command/` path are intentionally **unchanged** — they remain correct for Kilo commands.

**Accurate blast radius (no overstatement):** `getGlobalSkillsBase` feeds doctor/status checks and agent-skills-block resolution. Kilo's installer writes **commands** (not skills), so no files were previously being written to the wrong location — this corrects the *resolved path* the resolver reports. Making Kilo emit skills is a separate, deferred enhancement (out of scope here).

Verified against primary docs: https://kilo.ai/docs/customize/skills — "Global skills are located in the `.kilo` directory within your Home directory: `~/.kilo/skills/`".

## Root cause

`getGlobalSkillsBase` derived every non-Hermes runtime's skills base as `<configDir>/skills`. For Kilo, `<configDir>` is the XDG path `~/.config/kilo`, conflating two distinct directory roles (config vs. skills) that Kilo keeps separate.

## Testing

- **How verified:** New `tests/bug-783-kilo-global-skills-base.test.cjs` asserts both directory roles are separate: `getGlobalSkillsBase('kilo')` → `~/.kilo/skills`, `getGlobalConfigDir('kilo')` → `~/.config/kilo` (unchanged), plus decoupling and env-override (`KILO_CONFIG_DIR`/`XDG_CONFIG_HOME`) independence. TDD: tests failed red (`actual: ~/.config/kilo/skills`) before the fix, green after.
- **Regression test?** Yes — `tests/bug-783-kilo-global-skills-base.test.cjs` (5 assertions).
- **Platforms tested:** macOS (local) + Linux (Docker) via `gsd-test-both` — `fail 0`, `success: true`, all kilo tests pass on both. Full unit suite green.
- **Runtimes tested:** Kilo (path resolution); regression-checked that other runtimes' skills-base resolution is unchanged (`bug-3126` suite green).

## Checklist

- [x] Changeset added (`.changeset/783-kilo-global-skills-base.md`, type `Fixed`)
- [x] Regression test added and passing
- [x] Lint, changeset-lint, docs-lint green
- [x] Scope limited to the path-resolution fix; no behavioral change to config/command paths

## Breaking changes

None. Pure internal path-resolution correction; no public API or installer output for existing runtimes changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/806"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783444575&installation_id=134682257&pr_number=806&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F806&signature=18c2dbef8d21df248b2211c6185b5cd0a00a6b4b9c111c28197532b88d9527d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->