### PR TITLE
ci(#869): raise full-test Windows lane timeout 15m→20m

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -265,7 +265,10 @@ jobs:
     defaults:
       run:
         shell: ${{ matrix.shell }}
-    timeout-minutes: 15
+    # 20m, not 15m: the Windows full lane runs all 656 unit files in one job and
+    # has crept to ~14m+, so 15m started cancelling jobs mid-run (#869). Durable
+    # fix is to shard this lane — tracked separately.
+    timeout-minutes: 20
     env:
       GSD_PLUGIN_ROOT: .ci-gsd-plugin-root-disabled
     strategy:


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #869

> Linked issue #869 carries the `confirmed-bug` label.

---

## What was broken

The `full test (windows-latest, 22)` CI job runs all 656 unit files in a single lane and had crept to ~14m+ under its `timeout-minutes: 15` cap, so it started getting **cancelled mid-run on wall-clock** — red-blocking product-changing PRs even though every test passes (the job is killed on time, not a test failure). It tipped over on [#867](https://github.com/open-gsd/gsd-core/pull/867), cancelled at exactly 15m0s during "Run unit tests" (which had already reported `# fail 0`).

## What this fix does

Raises `timeout-minutes` on the `full test` job from `15` to `20` (`.github/workflows/test.yml`), restoring headroom for the slow Windows lane. macOS/Linux full lanes finish well under 15m, so a per-job bump is sufficient.

## Root cause

The full Windows-22 lane's runtime trends up as the unit suite grows (recent PRs: 12m31s → 13m45s → 14m18s → over 15m), and the 15m cap became the binding constraint. The durable fix is to shard the Windows full unit lane; this PR is the stopgap that unblocks merges now. Sharding is tracked as a separate follow-up (see #869).

## Testing

### How I verified the fix

CI-config change only. Validated the workflow YAML parses (`js-yaml`). The fix is proven by CI itself: this PR's own `full test (windows-latest, 22)` lane now has 20m to complete. No product code changed.

### Regression test added?

- [x] No — explain why: CI wall-clock/runner-capacity tuning is not unit-testable; the trend is monitored via job durations and the durable sharding follow-up (#869) removes the cliff.

### Platforms tested

- [ ] macOS
- [x] Windows (including backslash path handling) — this is the affected lane
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #869`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`) — unaffected; CI-config only
- [x] `no-changelog` applied — CI infrastructure, not user-facing
- [x] No unnecessary dependencies added

## Breaking changes

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/871"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783524114&installation_id=134682257&pr_number=871&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F871&signature=263c49d2ef6caf5573b7ede8ad6ee5e9ce498a96a86a49a04d7adc904ba8219a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->