### PR TITLE
feat(#788): expand Qwen Code hook-event coverage

### DIFF
--- a/.changeset/788-qwen-hook-events.md
+++ b/.changeset/788-qwen-hook-events.md
@@ -2,4 +2,4 @@
 type: Added
 pr: 802
 ---
-Qwen Code installs now register four additional hook events that Qwen Code supports beyond Claude Code: `SubagentStop`, `Stop`, and `PreCompact` (all wired to `gsd-context-monitor.js` for context headroom tracking at subagent completion, model stop, and pre-compaction), and `UserPromptSubmit` (wired to `gsd-prompt-guard.js` for prompt injection scanning on user input). These events are Qwen-only; Claude Code installs are unchanged. (#788)
+Qwen Code installs now register three additional hook events that Qwen Code supports beyond Claude Code: `SubagentStop`, `Stop`, and `PreCompact` — all wired to `gsd-context-monitor.js` for context headroom tracking at subagent completion, model stop, and pre-compaction. These events are Qwen-only; Claude Code installs are unchanged. `UserPromptSubmit` is deferred: `gsd-prompt-guard` exits unless `tool_name` is `Write|Edit`, making it a no-op for that payload shape. (#788)

--- a/.changeset/788-qwen-hook-events.md
+++ b/.changeset/788-qwen-hook-events.md
@@ -1,5 +1,5 @@
 ---
 type: Added
-pr: 802
+pr: 807
 ---
 Qwen Code installs now register three additional hook events that Qwen Code supports beyond Claude Code: `SubagentStop`, `Stop`, and `PreCompact` — all wired to `gsd-context-monitor.js` for context headroom tracking at subagent completion, model stop, and pre-compaction. These events are Qwen-only; Claude Code installs are unchanged. `UserPromptSubmit` is deferred: `gsd-prompt-guard` exits unless `tool_name` is `Write|Edit`, making it a no-op for that payload shape. (#788)

--- a/.changeset/788-qwen-hook-events.md
+++ b/.changeset/788-qwen-hook-events.md
@@ -1,0 +1,5 @@
+---
+type: Added
+pr: 802
+---
+Qwen Code installs now register four additional hook events that Qwen Code supports beyond Claude Code: `SubagentStop`, `Stop`, and `PreCompact` (all wired to `gsd-context-monitor.js` for context headroom tracking at subagent completion, model stop, and pre-compaction), and `UserPromptSubmit` (wired to `gsd-prompt-guard.js` for prompt injection scanning on user input). These events are Qwen-only; Claude Code installs are unchanged. (#788)

--- a/bin/install.js
+++ b/bin/install.js
@@ -7100,10 +7100,10 @@ function uninstall(isGlobal, runtime = 'claude') {
 
     // Remove GSD hooks from settings — per-hook granularity to preserve
     // user hooks that share an entry with a GSD hook (#1755 followup).
-    // Includes the 4 Qwen-only events added in #788 (SubagentStop, Stop,
-    // PreCompact, UserPromptSubmit) — safe to iterate for all runtimes;
-    // non-Qwen installs simply find no entries and skip.
-    for (const eventName of ['SessionStart', 'PostToolUse', 'AfterTool', 'PreToolUse', 'BeforeTool', 'SubagentStop', 'Stop', 'PreCompact', 'UserPromptSubmit']) {
+    // Includes the 3 Qwen-only events added in #788 (SubagentStop, Stop,
+    // PreCompact) — safe to iterate for all runtimes; non-Qwen installs
+    // simply find no entries and skip.
+    for (const eventName of ['SessionStart', 'PostToolUse', 'AfterTool', 'PreToolUse', 'BeforeTool', 'SubagentStop', 'Stop', 'PreCompact']) {
       if (settings.hooks && settings.hooks[eventName]) {
         const before = JSON.stringify(settings.hooks[eventName]);
         settings.hooks[eventName] = settings.hooks[eventName]
@@ -9886,16 +9886,20 @@ function install(isGlobal, runtime = 'claude', options = {}) {
     }
 
     // ── Qwen-only extended hook events (#788) ────────────────────────────────
-    // Qwen Code exposes 15 hook events — a superset of Claude Code.  These 4
-    // additional events are only registered for Qwen installs:
-    //   SubagentStop       — subagent lifecycle completion (context tracking)
-    //   Stop               — model stop / final-response moment (context tracking)
-    //   PreCompact         — fires before conversation compaction (context tracking)
-    //   UserPromptSubmit   — user submits a prompt (prompt injection scanning)
+    // Qwen Code exposes 15 hook events — a superset of Claude Code.  Three
+    // additional events are registered for Qwen installs:
+    //   SubagentStop  — subagent lifecycle completion (context headroom tracking)
+    //   Stop          — model stop / final-response moment (context headroom)
+    //   PreCompact    — fires before conversation compaction (most critical
+    //                   moment to surface context headroom warnings)
     //
-    // Wire gsd-context-monitor to the lifecycle events and gsd-prompt-guard to
-    // UserPromptSubmit — same hooks already used for PostToolUse / PreToolUse
-    // respectively, so no new hook files are needed.
+    // Wire gsd-context-monitor to all three — the same hook already used for
+    // PostToolUse — so no new hook files are needed.
+    //
+    // Note: UserPromptSubmit is NOT wired here.  That event carries the raw
+    // user prompt text, not a tool invocation, so gsd-prompt-guard (which
+    // exits unless tool_name is Write/Edit) would be a silent no-op.  A
+    // dedicated handler for UserPromptSubmit is deferred to a follow-on issue.
     //
     // Guard: isQwen is defined at the top of install() (line ~8254).
     if (isQwen) {
@@ -9923,31 +9927,6 @@ function install(isGlobal, runtime = 'claude', options = {}) {
         } else if (!alreadyHasContextMonitor && !fs.existsSync(contextMonitorFile)) {
           console.warn(`  ${yellow}⚠${reset}  Skipped ${qwenEvent} hook — gsd-context-monitor.js not found at target`);
         }
-      }
-
-      // UserPromptSubmit — run the prompt injection guard whenever the user
-      // submits a prompt.  Mirrors the PreToolUse Write|Edit guard but fires
-      // earlier, before any tool call, to surface injection attempts in the
-      // raw user turn.
-      if (!settings.hooks.UserPromptSubmit) {
-        settings.hooks.UserPromptSubmit = [];
-      }
-      const alreadyHasPromptGuardOnSubmit = settings.hooks.UserPromptSubmit.some(entry =>
-        entry.hooks && entry.hooks.some(h => h.command && h.command.includes('gsd-prompt-guard'))
-      );
-      if (!alreadyHasPromptGuardOnSubmit && fs.existsSync(promptGuardFile) && promptGuardCommand) {
-        settings.hooks.UserPromptSubmit.push({
-          hooks: [
-            {
-              type: 'command',
-              command: promptGuardCommand,
-              timeout: 5
-            }
-          ]
-        });
-        console.log(`  ${green}✓${reset} Configured UserPromptSubmit prompt injection guard (Qwen Code)`);
-      } else if (!alreadyHasPromptGuardOnSubmit && !fs.existsSync(promptGuardFile)) {
-        console.warn(`  ${yellow}⚠${reset}  Skipped UserPromptSubmit hook — gsd-prompt-guard.js not found at target`);
       }
     }
     // ── end Qwen-only extended hook events ────────────────────────────────────

--- a/bin/install.js
+++ b/bin/install.js
@@ -7099,8 +7099,11 @@ function uninstall(isGlobal, runtime = 'claude') {
     }
 
     // Remove GSD hooks from settings — per-hook granularity to preserve
-    // user hooks that share an entry with a GSD hook (#1755 followup)
-    for (const eventName of ['SessionStart', 'PostToolUse', 'AfterTool', 'PreToolUse', 'BeforeTool']) {
+    // user hooks that share an entry with a GSD hook (#1755 followup).
+    // Includes the 4 Qwen-only events added in #788 (SubagentStop, Stop,
+    // PreCompact, UserPromptSubmit) — safe to iterate for all runtimes;
+    // non-Qwen installs simply find no entries and skip.
+    for (const eventName of ['SessionStart', 'PostToolUse', 'AfterTool', 'PreToolUse', 'BeforeTool', 'SubagentStop', 'Stop', 'PreCompact', 'UserPromptSubmit']) {
       if (settings.hooks && settings.hooks[eventName]) {
         const before = JSON.stringify(settings.hooks[eventName]);
         settings.hooks[eventName] = settings.hooks[eventName]
@@ -9881,6 +9884,73 @@ function install(isGlobal, runtime = 'claude', options = {}) {
     } else if (!hasPhaseBoundaryHook && !phaseBoundaryCommand) {
       console.warn(`  ${yellow}⚠${reset}  Skipped phase boundary hook — Bash executable path unavailable (#3393)`);
     }
+
+    // ── Qwen-only extended hook events (#788) ────────────────────────────────
+    // Qwen Code exposes 15 hook events — a superset of Claude Code.  These 4
+    // additional events are only registered for Qwen installs:
+    //   SubagentStop       — subagent lifecycle completion (context tracking)
+    //   Stop               — model stop / final-response moment (context tracking)
+    //   PreCompact         — fires before conversation compaction (context tracking)
+    //   UserPromptSubmit   — user submits a prompt (prompt injection scanning)
+    //
+    // Wire gsd-context-monitor to the lifecycle events and gsd-prompt-guard to
+    // UserPromptSubmit — same hooks already used for PostToolUse / PreToolUse
+    // respectively, so no new hook files are needed.
+    //
+    // Guard: isQwen is defined at the top of install() (line ~8254).
+    if (isQwen) {
+      // SubagentStop, Stop, PreCompact — route through the context monitor so
+      // agents get context-headroom warnings at subagent completion, model stop,
+      // and pre-compaction (the most critical moment to surface headroom info).
+      for (const qwenEvent of ['SubagentStop', 'Stop', 'PreCompact']) {
+        if (!settings.hooks[qwenEvent]) {
+          settings.hooks[qwenEvent] = [];
+        }
+        const alreadyHasContextMonitor = settings.hooks[qwenEvent].some(entry =>
+          entry.hooks && entry.hooks.some(h => h.command && h.command.includes('gsd-context-monitor'))
+        );
+        if (!alreadyHasContextMonitor && fs.existsSync(contextMonitorFile) && contextMonitorCommand) {
+          settings.hooks[qwenEvent].push({
+            hooks: [
+              {
+                type: 'command',
+                command: contextMonitorCommand,
+                timeout: 10
+              }
+            ]
+          });
+          console.log(`  ${green}✓${reset} Configured ${qwenEvent} context monitor hook (Qwen Code)`);
+        } else if (!alreadyHasContextMonitor && !fs.existsSync(contextMonitorFile)) {
+          console.warn(`  ${yellow}⚠${reset}  Skipped ${qwenEvent} hook — gsd-context-monitor.js not found at target`);
+        }
+      }
+
+      // UserPromptSubmit — run the prompt injection guard whenever the user
+      // submits a prompt.  Mirrors the PreToolUse Write|Edit guard but fires
+      // earlier, before any tool call, to surface injection attempts in the
+      // raw user turn.
+      if (!settings.hooks.UserPromptSubmit) {
+        settings.hooks.UserPromptSubmit = [];
+      }
+      const alreadyHasPromptGuardOnSubmit = settings.hooks.UserPromptSubmit.some(entry =>
+        entry.hooks && entry.hooks.some(h => h.command && h.command.includes('gsd-prompt-guard'))
+      );
+      if (!alreadyHasPromptGuardOnSubmit && fs.existsSync(promptGuardFile) && promptGuardCommand) {
+        settings.hooks.UserPromptSubmit.push({
+          hooks: [
+            {
+              type: 'command',
+              command: promptGuardCommand,
+              timeout: 5
+            }
+          ]
+        });
+        console.log(`  ${green}✓${reset} Configured UserPromptSubmit prompt injection guard (Qwen Code)`);
+      } else if (!alreadyHasPromptGuardOnSubmit && !fs.existsSync(promptGuardFile)) {
+        console.warn(`  ${yellow}⚠${reset}  Skipped UserPromptSubmit hook — gsd-prompt-guard.js not found at target`);
+      }
+    }
+    // ── end Qwen-only extended hook events ────────────────────────────────────
   }
 
   // Compute the update-banner hook command alongside the others so

--- a/docs/how-to/install-on-your-runtime.md
+++ b/docs/how-to/install-on-your-runtime.md
@@ -250,7 +250,6 @@ Qwen Code supports 15 hook events. GSD registers the following events automatica
 | `SubagentStop` | `gsd-context-monitor.js` | Context headroom tracking after subagent completion |
 | `Stop` | `gsd-context-monitor.js` | Context headroom tracking before model stop |
 | `PreCompact` | `gsd-context-monitor.js` | Context awareness before conversation compaction |
-| `UserPromptSubmit` | `gsd-prompt-guard.js` | Prompt injection scan on user input |
 
 ---
 

--- a/docs/how-to/install-on-your-runtime.md
+++ b/docs/how-to/install-on-your-runtime.md
@@ -238,6 +238,20 @@ Skills land in `~/.qwen/skills/gsd-*/SKILL.md`.
 QWEN_CONFIG_DIR=~/.qwen-alt npx @opengsd/gsd-core@latest --qwen --global
 ```
 
+**Hook coverage**
+
+Qwen Code supports 15 hook events. GSD registers the following events automatically on install:
+
+| Event | Hook | Purpose |
+|---|---|---|
+| `SessionStart` | `gsd-check-update.js`, `gsd-session-state.sh` | Update check, session orientation |
+| `PostToolUse` | `gsd-context-monitor.js`, `gsd-read-injection-scanner.js`, `gsd-phase-boundary.sh`, `gsd-graphify-update.sh` | Context monitoring, read-time scan, phase boundary detection |
+| `PreToolUse` | `gsd-prompt-guard.js`, `gsd-read-guard.js`, `gsd-workflow-guard.js`, `gsd-worktree-path-guard.js`, `gsd-validate-commit.sh` | Prompt guard, read-before-edit, workflow + worktree safety, commit validation |
+| `SubagentStop` | `gsd-context-monitor.js` | Context headroom tracking after subagent completion |
+| `Stop` | `gsd-context-monitor.js` | Context headroom tracking before model stop |
+| `PreCompact` | `gsd-context-monitor.js` | Context awareness before conversation compaction |
+| `UserPromptSubmit` | `gsd-prompt-guard.js` | Prompt injection scan on user input |
+
 ---
 
 ### Augment Code

--- a/scripts/lint-test-file-count.allowlist.json
+++ b/scripts/lint-test-file-count.allowlist.json
@@ -121,6 +121,7 @@
     "install": {
       "files": [
         "bug-410-install-defaults-test-mode-guard.test.cjs",
+        "enh-788-qwen-hook-events.test.cjs",
         "install-minimal-hooks.test.cjs",
         "install-path-detection.test.cjs",
         "install-regressions.test.cjs",

--- a/scripts/lint-test-file-count.allowlist.json
+++ b/scripts/lint-test-file-count.allowlist.json
@@ -121,7 +121,6 @@
     "install": {
       "files": [
         "bug-410-install-defaults-test-mode-guard.test.cjs",
-        "enh-788-qwen-hook-events.test.cjs",
         "install-minimal-hooks.test.cjs",
         "install-path-detection.test.cjs",
         "install-regressions.test.cjs",

--- a/tests/enh-788-qwen-hook-events.test.cjs
+++ b/tests/enh-788-qwen-hook-events.test.cjs
@@ -1,0 +1,234 @@
+'use strict';
+
+process.env.GSD_TEST_MODE = '1';
+
+/**
+ * Enhancement #788: Expand Qwen Code hook-event coverage.
+ *
+ * Qwen Code supports 15 hook events; gsd previously registered only
+ * SessionStart and PostToolUse.  This suite asserts that a Qwen install
+ * registers the 4 new high-value events:
+ *   - SubagentStop   — subagent lifecycle finalisation
+ *   - Stop           — model stop / final-response hook
+ *   - PreCompact     — pre-compaction awareness
+ *   - UserPromptSubmit — prompt enrichment / validation
+ *
+ * Also asserts the inverse: Claude Code installs do NOT gain these events
+ * (strict scope guard).
+ *
+ * Source: https://qwenlm.github.io/qwen-code-docs/en/users/features/hooks/
+ */
+
+const { test, describe, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { install, uninstall } = require('../bin/install.js');
+const { createTempDir, cleanup } = require('./helpers.cjs');
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/** Extract all hook commands registered under `eventName` from settings. */
+function hooksForEvent(settings, eventName) {
+  if (!settings || !settings.hooks || !Array.isArray(settings.hooks[eventName])) return [];
+  return settings.hooks[eventName].flatMap(entry =>
+    (entry && Array.isArray(entry.hooks) ? entry.hooks : [])
+      .map(h => h && h.command)
+      .filter(Boolean)
+  );
+}
+
+// ─── Suite 1: Qwen — new events are registered ───────────────────────────────
+
+// Stub JS hook files that the installer checks with fs.existsSync() so hook
+// registration guards pass even when hooks/dist/ isn't built.
+const HOOKS_SRC = path.join(__dirname, '..', 'hooks');
+const STUB_HOOKS = [
+  'gsd-context-monitor.js',
+  'gsd-prompt-guard.js',
+  'gsd-check-update.js',
+];
+
+function stubHooksIntoTarget(targetDir) {
+  const hooksDest = path.join(targetDir, 'hooks');
+  fs.mkdirSync(hooksDest, { recursive: true });
+  for (const hookFile of STUB_HOOKS) {
+    const src = path.join(HOOKS_SRC, hookFile);
+    const dest = path.join(hooksDest, hookFile);
+    if (fs.existsSync(src)) {
+      fs.copyFileSync(src, dest);
+    } else {
+      // Minimal stub so existsSync passes
+      fs.writeFileSync(dest, '#!/usr/bin/env node\n// stub\n');
+    }
+    try { fs.chmodSync(dest, 0o755); } catch { /* Windows */ }
+  }
+}
+
+describe('enh-788: Qwen install registers 4 new hook events', () => {
+  let tmpDir;
+  let previousCwd;
+  let settings;
+
+  beforeEach(() => {
+    tmpDir = createTempDir('gsd-788-qwen-');
+    previousCwd = process.cwd();
+    process.chdir(tmpDir);
+
+    const targetDir = path.join(tmpDir, '.qwen');
+    fs.mkdirSync(targetDir, { recursive: true });
+    // Pre-populate hook files so installer registration guards (fs.existsSync)
+    // pass and hooks are actually registered in settings.json.
+    stubHooksIntoTarget(targetDir);
+
+    const result = install(false, 'qwen');
+    settings = result.settings;
+  });
+
+  afterEach(() => {
+    process.chdir(previousCwd);
+    cleanup(tmpDir);
+  });
+
+  test('install returns a settings object (not null)', () => {
+    assert.ok(settings !== null && typeof settings === 'object',
+      'Qwen install must return a non-null settings object');
+  });
+
+  test('SubagentStop event is registered with at least one hook', () => {
+    const cmds = hooksForEvent(settings, 'SubagentStop');
+    assert.ok(cmds.length > 0,
+      `Expected SubagentStop hooks; got: ${JSON.stringify(settings && settings.hooks)}`);
+  });
+
+  test('Stop event is registered with at least one hook', () => {
+    const cmds = hooksForEvent(settings, 'Stop');
+    assert.ok(cmds.length > 0,
+      `Expected Stop hooks; got: ${JSON.stringify(settings && settings.hooks)}`);
+  });
+
+  test('PreCompact event is registered with at least one hook', () => {
+    const cmds = hooksForEvent(settings, 'PreCompact');
+    assert.ok(cmds.length > 0,
+      `Expected PreCompact hooks; got: ${JSON.stringify(settings && settings.hooks)}`);
+  });
+
+  test('UserPromptSubmit event is registered with at least one hook', () => {
+    const cmds = hooksForEvent(settings, 'UserPromptSubmit');
+    assert.ok(cmds.length > 0,
+      `Expected UserPromptSubmit hooks; got: ${JSON.stringify(settings && settings.hooks)}`);
+  });
+
+  test('SubagentStop / Stop / PreCompact use gsd-context-monitor', () => {
+    for (const event of ['SubagentStop', 'Stop', 'PreCompact']) {
+      const cmds = hooksForEvent(settings, event);
+      assert.ok(
+        cmds.some(c => c.includes('gsd-context-monitor')),
+        `Event ${event} should use gsd-context-monitor; got commands: ${JSON.stringify(cmds)}`
+      );
+    }
+  });
+
+  test('UserPromptSubmit uses gsd-prompt-guard', () => {
+    const cmds = hooksForEvent(settings, 'UserPromptSubmit');
+    assert.ok(
+      cmds.some(c => c.includes('gsd-prompt-guard')),
+      `UserPromptSubmit should use gsd-prompt-guard; got commands: ${JSON.stringify(cmds)}`
+    );
+  });
+
+  test('install is idempotent — re-running does not duplicate entries', () => {
+    // Run install a second time in the same tmpDir (hooks already stubbed from beforeEach)
+    process.chdir(tmpDir);
+    const result2 = install(false, 'qwen');
+    const s2 = result2.settings;
+    for (const event of ['SubagentStop', 'Stop', 'PreCompact', 'UserPromptSubmit']) {
+      const cmds = hooksForEvent(s2, event);
+      // Should have exactly 1 command entry (dedup guard prevents doubling)
+      assert.strictEqual(cmds.length, 1,
+        `Event ${event} should have exactly 1 hook command after idempotent reinstall; got ${cmds.length}: ${JSON.stringify(cmds)}`);
+    }
+  });
+});
+
+// ─── Suite 2: Claude install does NOT get the new events ─────────────────────
+
+describe('enh-788: Claude install does NOT register Qwen-only hook events', () => {
+  let tmpDir;
+  let previousCwd;
+  let settings;
+
+  beforeEach(() => {
+    tmpDir = createTempDir('gsd-788-claude-');
+    previousCwd = process.cwd();
+    process.chdir(tmpDir);
+
+    const result = install(false, 'claude');
+    settings = result && result.settings;
+  });
+
+  afterEach(() => {
+    process.chdir(previousCwd);
+    cleanup(tmpDir);
+  });
+
+  test('Claude install does not register SubagentStop', () => {
+    const cmds = hooksForEvent(settings, 'SubagentStop');
+    assert.strictEqual(cmds.length, 0,
+      `Claude should NOT have SubagentStop; got: ${JSON.stringify(cmds)}`);
+  });
+
+  test('Claude install does not register Stop', () => {
+    const cmds = hooksForEvent(settings, 'Stop');
+    assert.strictEqual(cmds.length, 0,
+      `Claude should NOT have Stop; got: ${JSON.stringify(cmds)}`);
+  });
+
+  test('Claude install does not register PreCompact', () => {
+    const cmds = hooksForEvent(settings, 'PreCompact');
+    assert.strictEqual(cmds.length, 0,
+      `Claude should NOT have PreCompact; got: ${JSON.stringify(cmds)}`);
+  });
+
+  test('Claude install does not register UserPromptSubmit', () => {
+    const cmds = hooksForEvent(settings, 'UserPromptSubmit');
+    assert.strictEqual(cmds.length, 0,
+      `Claude should NOT have UserPromptSubmit; got: ${JSON.stringify(cmds)}`);
+  });
+});
+
+// ─── Suite 3: Uninstall removes the new event registrations ──────────────────
+
+describe('enh-788: Qwen uninstall removes new hook event entries', () => {
+  let tmpDir;
+  let previousCwd;
+
+  beforeEach(() => {
+    tmpDir = createTempDir('gsd-788-uninstall-');
+    previousCwd = process.cwd();
+    process.chdir(tmpDir);
+
+    const targetDir = path.join(tmpDir, '.qwen');
+    fs.mkdirSync(targetDir, { recursive: true });
+    stubHooksIntoTarget(targetDir);
+    install(false, 'qwen');
+  });
+
+  afterEach(() => {
+    process.chdir(previousCwd);
+    cleanup(tmpDir);
+  });
+
+  test('settings.json hook entries are removed on uninstall', () => {
+    uninstall(false, 'qwen');
+    const settingsPath = path.join(tmpDir, '.qwen', 'settings.json');
+    if (!fs.existsSync(settingsPath)) return; // already gone is also fine
+    const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+    for (const event of ['SubagentStop', 'Stop', 'PreCompact', 'UserPromptSubmit']) {
+      const cmds = hooksForEvent(settings, event);
+      assert.strictEqual(cmds.length, 0,
+        `After uninstall, ${event} should have 0 hooks; got: ${JSON.stringify(cmds)}`);
+    }
+  });
+});

--- a/tests/enh-788-qwen-hook-events.test.cjs
+++ b/tests/enh-788-qwen-hook-events.test.cjs
@@ -7,14 +7,20 @@ process.env.GSD_TEST_MODE = '1';
  *
  * Qwen Code supports 15 hook events; gsd previously registered only
  * SessionStart and PostToolUse.  This suite asserts that a Qwen install
- * registers the 4 new high-value events:
- *   - SubagentStop   — subagent lifecycle finalisation
- *   - Stop           — model stop / final-response hook
- *   - PreCompact     — pre-compaction awareness
- *   - UserPromptSubmit — prompt enrichment / validation
+ * registers the 3 new high-value events:
+ *   - SubagentStop  — subagent lifecycle finalisation (context tracking)
+ *   - Stop          — model stop / final-response hook (context tracking)
+ *   - PreCompact    — pre-compaction awareness (context tracking)
+ *
+ * All three are wired to gsd-context-monitor.js — the same hook used for
+ * PostToolUse — so context headroom warnings surface at these moments too.
+ *
+ * Note: UserPromptSubmit is NOT wired — gsd-prompt-guard exits unless
+ * tool_name is Write|Edit (PreToolUse shape), so it would be a no-op for
+ * the UserPromptSubmit payload.  Deferred to a follow-on issue.
  *
  * Also asserts the inverse: Claude Code installs do NOT gain these events
- * (strict scope guard).
+ * (strict isQwen scope guard).
  *
  * Source: https://qwenlm.github.io/qwen-code-docs/en/users/features/hooks/
  */
@@ -24,7 +30,7 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
 
-const { install, uninstall } = require('../bin/install.js');
+const { install, uninstall, validateHookFields } = require('../bin/install.js');
 const { createTempDir, cleanup } = require('./helpers.cjs');
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -38,8 +44,6 @@ function hooksForEvent(settings, eventName) {
       .filter(Boolean)
   );
 }
-
-// ─── Suite 1: Qwen — new events are registered ───────────────────────────────
 
 // Stub JS hook files that the installer checks with fs.existsSync() so hook
 // registration guards pass even when hooks/dist/ isn't built.
@@ -66,7 +70,19 @@ function stubHooksIntoTarget(targetDir) {
   }
 }
 
-describe('enh-788: Qwen install registers 4 new hook events', () => {
+/**
+ * Persist in-memory settings to disk, simulating what finishInstall() does
+ * (finishInstall is not exported).  Required for tests that call install()
+ * twice and need the second call to read the first call's hook registrations.
+ */
+function persistSettings(settingsPath, settings) {
+  fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+  fs.writeFileSync(settingsPath, JSON.stringify(validateHookFields(settings), null, 2) + '\n', 'utf8');
+}
+
+// ─── Suite 1: Qwen — new events are registered ───────────────────────────────
+
+describe('enh-788: Qwen install registers 3 new hook events', () => {
   let tmpDir;
   let previousCwd;
   let settings;
@@ -99,55 +115,37 @@ describe('enh-788: Qwen install registers 4 new hook events', () => {
   test('SubagentStop event is registered with at least one hook', () => {
     const cmds = hooksForEvent(settings, 'SubagentStop');
     assert.ok(cmds.length > 0,
-      `Expected SubagentStop hooks; got: ${JSON.stringify(settings && settings.hooks)}`);
+      `Expected SubagentStop hooks; got hooks: ${JSON.stringify(settings && settings.hooks)}`);
   });
 
   test('Stop event is registered with at least one hook', () => {
     const cmds = hooksForEvent(settings, 'Stop');
     assert.ok(cmds.length > 0,
-      `Expected Stop hooks; got: ${JSON.stringify(settings && settings.hooks)}`);
+      `Expected Stop hooks; got hooks: ${JSON.stringify(settings && settings.hooks)}`);
   });
 
   test('PreCompact event is registered with at least one hook', () => {
     const cmds = hooksForEvent(settings, 'PreCompact');
     assert.ok(cmds.length > 0,
-      `Expected PreCompact hooks; got: ${JSON.stringify(settings && settings.hooks)}`);
+      `Expected PreCompact hooks; got hooks: ${JSON.stringify(settings && settings.hooks)}`);
   });
 
-  test('UserPromptSubmit event is registered with at least one hook', () => {
+  test('UserPromptSubmit is NOT registered (handler not yet implemented for that payload shape)', () => {
+    // gsd-prompt-guard exits unless tool_name is Write|Edit — it is a no-op
+    // for UserPromptSubmit payloads.  Registration is deferred until a
+    // dedicated hook can process the user-prompt payload shape.
     const cmds = hooksForEvent(settings, 'UserPromptSubmit');
-    assert.ok(cmds.length > 0,
-      `Expected UserPromptSubmit hooks; got: ${JSON.stringify(settings && settings.hooks)}`);
+    assert.strictEqual(cmds.length, 0,
+      `UserPromptSubmit should NOT be registered yet; got: ${JSON.stringify(cmds)}`);
   });
 
-  test('SubagentStop / Stop / PreCompact use gsd-context-monitor', () => {
+  test('SubagentStop / Stop / PreCompact all use gsd-context-monitor', () => {
     for (const event of ['SubagentStop', 'Stop', 'PreCompact']) {
       const cmds = hooksForEvent(settings, event);
       assert.ok(
         cmds.some(c => c.includes('gsd-context-monitor')),
         `Event ${event} should use gsd-context-monitor; got commands: ${JSON.stringify(cmds)}`
       );
-    }
-  });
-
-  test('UserPromptSubmit uses gsd-prompt-guard', () => {
-    const cmds = hooksForEvent(settings, 'UserPromptSubmit');
-    assert.ok(
-      cmds.some(c => c.includes('gsd-prompt-guard')),
-      `UserPromptSubmit should use gsd-prompt-guard; got commands: ${JSON.stringify(cmds)}`
-    );
-  });
-
-  test('install is idempotent — re-running does not duplicate entries', () => {
-    // Run install a second time in the same tmpDir (hooks already stubbed from beforeEach)
-    process.chdir(tmpDir);
-    const result2 = install(false, 'qwen');
-    const s2 = result2.settings;
-    for (const event of ['SubagentStop', 'Stop', 'PreCompact', 'UserPromptSubmit']) {
-      const cmds = hooksForEvent(s2, event);
-      // Should have exactly 1 command entry (dedup guard prevents doubling)
-      assert.strictEqual(cmds.length, 1,
-        `Event ${event} should have exactly 1 hook command after idempotent reinstall; got ${cmds.length}: ${JSON.stringify(cmds)}`);
     }
   });
 });
@@ -190,15 +188,48 @@ describe('enh-788: Claude install does NOT register Qwen-only hook events', () =
     assert.strictEqual(cmds.length, 0,
       `Claude should NOT have PreCompact; got: ${JSON.stringify(cmds)}`);
   });
+});
 
-  test('Claude install does not register UserPromptSubmit', () => {
-    const cmds = hooksForEvent(settings, 'UserPromptSubmit');
-    assert.strictEqual(cmds.length, 0,
-      `Claude should NOT have UserPromptSubmit; got: ${JSON.stringify(cmds)}`);
+// ─── Suite 3: Idempotency — persisted reinstall does not duplicate hooks ──────
+
+describe('enh-788: Qwen install is idempotent across persisted reinstalls', () => {
+  let tmpDir;
+  let previousCwd;
+
+  beforeEach(() => {
+    tmpDir = createTempDir('gsd-788-idem-');
+    previousCwd = process.cwd();
+    process.chdir(tmpDir);
+
+    const targetDir = path.join(tmpDir, '.qwen');
+    fs.mkdirSync(targetDir, { recursive: true });
+    stubHooksIntoTarget(targetDir);
+  });
+
+  afterEach(() => {
+    process.chdir(previousCwd);
+    cleanup(tmpDir);
+  });
+
+  test('re-running after persisted first install does not duplicate hook entries', () => {
+    // First install: get settings and persist to disk (simulating finishInstall)
+    const result1 = install(false, 'qwen');
+    persistSettings(result1.settingsPath, result1.settings);
+
+    // Second install: reads the persisted settings.json — dedup guards apply
+    process.chdir(tmpDir);
+    const result2 = install(false, 'qwen');
+    const s2 = result2.settings;
+
+    for (const event of ['SubagentStop', 'Stop', 'PreCompact']) {
+      const cmds = hooksForEvent(s2, event);
+      assert.strictEqual(cmds.length, 1,
+        `Event ${event} should have exactly 1 hook command after idempotent reinstall; got ${cmds.length}: ${JSON.stringify(cmds)}`);
+    }
   });
 });
 
-// ─── Suite 3: Uninstall removes the new event registrations ──────────────────
+// ─── Suite 4: Uninstall removes the new event registrations ──────────────────
 
 describe('enh-788: Qwen uninstall removes new hook event entries', () => {
   let tmpDir;
@@ -212,7 +243,10 @@ describe('enh-788: Qwen uninstall removes new hook event entries', () => {
     const targetDir = path.join(tmpDir, '.qwen');
     fs.mkdirSync(targetDir, { recursive: true });
     stubHooksIntoTarget(targetDir);
-    install(false, 'qwen');
+
+    // Install and persist to disk so uninstall has a settings.json to clean
+    const result = install(false, 'qwen');
+    persistSettings(result.settingsPath, result.settings);
   });
 
   afterEach(() => {
@@ -223,9 +257,9 @@ describe('enh-788: Qwen uninstall removes new hook event entries', () => {
   test('settings.json hook entries are removed on uninstall', () => {
     uninstall(false, 'qwen');
     const settingsPath = path.join(tmpDir, '.qwen', 'settings.json');
-    if (!fs.existsSync(settingsPath)) return; // already gone is also fine
+    if (!fs.existsSync(settingsPath)) return; // file removed entirely is fine
     const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
-    for (const event of ['SubagentStop', 'Stop', 'PreCompact', 'UserPromptSubmit']) {
+    for (const event of ['SubagentStop', 'Stop', 'PreCompact']) {
       const cmds = hooksForEvent(settings, event);
       assert.strictEqual(cmds.length, 0,
         `After uninstall, ${event} should have 0 hooks; got: ${JSON.stringify(cmds)}`);


### PR DESCRIPTION
## Enhancement PR

---

## Linked Issue

Closes #788

---

## What this enhancement improves

Qwen Code supports 15 hook events — a superset of Claude Code's 11. Prior to this change, GSD only registered `SessionStart`, `PostToolUse`, `PreToolUse`, and a few others on Qwen installs, leaving three high-value lifecycle events unwired:

- `SubagentStop` — fires when a subagent finishes (context headroom tracking)
- `Stop` — fires at the model's final-response moment (context headroom checkpoint)
- `PreCompact` — fires just before conversation compaction (the most critical moment to surface context headroom warnings)

All three are now wired to `gsd-context-monitor.js` for Qwen installs, extending context-awareness coverage to these additional lifecycle moments. Claude Code installs are unchanged.

## Before / After

**Before:**

```
Qwen Code install — registered hook events:
  SessionStart    → gsd-check-update.js, gsd-session-state.sh
  PostToolUse     → gsd-context-monitor.js, ...
  PreToolUse      → gsd-prompt-guard.js, ...
  (SubagentStop, Stop, PreCompact — not registered)
```

**After:**

```
Qwen Code install — registered hook events:
  SessionStart    → gsd-check-update.js, gsd-session-state.sh
  PostToolUse     → gsd-context-monitor.js, ...
  PreToolUse      → gsd-prompt-guard.js, ...
  SubagentStop    → gsd-context-monitor.js   ← NEW (Qwen only)
  Stop            → gsd-context-monitor.js   ← NEW (Qwen only)
  PreCompact      → gsd-context-monitor.js   ← NEW (Qwen only)
```

## How it was implemented

- `bin/install.js`: Added a new `if (isQwen)` block that iterates `['SubagentStop', 'Stop', 'PreCompact']` and registers `gsd-context-monitor.js` for each — with the same dedup guard and `fs.existsSync` check used for `PostToolUse`. The uninstall event-sweep loop was extended to include the three new events.
- `docs/how-to/install-on-your-runtime.md`: Updated the Qwen hook coverage table to add the three new events.
- `.changeset/788-qwen-hook-events.md`: Added `Added` changeset fragment.

**`UserPromptSubmit` is intentionally NOT wired in this PR.** `gsd-prompt-guard` exits unless `tool_name` is `Write|Edit` (a PreToolUse payload field). The `UserPromptSubmit` payload carries raw user-prompt text with no `tool_name` field — wiring it would be a silent no-op. A dedicated handler is deferred to a follow-on issue; this decision is documented in code comments and the changeset.

## Testing

### How I verified the enhancement works

Automated test suite (`tests/enh-788-qwen-hook-events.test.cjs`) — 4 suites:

- **Suite 1 (Qwen registers 3 new events):** `SubagentStop`, `Stop`, `PreCompact` each have ≥1 hook command; all use `gsd-context-monitor`; `UserPromptSubmit` is asserted NOT registered (documents intentional exclusion).
- **Suite 2 (Claude install does NOT get new events):** `SubagentStop`, `Stop`, `PreCompact` have 0 hooks after a Claude Code install (strict `isQwen` scope guard).
- **Suite 3 (Idempotency):** Persists `settings.json` after first Qwen install, runs install again — each event still has exactly 1 hook command (dedup guard works across persisted reinstalls).
- **Suite 4 (Uninstall):** Installs + persists, then uninstalls — all three events are removed from `settings.json`.

Full suite: **3875 pass, 0 fail**.

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [x] N/A — hook registration is platform-agnostic JS; no path separator differences in this code path

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [x] Other: Qwen Code (Qwen-only change; Claude scope guard verified by test Suite 2)

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue — no additions or removals
- **Qwen-only:** All new hook registrations are inside the `if (isQwen)` guard. No Claude Code hook files, settings paths, or registration loops are modified.
- **Final event set: 3 events** (`SubagentStop`, `Stop`, `PreCompact`). `UserPromptSubmit` is deferred — `gsd-prompt-guard` is a no-op for that payload shape (no `tool_name` field in user-prompt payloads). Reason documented in code comments and changeset.

---

## Documentation

- [x] Updated the relevant file(s) under `docs/` to reflect this change
  - `docs/how-to/install-on-your-runtime.md` — Qwen hook coverage table updated with 3 new events

- [x] All `docs/` content added in this PR is written in English

## Checklist

- [x] Issue linked above with `Closes #788`
- [x] Linked issue has the `approved-enhancement` label
- [x] Changes are scoped to the approved enhancement — nothing extra included
- [x] All existing tests pass (`npm test` — 3875 pass, 0 fail)
- [x] New or updated tests cover the enhanced behavior (`tests/enh-788-qwen-hook-events.test.cjs`)
- [x] `.changeset/` fragment added (`.changeset/788-qwen-hook-events.md`)
- [x] No unnecessary dependencies added

## Breaking changes

None — new hook events are additive. Uninstall cleanly removes them.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/807"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783444579&installation_id=134682257&pr_number=807&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F807&signature=9440645ac5a25920f4741bf7f0726025e4bd47b94b6047ecd8e4b740259f9202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->