### PR TITLE
fix(#950): emit status: complete in quick-task SUMMARY frontmatter

### DIFF
--- a/.changeset/silly-pandas-munch.md
+++ b/.changeset/silly-pandas-munch.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 951
+---
+**`audit-open` no longer false-flags completed quick tasks** — quick-task SUMMARYs now carry `status: complete` in frontmatter by construction, so the milestone-close auditor stops reporting finished quick tasks as `[unknown]`.

--- a/agents/gsd-executor.md
+++ b/agents/gsd-executor.md
@@ -604,7 +604,7 @@ This file is the canonical output of this step. The orchestrator reads `.plannin
 
 **Use template:** @~/.claude/gsd-core/templates/summary.md
 
-**Frontmatter:** phase, plan, subsystem, tags, dependency graph (requires/provides/affects), tech-stack (added/patterns), key-files (created/modified), decisions, metrics (duration, completed date).
+**Frontmatter:** phase, plan, subsystem, tags, dependency graph (requires/provides/affects), tech-stack (added/patterns), key-files (created/modified), decisions, metrics (duration, completed date), status (`status: complete` — required so the audit-open scanner recognises the summary as done).
 
 **Title:** `# Phase [X] Plan [Y]: [Name] Summary`
 

--- a/gsd-core/templates/summary-complex.md
+++ b/gsd-core/templates/summary-complex.md
@@ -21,6 +21,7 @@ patterns-established:
   - "Pattern 1: description"
 duration: Xmin
 completed: YYYY-MM-DD
+status: complete
 ---
 
 # Phase [X]: [Name] Summary (Complex)

--- a/gsd-core/templates/summary-minimal.md
+++ b/gsd-core/templates/summary-minimal.md
@@ -15,6 +15,7 @@ key-files:
 key-decisions: []
 duration: Xmin
 completed: YYYY-MM-DD
+status: complete
 ---
 
 # Phase [X]: [Name] Summary (Minimal)

--- a/gsd-core/templates/summary-standard.md
+++ b/gsd-core/templates/summary-standard.md
@@ -16,6 +16,7 @@ key-decisions:
   - "Decision 1"
 duration: Xmin
 completed: YYYY-MM-DD
+status: complete
 ---
 
 # Phase [X]: [Name] Summary

--- a/gsd-core/templates/summary.md
+++ b/gsd-core/templates/summary.md
@@ -43,6 +43,7 @@ requirements-completed: []  # REQUIRED — Copy ALL requirement IDs from this pl
 # Metrics
 duration: Xmin
 completed: YYYY-MM-DD
+status: complete
 ---
 
 # Phase [X]: [Name] Summary

--- a/gsd-core/workflows/quick.md
+++ b/gsd-core/workflows/quick.md
@@ -728,7 +728,7 @@ SUMMARY.md and stop — the user must rerun with worktrees disabled.
 - Execute all tasks in the plan
 - Commit each task atomically (code changes only)
 - Run the <submodule_commit_guard> bash block before every \`git commit\` if SUBMODULE_PATHS is non-empty
-- Create summary at: ${QUICK_DIR}/${quick_id}-SUMMARY.md
+- Create summary at: ${QUICK_DIR}/${quick_id}-SUMMARY.md with `status: complete` in SUMMARY frontmatter (required so the audit-open milestone-close scanner recognises the task as done, not [unknown])
 - Do NOT commit docs artifacts (SUMMARY.md, STATE.md, PLAN.md) — the orchestrator handles the docs commit in Step 8
 - Do NOT update ROADMAP.md (quick tasks are separate from planned phases)
 </constraints>

--- a/tests/bug-950-quick-summary-status-complete.test.cjs
+++ b/tests/bug-950-quick-summary-status-complete.test.cjs
@@ -1,3 +1,4 @@
+// allow-test-rule: source-text-is-the-product
 /**
  * Regression tests for bug #950
  *
@@ -12,6 +13,7 @@
  *
  * Primary guard:   behavioral audit-scanner tests (tasks read by scanQuickTasks)
  * Secondary guard: template-contract text checks (template text IS the runtime contract)
+ * Writer-path guard: contract assertions on quick.md + gsd-executor.md (source-text-is-the-product)
  */
 
 'use strict';
@@ -27,9 +29,42 @@ const { auditOpenArtifacts } = auditModule;
 const { cleanup } = require('./helpers.cjs');
 
 const TEMPLATES_DIR = path.resolve(__dirname, '..', 'gsd-core', 'templates');
+const QUICK_MD = path.resolve(__dirname, '..', 'gsd-core', 'workflows', 'quick.md');
+const EXECUTOR_MD = path.resolve(__dirname, '..', 'agents', 'gsd-executor.md');
 
 function mkTmp() {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'bug-950-'));
+}
+
+/**
+ * Extract the first YAML frontmatter block from a file's content.
+ *
+ * Two layouts are handled:
+ *  - Leading frontmatter: file starts with `---\n…\n---` (summary-minimal/standard/complex.md)
+ *  - Fenced frontmatter: frontmatter lives inside a ```markdown … ``` fence (summary.md,
+ *    whose content IS a markdown example showing the template). In that case we extract
+ *    the `---\n…\n---` block that sits immediately after the opening fence line.
+ *
+ * Returns the raw text of the YAML block (between the two `---` delimiters, exclusive),
+ * or null if no frontmatter could be found.
+ */
+function extractFrontmatter(content) {
+  // Case 1: file begins with --- (leading frontmatter)
+  if (/^---\r?\n/.test(content)) {
+    const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n/);
+    return match ? match[1] : null;
+  }
+
+  // Case 2: frontmatter is embedded inside a fenced block (```markdown\n---\n…\n---\n)
+  const fenceMatch = content.match(/```(?:markdown|md)?\r?\n(---\r?\n[\s\S]*?\r?\n---)\r?\n/);
+  if (fenceMatch) {
+    // Strip the outer --- delimiters to get just the YAML body
+    const block = fenceMatch[1];
+    const inner = block.match(/^---\r?\n([\s\S]*?)\r?\n---$/);
+    return inner ? inner[1] : null;
+  }
+
+  return null;
 }
 
 describe('bug #950: quick-task SUMMARY must carry status: complete', () => {
@@ -180,39 +215,87 @@ describe('bug #950: quick-task SUMMARY must carry status: complete', () => {
   });
 
   // ── Secondary: template-contract checks ──────────────────────────────────
-  // (source-text-is-the-product exemption: template text is the runtime contract)
+  // Assertions are scoped to the actual YAML frontmatter block, not the whole file,
+  // so a stray `status: complete` in prose or examples cannot produce a false green.
 
   test('[TEMPLATE CONTRACT] summary.md contains status: complete in frontmatter', () => {
+    // summary.md is a documentation template — its frontmatter lives inside a
+    // ```markdown fence. extractFrontmatter() finds and returns that block.
     const content = fs.readFileSync(path.join(TEMPLATES_DIR, 'summary.md'), 'utf-8');
-    // The field must appear inside the YAML frontmatter block of the embedded template
-    // (between the ```markdown fence and the closing ```)
+    const fm = extractFrontmatter(content);
     assert.ok(
-      /^status:\s*complete\s*$/m.test(content),
-      'gsd-core/templates/summary.md must contain `status: complete` in its frontmatter template'
+      fm !== null,
+      'gsd-core/templates/summary.md: could not locate a YAML frontmatter block (leading --- or fenced ```markdown --- block)'
+    );
+    assert.ok(
+      /^status:\s*complete\s*$/m.test(fm),
+      `gsd-core/templates/summary.md: \`status: complete\` not found in the frontmatter block.\n` +
+      `Frontmatter extracted:\n${fm}`
     );
   });
 
   test('[TEMPLATE CONTRACT] summary-minimal.md contains status: complete in frontmatter', () => {
     const content = fs.readFileSync(path.join(TEMPLATES_DIR, 'summary-minimal.md'), 'utf-8');
+    const fm = extractFrontmatter(content);
     assert.ok(
-      /^status:\s*complete\s*$/m.test(content),
-      'gsd-core/templates/summary-minimal.md must contain `status: complete` in its frontmatter'
+      fm !== null,
+      'gsd-core/templates/summary-minimal.md: could not locate a leading YAML frontmatter block'
+    );
+    assert.ok(
+      /^status:\s*complete\s*$/m.test(fm),
+      `gsd-core/templates/summary-minimal.md: \`status: complete\` not found in the frontmatter block.\n` +
+      `Frontmatter extracted:\n${fm}`
     );
   });
 
   test('[TEMPLATE CONTRACT] summary-standard.md contains status: complete in frontmatter', () => {
     const content = fs.readFileSync(path.join(TEMPLATES_DIR, 'summary-standard.md'), 'utf-8');
+    const fm = extractFrontmatter(content);
     assert.ok(
-      /^status:\s*complete\s*$/m.test(content),
-      'gsd-core/templates/summary-standard.md must contain `status: complete` in its frontmatter'
+      fm !== null,
+      'gsd-core/templates/summary-standard.md: could not locate a leading YAML frontmatter block'
+    );
+    assert.ok(
+      /^status:\s*complete\s*$/m.test(fm),
+      `gsd-core/templates/summary-standard.md: \`status: complete\` not found in the frontmatter block.\n` +
+      `Frontmatter extracted:\n${fm}`
     );
   });
 
   test('[TEMPLATE CONTRACT] summary-complex.md contains status: complete in frontmatter', () => {
     const content = fs.readFileSync(path.join(TEMPLATES_DIR, 'summary-complex.md'), 'utf-8');
+    const fm = extractFrontmatter(content);
     assert.ok(
-      /^status:\s*complete\s*$/m.test(content),
-      'gsd-core/templates/summary-complex.md must contain `status: complete` in its frontmatter'
+      fm !== null,
+      'gsd-core/templates/summary-complex.md: could not locate a leading YAML frontmatter block'
+    );
+    assert.ok(
+      /^status:\s*complete\s*$/m.test(fm),
+      `gsd-core/templates/summary-complex.md: \`status: complete\` not found in the frontmatter block.\n` +
+      `Frontmatter extracted:\n${fm}`
+    );
+  });
+
+  // ── Writer-path contract checks ───────────────────────────────────────────
+  // Guards quick.md and gsd-executor.md so a future edit removing `status: complete`
+  // from the SUMMARY-creation instructions would fail the suite before the bug recurs.
+  // (source-text-is-the-product: the deployed .md text IS the runtime contract for agents)
+
+  test('[WRITER-PATH] quick.md constraints require status: complete in SUMMARY frontmatter', () => {
+    const content = fs.readFileSync(QUICK_MD, 'utf-8');
+    assert.ok(
+      /status:\s*complete/.test(content),
+      'gsd-core/workflows/quick.md must instruct the executor to write `status: complete` in the SUMMARY frontmatter. ' +
+      'The <constraints> block must contain the `status: complete` requirement so a future edit cannot silently drop it.'
+    );
+  });
+
+  test('[WRITER-PATH] gsd-executor.md frontmatter spec requires status: complete', () => {
+    const content = fs.readFileSync(EXECUTOR_MD, 'utf-8');
+    assert.ok(
+      /status[\s\S]{0,40}complete/.test(content),
+      'agents/gsd-executor.md must document `status: complete` as a required SUMMARY frontmatter field. ' +
+      'The Frontmatter section must include `status: complete` so the executor always emits it.'
     );
   });
 });

