### PR TITLE
fix(#965): emit structured json error for unexpected handler throws under --json-errors

### DIFF
--- a/.changeset/965-json-errors-unexpected-throw.md
+++ b/.changeset/965-json-errors-unexpected-throw.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 987
 ---
 **`--json-errors` now emits a structured error even when a handler throws unexpectedly** — an unexpected (non-`ExitError`) throw fell through to a raw stack trace on stderr, breaking SDK structured-error parsing. (#965)

--- a/.changeset/965-json-errors-unexpected-throw.md
+++ b/.changeset/965-json-errors-unexpected-throw.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`--json-errors` now emits a structured error even when a handler throws unexpectedly** — an unexpected (non-`ExitError`) throw fell through to a raw stack trace on stderr, breaking SDK structured-error parsing. (#965)

--- a/src/cli-exit.cts
+++ b/src/cli-exit.cts
@@ -1,3 +1,8 @@
+import fs from 'node:fs';
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import ioModule = require('./io.cjs');
+const { getJsonErrorMode, ERROR_REASON } = ioModule;
+
 /**
  * Error carrying a process exit code. CLI logic throws this instead of calling
  * process.exit() (banned by n/no-process-exit); runMain() translates it into
@@ -20,7 +25,8 @@ class ExitError extends Error {
  * process.on('exit') cleanup still fires). main may be sync or async:
  *   number return -> process.exitCode = it
  *   thrown ExitError -> process.exitCode = err.code (+ stderr err.message if hasUserMessage && code!=0)
- *   other throw -> stderr stack + process.exitCode = 1
+ *   other throw -> when json-error mode is active, emits structured { ok:false, reason, message }
+ *                  to stderr; otherwise writes raw stack trace. exit code = 1 in either case.
  */
 function runMain(main: () => number | void | Promise<number | void>): void {
   Promise.resolve()
@@ -32,8 +38,18 @@ function runMain(main: () => number | void | Promise<number | void>): void {
         process.exitCode = err.code;
         return;
       }
-      const e = err as Error;
-      process.stderr.write(`${e && e.stack ? e.stack : String(err)}\n`);
+      if (getJsonErrorMode()) {
+        const e = err as Error;
+        const payload = JSON.stringify({
+          ok: false,
+          reason: ERROR_REASON.SDK_FAIL_FAST,
+          message: (e && e.message) ? e.message : String(err),
+        }) + '\n';
+        fs.writeSync(2, payload);
+      } else {
+        const e = err as Error;
+        process.stderr.write(`${e && e.stack ? e.stack : String(err)}\n`);
+      }
       process.exitCode = 1;
     });
 }

--- a/tests/cli-exit.test.cjs
+++ b/tests/cli-exit.test.cjs
@@ -2,8 +2,15 @@
 
 const { describe, test } = require('node:test');
 const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const path = require('node:path');
 
 const { ExitError, runMain } = require('../scripts/lib/cli-exit.cjs');
+
+// Paths to the compiled product seam (src/cli-exit.cts → gsd-core/bin/lib/cli-exit.cjs)
+// used for json-error mode regression tests which require io.cjs integration.
+const BUILT_CLI_EXIT_PATH = path.resolve(__dirname, '../gsd-core/bin/lib/cli-exit.cjs');
+const IO_PATH = path.resolve(__dirname, '../gsd-core/bin/lib/io.cjs');
 
 /** Settle the runMain promise chain before asserting. */
 async function settle() {
@@ -157,5 +164,86 @@ describe('runMain', () => {
       process.stderr.write = origWrite;
       process.exitCode = saved !== undefined ? saved : 0;
     }
+  });
+});
+
+// ─── Regressions ─────────────────────────────────────────────────────────────
+
+/**
+ * bug #965 — runMain unexpected throw with --json-errors active emitted a raw
+ * stack trace instead of a structured { ok:false, reason, message } envelope.
+ * SDK consumers parsing structured errors would receive an unparseable string.
+ *
+ * Fix: src/cli-exit.cts non-ExitError catch branch now checks getJsonErrorMode()
+ * and emits the same structured envelope as error() when active.
+ *
+ * Tests run against the compiled product seam (gsd-core/bin/lib/cli-exit.cjs)
+ * via subprocess so that io.cjs module-level state is isolated per spawn.
+ */
+describe('regressions', () => {
+  /** Spawn a one-shot script that sets json-error mode and calls runMain with a throwing handler. */
+  function spawnJsonErrorRun({ jsonMode, errorType = 'TypeError', message = 'unexpected boom' } = {}) {
+    const script = `
+      const io = require(${JSON.stringify(IO_PATH)});
+      const { runMain } = require(${JSON.stringify(BUILT_CLI_EXIT_PATH)});
+      io.setJsonErrorMode(${jsonMode ? 'true' : 'false'});
+      runMain(() => { throw new ${errorType}(${JSON.stringify(message)}); });
+      setImmediate(() => {});
+    `;
+    return spawnSync(process.execPath, ['-e', script], { encoding: 'utf-8' });
+  }
+
+  describe('bug-965: unexpected throw in json-error mode emits structured envelope', () => {
+    test('stderr is a single parseable JSON object (not a raw stack trace)', () => {
+      const result = spawnJsonErrorRun({ jsonMode: true });
+      assert.strictEqual(result.status, 1,
+        `expected exit code 1, got ${result.status}; stderr: ${result.stderr}`);
+      const stderrTrimmed = result.stderr.trim();
+      assert.ok(stderrTrimmed.length > 0, 'expected non-empty stderr');
+      let parsed;
+      try {
+        parsed = JSON.parse(stderrTrimmed);
+      } catch (e) {
+        assert.fail(
+          `stderr is NOT valid JSON (raw stack trace leaked through):\n${stderrTrimmed}\nparse error: ${e.message}`
+        );
+      }
+      assert.strictEqual(parsed.ok, false, `expected ok:false, got: ${JSON.stringify(parsed)}`);
+      assert.strictEqual(parsed.reason, 'sdk_fail_fast',
+        `expected reason "sdk_fail_fast", got: ${parsed.reason}`);
+      assert.ok(
+        parsed.message && parsed.message.includes('unexpected boom'),
+        `expected message to include "unexpected boom", got: ${JSON.stringify(parsed.message)}`
+      );
+    });
+
+    test('stderr JSON works for RangeError as well as TypeError', () => {
+      const result = spawnJsonErrorRun({ jsonMode: true, errorType: 'RangeError', message: 'out of bounds' });
+      assert.strictEqual(result.status, 1);
+      const parsed = JSON.parse(result.stderr.trim());
+      assert.strictEqual(parsed.ok, false);
+      assert.strictEqual(parsed.reason, 'sdk_fail_fast');
+      assert.ok(parsed.message.includes('out of bounds'));
+    });
+
+    test('stdout is empty when unexpected throw emits structured error', () => {
+      const result = spawnJsonErrorRun({ jsonMode: true });
+      assert.strictEqual(result.stdout, '',
+        `expected empty stdout, got: ${result.stdout}`);
+    });
+
+    test('plain mode (json-error off) preserves raw stack trace on stderr', () => {
+      const result = spawnJsonErrorRun({ jsonMode: false });
+      assert.strictEqual(result.status, 1);
+      const stderrTrimmed = result.stderr.trim();
+      let parsed = null;
+      try { parsed = JSON.parse(stderrTrimmed); } catch { /* expected — not JSON */ }
+      assert.strictEqual(parsed, null,
+        `expected raw stack (non-JSON) on stderr in plain mode, but got valid JSON: ${stderrTrimmed.slice(0, 200)}`);
+      assert.ok(
+        stderrTrimmed.includes('unexpected boom'),
+        `expected "unexpected boom" in stderr, got: ${stderrTrimmed.slice(0, 200)}`
+      );
+    });
   });
 });


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #965

