### PR TITLE
fix(#913): guard top-level Claude Code plan-phase against role collapse

### DIFF
--- a/.changeset/913-plan-phase-toplevel-spawn-guard.md
+++ b/.changeset/913-plan-phase-toplevel-spawn-guard.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 913
+---
+**Top-level Claude Code `/gsd-plan-phase` now always spawns the researcher/planner/plan-checker agents instead of collapsing them inline** — a `<runtime_compatibility>` block after `</available_agent_types>` makes the Agent-availability requirement explicit and documents that the workflow fails-closed (stops with a clear log message) in genuinely Agent-less contexts; seven "ORCHESTRATOR RULE — CODEX RUNTIME" labels are renamed to "ALL RUNTIMES" so the guard applies universally; `execute-phase.md` scopes its existing "Other runtimes" inline-fallback prose to non-Claude contexts, preserving the #853 backgrounded-agent behaviour. (#913)

--- a/gsd-core/workflows/execute-phase.md
+++ b/gsd-core/workflows/execute-phase.md
@@ -21,8 +21,11 @@ Orchestrator coordinates, not executes. Each subagent loads the full execute-pla
   instead of spawning parallel agents. Only attempt parallel spawning if the user
   explicitly requests it — and in that case, rely on the spot-check fallback in step 3
   to detect completion.
-- **Other runtimes:** If `Agent`/`agent` tool is unavailable, use sequential inline execution as the
-  fallback. Check for tool availability at runtime rather than assuming based on runtime name.
+- **Other runtimes:** If `Agent`/`agent` tool is genuinely unavailable (e.g. a backgrounded
+  Claude Code agent per #853, or a non-Claude runtime), use sequential inline execution as
+  the fallback for executor parallelization only. If `Agent` IS available (top-level Claude
+  Code), you MUST spawn gsd-executor agents — inline execution is not authorized. Check for
+  actual tool availability, not runtime name.
 
 **Fallback rule:** If a spawned agent completes its work (commits visible, SUMMARY.md exists) but
 the orchestrator never receives the completion signal, treat it as successful based on spot-checks

--- a/gsd-core/workflows/plan-phase.md
+++ b/gsd-core/workflows/plan-phase.md
@@ -27,6 +27,31 @@ Valid GSD subagent types (use exact names — do not fall back to 'general-purpo
 - gsd-plan-checker — Reviews plan quality before execution
 </available_agent_types>
 
+<runtime_compatibility>
+**Subagent spawning — top-level Claude Code:**
+The Agent tool IS available in a top-level Claude Code session. Always spawn
+gsd-phase-researcher, gsd-planner, and gsd-plan-checker as separate Agent() calls.
+Never absorb these roles inline. Role separation is required regardless of `--chain`
+or `--auto` — those options suppress interactive prompts only; they NEVER authorize
+collapsing plan roles into the orchestrator context.
+
+**Backgrounded Claude Code (via manager/autonomous):**
+The calling workflow (manager.md / autonomous.md) already runs plan-phase inline via
+Skill() on Claude Code so that the plan-checker subagent can still spawn. plan-phase
+itself does not need to detect this case.
+
+**#1009 caveat (discuss-phase early-exit):**
+The "display the command and exit" instruction near `## 4` applies only to the
+discuss-phase early-exit path. It does NOT authorize inline role performance for any
+plan-phase agents.
+
+**Other runtimes:**
+If the Agent tool is genuinely absent (e.g. a backgrounded Claude Code agent per
+#853, or a non-Claude runtime that does not expose Agent/agent), log the gap and
+stop — do NOT perform researcher/planner/checker roles inline. Independent agent
+contexts are required for the plan-checker gate to be meaningful.
+</runtime_compatibility>
+
 <process>
 
 ## 0. Git Branch Invariant
@@ -537,7 +562,7 @@ Agent(
 )
 ```
 
-> **ORCHESTRATOR RULE — CODEX RUNTIME**: After calling Agent() above, stop working on this task immediately. Do not read more files, edit code, or run tests related to this task while the subagent is active. Wait for the subagent to return its result. This prevents duplicate work, conflicting edits, and wasted context. Only resume when the subagent result is available.
+> **ORCHESTRATOR RULE — ALL RUNTIMES**: After calling Agent() above, stop working on this task immediately. Do not read more files, edit code, or run tests related to this task while the subagent is active. Wait for the subagent to return its result. This prevents duplicate work, conflicting edits, and wasted context. Only resume when the subagent result is available.
 
 ### Handle Researcher Return
 
@@ -856,7 +881,7 @@ Agent(
 )
 ```
 
-> **ORCHESTRATOR RULE — CODEX RUNTIME**: After calling Agent() above, stop working on this task immediately. Do not read more files, edit code, or run tests related to this task while the subagent is active. Wait for the subagent to return its result. This prevents duplicate work, conflicting edits, and wasted context. Only resume when the subagent result is available.
+> **ORCHESTRATOR RULE — ALL RUNTIMES**: After calling Agent() above, stop working on this task immediately. Do not read more files, edit code, or run tests related to this task while the subagent is active. Wait for the subagent to return its result. This prevents duplicate work, conflicting edits, and wasted context. Only resume when the subagent result is available.
 
 **Handle return:**
 - **`## PATTERN MAPPING COMPLETE`:** Update `PATTERNS_PATH` to the created file path, continue to step 8.
@@ -1019,7 +1044,7 @@ Agent(
 )
 ```
 
-> **ORCHESTRATOR RULE — CODEX RUNTIME**: After calling Agent() above, stop working on this task immediately. Do not read more files, edit code, or run tests related to this task while the subagent is active. Wait for the subagent to return its result. This prevents duplicate work, conflicting edits, and wasted context. Only resume when the subagent result is available.
+> **ORCHESTRATOR RULE — ALL RUNTIMES**: After calling Agent() above, stop working on this task immediately. Do not read more files, edit code, or run tests related to this task while the subagent is active. Wait for the subagent to return its result. This prevents duplicate work, conflicting edits, and wasted context. Only resume when the subagent result is available.
 
 **If `CHUNKED_MODE` is `true`:** Skip the Agent() call above — proceed to step 8.5 instead.
 
@@ -1075,7 +1100,7 @@ Agent(
 )
 ```
 
-> **ORCHESTRATOR RULE — CODEX RUNTIME**: After calling Agent() above, stop working on this task immediately. Do not read more files, edit code, or run tests related to this task while the subagent is active. Wait for the subagent to return its result. This prevents duplicate work, conflicting edits, and wasted context. Only resume when the subagent result is available.
+> **ORCHESTRATOR RULE — ALL RUNTIMES**: After calling Agent() above, stop working on this task immediately. Do not read more files, edit code, or run tests related to this task while the subagent is active. Wait for the subagent to return its result. This prevents duplicate work, conflicting edits, and wasted context. Only resume when the subagent result is available.
 
 Handle return:
 - **`## OUTLINE COMPLETE`:** Read `PLAN-OUTLINE.md`, extract plan list. Continue to 8.5.2.
@@ -1119,7 +1144,7 @@ For each plan entry extracted from `PLAN-OUTLINE.md`:
    )
    ```
 
-   > **ORCHESTRATOR RULE — CODEX RUNTIME**: After calling Agent() above, stop working on this task immediately. Do not read more files, edit code, or run tests related to this task while the subagent is active. Wait for the subagent to return its result. This prevents duplicate work, conflicting edits, and wasted context. Only resume when the subagent result is available.
+   > **ORCHESTRATOR RULE — ALL RUNTIMES**: After calling Agent() above, stop working on this task immediately. Do not read more files, edit code, or run tests related to this task while the subagent is active. Wait for the subagent to return its result. This prevents duplicate work, conflicting edits, and wasted context. Only resume when the subagent result is available.
 
 4. **Verify disk:** Check `${PHASE_DIR}/{plan_id}-PLAN.md` exists. If missing: offer 1) Retry, 2) Stop.
 
@@ -1277,7 +1302,7 @@ Agent(
 )
 ```
 
-> **ORCHESTRATOR RULE — CODEX RUNTIME**: After calling Agent() above, stop working on this task immediately. Do not read more files, edit code, or run tests related to this task while the subagent is active. Wait for the subagent to return its result. This prevents duplicate work, conflicting edits, and wasted context. Only resume when the subagent result is available.
+> **ORCHESTRATOR RULE — ALL RUNTIMES**: After calling Agent() above, stop working on this task immediately. Do not read more files, edit code, or run tests related to this task while the subagent is active. Wait for the subagent to return its result. This prevents duplicate work, conflicting edits, and wasted context. Only resume when the subagent result is available.
 
 ## 11. Handle Checker Return
 
@@ -1392,7 +1417,7 @@ Agent(
 )
 ```
 
-> **ORCHESTRATOR RULE — CODEX RUNTIME**: After calling Agent() above, stop working on this task immediately. Do not read more files, edit code, or run tests related to this task while the subagent is active. Wait for the subagent to return its result. This prevents duplicate work, conflicting edits, and wasted context. Only resume when the subagent result is available.
+> **ORCHESTRATOR RULE — ALL RUNTIMES**: After calling Agent() above, stop working on this task immediately. Do not read more files, edit code, or run tests related to this task while the subagent is active. Wait for the subagent to return its result. This prevents duplicate work, conflicting edits, and wasted context. Only resume when the subagent result is available.
 
 After planner returns -> spawn checker again (step 10), increment iteration_count.
 

--- a/tests/plan-phase-drift-guard.test.cjs
+++ b/tests/plan-phase-drift-guard.test.cjs
@@ -135,3 +135,61 @@ describe('plan-phase workflow: Artifacts this phase produces section (#22)', () 
     );
   });
 });
+
+// ─── (C) Top-level spawn guard (#913) ────────────────────────────────────────
+
+describe('plan-phase workflow: top-level spawn guard (#913)', () => {
+  // Extract the runtime_compatibility block for targeted assertions
+  const rtBlock = (() => {
+    const m = workflow.match(/<runtime_compatibility>([\s\S]*?)<\/runtime_compatibility>/);
+    return m ? m[1] : '';
+  })();
+
+  test('workflow has a runtime_compatibility block asserting Agent is available at top-level', () => {
+    assert.ok(
+      rtBlock.length > 0,
+      'plan-phase must have a <runtime_compatibility> block — prevents role-collapse regression (#913)'
+    );
+    assert.ok(
+      rtBlock.includes('Agent tool IS available') || rtBlock.includes('Agent IS available'),
+      'plan-phase runtime_compatibility must assert that the Agent tool IS available at top-level Claude Code (#913)'
+    );
+    assert.ok(
+      rtBlock.toLowerCase().includes('top-level'),
+      'plan-phase runtime_compatibility must scope the IS-available assertion to top-level Claude Code (#913)'
+    );
+    assert.ok(
+      rtBlock.includes('Always spawn') || rtBlock.includes('always spawn'),
+      'plan-phase runtime_compatibility must state that plan roles must always be spawned (#913)'
+    );
+    assert.ok(
+      rtBlock.includes('Never absorb') || rtBlock.includes('never absorb'),
+      'plan-phase runtime_compatibility must state that roles must never be absorbed inline (#913)'
+    );
+  });
+
+  test('workflow states --chain/--auto suppress prompts only, not spawns', () => {
+    assert.ok(
+      rtBlock.includes('suppress') &&
+      (rtBlock.includes('prompts only') || rtBlock.includes('interactive prompts only')),
+      'plan-phase runtime_compatibility must document that --chain/--auto suppress prompts only, not spawns (#913)'
+    );
+  });
+
+  test('workflow does not contain unscoped CODEX RUNTIME orchestrator rule labels', () => {
+    // All "wait for subagent" rules must apply to ALL RUNTIMES, not just Codex
+    assert.ok(
+      !workflow.includes('ORCHESTRATOR RULE — CODEX RUNTIME'),
+      'plan-phase must not label orchestrator wait rules as "CODEX RUNTIME" — they apply to all runtimes including top-level Claude Code (#913)'
+    );
+  });
+
+  test('workflow contains ALL RUNTIMES orchestrator rule labels (count preserved)', () => {
+    // Must have all 7 agent-spawn wait rules still present (none dropped during rename)
+    const allRuntimesCount = (workflow.match(/ORCHESTRATOR RULE — ALL RUNTIMES/g) || []).length;
+    assert.ok(
+      allRuntimesCount >= 7,
+      `plan-phase must have at least 7 "ORCHESTRATOR RULE — ALL RUNTIMES" labels (one per agent spawn site); found ${allRuntimesCount} (#913)`
+    );
+  });
+});

