### PR TITLE
fix(#916): deterministic phase-complete subprocess in regression tests

### DIFF
--- a/tests/phase.test.cjs
+++ b/tests/phase.test.cjs
@@ -3364,6 +3364,55 @@ describe('bug #1962: normalizePhaseName preserves letter suffix case', () => {
 // (consolidated from tests/bug-1998-phase-complete-checkbox.test.cjs)
 // ─────────────────────────────────────────────────────────────────────────────
 
+/**
+ * Run `gsd-tools phase complete <phase>` for the phase-complete regression
+ * suites and return its stdout.
+ *
+ * `phase complete` writes ROADMAP.md as its LAST step, after a read-heavy
+ * parse/lock sequence (ROADMAP read, two extractCurrentMilestone STATE.md
+ * parses, REQUIREMENTS read, phase-dir scan, STATE read — all before the single
+ * writePlanningFileSet flush). Under the high-concurrency docker run (~672 test
+ * files in parallel), a tight 10s timeout could fire mid-parse and SIGTERM the
+ * subprocess BEFORE that write landed, leaving ROADMAP.md untouched. Call sites
+ * that used a bare `catch {}` then silently proceeded to assert on the pristine
+ * file — an intermittent "checkbox not checked" failure (bug #1998 flake).
+ *
+ * Two-part fix, no retry loop:
+ *  1. A generous timeout so the test's own timer never kills the subprocess
+ *     under load (10s cold-node startup × 672-way CPU/IO contention was the
+ *     real culprit — all I/O is scoped to tmpDir, so there is no cross-process
+ *     race to blame).
+ *  2. Never silently swallow a signal/timeout kill: it means the process was
+ *     terminated before completing its writes, so we surface it loudly with
+ *     context instead of letting it masquerade as an assertion failure. A
+ *     *clean* non-zero exit is still tolerated when `tolerateExit` is set,
+ *     because the ROADMAP write has already landed before any post-write step
+ *     that may exit non-zero in these minimal fixtures.
+ */
+function runPhaseComplete(tmpDir, { phase = '1', tolerateExit = false } = {}) {
+  try {
+    return execFileSync('node', [GSD_TOOLS_BIN, 'phase', 'complete', phase], {
+      cwd: tmpDir,
+      timeout: 60000,
+      encoding: 'utf-8',
+    });
+  } catch (err) {
+    // A signal/timeout kill terminated the process before it finished writing —
+    // never tolerate it; surface it with whatever output was captured.
+    if (err.killed || err.signal != null || err.code === 'ETIMEDOUT') {
+      throw new Error(
+        `gsd-tools phase complete ${phase} was killed before completion ` +
+          `(signal=${err.signal}, code=${err.code}). ` +
+          `stdout=${err.stdout || ''} stderr=${err.stderr || ''}`
+      );
+    }
+    if (tolerateExit) {
+      return `${err.stdout || ''}${err.stderr || ''}`;
+    }
+    throw err;
+  }
+}
+
 describe('bug #1998: phase complete updates overview checkbox', () => {
   let tmpDir;
   let planningDir;
@@ -3419,11 +3468,7 @@ describe('bug #1998: phase complete updates overview checkbox', () => {
       '| 2. Features | 0/1 | Pending | - |',
     ].join('\n'));
 
-    try {
-      execFileSync('node', [GSD_TOOLS_BIN, 'phase', 'complete', '1'], { cwd: tmpDir, timeout: 10000 });
-    } catch {
-      // Command may exit non-zero if STATE.md update fails, but ROADMAP.md update happens first
-    }
+    runPhaseComplete(tmpDir, { tolerateExit: true });
 
     const result = fs.readFileSync(roadmapPath, 'utf-8');
     assert.match(result, /- \[x\] \*\*Phase 1: Foundation\*\*/, 'overview checkbox should be checked');
@@ -3468,11 +3513,7 @@ describe('bug #1998: phase complete updates overview checkbox', () => {
       '</details>',
     ].join('\n'));
 
-    try {
-      execFileSync('node', [GSD_TOOLS_BIN, 'phase', 'complete', '1'], { cwd: tmpDir, timeout: 10000 });
-    } catch {
-      // May exit non-zero
-    }
+    runPhaseComplete(tmpDir, { tolerateExit: true });
 
     const result = fs.readFileSync(roadmapPath, 'utf-8');
     assert.match(result, /- \[x\] \*\*Phase 1: Setup\*\*/, 'current milestone checkbox should be checked');
@@ -3559,11 +3600,7 @@ describe('bug #2005: phase complete updates plan count when milestone is inside 
       '</details>',
     ].join('\n'));
 
-    try {
-      execFileSync('node', [GSD_TOOLS_BIN, 'phase', 'complete', '1'], { cwd: tmpDir, timeout: 10000 });
-    } catch {
-      // May exit non-zero if STATE.md update fails, but ROADMAP.md update is the target
-    }
+    runPhaseComplete(tmpDir, { tolerateExit: true });
 
     const result = fs.readFileSync(roadmapPath, 'utf-8');
 
@@ -3619,9 +3656,7 @@ describe('bug #2005: phase complete updates plan count when milestone is inside 
       '</details>',
     ].join('\n'));
 
-    try {
-      execFileSync('node', [GSD_TOOLS_BIN, 'phase', 'complete', '1'], { cwd: tmpDir, timeout: 10000 });
-    } catch {}
+    runPhaseComplete(tmpDir, { tolerateExit: true });
 
     const result = fs.readFileSync(roadmapPath, 'utf-8');
 
@@ -3709,22 +3744,7 @@ describe('bug #2526: phase complete warns about unregistered REQ-IDs', () => {
       '| REQ-001 | 1 | Pending |',
     ].join('\n'));
 
-    let stdout = '';
-    let stderr = '';
-    try {
-      const result = execFileSync('node', [GSD_TOOLS_BIN, 'phase', 'complete', '1'], {
-        cwd: tmpDir,
-        timeout: 10000,
-        encoding: 'utf-8',
-      });
-      stdout = result;
-    } catch (err) {
-      stdout = err.stdout || '';
-      stderr = err.stderr || '';
-      throw err;
-    }
-
-    const combined = stdout + stderr;
+    const combined = runPhaseComplete(tmpDir);
     assert.match(combined, /REQ-002/, 'output should mention REQ-002 as missing from Traceability table');
     assert.match(combined, /REQ-003/, 'output should mention REQ-003 as missing from Traceability table');
   });
@@ -3776,22 +3796,7 @@ describe('bug #2526: phase complete warns about unregistered REQ-IDs', () => {
       '| REQ-002 | 1 | Pending |',
     ].join('\n'));
 
-    let stdout = '';
-    let stderr = '';
-    try {
-      const result = execFileSync('node', [GSD_TOOLS_BIN, 'phase', 'complete', '1'], {
-        cwd: tmpDir,
-        timeout: 10000,
-        encoding: 'utf-8',
-      });
-      stdout = result;
-    } catch (err) {
-      stdout = err.stdout || '';
-      stderr = err.stderr || '';
-      throw err;
-    }
-
-    const combined = stdout + stderr;
+    const combined = runPhaseComplete(tmpDir);
     assert.doesNotMatch(
       combined,
       /unregistered|missing.*traceability|not in.*traceability/i,
@@ -3845,22 +3850,7 @@ describe('bug #2526: phase complete warns about unregistered REQ-IDs', () => {
       '| REQ-001 | 1 | Pending |',
     ].join('\n'));
 
-    let stdout = '';
-    let stderr = '';
-    try {
-      const result = execFileSync('node', [GSD_TOOLS_BIN, 'phase', 'complete', '1'], {
-        cwd: tmpDir,
-        timeout: 10000,
-        encoding: 'utf-8',
-      });
-      stdout = result;
-    } catch (err) {
-      stdout = err.stdout || '';
-      stderr = err.stderr || '';
-      throw err;
-    }
-
-    const combined = stdout + stderr;
+    const combined = runPhaseComplete(tmpDir);
     assert.match(combined, /REQ-002/, 'should warn about REQ-002');
     assert.match(combined, /REQ-003/, 'should warn about REQ-003');
     assert.match(combined, /REQ-004/, 'should warn about REQ-004');


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #916

> Linked issue carries the `confirmed-bug` label.

---

## What was broken

The `bug #1998` regression subtest `checkbox updated when archived milestones exist in <details>` (`tests/phase.test.cjs`) flaked **only** under the high-concurrency docker run (`gsd-test`, ~672 test files in parallel): the current-milestone checkbox was intermittently left unchecked (both phases rendered `- [ ]`). It passed reliably on Mac local, in `npm run test:unit`, and on clean `gsd-test --reset` re-runs.

## What this fix does

Consolidates all 7 duplicated `phase complete` call sites across the `#1998`, `#2005`, and `#2526` regression suites into one shared `runPhaseComplete()` helper that (1) raises the subprocess timeout from 10s to 60s so the test's own timer never kills the CLI under load, and (2) never silently swallows a signal/timeout kill — it rethrows loudly with captured output — while still tolerating a *clean* non-zero exit for the ROADMAP-asserting tests. No retry loop.

## Root cause

`gsd-tools phase complete` writes `ROADMAP.md` as its **last** step (`writePlanningFileSet`), after a read-heavy parse/lock sequence (ROADMAP read → two `extractCurrentMilestone` STATE.md parses → REQUIREMENTS read → phase-dir scan → STATE read). Under ~672-way parallel CPU/IO contention the tight `timeout: 10000` fired mid-parse and Node SIGTERM'd the subprocess **before** that write landed, leaving `ROADMAP.md` pristine. The bare `catch {}` swallowed the SIGTERM, so a timeout-kill masqueraded as a "checkbox not checked" assertion failure. The `<details>` variant flaked most because its milestone extraction does strictly more work. All I/O is scoped to each test's `mkdtemp` `tmpDir`, so there is no cross-process filesystem race — the timeout was the sole cause.

## Testing

### How I verified the fix

- 3× `gsd-test --reset` full docker runs (13207 tests / 2311 suites each, including a heavier ~124s-wall run under elevated contention) — **0 failures**, the previously-flaky subtest green every round.
- `npm run build:lib` + the affected suites (`#1998`/`#2005`/`#2526`, 7 tests) pass locally on the rebased `next` base.
- `npm run lint` clean; independent `/code-review`, `/security-review`, and Codex adversarial review all returned no findings.

### Regression test added?

- [x] No — explain why: the bug was non-determinism in the **test harness itself** (a timeout-kill under load masked by a silent catch), not in product code. There is no deterministic unit test for "subprocess killed under parallel load"; the fix instead removes the source of non-determinism in the existing regression tests, and determinism is verified by repeated full docker `--reset` runs.

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

> Change is platform-agnostic test-harness code (timeout value + error discrimination). Windows is covered by CI.

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment not required — test-only change, no user-facing files touched (`changeset-lint` → `ok_no_user_facing_changes`)
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/917"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783567626&installation_id=134682257&pr_number=917&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F917&signature=419089f1583b5cb671c059ca431b82aea1baa1acac99cd308b2b7c8017e3f11d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->