### PR TITLE
fix(#1034): correct stale intel.cts comments to canonical INTEL_FILES names

### DIFF
--- a/src/intel.cts
+++ b/src/intel.cts
@@ -185,7 +185,7 @@ interface IntelQueryResult {
 
 /**
  * Query intel files for a search term.
- * Searches across all JSON intel files (keys and values) and arch.md (text lines).
+ * Searches across all JSON intel files in INTEL_FILES (keys and values), including arch-decisions.json (parsed as JSON, not as text).
  */
 function intelQuery(term: string, planningDir: string): IntelQueryResult | DisabledResponse {
   if (!isIntelEnabled(planningDir)) return disabledResponse();
@@ -417,7 +417,7 @@ function intelValidate(planningDir: string): IntelValidateResult | DisabledRespo
 
     // Validate entries are objects with expected fields
     if (data.entries && typeof data.entries === 'object') {
-      // files.json: check exports are actual symbol names (no spaces)
+      // file-roles.json (INTEL_FILES key 'files'): check exports are actual symbol names (no spaces)
       if (key === 'files') {
         for (const [entryPath, entry] of Object.entries(data.entries)) {
           const entryObj = entry as Record<string, unknown>;
@@ -438,7 +438,7 @@ function intelValidate(planningDir: string): IntelValidateResult | DisabledRespo
         }
       }
 
-      // deps.json: check entries have version, type, used_by
+      // dependency-graph.json (INTEL_FILES key 'deps'): check entries have version, type, used_by
       if (key === 'deps') {
         for (const [depName, entry] of Object.entries(data.entries)) {
           const entryObj = entry as Record<string, unknown>;


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #1034

---

## What was broken

Three maintainer-facing comments in `src/intel.cts` still referenced the **retired** short/markdown intel filenames (`files.json`, `deps.json`, `arch.md`) and described arch as searched "text lines", even though the implementation iterates the exported `INTEL_FILES` map and `safeReadJson`s every entry — arch included — as JSON.

## What this fix does

Updates the three comments to cite the canonical `INTEL_FILES` names (`file-roles.json`, `dependency-graph.json`, `arch-decisions.json`) and the JSON-for-arch behavior. Comment-only — no code, no behavior change.

- `intelQuery` JSDoc (L188): no longer claims it searches `arch.md (text lines)`; now notes `arch-decisions.json` is parsed as JSON.
- L420: `// files.json:` → `// file-roles.json (INTEL_FILES key 'files'):`
- L442: `// deps.json:` → `// dependency-graph.json (INTEL_FILES key 'deps'):`

## Root cause

Documentation drift: the comments were written against the pre-canonical filename scheme and weren't updated when the module moved to `INTEL_FILES` long names with arch parsed as JSON. Deferred from the #1000 fix to keep that PR scoped to the agent prompt.

## Testing

### How I verified the fix

`npm run build:lib` (tsc) exits 0; `git diff src/intel.cts` shows exactly the three comment lines changed (+3/-3), no code touched; `npm run lint` exits 0; full docker `gsd-test-summary` suite green.

### Regression test added?

- [x] No — explain why: comment-only documentation change with no observable behavior; the `no-source-grep` test rule forbids asserting on source-comment strings, so there is no compliant regression test to add.

### Platforms tested

- [x] N/A (not platform-specific)

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix — **not user-facing; `no-changelog` label applied**
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1036"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783775091&installation_id=134682257&pr_number=1036&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1036&signature=7a448131f953275fb17b4deb522f5bd1dada59d7aa57ef7cf4414d6e26b2f0ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->