### PR TITLE
fix(#1004): detect http-route hook registrations in installer presence check

### DIFF
--- a/.changeset/1004-installer-http-hook-presence.md
+++ b/.changeset/1004-installer-http-hook-presence.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 1032
 ---
 **Installer no longer appends a duplicate managed hook when it is registered via an HTTP route** — a hook re-registered as a `type:"http"` entry (local hook-server routing) carries its identity only in `url`, which the installer's presence check ignored, so a stock command duplicate was appended on every install/update and the hook ran twice per event. The presence check now also inspects `h.url`. (#1004)

--- a/.changeset/1004-installer-http-hook-presence.md
+++ b/.changeset/1004-installer-http-hook-presence.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**Installer no longer appends a duplicate managed hook when it is registered via an HTTP route** — a hook re-registered as a `type:"http"` entry (local hook-server routing) carries its identity only in `url`, which the installer's presence check ignored, so a stock command duplicate was appended on every install/update and the hook ran twice per event. The presence check now also inspects `h.url`. (#1004)

--- a/bin/install.js
+++ b/bin/install.js
@@ -11926,15 +11926,18 @@ function install(isGlobal, runtime = 'claude', options = {}) {
   }
 
   // Helper: detect whether a hook entry references a managed hook by name.
-  // Checks both the plain command string (standard form) and the args array
-  // (command+args / wrapped-launcher form used by windowless launchers on
-  // Windows and some custom PATH-less environments).  Without this check the
-  // presence guards below only inspect h.command, so an args-form wrapper is
-  // invisible and a stock string-command entry is appended on every
-  // install/update, running the hook twice. (#976)
+  // Checks all three registration shapes:
+  //   • plain command string (standard form)
+  //   • args array (command+args / wrapped-launcher form used by windowless
+  //     launchers on Windows and some custom PATH-less environments) (#976)
+  //   • url field (type:"http" local-server routing form) (#1004)
+  // Without covering all three, an http-form or args-form entry is invisible
+  // and a stock string-command entry is appended on every install/update,
+  // running the hook twice.
   function referencesHook(h, hookName) {
     return (typeof h.command === 'string' && h.command.includes(hookName)) ||
-      (Array.isArray(h.args) && h.args.some(a => typeof a === 'string' && a.includes(hookName)));
+      (Array.isArray(h.args) && h.args.some(a => typeof a === 'string' && a.includes(hookName))) ||
+      (typeof h.url === 'string' && h.url.includes(hookName));
   }
 
   // Configure SessionStart hook for update checking (skip for opencode)

--- a/tests/install-regressions.test.cjs
+++ b/tests/install-regressions.test.cjs
@@ -770,3 +770,103 @@ describe('#976 regression: installer does not duplicate managed hooks when regis
     );
   });
 });