--- a/tests/workflow-size-budget.test.cjs
+++ b/tests/workflow-size-budget.test.cjs
@@ -81,8 +81,8 @@ const GRACE = 3000;
 // current high-water mark within GRACE (#597 tighten-only ratchet).
 // XL high-water mark is execute-phase.md — note that under LINES it was
 // plan-phase; bytes genuinely re-rank the tier, which is the point of #717.
-// actualMax=91161 (execute-phase, #891 launcher shim expansion — added 17 runtime home arms);
-// slack=1839 ≤ GRACE. plan-phase.md=88120, new-project.md=58110; both well under ceiling.
+// actualMax=92525 (execute-phase, #913 inline-fallback scope clarification);
+// slack=475 ≤ GRACE. plan-phase.md=90501 (#913 runtime_compatibility block + label rename), new-project.md=58110.
 const XL_BUDGET = 93000;
 // LARGE high-water mark is docs-update.md. actualMax=54410 (#891 launcher shim expansion);
 // slack=1590 ≤ GRACE. quick.md=45710, autonomous.md=38030.
@@ -95,8 +95,8 @@ const DEFAULT_BUDGET = 40000;
 // Grandfathered at current sizes — see PR #2551 for the progressive-disclosure
 // pattern that future shrinks should follow. Byte counts noted for reference.
 const XL_WORKFLOWS = new Set([
-  'execute-phase',  // 91161 bytes (tier high-water mark; grew in #891 launcher shim expansion)
-  'plan-phase',     // 85068 bytes
+  'execute-phase',  // 92525 bytes (tier high-water mark; grew in #913 inline-fallback scope clarification)
+  'plan-phase',     // 90501 bytes (grew in #913 runtime_compatibility block + label rename)
   'new-project',    // 55850 bytes
 ]);
 


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #913

