### PR TITLE
fix(#856): clean profile pipeline temp dirs

### DIFF
--- a/.changeset/856-temp-dir-cleanup.md
+++ b/.changeset/856-temp-dir-cleanup.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 856
+---
+Moved profile-pipeline extraction/sample temp directories under the dedicated GSD temp root so stale reaping can find them, and added cleanup for tests that created `gsd-*` temp directories without teardown.

--- a/src/profile-pipeline.cts
+++ b/src/profile-pipeline.cts
@@ -18,7 +18,7 @@ import os from 'node:os';
 import readline from 'node:readline';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import core = require('./core.cjs');
-const { output, error, reapStaleTempFiles } = core;
+const { output, error, reapStaleTempFiles, GSD_TEMP_DIR } = core;
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -413,7 +413,8 @@ async function cmdExtractMessages(projectArg: string, options: { sessionId?: str
   }
 
   reapStaleTempFiles('gsd-pipeline-', { dirsOnly: true });
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-pipeline-'));
+  fs.mkdirSync(GSD_TEMP_DIR, { recursive: true });
+  const tmpDir = fs.mkdtempSync(path.join(GSD_TEMP_DIR, 'gsd-pipeline-'));
   const outputPath = path.join(tmpDir, 'extracted-messages.jsonl');
 
   let sessionsProcessed = 0;
@@ -601,7 +602,8 @@ async function cmdProfileSample(overridePath: string | null | undefined, options
   }
 
   reapStaleTempFiles('gsd-profile-', { dirsOnly: true });
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-profile-'));
+  fs.mkdirSync(GSD_TEMP_DIR, { recursive: true });
+  const tmpDir = fs.mkdtempSync(path.join(GSD_TEMP_DIR, 'gsd-profile-'));
   const outputPath = path.join(tmpDir, 'profile-sample.jsonl');
   for (const msg of allMessages) {
     fs.appendFileSync(outputPath, JSON.stringify(msg) + '\n');

--- a/tests/changeset-github-release-notes.test.cjs
+++ b/tests/changeset-github-release-notes.test.cjs
@@ -1,7 +1,7 @@
 'use strict';
 process.env.GSD_TEST_MODE = '1';
 
-const { test, describe } = require('node:test');
+const { test, describe, afterEach } = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const os = require('node:os');
@@ -17,6 +17,15 @@ const {
   renderGithubReleaseNotes,
 } = require(path.join(ROOT, 'scripts', 'changeset', 'github-release-notes.cjs'));
 
+const tempRepos = new Set();
+
+afterEach(() => {
+  for (const repo of tempRepos) {
+    fs.rmSync(repo, { recursive: true, force: true, maxRetries: 20, retryDelay: 250 });
+  }
+  tempRepos.clear();
+});
+
 function run(command, args, cwd, env) {
   const result = cp.spawnSync(command, args, { cwd, encoding: 'utf8', env: env || process.env });
   assert.equal(result.status, 0, `${command} ${args.join(' ')}\nstdout=${result.stdout}\nstderr=${result.stderr}`);
@@ -31,6 +40,7 @@ function writeFragment(repo, name, type, pr, body) {
 
 function createTaggedRepo() {
   const repo = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-release-notes-'));
+  tempRepos.add(repo);
   // Isolate from the developer's global/system git config (e.g. gpgSign settings)
   // by pointing GIT_CONFIG_GLOBAL and GIT_CONFIG_SYSTEM at an empty file inside
   // the temp dir. This prevents tag.gpgSign / commit.gpgSign / tag.forceSignAnnotated

--- a/tests/changeset-github-release-notes.test.cjs
+++ b/tests/changeset-github-release-notes.test.cjs
@@ -16,12 +16,13 @@ const {
   serializeGithubReleaseNotes,
   renderGithubReleaseNotes,
 } = require(path.join(ROOT, 'scripts', 'changeset', 'github-release-notes.cjs'));
+const { cleanup } = require('./helpers.cjs');
 
 const tempRepos = new Set();
 
 afterEach(() => {
   for (const repo of tempRepos) {
-    fs.rmSync(repo, { recursive: true, force: true, maxRetries: 20, retryDelay: 250 });
+    cleanup(repo);
   }
   tempRepos.clear();
 });

--- a/tests/enh-2415-claude-md-link-mode.test.cjs
+++ b/tests/enh-2415-claude-md-link-mode.test.cjs
@@ -17,12 +17,13 @@ const path = require('node:path');
 const os = require('node:os');
 
 const { cmdGenerateClaudeMd } = require('../gsd-core/bin/lib/profile-output.cjs');
+const { cleanup } = require('./helpers.cjs');
 
 const tempDirs = new Set();
 
 afterEach(() => {
   for (const dir of tempDirs) {
-    fs.rmSync(dir, { recursive: true, force: true, maxRetries: 20, retryDelay: 250 });
+    cleanup(dir);
   }
   tempDirs.clear();
 });

--- a/tests/enh-2415-claude-md-link-mode.test.cjs
+++ b/tests/enh-2415-claude-md-link-mode.test.cjs
@@ -10,7 +10,7 @@
  * content when claude_md_assembly.mode is "link".
  */
 
-const { test } = require('node:test');
+const { test, afterEach } = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
@@ -18,8 +18,18 @@ const os = require('node:os');
 
 const { cmdGenerateClaudeMd } = require('../gsd-core/bin/lib/profile-output.cjs');
 
+const tempDirs = new Set();
+
+afterEach(() => {
+  for (const dir of tempDirs) {
+    fs.rmSync(dir, { recursive: true, force: true, maxRetries: 20, retryDelay: 250 });
+  }
+  tempDirs.clear();
+});
+
 function makeTempProject(files = {}) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-2415-'));
+  tempDirs.add(dir);
   fs.mkdirSync(path.join(dir, '.planning', 'codebase'), { recursive: true });
   for (const [rel, content] of Object.entries(files)) {
     const abs = path.join(dir, rel);

--- a/tests/enh-2446-milestones-drift.test.cjs
+++ b/tests/enh-2446-milestones-drift.test.cjs
@@ -15,12 +15,13 @@ const path = require('node:path');
 const os = require('node:os');
 
 const { cmdValidateHealth } = require('../gsd-core/bin/lib/verify.cjs');
+const { cleanup } = require('./helpers.cjs');
 
 const tempDirs = new Set();
 
 afterEach(() => {
   for (const dir of tempDirs) {
-    fs.rmSync(dir, { recursive: true, force: true, maxRetries: 20, retryDelay: 250 });
+    cleanup(dir);
   }
   tempDirs.clear();
 });

--- a/tests/enh-2446-milestones-drift.test.cjs
+++ b/tests/enh-2446-milestones-drift.test.cjs
@@ -8,7 +8,7 @@
  * Tests for gsd-health MILESTONES.md drift detection (#2446).
  */
 
-const { test } = require('node:test');
+const { test, afterEach } = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
@@ -16,8 +16,18 @@ const os = require('node:os');
 
 const { cmdValidateHealth } = require('../gsd-core/bin/lib/verify.cjs');
 
+const tempDirs = new Set();
+
+afterEach(() => {
+  for (const dir of tempDirs) {
+    fs.rmSync(dir, { recursive: true, force: true, maxRetries: 20, retryDelay: 250 });
+  }
+  tempDirs.clear();
+});
+
 function makeTempProject(files = {}) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-2446-'));
+  tempDirs.add(dir);
   fs.mkdirSync(path.join(dir, '.planning', 'milestones'), { recursive: true });
   for (const [rel, content] of Object.entries(files)) {
     const abs = path.join(dir, rel);

--- a/tests/enh-2448-artifact-registry.test.cjs
+++ b/tests/enh-2448-artifact-registry.test.cjs
@@ -16,12 +16,13 @@ const os = require('node:os');
 
 const { isCanonicalPlanningFile, CANONICAL_EXACT } = require('../gsd-core/bin/lib/artifacts.cjs');
 const { cmdValidateHealth } = require('../gsd-core/bin/lib/verify.cjs');
+const { cleanup } = require('./helpers.cjs');
 
 const tempDirs = new Set();
 
 afterEach(() => {
   for (const dir of tempDirs) {
-    fs.rmSync(dir, { recursive: true, force: true, maxRetries: 20, retryDelay: 250 });
+    cleanup(dir);
   }
   tempDirs.clear();
 });

--- a/tests/enh-2448-artifact-registry.test.cjs
+++ b/tests/enh-2448-artifact-registry.test.cjs
@@ -8,7 +8,7 @@
  * Tests for canonical artifact registry and gsd-health W019 lint (#2448).
  */
 
-const { test, describe } = require('node:test');
+const { test, describe, afterEach } = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
@@ -17,8 +17,18 @@ const os = require('node:os');
 const { isCanonicalPlanningFile, CANONICAL_EXACT } = require('../gsd-core/bin/lib/artifacts.cjs');
 const { cmdValidateHealth } = require('../gsd-core/bin/lib/verify.cjs');
 
+const tempDirs = new Set();
+
+afterEach(() => {
+  for (const dir of tempDirs) {
+    fs.rmSync(dir, { recursive: true, force: true, maxRetries: 20, retryDelay: 250 });
+  }
+  tempDirs.clear();
+});
+
 function makeTempProject(files = {}) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-2448-'));
+  tempDirs.add(dir);
   fs.mkdirSync(path.join(dir, '.planning', 'phases'), { recursive: true });
   for (const [rel, content] of Object.entries(files)) {
     const abs = path.join(dir, rel);

--- a/tests/profile-pipeline.test.cjs
+++ b/tests/profile-pipeline.test.cjs
@@ -9,6 +9,7 @@ const { test, describe, beforeEach, afterEach } = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('fs');
 const path = require('path');
+const os = require('os');
 const { runGsdTools, createTempDir, createTempProject, cleanup } = require('./helpers.cjs');
 
 // ─── scan-sessions ────────────────────────────────────────────────────────────
@@ -107,6 +108,11 @@ describe('extract-messages command', () => {
     assert.strictEqual(out.messages_extracted, 2, 'should extract 2 genuine user messages');
     assert.strictEqual(out.project, 'my-project');
     assert.ok(out.output_file, 'should have output file path');
+    assert.ok(
+      out.output_file.startsWith(path.join(os.tmpdir(), 'gsd') + path.sep),
+      `output file should be under the dedicated GSD temp dir: ${out.output_file}`,
+    );
+    cleanup(path.dirname(out.output_file));
   });
 
   test('filters out meta and internal messages', () => {
@@ -131,6 +137,46 @@ describe('extract-messages command', () => {
     assert.ok(result.success, `Failed: ${result.error}`);
     const out = JSON.parse(result.output);
     assert.strictEqual(out.messages_extracted, 2, 'should only extract 2 genuine external messages');
+    cleanup(path.dirname(out.output_file));
+  });
+});
+
+// ─── profile-sample ──────────────────────────────────────────────────────────
+
+describe('profile-sample command', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempDir('gsd-profile-test-');
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('writes sample output under dedicated GSD temp directory', () => {
+    const sessionsDir = path.join(tmpDir, 'projects');
+    const projectDir = path.join(sessionsDir, 'sample-project');
+    fs.mkdirSync(projectDir, { recursive: true });
+
+    const messages = [
+      { type: 'user', userType: 'external', message: { content: 'sample me' }, timestamp: new Date().toISOString() },
+    ];
+    fs.writeFileSync(
+      path.join(projectDir, 'session-001.jsonl'),
+      messages.map(m => JSON.stringify(m)).join('\n')
+    );
+
+    const result = runGsdTools(['profile-sample', '--path', sessionsDir, '--raw'], tmpDir);
+    assert.ok(result.success, `Failed: ${result.error}`);
+
+    const out = JSON.parse(result.output);
+    assert.strictEqual(out.messages_sampled, 1, 'should sample the synthetic message');
+    assert.ok(
+      out.output_file.startsWith(path.join(os.tmpdir(), 'gsd') + path.sep),
+      `output file should be under the dedicated GSD temp dir: ${out.output_file}`,
+    );
+    cleanup(path.dirname(out.output_file));
   });
 });
 


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #856

> The linked issue has the `confirmed-bug` label.

---

## What was broken

`profile-pipeline` created `gsd-pipeline-*` and `gsd-profile-*` output directories directly under `os.tmpdir()`, while the stale temp reaper scans the dedicated GSD temp root. Several tests also created `/tmp/gsd-*` fixture directories without teardown.

## What this fix does

Profile-pipeline temp output now lives under the dedicated GSD temp root (`os.tmpdir()/gsd`), so existing stale-temp cleanup can see it. The affected tests now register temp directories for cleanup through the shared test cleanup helper.

Scope note: #862 fixes the separate install-time `gsd-cmd-rewrites-*` leak. This PR is complementary and touches different files.

## Root cause

`cmdExtractMessages` and `cmdProfileSample` called the GSD temp reaper, but then created their output directories outside the root that the reaper scans. The fixture tests used direct `fs.mkdtempSync(os.tmpdir()/gsd-*)` setup without a matching cleanup path.

## Testing

### How I verified the fix

```bash
npm run build:lib
npm run lint:changeset
npx eslint tests/changeset-github-release-notes.test.cjs tests/enh-2415-claude-md-link-mode.test.cjs tests/enh-2446-milestones-drift.test.cjs tests/enh-2448-artifact-registry.test.cjs --cache --cache-location node_modules/.cache/eslint/
node --test tests/profile-pipeline.test.cjs \
  tests/enh-2415-claude-md-link-mode.test.cjs \
  tests/enh-2446-milestones-drift.test.cjs \
  tests/enh-2448-artifact-registry.test.cjs \
  tests/changeset-github-release-notes.test.cjs
find /tmp -maxdepth 1 \\( -name 'gsd-2415-*' -o -name 'gsd-2446-*' -o -name 'gsd-2448-*' -o -name 'gsd-release-notes-*' -o -name 'gsd-pipeline-*' -o -name 'gsd-profile-*' \\) -print
find /tmp/gsd -maxdepth 1 \\( -name 'gsd-pipeline-*' -o -name 'gsd-profile-*' \\) -print 2>/dev/null
```

Results:

- ESLint on touched test files: pass
- `node --test ...`: 34/34 pass
- `lint:changeset`: pass
- both `find` checks returned no matching paths after the test run

### Regression test added?

- [x] Yes — added a test that would have caught this bug

### Platforms tested

- [x] Linux
- [x] N/A (not platform-specific)

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #856`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix
- [x] No unnecessary dependencies added

## Breaking changes

None