### PR TITLE
fix: detect Codex agent pair drift

### DIFF
--- a/src/core.cts
+++ b/src/core.cts
@@ -213,6 +213,128 @@ interface AgentsInstalledResult {
   installed_agents: string[];
   agents_dir: string;
   agent_runtime: string;
+  agent_pair_drift_checked: boolean;
+  agent_pair_drift: boolean;
+  agent_pair_drift_toml_only: string[];
+  agent_pair_drift_md_only: string[];
+}
+
+interface AgentPairNames {
+  md: Set<string>;
+  toml: Set<string>;
+}
+
+interface AgentPairDriftResult {
+  checked: boolean;
+  has_drift: boolean;
+  toml_only: string[];
+  md_only: string[];
+}
+
+function emptyAgentPairDrift(): AgentPairDriftResult {
+  return {
+    checked: false,
+    has_drift: false,
+    toml_only: [],
+    md_only: [],
+  };
+}
+
+function collectLiveAgentPairs(agentsDir: string): AgentPairNames {
+  const pairs: AgentPairNames = { md: new Set<string>(), toml: new Set<string>() };
+
+  const agentFiles = fs
+    .readdirSync(agentsDir, { withFileTypes: true })
+    .filter((entry) => entry.isFile());
+
+  for (const entry of agentFiles) {
+    if (/^gsd-[a-z0-9-]+\.toml$/i.test(entry.name)) {
+      pairs.toml.add(entry.name.slice(0, -'.toml'.length));
+    } else if (/^gsd-[a-z0-9-]+\.md$/i.test(entry.name) && !entry.name.endsWith('.agent.md')) {
+      pairs.md.add(entry.name.slice(0, -'.md'.length));
+    }
+  }
+
+  return pairs;
+}
+
+function readManifestAgentPairs(manifestPath: string): AgentPairNames | null {
+  if (!fs.existsSync(manifestPath)) {
+    return null;
+  }
+
+  try {
+    const manifest: unknown = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+
+    const files =
+      manifest &&
+      typeof manifest === 'object' &&
+      'files' in manifest &&
+      manifest.files &&
+      typeof manifest.files === 'object'
+        ? manifest.files
+        : null;
+
+    if (!files) {
+      return null;
+    }
+
+    return Object.keys(files).reduce<AgentPairNames>(
+      (pairs, key) => {
+        const mdMatch = key.match(/^agents\/(gsd-[a-z0-9-]+)\.md$/i);
+
+        if (mdMatch && !key.endsWith('.agent.md')) {
+          pairs.md.add(mdMatch[1]);
+
+          return pairs;
+        }
+
+        const tomlMatch = key.match(/^agents\/(gsd-[a-z0-9-]+)\.toml$/i);
+
+        if (tomlMatch) {
+          pairs.toml.add(tomlMatch[1]);
+        }
+
+        return pairs;
+      },
+      { md: new Set<string>(), toml: new Set<string>() },
+    );
+  } catch {
+    return null;
+  }
+}
+
+function compareAgentPairs(expected: AgentPairNames, actual: AgentPairNames): AgentPairDriftResult {
+  const tomlOnly = [...expected.toml].filter((agent) => !actual.md.has(agent)).sort();
+  const mdOnly = [...expected.md].filter((agent) => !actual.toml.has(agent)).sort();
+
+  return {
+    checked: true,
+    has_drift: tomlOnly.length > 0 || mdOnly.length > 0,
+    toml_only: tomlOnly,
+    md_only: mdOnly,
+  };
+}
+
+function collectAgentPairDrift(agentsDir: string): AgentPairDriftResult {
+  if (!fs.existsSync(agentsDir)) {
+    return emptyAgentPairDrift();
+  }
+
+  const livePairs = collectLiveAgentPairs(agentsDir);
+  const manifestPairs = readManifestAgentPairs(
+    path.join(path.dirname(agentsDir), 'gsd-file-manifest.json'),
+  );
+
+  if (manifestPairs && manifestPairs.md.size > 0 && manifestPairs.toml.size > 0) {
+    return compareAgentPairs(manifestPairs, livePairs);
+  }
+
+  if (livePairs.md.size === 0 || livePairs.toml.size === 0) {
+    return emptyAgentPairDrift();
+  }
+
+  return compareAgentPairs(livePairs, livePairs);
 }
 
 /**
@@ -228,12 +350,17 @@ function checkAgentsInstalled(runtime?: string): AgentsInstalledResult {
   const missing: string[] = [];
 
   if (!fs.existsSync(agentsDir)) {
+    const pairDrift = collectAgentPairDrift(agentsDir);
     return {
       agents_installed: false,
       missing_agents: expectedAgents,
       installed_agents: [],
       agents_dir: agentsDir,
       agent_runtime: resolvedRuntime,
+      agent_pair_drift_checked: pairDrift.checked,
+      agent_pair_drift: pairDrift.has_drift,
+      agent_pair_drift_toml_only: pairDrift.toml_only,
+      agent_pair_drift_md_only: pairDrift.md_only,
     };
   }
 
@@ -259,12 +386,18 @@ function checkAgentsInstalled(runtime?: string): AgentsInstalledResult {
     }
   }
 
+  const pairDrift = collectAgentPairDrift(agentsDir);
+
   return {
-    agents_installed: installed.length > 0 && missing.length === 0,
+    agents_installed: installed.length > 0 && missing.length === 0 && !pairDrift.has_drift,
     missing_agents: missing,
     installed_agents: installed,
     agents_dir: agentsDir,
     agent_runtime: resolvedRuntime,
+    agent_pair_drift_checked: pairDrift.checked,
+    agent_pair_drift: pairDrift.has_drift,
+    agent_pair_drift_toml_only: pairDrift.toml_only,
+    agent_pair_drift_md_only: pairDrift.md_only,
   };
 }
 

--- a/src/verify.cts
+++ b/src/verify.cts
@@ -998,7 +998,16 @@ function cmdValidateHealth(
   try {
     const agentStatus = checkAgentsInstalled();
     if (!agentStatus.agents_installed) {
-      if ((agentStatus.installed_agents).length === 0) {
+      if (agentStatus.agent_pair_drift) {
+        const tomlOnly = (agentStatus.agent_pair_drift_toml_only || []).join(', ') || 'none';
+        const mdOnly = (agentStatus.agent_pair_drift_md_only || []).join(', ') || 'none';
+        addIssue(
+          'warning',
+          'W010',
+          `GSD agent pair drift in ${agentStatus.agents_dir}: toml-only [${tomlOnly}], md-only [${mdOnly}]`,
+          `Run the GSD installer/update: npx ${PACKAGE_NAME}@latest`,
+        );
+      } else if ((agentStatus.installed_agents).length === 0) {
         addIssue(
           'warning',
           'W010',
@@ -1522,6 +1531,10 @@ function cmdValidateAgents(cwd: string, raw: boolean): void {
       agents_found: agentStatus.agents_installed,
       installed: agentStatus.installed_agents,
       missing: agentStatus.missing_agents,
+      agent_pair_drift_checked: agentStatus.agent_pair_drift_checked,
+      agent_pair_drift: agentStatus.agent_pair_drift,
+      agent_pair_drift_toml_only: agentStatus.agent_pair_drift_toml_only,
+      agent_pair_drift_md_only: agentStatus.agent_pair_drift_md_only,
       expected,
     },
     raw,

--- a/tests/agent-install-validation.test.cjs
+++ b/tests/agent-install-validation.test.cjs
@@ -373,6 +373,8 @@ describe('validate agents subcommand (#1371)', () => {
     assert.ok('installed' in output, 'Must include installed array');
     assert.ok('missing' in output, 'Must include missing array');
     assert.ok('agents_found' in output, 'Must include agents_found boolean');
+    assert.ok('agent_pair_drift_checked' in output, 'Must include agent_pair_drift_checked boolean');
+    assert.ok('agent_pair_drift' in output, 'Must include agent_pair_drift boolean');
   });
 
   test('validate agents lists all expected agent types', () => {
@@ -382,5 +384,57 @@ describe('validate agents subcommand (#1371)', () => {
     const output = JSON.parse(result.output);
     // The expected agents come from MODEL_PROFILES keys
     assert.ok(output.expected.length > 0, 'Must have expected agents');
+  });
+
+  test('validate agents does not flag md-only agents as pair drift for non-Codex runtimes', () => {
+    const agentsDir = path.join(tmpDir, 'agents-md-only');
+    fs.mkdirSync(agentsDir, { recursive: true });
+    for (const name of EXPECTED_AGENTS) {
+      fs.writeFileSync(
+        path.join(agentsDir, `${name}.md`),
+        `---\nname: ${name}\ndescription: Test agent\n---\nAgent content.\n`
+      );
+    }
+
+    const result = runGsdTools('validate agents --raw', tmpDir, { GSD_AGENTS_DIR: agentsDir });
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.agents_found, true);
+    assert.strictEqual(output.agent_pair_drift_checked, false);
+    assert.strictEqual(output.agent_pair_drift, false);
+    assert.deepStrictEqual(output.agent_pair_drift_toml_only, []);
+    assert.deepStrictEqual(output.agent_pair_drift_md_only, []);
+  });
+
+  test('validate agents flags manifest-backed generated agent pair drift', () => {
+    const agentsDir = path.join(tmpDir, 'agents');
+    fs.mkdirSync(agentsDir, { recursive: true });
+    const manifestFiles = {};
+    for (const name of EXPECTED_AGENTS) {
+      fs.writeFileSync(
+        path.join(agentsDir, `${name}.md`),
+        `---\nname: ${name}\ndescription: Test agent\n---\nAgent content.\n`
+      );
+      manifestFiles[`agents/${name}.md`] = 'test-md-hash';
+      manifestFiles[`agents/${name}.toml`] = 'test-toml-hash';
+    }
+    fs.writeFileSync(
+      path.join(tmpDir, 'gsd-file-manifest.json'),
+      JSON.stringify({ version: 'test', files: manifestFiles }, null, 2)
+    );
+
+    const result = runGsdTools('validate agents --raw', tmpDir, {
+      GSD_AGENTS_DIR: agentsDir,
+      GSD_RUNTIME: 'codex',
+    });
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.agents_found, false);
+    assert.strictEqual(output.agent_pair_drift_checked, true);
+    assert.strictEqual(output.agent_pair_drift, true);
+    assert.deepStrictEqual(output.agent_pair_drift_toml_only, []);
+    assert.deepStrictEqual(output.agent_pair_drift_md_only, EXPECTED_AGENTS.slice().sort());
   });
 });


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

Fixes #1058

> The linked issue must have the `confirmed-bug` label. If it doesn't, ask a maintainer to confirm the bug before continuing.

---

## What was broken

`validate agents --raw` could report Codex agents as installed when the install manifest expected both generated `agents/gsd-*.md` and `agents/gsd-*.toml` files, but one side of that generated pair was missing.

That produced a false healthy result for an incomplete manifest-backed Codex agent install.

## What this fix does

Adds Codex generated-agent pair drift detection to the installed-agent validation path. When the manifest declares both `.md` and `.toml` generated artifacts, validation now compares the manifest-backed expected pair set against the files on disk and reports missing counterparts.

The same drift state is exposed in `validate agents --raw` and surfaced through the existing `W010` health warning with the normal installer/update repair hint.

## Root cause

Agent validation checked agent-name presence across supported runtime formats. That was enough for missing-agent detection, but it did not model generated Codex `.md` / `.toml` files as managed pairs, so a partial generated pair set could satisfy the existing installed-agent check.

## Testing

### How I verified the fix

Local verification:

- `npm run build:lib`
- `npm run lint -- --no-cache src/core.cts src/verify.cts tests/agent-install-validation.test.cjs`
- `node --test tests/agent-install-validation.test.cjs`
- `node gsd-core/bin/gsd-tools.cjs validate agents --raw`
- `GSD_RUNTIME=codex node gsd-core/bin/gsd-tools.cjs validate agents --raw`
- `node scripts/changeset/lint.cjs`

### Regression test added?

- [x] Yes — added a manifest-backed generated agent pair drift test
- [ ] No — explain why:

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [x] Other: Codex
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [ ] Linked issue has the `confirmed-bug` label — pending maintainer triage on #1058
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [ ] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None. This adds validation fields and a warning for an incomplete generated Codex agent install; existing complete installs and single-format installs remain valid.