### PR TITLE
fix(#978): parse --force in milestone complete dispatcher so the guard's documented override works

### DIFF
--- a/.changeset/978-milestone-complete-force-flag.md
+++ b/.changeset/978-milestone-complete-force-flag.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 982
 ---
 **`gsd-tools milestone complete --force` now actually overrides the unstarted-phase guard** — the dispatcher never parsed `--force`, so the guard's own documented escape hatch was inert. (#978)

--- a/.changeset/978-milestone-complete-force-flag.md
+++ b/.changeset/978-milestone-complete-force-flag.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`gsd-tools milestone complete --force` now actually overrides the unstarted-phase guard** — the dispatcher never parsed `--force`, so the guard's own documented escape hatch was inert. (#978)

--- a/gsd-core/bin/gsd-tools.cjs
+++ b/gsd-core/bin/gsd-tools.cjs
@@ -1155,7 +1155,8 @@ async function runCommand(command, args, cwd, raw, defaultValue, originalCommand
       if (subcommand === 'complete') {
         const milestoneName = parseMultiwordArg(args, 'name');
         const archivePhases = args.includes('--archive-phases');
-        milestone.cmdMilestoneComplete(cwd, args[2], { name: milestoneName, archivePhases }, raw);
+        const force = args.includes('--force');
+        milestone.cmdMilestoneComplete(cwd, args[2], { name: milestoneName, archivePhases, force }, raw);
       } else {
         error('Unknown milestone subcommand. Available: complete', ERROR_REASON.SDK_UNKNOWN_COMMAND);
       }

--- a/scripts/lint-regression-test-names.allowlist.json
+++ b/scripts/lint-regression-test-names.allowlist.json
@@ -259,5 +259,6 @@
   "bug-941-managed-hooks-registry-manifest.test.cjs",
   "bug-947-hermes-gsd-prefix.test.cjs",
   "bug-948-state-noop-write-guard.test.cjs",
-  "bug-950-quick-summary-status-complete.test.cjs"
+  "bug-950-quick-summary-status-complete.test.cjs",
+  "bug-978-milestone-complete-force.test.cjs"
 ]

--- a/scripts/lint-test-file-count.allowlist.json
+++ b/scripts/lint-test-file-count.allowlist.json
@@ -45,6 +45,7 @@
     "milestone": {
       "files": [
         "bug-730-milestone-phase-details-scope.test.cjs",
+        "bug-978-milestone-complete-force.test.cjs",
         "milestone-archive.test.cjs",
         "milestone-helper.test.cjs",
         "milestone-prefixed-convention.test.cjs",

--- a/tests/bug-978-milestone-complete-force.test.cjs
+++ b/tests/bug-978-milestone-complete-force.test.cjs
@@ -1,0 +1,89 @@
+'use strict';
+
+/**
+ * Regression test for bug #978: `gsd-tools milestone complete --force` was a
+ * dead flag.  The milestone source (src/milestone.cts) has a guard that checks
+ * `options.force` and tells users to "Re-run with --force to override", but the
+ * CLI dispatcher (gsd-core/bin/gsd-tools.cjs) never parsed `--force` and never
+ * passed it into the options object.  So `options.force` was always `undefined`
+ * and the guard could never be overridden regardless of what the user typed.
+ */
+
+const { test, describe, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const { runGsdTools, createTempProject, cleanup } = require('./helpers.cjs');
+
+/**
+ * Build a fixture where the guard will fire:
+ *  - STATE.md has `milestone: <version>` so the guard's version-match check is
+ *    satisfied.
+ *  - ROADMAP.md lists a `### Phase 999.1: Backlog Work` heading for that
+ *    milestone, but there is NO on-disk phase directory for it.
+ *
+ * This guarantees "unstarted phase" detection without touching any real phases.
+ */
+function makeGuardFixture(tmpDir, version) {
+  // STATE.md with frontmatter milestone field matching the version
+  fs.writeFileSync(
+    path.join(tmpDir, '.planning', 'STATE.md'),
+    `---\nmilestone: ${version}\n---\n# State\n\n**Status:** In progress\n**Last Activity:** 2025-01-01\n**Last Activity Description:** Working\n`,
+  );
+
+  // ROADMAP.md — the heading must include the version so getMilestonePhaseFilter
+  // does not return missingExplicitVersion.  Phase 999.1 has no on-disk dir.
+  fs.writeFileSync(
+    path.join(tmpDir, '.planning', 'ROADMAP.md'),
+    `# Roadmap ${version}\n\n### Phase 999.1: Backlog Work\n**Goal:** Not started\n`,
+  );
+}
+
+describe('bug-978: milestone complete --force overrides unstarted-phase guard', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempProject('gsd-bug-978-');
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('without --force the guard fires and emits the documented error message', () => {
+    makeGuardFixture(tmpDir, 'v1.0');
+
+    const result = runGsdTools(
+      ['milestone', 'complete', 'v1.0', '--name', 'Regression Test'],
+      tmpDir,
+    );
+
+    assert.strictEqual(result.success, false, 'command should fail without --force');
+    assert.ok(
+      result.error.includes('Re-run with --force to override'),
+      `expected guard error message; got: ${result.error}`,
+    );
+  });
+
+  test('with --force the guard is bypassed and the command succeeds', () => {
+    makeGuardFixture(tmpDir, 'v1.0');
+
+    const result = runGsdTools(
+      ['milestone', 'complete', 'v1.0', '--name', 'Regression Test', '--force'],
+      tmpDir,
+    );
+
+    assert.ok(
+      result.success,
+      `command should succeed with --force but failed: ${result.error}`,
+    );
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.version, 'v1.0');
+    // Milestone entry should have been created even though phase 999.1 has no dir
+    assert.ok(
+      fs.existsSync(path.join(tmpDir, '.planning', 'MILESTONES.md')),
+      'MILESTONES.md should have been created',
+    );
+  });
+});


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #978

---

## What was broken

`gsd-tools milestone complete --force` was a dead flag. The unstarted-phase guard (added for #557) refuses to complete when the ROADMAP lists a `### Phase N:` heading with no on-disk directory, and its error tells the user to **"Re-run with `--force` to override."** But the CLI dispatcher built `options` from only `--name` and `--archive-phases` and never parsed `--force`, so `options.force` was always `undefined` and the guard's own documented escape hatch could never fire.

## What this fix does

Parses `--force` in the `milestone complete` dispatcher arm and threads it into the options object the guard already reads (`{ name, archivePhases, force }`). One line plus the pass-through; the guard in the milestone module already honors `options.force`, so no guard change was needed.

## Root cause

Dispatcher/guard mismatch: the guard consumed `options.force` while the dispatcher dropped `--force` on the floor (parsed only `--name` / `--archive-phases`). `!options.force` was therefore always `true`, making the guard un-overridable whenever a backlog-styled `### Phase 999.x` heading (a common, legitimate roadmap pattern) had no directory.

## Testing

### How I verified the fix

Added `tests/bug-978-milestone-complete-force.test.cjs` — a behavioral test that builds a temp GSD project whose ROADMAP has a directory-less `### Phase 999.1:` heading and whose STATE milestone matches the version, then runs `milestone complete` both **with** and **without** `--force`:
- **without `--force`** → the guard fires and emits the documented error (proves the test discriminates).
- **with `--force`** → the guard is bypassed and completion succeeds.

The test **fails before** the fix (`with --force the guard is bypassed` assertion errors with `Cannot mark milestone complete ... Re-run with --force to override`) and **passes after**. `tests/milestone.test.cjs` (39/39) and the full suite are green on Mac + Docker (`gsd-test --both`: 16056 passed, 0 failed). Codex adversarial review: no blocking findings.

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [x] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific — pure CLI argument parsing)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`Fixed`)
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/982"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783684571&installation_id=134682257&pr_number=982&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F982&signature=cecbacfcbe87bc1e6b819ec5682aff59437ae2c34114d796516c3182a95917fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->