### PR TITLE
fix(#872): make roadmap-phase-fallback tests hermetic against ambient GSD env

### DIFF
--- a/scripts/run-tests.cjs
+++ b/scripts/run-tests.cjs
@@ -236,6 +236,14 @@ function main() {
   // Build the gitignored bin/lib artifact if absent, before any test requires it.
   ensureBuiltArtifacts();
 
+  // Hermeticity: in-process tests resolve `.planning` via planningDir(cwd), which
+  // honours GSD_PROJECT/GSD_WORKSTREAM. A developer shell inside a GSD workstream
+  // exports GSD_WORKSTREAM, which would redirect fixture STATE.md reads away from
+  // each <tmp>/.planning and silently diverge from the clean CI/Docker env. Strip
+  // them so the local runner matches CI; tests that need them set them explicitly.
+  delete process.env.GSD_PROJECT;
+  delete process.env.GSD_WORKSTREAM;
+
   // Log selected files to stderr for CI / harness-test visibility.
   // node:test default reporter doesn't echo filenames, so this gives
   // operators a single stable line they can grep.

--- a/tests/roadmap-phase-fallback.test.cjs
+++ b/tests/roadmap-phase-fallback.test.cjs
@@ -11,6 +11,26 @@ const fs = require('fs');
 const path = require('path');
 const { runGsdTools, createTempProject, cleanup } = require('./helpers.cjs');
 
+// The planning-dir resolver (planningDir) is workstream-aware and honours
+// GSD_PROJECT / GSD_WORKSTREAM. These suites write STATE.md to <tmp>/.planning
+// and assume that is where it is read from, so a developer shell inside a GSD
+// workstream would otherwise redirect the read and break extractCurrentMilestone.
+// Isolate the vars so the file is hermetic when run directly via `node --test`.
+let savedGsdProject;
+let savedGsdWorkstream;
+beforeEach(() => {
+  savedGsdProject = process.env.GSD_PROJECT;
+  savedGsdWorkstream = process.env.GSD_WORKSTREAM;
+  delete process.env.GSD_PROJECT;
+  delete process.env.GSD_WORKSTREAM;
+});
+afterEach(() => {
+  if (savedGsdProject !== undefined) process.env.GSD_PROJECT = savedGsdProject;
+  else delete process.env.GSD_PROJECT;
+  if (savedGsdWorkstream !== undefined) process.env.GSD_WORKSTREAM = savedGsdWorkstream;
+  else delete process.env.GSD_WORKSTREAM;
+});
+
 /**
  * Helper: write STATE.md with a milestone version so extractCurrentMilestone
  * will slice the roadmap to only that milestone's section.
@@ -363,6 +383,51 @@ This is the active milestone body.
       !slice.includes('closed milestone body'),
       'preamble must NOT contain closed v8.0-F body text (preamble boundary fix)'
     );
+  });
+
+  test('(7) workstream-aware: STATE.md under GSD_WORKSTREAM is read from the workstream subdir', () => {
+    // Regression guard for the env-leak that made these suites pass in clean CI but
+    // fail in a developer's GSD_WORKSTREAM shell. planningDir() is workstream-aware,
+    // so STATE.md lives at <cwd>/.planning/workstreams/<ws>/STATE.md. Setting the env
+    // here makes clean CI exercise the polluted-env resolution path.
+    process.env.GSD_WORKSTREAM = 'guard-ws';
+    try {
+      const wsPlanning = path.join(tmpDir, '.planning', 'workstreams', 'guard-ws');
+      fs.mkdirSync(wsPlanning, { recursive: true });
+      fs.writeFileSync(path.join(wsPlanning, 'STATE.md'), '---\nmilestone: v8.0\n---\n');
+      const roadmap = `# Project Roadmap
+
+## v8.0 Overview — v8.0-F (CLOSED FAIL 2026-05-18)
+
+This is the closed milestone body with some text.
+
+### Phase 24: ARCHIVED
+**Goal:** This phase is done and archived.
+
+## v8.0-B Overview (STARTED 2026-05-18)
+
+This is the active milestone body.
+
+### Phase 31: EVAL
+**Goal:** Evaluate the new system.
+
+## v9.0 Future Milestone
+
+### Phase 40: FUTURE
+**Goal:** Future work.
+`;
+      const slice = core.extractCurrentMilestone(roadmap, tmpDir);
+      assert.ok(
+        slice.includes('Phase 31: EVAL'),
+        'workstream-scoped STATE.md must select the active v8.0-B section',
+      );
+      assert.ok(
+        !slice.includes('Phase 24: ARCHIVED'),
+        'closed section must still be excluded under a workstream env',
+      );
+    } finally {
+      delete process.env.GSD_WORKSTREAM;
+    }
   });
 
   test('(2) double-closed-skip: third sibling (active) selected when first two are closed', () => {

--- a/tests/run-tests-harness.test.cjs
+++ b/tests/run-tests-harness.test.cjs
@@ -260,6 +260,32 @@ test('boom', () => { throw new Error('intentional'); });
     });
   });
 
+  describe('env hermeticity', () => {
+    // Regression guard for the two `delete process.env.GSD_PROJECT/GSD_WORKSTREAM`
+    // lines added in scripts/run-tests.cjs main() right after ensureBuiltArtifacts().
+    // If those deletions are removed, the fixture's assertions fail inside the child
+    // node:test process → non-zero harness exit → this test fails → CI catches it.
+    test('harness strips GSD_PROJECT and GSD_WORKSTREAM before running child tests', () => {
+      // Write a fixture that asserts both vars are absent in the child process env.
+      const FIXTURE = `'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+test('ambient GSD workstream vars are stripped by the runner', () => {
+  assert.strictEqual(process.env.GSD_PROJECT, undefined);
+  assert.strictEqual(process.env.GSD_WORKSTREAM, undefined);
+});
+`;
+      fs.writeFileSync(path.join(tmpDir, 'env-hermeticity.test.cjs'), FIXTURE, 'utf8');
+      // Pass both vars in the ambient env given to the harness process.
+      // The harness must delete them before spawning the child node:test process.
+      const r = runHarness(tmpDir, [], {
+        GSD_PROJECT: 'ambient-proj',
+        GSD_WORKSTREAM: 'ambient-ws',
+      });
+      assert.strictEqual(r.status, 0, r.stderr);
+    });
+  });
+
   describe('Windows argv-overflow chunking (issue #3597)', () => {
     // Windows CreateProcess caps lpCommandLine at 32,767 chars. With ~550
     // tests the unchunked spawn fails instantly on Windows with no test


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #872

## What was broken

`tests/roadmap-phase-fallback.test.cjs` failed on a developer's machine while passing in CI/Docker — not a Node-version difference (it reproduces identically on Node 26 and the Docker Node). The real trigger was ambient `GSD_WORKSTREAM` / `GSD_PROJECT` leaking into the in-process planning-dir resolution. Reproduce on any machine: `GSD_WORKSTREAM=foo node --test tests/roadmap-phase-fallback.test.cjs` (14/19 fail; `GSD_PROJECT=bar` → 7 fail; clean env → all pass).

## What this fix does

- `scripts/run-tests.cjs`: strips `GSD_PROJECT` / `GSD_WORKSTREAM` before spawning test children, so the local runner's env matches the clean CI/Docker env (covers all in-process fixture tests; workstream-specific tests set their own vars).
- `tests/roadmap-phase-fallback.test.cjs`: file-level `beforeEach`/`afterEach` that save→delete→restore both vars, making the file hermetic when run directly via `node --test` from a workstream shell.

## Root cause

`extractCurrentMilestone(content, cwd)` reads STATE.md from `path.join(planningDir(cwd), 'STATE.md')`. `planningDir` (`src/planning-workspace.cts`) is workstream-aware: it appends `/<project>` or `/workstreams/<ws>` to `<cwd>/.planning` when `GSD_PROJECT`/`GSD_WORKSTREAM` are set. The fixtures write STATE.md to the plain `<tmp>/.planning/STATE.md`, so an ambient `GSD_WORKSTREAM` redirected the read to a non-existent workstream subdir → `version` stayed `null` → the function returned `stripShippedMilestones(content)` (only strips `<details>`, leaves `##` closed sections) → the "slice must NOT include [closed section]" assertions failed. CI/Docker runs with a clean env, so the redirect path was never exercised. This is a test-hermeticity defect — production legitimately reads per-workstream STATE.md.

## Testing

### How I verified the fix

- `node --test tests/roadmap-phase-fallback.test.cjs` → 20/20 pass
- `GSD_WORKSTREAM=foo node --test tests/roadmap-phase-fallback.test.cjs` → 20/20 (was 14 fail) — the original repro, now green
- `GSD_PROJECT=bar node --test tests/roadmap-phase-fallback.test.cjs` → 20/20 (was 7 fail)
- Full suite (`node scripts/run-tests.cjs`, Mac/Node 26): 4303 pass, 0 fail
- `gsd-test` (Linux Docker): 12728 pass, 0 fail
- `eslint` on all changed files: clean
- Codex adversarial review, `/code-review`, `/security-review`: no actionable correctness/security findings

### Regression test added?

- [x] Yes — added a test that would have caught this bug

Two guards: (1) a test in `roadmap-phase-fallback.test.cjs` that sets `GSD_WORKSTREAM`, writes STATE.md to the workstream subdir, and asserts the active sub-milestone is still selected (pins workstream-aware resolution and makes clean CI exercise the polluted-env path); (2) a test in `run-tests-harness.test.cjs` asserting the runner strips both vars before spawning children — verified to fail if the deletion is removed.

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux

> Not platform-specific — the bug is environment-variable driven, not OS-specific. Verified on macOS (Node 26) and Linux (Docker).

### Runtimes tested

- [x] N/A (not runtime-specific)

> Test-infrastructure change only.

---

## Checklist

- [x] Issue linked above with `Fixes #872`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment — N/A: scripts/+tests/-only change is not user-facing; the changeset gate auto-passes (`OK_NO_USER_FACING_CHANGES`), no `no-changelog` label required
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/873"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783524599&installation_id=134682257&pr_number=873&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F873&signature=0b15486339215c254cd6194b2c1a00df26323bfaf1422908dd18efd69ce4f4d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->