### PR TITLE
feat(#435): full Cartesian matrix cross-product expansion in workflow-policy linter

### DIFF
--- a/scripts/workflow-policy.cjs
+++ b/scripts/workflow-policy.cjs
@@ -37,6 +37,26 @@ function runnerDefault(runner) {
 }
 
 // ---------------------------------------------------------------------------
+// Matrix expansion helpers
+// ---------------------------------------------------------------------------
+
+// Build the GitHub Actions Cartesian product of the given base-list matrix
+// keys. Returns one context object per realized job, each mapping every key
+// to a stringified value. A single key yields one context per value (identical
+// to the legacy base-list expansion); N keys yield the full cross-product.
+// Values are stringified to match runner-label comparison and matrix-expression
+// resolution, which operate on strings.
+function cartesianProduct(keys, matrix) {
+  return keys.reduce(
+    (contexts, key) =>
+      contexts.flatMap((context) =>
+        matrix[key].map((value) => ({ ...context, [key]: String(value) })),
+      ),
+    [{}],
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Matrix expansion
 // ---------------------------------------------------------------------------
 
@@ -88,19 +108,32 @@ function expandRunsOn(runsOnRaw, matrix) {
     }
   }
 
-  // Collect values from matrix.<key> list (e.g. matrix.os: [ubuntu, macos])
-  // These base-list entries have no extra context beyond the key itself.
-  // Each entry is pushed unconditionally — deduplicating by runner alone
-  // would collapse distinct Cartesian rows (e.g. duplicate os values paired
-  // with different shell values) and hide policy violations on later rows.
+  // GitHub Actions realizes one job per element of the Cartesian product of all
+  // base-list matrix keys (every matrix.<k> that is an array, excluding the
+  // include/exclude control keys), and each realized job's context carries a
+  // value for EVERY matrix key — so ${{ matrix.<key> }} references (e.g. in a
+  // shell: field) resolve against any realization, not only the runs-on key.
+  // Single-axis matrices yield exactly one realization per value, identical to
+  // the prior behavior; only multi-axis matrices change shape.
+  // Each realization is pushed unconditionally — deduplicating by runner label
+  // would collapse distinct Cartesian rows (e.g. matrix.os: [macos-latest,
+  // macos-latest] paired with different shells) and hide policy violations.
   if (Array.isArray(matrix[key])) {
-    for (const val of matrix[key]) {
-      const runner = String(val);
-      realizations.push({ runner, resolvable: true, context: { [key]: runner } });
+    const baseListKeys = Object.keys(matrix).filter(
+      (k) => k !== 'include' && k !== 'exclude' && Array.isArray(matrix[k]),
+    );
+    for (const context of cartesianProduct(baseListKeys, matrix)) {
+      realizations.push({ runner: context[key], resolvable: true, context });
     }
   }
 
-  // matrix.exclude: remove matches
+  // matrix.exclude: remove matches by runner label (first match only).
+  // KNOWN LIMITATION (out of scope for #435, tracked as a follow-up): this
+  // matches on the runs-on key's runner label rather than the full exclude
+  // tuple, so a multi-axis exclude like { os: macos-latest, shell: bash } can
+  // remove the wrong cross-product cell. Full GitHub Actions tuple-match
+  // (including the include-rows-are-not-excluded rule) is deferred; #435 scopes
+  // only the base-list cross-product expansion above.
   if (Array.isArray(matrix.exclude)) {
     for (const excl of matrix.exclude) {
       if (excl && excl[key] != null) {

--- a/tests/policy-shell-pinning.test.cjs
+++ b/tests/policy-shell-pinning.test.cjs
@@ -492,24 +492,20 @@ jobs:
 });
 
 // ---------------------------------------------------------------------------
-// Test 8a — Counter-test: Cartesian matrix os × shell — dedup must not collapse rows by runner alone
+// Test 8a — Cartesian matrix os × shell — full cross-product expansion resolves
+//            matrix.shell per realization
 // (mechanism: matrix.os: [macos-latest, macos-latest] with matrix.shell: [zsh, bash]
 //  and runs-on: ${{ matrix.os }}, step shell: ${{ matrix.shell }}.
-//  The base-list path in expandRunsOn previously deduped by runner alone, collapsing
-//  both macos-latest rows into one. Post-fix: each entry is pushed unconditionally,
-//  producing 2 realizations from the base-list os array.
+//  GitHub Actions realizes a 2×2 grid (4 jobs). After the Cartesian-product fix,
+//  expandRunsOn must produce 4 realizations, each carrying BOTH os AND shell in
+//  context so that ${{ matrix.shell }} resolves per realization.
 //
-//  NOTE: Cartesian cross-product expansion (expanding the full os × shell grid so
-//  that each realization carries BOTH os and shell in its context) is not yet
-//  implemented in expandRunsOn. The base-list path only records { os: runner } in
-//  context, so ${{ matrix.shell }} on the step cannot be resolved and the linter
-//  emits UNRESOLVABLE_MATRIX. The ideal post-Cartesian-expansion behavior would be
-//  2 WRONG_SHELL_FOR_OS violations (the bash rows). That is a separate follow-up bug.
-//
-//  This test validates the dedupe fix only: 2 violations must be produced (not 1),
-//  proving the base-list path no longer collapses duplicate runner values.
+//  Expected post-fix behavior:
+//    - 4 total step-results (2 os × 2 shell)
+//    - exactly 2 WRONG_SHELL_FOR_OS violations — the two bash cells on macos-latest
+//    - ZERO UNRESOLVABLE_MATRIX violations (matrix.shell is now fully resolved)
 // ---------------------------------------------------------------------------
-describe('Cartesian matrix os × shell — dedup must not collapse rows by runner alone', () => {
+describe('Cartesian matrix os × shell — full cross-product expansion resolves matrix.shell per realization', () => {
   const CARTESIAN_MATRIX_YAML = `
 name: Cartesian Matrix
 jobs:
@@ -525,41 +521,157 @@ jobs:
         run: echo hi
 `;
 
-  test('Cartesian matrix os × shell — dedup must not collapse rows by runner alone', () => {
+  test('2×2 Cartesian product yields 4 step-results, 2 WRONG_SHELL_FOR_OS violations, 0 UNRESOLVABLE_MATRIX', () => {
     const result = inspectWorkflow(CARTESIAN_MATRIX_YAML, { filePath: '<synthetic-cartesian-matrix>' });
 
-    const violations = result.jobs
-      .flatMap(j => j.steps)
-      .filter(s => s.violation !== null);
+    const allSteps = result.jobs.flatMap(j => j.steps);
+    const violations = allSteps.filter(s => s.violation !== null);
+    const unresolvable = violations.filter(s => s.violation === VIOLATION.UNRESOLVABLE_MATRIX);
+    const wrongShell = violations.filter(s => s.violation === VIOLATION.WRONG_SHELL_FOR_OS);
 
-    // The dedupe fix ensures both macos-latest entries in matrix.os are expanded
-    // independently, yielding 2 realizations — not 1 (as the old dedup-by-runner
-    // guard would produce). Each realization's ${{ matrix.shell }} is currently
-    // UNRESOLVABLE_MATRIX because the base-list path doesn't yet carry shell context
-    // (Cartesian cross-product is a separate follow-up fix).
+    // 4 step-results: 2 os values × 2 shell values = 4 realizations, each with 1 step
     assert.strictEqual(
-      violations.length,
+      allSteps.length,
+      4,
+      `Expected 4 step-results (2×2 Cartesian product) but got ${allSteps.length}. All steps: ` +
+      allSteps.map(s => `runner=${s.runner} shell=${s.effectiveShell} violation=${s.violation}`).join(', ')
+    );
+
+    // Core regression proof: ZERO UNRESOLVABLE_MATRIX (matrix.shell now resolves)
+    assert.strictEqual(
+      unresolvable.length,
+      0,
+      `Expected 0 UNRESOLVABLE_MATRIX violations but got ${unresolvable.length}: ` +
+      unresolvable.map(v => `runner=${v.runner} shell=${v.effectiveShell} type=${v.violation}`).join(', ')
+    );
+
+    // Exactly 2 WRONG_SHELL_FOR_OS: the two bash cells on macos-latest
+    assert.strictEqual(
+      wrongShell.length,
       2,
-      `Expected exactly 2 violations (dedup fix: both macos-latest rows preserved) but got ${violations.length}: ` +
+      `Expected exactly 2 WRONG_SHELL_FOR_OS violations (bash on macos-latest) but got ${wrongShell.length}: ` +
       violations.map(v => `runner=${v.runner} shell=${v.effectiveShell} type=${v.violation}`).join(', ')
     );
 
-    for (const v of violations) {
+    for (const v of wrongShell) {
       assert.strictEqual(
         v.runner,
         'macos-latest',
         `Expected violation runner to be macos-latest but got ${v.runner}`
       );
-      // UNRESOLVABLE_MATRIX because Cartesian cross-product expansion is not yet
-      // implemented; ${{ matrix.shell }} cannot be resolved from base-list context.
-      // When Cartesian expansion is added, these will become WRONG_SHELL_FOR_OS
-      // (for the bash rows) and compliant (for the zsh rows).
       assert.strictEqual(
-        v.violation,
-        VIOLATION.UNRESOLVABLE_MATRIX,
-        `Expected UNRESOLVABLE_MATRIX (shell key absent from base-list context) but got ${v.violation}`
+        v.effectiveShell,
+        'bash',
+        `Expected effectiveShell to be bash (the violating cell) but got ${v.effectiveShell}`
       );
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 8b — Cartesian matrix os × node-version — compliant cross-product carries
+//            extra axis without violations
+// (mechanism: matrix.os: [ubuntu-latest, ubuntu-latest] with
+//  matrix.node-version: [22, 24], step shell: bash (literal).
+//  The cross-product yields 4 realizations. ubuntu-latest + bash = compliant.
+//  Pre-fix: only os is expanded → 2 step-results. Post-fix: 4 step-results.
+//  This is the fail-first signal for the Cartesian expansion fix.
+// ---------------------------------------------------------------------------
+describe('Cartesian matrix os × node-version — compliant cross-product yields 4 step-results with 0 violations', () => {
+  const CARTESIAN_COMPLIANT_YAML = `
+name: Cartesian Compliant
+jobs:
+  build:
+    runs-on: \${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, ubuntu-latest]
+        node-version: [22, 24]
+    steps:
+      - name: Run tests
+        shell: bash
+        run: npm test
+`;
+
+  test('2×2 Cartesian product yields 4 step-results (fail-first signal pre-fix: 2) and 0 violations', () => {
+    const result = inspectWorkflow(CARTESIAN_COMPLIANT_YAML, { filePath: '<synthetic-cartesian-compliant>' });
+
+    const allSteps = result.jobs.flatMap(j => j.steps);
+    const violations = allSteps.filter(s => s.violation !== null);
+
+    // Pre-fix: only os is expanded → 2 step-results; post-fix: 4
+    assert.strictEqual(
+      allSteps.length,
+      4,
+      `Expected 4 step-results (2 os × 2 node-version Cartesian product) but got ${allSteps.length}. ` +
+      `If you see 2, the Cartesian expansion fix is not yet applied. All steps: ` +
+      allSteps.map(s => `runner=${s.runner} shell=${s.effectiveShell} violation=${s.violation}`).join(', ')
+    );
+
+    // ubuntu-latest + literal bash = compliant; no violations expected
+    assert.strictEqual(
+      violations.length,
+      0,
+      `Expected 0 violations (ubuntu-latest + bash is compliant) but got ${violations.length}: ` +
+      violations.map(v => `runner=${v.runner} shell=${v.effectiveShell} type=${v.violation}`).join(', ')
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 8c — Property-based: for any 1–3 base-list axes with 1–3 values each,
+//            step count === Cartesian product of axis lengths
+// (fast-check is a devDependency: fast-check ^4.8.0)
+// ---------------------------------------------------------------------------
+const fc = require('fast-check');
+
+describe('property-based: step count equals product of all axis lengths for arbitrary base-list matrices', () => {
+  test('step count === product(axisLengths) for 1–3 axes with 1–3 values each', () => {
+    // Axis keys named k0, k1, k2; values restricted to [A-Za-z0-9-] to keep YAML well-formed.
+    // runs-on references ${{ matrix.k0 }}; the single step's shell references the
+    // LAST matrix axis key (${{ matrix.kLast }}) so that a dropped axis key would
+    // surface as UNRESOLVABLE_MATRIX rather than silently resolving.
+    const axisValueArb = fc.stringMatching(/^[A-Za-z][A-Za-z0-9-]{0,7}$/);
+    const axisArb = fc.array(axisValueArb, { minLength: 1, maxLength: 3 });
+    const matrixArb = fc.array(axisArb, { minLength: 1, maxLength: 3 });
+
+    fc.assert(
+      fc.property(matrixArb, (axes) => {
+        // Build YAML matrix block
+        const keys = axes.map((_, i) => `k${i}`);
+        const lastKey = keys[keys.length - 1];
+        const matrixLines = keys.map((k, i) => `        ${k}: [${axes[i].join(', ')}]`);
+
+        const yaml = [
+          'name: PropertyTest',
+          'jobs:',
+          '  build:',
+          '    runs-on: ${{ matrix.k0 }}',
+          '    strategy:',
+          '      matrix:',
+          ...matrixLines,
+          '    steps:',
+          '      - name: Run tests',
+          `        shell: \${{ matrix.${lastKey} }}`,
+          '        run: echo hi',
+        ].join('\n');
+
+        const result = inspectWorkflow(yaml, { filePath: '<property-test>' });
+        const allSteps = result.jobs.flatMap(j => j.steps);
+        const actualSteps = allSteps.length;
+        const expectedSteps = axes.reduce((acc, axis) => acc * axis.length, 1);
+
+        // Every realization must carry the last axis key in context so that
+        // ${{ matrix.kLast }} resolves. If the key is absent from any
+        // realization's context, effectiveShell fires UNRESOLVABLE_MATRIX.
+        const noUnresolvable = allSteps.every(
+          s => s.violation !== VIOLATION.UNRESOLVABLE_MATRIX,
+        );
+
+        return actualSteps === expectedSteps && noUnresolvable;
+      }),
+      { seed: 42, numRuns: 100 }
+    );
   });
 });
 


### PR DESCRIPTION
## Enhancement PR

## Linked Issue

Closes #435

The linked issue carries the `approved-enhancement` label (approved 2026-06-01).

---

## What this enhancement improves

`scripts/workflow-policy.cjs` — the `expandRunsOn` function that enumerates CI realizations from `strategy.matrix` blocks (the shell-pinning policy linter introduced by PR #434).

## Before / After

**Before:**
`expandRunsOn` expanded a multi-axis `strategy.matrix` **one key at a time**. For `matrix.os: [a, b]` + `matrix.shell: [x, y]` it produced realizations whose `context` carried only the runs-on key (`{ os: a }`, `{ os: b }`), dropping `shell` entirely. `${{ matrix.shell }}` could not be resolved against an `os`-only context, so the linter emitted spurious `UNRESOLVABLE_MATRIX` violations for every Cartesian cell. Shell-pinning coverage was incomplete for multi-axis jobs.

**After:**
`expandRunsOn` enumerates the full GitHub Actions cross-product of all base-list matrix keys. Each realization's `context` carries a value for **every** matrix key, so `${{ matrix.<key> }}` resolves per realization.

```
matrix.os: [ubuntu-latest, windows-2025] + matrix.shell: [bash, pwsh]
  → 4 realizations:
      { os: ubuntu-latest,  shell: bash }
      { os: ubuntu-latest,  shell: pwsh }
      { os: windows-2025,   shell: bash }
      { os: windows-2025,   shell: pwsh }
```

`UNRESOLVABLE_MATRIX` no longer fires for compliant Cartesian workflows; genuine per-cell shell mismatches are now reported as `WRONG_SHELL_FOR_OS`.

## How it was implemented

- `scripts/workflow-policy.cjs` — added a named `cartesianProduct(keys, matrix)` helper (a `reduce`/`flatMap` over the base-list arrays) and rewrote the base-list block of `expandRunsOn` to collect every `matrix.<k>` array (excluding the `include`/`exclude` control keys) and push one realization per cross-product tuple, with `runner = context[runsOnKey]`.
- **Single-axis matrices are byte-for-byte identical** to the prior behavior (the cross-product of one array is that array; same order, same `String()` stringification, same `{ [key]: runner }` context shape). Only multi-axis matrices change shape.
- The `include` and `exclude` blocks are **unchanged**. Full tuple-aware `exclude` (and GitHub Actions' include-rows-are-not-excluded rule) is a documented out-of-scope follow-up — the existing runner-label `exclude` is annotated in-code as a known limitation. This matches the scoping decision recorded on the issue.

Key files:
- `scripts/workflow-policy.cjs` (`cartesianProduct` + base-list block of `expandRunsOn`)
- `tests/policy-shell-pinning.test.cjs` (test coverage)

## Testing

### How I verified the enhancement works

Strict TDD (red → green):

- **Red (pre-fix):** the new/updated tests fail against the old code — the `os × shell` test gets `2` step-results (expected `4`); the `os × node-version` compliant test gets `2` (expected `4`); the property test fails on a 2-axis counterexample. This is the negative proof required by `RULESET.TESTS.regression-must-fail-first`.
- **Green (post-fix):** all 15 tests in `tests/policy-shell-pinning.test.cjs` pass.

Tests added/updated:
- **Updated** the `os × shell` test to assert post-fix behavior: 4 step realizations, exactly 2 `WRONG_SHELL_FOR_OS` (the `bash` cells on `macos-latest`), and **0** `UNRESOLVABLE_MATRIX` (the core regression proof that `matrix.shell` now resolves).
- **Added** a compliant `os × node-version` cross-product test (4 realizations, 0 violations) — proves the cross-product multiplies realizations and carries a non-runs-on axis into context harmlessly.
- **Added** a `fast-check` property test: for arbitrary 1–3 axis matrices, the realization count equals the product of axis lengths **and** no realization drops an axis key (the step references `${{ matrix.kLast }}` and asserts zero `UNRESOLVABLE_MATRIX`).

Gates run: `npm run lint` (clean), Codex adversarial review, `/code-review`, `/security-review` (no findings), and `gsd-test-both` (Mac local + Linux Docker, **exit 0, 0 failures**).

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [x] N/A (not platform-specific — pure in-memory array transformation, no path/newline/OS-API surface; verified on macOS + Linux Docker which mirrors CI)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific — internal CI policy linter)

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue — no additions or removals
- [x] If scope changed during implementation, I updated the issue and got re-approval before continuing (N/A — scope unchanged; `exclude` left as the issue specified)

---

## Documentation

- [ ] Updated the relevant file(s) under `docs/` to reflect this change
- [x] All `docs/` content added in this PR is written in English (N/A — no docs added)
- [x] If genuinely no user-facing docs impact (infrastructure / internal refactor / test-only), apply the `no-docs` label **or** add a `docs-exempt` marker — this PR touches only the internal CI linter (`scripts/`) and its tests; no user-facing command, output, config, or behavior changes, so the `no-changelog`/`no-docs` labels apply.

## Checklist

- [x] Issue linked above with `Closes #435`
- [x] Linked issue has the `approved-enhancement` label
- [x] Changes are scoped to the approved enhancement — nothing extra included
- [x] All existing tests pass (`npm test` / `gsd-test-both` exit 0)
- [x] New or updated tests cover the enhanced behavior
- [x] No `.changeset/` fragment — the change touches only `scripts/` + `tests/` (outside the changeset gate's enforced paths: `bin/`, `gsd-core/`, `agents/`, `commands/`, `hooks/`, `sdk/src/`) and is not user-facing; `no-changelog` label applied
- [x] No unnecessary dependencies added (`fast-check` was already a devDependency)

## Breaking changes

None. Linter output changes only for Cartesian-matrix workflows, of which there are none in this repo today; single-axis and `include`-based matrices produce identical output.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1050"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783790275&installation_id=134682257&pr_number=1050&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1050&signature=47e79c0d0a8bd05fe62126a453bc029e40bfb181e72d0fe9e5573ca516d6359c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->