### PR TITLE
feat(#1046): phase 5c — drive commandStyle from the runtime descriptor — ADR-857/1016

### DIFF
--- a/src/runtime-slash.cts
+++ b/src/runtime-slash.cts
@@ -55,8 +55,17 @@ export function formatGsdSlash(commandName: unknown, runtime: unknown): unknown 
 
   const runtimeText = (typeof runtime === 'string' && runtime ? runtime : 'claude').toLowerCase();
   const rt = canonicalizeRuntimeName(runtimeText) || runtimeText;
-  if (rt === 'codex') {
-    // Codex skills are invoked as $gsd-<cmd> (shell-var syntax). The command
+
+  // Descriptor-driven: look up commandStyle from the capability registry.
+  // Mirrors the lazy-require pattern from runtime-homes.cts §getGlobalConfigDir.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { runtimes } = require('./capability-registry.cjs') as {
+    runtimes: Record<string, { runtime?: { commandStyle?: string } }>;
+  };
+  const style = runtimes[rt]?.runtime?.commandStyle;
+
+  if (style === 'shell-var') {
+    // shell-var runtimes (currently: codex) use $gsd-<cmd> syntax. The command
     // token is lowercased because shell-var identifiers are conventionally
     // lowercase; matches the convertCodexSlash() projection in bin/install.js.
     return `$gsd-${token.toLowerCase()}${tail}`;

--- a/tests/bug-3584-runtime-slash-formatter.test.cjs
+++ b/tests/bug-3584-runtime-slash-formatter.test.cjs
@@ -195,6 +195,86 @@ describe('formatGsdSlash — runtime-aware slash command formatter', () => {
   });
 });
 