---

## What was broken

When `/gsd-plan-phase` was invoked at the top level in Claude Code (not from a background agent), the workflow collapsed the researcher, planner, and plan-checker roles inline instead of spawning them as separate agents. The orchestrator rules were scoped to "CODEX RUNTIME" only, so Claude Code's top-level context silently fell through to inline execution.

## What this fix does

Three-part fix:

1. **`plan-phase.md` — `<runtime_compatibility>` block**: adds an explicit Agent-availability guard after `</available_agent_types>` that requires the `Agent` tool to be present. If absent (genuinely Agent-less context), the workflow fails-closed: stops and logs a clear message rather than silently collapsing roles inline.

2. **`plan-phase.md` — orchestrator rule rename**: seven "ORCHESTRATOR RULE — CODEX RUNTIME" labels are renamed to "ALL RUNTIMES" so the spawn requirement is universal, not Codex-specific.

3. **`execute-phase.md` — scope the inline fallback**: the existing "Other runtimes" inline-fallback prose is explicitly scoped to non-Claude contexts, preserving the #853 backgrounded-agent behaviour for Claude Code background agents (which have no `Agent` tool by design).

## Root cause

The orchestrator rules that enforce agent spawning were labelled "CODEX RUNTIME", causing the model in Claude Code top-level context to conclude they did not apply to it and to proceed with inline role collapse instead.