---

## What was broken

`gsd-tools` supports `--json-errors` / `GSD_JSON_ERRORS=1`, under which SDK consumers expect **every** error on stderr to be a structured `{ ok: false, reason, ... }` object. That held only for *intentional* errors (a handler calling `error()`, which throws `ExitError`). An **unexpected** throw inside a handler (a real bug — `TypeError`, etc.) bypassed `error()` and fell through to `runMain`'s catch-all, which wrote a **raw stack trace** to stderr — even when `--json-errors` was active — breaking structured-error parsing.

## What this fix does

In `runMain`'s non-`ExitError` catch branch, when json-error mode is active the error is now emitted as a structured object — `{ ok: false, reason: "sdk_fail_fast", message }` — matching the exact envelope shape `error()` produces in `io.cts` (same keys, trailing newline, via `fs.writeSync(2, …)`). When json mode is **off**, the existing raw-stack behavior is unchanged. Exit code remains `1` in both modes.

## Root cause

The structured-error path lived only in `error()`/`ExitError`; `runMain`'s catch-all (`src/cli-exit.cts`) never consulted json-error mode, so any non-`ExitError` throw produced an unstructured stack. This mirrors the capability-dispatch gap already fixed in #961 — this PR closes the pre-existing host-wide version.

## Testing

### How I verified the fix

Added regression coverage in `tests/cli-exit.test.cjs` (`describe('regressions')`) that spawns the **built** `cli-exit.cjs` seam with an injected handler that throws a non-`ExitError`, under `GSD_JSON_ERRORS=1`, and asserts stderr is a single parseable JSON object (`ok:false`, a `reason`) rather than a raw stack — plus a case confirming the raw-stack behavior is preserved when json mode is off. Fails before the fix (raw `TypeError:` stack leaks), passes after. `tests/io.test.cjs` and the full suite are green on Mac + Docker. Codex adversarial review: no blocking findings (envelope shape confirmed identical to `error()`; the unrelated `scripts/lib/cli-exit.cjs` copy is not reachable by `--json-errors`).

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [x] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (SDK consumers of `gsd-tools --json-errors`, not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`Fixed`)
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/987"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783689304&installation_id=134682257&pr_number=987&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F987&signature=3aaae33ea6b73d5b5c15d5060262acf73284480da5c001e42a70cf670591c795"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->