### PR TITLE
feat(#773): add --ephemeral and --dangerously-bypass-hook-trust to automated codex exec wrappers

### DIFF
--- a/.changeset/mellow-yaks-bark.md
+++ b/.changeset/mellow-yaks-bark.md
@@ -1,6 +1,6 @@
 ---
 type: Changed
-pr: 773
+pr: 824
 ---
 <!-- docs-exempt: internal workflow change to automated codex exec invocations only; the flags affect session isolation and hook-trust behavior in non-interactive CI runs, not any user-facing command, config key, or output format -->
 Automated `codex exec` invocations in the review workflow now include `--ephemeral` (no session-state accumulation across automated/CI runs) and `--dangerously-bypass-hook-trust` (skip hook-trust prompts for hooks managed by gsd-core itself). These flags apply only to the non-interactive reviewer invocations in `gsd-core/workflows/review.md`. (#773)

--- a/.changeset/mellow-yaks-bark.md
+++ b/.changeset/mellow-yaks-bark.md
@@ -1,0 +1,6 @@
+---
+type: Changed
+pr: 773
+---
+<!-- docs-exempt: internal workflow change to automated codex exec invocations only; the flags affect session isolation and hook-trust behavior in non-interactive CI runs, not any user-facing command, config key, or output format -->
+Automated `codex exec` invocations in the review workflow now include `--ephemeral` (no session-state accumulation across automated/CI runs) and `--dangerously-bypass-hook-trust` (skip hook-trust prompts for hooks managed by gsd-core itself). These flags apply only to the non-interactive reviewer invocations in `gsd-core/workflows/review.md`. (#773)

--- a/gsd-core/workflows/review.md
+++ b/gsd-core/workflows/review.md
@@ -248,9 +248,9 @@ fi
 **Codex:**
 ```bash
 if [ -n "$CODEX_MODEL" ] && [ "$CODEX_MODEL" != "null" ]; then
-  cat /tmp/gsd-review-prompt-{phase}.md | codex exec --model "$CODEX_MODEL" --skip-git-repo-check - 2>/dev/null > /tmp/gsd-review-codex-{phase}.md
+  cat /tmp/gsd-review-prompt-{phase}.md | codex exec --ephemeral --dangerously-bypass-hook-trust --model "$CODEX_MODEL" --skip-git-repo-check - 2>/dev/null > /tmp/gsd-review-codex-{phase}.md
 else
-  cat /tmp/gsd-review-prompt-{phase}.md | codex exec --skip-git-repo-check - 2>/dev/null > /tmp/gsd-review-codex-{phase}.md
+  cat /tmp/gsd-review-prompt-{phase}.md | codex exec --ephemeral --dangerously-bypass-hook-trust --skip-git-repo-check - 2>/dev/null > /tmp/gsd-review-codex-{phase}.md
 fi
 ```
 

--- a/tests/enh-773-codex-exec-automation-flags.test.cjs
+++ b/tests/enh-773-codex-exec-automation-flags.test.cjs
@@ -1,0 +1,68 @@
+'use strict';
+
+// allow-test-rule: source-text-is-the-product
+// Workflow markdown is runtime contract; these assertions verify that
+// automated codex exec invocations carry the correct automation flags.
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+describe('enh-773: automated codex exec invocations include --ephemeral and --dangerously-bypass-hook-trust', () => {
+  const workflow = fs.readFileSync(
+    path.join(process.cwd(), 'gsd-core', 'workflows', 'review.md'),
+    'utf8'
+  );
+
+  // Extract all codex exec invocation lines from code fences
+  const codexExecLines = workflow
+    .split('\n')
+    .filter((line) => line.includes('codex exec'));
+
+  test('review.md contains at least one codex exec invocation', () => {
+    assert.ok(
+      codexExecLines.length > 0,
+      'review.md must contain at least one codex exec invocation'
+    );
+  });
+
+  test('every codex exec invocation includes --ephemeral', () => {
+    for (const line of codexExecLines) {
+      assert.ok(
+        line.includes('--ephemeral'),
+        `codex exec invocation is missing --ephemeral:\n  ${line.trim()}`
+      );
+    }
+  });
+
+  test('every codex exec invocation includes --dangerously-bypass-hook-trust', () => {
+    for (const line of codexExecLines) {
+      assert.ok(
+        line.includes('--dangerously-bypass-hook-trust'),
+        `codex exec invocation is missing --dangerously-bypass-hook-trust:\n  ${line.trim()}`
+      );
+    }
+  });
+
+  test('--ephemeral appears before the prompt argument (flag ordering)', () => {
+    for (const line of codexExecLines) {
+      const ephemeralPos = line.indexOf('--ephemeral');
+      const promptPos = line.indexOf(' - ');
+      if (promptPos === -1) continue; // no stdin prompt arg on this line
+      assert.ok(
+        ephemeralPos < promptPos,
+        `--ephemeral must appear before the stdin prompt argument:\n  ${line.trim()}`
+      );
+    }
+  });
+
+  test('--skip-git-repo-check is preserved alongside automation flags', () => {
+    for (const line of codexExecLines) {
+      assert.ok(
+        line.includes('--skip-git-repo-check'),
+        `codex exec invocation lost --skip-git-repo-check:\n  ${line.trim()}`
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Enhancement PR

## Linked Issue

Closes #773

## What this enhancement improves

Adds `--ephemeral` and `--dangerously-bypass-hook-trust` flags to the two `codex exec` invocations in the automated review workflow (`gsd-core/workflows/review.md`), ensuring each automated review run starts from a clean state and suppresses the interactive hook-trust prompt in CI/non-interactive contexts.

## Before / After

**Before:** The two `codex exec` template commands in `review.md` (one for `$CODEX_MODEL` set, one for the default model path) lacked `--ephemeral` and `--dangerously-bypass-hook-trust`, causing potential session-state accumulation across automated runs and interactive hook-trust prompts that block CI.

**After:** Both invocations include `--ephemeral` (clean slate per run) and `--dangerously-bypass-hook-trust` (suppresses interactive prompt). This flag is safe here because the hooks in scope are gsd-core-managed hooks installed by gsd itself — not arbitrary user hooks — and the flag is scoped only to the two review-phase snippets.

## How it was implemented

- `gsd-core/workflows/review.md` — added `--ephemeral` and `--dangerously-bypass-hook-trust` to both `codex exec` template commands (+2/-2 lines)
- `.changeset/mellow-yaks-bark.md` — changeset entry
- `tests/enh-773-codex-exec-automation-flags.test.cjs` — 68 lines of new tests asserting both flags are present on both codex exec invocation paths in `review.md`

## Testing

- `npm run build:lib` — clean
- `npm run lint` — clean
- `npm test` — 3968 pass, 0 fail, 1 skipped
- `GITHUB_BASE_REF=next npm run lint:docs` — `ok docs-lint: ok_fragments_exempt`

### Platforms tested
- [x] macOS
- [x] Linux
- [ ] Windows (covered by CI matrix)

## Scope confirmation

- [x] Implementation matches the approved enhancement scope

## Documentation

- [x] Updated relevant docs / or docs-exempt where internal

## Checklist

- [x] Issue linked with `Closes #773`
- [x] Linked issue has `approved-enhancement`
- [x] Tests cover the new behavior
- [x] `.changeset/` fragment added
- [x] `npm test` green

## Breaking changes

None
