### PR TITLE
chore(#930): remove self-masking next dist-tag repoint from release finalize

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -642,16 +642,6 @@ jobs:
             --post \
             --allow-missing-webhook
 
-      - name: Clean up next dist-tag
-        if: ${{ !inputs.dry_run }}
-        env:
-          VERSION: ${{ inputs.version }}
-        run: |
-          # Point next to the stable release so @next never returns something
-          # older than @latest. This prevents stale pre-release installs.
-          npm dist-tag add "@opengsd/gsd-core@${VERSION}" next 2>/dev/null || true
-          echo "✓ next dist-tag updated to v${VERSION}"
-
       - name: Verify publish
         if: ${{ !inputs.dry_run }}
         env:

--- a/docs/adr/660-release-from-next-head.md
+++ b/docs/adr/660-release-from-next-head.md
@@ -79,7 +79,7 @@ or a movable tag — as the RC surface.** Concretely:
 4. **RC = the `@next` dist-tag, full stop.** Testers run `npm i -g @opengsd/gsd-core@next`.
    Because each `rc` run is cut from `next` HEAD, every rc.N already includes all prior fixes.
    No long-lived branch, no tag movement. `finalize` promotes the released version to `@latest`
-   (and keeps the existing `npm dist-tag add … next` so `@next` never trails `@latest`).
+   (`@next` remains the prerelease channel managed exclusively by the `rc` job; `finalize` does not repoint it).
 
 5. **Everything else stays:** custom changesets + CHANGELOG render, release-notes formatter,
    smoke-test gates, provenance, `main`/`next`, `auto-backmerge` (main→next).


### PR DESCRIPTION
## What

Removes the **"Clean up next dist-tag"** step from the `finalize` job in `.github/workflows/release.yml`, and updates ADR-660 to match.

Closes #930

## Why

The step was self-masking and did something the release model doesn't want:

1. **Self-masking / false success.** `npm dist-tag add … next 2>/dev/null || true` followed by an unconditional `echo "✓ … updated"` reported success even when the command failed. Under the finalize job's **OIDC trusted publishing** (no `NODE_AUTH_TOKEN`), `npm dist-tag add` can't write dist-tags (publish-scoped only), so the repoint silently no-op'd while the log claimed success. It masked *any* failure of that command.
2. **Unwanted behavior.** `@next` is intentionally the **prerelease channel**, set by the `rc` job's `npm publish --tag next`. `@next` pointing at the latest RC (even if older than `@latest`) is by design and stays put until a new prerelease is cut. `finalize` should not repoint `next`→stable.

## Change

- Delete the step (name + `if` + `env` + `run`). Nothing downstream consumed its output; the `rc` job's `--tag next` publish remains the sole manager of `@next`, and "Verify publish" still checks `--dist-tag latest`.
- ADR-660: the `@next` description now states `finalize` does not repoint it.

## Type

CI/release-workflow internal change, no user-facing behavior → `no-changelog`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/931"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783602061&installation_id=134682257&pr_number=931&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F931&signature=895db74313bfaef2165b2abef29ac7107d1ee5fe593bc038feadb20707286989"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->