## Testing

### How I verified the fix

- `node --test tests/plan-phase-drift-guard.test.cjs` — 15/15 pass (includes new #913 assertions verifying the `<runtime_compatibility>` block, the `--chain/--auto` scope note, and the ALL RUNTIMES label count)
- `node --test tests/workflow-size-budget.test.cjs` — 123/123 pass (XL ceiling for plan-phase and execute-phase verified)
- `node --test tests/skill-frontmatter-contract.test.cjs` — 9/9 pass (args-anchor contract confirmed — new block did not re-anchor the window)
- `npm run lint` — clean

### Regression test added?

- [x] Yes — added a test that would have caught this bug (`tests/plan-phase-drift-guard.test.cjs` suite "top-level spawn guard (#913)")

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [x] N/A (not platform-specific)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___

---

## Checklist

- [x] Issue linked above with `Fixes #913` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added — `.changeset/913-plan-phase-toplevel-spawn-guard.md` (type: Fixed)
- [x] No unnecessary dependencies added

## Breaking changes

None — the #853 backgrounded-agent behaviour is explicitly preserved. The fails-closed guard only fires in contexts that genuinely lack the `Agent` tool.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/915"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783567115&installation_id=134682257&pr_number=915&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F915&signature=a6cdcc6caa233415ebc593197dca1e0212d406d66663bfcdc093428a3c3ef7fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->