+
+// ─── #1004 — http-form hook presence detection ────────────────────────────────
+//
+// Claude Code hooks support a type:"http" form where the hook identity lives
+// in h.url (no command, no args).  Pre-fix, referencesHook() only inspected
+// h.command and h.args, so an http-form entry was invisible and a stock
+// string-command entry was appended on every install, running the hook twice.
+// This is the same duplicate-append failure as #976 (args-form), one shape further.
+
+describe('#1004 regression: installer does not duplicate managed hooks when registered in http form', () => {
+  let tmpDir;
+  let previousCwd;
+
+  beforeEach(() => {
+    tmpDir = createTempDir('gsd-1004-http-form-');
+    previousCwd = process.cwd();
+    process.chdir(tmpDir);
+
+    assert.strictEqual(typeof install, 'function',
+      'install must be exported from bin/install.js');
+  });
+
+  afterEach(() => {
+    process.chdir(previousCwd);
+    cleanup(tmpDir);
+  });
+
+  test('does not add a second SessionStart entry when gsd-check-update is already in http form', () => {
+    const targetDir = path.join(tmpDir, '.claude');
+    fs.mkdirSync(targetDir, { recursive: true });
+
+    // Pass 1: run install with no pre-existing settings to create the
+    // gsd-file-manifest.json that the installer migration uses to decide
+    // whether a hook file is managed (kept) or foreign (removed).
+    // Without a manifest, migration removes any hook stubs as "unrecognized
+    // GSD-looking files", making fs.existsSync(checkUpdateFile) return false
+    // and skipping the duplicate-adding path.
+    install(false, 'claude');
+
+    // Now stub the hook files so fs.existsSync guards pass on pass 2.
+    // The manifest now exists, so migration classifies the stubs as
+    // manifest-managed and leaves them alone.
+    stubHooksIntoDir(targetDir, ['gsd-check-update.js']);
+
+    // Local Claude installs read/write settings.local.json (not settings.json).
+    // Overwrite settings.local.json with the hook in http form.
+    // The GSD hook name appears only in h.url — no command, no args.
+    const hookUrl = 'http://127.0.0.1:18923/hooks/gsd-check-update';
+    const preExistingSettings = {
+      hooks: {
+        SessionStart: [
+          {
+            hooks: [
+              {
+                type: 'http',
+                url: hookUrl,
+                timeout: 5,
+              },
+            ],
+          },
+        ],
+      },
+    };
+    fs.writeFileSync(
+      path.join(targetDir, 'settings.local.json'),
+      JSON.stringify(preExistingSettings, null, 2) + '\n',
+    );
+
+    // Pass 2: run install again — the pre-existing http-form entry must
+    // suppress the duplicate stock string-command registration.
+    const result = install(false, 'claude');
+    const settings = result && result.settings;
+
+    assert.ok(settings && settings.hooks && Array.isArray(settings.hooks.SessionStart),
+      'settings.hooks.SessionStart must be an array after install');
+
+    // Count all hook entries (at any nesting level) that reference gsd-check-update,
+    // including the url arm so http-form entries are visible.
+    const allEntries = settings.hooks.SessionStart.flatMap(entry =>
+      Array.isArray(entry && entry.hooks) ? entry.hooks : []
+    );
+    const matching = allEntries.filter(h =>
+      (typeof h.command === 'string' && h.command.includes('gsd-check-update')) ||
+      (Array.isArray(h.args) && h.args.some(a => typeof a === 'string' && a.includes('gsd-check-update'))) ||
+      (typeof h.url === 'string' && h.url.includes('gsd-check-update'))
+    );
+
+    assert.strictEqual(
+      matching.length,
+      1,
+      [
+        'Expected exactly 1 hook entry referencing gsd-check-update after install,',
+        `got ${matching.length}.`,
+        'The installer added a duplicate because it could not detect the http-form registration.',
+        'referencesHook() must check h.url in addition to h.command and h.args. (#1004)',
+        `All matching entries: ${JSON.stringify(matching)}`,
+      ].join(' '),
+    );
+  });
+});


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #1004

> The linked issue carries the `confirmed-bug` label.

---

## What was broken

The installer's hook-presence check (`referencesHook` in `bin/install.js`) only inspected `h.command` and `h.args`. A managed hook re-registered as a `type:"http"` entry — whose identity lives only in `h.url` (local hook-server routing) — was invisible, so the installer appended a stock command duplicate on every install/update and the hook ran twice per event.

## What this fix does

Adds a third arm to `referencesHook` that also inspects `h.url`, so an http-route registration of a managed hook is detected and the duplicate stock entry is no longer appended. This mirrors the existing `h.args` arm added for the command+args form in #976.

## Root cause

`referencesHook` was introduced (#976/#994) to cover the command+args wrapped-launcher shape, but Claude Code hooks also support a `type:"http"` shape that carries the hook name only in `url`. That shape was never added to the presence heuristic, so the guards that call `referencesHook` (`gsd-check-update`, `gsd-context-monitor`, `gsd-prompt-guard`, `gsd-read-guard`, etc.) treated an http-registered managed hook as absent.

## Testing

### How I verified the fix

Added a behavioral regression test in `tests/install-regressions.test.cjs` (`#1004 regression` block) that mirrors the `#976` end-to-end install harness: it pre-seeds `settings.local.json` with the hook in `type:"http"` form, runs `install()` twice, and asserts exactly one entry references the hook. The test fails (count 2) before the fix and passes after. Full suite green on Linux docker (mirrors ubuntu CI): 14040 pass / 0 fail.

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [x] N/A (not platform-specific)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1032"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783772683&installation_id=134682257&pr_number=1032&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1032&signature=8f2a8cb4cfd2859edda9f222ce795970203470d822a7a569cd268838c26c23d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->