--- a/tests/bug-950-quick-summary-status-complete.test.cjs
+++ b/tests/bug-950-quick-summary-status-complete.test.cjs
@@ -1,0 +1,218 @@
+/**
+ * Regression tests for bug #950
+ *
+ * audit-open chronically flagged genuinely-complete quick tasks as [unknown]
+ * because NO shipped summary template carried a `status:` frontmatter field —
+ * so status was only emitted when the writing agent improvised it.
+ *
+ * The fix: add `status: complete` to all four summary templates and enforce it
+ * in the executor agent + quick.md workflow. Tests here exercise the scanner
+ * directly via auditOpenArtifacts() and also guard template text as a secondary
+ * contract check.
+ *
+ * Primary guard:   behavioral audit-scanner tests (tasks read by scanQuickTasks)
+ * Secondary guard: template-contract text checks (template text IS the runtime contract)
+ */
+
+'use strict';
+
+const { describe, test, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const auditModule = require('../gsd-core/bin/lib/audit.cjs');
+const { auditOpenArtifacts } = auditModule;
+const { cleanup } = require('./helpers.cjs');
+
+const TEMPLATES_DIR = path.resolve(__dirname, '..', 'gsd-core', 'templates');
+
+function mkTmp() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'bug-950-'));
+}
+
+describe('bug #950: quick-task SUMMARY must carry status: complete', () => {
+  // Ensure GSD env vars do not redirect planningDir() away from our fixture.
+  let prevProject, prevWorkstream;
+  before(() => {
+    prevProject = process.env.GSD_PROJECT;
+    prevWorkstream = process.env.GSD_WORKSTREAM;
+    delete process.env.GSD_PROJECT;
+    delete process.env.GSD_WORKSTREAM;
+  });
+  after(() => {
+    if (prevProject !== undefined) process.env.GSD_PROJECT = prevProject;
+    if (prevWorkstream !== undefined) process.env.GSD_WORKSTREAM = prevWorkstream;
+  });
+
+  // ── Behavioral: scanner recognizes complete quick tasks ───────────────────
+
+  test('[PRIMARY] quick task SUMMARY with status: complete is NOT flagged open', () => {
+    // Simulates an executor that correctly wrote the SUMMARY with status: complete
+    // (as required after the fix). The scanner must report 0 open quick tasks.
+    const cwd = mkTmp();
+    try {
+      const quickId = '260609-test-status-complete';
+      const taskDir = path.join(cwd, '.planning', 'quick', quickId);
+      fs.mkdirSync(taskDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(taskDir, `${quickId}-SUMMARY.md`),
+        [
+          '---',
+          'status: complete',
+          'date: 2026-06-09',
+          'slug: test-status-complete',
+          '---',
+          '',
+          '# Quick Task Summary',
+          '',
+          'Task completed successfully.',
+        ].join('\n'),
+        'utf-8'
+      );
+
+      const result = auditOpenArtifacts(cwd);
+      const realQuickTasks = result.items.quick_tasks.filter(
+        i => !i.scan_error && !i._remainder_count
+      );
+
+      assert.equal(
+        realQuickTasks.length,
+        0,
+        `quick task SUMMARY with status: complete must NOT appear as open; ` +
+        `got: ${JSON.stringify(realQuickTasks)}`
+      );
+      assert.equal(result.counts.quick_tasks, 0);
+    } finally {
+      cleanup(cwd);
+    }
+  });
+
+  test('[PRIMARY] quick task SUMMARY without status: field is still flagged [unknown]', () => {
+    // Negative case: a SUMMARY that lacks status: still surfaces as [unknown].
+    // This proves the scanner still catches real gaps — the fix must be on the writer side.
+    const cwd = mkTmp();
+    try {
+      const quickId = '260609-test-no-status';
+      const taskDir = path.join(cwd, '.planning', 'quick', quickId);
+      fs.mkdirSync(taskDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(taskDir, `${quickId}-SUMMARY.md`),
+        [
+          '---',
+          'date: 2026-06-09',
+          'slug: test-no-status',
+          '---',
+          '',
+          '# Quick Task Summary',
+          '',
+          'Task done, but no status field.',
+        ].join('\n'),
+        'utf-8'
+      );
+
+      const result = auditOpenArtifacts(cwd);
+      const realQuickTasks = result.items.quick_tasks.filter(
+        i => !i.scan_error && !i._remainder_count
+      );
+
+      assert.equal(
+        realQuickTasks.length,
+        1,
+        `quick task SUMMARY without status: must appear as open (unknown); ` +
+        `got: ${JSON.stringify(realQuickTasks)}`
+      );
+      assert.equal(realQuickTasks[0].status, 'unknown', 'expected status to be unknown');
+    } finally {
+      cleanup(cwd);
+    }
+  });
+
+  test('[PRIMARY] quick task without any SUMMARY is still flagged [missing]', () => {
+    // Proves the missing-SUMMARY case still surfaces.
+    const cwd = mkTmp();
+    try {
+      const quickId = '260609-test-missing-summary';
+      const taskDir = path.join(cwd, '.planning', 'quick', quickId);
+      fs.mkdirSync(taskDir, { recursive: true });
+      // No SUMMARY file at all.
+
+      const result = auditOpenArtifacts(cwd);
+      const realQuickTasks = result.items.quick_tasks.filter(
+        i => !i.scan_error && !i._remainder_count
+      );
+
+      assert.equal(realQuickTasks.length, 1, 'missing SUMMARY must still be flagged');
+      assert.equal(realQuickTasks[0].status, 'missing');
+    } finally {
+      cleanup(cwd);
+    }
+  });
+
+  test('[PRIMARY] SUMMARY with status: COMPLETE (uppercase) is also recognized', () => {
+    // Scanner lowercases before comparing — verify case-insensitivity holds.
+    const cwd = mkTmp();
+    try {
+      const quickId = '260609-test-uppercase-complete';
+      const taskDir = path.join(cwd, '.planning', 'quick', quickId);
+      fs.mkdirSync(taskDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(taskDir, `${quickId}-SUMMARY.md`),
+        '---\nstatus: COMPLETE\n---\n# Summary\nDone.\n',
+        'utf-8'
+      );
+
+      const result = auditOpenArtifacts(cwd);
+      const realQuickTasks = result.items.quick_tasks.filter(
+        i => !i.scan_error && !i._remainder_count
+      );
+
+      assert.equal(
+        realQuickTasks.length,
+        0,
+        `quick task SUMMARY with status: COMPLETE (uppercase) must not appear as open; ` +
+        `got: ${JSON.stringify(realQuickTasks)}`
+      );
+    } finally {
+      cleanup(cwd);
+    }
+  });
+
+  // ── Secondary: template-contract checks ──────────────────────────────────
+  // (source-text-is-the-product exemption: template text is the runtime contract)
+
+  test('[TEMPLATE CONTRACT] summary.md contains status: complete in frontmatter', () => {
+    const content = fs.readFileSync(path.join(TEMPLATES_DIR, 'summary.md'), 'utf-8');
+    // The field must appear inside the YAML frontmatter block of the embedded template
+    // (between the ```markdown fence and the closing ```)
+    assert.ok(
+      /^status:\s*complete\s*$/m.test(content),
+      'gsd-core/templates/summary.md must contain `status: complete` in its frontmatter template'
+    );
+  });
+
+  test('[TEMPLATE CONTRACT] summary-minimal.md contains status: complete in frontmatter', () => {
+    const content = fs.readFileSync(path.join(TEMPLATES_DIR, 'summary-minimal.md'), 'utf-8');
+    assert.ok(
+      /^status:\s*complete\s*$/m.test(content),
+      'gsd-core/templates/summary-minimal.md must contain `status: complete` in its frontmatter'
+    );
+  });
+
+  test('[TEMPLATE CONTRACT] summary-standard.md contains status: complete in frontmatter', () => {
+    const content = fs.readFileSync(path.join(TEMPLATES_DIR, 'summary-standard.md'), 'utf-8');
+    assert.ok(
+      /^status:\s*complete\s*$/m.test(content),
+      'gsd-core/templates/summary-standard.md must contain `status: complete` in its frontmatter'
+    );
+  });
+
+  test('[TEMPLATE CONTRACT] summary-complex.md contains status: complete in frontmatter', () => {
+    const content = fs.readFileSync(path.join(TEMPLATES_DIR, 'summary-complex.md'), 'utf-8');
+    assert.ok(
+      /^status:\s*complete\s*$/m.test(content),
+      'gsd-core/templates/summary-complex.md must contain `status: complete` in its frontmatter'
+    );
+  });
+});


