### PR TITLE
fix(#976): detect command+args (wrapped) hook registrations in installer presence checks

### DIFF
--- a/.changeset/fancy-book-path.md
+++ b/.changeset/fancy-book-path.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**The installer no longer re-adds a duplicate managed hook when the user registered it in `command`+`args` (wrapped) form** — the presence checks only inspected `h.command`, so an args-form wrapper (a common Windows windowless-launcher mitigation) was invisible and a stock entry was appended on every install/update, running the hook twice. (#976)

--- a/.changeset/fancy-book-path.md
+++ b/.changeset/fancy-book-path.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 994
 ---
 **The installer no longer re-adds a duplicate managed hook when the user registered it in `command`+`args` (wrapped) form** — the presence checks only inspected `h.command`, so an args-form wrapper (a common Windows windowless-launcher mitigation) was invisible and a stock entry was appended on every install/update, running the hook twice. (#976)

--- a/bin/install.js
+++ b/bin/install.js
@@ -725,6 +725,10 @@ function rewriteLegacyManagedNodeHookCommands(settings, absoluteRunner, opts) {
       if (!entry || !Array.isArray(entry.hooks)) continue;
       for (const h of entry.hooks) {
         if (!h || typeof h.command !== 'string') continue;
+        // args-form entries have the script path in h.args[] and h.command is
+        // the launcher executable (not a managed hook command).  These are
+        // intentional user wrappers — do not rewrite them. (#976)
+        if (Array.isArray(h.args) && h.args.length > 0) continue;
         let trimmed = h.command.trim();
         const hadPowerShellCallOperator = platform === 'win32' && /^&\s+/.test(trimmed);
         if (hadPowerShellCallOperator) {
@@ -11845,6 +11849,18 @@ function install(isGlobal, runtime = 'claude', options = {}) {
     }
   }
 
+  // Helper: detect whether a hook entry references a managed hook by name.
+  // Checks both the plain command string (standard form) and the args array
+  // (command+args / wrapped-launcher form used by windowless launchers on
+  // Windows and some custom PATH-less environments).  Without this check the
+  // presence guards below only inspect h.command, so an args-form wrapper is
+  // invisible and a stock string-command entry is appended on every
+  // install/update, running the hook twice. (#976)
+  function referencesHook(h, hookName) {
+    return (typeof h.command === 'string' && h.command.includes(hookName)) ||
+      (Array.isArray(h.args) && h.args.some(a => typeof a === 'string' && a.includes(hookName)));
+  }
+
   // Configure SessionStart hook for update checking (skip for opencode)
   if (!isOpencode && !isKilo) {
     if (!settings.hooks) {
@@ -11855,7 +11871,7 @@ function install(isGlobal, runtime = 'claude', options = {}) {
     }
 
     const hasGsdUpdateHook = settings.hooks.SessionStart.some(entry =>
-      entry.hooks && entry.hooks.some(h => h.command && h.command.includes('gsd-check-update'))
+      entry.hooks && entry.hooks.some(h => referencesHook(h, 'gsd-check-update'))
     );
 
     // Guard: only register if the hook file was actually installed (#1754).
@@ -11883,7 +11899,7 @@ function install(isGlobal, runtime = 'claude', options = {}) {
     }
 
     const hasContextMonitorHook = settings.hooks[postToolEvent].some(entry =>
-      entry.hooks && entry.hooks.some(h => h.command && h.command.includes('gsd-context-monitor'))
+      entry.hooks && entry.hooks.some(h => referencesHook(h, 'gsd-context-monitor'))
     );
 
     const contextMonitorFile = path.join(targetDir, 'hooks', 'gsd-context-monitor.js');
@@ -11904,14 +11920,14 @@ function install(isGlobal, runtime = 'claude', options = {}) {
     } else {
       // Migrate existing context monitor hooks: add matcher and timeout if missing
       for (const entry of settings.hooks[postToolEvent]) {
-        if (entry.hooks && entry.hooks.some(h => h.command && h.command.includes('gsd-context-monitor'))) {
+        if (entry.hooks && entry.hooks.some(h => referencesHook(h, 'gsd-context-monitor'))) {
           let migrated = false;
           if (!entry.matcher) {
             entry.matcher = 'Bash|Edit|Write|MultiEdit|Agent|Task';
             migrated = true;
           }
           for (const h of entry.hooks) {
-            if (h.command && h.command.includes('gsd-context-monitor') && !h.timeout) {
+            if (referencesHook(h, 'gsd-context-monitor') && !h.timeout) {
               h.timeout = 10;
               migrated = true;
             }
@@ -11931,7 +11947,7 @@ function install(isGlobal, runtime = 'claude', options = {}) {
     }
 
     const hasPromptGuardHook = settings.hooks[preToolEvent].some(entry =>
-      entry.hooks && entry.hooks.some(h => h.command && h.command.includes('gsd-prompt-guard'))
+      entry.hooks && entry.hooks.some(h => referencesHook(h, 'gsd-prompt-guard'))
     );
 
     const promptGuardFile = path.join(targetDir, 'hooks', 'gsd-prompt-guard.js');
@@ -11955,7 +11971,7 @@ function install(isGlobal, runtime = 'claude', options = {}) {
     // Prevents infinite retry loops when non-Claude models attempt to edit
     // files without reading them first. Advisory-only — does not block.
     const hasReadGuardHook = settings.hooks[preToolEvent].some(entry =>
-      entry.hooks && entry.hooks.some(h => h.command && h.command.includes('gsd-read-guard'))
+      entry.hooks && entry.hooks.some(h => referencesHook(h, 'gsd-read-guard'))
     );
 
     const readGuardFile = path.join(targetDir, 'hooks', 'gsd-read-guard.js');
@@ -11979,7 +11995,7 @@ function install(isGlobal, runtime = 'claude', options = {}) {
     // Scans content returned by the Read tool for injection patterns, including
     // summarisation-specific patterns that survive context compression.
     const hasReadInjectionScannerHook = settings.hooks[postToolEvent].some(entry =>
-      entry.hooks && entry.hooks.some(h => h.command && h.command.includes('gsd-read-injection-scanner'))
+      entry.hooks && entry.hooks.some(h => referencesHook(h, 'gsd-read-injection-scanner'))
     );
 
     const readInjectionScannerFile = path.join(targetDir, 'hooks', 'gsd-read-injection-scanner.js');
@@ -12013,7 +12029,7 @@ function install(isGlobal, runtime = 'claude', options = {}) {
       : localCmd('gsd-workflow-guard.js');
     const workflowGuardMatcher = 'Bash|Edit|Write|MultiEdit';
     const workflowGuardHookEntry = settings.hooks[preToolEvent].find(entry =>
-      entry.hooks && entry.hooks.some(h => h.command && h.command.includes('gsd-workflow-guard'))
+      entry.hooks && entry.hooks.some(h => referencesHook(h, 'gsd-workflow-guard'))
     );
     const hasWorkflowGuardHook = Boolean(workflowGuardHookEntry);
 
@@ -12045,7 +12061,7 @@ function install(isGlobal, runtime = 'claude', options = {}) {
       ? buildHookCommand(targetDir, 'gsd-worktree-path-guard.js', hookOpts)
       : localCmd('gsd-worktree-path-guard.js');
     const hasWorktreePathGuardHook = settings.hooks[preToolEvent].some(entry =>
-      entry.hooks && entry.hooks.some(h => h.command && h.command.includes('gsd-worktree-path-guard'))
+      entry.hooks && entry.hooks.some(h => referencesHook(h, 'gsd-worktree-path-guard'))
     );
     const worktreePathGuardFile = path.join(targetDir, 'hooks', 'gsd-worktree-path-guard.js');
     if (!hasWorktreePathGuardHook && fs.existsSync(worktreePathGuardFile) && worktreePathGuardCommand) {
@@ -12069,7 +12085,7 @@ function install(isGlobal, runtime = 'claude', options = {}) {
       ? buildHookCommand(targetDir, 'gsd-validate-commit.sh', hookOpts)
       : localShellCmd('gsd-validate-commit.sh');
     const hasValidateCommitHook = settings.hooks[preToolEvent].some(entry =>
-      entry.hooks && entry.hooks.some(h => h.command && h.command.includes('gsd-validate-commit'))
+      entry.hooks && entry.hooks.some(h => referencesHook(h, 'gsd-validate-commit'))
     );
     // Guard: only register if the .sh file was actually installed. If the npm package
     // omitted the file (as happened in v1.32.0, bug #1817), registering a missing hook
@@ -12101,7 +12117,7 @@ function install(isGlobal, runtime = 'claude', options = {}) {
       ? buildHookCommand(targetDir, 'gsd-graphify-update.sh', hookOpts)
       : localShellCmd('gsd-graphify-update.sh');
     const hasGraphifyUpdateHook = settings.hooks[postToolEvent].some(entry =>
-      entry.hooks && entry.hooks.some(h => h.command && h.command.includes('gsd-graphify-update'))
+      entry.hooks && entry.hooks.some(h => referencesHook(h, 'gsd-graphify-update'))
     );
     const graphifyUpdateFile = path.join(targetDir, 'hooks', 'gsd-graphify-update.sh');
     if (!hasGraphifyUpdateHook && fs.existsSync(graphifyUpdateFile) && graphifyUpdateCommand) {
@@ -12127,7 +12143,7 @@ function install(isGlobal, runtime = 'claude', options = {}) {
       ? buildHookCommand(targetDir, 'gsd-session-state.sh', hookOpts)
       : localShellCmd('gsd-session-state.sh');
     const hasSessionStateHook = settings.hooks.SessionStart.some(entry =>
-      entry.hooks && entry.hooks.some(h => h.command && h.command.includes('gsd-session-state'))
+      entry.hooks && entry.hooks.some(h => referencesHook(h, 'gsd-session-state'))
     );
     const sessionStateFile = path.join(targetDir, 'hooks', 'gsd-session-state.sh');
     if (!hasSessionStateHook && fs.existsSync(sessionStateFile) && sessionStateCommand) {
@@ -12151,7 +12167,7 @@ function install(isGlobal, runtime = 'claude', options = {}) {
       ? buildHookCommand(targetDir, 'gsd-phase-boundary.sh', hookOpts)
       : localShellCmd('gsd-phase-boundary.sh');
     const hasPhaseBoundaryHook = settings.hooks[postToolEvent].some(entry =>
-      entry.hooks && entry.hooks.some(h => h.command && h.command.includes('gsd-phase-boundary'))
+      entry.hooks && entry.hooks.some(h => referencesHook(h, 'gsd-phase-boundary'))
     );
     const phaseBoundaryFile = path.join(targetDir, 'hooks', 'gsd-phase-boundary.sh');
     if (!hasPhaseBoundaryHook && fs.existsSync(phaseBoundaryFile) && phaseBoundaryCommand) {
@@ -12195,7 +12211,7 @@ function install(isGlobal, runtime = 'claude', options = {}) {
           settings.hooks[event] = [];
         }
         const alreadyHasContextMonitor = settings.hooks[event].some(entry =>
-          entry.hooks && entry.hooks.some(h => h.command && h.command.includes('gsd-context-monitor'))
+          entry.hooks && entry.hooks.some(h => referencesHook(h, 'gsd-context-monitor'))
         );
         if (!alreadyHasContextMonitor && fs.existsSync(contextMonitorFile) && contextMonitorCommand) {
           settings.hooks[event].push({
@@ -12244,7 +12260,7 @@ function install(isGlobal, runtime = 'claude', options = {}) {
           settings.hooks[geminiEvent] = [];
         }
         const alreadyHasContextMonitor = settings.hooks[geminiEvent].some(entry =>
-          entry.hooks && entry.hooks.some(h => h.command && h.command.includes('gsd-context-monitor'))
+          entry.hooks && entry.hooks.some(h => referencesHook(h, 'gsd-context-monitor'))
         );
         if (!alreadyHasContextMonitor && fs.existsSync(contextMonitorFile) && contextMonitorCommand) {
           settings.hooks[geminiEvent].push({
@@ -12281,7 +12297,7 @@ function install(isGlobal, runtime = 'claude', options = {}) {
       }
       const configReloadFile = path.join(targetDir, 'hooks', 'gsd-config-reload.js');
       const alreadyHasConfigReload = settings.hooks.FileChanged.some(entry =>
-        entry.hooks && entry.hooks.some(h => h.command && h.command.includes('gsd-config-reload'))
+        entry.hooks && entry.hooks.some(h => referencesHook(h, 'gsd-config-reload'))
       );
       if (!alreadyHasConfigReload && fs.existsSync(configReloadFile) && configReloadCommand) {
         settings.hooks.FileChanged.push({
@@ -12452,7 +12468,7 @@ function finishInstall(settingsPath, settings, statuslineCommand, shouldInstallS
       if (!settings.hooks) settings.hooks = {};
       if (!settings.hooks.SessionStart) settings.hooks.SessionStart = [];
       const alreadyRegistered = settings.hooks.SessionStart.some(entry =>
-        entry && entry.hooks && entry.hooks.some(h => h && h.command && h.command.includes('gsd-update-banner'))
+        entry && entry.hooks && entry.hooks.some(h => h && referencesHook(h, 'gsd-update-banner'))
       );
       const bannerHookFile = configDir ? path.join(configDir, 'hooks', 'gsd-update-banner.js') : null;
       const bannerInstalled = bannerHookFile ? fs.existsSync(bannerHookFile) : false;

--- a/src/shell-command-projection.cts
+++ b/src/shell-command-projection.cts
@@ -219,12 +219,25 @@ function managedHookCommandSurfaceSet(surface: string = 'settings-json', include
   return new Set([...base, ...aliases]);
 }
 
-export function isManagedHookCommand(commandText: unknown, opts: { surface?: string; includeLegacyAliases?: boolean; configDir?: string } = {}): boolean {
+export function isManagedHookCommand(commandText: unknown, opts: { surface?: string; includeLegacyAliases?: boolean; configDir?: string; args?: unknown[] } = {}): boolean {
   if (typeof commandText !== 'string') return false;
   const surface = opts.surface || 'settings-json';
   const includeLegacyAliases = opts.includeLegacyAliases === true;
   const managedBasenames = managedHookCommandSurfaceSet(surface, includeLegacyAliases);
   if (!managedBasenames || managedBasenames.size === 0) return false;
+
+  // args-form check: the managed hook filename may appear in args[] rather than
+  // in command when a windowless launcher wraps the Node invocation. (#976)
+  // Only treat as managed when an arg basename matches the managed hook set —
+  // prevents false-positives for non-GSD entries that happen to share a path segment.
+  if (Array.isArray(opts.args) && opts.args.length > 0) {
+    for (const arg of opts.args) {
+      if (typeof arg !== 'string') continue;
+      const argBasename = arg.replace(/\\/g, '/').split('/').pop() || '';
+      if (isManagedHookBasename(argBasename, { surface })) return true;
+    }
+  }
+
   const normalizedCommand = commandText.replace(/\\/g, '/');
 
   if (typeof opts.configDir === 'string' && opts.configDir.length > 0) {

--- a/tests/install-regressions.test.cjs
+++ b/tests/install-regressions.test.cjs
@@ -14,7 +14,7 @@
  * Closes #3758
  */
 
-const { test, describe } = require('node:test');
+const { test, describe, beforeEach, afterEach } = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
@@ -37,12 +37,33 @@ try {
   else process.env.GSD_TEST_MODE = savedTestMode;
 }
 
-const { installRuntimeArtifacts, uninstallRuntimeArtifacts, mergeClaudePermissions, GSD_CLAUDE_ALLOW_PERMISSIONS, GSD_CLAUDE_DENY_PERMISSIONS } = installExports || {};
+const { install, installRuntimeArtifacts, uninstallRuntimeArtifacts, mergeClaudePermissions, GSD_CLAUDE_ALLOW_PERMISSIONS, GSD_CLAUDE_DENY_PERMISSIONS, rewriteLegacyManagedNodeHookCommands, resolveNodeRunner } = installExports || {};
 
 const INSTALL_SCRIPT = path.join(__dirname, '..', 'bin', 'install.js');
+const HOOKS_SRC = path.join(__dirname, '..', 'hooks');
 const REAL_COMMANDS_DIR = path.join(__dirname, '..', 'commands', 'gsd');
 const MANIFEST = loadSkillsManifest(REAL_COMMANDS_DIR);
 const RESOLVED_CORE = resolveProfile({ modes: ['core'], manifest: MANIFEST });
+
+/**
+ * Stub managed GSD hook files into targetDir/hooks/ so that
+ * fs.existsSync guards in the installer pass during tests where
+ * hooks/dist/ is not built.
+ */
+function stubHooksIntoDir(targetDir, hookNames) {
+  const hooksDest = path.join(targetDir, 'hooks');
+  fs.mkdirSync(hooksDest, { recursive: true });
+  for (const hookFile of hookNames) {
+    const src = path.join(HOOKS_SRC, hookFile);
+    const dest = path.join(hooksDest, hookFile);
+    if (fs.existsSync(src)) {
+      fs.copyFileSync(src, dest);
+    } else {
+      fs.writeFileSync(dest, '#!/usr/bin/env node\n// stub\n');
+    }
+    try { fs.chmodSync(dest, 0o755); } catch { /* Windows */ }
+  }
+}
 
 // ─── Defect #1 — Hermes upgrade: bare-stem dirs from #3664 era become stale ──
 //
@@ -608,5 +629,144 @@ describe('mergeClaudePermissions (#768): end-to-end install writes permissions t
       'user Bash(git *) allow entry must survive uninstall');
     assert.ok(deny.includes('WebSearch'),
       'user WebSearch deny entry must survive uninstall');
+  });
+});
+
+// ─── #976 — args-form hook presence detection ─────────────────────────────────
+//
+// Claude Code hooks support a command+args form (executable in `command`,
+// script path in `args[]`) used by windowless-launcher wrappers on Windows.
+// Pre-fix, hasGsdUpdateHook (and sibling checks) only inspected h.command,
+// so an args-form entry was invisible and a stock string-command entry was
+// appended on every install/update, running the hook twice.
+
+describe('#976 regression: installer does not duplicate managed hooks when registered in command+args form', () => {
+  let tmpDir;
+  let previousCwd;
+
+  beforeEach(() => {
+    tmpDir = createTempDir('gsd-976-args-form-');
+    previousCwd = process.cwd();
+    process.chdir(tmpDir);
+
+    assert.strictEqual(typeof install, 'function',
+      'install must be exported from bin/install.js');
+  });
+
+  afterEach(() => {
+    process.chdir(previousCwd);
+    cleanup(tmpDir);
+  });
+
+  test('does not add a second SessionStart entry when gsd-check-update is already in args-form', () => {
+    const targetDir = path.join(tmpDir, '.claude');
+    fs.mkdirSync(targetDir, { recursive: true });
+
+    // Pass 1: run install with no pre-existing settings to create the
+    // gsd-file-manifest.json that the installer migration uses to decide
+    // whether a hook file is managed (kept) or foreign (removed).
+    // Without a manifest, the installer migration removes any hook stubs we
+    // place in hooks/ as "unrecognized GSD-looking files", which would make
+    // fs.existsSync(checkUpdateFile) return false and skip duplicate-adding.
+    install(false, 'claude');
+
+    // Now stub the hook files so fs.existsSync guards pass on pass 2.
+    // At this point the manifest exists, so migration classifies the stubs as
+    // manifest-managed and leaves them alone.
+    stubHooksIntoDir(targetDir, ['gsd-check-update.js']);
+
+    // Local Claude installs read/write settings.local.json (not settings.json).
+    // Overwrite settings.local.json with the hook in command+args form
+    // (wrapped launcher). The GSD hook filename appears in args[], not in command.
+    const launcherCommand = '/usr/local/bin/node-launcher';
+    const hookPath = path.join(targetDir, 'hooks', 'gsd-check-update.js');
+    const preExistingSettings = {
+      hooks: {
+        SessionStart: [
+          {
+            hooks: [
+              {
+                type: 'command',
+                command: launcherCommand,
+                args: [hookPath],
+              },
+            ],
+          },
+        ],
+      },
+    };
+    fs.writeFileSync(
+      path.join(targetDir, 'settings.local.json'),
+      JSON.stringify(preExistingSettings, null, 2) + '\n',
+    );
+
+    // Pass 2: run install again — the pre-existing args-form entry must
+    // suppress the duplicate stock string-command registration.
+    const result = install(false, 'claude');
+    const settings = result && result.settings;
+
+    assert.ok(settings && settings.hooks && Array.isArray(settings.hooks.SessionStart),
+      'settings.hooks.SessionStart must be an array after install');
+
+    // Count all hook entries (at any nesting level) that reference gsd-check-update.
+    const allEntries = settings.hooks.SessionStart.flatMap(entry =>
+      Array.isArray(entry && entry.hooks) ? entry.hooks : []
+    );
+    const matching = allEntries.filter(h =>
+      (typeof h.command === 'string' && h.command.includes('gsd-check-update')) ||
+      (Array.isArray(h.args) && h.args.some(a => typeof a === 'string' && a.includes('gsd-check-update')))
+    );
+
+    assert.strictEqual(
+      matching.length,
+      1,
+      [
+        'Expected exactly 1 hook entry referencing gsd-check-update after install,',
+        `got ${matching.length}.`,
+        'The installer added a duplicate because it could not detect the args-form registration.',
+        `All matching entries: ${JSON.stringify(matching)}`,
+      ].join(' '),
+    );
+  });
+
+  test('rewriteLegacyManagedNodeHookCommands leaves args-form launcher entries unchanged', () => {
+    assert.strictEqual(typeof rewriteLegacyManagedNodeHookCommands, 'function',
+      'rewriteLegacyManagedNodeHookCommands must be exported from bin/install.js');
+
+    const launcherCommand = '/usr/local/bin/node-launcher';
+    const hookPath = '/Users/user/.claude/hooks/gsd-check-update.js';
+    const settings = {
+      hooks: {
+        SessionStart: [
+          {
+            hooks: [
+              {
+                type: 'command',
+                command: launcherCommand,
+                args: [hookPath],
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    const runner = resolveNodeRunner() || '/usr/local/bin/node';
+    const changed = rewriteLegacyManagedNodeHookCommands(settings, runner, { platform: process.platform });
+
+    // The args-form launcher entry must NOT be rewritten — it is an intentional
+    // user wrapper and the script path lives in args[], not command.
+    assert.strictEqual(changed, false,
+      'rewriteLegacyManagedNodeHookCommands must not rewrite args-form entries (#976)');
+    assert.strictEqual(
+      settings.hooks.SessionStart[0].hooks[0].command,
+      launcherCommand,
+      'args-form command must remain unchanged after rewrite pass',
+    );
+    assert.deepStrictEqual(
+      settings.hooks.SessionStart[0].hooks[0].args,
+      [hookPath],
+      'args-form args must remain unchanged after rewrite pass',
+    );
   });
 });


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #976

---

## What was broken

The installer's "hook already registered?" checks in `bin/install.js` only inspected each hook entry's `command` string. Claude Code hooks also support a `command`+`args` form (executable in `command`, script path in `args[]`) — a common Windows windowless-launcher mitigation. An args-form registration was invisible to the presence checks, so **every install/update re-added a duplicate stock string-command entry** next to the user's wrapper, and the affected managed hook then ran **twice** per event (and on pre-#685/#799 versions the stock entry resumed the console-window flashing the wrapper existed to avoid).

## What this fix does

- Adds a `referencesHook(h, name)` helper that treats a hook as registered when the managed hook filename appears in `h.command` **or** in `h.args[]` (with `typeof` guards on both), and rewrites all 12 `has*Hook` presence predicates to use it.
- Extends `isManagedHookCommand()` (`src/shell-command-projection.cts`) to recognize args-form references too — conservatively, matching only known managed hook basenames (existing uninstall/cleanup call sites still pass `command` only, so removal scope is unchanged).
- Makes `rewriteLegacyManagedNodeHookCommands` explicitly **skip** entries with a non-empty `args[]` — those are intentional user wrappers and must not be rewritten.

## Root cause

The presence/management predicates keyed exclusively off the `command` string, so the `command`+`args` registration shape was structurally undetectable.

## Testing

### How I verified the fix

Added a regression block to `tests/install-regressions.test.cjs`: a two-pass install that seeds an args-form `SessionStart` entry referencing `gsd-check-update` between passes, then asserts exactly **one** entry references that hook after the second install. Fails before the fix (`got 2` — the duplicate stock entry), passes after. A second test asserts `rewriteLegacyManagedNodeHookCommands` leaves an args-form launcher entry unchanged. Full `npm test` (6949 tests) and the installer/shell-command-projection suites pass; `npm run lint` and `npm run build:lib` clean. Codex adversarial review: no blocking findings.

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [x] macOS
- [x] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [ ] N/A

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`Fixed`)
- [x] No unnecessary dependencies added

## Breaking changes

None. _Note: `bin/install.js` is also touched by sibling PRs #977 (`normalizeNodePath`) and #983 (Trae/Windsurf converters) in different regions — whichever merges second will need a trivial rebase._

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/994"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783693938&installation_id=134682257&pr_number=994&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F994&signature=415bb3c988b736ea725dd7f45e102e46ce82c1d81c8e19e4e5f30f81220b8d03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->