### PR TITLE
fix(#837): three-dot diff in ci-test-scope so docs-only PRs skip the heavy matrix

### DIFF
--- a/scripts/ci-test-scope.cjs
+++ b/scripts/ci-test-scope.cjs
@@ -289,7 +289,12 @@ function changedFiles(args) {
   if (!args.base || !args.head) {
     throw new Error('--base/--head or --files is required');
   }
-  const stdout = execFileSync('git', ['diff', '--name-only', args.base, args.head], {
+  // Three-dot diff (merge-base...head) matches GitHub's PR "Files changed" semantics.
+  // A two-dot `git diff base head` would surface every file `next` gained after this
+  // branch's merge-base, mis-flagging product_changed/full_matrix on docs-only PRs cut
+  // from a slightly stale base (#837). The `changes` job checks out with fetch-depth: 0,
+  // so the merge-base is always available.
+  const stdout = execFileSync('git', ['diff', '--name-only', `${args.base}...${args.head}`], {
     encoding: 'utf8',
   });
   return splitFiles(stdout);

--- a/tests/ci-test-scope.test.cjs
+++ b/tests/ci-test-scope.test.cjs
@@ -5,6 +5,8 @@ const assert = require('node:assert/strict');
 const { spawnSync } = require('child_process');
 const path = require('path');
 const fs = require('fs');
+const os = require('node:os');
+const { cleanup } = require('./helpers.cjs');
 
 const ROOT = path.join(__dirname, '..');
 const SCRIPT = path.join(ROOT, 'scripts', 'ci-test-scope.cjs');
@@ -207,6 +209,74 @@ describe('ci-test-scope.cjs', () => {
     assert.deepStrictEqual(result.targeted_tests, ['unit'],
       'targeted_tests must be [\'unit\'] when code changed but no rule matched');
   });
+
+  test('three-dot diff: docs-only PR on a stale base ignores product commits next gained after the merge-base', () => {
+    // Reproduces #837: a docs-only PR branched from a slightly older `next`.
+    // After the branch point, `next` advances with a PRODUCT commit. A two-dot
+    // `git diff base head` would surface that product file (flipping product_changed/
+    // full_matrix true); a three-dot `git diff base...head` (vs the merge-base, which is
+    // GitHub's PR semantics) must see ONLY the docs change.
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ci-scope-837-'));
+    try {
+      const git = (...a) => {
+        const r = spawnSync('git', a, { cwd: tmp, encoding: 'utf8' });
+        assert.strictEqual(r.status, 0, `git ${a.join(' ')} failed: ${r.stderr}`);
+        return r.stdout.trim();
+      };
+      git('init', '-q');
+      git('config', 'user.email', 'test@example.com');
+      git('config', 'user.name', 'Test');
+      git('config', 'commit.gpgsign', 'false');
+
+      // merge-base: a docs file + a product file (package.json)
+      fs.mkdirSync(path.join(tmp, 'tests'), { recursive: true }); // existingTests() reads tests/
+      fs.mkdirSync(path.join(tmp, 'docs'), { recursive: true });
+      fs.writeFileSync(path.join(tmp, 'docs', 'a.md'), 'base\n');
+      fs.writeFileSync(path.join(tmp, 'package.json'), '{"name":"x","version":"1.0.0"}\n');
+      git('add', '-A');
+      git('commit', '-qm', 'merge-base');
+      const baseBranch = git('rev-parse', '--abbrev-ref', 'HEAD');
+
+      // PR branch (head): docs-only change
+      git('checkout', '-q', '-b', 'feature');
+      fs.writeFileSync(path.join(tmp, 'docs', 'a.md'), 'base\nnew docs line\n');
+      git('add', '-A');
+      git('commit', '-qm', 'docs: add line');
+      const head = git('rev-parse', 'HEAD');
+
+      // base advances (next gains a PRODUCT commit after the merge-base)
+      git('checkout', '-q', baseBranch);
+      fs.writeFileSync(path.join(tmp, 'package.json'), '{"name":"x","version":"2.0.0"}\n');
+      git('add', '-A');
+      git('commit', '-qm', 'chore: bump version on next');
+      const base = git('rev-parse', 'HEAD');
+
+      const r = spawnSync(process.execPath, [SCRIPT, '--base', base, '--head', head], {
+        cwd: tmp,
+        encoding: 'utf8',
+      });
+      assert.strictEqual(r.status, 0, `script failed: stderr=${r.stderr}\nstdout=${r.stdout}`);
+      const result = JSON.parse(r.stdout);
+
+      assert.deepStrictEqual(
+        result.changed_files,
+        ['docs/a.md'],
+        `expected three-dot diff to see only the docs file, got: ${JSON.stringify(result.changed_files)}`,
+      );
+      assert.strictEqual(
+        result.product_changed,
+        false,
+        `docs-only PR must not set product_changed even on a stale base, got: ${JSON.stringify(result)}`,
+      );
+      assert.strictEqual(
+        result.full_matrix,
+        false,
+        `docs-only PR must not set full_matrix even on a stale base, got: ${JSON.stringify(result)}`,
+      );
+    } finally {
+      cleanup(tmp);
+    }
+  });
 });
 
 describe('ci-test-scope superset invariant (#494)', () => {
@@ -332,6 +402,40 @@ describe('INERT_WORKFLOWS allowlist integrity guard', () => {
       assert.strictEqual(result.full_matrix, false,
         `${name}: expected full_matrix=false`);
     }
+  });
+});
+
+describe('test.yml changes job contract (#837)', () => {
+  // ci-test-scope.cjs uses a three-dot `git diff base...head`, which requires the
+  // merge-base commit to be locally present. The `changes` job in test.yml guarantees
+  // this via `fetch-depth: 0` on its checkout step. This test pins that contract so
+  // any future reduction of fetch-depth fails CI loudly (#837).
+  test('changes job checkout step sets fetch-depth: 0 (required for three-dot diff merge-base)', () => {
+    const workflowPath = path.join(WORKFLOWS_DIR, 'test.yml');
+    const text = fs.readFileSync(workflowPath, 'utf8');
+    const lines = text.split('\n');
+
+    // Locate the `changes:` job (two-space-indented top-level job key).
+    const jobStart = lines.findIndex(l => /^ {2}changes:\s*$/.test(l));
+    assert.ok(jobStart !== -1, 'Could not find `  changes:` job in test.yml');
+
+    // Find the next top-level job key at the same two-space indentation to bound the region.
+    let jobEnd = lines.length;
+    for (let i = jobStart + 1; i < lines.length; i++) {
+      if (/^ {2}[A-Za-z0-9_-]+:\s*$/.test(lines[i])) {
+        jobEnd = i;
+        break;
+      }
+    }
+
+    const changesJobText = lines.slice(jobStart, jobEnd).join('\n');
+
+    assert.ok(
+      /fetch-depth:\s*0/.test(changesJobText),
+      'changes job checkout must set `fetch-depth: 0` so the three-dot `git diff base...head` ' +
+      'in ci-test-scope.cjs can resolve the merge-base locally (#837). ' +
+      'Reducing fetch-depth breaks the three-dot diff and causes incorrect scope detection.',
+    );
   });
 });
 


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #837

> Linked issue has the `confirmed-bug` label.

---

## What was broken

The CI test-scope detector (`scripts/ci-test-scope.cjs`) ran the full cross-platform matrix (Windows + macOS) **and** `coverage` on **docs-only PRs**, defeating the docs/inert skip flow from #764 / #798. Concrete example: [#835](https://github.com/open-gsd/gsd-core/pull/835) changed only two `docs/` files yet triggered the full Windows + macOS matrix while `test (inert CI)` was skipped — the exact inverse of intended behavior.

## What this fix does

Switches changed-file detection in `changedFiles()` from a **two-dot** `git diff --name-only <base> <head>` to a **three-dot** `git diff --name-only <base>...<head>` (diff vs the merge-base), matching GitHub's PR "Files changed" semantics. Docs-only PRs now correctly yield `product_changed=false` / `full_matrix=false` regardless of how far `next` has advanced since the branch point.

## Root cause

`base` is `github.event.pull_request.base.sha` — the *moving tip* of `next`. A two-dot diff compares end states, so when a PR branch is cut from a slightly older `next`, every product file `next` gained since the branch's merge-base appears as "changed," flipping `product_changed`/`full_matrix` to true. The three-dot form diffs against the merge-base, which is precisely what the PR itself contributed.

Verified on #835: three-dot `base...head` = 2 docs files (matches GitHub's view); two-dot `base head` = 54 files including `bin/`, `src/`, `hooks/`, `tests/*.test.cjs`, `package.json`.

## Testing

### How I verified the fix

- **Regression test** builds a temp git repo with a stale-base topology (merge-base → docs-only commit on head; a *product* commit added to base after the branch point) and asserts the three-dot result sees only the docs file with `product_changed=false`/`full_matrix=false`. It **fails on the old two-dot code** (`changed_files` includes the product `package.json`) and **passes on the fix**.
- **Guard test** pins `fetch-depth: 0` on the `changes` job in `test.yml` — the three-dot merge-base requires full history, so reducing depth must fail CI loudly.
- `tests/ci-test-scope.test.cjs`: **33 pass / 0 fail**. ESLint clean. gsd-test (macOS local + Linux Docker) green.

### Regression test added?

- [x] Yes — added a test that would have caught this bug

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling) — *not platform-specific; `git diff --name-only` emits forward-slash paths, test uses `os.tmpdir()`/`path.join` and `helpers.cleanup()` for Windows-EBUSY safety*
- [x] Linux

### Runtimes tested

- [x] N/A (not runtime-specific) — CI tooling, not a GSD runtime feature

---

## Checklist

- [x] Issue linked above with `Fixes #837`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass
- [x] `.changeset/` fragment N/A — change touches only `scripts/` + `tests/` (outside the changeset-required path set) and has no user-facing impact; `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/841"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783469379&installation_id=134682257&pr_number=841&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F841&signature=3453e5a4c5a5314f016c433048ac1bae5a35dcdb7ac351ebf459567fbaec16e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->