### PR DESCRIPTION
## What was broken

The `audit-open` milestone-close scanner (`scanQuickTasks()` in `src/audit.cts`) decides a quick task is complete by reading `status:` from `{quick_id}-SUMMARY.md` frontmatter. Only `status: complete` (case-insensitive) is treated as done.

However, **none of the shipped SUMMARY templates** carried a `status:` field, and the executor agent's frontmatter spec did not list one. The field only appeared when the writing agent improvised it — which it did not reliably do. Result: genuinely-complete quick tasks were chronically flagged `[unknown]` at milestone close (confirmed case: 17/64 SUMMARYs, six consecutive false-positive closes).

## The fix (writer-side, defense-in-depth)

The scanner is correct and **unchanged**. The fix guarantees `status: complete` by construction on the writer side:

1. **`gsd-core/templates/summary.md`** — added `status: complete` to the embedded frontmatter block
2. **`gsd-core/templates/summary-minimal.md`** — added `status: complete` to frontmatter
3. **`gsd-core/templates/summary-standard.md`** — added `status: complete` to frontmatter
4. **`gsd-core/templates/summary-complex.md`** — added `status: complete` to frontmatter
5. **`agents/gsd-executor.md`** — added `status` to the documented frontmatter field list in `<summary_creation>` with a note explaining why it is required
6. **`gsd-core/workflows/quick.md`** — added explicit constraint to the executor's `<constraints>` block: `status: complete` must be set in SUMMARY frontmatter