+describe('formatGsdSlash — descriptor-driven commandStyle (ADR-857 phase 5c)', () => {
+  // These three assertions are the non-vacuous equivalence anchor for the
+  // descriptor-driven branch: the formatter reads commandStyle from the
+  // capability registry instead of hardcoding `if (rt === 'codex')`.
+
+  test('codex (commandStyle=shell-var) → $gsd- with lowercased token', () => {
+    // The registry carries commandStyle=shell-var for codex. The formatter
+    // must look it up and emit the shell-var form, lowercasing only the token.
+    assert.strictEqual(formatGsdSlash('Foo', 'codex'), '$gsd-foo');
+  });
+
+  test('slash-hyphen runtime (claude) → /gsd- with case-preserved token', () => {
+    // claude descriptor has commandStyle=slash-hyphen. Token case is preserved.
+    assert.strictEqual(formatGsdSlash('Foo', 'claude'), '/gsd-Foo');
+  });
+
+  test('slash-hyphen runtime (cursor) → /gsd- with case-preserved token', () => {
+    // cursor descriptor has commandStyle=slash-hyphen.
+    assert.strictEqual(formatGsdSlash('Foo', 'cursor'), '/gsd-Foo');
+  });
+
+  test('unknown runtime (no registry entry) → /gsd- default (slash-hyphen fallback)', () => {
+    // An unknown runtime has no descriptor entry → runtimes[rt] is undefined →
+    // style is undefined → not 'shell-var' → falls through to /gsd- default.
+    assert.strictEqual(formatGsdSlash('foo', 'doesnotexist'), '/gsd-foo');
+  });
+});
+
+describe('formatGsdSlash — registry-parity: prefix and casing are a pure function of commandStyle', () => {
+  // Non-vacuous proof that the REGISTRY drives the decision, not a hardcoded
+  // `rt === 'codex'` check. For every runtime id in capability-registry.cjs we
+  // derive the expected prefix and lowercasing linkage directly from the
+  // registry's commandStyle field and assert that formatGsdSlash matches.
+  //
+  // This fails if:
+  //   (a) anyone reverts the formatter to a hardcode that diverges from the
+  //       registry (e.g. a future runtime gets commandStyle=shell-var but the
+  //       formatter still only special-cases 'codex'); or
+  //   (b) a runtime's commandStyle is changed in the registry without
+  //       formatGsdSlash following suit.
+  const { runtimes } = require(
+    path.join(ROOT, 'gsd-core', 'bin', 'lib', 'capability-registry.cjs'),
+  );
+
+  const TOKEN_MIXED = 'SomeCmd'; // mixed-case to distinguish lowercasing behaviour
+
+  for (const [id, descriptor] of Object.entries(runtimes)) {
+    const style = descriptor.runtime.commandStyle;
+
+    test(`${id}: commandStyle=${style} → formatGsdSlash prefix and casing match registry`, () => {
+      const result = formatGsdSlash(TOKEN_MIXED, id);
+
+      if (style === 'shell-var') {
+        // shell-var runtimes must emit $gsd-<lowercased-token>
+        assert.ok(
+          result.startsWith('$gsd-'),
+          `[${id}] expected $gsd- prefix (commandStyle=shell-var), got: ${result}`,
+        );
+        assert.strictEqual(
+          result,
+          `$gsd-${TOKEN_MIXED.toLowerCase()}`,
+          `[${id}] shell-var must lowercase the token`,
+        );
+      } else {
+        // slash-hyphen (or any other non-shell-var value) must emit /gsd-<token>
+        // with case preserved (no lowercasing)
+        assert.ok(
+          result.startsWith('/gsd-'),
+          `[${id}] expected /gsd- prefix (commandStyle=${style}), got: ${result}`,
+        );
+        assert.strictEqual(
+          result,
+          `/gsd-${TOKEN_MIXED}`,
+          `[${id}] slash-hyphen must preserve token case`,
+        );
+      }
+    });
+  }
+});
+
 describe('resolveRuntime — env > config > default', () => {
   test('process.env.GSD_RUNTIME wins over everything', () => {
     const saved = process.env.GSD_RUNTIME;


### PR DESCRIPTION
## Enhancement PR

## Linked Issue

Closes #1046

> Parent epic: #857. **Phase 5c** — `formatGsdSlash` resolves command style from the runtime descriptor (`registry.runtimes[id].runtime.commandStyle`) instead of the hardcoded `if (rt === 'codex')`. **Equivalence-preserving** — the trivial 2-value axis (ADR-1016 §8 rung 3).

## Before / After

**Before:** `if (rt === 'codex') return $gsd-${token.toLowerCase()}${tail}; return /gsd-${token}${tail}`.

**After:** lazy `require('./capability-registry.cjs')`; `const style = runtimes[rt]?.runtime?.commandStyle`; `if (style === 'shell-var') → $gsd-` + lowercased token; else `/gsd-` + case-preserved token.

## Equivalence (Codex-verified)

- **codex** (`commandStyle: shell-var`) → `$gsd-<lowercased-token><tail>` — unchanged.
- **all 15 others** (`slash-hyphen`) → `/gsd-<case-preserved-token><tail>` — unchanged.
- **unknown/unmapped runtime** → `runtimes[rt]` undefined → not `shell-var` → `/gsd-` (matches the old `else`).
- `canonicalizeRuntimeName` still applied before lookup (codex aliases → the `codex` key); input normalization + `'claude'` default + defensive returns all preserved. The lazy require has no circular-load risk (mirrors 5b's runtime-homes pattern).

## Testing

- `tests/bug-3584-runtime-slash-formatter.test.cjs` + `-emitters.test.cjs` anchors stay green; added a **registry-parity test** — 16 parametrized sub-tests deriving the expected prefix + lowercasing directly from each runtime's `commandStyle`, so the prefix is proven a *pure function of the registry* (catches any future hardcode-vs-registry divergence or a runtime's style change).
- `build` clean; `lint` clean; full unit **0 fail** (13837 across 3 chunks); `capability-registry.cjs` (registry) untouched.
- **gsd-test docker (clean `--reset`): 17471 / 0.**

### Platforms tested
- [x] macOS · [x] Linux (clean-build docker) · [ ] Windows (CI)

### Runtimes tested
- [x] Equivalence proven for codex + all 15 + unknown via the registry-parity test.

## Scope confirmation

- [x] Matches #1046 — drive `commandStyle`, equivalence-preserving; only `src/runtime-slash.cts` + the formatter test changed
- [x] TOOL_MENTION_SIGIL (codex tool-mention sigil in install.js) is a separate concern, untouched

## Documentation

- [x] Internal resolver change; no user-facing behavior change → `no-changelog`.

## Breaking changes

None — equivalence-preserving (codex `$gsd-`, all others + unknown `/gsd-`, lowercasing + tail preserved).

## Out of scope

5d (artifactLayout) … 5g (InstallPlan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1048"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783787501&installation_id=134682257&pr_number=1048&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1048&signature=565e028e11b846044df09b7f210aad711e82d8d1b6662c32b9f822d7108d270e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->