### PR TITLE
chore(#57): add runtime install no-drift guard tests

### DIFF
--- a/.changeset/runtime-install-no-drift-tests.md
+++ b/.changeset/runtime-install-no-drift-tests.md
@@ -1,0 +1,6 @@
+---
+type: Changed
+pr: 867
+---
+Added no-drift guard tests (`tests/issue-57-runtime-install-no-drift.test.cjs`) that protect the Runtime Install Policy Module boundary (ADR-58) and the explicit Runtime Config Adapter Registry (#60). They fail loudly when supported-runtime metadata is added to an installer call site (`allRuntimes`, the interactive `runtimeMap` menu) without a matching registry adapter entry, or when config-mutation dispatch escapes the registry's declared install surfaces — catching reintroduction of the scattered per-runtime branching those seams removed.
+<!-- docs-exempt: test-only — adds architecture-guard tests, no user-facing behavior, command, or config change -->

--- a/tests/issue-57-runtime-install-no-drift.test.cjs
+++ b/tests/issue-57-runtime-install-no-drift.test.cjs
@@ -1,0 +1,201 @@
+'use strict';
+
+// Issue #57 — Runtime Install No-Drift Tests.
+//
+// Protects the Runtime Install Policy Module boundary (ADR-58) and the explicit
+// Runtime Config Adapter Registry (#60) now that the policy boundary (#58),
+// explicit adapter registry (#60), and legacy directory-helper retirement (#56)
+// have landed. These guards FAIL when:
+//
+//   (AC1) supported-runtime metadata is added to an installer/query call site
+//         without going through the runtime registry projection, or
+//   (AC2) config-mutation dispatch bypasses the explicit adapter registry.
+//
+// (AC3) Assertions are behavioral (require + reflect on live exports) wherever
+// behavior can cover the contract; the two source-text assertions are structural
+// guards that behavioral checks cannot replace, and are annotated per repo
+// convention. (AC4) The existing installer / runtime-policy / runtime-global-skills
+// suites must stay green — verified by running them alongside this file, not
+// asserted here.
+//
+// Known INTENTIONAL asymmetries — these are not drift; do not "fix" them by
+// tightening the invariants:
+//   - `grok` appears in runtime-homes.cjs's getGlobalConfigDir switch but NOT in
+//     the registry / artifact-layout supported sets (it resolves a config-dir home
+//     but is not an installable artifact target). So runtime-homes' full switch set
+//     is never tied into the equality invariant — it is only probed forward, per
+//     installable runtime.
+//   - getGlobalConfigDir() falls back to ~/.claude for an UNKNOWN runtime instead
+//     of throwing (a deliberately liberal projection). Only the registry and
+//     artifact-layout projections are loud gates, so only those are asserted to
+//     throw on an unknown runtime.
+//
+// Coverage boundary (deliberate, see #57 follow-up): the structural guard below
+// catches a NEW inline `runtime === '...'` branch against an UNREGISTERED runtime.
+// It cannot catch a duplicate inline config write added for an ALREADY-registered
+// runtime — distinguishing that from the ~169 legitimate per-runtime comparisons in
+// the installer requires driving install()/finishInstall() against a mocked
+// filesystem and asserting the written surfaces match resolveRuntimeConfigIntent().
+// That behavioral install-driver harness is out of scope for this no-drift pass.
+//
+// The forward invariant `allRuntimes ⊆ artifact-layout` is already covered by
+// tests/install-runtime-artifacts.test.cjs; this file does not duplicate it.
+
+process.env.GSD_TEST_MODE = '1'; // must precede require of bin/install.js
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const ROOT = path.join(__dirname, '..');
+const LIB = path.join(ROOT, 'gsd-core', 'bin', 'lib');
+
+const { allRuntimes, runtimeMap } = require(path.join(ROOT, 'bin', 'install.js'));
+const {
+  resolveRuntimeConfigIntent,
+  ALLOWED_CONFIG_RUNTIMES,
+  INSTALL_SURFACES,
+} = require(path.join(LIB, 'runtime-config-adapter-registry.cjs'));
+const { resolveRuntimeArtifactLayout } = require(
+  path.join(LIB, 'runtime-artifact-layout.cjs'),
+);
+const { getGlobalConfigDir } = require(path.join(LIB, 'runtime-homes.cjs'));
+
+const sorted = (iterable) => [...iterable].sort();
+
+// A runtime name that is deliberately not real and is not a prototype-chain key.
+const SENTINEL = '__drift_sentinel_runtime__';
+
+describe('issue-57 AC1 — supported-runtime metadata has one projected source of truth', () => {
+  test('installer allRuntimes, interactive runtimeMap, and registry agree on the supported set', () => {
+    const installable = sorted(allRuntimes);
+    assert.deepStrictEqual(
+      installable,
+      sorted(Object.values(runtimeMap)),
+      'Drift: bin/install.js `allRuntimes` and the interactive `runtimeMap` selection menu '
+        + 'diverged. A runtime selectable in the prompt but absent from allRuntimes (or vice '
+        + 'versa) is a supported-runtime call site that skipped the projection.',
+    );
+    assert.deepStrictEqual(
+      installable,
+      sorted(ALLOWED_CONFIG_RUNTIMES),
+      'Drift: bin/install.js `allRuntimes` and `ALLOWED_CONFIG_RUNTIMES` (runtime config '
+        + 'adapter registry) diverged. A runtime added to an installer call site without a '
+        + 'registry adapter entry bypasses the registry projection — register it in '
+        + 'src/runtime-config-adapter-registry.cts.',
+    );
+  });
+
+  test('every installable runtime resolves a config intent through the registry', () => {
+    for (const runtime of allRuntimes) {
+      const intent = resolveRuntimeConfigIntent(runtime);
+      assert.equal(
+        intent.runtime,
+        runtime,
+        `${runtime} must resolve its own config intent through resolveRuntimeConfigIntent`,
+      );
+    }
+  });
+
+  test('every installable runtime resolves a global config dir through runtime-homes', () => {
+    for (const runtime of allRuntimes) {
+      const dir = getGlobalConfigDir(runtime);
+      assert.equal(typeof dir, 'string', `${runtime} config dir must be a string`);
+      assert.ok(dir.length > 0, `${runtime} must resolve a non-empty global config dir`);
+    }
+  });
+});
+
+describe('issue-57 AC2 — config-mutation dispatch is closed over the explicit registry', () => {
+  test('every config intent uses a registry-declared install surface', () => {
+    const surfaces = new Set(INSTALL_SURFACES);
+    for (const runtime of allRuntimes) {
+      const { installSurface } = resolveRuntimeConfigIntent(runtime);
+      assert.ok(
+        surfaces.has(installSurface),
+        `${runtime} dispatches config via unregistered surface "${installSurface}" — add it `
+          + 'to INSTALL_SURFACES in the registry instead of branching on it inline.',
+      );
+    }
+  });
+
+  test('every finishInstall permission writer is null or a registry-known runtime', () => {
+    // Registry-derived (no hand-maintained vocabulary): a permission writer either
+    // names a runtime that is itself in the registry, or is null. A writer pointing
+    // at an unregistered runtime would mean finishInstall dispatches a config mutation
+    // outside the registry's known set.
+    for (const runtime of allRuntimes) {
+      const { finishPermissionWriter } = resolveRuntimeConfigIntent(runtime);
+      assert.ok(
+        finishPermissionWriter === null || ALLOWED_CONFIG_RUNTIMES.has(finishPermissionWriter),
+        `${runtime} uses finishPermissionWriter "${finishPermissionWriter}", which is neither `
+          + 'null nor a registry-known runtime — route it through a registered adapter.',
+      );
+    }
+  });
+
+  test('unknown runtime fails loudly through both strict projections (no silent fallthrough)', () => {
+    assert.throws(
+      () => resolveRuntimeConfigIntent(SENTINEL),
+      TypeError,
+      'config adapter registry must reject an unknown runtime, not dispatch it silently',
+    );
+    assert.throws(
+      () => resolveRuntimeArtifactLayout(SENTINEL, path.join(os.tmpdir(), 'gsd-57'), 'global'),
+      TypeError,
+      'artifact-layout projection must reject an unknown runtime',
+    );
+  });
+
+  test('registry rejects prototype-chain keys (no proto-pollution dispatch bypass)', () => {
+    for (const key of ['__proto__', 'constructor', 'prototype', 'toString']) {
+      assert.throws(
+        () => resolveRuntimeConfigIntent(key),
+        TypeError,
+        `${key} must throw, not resolve via the prototype chain`,
+      );
+    }
+  });
+
+  // allow-test-rule: structural guard over bin/install.js source. Behavioral assertions
+  // cannot observe inline `runtime === '...'` config branching, so this enforces that
+  // every inline per-runtime branch references a runtime the adapter registry knows
+  // about — a NEW branch against an unregistered runtime name fails here. It matches
+  // positive equality only (`runtime === '<name>'` / `runtime === "<name>"`, both quote
+  // styles), so `runtime !== 'string'`-style type guards are not implicated. See the
+  // "coverage boundary" note at the top of the file for what this can and cannot catch.
+  test('every inline `runtime === "..."` branch references a registry-known runtime', () => {
+    const src = fs.readFileSync(path.join(ROOT, 'bin', 'install.js'), 'utf8');
+    const literals = new Set(
+      [...src.matchAll(/runtime === (?:'([a-z][a-z0-9-]*)'|"([a-z][a-z0-9-]*)")/g)]
+        .map((m) => m[1] ?? m[2]),
+    );
+    assert.ok(literals.size > 0, 'expected to find inline runtime comparisons in bin/install.js');
+    const unregistered = [...literals].filter((r) => !ALLOWED_CONFIG_RUNTIMES.has(r));
+    assert.deepStrictEqual(
+      unregistered,
+      [],
+      `inline 'runtime === "..."' branch(es) reference runtimes absent from the config adapter `
+        + `registry: ${unregistered.join(', ')} — register them in `
+        + 'src/runtime-config-adapter-registry.cts or route the logic through '
+        + 'resolveRuntimeConfigIntent instead of branching inline.',
+    );
+  });
+
+  // allow-test-rule: delegation-presence guard. Catches wholesale removal of the registry
+  // dispatch (a regression to scattered per-runtime config branching). Presence-style, not
+  // absence-grep, so it does not bite on incidental non-config `runtime === '...'` checks.
+  test('bin/install.js requires the config adapter registry and dispatches through it', () => {
+    const src = fs.readFileSync(path.join(ROOT, 'bin', 'install.js'), 'utf8');
+    assert.ok(
+      src.includes('runtime-config-adapter-registry'),
+      'bin/install.js no longer requires the runtime config adapter registry',
+    );
+    assert.ok(
+      src.includes('resolveRuntimeConfigIntent('),
+      'bin/install.js no longer dispatches config through resolveRuntimeConfigIntent',
+    );
+  });
+});


### PR DESCRIPTION
## Enhancement PR

## Linked Issue

Closes #57

> Linked issue #57 carries the `approved-enhancement` label (approved 2026-06-01: "No-drift tests are valid follow-on work … sequence after #58 and #60"). Both blockers are now merged — #58 ([#762](https://github.com/open-gsd/gsd-core/pull/762)) and #60 ([#795](https://github.com/open-gsd/gsd-core/pull/795)) — so the seam these tests protect now exists.

---

## What this enhancement improves

Test coverage for the **Runtime Install Policy Module boundary** (ADR-58) and the **explicit Runtime Config Adapter Registry** (#60). Adds no-drift architecture-guard tests that catch future reintroduction of scattered runtime-fact ownership or config-mutation branching outside those seams.

## Before / After

**Before:** Nothing asserts that the installer's supported-runtime call sites and the registry projection stay in lockstep. A contributor could add a runtime to `allRuntimes` / the interactive `runtimeMap` menu without a registry adapter entry, or add an inline `if (runtime === 'x') writeXConfig()` branch, and no test would notice. Existing coverage only checks `allRuntimes ⊆ artifact-layout` (one direction), not the registry.

**After:** `tests/issue-57-runtime-install-no-drift.test.cjs` fails loudly on that drift:
- **AC1** — three-way set equality across `allRuntimes`, `runtimeMap` values, and `ALLOWED_CONFIG_RUNTIMES`; every installable runtime must resolve a config intent (registry), a layout, and a global config dir (runtime-homes).
- **AC2** — every config intent uses a registry-declared `INSTALL_SURFACES` value; every `finishPermissionWriter` is `null` or a registry-known runtime; unknown and prototype-chain runtimes fail loudly through both strict projections; and a new inline `runtime === '<unregistered>'` branch (single- or double-quoted) in `bin/install.js` is rejected.

## How it was implemented

A single new `node:test` file. Assertions are **behavioral** (`require` + reflect on the live exports of `bin/install.js`, `runtime-config-adapter-registry.cjs`, `runtime-artifact-layout.cjs`, `runtime-homes.cjs`) wherever behavior can cover the contract (AC3); two `// allow-test-rule:`-annotated structural source guards cover what behavior cannot. No production code changed.

**Documented coverage boundary:** detecting a duplicate inline config write for an *already-registered* runtime would require driving `install()`/`finishInstall()` against a mocked filesystem — disproportionate here and out of scope; noted in-file as a follow-up.

## Testing

### How I verified the enhancement works

- New file: **9/9 pass** on macOS and Linux Docker.
- **Bite-verified:** removing a runtime from the registry fails 4 guards; an injected `runtime === '<unregistered>'` branch (both quote styles) is rejected — the guards are non-vacuous.
- AC4: existing installer / runtime-policy / runtime-global-skills suites stay green.
- Full suite: **Mac 12715 pass / 0 fail**, **Linux Docker 14709 both-passed / 0 fail** (`gsd-test-both`).
- `eslint`, `lint:test-file-count`, Codex adversarial-review, `/code-review`, `/security-review` — all run; findings addressed (registry-derived permission-writer assertion, both-quote regex, runtimeMap call-site coverage).

> Note: `gsd-test-both` also surfaced 9 **pre-existing, Mac-only** failures in `tests/roadmap-phase-fallback.test.cjs` (`extractCurrentMilestone`, #145) that pass on Linux/Docker and are unrelated to this PR (the module is untouched here). Tracked separately.

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific) — guards the registry's full 15-runtime set generically

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue — no additions or removals
- [x] If scope changed during implementation, I updated the issue and got re-approval before continuing — N/A

---

## Documentation

- [ ] Updated the relevant file(s) under `docs/` to reflect this change
- [x] All `docs/` content added in this PR is written in English — N/A
- [x] Test-only — `<!-- docs-exempt: ... -->` added inside the changeset fragment

## Checklist

- [x] Issue linked above with `Closes #57`
- [x] Linked issue has the `approved-enhancement` label
- [x] Changes are scoped to the approved enhancement — nothing extra included
- [x] All existing tests pass (`npm test`)
- [x] New or updated tests cover the enhanced behavior
- [x] `.changeset/` fragment added (`type: Changed`, with `docs-exempt`)
- [x] No unnecessary dependencies added

## Breaking changes

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/867"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783522025&installation_id=134682257&pr_number=867&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F867&signature=010794341bcda120c0c2307e2a537a3eac88c4a045e83b929ac7b1a9968580b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->