### PR TITLE
fix(#904): normalize phase number in init.execute-phase branch_name

### DIFF
--- a/.changeset/904-init-execute-phase-normalize-branch.md
+++ b/.changeset/904-init-execute-phase-normalize-branch.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 904
+---
+**`init execute-phase` and `cmdCommit` now produce correct `branch_name` when `project_code` is set** — the `{phase}` substitution in `phase_branch_template` now calls `normalizePhaseName()`, stripping the project-code prefix and zero-padding the number, so the generated branch is e.g. `gsd/phase-01-foundation` instead of `gsd/phase-CK-01-foundation`. Both the execute-phase output path (`src/init.cts`) and the pre-execution commit path (`src/commands.cts`) are fixed. (#904)

--- a/src/commands.cts
+++ b/src/commands.cts
@@ -547,7 +547,7 @@ function cmdCommit(cwd: string, message: string | undefined, files: string[] | u
         const phaseInfo = findPhaseInternal(cwd, phaseNum) as Record<string, unknown> | null;
         if (phaseInfo) {
           branchName = (config['phase_branch_template'] as string)
-            .replace('{phase}', phaseInfo['phase_number'] as string)
+            .replace('{phase}', normalizePhaseName(phaseInfo['phase_number']))
             .replace('{slug}', (phaseInfo['phase_slug'] as string) || 'phase');
         }
       }

--- a/src/init.cts
+++ b/src/init.cts
@@ -260,7 +260,7 @@ function cmdInitExecutePhase(
       config.branching_strategy === 'phase' && phaseInfo
         ? (config.phase_branch_template as string)
             .replace('{project}', (config.project_code as string) || '')
-            .replace('{phase}', phaseInfo['phase_number'] as string)
+            .replace('{phase}', normalizePhaseName(phaseInfo['phase_number']))
             .replace('{slug}', (phaseInfo['phase_slug'] as string) || 'phase')
         : config.branching_strategy === 'milestone'
           ? (config.milestone_branch_template as string)

--- a/tests/init.test.cjs
+++ b/tests/init.test.cjs
@@ -538,6 +538,35 @@ describe('init plan-phase zero-padded phase number (bug #2391)', () => {
     assert.strictEqual(out03.phase_req_ids, out3.phase_req_ids,
       'phase_req_ids must be identical regardless of padding');
   });
+
+  // ── #904: branch_name must use normalized (stripped + zero-padded) phase number ──
+  // When project_code is set (e.g. "CK") the phase directory is prefixed:
+  // "CK-01-foundation". extractPhaseToken returns "CK-01" as phase_number.
+  // branch_name must call normalizePhaseName so it strips the prefix and zero-pads,
+  // producing "gsd/phase-01-foundation" rather than "gsd/phase-CK-01-foundation".
+  test('branch_name uses normalized phase number when project_code prefixes phase dir (#904)', () => {
+    seedPhase(tmpDir, 'CK-01-foundation', {
+      'CK-01-01-PLAN.md': '# Plan',
+    });
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({
+        project_code: 'CK',
+        git: {
+          branching_strategy: 'phase',
+          phase_branch_template: 'gsd/phase-{phase}-{slug}',
+        },
+      }, null, 2)
+    );
+
+    const result = runGsdTools('init execute-phase 1', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    // branch_name must use the normalized phase number, not the raw "CK-01" token
+    assert.strictEqual(output.branch_name, 'gsd/phase-01-foundation',
+      'branch_name must use normalized phase number (strip project_code prefix, zero-pad), not raw phase_number');
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #904

---

## What was broken

When `project_code` is set (e.g. `"CK"`), `extractPhaseToken` returns the full prefixed token (e.g. `"CK-01"`) as `phase_number`. The `{phase}` substitution in `phase_branch_template` used this raw value directly, producing branch names like `gsd/phase-CK-01-foundation` instead of the documented padded-numeric form `gsd/phase-01-foundation`.

## What this fix does

Wraps the `{phase}` substitution in `normalizePhaseName()` at both affected sites:

- **`src/init.cts`** — `cmdInitExecutePhase`: the `branch_name` field emitted in the execute-phase JSON output.
- **`src/commands.cts`** — `cmdCommit`: the branch name derived during the pre-execution commit path.

`normalizePhaseName()` strips the project-code prefix and zero-pads the numeric part, aligning the generated branch name with the documented `{phase}` contract (padded number only). This is an intentional, correct behavioral change: `PROJ-42` → `42` (then zero-padded per config).

## Root cause

`phase_number` in the phase-info record is the raw token returned by `extractPhaseToken`, which includes the project-code prefix when one is configured. The `{phase}` substitution was applied to this raw value rather than the normalized numeric form. The `padded_phase` field already uses `normalizePhaseName()` but `branch_name` construction did not.

## Testing

### How I verified the fix

Added a regression test in `tests/init.test.cjs` (under the `init plan-phase zero-padded phase number (bug #2391)` suite) that:
1. Seeds a phase directory named `CK-01-foundation` with `project_code: "CK"` configured.
2. Runs `init execute-phase 1`.
3. Asserts `branch_name === "gsd/phase-01-foundation"` (not `"gsd/phase-CK-01-foundation"`).

All 94 init tests pass (`node --test tests/init.test.cjs`: 94 pass, 0 fail).

### Regression test added?

- [x] Yes — added a test that would have caught this bug

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [x] N/A (not platform-specific — string manipulation only, no path handling)

### Runtimes tested

- [x] N/A (not runtime-specific — core data-layer fix)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added (`904-init-execute-phase-normalize-branch.md`, type: Fixed)
- [x] No unnecessary dependencies added

## Breaking changes

The generated `branch_name` for projects with `project_code` set changes from `gsd/phase-PROJ-NN-slug` to `gsd/phase-NN-slug`. This aligns with the documented `{phase}` contract (padded number only) and matches the value already used by `padded_phase`. Any workflow that was branching off the old (incorrect) name will need to update to the corrected form.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/909"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783563897&installation_id=134682257&pr_number=909&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F909&signature=eaf755af479034bd12e9a19e9e40b644e20ad6eb0804e56669f4f0c108711d2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->