### PR TITLE
fix(#997): create canonical ~/.claude/gsd-core path for plugin installs

### DIFF
--- a/hooks/gsd-ensure-canonical-path.js
+++ b/hooks/gsd-ensure-canonical-path.js
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+// gsd-hook-version: {{GSD_VERSION}}
+/**
+ * SessionStart hook: ensure the canonical ~/.claude/gsd-core path exists when
+ * GSD runs as a Claude Code marketplace plugin.
+ *
+ * Why this is needed
+ * ------------------
+ * GSD's agents, commands, and prompt templates @-include the canonical path
+ * `~/.claude/gsd-core/...` (workflows, references, templates, contexts, bin).
+ * In a classic `bin/install.js` install that directory is populated on disk.
+ * In a Claude Code *marketplace plugin* install it is never created: the
+ * plugin manager only unpacks the package into the version-pinned plugin cache
+ * (`~/.claude/plugins/cache/<marketplace>/gsd-core/<version>/`) and never runs
+ * install.js. So every @-include resolves to nothing and gsd agents fail with:
+ *
+ *   "executor prompt template @-references ~/.claude/gsd-core/... paths, but
+ *    this is a plugin-based install where those paths are empty."
+ *
+ * Claude Code @-includes expand `~` and resolve absolute paths, but do NOT
+ * expand environment variables, so the bundled files cannot reference
+ * `${CLAUDE_PLUGIN_ROOT}` directly (that variable is only expanded in
+ * hooks.json command strings, not in markdown bodies). This hook bridges the
+ * gap by making `~/.claude/gsd-core` a real directory whose immutable bundled
+ * subdirectories are symlinked to this plugin's bundled `gsd-core/` tree.
+ *
+ * Design notes
+ * ------------
+ * - The canonical target is `os.homedir()/.claude/gsd-core` (literal `~`),
+ *   NOT CLAUDE_CONFIG_DIR: the bundled includes hardcode `@~/.claude/...`,
+ *   which Claude Code expands to the home dir regardless of CLAUDE_CONFIG_DIR.
+ * - No-op when the bundled tree already IS the canonical path (a classic
+ *   install): nothing is linked.
+ * - Real top-level entries (a user's USER-PROFILE.md, or a classic install)
+ *   are NEVER clobbered: only symlinks are managed.
+ * - Stale/dangling symlinks (entries renamed or dropped in a newer bundle, or
+ *   links into a removed older version dir) are pruned, so the shim self-heals
+ *   after `claude plugin update`.
+ * - Plugin root is derived from __dirname (this file lives at
+ *   <pluginRoot>/hooks/), so it does not depend on CLAUDE_PLUGIN_ROOT being
+ *   propagated into the hook process environment.
+ * - Best-effort and non-blocking: any failure is swallowed and the hook always
+ *   exits 0, so a filesystem hiccup can never break SessionStart.
+ */
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+function isDir(p) {
+  try { return fs.statSync(p).isDirectory(); } catch (_) { return false; }
+}
+function isSymlink(p) {
+  try { return fs.lstatSync(p).isSymbolicLink(); } catch (_) { return false; }
+}
+function safeReaddir(p) {
+  try { return fs.readdirSync(p); } catch (_) { return []; }
+}
+
+function main() {
+  const pluginRoot = path.resolve(__dirname, '..');
+  const bundled = path.join(pluginRoot, 'gsd-core');
+  if (!isDir(bundled)) return; // nothing to link
+
+  const canonical = path.join(os.homedir(), '.claude', 'gsd-core');
+
+  // Classic install: the bundled tree already lives at the canonical path.
+  if (path.resolve(bundled) === path.resolve(canonical)) return;
+
+  // A previous shim may have left a whole-dir symlink; we manage per-entry.
+  if (isSymlink(canonical)) {
+    try { fs.unlinkSync(canonical); } catch (_) { /* ignore */ }
+  }
+  fs.mkdirSync(canonical, { recursive: true });
+
+  // Prune our own dangling symlinks (only symlinks are touched; real entries,
+  // i.e. user content or a classic install, are preserved).
+  for (const name of safeReaddir(canonical)) {
+    const p = path.join(canonical, name);
+    if (isSymlink(p) && !fs.existsSync(p)) {
+      try { fs.unlinkSync(p); } catch (_) { /* ignore */ }
+    }
+  }
+
+  // Symlink each bundled entry into the canonical dir. Skip any entry already
+  // present as a REAL (non-symlink) file/dir.
+  const dirLinkType = process.platform === 'win32' ? 'junction' : 'dir';
+  for (const name of safeReaddir(bundled)) {
+    const src = path.join(bundled, name);
+    const dest = path.join(canonical, name);
+    if (fs.existsSync(dest) && !isSymlink(dest)) continue; // preserve real entry
+    try {
+      if (isSymlink(dest)) fs.unlinkSync(dest);
+      fs.symlinkSync(src, dest, isDir(src) ? dirLinkType : 'file');
+    } catch (_) { /* best-effort; never block the session */ }
+  }
+}
+
+try { main(); } catch (_) { /* never block SessionStart */ }
+process.exit(0);

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -3,6 +3,7 @@
     "SessionStart": [
       {
         "hooks": [
+          { "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/gsd-ensure-canonical-path.js\"", "timeout": 5 },
           { "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/gsd-check-update.js\"" }
         ]
       }

--- a/hooks/managed-hooks-registry.cjs
+++ b/hooks/managed-hooks-registry.cjs
@@ -22,6 +22,7 @@ const MANAGED_HOOKS = [
   'gsd-context-monitor.js',
   'gsd-cursor-post-tool.js',
   'gsd-cursor-session-start.js',
+  'gsd-ensure-canonical-path.js',
   'gsd-graphify-update.sh',
   'gsd-phase-boundary.sh',
   'gsd-prompt-guard.js',

--- a/scripts/build-hooks.js
+++ b/scripts/build-hooks.js
@@ -29,6 +29,10 @@ const HOOKS_TO_COPY = [
   // Required by gsd-check-update-worker.js at runtime — must ship alongside it
   // so require('./managed-hooks-registry.cjs') resolves in the installed hooks/ dir.
   'managed-hooks-registry.cjs',
+  // Claude Code SessionStart hook (#997) — recreates the canonical
+  // ~/.claude/gsd-core compatibility path that bundled @-includes target but a
+  // marketplace plugin install never populates. No-op in classic installs.
+  'gsd-ensure-canonical-path.js',
   'gsd-context-monitor.js',
   // Cursor lifecycle hooks (issue #777): sessionStart context injection + postToolUse monitor
   'gsd-cursor-session-start.js',

--- a/tests/bug-997-plugin-canonical-gsd-core-path.test.cjs
+++ b/tests/bug-997-plugin-canonical-gsd-core-path.test.cjs
@@ -1,0 +1,161 @@
+'use strict';
+
+/**
+ * Regression tests for #997.
+ *
+ * GSD's bundled agents/commands/templates @-include the canonical path
+ * `~/.claude/gsd-core/...`. A classic `bin/install.js` install populates that
+ * directory; a Claude Code *marketplace plugin* install never does (the plugin
+ * manager only unpacks into the version-pinned cache and never runs
+ * install.js), so every @-include resolves to nothing and gsd agents fail.
+ *
+ * The SessionStart hook hooks/gsd-ensure-canonical-path.js bridges the gap by
+ * making ~/.claude/gsd-core a real directory whose immutable bundled subdirs
+ * are symlinked to the plugin's bundled gsd-core/ tree. These tests drive the
+ * hook in a sandboxed HOME against a throwaway plugin layout.
+ *
+ * Cross-platform note: on Windows the hook creates directory *junctions*, which
+ * lstat() does not report as symlinks, so link-ness is asserted via realpath
+ * equality (resolves both symlinks and junctions) rather than isSymbolicLink().
+ */
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+const helpers = require('./helpers.cjs');
+
+const REPO_ROOT = path.join(__dirname, '..');
+const HOOK_SRC = path.join(REPO_ROOT, 'hooks', 'gsd-ensure-canonical-path.js');
+const SUBDIRS = ['references', 'workflows', 'templates', 'contexts', 'bin'];
+
+// Throwaway plugin layout: <root>/plugin/hooks/<hook> + <root>/plugin/gsd-core/<subdirs>,
+// with HOME pointed at <root>/home so the hook writes to <home>/.claude/gsd-core.
+function makeSandbox(prefix = 'gsd-canonical-') {
+  const tmp = helpers.createTempDir(prefix);
+  const pluginRoot = path.join(tmp, 'plugin');
+  const home = path.join(tmp, 'home');
+  fs.mkdirSync(path.join(pluginRoot, 'hooks'), { recursive: true });
+  for (const sub of SUBDIRS) {
+    fs.mkdirSync(path.join(pluginRoot, 'gsd-core', sub), { recursive: true });
+    fs.writeFileSync(path.join(pluginRoot, 'gsd-core', sub, 'probe.md'), `# ${sub} probe\n`);
+  }
+  fs.mkdirSync(path.join(home, '.claude'), { recursive: true });
+  fs.copyFileSync(HOOK_SRC, path.join(pluginRoot, 'hooks', 'gsd-ensure-canonical-path.js'));
+  return { tmp, pluginRoot, home };
+}
+
+function runHook(hookPath, home) {
+  execFileSync('node', [hookPath], { env: { ...process.env, HOME: home, USERPROFILE: home } });
+}
+
+function isLink(p) {
+  try { return fs.lstatSync(p).isSymbolicLink(); } catch (_) { return false; }
+}
+function linksTo(linkPath, targetPath) {
+  return fs.realpathSync(linkPath) === fs.realpathSync(targetPath);
+}
+
+describe('#997: plugin install canonical ~/.claude/gsd-core path', () => {
+  test('bridges bundled subdirs so @-includes resolve', () => {
+    const { tmp, pluginRoot, home } = makeSandbox();
+    try {
+      runHook(path.join(pluginRoot, 'hooks', 'gsd-ensure-canonical-path.js'), home);
+      const canonical = path.join(home, '.claude', 'gsd-core');
+      for (const sub of SUBDIRS) {
+        const entry = path.join(canonical, sub);
+        const bundled = path.join(pluginRoot, 'gsd-core', sub);
+        assert.ok(linksTo(entry, bundled), `${sub} should resolve to the bundled dir`);
+        const probe = path.join(entry, 'probe.md');
+        assert.ok(fs.existsSync(probe), `@~/.claude/gsd-core/${sub}/probe.md should resolve`);
+        assert.equal(fs.readFileSync(probe, 'utf8'), `# ${sub} probe\n`);
+      }
+    } finally {
+      helpers.cleanup(tmp);
+    }
+  });
+
+  test('is idempotent', () => {
+    const { tmp, pluginRoot, home } = makeSandbox();
+    try {
+      const hook = path.join(pluginRoot, 'hooks', 'gsd-ensure-canonical-path.js');
+      runHook(hook, home);
+      runHook(hook, home);
+      const refs = path.join(home, '.claude', 'gsd-core', 'references');
+      assert.ok(linksTo(refs, path.join(pluginRoot, 'gsd-core', 'references')));
+      assert.ok(fs.existsSync(path.join(refs, 'probe.md')));
+    } finally {
+      helpers.cleanup(tmp);
+    }
+  });
+
+  test('prunes dangling symlinks left by an older bundle version', () => {
+    const { tmp, pluginRoot, home } = makeSandbox();
+    try {
+      const hook = path.join(pluginRoot, 'hooks', 'gsd-ensure-canonical-path.js');
+      runHook(hook, home);
+      const dangling = path.join(home, '.claude', 'gsd-core', 'removed-in-new-version');
+      fs.symlinkSync(path.join(tmp, 'does-not-exist'), dangling);
+      runHook(hook, home);
+      assert.ok(!fs.existsSync(dangling) && !isLink(dangling), 'dangling link should be pruned');
+    } finally {
+      helpers.cleanup(tmp);
+    }
+  });
+
+  test('preserves real user-generated top-level files', () => {
+    const { tmp, pluginRoot, home } = makeSandbox();
+    try {
+      const hook = path.join(pluginRoot, 'hooks', 'gsd-ensure-canonical-path.js');
+      runHook(hook, home);
+      const profile = path.join(home, '.claude', 'gsd-core', 'USER-PROFILE.md');
+      fs.writeFileSync(profile, 'my profile\n');
+      runHook(hook, home);
+      assert.ok(!isLink(profile), 'USER-PROFILE.md must stay a real file');
+      assert.equal(fs.readFileSync(profile, 'utf8'), 'my profile\n');
+    } finally {
+      helpers.cleanup(tmp);
+    }
+  });
+
+  test('no-op when the bundled tree already is the canonical path (classic install)', () => {
+    // Classic install: plugin root = <home>/.claude, so the bundled gsd-core
+    // lives at <home>/.claude/gsd-core (== canonical). The hook must not
+    // convert the real dirs into self-referential symlinks.
+    const tmp = helpers.createTempDir('gsd-canonical-classic-');
+    try {
+      const home = path.join(tmp, 'home');
+      const claude = path.join(home, '.claude');
+      fs.mkdirSync(path.join(claude, 'hooks'), { recursive: true });
+      fs.mkdirSync(path.join(claude, 'gsd-core', 'references'), { recursive: true });
+      fs.writeFileSync(path.join(claude, 'gsd-core', 'references', 'real.md'), 'real\n');
+      const hook = path.join(claude, 'hooks', 'gsd-ensure-canonical-path.js');
+      fs.copyFileSync(HOOK_SRC, hook);
+      runHook(hook, home);
+      const refs = path.join(claude, 'gsd-core', 'references');
+      assert.ok(!isLink(refs) && fs.statSync(refs).isDirectory(),
+        'classic-install dirs must remain real, not symlinked');
+      assert.equal(fs.readFileSync(path.join(refs, 'real.md'), 'utf8'), 'real\n');
+    } finally {
+      helpers.cleanup(tmp);
+    }
+  });
+
+  describe('wiring', () => {
+    test('registered as a SessionStart hook in hooks.json', () => {
+      const hooksJson = require(path.join(REPO_ROOT, 'hooks', 'hooks.json'));
+      const cmds = hooksJson.hooks.SessionStart.flatMap(g => g.hooks.map(h => h.command));
+      assert.ok(cmds.some(c => c.includes('gsd-ensure-canonical-path.js')),
+        'gsd-ensure-canonical-path.js must be wired as a SessionStart hook');
+    });
+    test('listed in MANAGED_HOOKS', () => {
+      const { MANAGED_HOOKS } = require(path.join(REPO_ROOT, 'hooks', 'managed-hooks-registry.cjs'));
+      assert.ok(MANAGED_HOOKS.includes('gsd-ensure-canonical-path.js'));
+    });
+    test('listed in build-hooks HOOKS_TO_COPY', () => {
+      const { HOOKS_TO_COPY } = require(path.join(REPO_ROOT, 'scripts', 'build-hooks.js'));
+      assert.ok(HOOKS_TO_COPY.includes('gsd-ensure-canonical-path.js'));
+    });
+  });
+});


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #997

> Note for maintainers: #997 is freshly filed and not yet labeled `confirmed-bug` (I'm not a maintainer, so I can't apply it). The bug is deterministic and reproduces on `next` (105 files still `@`-include `~/.claude/gsd-core/...`). Happy to wait for triage before review.

## What was broken

In a Claude Code **marketplace plugin** install, every bundled agent/command/template that `@`-includes `~/.claude/gsd-core/...` resolves to nothing, so gsd agents fail (e.g. the executor: "@-references ~/.claude/gsd-core/... paths, but this is a plugin-based install where those paths are empty").

## What this fix does

Adds a SessionStart hook, `hooks/gsd-ensure-canonical-path.js`, that makes `~/.claude/gsd-core` a real directory whose immutable bundled subdirs (`bin`, `contexts`, `references`, `templates`, `workflows`) are symlinked to the plugin's bundled `gsd-core/`. This restores the exact path the existing `@`-includes already use, so **no references change**.

## Root cause

The canonical `~/.claude/gsd-core/` directory is populated only by `bin/install.js` (it copies the bundled `gsd-core/` tree into `join(configDir, 'gsd-core')`). A marketplace plugin install never runs `install.js` — the plugin manager only unpacks into the version-pinned cache — so the directory is never created. The references can't switch to `${CLAUDE_PLUGIN_ROOT}` because Claude Code does not expand environment variables in markdown `@`-includes (only `~` and absolute/relative paths); that variable is only expanded in `hooks.json` command strings, which is why a hook can resolve it and the bundled markdown cannot.

The hook is a no-op in classic installs (the bundled tree already *is* the canonical path), preserves real user-generated files (e.g. `USER-PROFILE.md`), prunes stale symlinks so it self-heals after `claude plugin update` (the cache path is version-pinned), uses Windows directory junctions, derives the plugin root from `__dirname` (no dependency on `CLAUDE_PLUGIN_ROOT` reaching the hook env), and never blocks the session (always exits 0). It is wired first in `SessionStart` and registered in both `MANAGED_HOOKS` and `HOOKS_TO_COPY`.

## Testing

### How I verified the fix

`tests/bug-997-plugin-canonical-gsd-core-path.test.cjs` drives the hook in a sandboxed `HOME` against a throwaway plugin layout and asserts: bundled subdirs resolve through the canonical path (via `realpath`, so it holds for POSIX symlinks and Windows junctions alike), idempotency, dangling-link pruning, real-file preservation, and the classic-install no-op. It also asserts the wiring (`hooks.json` SessionStart, `MANAGED_HOOKS`, `HOOKS_TO_COPY`).

Locally on macOS: the new test (8) and the existing `managed-hooks` / `orphaned-hooks` contract tests (11) pass; `eslint .` is clean; `npm run build:hooks` copies the hook into `dist/` and stamps the version banner; `npm run lint:skill-deps` passes.

### Regression test added?

- [x] Yes — added a test that would have caught this bug

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling) — junction path is implemented (`fs.symlinkSync(..., 'junction')`) but not exercised on a Windows runner locally
- [ ] Linux — logic is path-independent; not run locally
- [x] N/A (not platform-specific) — core logic

### Runtimes tested

- [x] Claude Code
- [ ] N/A (the bug is specific to the Claude Code plugin install path)

---

## Checklist

- [x] Issue linked above with `Fixes #997`
- [ ] Linked issue has the `confirmed-bug` label — pending maintainer triage (see note above)
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass (`npm test`) — ran the affected hook-contract tests + new test + lint locally; happy to run the full suite in CI
- [x] `.changeset/` fragment added
- [x] No unnecessary dependencies added

## Breaking changes

None
