### PR TITLE
fix(#973): add Edit to gsd-planner tools and forbid whole-file Write of ROADMAP.md

### DIFF
--- a/.changeset/973-gsd-planner-edit-tool.md
+++ b/.changeset/973-gsd-planner-edit-tool.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`gsd-planner` now ships the `Edit` tool, so it can no longer destroy `ROADMAP.md` via a whole-file `Write`** — the planner had `Write` but not `Edit` (the #571/#581 writer-agent gap), so an in-place ROADMAP edit fell back to a full overwrite that truncated committed milestone history. The `update_roadmap` step now directs scoped `Edit` calls and explicitly forbids passing the full file to `Write`. (#973)

--- a/.changeset/973-gsd-planner-edit-tool.md
+++ b/.changeset/973-gsd-planner-edit-tool.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 989
 ---
 **`gsd-planner` now ships the `Edit` tool, so it can no longer destroy `ROADMAP.md` via a whole-file `Write`** — the planner had `Write` but not `Edit` (the #571/#581 writer-agent gap), so an in-place ROADMAP edit fell back to a full overwrite that truncated committed milestone history. The `update_roadmap` step now directs scoped `Edit` calls and explicitly forbids passing the full file to `Write`. (#973)

--- a/agents/gsd-planner.md
+++ b/agents/gsd-planner.md
@@ -998,7 +998,7 @@ Use template structure for each PLAN.md.
 
 These PLAN.md files are the canonical output of this agent. The orchestrator reads each `.planning/phases/{padded_phase}-{slug}/{padded_phase}-{NN}-PLAN.md` from disk after you return; it does NOT read your return message for the file content.
 
-**Write is authorized ONLY for net-new PLAN.md creation.** For any file that already exists on disk — including `ROADMAP.md` and any existing `.planning/` file — you MUST use `Edit` (scoped replacement), not `Write`. A whole-file `Write` on an existing curated file destroys all content outside your diff window and cannot be recovered without git. See the `update_roadmap` step for the ROADMAP.md Edit discipline.
+**Write is for net-new PLAN.md only.** For any existing file (`ROADMAP.md`, `.planning/` files) use `Edit` (scoped replacement), never `Write`. See `update_roadmap`.
 
 1. **Default: write each PLAN.md in a single `Write` call.** On most runtimes this is correct and reliable — do this unless rule 4 applies.
 2. **Do NOT return the PLAN.md content in your response.** Your return message is a brief confirmation (see `<structured_returns>`); the content lives on disk.
@@ -1064,7 +1064,7 @@ Returns JSON: `{ valid, errors, warnings, task_count, tasks }`
 <step name="update_roadmap">
 Update ROADMAP.md to finalize phase placeholders:
 
-**CRITICAL — use `Edit` (scoped), NOT `Write`, for ROADMAP.md.** ROADMAP.md contains committed milestone history across all phases. A whole-file `Write` destroys every phase entry outside your diff window (incident: 292-line file truncated to 16 lines). You MUST use the `Edit` tool to replace only the target phase section. If the changes are too broad for a single `Edit`, use multiple targeted `Edit` calls — one per field. NEVER pass the entire ROADMAP.md content to `Write`.
+**CRITICAL — use `Edit` (scoped), NOT `Write`, for ROADMAP.md.** A whole-file `Write` destroys all phase entries outside your diff window. Use `Edit` to replace only the target section; use multiple `Edit` calls if needed. NEVER pass the entire ROADMAP.md content to `Write`.
 
 1. Read `.planning/ROADMAP.md`
 2. Find phase entry (`### Phase {N}:`)

--- a/agents/gsd-planner.md
+++ b/agents/gsd-planner.md
@@ -1,7 +1,7 @@
 ---
 name: gsd-planner
 description: Creates executable phase plans with task breakdown, dependency analysis, and goal-backward verification. Spawned by /gsd:plan-phase orchestrator.
-tools: Read, Write, Bash, Glob, Grep, WebFetch, mcp__context7__*
+tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, mcp__context7__*
 color: green
 # hooks:
 #   PostToolUse:
@@ -998,6 +998,8 @@ Use template structure for each PLAN.md.
 
 These PLAN.md files are the canonical output of this agent. The orchestrator reads each `.planning/phases/{padded_phase}-{slug}/{padded_phase}-{NN}-PLAN.md` from disk after you return; it does NOT read your return message for the file content.
 
+**Write is authorized ONLY for net-new PLAN.md creation.** For any file that already exists on disk — including `ROADMAP.md` and any existing `.planning/` file — you MUST use `Edit` (scoped replacement), not `Write`. A whole-file `Write` on an existing curated file destroys all content outside your diff window and cannot be recovered without git. See the `update_roadmap` step for the ROADMAP.md Edit discipline.
+
 1. **Default: write each PLAN.md in a single `Write` call.** On most runtimes this is correct and reliable — do this unless rule 4 applies.
 2. **Do NOT return the PLAN.md content in your response.** Your return message is a brief confirmation (see `<structured_returns>`); the content lives on disk.
 3. **Do NOT use `Bash(cat << 'EOF')` or heredoc** for file creation. Use the `Write` tool.
@@ -1062,9 +1064,11 @@ Returns JSON: `{ valid, errors, warnings, task_count, tasks }`
 <step name="update_roadmap">
 Update ROADMAP.md to finalize phase placeholders:
 
+**CRITICAL — use `Edit` (scoped), NOT `Write`, for ROADMAP.md.** ROADMAP.md contains committed milestone history across all phases. A whole-file `Write` destroys every phase entry outside your diff window (incident: 292-line file truncated to 16 lines). You MUST use the `Edit` tool to replace only the target phase section. If the changes are too broad for a single `Edit`, use multiple targeted `Edit` calls — one per field. NEVER pass the entire ROADMAP.md content to `Write`.
+
 1. Read `.planning/ROADMAP.md`
 2. Find phase entry (`### Phase {N}:`)
-3. Update placeholders:
+3. Update placeholders using `Edit` (scoped replacement only):
 
 **Goal** (only if placeholder):
 - `[To be planned]` → derive from CONTEXT.md > RESEARCH.md > phase description
@@ -1080,7 +1084,7 @@ Plans:
 - [ ] {phase}-02-PLAN.md — {brief objective}
 ```
 
-4. Write updated ROADMAP.md
+4. Apply changes with `Edit` (scoped) — use the `gsd roadmap` subcommands (run by the orchestrator) for structural ROADMAP mutations; reserve direct `Edit` for placeholder fills only.
 </step>
 
 <step name="git_commit">

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -161,7 +161,7 @@ GSD uses a multi-agent architecture where thin orchestrators (workflow files) sp
 |----------|-------|
 | **Spawned by** | `/gsd-plan-phase`, `/gsd-quick` |
 | **Parallelism** | Single instance |
-| **Tools** | Read, Write, Bash, Glob, Grep, WebFetch, mcp (context7) |
+| **Tools** | Read, Write, Edit, Bash, Glob, Grep, WebFetch, mcp (context7) |
 | **Model (balanced)** | Opus |
 | **Color** | Green |
 | **Produces** | `{phase}-{N}-PLAN.md` files |

--- a/tests/agent-frontmatter.test.cjs
+++ b/tests/agent-frontmatter.test.cjs
@@ -435,6 +435,7 @@ describe('EDITWRITE: section-writer agents must have both Write and Edit in tool
     'gsd-phase-researcher',
     'gsd-ui-researcher',
     'gsd-debug-session-manager',
+    'gsd-planner', // #973: planner lacked Edit; whole-file Write truncated ROADMAP.md
   ];
 
   for (const agent of SECTION_WRITER_AGENTS) {


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #973

---

## What was broken

`gsd-planner` shipped `tools: Read, Write, … ` — `Write` but **no `Edit`** — the same writer-agent gap fixed for six other agents in #571 / #575 / #581. With no `Edit` tool, a planner step that intends a scoped in-place edit of an existing file reaches for `Write` (a whole-file overwrite). In a real `/gsd-plan-phase --reviews` replan this truncated `ROADMAP.md` from 292 → 16 lines, destroying three milestones of committed history. The file also still carried the commented-out `PostToolUse` `Write|Edit` hook — the "Edit was always intended" signature.

## What this fix does

1. Adds `Edit` to `gsd-planner`'s `tools:` line (keeps `Write` for net-new `PLAN.md` creation).
2. Tightens the planner's Write contract: `Write` is now explicitly authorized **only** for net-new `PLAN.md` creation, and the roadmap step mandates a scoped `Edit` (never a whole-file `Write`) for `ROADMAP.md` and any existing curated `.planning/` file — phrased as a blocking rule, since agents rationalize advisory warnings.
3. Updates the `docs/AGENTS.md` `gsd-planner` tools row to match.

The broader catastrophic-shrink write guard the issue also proposes is intentionally deferred as a follow-on (this PR is the high-leverage root-cause fix, identical in shape to #575 / #581).

## Root cause

Writer agent with `Write` but not `Edit`, modifying an existing multi-section file → the model falls back to a whole-file replace from a partial in-context window and reports success. `ROADMAP.md`'s blast radius is larger than the spec/research files the #581 audit covered (it carries committed milestone history), and the planner was outside that audit's six-agent scope.

## Testing

### How I verified the fix

Extended the existing #581 writer-agent contract test (`tests/agent-frontmatter.test.cjs`, `SECTION_WRITER_AGENTS`) to include `gsd-planner` — it asserts any agent with `Write` also has `Edit`. Fails before the fix (`gsd-planner missing Edit in tools:`), passes after. Confirmed no ripple to `scripts/research-profiles.cjs` (gsd-planner is not a generated researcher). Codex adversarial review: no blocking findings (the `docs/AGENTS.md` row staleness it flagged is fixed in this PR).

### Regression test added?

- [x] Yes — extended the #581 writer-agent contract test to cover `gsd-planner`
- [ ] No — explain why:

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [x] N/A (not platform-specific — agent frontmatter contract)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (agent definition; applies to every runtime that loads the planner)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`Fixed`)
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/989"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783691116&installation_id=134682257&pr_number=989&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F989&signature=ff71c0c36651cc280e7871cb2da8cbfcf8c9bed807c9414ee369e492b7a4a1d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->