### PR TITLE
fix(#856): remove gsd-cmd-rewrites temp dirs after install

### DIFF
--- a/.changeset/humble-deer-gather.md
+++ b/.changeset/humble-deer-gather.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 862
+---
+**Installer no longer leaks `gsd-cmd-rewrites-*` temp directories.** Each install that emitted slash commands left one `fs.mkdtempSync` directory under the system temp root; on `tmpfs` `/tmp` hosts these accumulated and consumed RAM-backed storage. `installRuntimeArtifacts()` now removes the temp copy in a `finally` once command files are copied.

--- a/bin/install.js
+++ b/bin/install.js
@@ -7568,59 +7568,67 @@ function installRuntimeArtifacts(runtime, configDir, scope, resolvedProfile) {
       // Returns a temp dir with rewritten content so source files are never mutated.
       stagedForCopy = applyRuntimeContentRewritesForCommandsInPlace(staged, runtime, pathPrefix);
     }
-    const dest = path.join(layout.configDir, kind.destSubpath);
-    fs.mkdirSync(dest, { recursive: true });
+    // applyRuntimeContentRewritesForCommandsInPlace() returns a fresh mkdtemp dir under
+    // os.tmpdir() (gsd-cmd-rewrites-*); remove it once copied so it does not accumulate (#856).
+    const tempToClean = stagedForCopy !== staged ? stagedForCopy : null;
+    try {
+      const dest = path.join(layout.configDir, kind.destSubpath);
+      fs.mkdirSync(dest, { recursive: true });
+      if (kind.kind === 'skills' && fs.existsSync(dest)) {
+        // Pre-prune: snapshot user-owned content before _removeGsdEntries wipes it,
+        // then restore after. This preserves user dirs across a wipe-and-replace
+        // install (#2973 / #3664).
+        //
+        // For prefix='' (Hermes): _removeGsdEntries wipes the entire dest dir (skills/gsd/).
+        // Preserve every subdir that is NOT in the staged set — those are user-added dirs
+        // (e.g. user-content/) that GSD does not manage.
+        //
+        // For prefix='gsd-' (others): _removeGsdEntries removes only gsd-* entries.
+        // Non-gsd-* user dirs (e.g. my-custom-skill/) are untouched. Only preserve the
+        // explicit user-owned GSD-prefixed skill gsd-dev-preferences, which GSD does not
+        // reinstall from source but must survive the prune (#2973).
+        const toPreserve = new Map(); // dirName -> Map<relPath, Buffer>
 
-    if (kind.kind === 'skills' && fs.existsSync(dest)) {
-      // Pre-prune: snapshot user-owned content before _removeGsdEntries wipes it,
-      // then restore after. This preserves user dirs across a wipe-and-replace
-      // install (#2973 / #3664).
-      //
-      // For prefix='' (Hermes): _removeGsdEntries wipes the entire dest dir (skills/gsd/).
-      // Preserve every subdir that is NOT in the staged set — those are user-added dirs
-      // (e.g. user-content/) that GSD does not manage.
-      //
-      // For prefix='gsd-' (others): _removeGsdEntries removes only gsd-* entries.
-      // Non-gsd-* user dirs (e.g. my-custom-skill/) are untouched. Only preserve the
-      // explicit user-owned GSD-prefixed skill gsd-dev-preferences, which GSD does not
-      // reinstall from source but must survive the prune (#2973).
-      const toPreserve = new Map(); // dirName -> Map<relPath, Buffer>
+        if (kind.prefix === '') {
+          // Hermes: wipes entire dest dir — preserve anything not in staged.
+          const stagedNames = fs.existsSync(stagedForCopy)
+            ? new Set(fs.readdirSync(stagedForCopy, { withFileTypes: true })
+                .filter(e => e.isDirectory()).map(e => e.name))
+            : new Set();
+          for (const entry of fs.readdirSync(dest, { withFileTypes: true })) {
+            if (!entry.isDirectory() || stagedNames.has(entry.name)) continue;
+            const snap = _snapshotDir(path.join(dest, entry.name));
+            if (snap.size > 0) toPreserve.set(entry.name, snap);
+          }
+        } else {
+          // Non-Hermes: only preserve explicitly user-owned GSD-prefixed skill dirs.
+          // gsd-dev-preferences is the sole user-customisable skill in this category.
+          const USER_OWNED_SKILL_DIRS = ['gsd-dev-preferences'];
+          for (const dirName of USER_OWNED_SKILL_DIRS) {
+            const skillDir = path.join(dest, dirName);
+            if (!fs.existsSync(skillDir)) continue;
+            const snap = _snapshotDir(skillDir);
+            if (snap.size > 0) toPreserve.set(dirName, snap);
+          }
+        }
 
-      if (kind.prefix === '') {
-        // Hermes: wipes entire dest dir — preserve anything not in staged.
-        const stagedNames = fs.existsSync(stagedForCopy)
-          ? new Set(fs.readdirSync(stagedForCopy, { withFileTypes: true })
-              .filter(e => e.isDirectory()).map(e => e.name))
-          : new Set();
-        for (const entry of fs.readdirSync(dest, { withFileTypes: true })) {
-          if (!entry.isDirectory() || stagedNames.has(entry.name)) continue;
-          const snap = _snapshotDir(path.join(dest, entry.name));
-          if (snap.size > 0) toPreserve.set(entry.name, snap);
+        _removeGsdEntries(dest, kind);
+        _copyStaged(stagedForCopy, dest, kind);
+
+        // Restore user-owned dirs after the prune+copy
+        for (const [dirName, snap] of toPreserve) {
+          _restoreDir(path.join(dest, dirName), snap);
         }
       } else {
-        // Non-Hermes: only preserve explicitly user-owned GSD-prefixed skill dirs.
-        // gsd-dev-preferences is the sole user-customisable skill in this category.
-        const USER_OWNED_SKILL_DIRS = ['gsd-dev-preferences'];
-        for (const dirName of USER_OWNED_SKILL_DIRS) {
-          const skillDir = path.join(dest, dirName);
-          if (!fs.existsSync(skillDir)) continue;
-          const snap = _snapshotDir(skillDir);
-          if (snap.size > 0) toPreserve.set(dirName, snap);
-        }
+        // For non-skills kinds (commands, agents): no user content to preserve;
+        // just prune stale gsd-* entries and copy new ones.
+        _removeGsdEntries(dest, kind);
+        _copyStaged(stagedForCopy, dest, kind);
       }
-
-      _removeGsdEntries(dest, kind);
-      _copyStaged(stagedForCopy, dest, kind);
-
-      // Restore user-owned dirs after the prune+copy
-      for (const [dirName, snap] of toPreserve) {
-        _restoreDir(path.join(dest, dirName), snap);
+    } finally {
+      if (tempToClean) {
+        try { fs.rmSync(tempToClean, { recursive: true, force: true }); } catch { /* best-effort */ }
       }
-    } else {
-      // For non-skills kinds (commands, agents): no user content to preserve;
-      // just prune stale gsd-* entries and copy new ones.
-      _removeGsdEntries(dest, kind);
-      _copyStaged(stagedForCopy, dest, kind);
     }
   }
 }

--- a/tests/enh-790-augment-commands.test.cjs
+++ b/tests/enh-790-augment-commands.test.cjs
@@ -135,6 +135,41 @@ describe('enh-790 — installRuntimeArtifacts augment emits both commands and sk
   });
 });
 