## Root cause

Writer/reader contract gap: the scanner expected a field the templates never emitted. No single owner — the scanner was written correctly against a spec, but the templates predated the spec.

## Blast-radius analysis

`summary.md` is shared between quick-task SUMMARYs and phase-plan SUMMARYs. Concern: does baking `status: complete` into the shared template affect phase-plan consumers?

**Finding: no behavioral regression.** Phase `disk_status` (used by `init.cts`, `roadmap.cts`, `commands.cts`) is derived purely from file-count heuristics (summaries-vs-plans) — it never reads SUMMARY frontmatter `status:`. The only scanner that reads `status:` from a SUMMARY is `scanQuickTasks()` in `audit.cts`, which exclusively reads from `.planning/quick/`. Adding the field to phase-plan SUMMARYs is inert and the value `complete` is semantically accurate for a finished plan.

**Decision: use the shared template** (not a quick-specific variant), because:
- No other consumer is affected (verified by grep of `src/`, `bin/`, `tests/`)
- Defense-in-depth: phase-plan SUMMARYs now also carry the field, future-proofing against scanners that might query it
- Simpler than forking a quick-specific template variant

## Testing

**Regression test:** `tests/bug-950-quick-summary-status-complete.test.cjs`

- RED before fix: 4 template-contract tests fail (templates lack `status: complete`); 4 behavioral scanner tests already pass (scanner logic is correct)
- GREEN after fix: all 8 tests pass

Test coverage:
- `[PRIMARY]` quick task SUMMARY with `status: complete` → NOT flagged open
- `[PRIMARY]` quick task SUMMARY without `status:` → still flagged `[unknown]` (scanner still catches real gaps)
- `[PRIMARY]` quick task without any SUMMARY → still flagged `[missing]`
- `[PRIMARY]` `status: COMPLETE` (uppercase) → recognized (case-insensitive)
- `[TEMPLATE CONTRACT]` all four template files contain `status: complete`

Related tests also pass: `bug-2836-audit-open-summary-uat-drift.test.cjs`, `bug-2659-audit-open-crash.test.cjs`, `bug-2911-audit-open-output-shape.test.cjs`, `audit-fix-command.test.cjs` (49/49)

**Platforms:** Template/workflow/agent .md changes are platform-agnostic; no binary or runtime-specific code changed.

**Breaking changes:** None. `status: complete` is an additive frontmatter field. Existing SUMMARYs on disk without it continue to surface correctly as `[unknown]` until regenerated.

Fixes #950

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/951"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783647780&installation_id=134682257&pr_number=951&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F951&signature=96174c62eb7a17cb6c8a7cf86b0fd36147cb6bdeed2143399704c6f89cf7ff8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->