+describe('enh-790 — installRuntimeArtifacts does not leak temp dirs', () => {
+  test('install cleans up gsd-cmd-rewrites-* temp dirs (no leak) — #856', (t) => {
+    const { resolveProfile } = require('../gsd-core/bin/lib/install-profiles.cjs');
+    const RESOLVED_FULL = resolveProfile({ modes: ['full'], manifest: MANIFEST });
+
+    // Isolate os.tmpdir() to a private root so parallel test processes can't race
+    // on the shared system temp dir. os.tmpdir() resolves $TMPDIR/$TEMP/$TMP per call.
+    const isolatedTmp = createTempDir('gsd-enh790-tmproot-');
+    const prev = { TMPDIR: process.env.TMPDIR, TEMP: process.env.TEMP, TMP: process.env.TMP };
+    process.env.TMPDIR = isolatedTmp;
+    process.env.TEMP = isolatedTmp;
+    process.env.TMP = isolatedTmp;
+
+    const configDir = createTempDir('gsd-enh790-leak-');
+    t.after(() => {
+      for (const k of ['TMPDIR', 'TEMP', 'TMP']) {
+        if (prev[k] === undefined) delete process.env[k];
+        else process.env[k] = prev[k];
+      }
+      cleanup(configDir);
+      cleanup(isolatedTmp);
+    });
+
+    installRuntimeArtifacts('augment', configDir, 'global', RESOLVED_FULL);
+
+    // The install creates its gsd-cmd-rewrites-* temp dirs under the isolated root;
+    // after the fix none must remain.
+    const leaked = fs.readdirSync(isolatedTmp).filter(n => n.startsWith('gsd-cmd-rewrites-'));
+    assert.ok(
+      leaked.length === 0,
+      `installer must not leak gsd-cmd-rewrites-* temp dirs; leaked: ${leaked.join(', ')}`
+    );
+  });
+});
+
 // ─── Uninstall contract ──────────────────────────────────────────────────────
 
 describe('enh-790 — uninstallRuntimeArtifacts removes augment commands', () => {


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #856

> The linked issue has the `confirmed-bug` label.

---

## What was broken

Every install that processed a `commands` artifact kind leaked one `gsd-cmd-rewrites-*` temp directory under `os.tmpdir()`. On hosts where `/tmp` is `tmpfs`, these accumulate and consume RAM-backed storage.

## What this fix does

`installRuntimeArtifacts()` now removes the temp directory returned by `applyRuntimeContentRewritesForCommandsInPlace()` once the copy completes (or fails), so nothing is left behind under `os.tmpdir()`.

## Root cause

`applyRuntimeContentRewritesForCommandsInPlace()` creates a fresh `fs.mkdtempSync(os.tmpdir()/gsd-cmd-rewrites-*)`, writes rewritten command markdown into it, and **returns** it (a temp copy is used so the package source is never mutated). The caller copied from it via `_copyStaged()` but never deleted it — only the rewrite function's own error path cleaned up. So each `commands` kind per install leaked one dir.

The fix wraps the per-kind copy body in `try/finally` and `rmSync`s the temp dir, guarded by `stagedForCopy !== staged` so it only ever targets the commands temp copy (the skills path rewrites in place and returns the same `staged` dir — never deleted). Destination creation was moved inside the `try` so a `mkdirSync` failure still triggers cleanup.

Scope note: this addresses the concrete production leak called out as the starting point in the issue. The broader audit of direct `os.tmpdir()/gsd-*` **test fixtures** (which already clean up via `t.after`/`cleanup`) is left as follow-up.

## Testing

### How I verified the fix

Added a regression test (`tests/enh-790-augment-commands.test.cjs`) that isolates `os.tmpdir()` to a private `TMPDIR`/`TEMP`/`TMP` root (so it is deterministic under the parallel test runner), runs a full-profile Augment install, and asserts no `gsd-cmd-rewrites-*` directory survives. It fails before the fix (`leaked: gsd-cmd-rewrites-…`) and passes after. Full local suite: 4089 pass / 0 fail. Codex adversarial review run; both low-severity findings (early temp creation before `try`; tmpdir snapshot race) were addressed.

### Regression test added?

- [x] Yes — added a test that would have caught this bug

### Platforms tested

- [x] macOS
- [x] N/A (not platform-specific) — uses `os.tmpdir()` + `fs.rmSync`, no path-separator logic

### Runtimes tested

- [x] N/A (not runtime-specific) — installer temp handling, exercised via the Augment layout

---

## Checklist

- [x] Issue linked above with `Fixes #856`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/862"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783516978&installation_id=134682257&pr_number=862&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F862&signature=ad4e7191b43be1fdd896b0a67330728304f30b559ed21211e895b55f01a53a18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->