### PR TITLE
feat(#247): runtime-neutral phase uat-passed predicate from HUMAN-UAT results

### DIFF
--- a/.changeset/happy-otters-leap.md
+++ b/.changeset/happy-otters-leap.md
@@ -1,5 +1,5 @@
 ---
 type: Added
-pr: 0
+pr: 1063
 ---
-**`phase uat-passed` predicate** — new runtime-neutral command evaluates HUMAN-UAT results with markdown-aware parsing (ignores frontmatter, fenced code, blockquotes, and HTML comments) and reports pass only when every required check passes. (#0)
+**`phase uat-passed` predicate** — new runtime-neutral command evaluates HUMAN-UAT results with markdown-aware parsing (ignores frontmatter, fenced code, blockquotes, and HTML comments) and reports pass only when every required check passes. (#1063)

--- a/.changeset/happy-otters-leap.md
+++ b/.changeset/happy-otters-leap.md
@@ -1,0 +1,5 @@
+---
+type: Added
+pr: 0
+---
+**`phase uat-passed` predicate** — new runtime-neutral command evaluates HUMAN-UAT results with markdown-aware parsing (ignores frontmatter, fenced code, blockquotes, and HTML comments) and reports pass only when every required check passes. (#0)

--- a/.gitignore
+++ b/.gitignore
@@ -173,6 +173,7 @@ build/
 /gsd-core/bin/lib/verify.cjs
 /gsd-core/bin/lib/init.cjs
 /gsd-core/bin/lib/uat.cjs
+/gsd-core/bin/lib/uat-predicate.cjs
 /gsd-core/bin/lib/workstream.cjs
 /gsd-core/bin/lib/roadmap.cjs
 /gsd-core/bin/lib/audit.cjs

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -198,6 +198,9 @@ The GSD-RESEARCH capability behind an L2-hybrid seam: code owns cache + provider
 - `GSD-RESEARCH.CONTEXT-DISCIPLINE=less-context levers: subagent isolation + compact provider output + fetches-to-disk + cache-returns-digest; API clear_tool_uses/memory tool are the conceptual model, not a Claude Code harness knob`
 - `DEFECT.RESEARCH-PROVIDER-PROSE-DRIFT=provider waterfall duplicated across N researcher agent .md files drifts independently (META.RULE.brief-no-paraphrase); fix-forward=research-provider.cjs single source of truth + generated agents (#657)`
 
+### UAT-Passed Predicate
+Runtime-neutral predicate evaluating `*-UAT.md` / `*-VERIFICATION.md` result fields with markdown-aware parsing that ignores false-positive contexts (frontmatter body, fenced code, HTML comments, blockquotes). Returns `passed: true` only when all required checks pass; supports `--require-verification` to demand at least one VERIFICATION.md file alongside UAT results. Output envelope: `{ passed, uat_files[], verification_files[], checks[], blockers[], policy }`. Source: `gsd-core/bin/lib/uat-predicate.cjs` (generated from `src/uat-predicate.cts`). Wired via `phase uat-passed` alias → `phase-command-router` → `cmdPhaseUatPassed`.
+
 ### MVP Mode
 Phase-level planning mode that frames work as a vertical slice (UI → API → DB) of one user-visible capability instead of horizontal layers. Resolved at workflow init via the precedence chain: `--mvp` CLI flag → ROADMAP.md `**Mode:** mvp` field → `workflow.mvp_mode` config → false. All-or-nothing per phase (PRD #2826 Q1). Surfaced as `MVP_MODE=true|false` to the planner, executor, verifier, and discovery surfaces (progress, stats, graphify). Canonical parser: `roadmap.cjs` `**Mode:**` field; canonical resolution chain documented in `workflows/plan-phase.md`. Concept index: `references/mvp-concepts.md`.
 

--- a/docs/CLI-TOOLS.md
+++ b/docs/CLI-TOOLS.md
@@ -118,6 +118,10 @@ node gsd-tools.cjs phase remove <phase> [--force]
 # Mark phase complete, update state + roadmap
 node gsd-tools.cjs phase complete <phase>
 
+# Evaluate HUMAN-UAT results for a phase (markdown-aware; ignores false-positive contexts)
+# Returns JSON: { passed, uat_files[], verification_files[], checks[], blockers[], policy }
+node gsd-tools.cjs phase uat-passed <phase> [--require-verification]
+
 # Index plans with waves and status
 node gsd-tools.cjs phase-plan-index <phase>
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -490,6 +490,37 @@ Retroactively audit and fill Nyquist validation gaps.
 
 ---
 
+### `phase uat-passed <N> [--require-verification]`
+
+Runtime-neutral predicate that evaluates HUMAN-UAT results for a phase and reports whether all required checks passed. Uses markdown-aware parsing that ignores false-positive contexts (YAML frontmatter, fenced code blocks, HTML comments, and blockquotes), so incomplete checkbox fragments in prose sections never trigger a false pass.
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `N` | **Yes** | Phase number to evaluate |
+| `--require-verification` | No | Require at least one `*-VERIFICATION.md` file alongside UAT results; fails if none are found |
+
+**Output fields (JSON):**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `passed` | `boolean` | `true` only when at least one check exists AND all checks pass AND no blockers — fail-closed (no vacuous pass) |
+| `uat_files` | `string[]` | Filenames of `*-UAT.md` files evaluated |
+| `verification_files` | `string[]` | Filenames of `*-VERIFICATION.md` files evaluated |
+| `checks[]` | `{ file, test, name, result, passing }[]` | Per-item evaluation results parsed from heading blocks |
+| `blockers[]` | `string[]` | Human-readable reasons for failure (frontmatter issues, failing/missing test items, policy violations, malformed markdown) — NOT a subset of `checks[]` |
+| `no_uat_artifacts` | `boolean` | `true` when no real UAT test items were parsed (no `*-UAT.md` files, unreadable dir, or files with no test blocks); when `true`, `passed` is always `false` |
+| `policy.require_verification` | `boolean` | Whether `--require-verification` was active |
+
+**Programmatic access:** `node gsd-tools.cjs phase uat-passed <N> [--require-verification] [--raw]` — see [CLI Tools Reference](CLI-TOOLS.md)
+
+```bash
+node gsd-tools.cjs phase uat-passed 3                        # Evaluate UAT for phase 3
+node gsd-tools.cjs phase uat-passed 3 --require-verification # Also require VERIFICATION.md
+node gsd-tools.cjs phase uat-passed 3 --raw                  # Machine-readable JSON output
+```
+
+---
+
 ## Navigation Commands
 
 ### `/gsd-progress`

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -164,6 +164,7 @@
   - [Statusline Context Position](#140-statusline-context-position)
   - [Milestone Tag Creation Toggle](#141-milestone-tag-creation-toggle)
   - [Structured JSON Error Mode](#142-structured-json-error-mode)
+  - [UAT-Passed Predicate](#143-uat-passed-predicate)
 
 ---
 
@@ -3043,6 +3044,38 @@ explicit reviewer flags -> --all -> review.default_reviewers -> all detected rev
 - REQ-JSON-ERRORS-01: Unknown commands, validation errors, timeouts, native failures, fallback failures, and internal errors MUST map to canonical error kinds.
 - REQ-JSON-ERRORS-02: CLI exit code mapping MUST remain stable for automation callers.
 - REQ-JSON-ERRORS-03: Human-readable output MUST remain the default when `--json-errors` is absent.
+
+---
+
+### 143. UAT-Passed Predicate
+
+**CLI:** `node gsd-tools.cjs phase uat-passed <N> [--require-verification]`
+
+**Purpose:** Provide a runtime-neutral, automatable predicate that evaluates HUMAN-UAT results for a phase and returns a structured pass/fail verdict with full diagnostic detail.
+
+**Behavior:** Locates `*-UAT.md` and optionally `*-VERIFICATION.md` files for the given phase, parses UAT test blocks (heading-block parser, column-0 result lines) with a markdown-aware stripper that removes false-positive contexts (YAML frontmatter, fenced code blocks, HTML comments, and blockquotes). Returns `passed: true` only when at least one check exists AND all checks pass AND no blockers — fail-closed, no vacuous pass. The `--require-verification` flag requires at least one `*-VERIFICATION.md` with an allowlisted passing status; the command fails without one.
+
+**Output envelope:** `{ passed, uat_files[], verification_files[], checks[], blockers[], no_uat_artifacts, policy: { require_verification } }`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `passed` | `boolean` | `true` only when ≥1 check exists AND all passing AND no blockers |
+| `uat_files` | `string[]` | Filenames of `*-UAT.md` files evaluated |
+| `verification_files` | `string[]` | Filenames of `*-VERIFICATION.md` files evaluated |
+| `checks[]` | `{ file, test, name, result, passing }[]` | Per-item results from heading blocks |
+| `blockers[]` | `string[]` | Human-readable failure reasons (frontmatter, failing/missing items, policy, malformed markdown) |
+| `no_uat_artifacts` | `boolean` | `true` when no test items were parsed; `passed` is always `false` when `true` |
+| `policy.require_verification` | `boolean` | Whether `--require-verification` was active |
+
+**Requirements:**
+- REQ-UAT-PRED-01: The predicate MUST ignore result lines inside YAML frontmatter, fenced code blocks, HTML comments, and blockquotes.
+- REQ-UAT-PRED-02: `passed: true` MUST require at least one check AND all checks passing AND no blockers (fail-closed, no vacuous pass).
+- REQ-UAT-PRED-03: `--require-verification` MUST cause the command to fail when no `*-VERIFICATION.md` file with an allowlisted passing status is found.
+- REQ-UAT-PRED-04: `blockers[]` contains all human-readable failure reasons including frontmatter issues, policy violations, and malformed markdown — NOT limited to a subset of `checks[]`.
+- REQ-UAT-PRED-05: The module MUST be runtime-neutral (no runtime-specific env checks or exit shortcuts).
+- REQ-UAT-PRED-06: A heading block with no column-0 `result:` line emits `result:'missing'` (blocker); test items are never silently dropped.
+
+**Reference:** [Phase Management Commands](COMMANDS.md#phase-uat-passed-n---require-verification)
 
 ---
 

--- a/docs/INVENTORY-MANIFEST.json
+++ b/docs/INVENTORY-MANIFEST.json
@@ -356,6 +356,7 @@
       "surface.cjs",
       "task-command-router.cjs",
       "template.cjs",
+      "uat-predicate.cjs",
       "uat.cjs",
       "ui-safety-gate.cjs",
       "update-context.cjs",

--- a/docs/INVENTORY.md
+++ b/docs/INVENTORY.md
@@ -371,7 +371,7 @@ The `gsd-planner` agent is decomposed into a core agent plus reference modules t
 
 ---
 
-## CLI Modules (105 shipped)
+## CLI Modules (106 shipped)
 
 Full listing: `gsd-core/bin/lib/*.cjs`.
 
@@ -468,6 +468,7 @@ Full listing: `gsd-core/bin/lib/*.cjs`.
 | `task-command-router.cjs` | Thin CJS subcommand router adapter for `gsd-tools task` |
 | `template.cjs` | Template selection and filling with variable substitution |
 | `uat.cjs` | UAT file parsing, verification debt tracking, audit-uat support |
+| `uat-predicate.cjs` | UAT-passed predicate — markdown-aware evaluation of HUMAN-UAT results; returns pass only when all required checks pass; ignores false-positive contexts (frontmatter, fenced code, blockquotes, HTML comments) |
 | `ui-safety-gate.cjs` | Shell-free word-boundary UI token detector (#3706, #3718); reads phase-section text from stdin, exits 0 (UI found) or 1 (no UI); also deployed to `gsd-core/bin/lib/` so the GSD installer ships it to `$RUNTIME_DIR` (#448) |
 | `update-context.cjs` | Pure install-context resolver for `/gsd:update` — runtime/scope/config-dir/version detection (LOCAL/GLOBAL/UNKNOWN) ported from update.md bash; backs `gsd-tools update-context` (#498) |
 | `validate-command-router.cjs` | Thin CJS subcommand router adapter for `gsd-tools validate` |

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -137,6 +137,7 @@ export default tseslint.config(
       'gsd-core/bin/lib/profile-pipeline.cjs',
       'gsd-core/bin/lib/template.cjs',
       'gsd-core/bin/lib/uat.cjs',
+      'gsd-core/bin/lib/uat-predicate.cjs',
       'gsd-core/bin/lib/workstream.cjs',
       'gsd-core/bin/lib/roadmap.cjs',
       'gsd-core/bin/lib/audit.cjs',

--- a/src/phase-command-router.cts
+++ b/src/phase-command-router.cts
@@ -32,6 +32,7 @@ interface PhaseHandlers {
   cmdPhaseInsert: (cwd: string, pos: string | undefined, desc: string, raw: boolean) => void;
   cmdPhaseRemove: (cwd: string, phaseNum: string, opts: { force: boolean }, raw: boolean) => void;
   cmdPhaseComplete: (cwd: string, phaseNum: string | undefined, raw: boolean) => void;
+  cmdPhaseUatPassed: (cwd: string, phaseNum: string | undefined, raw: boolean, opts?: { policy?: { requireVerification?: boolean } }) => void;
 }
 
 interface RoutePhaseCommandOptions {
@@ -162,6 +163,23 @@ function routePhaseCommand({ phase, args, cwd, raw, error }: RoutePhaseCommandOp
       },
       complete: (_ctx: Record<string, unknown>): { ok: true; data: null } => {
         phase.cmdPhaseComplete(cwd, args[2], raw);
+        return { ok: true as const, data: null };
+      },
+      'uat-passed': (_ctx: Record<string, unknown>): { ok: true; data: null } => {
+        let requireVerification = false;
+        const positional: string[] = [];
+        for (const token of args.slice(2)) {
+          if (token === '--require-verification') {
+            requireVerification = true;
+          } else if (token === '--raw') {
+            // --raw is handled by the outer CLI layer; accepted here silently
+          } else if (token.startsWith('--')) {
+            return makeInvalidArgs(token, `phase uat-passed does not support ${token}`) as never;
+          } else {
+            positional.push(token);
+          }
+        }
+        phase.cmdPhaseUatPassed(cwd, positional[0], raw, { policy: { requireVerification } });
         return { ok: true as const, data: null };
       },
     },

--- a/src/phase.cts
+++ b/src/phase.cts
@@ -29,6 +29,9 @@ import stateMod = require('./state.cjs');
 import { platformWriteSync, platformReadSync, platformEnsureDir } from './shell-command-projection.cjs';
 import { formatGsdSlash, resolveRuntime } from './runtime-slash.cjs';
 import { deriveProgressFromRoadmap, clampPercent } from './phase-lifecycle.cjs';
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- uat-predicate.cjs is an export= CommonJS module
+import uatPredicate = require('./uat-predicate.cjs');
+const { evaluateUatPassed } = uatPredicate;
 
 const {
   escapeRegex,
@@ -1712,6 +1715,28 @@ function cmdPhaseComplete(cwd: string, phaseNum: string, raw: boolean): void {
   output(result, raw);
 }
 
+function cmdPhaseUatPassed(
+  cwd: string,
+  phaseNum: string | undefined,
+  raw: boolean,
+  opts: { policy?: { requireVerification?: boolean } } = {},
+): void {
+  if (!phaseNum) {
+    error('phase number required for phase uat-passed');
+  }
+
+  const phaseInfoRaw = findPhaseInternal(cwd, phaseNum!);
+  if (!phaseInfoRaw) {
+    error(`Phase ${phaseNum} not found`);
+  }
+  const phaseInfo = phaseInfoRaw as unknown as Record<string, unknown>;
+  const phaseFullDir = path.join(cwd, phaseInfo['directory'] as string);
+
+  const report = evaluateUatPassed(phaseFullDir, { policy: opts.policy });
+
+  output({ phase: phaseNum, ...report }, raw);
+}
+
 export = {
   cmdPhasesList,
   cmdPhaseNextDecimal,
@@ -1723,5 +1748,6 @@ export = {
   cmdPhaseInsert,
   cmdPhaseRemove,
   cmdPhaseComplete,
+  cmdPhaseUatPassed,
   computeDependencyLevels,
 };

--- a/src/uat-predicate.cts
+++ b/src/uat-predicate.cts
@@ -1,0 +1,385 @@
+/**
+ * UAT Predicate — Pure-computation UAT pass/fail evaluation
+ *
+ * Evaluates all *-UAT.md and *-VERIFICATION.md files in a phase directory and
+ * returns a typed report. Used by `phase uat-passed` to harden against the
+ * naive whole-file regex in cmdPhaseComplete which false-matches `result:` lines
+ * inside frontmatter, fenced code blocks, blockquotes, and HTML comments.
+ *
+ * Issue #247 — phase uat-passed predicate
+ *
+ * ADR-457 build-at-publish: compiled by tsc to gsd-core/bin/lib/uat-predicate.cjs.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import frontmatter = require('./frontmatter.cjs');
+const { extractFrontmatter } = frontmatter;
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface UatCheckItem {
+  file: string;
+  test: number;
+  name: string;
+  result: string;
+  passing: boolean;
+}
+
+interface UatPassedReport {
+  passed: boolean;
+  uat_files: string[];
+  verification_files: string[];
+  checks: UatCheckItem[];
+  blockers: string[];
+  no_uat_artifacts: boolean;
+  policy: {
+    require_verification: boolean;
+  };
+}
+
+// ─── Blocking state sets (documented for maintainability) ─────────────────────
+
+// UAT file frontmatter `status` values that indicate the file is not fully done
+const BLOCKING_UAT_FM_STATUSES = new Set([
+  'partial', 'diagnosed', 'pending', 'blocked', 'in_progress', 'failed',
+]);
+
+// UAT file frontmatter `result` values that indicate failure
+const BLOCKING_UAT_FM_RESULTS = new Set(['pending', 'blocked', 'failed']);
+
+// VERIFICATION file frontmatter `status` values that indicate passing
+const PASSING_VERIFICATION_STATUSES = new Set([
+  'complete', 'verified', 'passed', 'human_passed',
+]);
+
+// VERIFICATION file frontmatter `status` values that explicitly block
+const BLOCKING_VERIFICATION_FM_STATUSES = new Set([
+  'human_needed', 'gaps_found', 'pending', 'blocked', 'partial',
+  'failed', 'in_progress',
+]);
+
+// UAT test-item `result` values that count as passing
+const PASSING_RESULTS = new Set(['passed', 'pass']);
+
+// ─── stripFalsePositiveContexts ───────────────────────────────────────────────
+
+/**
+ * Remove contexts that can contain `result: ...` lines that are NOT real test results:
+ *   (a) leading frontmatter block at byte 0
+ *   (b) HTML comments (unterminated comments swallow to EOF — fail-closed)
+ *   (c) fenced code blocks (backtick and tilde, indented too) via CommonMark state machine
+ *   (d) blockquote lines
+ *
+ * Each step is a composable function (Kernighan's Law — independently testable).
+ * Returns surviving lines joined by '\n'. Robust to CRLF input.
+ */
+function stripFalsePositiveContexts(content: string): string {
+  // Step (a): strip leading frontmatter block only at byte 0
+  let stripped = content.replace(/^---\r?\n[\s\S]*?\r?\n---[ \t]*(\r?\n|$)/, '');
+
+  // Step (b): remove HTML comments anywhere; unterminated comment swallows to EOF
+  stripped = stripped.replace(/<!--[\s\S]*?(?:-->|$)/g, '');
+
+  // Step (c): remove fenced code blocks via CommonMark-style state machine (handles CRLF + indented fences)
+  stripped = _stripFencedBlocks(stripped).text;
+
+  // Step (d): remove blockquote lines
+  stripped = stripped
+    .split('\n')
+    .filter(line => !/^\s*>/.test(line))
+    .join('\n');
+
+  return stripped;
+}
+
+interface FenceState {
+  char: '`' | '~';
+  len: number;
+}
+
+interface StripFencedResult {
+  text: string;
+  unterminatedFence: boolean;
+}
+
+/**
+ * CommonMark-style fenced-code-block stripper.
+ * Tracks the opening delimiter char and length so that a ~~~ line inside a
+ * ``` fence is correctly treated as fence content, not a closing delimiter.
+ *
+ * Opening rule: first delimiter line with char+len sets openFence.
+ * Closing rule: delimiter line with SAME char, run length >= openFence.len,
+ *   and NO trailing non-whitespace text closes the fence.
+ * All delimiter and content lines are dropped; non-fence lines are kept.
+ * Returns the kept text plus unterminatedFence:true if EOF inside a fence.
+ */
+function _stripFencedBlocks(content: string): StripFencedResult {
+  const lines = content.split('\n');
+  const kept: string[] = [];
+  let openFence: FenceState | null = null;
+  const delimRe = /^(\s*)(`{3,}|~{3,})(.*)$/;
+
+  for (const rawLine of lines) {
+    // Tolerate CRLF: strip trailing \r for matching, but we work on split-by-\n lines
+    // (the outer caller joined by \n already; we just handle a stray \r in the last char)
+    const line = rawLine.replace(/\r$/, '');
+    const m = delimRe.exec(line);
+    if (m) {
+      const char = m[2][0] as '`' | '~';
+      const len = m[2].length;
+      const trailing = m[3];
+      if (openFence === null) {
+        // Opening delimiter — drop this line and record the fence
+        openFence = { char, len };
+      } else if (char === openFence.char && len >= openFence.len && /^\s*$/.test(trailing)) {
+        // Closing delimiter (same char, sufficient length, no trailing text) — drop and close
+        openFence = null;
+      }
+      // else: mismatched delimiter inside fence (e.g. ~~~ inside ```) — drop as content
+      continue; // delimiter lines are always dropped
+    }
+    if (openFence === null) {
+      kept.push(rawLine);
+    }
+    // Lines inside fence are dropped
+  }
+
+  return { text: kept.join('\n'), unterminatedFence: openFence !== null };
+}
+
+/**
+ * Analyse raw markdown for structural anomalies (unterminated fence / comment).
+ * Exported for unit-testability and used by evaluateUatPassed for per-file malformed detection.
+ *
+ * FIX C: properly balanced comments are stripped before checking for a dangling <!--,
+ * so an earlier closed comment does not mask a later unterminated one.
+ */
+function analyzeMarkdown(raw: string): { unterminatedFence: boolean; unterminatedComment: boolean } {
+  // Strip all properly-balanced comments first, then check for a leftover <!--
+  const afterBalanced = raw.replace(/<!--[\s\S]*?-->/g, '');
+  const unterminatedComment = afterBalanced.includes('<!--');
+
+  // Run the fence state machine on the raw content for an accurate unterminated-fence signal
+  const { unterminatedFence } = _stripFencedBlocks(raw);
+
+  return { unterminatedFence, unterminatedComment };
+}
+
+// ─── parseUatResultItems ──────────────────────────────────────────────────────
+
+/**
+ * HEADING-BLOCK parser: scan the CLEANED body (after stripFalsePositiveContexts)
+ * for UAT test blocks.
+ *
+ * For each ### N. Name heading, the block spans until the next ### heading or EOF.
+ * Within each block, find a column-0 anchored result line (rejects indented YAML
+ * block-scalar bodies and inline/quoted fakes).
+ *
+ * - If a heading block has NO column-0 result line → emit result:'missing' (blocker).
+ * - Support bracketed [passed] and bare passed (#2273).
+ * - Returns ALL items (both passing and non-passing).
+ */
+function parseUatResultItems(cleanContent: string): Array<{ test: number; name: string; result: string }> {
+  const items: Array<{ test: number; name: string; result: string }> = [];
+
+  // Find all ### N. Name headings (line-anchored)
+  const headingPattern = /^###\s*(\d+)\.\s*(.+)$/gm;
+  const headings: Array<{ index: number; test: number; name: string }> = [];
+  let hMatch: RegExpExecArray | null;
+  while ((hMatch = headingPattern.exec(cleanContent)) !== null) {
+    headings.push({
+      index: hMatch.index + hMatch[0].length,
+      test: parseInt(hMatch[1], 10),
+      name: hMatch[2].trim(),
+    });
+  }
+
+  for (let i = 0; i < headings.length; i++) {
+    const h = headings[i];
+    const blockStart = h.index;
+    // More precise: find next heading's position in the original string
+    // We'll slice from current heading end to the position just before next heading's "###"
+    const nextHeadingMatch = i + 1 < headings.length
+      ? cleanContent.lastIndexOf('\n###', headings[i + 1].index)
+      : -1;
+    const blockContent = nextHeadingMatch >= blockStart
+      ? cleanContent.slice(blockStart, nextHeadingMatch)
+      : cleanContent.slice(blockStart);
+
+    // Column-0 anchored result line: /^result:[ \t]*\[?([\w-]+)\]?/mi
+    // Uses [ \t]* (not \s*) so the captured value must sit on the SAME line as result:.
+    // A result: key with the value on a subsequent line yields no match → 'missing' (blocker).
+    const resultMatch = /^result:[ \t]*\[?([\w-]+)\]?/mi.exec(blockContent);
+    if (resultMatch) {
+      items.push({
+        test: h.test,
+        name: h.name,
+        result: resultMatch[1].toLowerCase(),
+      });
+    } else {
+      // No column-0 result line → emit 'missing' (a non-passing state)
+      items.push({
+        test: h.test,
+        name: h.name,
+        result: 'missing',
+      });
+    }
+  }
+
+  return items;
+}
+
+// ─── evaluateUatPassed ────────────────────────────────────────────────────────
+
+/**
+ * Evaluate all UAT/VERIFICATION files in a phase directory.
+ * Returns a UatPassedReport with the locked, stable shape defined by the interface.
+ *
+ * FAIL-CLOSED: any absence/ambiguity/malformed input → NOT passed.
+ * Pass requires at least one real passing check AND no blockers.
+ */
+function evaluateUatPassed(
+  phaseFullDir: string,
+  opts?: { policy?: { requireVerification?: boolean } },
+): UatPassedReport {
+  const requireVerification = opts?.policy?.requireVerification === true;
+
+  const blockers: string[] = [];
+  const checks: UatCheckItem[] = [];
+  const uatFiles: string[] = [];
+  const verificationFiles: string[] = [];
+
+  // Read the directory — if unreadable, treat as no files (fail-closed: no artifacts → not passed)
+  let dirEntries: string[] = [];
+  try {
+    dirEntries = fs.readdirSync(phaseFullDir);
+  } catch {
+    // Unreadable dir — no_uat_artifacts:true, passed:false
+    const no_uat_artifacts = true;
+    if (requireVerification) {
+      blockers.push('policy: verification required but no passing *-VERIFICATION.md found');
+    }
+    return {
+      passed: false,
+      uat_files: [],
+      verification_files: [],
+      checks: [],
+      blockers,
+      no_uat_artifacts,
+      policy: { require_verification: requireVerification },
+    };
+  }
+
+  // Filter UAT and VERIFICATION files using the same filter as cmdPhaseComplete
+  const uatFileNames = dirEntries.filter(f => f.includes('-UAT') && f.endsWith('.md'));
+  const verFileNames = dirEntries.filter(f => f.includes('-VERIFICATION') && f.endsWith('.md'));
+
+  // ── Process UAT files ──────────────────────────────────────────────────────
+  for (const file of uatFileNames) {
+    uatFiles.push(file);
+    let raw = '';
+    try {
+      raw = fs.readFileSync(path.join(phaseFullDir, file), 'utf-8');
+    } catch {
+      blockers.push(`${file}: could not read file`);
+      continue;
+    }
+
+    // ── Per-file malformed markdown guard ──────────────────────────────────
+    // FIX D: use accurate signals from analyzeMarkdown instead of heuristics.
+    // unterminatedFence: CommonMark state machine detects a genuinely unclosed fence.
+    // unterminatedComment: strips balanced comments first, then checks for leftover <!--.
+    const { unterminatedFence, unterminatedComment } = analyzeMarkdown(raw);
+    if (unterminatedFence || unterminatedComment) {
+      blockers.push(`${file}: malformed markdown (unterminated fence or comment)`);
+    }
+
+    const fm = extractFrontmatter(raw) as Record<string, unknown>;
+
+    // File-level frontmatter status check
+    if (fm['status'] && BLOCKING_UAT_FM_STATUSES.has(fm['status'] as string)) {
+      blockers.push(`${file}: frontmatter status=${fm['status'] as string}`);
+    }
+    // File-level frontmatter result check
+    if (fm['result'] && BLOCKING_UAT_FM_RESULTS.has(fm['result'] as string)) {
+      blockers.push(`${file}: frontmatter result=${fm['result'] as string}`);
+    }
+
+    // Parse test items from the cleaned body (hardened against false positives)
+    const cleanContent = stripFalsePositiveContexts(raw);
+    const items = parseUatResultItems(cleanContent);
+
+    for (const item of items) {
+      const passing = PASSING_RESULTS.has(item.result);
+      checks.push({
+        file,
+        test: item.test,
+        name: item.name,
+        result: item.result,
+        passing,
+      });
+      if (!passing) {
+        blockers.push(`${file}: test ${item.test} (${item.result})`);
+      }
+    }
+  }
+
+  // ── Process VERIFICATION files ─────────────────────────────────────────────
+  let hasPassingVerification = false;
+  for (const file of verFileNames) {
+    verificationFiles.push(file);
+    let raw = '';
+    try {
+      raw = fs.readFileSync(path.join(phaseFullDir, file), 'utf-8');
+    } catch {
+      blockers.push(`${file}: could not read verification file`);
+      continue;
+    }
+
+    const vfm = extractFrontmatter(raw) as Record<string, unknown>;
+    const vStatus = vfm['status'] as string | undefined;
+
+    if (vStatus && BLOCKING_VERIFICATION_FM_STATUSES.has(vStatus)) {
+      blockers.push(`${file}: verification status=${vStatus}`);
+    } else if (vStatus && PASSING_VERIFICATION_STATUSES.has(vStatus)) {
+      // Allowlist: only explicitly-passing statuses count
+      hasPassingVerification = true;
+    }
+    // Missing or unknown status: does NOT count as passing, does NOT push a blocker
+    // (handled by the requireVerification policy check below if needed)
+  }
+
+  // ── Policy: requireVerification ───────────────────────────────────────────
+  if (requireVerification && !hasPassingVerification) {
+    blockers.push('policy: verification required but no passing *-VERIFICATION.md found');
+  }
+
+  // ── Determine no_uat_artifacts and passed ─────────────────────────────────
+  // no_uat_artifacts: true when no real UAT test items were parsed from any file
+  const no_uat_artifacts = checks.length === 0;
+
+  // FIX 1: require positive passing evidence; no vacuous pass
+  // passed = no blockers AND at least one check AND all checks passing
+  const passed = blockers.length === 0 && checks.length > 0 && checks.every(c => c.passing);
+
+  return {
+    passed,
+    uat_files: uatFiles,
+    verification_files: verificationFiles,
+    checks,
+    blockers,
+    no_uat_artifacts,
+    policy: {
+      require_verification: requireVerification,
+    },
+  };
+}
+
+export = {
+  stripFalsePositiveContexts,
+  parseUatResultItems,
+  analyzeMarkdown,
+  evaluateUatPassed,
+};

--- a/src/uat-predicate.cts
+++ b/src/uat-predicate.cts
@@ -157,11 +157,20 @@ function _stripFencedBlocks(content: string): StripFencedResult {
  * so an earlier closed comment does not mask a later unterminated one.
  */
 function analyzeMarkdown(raw: string): { unterminatedFence: boolean; unterminatedComment: boolean } {
-  // Strip all properly-balanced comments first, then check for a leftover <!--
-  const afterBalanced = raw.replace(/<!--[\s\S]*?-->/g, '');
-  const unterminatedComment = afterBalanced.includes('<!--');
+  // Detect an unterminated HTML comment via a paired scan: every `<!--` must
+  // have a following `-->`. Using indexOf (not a regex .replace of the comment
+  // token) avoids the js/incomplete-multi-character-sanitization pattern — and
+  // is exact: a closed earlier comment never masks a later unterminated one.
+  let unterminatedComment = false;
+  for (let i = 0; ; ) {
+    const open = raw.indexOf('<!--', i);
+    if (open === -1) break;
+    const close = raw.indexOf('-->', open + 4);
+    if (close === -1) { unterminatedComment = true; break; }
+    i = close + 3;
+  }
 
-  // Run the fence state machine on the raw content for an accurate unterminated-fence signal
+  // Fence state machine gives the accurate unterminated-fence signal.
   const { unterminatedFence } = _stripFencedBlocks(raw);
 
   return { unterminatedFence, unterminatedComment };

--- a/tests/247-phase-uat-passed.test.cjs
+++ b/tests/247-phase-uat-passed.test.cjs
@@ -1,0 +1,267 @@
+'use strict';
+
+/**
+ * Integration tests for `phase uat-passed <N>` CLI command.
+ * Issue #247 — phase uat-passed predicate
+ *
+ * Tests the full dispatch path: gsd-tools → phase-command-router → phase.cmdPhaseUatPassed
+ */
+
+const { test, describe, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { runGsdTools, createTempProject, cleanup } = require('./helpers.cjs');
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Set up a minimal project with a phase directory and ROADMAP so that
+ * findPhaseInternal(cwd, phaseNum) can resolve it.
+ * Returns { tmpDir, phaseDir }.
+ */
+function setupProject(phaseSlug = '01-feature') {
+  const tmpDir = createTempProject();
+  fs.writeFileSync(
+    path.join(tmpDir, '.planning', 'ROADMAP.md'),
+    [
+      '# Roadmap',
+      '',
+      '- [ ] Phase 1: Feature',
+      '',
+      '### Phase 1: Feature',
+      '**Goal:** Build feature',
+      '**Plans:** 1 plans',
+      '',
+    ].join('\n'),
+  );
+  const phaseDir = path.join(tmpDir, '.planning', 'phases', phaseSlug);
+  fs.mkdirSync(phaseDir, { recursive: true });
+  return { tmpDir, phaseDir };
+}
+
+function writeUatFile(phaseDir, filename, content) {
+  fs.writeFileSync(path.join(phaseDir, filename), content, 'utf-8');
+}
+
+function makePassingUat() {
+  return [
+    '---',
+    'status: passed',
+    '---',
+    '',
+    '# UAT Results',
+    '',
+    '### 1. Login works',
+    'expected: User logs in successfully',
+    'result: passed',
+    '',
+  ].join('\n');
+}
+
+function makePendingUat() {
+  return [
+    '---',
+    'status: partial',
+    '---',
+    '',
+    '# UAT Results',
+    '',
+    '### 1. Login works',
+    'expected: User logs in successfully',
+    'result: passed',
+    '',
+    '### 2. Logout works',
+    'expected: User logs out successfully',
+    'result: pending',
+    '',
+  ].join('\n');
+}
+
+function makeFencedFalsePositiveUat() {
+  // Only "result: passed" lines are inside a fenced block.
+  // The real test has result: pending → should evaluate to passed:false.
+  return [
+    '---',
+    'status: partial',
+    '---',
+    '',
+    '# UAT Results',
+    '',
+    '## Example (do not run)',
+    '```',
+    '### 1. Test',
+    'expected: Example',
+    'result: passed',
+    '```',
+    '',
+    '### 1. Real Test',
+    'expected: The thing works',
+    'result: pending',
+    '',
+  ].join('\n');
+}
+
+// ─── Basic pass/fail cases ─────────────────────────────────────────────────────
+
+describe('phase uat-passed — basic pass/fail', () => {
+  let tmpDir;
+  let phaseDir;
+
+  beforeEach(() => {
+    ({ tmpDir, phaseDir } = setupProject('01-feature'));
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('passing UAT → passed:true with correct JSON shape', () => {
+    writeUatFile(phaseDir, 'feature-UAT.md', makePassingUat());
+    const result = runGsdTools('phase uat-passed 1', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}\nOutput: ${result.output}`);
+
+    const out = JSON.parse(result.output);
+    assert.strictEqual(out.passed, true);
+    assert.strictEqual(out.phase, '1');
+    assert.ok(Array.isArray(out.uat_files), 'uat_files must be an array');
+    assert.ok(Array.isArray(out.verification_files), 'verification_files must be an array');
+    assert.ok(Array.isArray(out.checks), 'checks must be an array');
+    assert.ok(Array.isArray(out.blockers), 'blockers must be an array');
+    assert.ok(out.policy && typeof out.policy.require_verification === 'boolean',
+      'policy.require_verification must be a boolean');
+    assert.strictEqual(typeof out.no_uat_artifacts, 'boolean', 'no_uat_artifacts must be a boolean');
+    assert.strictEqual(out.no_uat_artifacts, false, 'no_uat_artifacts must be false when checks exist');
+    assert.strictEqual(out.blockers.length, 0);
+  });
+
+  test('pending UAT → passed:false', () => {
+    writeUatFile(phaseDir, 'feature-UAT.md', makePendingUat());
+    const result = runGsdTools('phase uat-passed 1', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const out = JSON.parse(result.output);
+    assert.strictEqual(out.passed, false);
+    assert.strictEqual(out.phase, '1');
+    assert.ok(out.blockers.length > 0, 'Should have blockers for pending test');
+  });
+
+  test('false-positive only (fenced block) → passed:false', () => {
+    writeUatFile(phaseDir, 'feature-UAT.md', makeFencedFalsePositiveUat());
+    const result = runGsdTools('phase uat-passed 1', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const out = JSON.parse(result.output);
+    assert.strictEqual(out.passed, false,
+      'result:passed inside a fenced block must not flip the predicate to passed');
+  });
+
+  test('no UAT files → passed:false + no_uat_artifacts:true (fail-closed, no vacuous pass)', () => {
+    // Phase directory exists but has no UAT files — fail-closed: absence is NOT a pass
+    const result = runGsdTools('phase uat-passed 1', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const out = JSON.parse(result.output);
+    assert.strictEqual(out.passed, false,
+      'Phase with no UAT files must NOT vacuously pass — fail-closed predicate');
+    assert.strictEqual(out.no_uat_artifacts, true,
+      'no_uat_artifacts must be true when no UAT items found');
+    assert.deepStrictEqual(out.uat_files, []);
+  });
+});
+
+// ─── --require-verification flag ──────────────────────────────────────────────
+
+describe('phase uat-passed — --require-verification flag', () => {
+  let tmpDir;
+  let phaseDir;
+
+  beforeEach(() => {
+    ({ tmpDir, phaseDir } = setupProject('01-feature'));
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('--require-verification with no verification file → passed:false', () => {
+    writeUatFile(phaseDir, 'feature-UAT.md', makePassingUat());
+    const result = runGsdTools('phase uat-passed 1 --require-verification', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const out = JSON.parse(result.output);
+    assert.strictEqual(out.passed, false,
+      'require-verification with no verification file should fail');
+    assert.strictEqual(out.policy.require_verification, true);
+    assert.ok(out.blockers.some(b => /verification required/i.test(b)),
+      `Expected verification-required blocker, got: ${JSON.stringify(out.blockers)}`);
+  });
+
+  test('--require-verification with passing verification → passed:true', () => {
+    writeUatFile(phaseDir, 'feature-UAT.md', makePassingUat());
+    writeUatFile(phaseDir, 'feature-VERIFICATION.md', '---\nstatus: passed\n---\n\nVerified OK.');
+    const result = runGsdTools('phase uat-passed 1 --require-verification', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const out = JSON.parse(result.output);
+    assert.strictEqual(out.passed, true);
+    assert.strictEqual(out.policy.require_verification, true);
+  });
+});
+
+// ─── Error cases ──────────────────────────────────────────────────────────────
+
+describe('phase uat-passed — error cases', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempProject();
+    // Write a minimal ROADMAP so phase 1 exists
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      [
+        '# Roadmap',
+        '',
+        '### Phase 1: Feature',
+        '**Goal:** Build feature',
+        '',
+      ].join('\n'),
+    );
+    fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '01-feature'), { recursive: true });
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('missing phase number → error message', () => {
+    const result = runGsdTools('phase uat-passed', tmpDir);
+    assert.ok(!result.success, 'Should fail with no phase number');
+    assert.ok(
+      result.error.includes('phase number required') ||
+      result.error.includes('Available:'),
+      `Expected phase-number-required error, got: ${result.error}`,
+    );
+  });
+
+  test('unknown phase number → error message', () => {
+    const result = runGsdTools('phase uat-passed 99', tmpDir);
+    assert.ok(!result.success, 'Should fail for unknown phase');
+    assert.ok(
+      result.error.includes('not found') || result.error.includes('99'),
+      `Expected not-found error, got: ${result.error}`,
+    );
+  });
+
+  test('unknown flag (typo --require-verifcation) → InvalidArgs error, not silent pass', () => {
+    const result = runGsdTools('phase uat-passed 1 --require-verifcation', tmpDir);
+    assert.ok(!result.success,
+      'Unknown flag must cause an error, not silently pass');
+    assert.ok(
+      result.error.includes('--require-verifcation') ||
+      result.error.includes('does not support') ||
+      result.error.includes('invalid'),
+      `Expected unknown-flag error, got: ${result.error}`,
+    );
+  });
+});

--- a/tests/uat-predicate.test.cjs
+++ b/tests/uat-predicate.test.cjs
@@ -1,0 +1,1295 @@
+'use strict';
+
+/**
+ * Unit tests for uat-predicate.cjs
+ * Tests the pure-computation module: stripFalsePositiveContexts,
+ * parseUatResultItems, evaluateUatPassed.
+ *
+ * Issue #247 — phase uat-passed predicate
+ */
+
+const { test, describe, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const fc = require('fast-check');
+
+const {
+  stripFalsePositiveContexts,
+  parseUatResultItems,
+  analyzeMarkdown,
+  evaluateUatPassed,
+} = require('../gsd-core/bin/lib/uat-predicate.cjs');
+const { cleanup } = require('./helpers.cjs');
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeTmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-uat-pred-test-'));
+}
+
+function rmDir(dir) {
+  cleanup(dir);
+}
+
+function writeFile(dir, name, content) {
+  fs.writeFileSync(path.join(dir, name), content, 'utf-8');
+}
+
+function makePassingUat(n = 1) {
+  const tests = Array.from({ length: n }, (_, i) => [
+    `### ${i + 1}. Test ${i + 1}`,
+    `expected: It works`,
+    `result: passed`,
+    '',
+  ].join('\n')).join('\n');
+  return `---\nstatus: passed\n---\n\n# UAT\n\n${tests}`;
+}
+
+// ─── stripFalsePositiveContexts ────────────────────────────────────────────────
+
+describe('stripFalsePositiveContexts — frontmatter', () => {
+  test('removes leading frontmatter block', () => {
+    const input = '---\nstatus: pending\nresult: pending\n---\n\nReal content here.';
+    const out = stripFalsePositiveContexts(input);
+    assert.ok(!out.includes('result: pending'), 'frontmatter result: pending should be stripped');
+    assert.ok(out.includes('Real content here.'), 'body content must be preserved');
+  });
+
+  test('does not strip non-frontmatter --- dividers later in document', () => {
+    const input = '---\nstatus: ok\n---\n\n# Section\n\n---\n\nMore content.';
+    const out = stripFalsePositiveContexts(input);
+    assert.ok(out.includes('More content.'), 'content after a non-frontmatter divider must survive');
+  });
+
+  test('handles CRLF frontmatter', () => {
+    const input = '---\r\nstatus: partial\r\nresult: pending\r\n---\r\n\r\nBody text.';
+    const out = stripFalsePositiveContexts(input);
+    assert.ok(!out.includes('result: pending'), 'CRLF frontmatter must be stripped');
+    assert.ok(out.includes('Body text.'), 'body after CRLF frontmatter must survive');
+  });
+});
+
+describe('stripFalsePositiveContexts — HTML comments', () => {
+  test('removes single-line HTML comment', () => {
+    const input = 'Before\n<!-- result: pending -->\nAfter';
+    const out = stripFalsePositiveContexts(input);
+    assert.ok(!out.includes('result: pending'), 'HTML comment content must be stripped');
+    assert.ok(out.includes('Before'), 'content before comment must survive');
+    assert.ok(out.includes('After'), 'content after comment must survive');
+  });
+
+  test('removes multi-line HTML comment', () => {
+    const input = 'A\n<!--\n### 1. Test\nexpected: Foo\nresult: pending\n-->\nB';
+    const out = stripFalsePositiveContexts(input);
+    assert.ok(!out.includes('result: pending'), 'multi-line HTML comment content must be stripped');
+    assert.ok(out.includes('A'), 'content before comment must survive');
+    assert.ok(out.includes('B'), 'content after comment must survive');
+  });
+
+  test('unterminated HTML comment swallows to EOF (fail-closed)', () => {
+    const input = 'Before\n<!--\nresult: passed\nstill in comment';
+    const out = stripFalsePositiveContexts(input);
+    assert.ok(!out.includes('result: passed'), 'unterminated comment must swallow to EOF');
+    assert.ok(out.includes('Before'), 'content before comment must survive');
+  });
+});
+
+describe('stripFalsePositiveContexts — fenced code blocks', () => {
+  test('removes backtick fence with result inside', () => {
+    const input = 'Before\n```\n### 1. Test\nexpected: X\nresult: pending\n```\nAfter';
+    const out = stripFalsePositiveContexts(input);
+    assert.ok(!out.includes('result: pending'), 'content inside ``` fence must be stripped');
+    assert.ok(out.includes('Before'), 'content before fence must survive');
+    assert.ok(out.includes('After'), 'content after fence must survive');
+  });
+
+  test('removes tilde fence', () => {
+    const input = 'Before\n~~~\n### 1. Test\nexpected: X\nresult: blocked\n~~~\nAfter';
+    const out = stripFalsePositiveContexts(input);
+    assert.ok(!out.includes('result: blocked'), 'content inside ~~~ fence must be stripped');
+    assert.ok(out.includes('After'), 'content after tilde fence must survive');
+  });
+
+  test('handles indented fence', () => {
+    const input = 'Before\n   ```\n### 1. Test\nresult: pending\n   ```\nAfter';
+    const out = stripFalsePositiveContexts(input);
+    assert.ok(!out.includes('result: pending'), 'content inside indented fence must be stripped');
+  });
+
+  test('handles CRLF in fenced block', () => {
+    const input = 'Before\r\n```\r\nresult: pending\r\n```\r\nAfter';
+    const out = stripFalsePositiveContexts(input);
+    assert.ok(!out.includes('result: pending'), 'CRLF fenced content must be stripped');
+  });
+
+  test('preserves content after multiple fenced blocks', () => {
+    const input = [
+      'Real intro',
+      '```',
+      'result: pending',
+      '```',
+      '',
+      '### 1. Real Test',
+      'expected: Works',
+      'result: passed',
+      '',
+      '```',
+      'result: pending',
+      '```',
+      'Trailing',
+    ].join('\n');
+    const out = stripFalsePositiveContexts(input);
+    assert.ok(out.includes('result: passed'), 'real result outside fence must survive');
+    assert.ok(!out.includes('result: pending'), 'fenced result: pending must be stripped');
+  });
+});
+
+describe('stripFalsePositiveContexts — blockquotes', () => {
+  test('removes blockquote lines', () => {
+    const input = 'Before\n> ### 1. Test\n> result: pending\nAfter';
+    const out = stripFalsePositiveContexts(input);
+    assert.ok(!out.includes('result: pending'), 'blockquote content must be stripped');
+    assert.ok(out.includes('Before'), 'content before blockquote must survive');
+    assert.ok(out.includes('After'), 'content after blockquote must survive');
+  });
+
+  test('removes indented blockquote lines', () => {
+    const input = 'Before\n  > result: pending\nAfter';
+    const out = stripFalsePositiveContexts(input);
+    assert.ok(!out.includes('result: pending'), 'indented blockquote content must be stripped');
+  });
+});
+
+// ─── parseUatResultItems ───────────────────────────────────────────────────────
+
+describe('parseUatResultItems', () => {
+  test('parses a single passing test', () => {
+    const content = '### 1. Login flow\nexpected: User logs in\nresult: passed\n';
+    const items = parseUatResultItems(content);
+    assert.strictEqual(items.length, 1);
+    assert.strictEqual(items[0].test, 1);
+    assert.strictEqual(items[0].name, 'Login flow');
+    assert.strictEqual(items[0].result, 'passed');
+  });
+
+  test('parses bracketed result [passed] (#2273)', () => {
+    const content = '### 1. Login flow\nexpected: User logs in\nresult: [passed]\n';
+    const items = parseUatResultItems(content);
+    assert.strictEqual(items.length, 1);
+    assert.strictEqual(items[0].result, 'passed');
+  });
+
+  test('parses bracketed result [pass]', () => {
+    const content = '### 1. Login flow\nexpected: User logs in\nresult: [pass]\n';
+    const items = parseUatResultItems(content);
+    assert.strictEqual(items.length, 1);
+    assert.strictEqual(items[0].result, 'pass');
+  });
+
+  test('parses multiple tests with mixed results', () => {
+    const content = [
+      '### 1. Test A',
+      'expected: A',
+      'result: passed',
+      '',
+      '### 2. Test B',
+      'expected: B',
+      'result: pending',
+      '',
+      '### 3. Test C',
+      'expected: C',
+      'result: failed',
+      '',
+    ].join('\n');
+    const items = parseUatResultItems(content);
+    assert.strictEqual(items.length, 3);
+    assert.strictEqual(items[0].result, 'passed');
+    assert.strictEqual(items[1].result, 'pending');
+    assert.strictEqual(items[2].result, 'failed');
+  });
+
+  test('returns empty array for content with no test blocks', () => {
+    const items = parseUatResultItems('Just some markdown with no test blocks.');
+    assert.strictEqual(items.length, 0);
+  });
+
+  test('lowercases result value', () => {
+    const content = '### 1. Test\nexpected: Foo\nresult: PASSED\n';
+    const items = parseUatResultItems(content);
+    assert.strictEqual(items[0].result, 'passed');
+  });
+
+  test('heading with NO result line → result:missing (blocker state, not dropped)', () => {
+    const content = [
+      '### 1. Test without result',
+      'expected: Something',
+      'some notes here',
+      '',
+    ].join('\n');
+    const items = parseUatResultItems(content);
+    assert.strictEqual(items.length, 1);
+    assert.strictEqual(items[0].result, 'missing');
+  });
+
+  test('result: line with leading whitespace (indented scalar) is NOT parsed as column-0', () => {
+    // A real failing test uses block-scalar expected: with blank line before result
+    // The result: with leading whitespace should not be treated as a column-0 result
+    const content = [
+      '### 1. Test A',
+      'expected: |',
+      '  multi',
+      '  line',
+      '',
+      '  result: pending',
+      '',
+    ].join('\n');
+    // The indented result: should not match; heading has no column-0 result → 'missing'
+    const items = parseUatResultItems(content);
+    assert.strictEqual(items.length, 1);
+    assert.strictEqual(items[0].result, 'missing',
+      'Indented result: line must not be parsed as column-0 result');
+  });
+
+  test('block-scalar expected: with blank line then column-0 result: is parsed correctly', () => {
+    // Real failing test: block-scalar expected: | followed by blank + real result: pending
+    const content = [
+      '### 1. Test A',
+      'expected: |',
+      '  multi',
+      '  line',
+      '',
+      'result: pending',
+      '',
+    ].join('\n');
+    const items = parseUatResultItems(content);
+    assert.strictEqual(items.length, 1);
+    assert.strictEqual(items[0].result, 'pending',
+      'Column-0 result: after blank line must be parsed correctly');
+  });
+});
+
+// ─── evaluateUatPassed — boundary coverage ────────────────────────────────────
+
+describe('evaluateUatPassed — boundary coverage', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+  });
+
+  afterEach(() => {
+    rmDir(tmpDir);
+  });
+
+  test('0 UAT files → passed:false, no_uat_artifacts:true (fail-closed, no vacuous pass)', () => {
+    const report = evaluateUatPassed(tmpDir);
+    assert.strictEqual(report.passed, false,
+      'No UAT files must NOT vacuously pass — fail-closed');
+    assert.strictEqual(report.no_uat_artifacts, true);
+    assert.deepStrictEqual(report.uat_files, []);
+    assert.deepStrictEqual(report.blockers, []);
+  });
+
+  test('1 passing test → passed:true, no_uat_artifacts:false', () => {
+    writeFile(tmpDir, 'phase-UAT.md', makePassingUat(1));
+    const report = evaluateUatPassed(tmpDir);
+    assert.strictEqual(report.passed, true);
+    assert.strictEqual(report.no_uat_artifacts, false);
+    assert.strictEqual(report.blockers.length, 0);
+    assert.strictEqual(report.checks.length, 1);
+    assert.strictEqual(report.checks[0].passing, true);
+  });
+
+  test('N all-passing tests → passed:true', () => {
+    writeFile(tmpDir, 'phase-UAT.md', makePassingUat(5));
+    const report = evaluateUatPassed(tmpDir);
+    assert.strictEqual(report.passed, true);
+    assert.strictEqual(report.checks.every(c => c.passing), true);
+  });
+
+  test('N-1 passing + 1 pending → passed:false', () => {
+    // 3 tests total: tests 1,2 passed; test 3 pending
+    const content = [
+      '---', 'status: partial', '---', '',
+      '### 1. Test A', 'expected: A', 'result: passed', '',
+      '### 2. Test B', 'expected: B', 'result: passed', '',
+      '### 3. Test C', 'expected: C', 'result: pending', '',
+    ].join('\n');
+    writeFile(tmpDir, 'phase-UAT.md', content);
+    const report = evaluateUatPassed(tmpDir);
+    assert.strictEqual(report.passed, false);
+    assert.ok(report.blockers.some(b => /test 3/i.test(b) || /pending/i.test(b)),
+      `Expected blocker for pending test, got: ${JSON.stringify(report.blockers)}`);
+  });
+
+  test('1 blocked test → passed:false', () => {
+    const content = [
+      '---', 'status: partial', '---', '',
+      '### 1. Test A', 'expected: A', 'result: blocked', '',
+    ].join('\n');
+    writeFile(tmpDir, 'phase-UAT.md', content);
+    const report = evaluateUatPassed(tmpDir);
+    assert.strictEqual(report.passed, false);
+  });
+
+  test('1 skipped test → passed:false', () => {
+    const content = [
+      '---', 'status: partial', '---', '',
+      '### 1. Test A', 'expected: A', 'result: skipped', '',
+    ].join('\n');
+    writeFile(tmpDir, 'phase-UAT.md', content);
+    const report = evaluateUatPassed(tmpDir);
+    assert.strictEqual(report.passed, false);
+  });
+
+  test('1 failed test → passed:false', () => {
+    const content = [
+      '---', 'status: partial', '---', '',
+      '### 1. Test A', 'expected: A', 'result: failed', '',
+    ].join('\n');
+    writeFile(tmpDir, 'phase-UAT.md', content);
+    const report = evaluateUatPassed(tmpDir);
+    assert.strictEqual(report.passed, false);
+  });
+
+  test('1 human_needed test → passed:false', () => {
+    const content = [
+      '---', 'status: partial', '---', '',
+      '### 1. Test A', 'expected: A', 'result: human_needed', '',
+    ].join('\n');
+    writeFile(tmpDir, 'phase-UAT.md', content);
+    const report = evaluateUatPassed(tmpDir);
+    assert.strictEqual(report.passed, false);
+  });
+
+  test('heading with no result line → result:missing → blocker → passed:false', () => {
+    const content = [
+      '### 1. Test without result',
+      'expected: It should work',
+      'some notes but no result',
+      '',
+    ].join('\n');
+    writeFile(tmpDir, 'phase-UAT.md', content);
+    const report = evaluateUatPassed(tmpDir);
+    assert.strictEqual(report.passed, false);
+    assert.ok(report.checks.some(c => c.result === 'missing' && !c.passing),
+      `Expected missing check item, got checks: ${JSON.stringify(report.checks)}`);
+    assert.ok(report.blockers.some(b => /missing/i.test(b)),
+      `Expected missing blocker, got: ${JSON.stringify(report.blockers)}`);
+  });
+});
+
+// ─── evaluateUatPassed — frontmatter status checks ────────────────────────────
+
+describe('evaluateUatPassed — frontmatter status', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+  });
+
+  afterEach(() => {
+    rmDir(tmpDir);
+  });
+
+  const failingUatStatuses = ['partial', 'diagnosed', 'pending', 'blocked', 'in_progress', 'failed'];
+  const failingUatResults = ['pending', 'blocked', 'failed'];
+
+  for (const status of failingUatStatuses) {
+    test(`UAT frontmatter status=${status} → passed:false`, () => {
+      const content = [
+        '---', `status: ${status}`, '---', '',
+        '### 1. Test A', 'expected: A', 'result: passed', '',
+      ].join('\n');
+      writeFile(tmpDir, 'phase-UAT.md', content);
+      const report = evaluateUatPassed(tmpDir);
+      assert.strictEqual(report.passed, false,
+        `status=${status} should cause failure`);
+      assert.ok(report.blockers.some(b => b.includes(status)),
+        `Blocker should mention status=${status}, got: ${JSON.stringify(report.blockers)}`);
+    });
+  }
+
+  for (const result of failingUatResults) {
+    test(`UAT frontmatter result=${result} → passed:false`, () => {
+      const content = [
+        '---', `result: ${result}`, '---', '',
+        '### 1. Test A', 'expected: A', 'result: passed', '',
+      ].join('\n');
+      writeFile(tmpDir, 'phase-UAT.md', content);
+      const report = evaluateUatPassed(tmpDir);
+      assert.strictEqual(report.passed, false,
+        `fm result=${result} should cause failure`);
+    });
+  }
+});
+
+// ─── evaluateUatPassed — VERIFICATION file checks ─────────────────────────────
+
+describe('evaluateUatPassed — VERIFICATION files', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+  });
+
+  afterEach(() => {
+    rmDir(tmpDir);
+  });
+
+  test('VERIFICATION with status human_needed → passed:false', () => {
+    writeFile(tmpDir, 'phase-UAT.md', makePassingUat(1));
+    writeFile(tmpDir, 'phase-VERIFICATION.md', '---\nstatus: human_needed\n---\n\nNeeds human check.');
+    const report = evaluateUatPassed(tmpDir);
+    assert.strictEqual(report.passed, false);
+    assert.ok(report.blockers.some(b => /human_needed/i.test(b)),
+      `Expected human_needed blocker, got: ${JSON.stringify(report.blockers)}`);
+  });
+
+  test('VERIFICATION with status gaps_found → passed:false', () => {
+    writeFile(tmpDir, 'phase-UAT.md', makePassingUat(1));
+    writeFile(tmpDir, 'phase-VERIFICATION.md', '---\nstatus: gaps_found\n---\n\nHas gaps.');
+    const report = evaluateUatPassed(tmpDir);
+    assert.strictEqual(report.passed, false);
+    assert.ok(report.blockers.some(b => /gaps_found/i.test(b)),
+      `Expected gaps_found blocker, got: ${JSON.stringify(report.blockers)}`);
+  });
+
+  test('VERIFICATION with status pending → passed:false', () => {
+    writeFile(tmpDir, 'phase-UAT.md', makePassingUat(1));
+    writeFile(tmpDir, 'phase-VERIFICATION.md', '---\nstatus: pending\n---\n');
+    const report = evaluateUatPassed(tmpDir);
+    assert.strictEqual(report.passed, false);
+  });
+
+  test('VERIFICATION with status failed → passed:false (blocking)', () => {
+    writeFile(tmpDir, 'phase-UAT.md', makePassingUat(1));
+    writeFile(tmpDir, 'phase-VERIFICATION.md', '---\nstatus: failed\n---\n');
+    const report = evaluateUatPassed(tmpDir);
+    assert.strictEqual(report.passed, false);
+    assert.ok(report.blockers.some(b => /failed/i.test(b)),
+      `Expected failed blocker, got: ${JSON.stringify(report.blockers)}`);
+  });
+
+  test('VERIFICATION with status in_progress → passed:false (blocking)', () => {
+    writeFile(tmpDir, 'phase-UAT.md', makePassingUat(1));
+    writeFile(tmpDir, 'phase-VERIFICATION.md', '---\nstatus: in_progress\n---\n');
+    const report = evaluateUatPassed(tmpDir);
+    assert.strictEqual(report.passed, false);
+    assert.ok(report.blockers.some(b => /in_progress/i.test(b)),
+      `Expected in_progress blocker, got: ${JSON.stringify(report.blockers)}`);
+  });
+
+  test('VERIFICATION with missing status does NOT satisfy --require-verification', () => {
+    writeFile(tmpDir, 'phase-UAT.md', makePassingUat(1));
+    writeFile(tmpDir, 'phase-VERIFICATION.md', '# Verification\nNo frontmatter status.\n');
+    const report = evaluateUatPassed(tmpDir, { policy: { requireVerification: true } });
+    assert.strictEqual(report.passed, false,
+      'Missing verification status must not satisfy requireVerification');
+    assert.ok(report.blockers.some(b => /verification required/i.test(b)),
+      `Expected verification-required blocker, got: ${JSON.stringify(report.blockers)}`);
+  });
+
+  test('VERIFICATION with unknown status does NOT satisfy --require-verification', () => {
+    writeFile(tmpDir, 'phase-UAT.md', makePassingUat(1));
+    writeFile(tmpDir, 'phase-VERIFICATION.md', '---\nstatus: some_unknown_status\n---\n');
+    const report = evaluateUatPassed(tmpDir, { policy: { requireVerification: true } });
+    assert.strictEqual(report.passed, false,
+      'Unknown verification status must not satisfy requireVerification');
+    assert.ok(report.blockers.some(b => /verification required/i.test(b)),
+      `Expected verification-required blocker, got: ${JSON.stringify(report.blockers)}`);
+  });
+
+  test('VERIFICATION with status passed → does not block', () => {
+    writeFile(tmpDir, 'phase-UAT.md', makePassingUat(1));
+    writeFile(tmpDir, 'phase-VERIFICATION.md', '---\nstatus: passed\n---\n\nAll good.');
+    const report = evaluateUatPassed(tmpDir);
+    assert.strictEqual(report.passed, true);
+    assert.strictEqual(report.verification_files.length, 1);
+  });
+
+  test('VERIFICATION with status complete → does not block', () => {
+    writeFile(tmpDir, 'phase-UAT.md', makePassingUat(1));
+    writeFile(tmpDir, 'phase-VERIFICATION.md', '---\nstatus: complete\n---\n\nAll good.');
+    const report = evaluateUatPassed(tmpDir);
+    assert.strictEqual(report.passed, true);
+  });
+
+  test('VERIFICATION with status verified → does not block', () => {
+    writeFile(tmpDir, 'phase-UAT.md', makePassingUat(1));
+    writeFile(tmpDir, 'phase-VERIFICATION.md', '---\nstatus: verified\n---\n\nAll good.');
+    const report = evaluateUatPassed(tmpDir);
+    assert.strictEqual(report.passed, true);
+  });
+
+  test('VERIFICATION with status human_passed → does not block', () => {
+    writeFile(tmpDir, 'phase-UAT.md', makePassingUat(1));
+    writeFile(tmpDir, 'phase-VERIFICATION.md', '---\nstatus: human_passed\n---\n\nAll good.');
+    const report = evaluateUatPassed(tmpDir);
+    assert.strictEqual(report.passed, true);
+  });
+
+  test('VERIFICATION status complete satisfies --require-verification', () => {
+    writeFile(tmpDir, 'phase-UAT.md', makePassingUat(1));
+    writeFile(tmpDir, 'phase-VERIFICATION.md', '---\nstatus: complete\n---\n\nAll good.');
+    const report = evaluateUatPassed(tmpDir, { policy: { requireVerification: true } });
+    assert.strictEqual(report.passed, true);
+    assert.strictEqual(report.policy.require_verification, true);
+  });
+
+  test('VERIFICATION status verified satisfies --require-verification', () => {
+    writeFile(tmpDir, 'phase-UAT.md', makePassingUat(1));
+    writeFile(tmpDir, 'phase-VERIFICATION.md', '---\nstatus: verified\n---\n\nAll good.');
+    const report = evaluateUatPassed(tmpDir, { policy: { requireVerification: true } });
+    assert.strictEqual(report.passed, true);
+  });
+});
+
+// ─── evaluateUatPassed — policy.requireVerification ───────────────────────────
+
+describe('evaluateUatPassed — policy.requireVerification', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+  });
+
+  afterEach(() => {
+    rmDir(tmpDir);
+  });
+
+  test('requireVerification=true with no verification file → passed:false', () => {
+    writeFile(tmpDir, 'phase-UAT.md', makePassingUat(1));
+    const report = evaluateUatPassed(tmpDir, { policy: { requireVerification: true } });
+    assert.strictEqual(report.passed, false);
+    assert.ok(report.blockers.some(b => /verification required/i.test(b)),
+      `Expected verification-required blocker, got: ${JSON.stringify(report.blockers)}`);
+    assert.strictEqual(report.policy.require_verification, true);
+  });
+
+  test('requireVerification=true with passing verification → passed:true', () => {
+    writeFile(tmpDir, 'phase-UAT.md', makePassingUat(1));
+    writeFile(tmpDir, 'phase-VERIFICATION.md', '---\nstatus: passed\n---\n\nOK.');
+    const report = evaluateUatPassed(tmpDir, { policy: { requireVerification: true } });
+    assert.strictEqual(report.passed, true);
+    assert.strictEqual(report.policy.require_verification, true);
+  });
+
+  test('requireVerification=false (default) with no verification file → passed:true', () => {
+    writeFile(tmpDir, 'phase-UAT.md', makePassingUat(1));
+    const report = evaluateUatPassed(tmpDir, { policy: { requireVerification: false } });
+    assert.strictEqual(report.passed, true);
+    assert.strictEqual(report.policy.require_verification, false);
+  });
+});
+
+// ─── evaluateUatPassed — malformed markdown guard ─────────────────────────────
+
+describe('evaluateUatPassed — malformed markdown blocker', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+  });
+
+  afterEach(() => {
+    rmDir(tmpDir);
+  });
+
+  test('unterminated code fence → malformed blocker → passed:false (even with real result:passed)', () => {
+    const content = [
+      '### 1. Real Test',
+      'expected: Something',
+      'result: passed',
+      '',
+      '```',
+      'unterminated fence — no closing delimiter',
+    ].join('\n');
+    writeFile(tmpDir, 'phase-UAT.md', content);
+    const report = evaluateUatPassed(tmpDir);
+    assert.strictEqual(report.passed, false,
+      'Unterminated fence must always block, even if a result:passed exists');
+    assert.ok(report.blockers.some(b => /malformed/i.test(b)),
+      `Expected malformed blocker, got: ${JSON.stringify(report.blockers)}`);
+  });
+
+  test('unterminated HTML comment → malformed blocker → passed:false', () => {
+    const content = [
+      '### 1. Real Test',
+      'expected: Something',
+      'result: passed',
+      '',
+      '<!-- unterminated comment',
+      'no closing arrow',
+    ].join('\n');
+    writeFile(tmpDir, 'phase-UAT.md', content);
+    const report = evaluateUatPassed(tmpDir);
+    assert.strictEqual(report.passed, false,
+      'Unterminated comment must always block');
+    assert.ok(report.blockers.some(b => /malformed/i.test(b)),
+      `Expected malformed blocker, got: ${JSON.stringify(report.blockers)}`);
+  });
+
+  test('well-formed fences → no malformed blocker', () => {
+    const content = [
+      '### 1. Real Test',
+      'expected: Something',
+      'result: passed',
+      '',
+      '```',
+      'code here',
+      '```',
+    ].join('\n');
+    writeFile(tmpDir, 'phase-UAT.md', content);
+    const report = evaluateUatPassed(tmpDir);
+    assert.ok(!report.blockers.some(b => /malformed/i.test(b)),
+      'Well-formed fences must not produce malformed blocker');
+  });
+});
+
+// ─── evaluateUatPassed — hardening regressions (the heart of #247) ────────────
+
+describe('evaluateUatPassed — false-positive hardening regressions', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+  });
+
+  afterEach(() => {
+    rmDir(tmpDir);
+  });
+
+  test('#247: result:passed inside fenced block: parseUatResultItems returns [] for fake, evaluateUatPassed → passed:false + no_uat_artifacts:true', () => {
+    // ONLY result: passed is inside a fenced block — no real test blocks
+    const rawContent = [
+      '```',
+      '### 1. Fake Test',
+      'expected: Example output',
+      'result: passed',
+      '```',
+    ].join('\n');
+    // After stripping, the clean content has no headings at all
+    const clean = stripFalsePositiveContexts(rawContent);
+    const items = parseUatResultItems(clean);
+    assert.strictEqual(items.length, 0, 'Fake result inside fence must produce no items');
+
+    writeFile(tmpDir, 'phase-UAT.md', rawContent);
+    const report = evaluateUatPassed(tmpDir);
+    assert.strictEqual(report.passed, false,
+      'result:passed inside a fenced block must not flip passed to true');
+    assert.strictEqual(report.no_uat_artifacts, true,
+      'no real UAT items → no_uat_artifacts:true');
+  });
+
+  test('#247: result:passed inside blockquote: parseUatResultItems returns [] + evaluateUatPassed → passed:false + no_uat_artifacts:true', () => {
+    const rawContent = [
+      '> ### 1. Test',
+      '> expected: Example',
+      '> result: passed',
+    ].join('\n');
+    const clean = stripFalsePositiveContexts(rawContent);
+    const items = parseUatResultItems(clean);
+    assert.strictEqual(items.length, 0, 'Fake result inside blockquote must produce no items');
+
+    writeFile(tmpDir, 'phase-UAT.md', rawContent);
+    const report = evaluateUatPassed(tmpDir);
+    assert.strictEqual(report.passed, false);
+    assert.strictEqual(report.no_uat_artifacts, true);
+  });
+
+  test('#247: result:passed inside HTML comment: parseUatResultItems returns [] + evaluateUatPassed → passed:false + no_uat_artifacts:true', () => {
+    const rawContent = [
+      '<!-- ### 1. Test',
+      'expected: Example',
+      'result: passed -->',
+    ].join('\n');
+    const clean = stripFalsePositiveContexts(rawContent);
+    const items = parseUatResultItems(clean);
+    assert.strictEqual(items.length, 0, 'Fake result inside HTML comment must produce no items');
+
+    writeFile(tmpDir, 'phase-UAT.md', rawContent);
+    const report = evaluateUatPassed(tmpDir);
+    assert.strictEqual(report.passed, false);
+    assert.strictEqual(report.no_uat_artifacts, true);
+  });
+
+  test('#247: result:passed inside frontmatter: parseUatResultItems returns [] + evaluateUatPassed → passed:false + no_uat_artifacts:true', () => {
+    const rawContent = [
+      '---',
+      'example_result: passed',
+      '---',
+      '',
+      'No real test blocks here.',
+    ].join('\n');
+    const clean = stripFalsePositiveContexts(rawContent);
+    const items = parseUatResultItems(clean);
+    assert.strictEqual(items.length, 0, 'Fake result inside frontmatter must produce no items');
+
+    writeFile(tmpDir, 'phase-UAT.md', rawContent);
+    const report = evaluateUatPassed(tmpDir);
+    assert.strictEqual(report.passed, false);
+    assert.strictEqual(report.no_uat_artifacts, true);
+  });
+
+  test('#247: result:passed inside fenced block is NOT treated as passing test (with real failing test)', () => {
+    const content = [
+      '---',
+      'status: partial',
+      '---',
+      '',
+      '# Example',
+      '',
+      '```',
+      '### 1. Test',
+      'expected: Example output',
+      'result: passed',
+      '```',
+      '',
+      '### 1. Real Test',
+      'expected: Something',
+      'result: pending',
+      '',
+    ].join('\n');
+    writeFile(tmpDir, 'phase-UAT.md', content);
+    const report = evaluateUatPassed(tmpDir);
+    assert.strictEqual(report.passed, false,
+      'result:passed inside a fenced block must not flip passed to true');
+    assert.ok(report.checks.some(c => c.result === 'pending' && !c.passing),
+      'Real pending test must be captured');
+  });
+
+  test('#247: result:passed inside blockquote is NOT treated as passing test', () => {
+    const content = [
+      '---',
+      'status: partial',
+      '---',
+      '',
+      '> ### 1. Test',
+      '> expected: Example',
+      '> result: passed',
+      '',
+      '### 1. Real Test',
+      'expected: Something',
+      'result: pending',
+      '',
+    ].join('\n');
+    writeFile(tmpDir, 'phase-UAT.md', content);
+    const report = evaluateUatPassed(tmpDir);
+    assert.strictEqual(report.passed, false,
+      'result:passed inside a blockquote must not flip passed to true');
+  });
+
+  test('#247: result:passed inside HTML comment is NOT treated as passing test', () => {
+    const content = [
+      '---',
+      'status: partial',
+      '---',
+      '',
+      '<!-- ### 1. Test',
+      'expected: Example',
+      'result: passed -->',
+      '',
+      '### 1. Real Test',
+      'expected: Something',
+      'result: pending',
+      '',
+    ].join('\n');
+    writeFile(tmpDir, 'phase-UAT.md', content);
+    const report = evaluateUatPassed(tmpDir);
+    assert.strictEqual(report.passed, false,
+      'result:passed inside an HTML comment must not flip passed to true');
+  });
+
+  test('#247: result:passed inside frontmatter example is NOT treated as passing test', () => {
+    const content = [
+      '---',
+      'status: partial',
+      'example_result: passed',
+      '---',
+      '',
+      '### 1. Real Test',
+      'expected: Something',
+      'result: pending',
+      '',
+    ].join('\n');
+    writeFile(tmpDir, 'phase-UAT.md', content);
+    const report = evaluateUatPassed(tmpDir);
+    assert.strictEqual(report.passed, false,
+      'result:passed in frontmatter must not flip passed to true');
+  });
+
+  test('#247: real passing test block outside all contexts → passed:true', () => {
+    const content = [
+      '---',
+      'status: passed',
+      '---',
+      '',
+      '# UAT Results',
+      '',
+      '### 1. Login works',
+      'expected: User logs in',
+      'result: passed',
+      '',
+    ].join('\n');
+    writeFile(tmpDir, 'phase-UAT.md', content);
+    const report = evaluateUatPassed(tmpDir);
+    assert.strictEqual(report.passed, true,
+      'A real passing test outside false-positive contexts must pass');
+  });
+
+  test('block-scalar expected: followed by blank line + result: pending → parsed as blocker (not dropped)', () => {
+    const content = [
+      '### 1. Test A',
+      'expected: |',
+      '  multi',
+      '  line expected output',
+      '',
+      'result: pending',
+      '',
+    ].join('\n');
+    writeFile(tmpDir, 'phase-UAT.md', content);
+    const report = evaluateUatPassed(tmpDir);
+    assert.strictEqual(report.passed, false,
+      'Block-scalar expected: with result: pending must be captured as a blocker');
+    assert.ok(report.checks.some(c => c.result === 'pending' && !c.passing),
+      `Expected pending check, got: ${JSON.stringify(report.checks)}`);
+  });
+});
+
+// ─── evaluateUatPassed — output shape contract ───────────────────────────────
+
+describe('evaluateUatPassed — output shape (Hyrum\'s Law contract)', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+  });
+
+  afterEach(() => {
+    rmDir(tmpDir);
+  });
+
+  test('returns all required fields in the locked shape including no_uat_artifacts', () => {
+    writeFile(tmpDir, 'phase-UAT.md', makePassingUat(1));
+    const report = evaluateUatPassed(tmpDir);
+
+    // Locked field names
+    assert.ok('passed' in report, 'report.passed must exist');
+    assert.ok('uat_files' in report, 'report.uat_files must exist');
+    assert.ok('verification_files' in report, 'report.verification_files must exist');
+    assert.ok('checks' in report, 'report.checks must exist');
+    assert.ok('blockers' in report, 'report.blockers must exist');
+    assert.ok('no_uat_artifacts' in report, 'report.no_uat_artifacts must exist');
+    assert.ok('policy' in report, 'report.policy must exist');
+    assert.ok('require_verification' in report.policy, 'report.policy.require_verification must exist');
+
+    // checks item shape
+    if (report.checks.length > 0) {
+      const c = report.checks[0];
+      assert.ok('file' in c, 'check.file must exist');
+      assert.ok('test' in c, 'check.test must exist');
+      assert.ok('name' in c, 'check.name must exist');
+      assert.ok('result' in c, 'check.result must exist');
+      assert.ok('passing' in c, 'check.passing must exist');
+    }
+  });
+
+  test('no_uat_artifacts is false when real checks exist', () => {
+    writeFile(tmpDir, 'phase-UAT.md', makePassingUat(1));
+    const report = evaluateUatPassed(tmpDir);
+    assert.strictEqual(report.no_uat_artifacts, false);
+  });
+
+  test('no_uat_artifacts is true when no checks exist', () => {
+    const report = evaluateUatPassed(tmpDir);
+    assert.strictEqual(report.no_uat_artifacts, true);
+  });
+
+  test('uat_files contains the filename', () => {
+    writeFile(tmpDir, 'my-UAT.md', makePassingUat(1));
+    const report = evaluateUatPassed(tmpDir);
+    assert.ok(report.uat_files.includes('my-UAT.md'),
+      `uat_files should include 'my-UAT.md', got: ${JSON.stringify(report.uat_files)}`);
+  });
+
+  test('verification_files contains the filename', () => {
+    writeFile(tmpDir, 'phase-UAT.md', makePassingUat(1));
+    writeFile(tmpDir, 'phase-VERIFICATION.md', '---\nstatus: passed\n---\n');
+    const report = evaluateUatPassed(tmpDir);
+    assert.ok(report.verification_files.includes('phase-VERIFICATION.md'),
+      `verification_files should include 'phase-VERIFICATION.md', got: ${JSON.stringify(report.verification_files)}`);
+  });
+});
+
+// ─── FIX A regression: nested-fence (~~~ inside ```) ─────────────────────────
+
+describe('FIX A — nested fence: ~~~ inside ``` does not prematurely close outer fence', () => {
+  let tmpDir;
+
+  beforeEach(() => { tmpDir = makeTmpDir(); });
+  afterEach(() => { rmDir(tmpDir); });
+
+  test('parseUatResultItems sees [] for fake inside ``` that encloses ~~~', () => {
+    // A backtick fence that contains an inner ~~~ fence with a fake test block.
+    // The ~~~ must NOT close the ``` fence — the whole interior is content and is dropped.
+    const raw = [
+      '```',
+      '~~~',
+      '### 1. Fake',
+      'expected: X',
+      'result: passed',
+      '~~~',
+      '```',
+    ].join('\n');
+    const clean = stripFalsePositiveContexts(raw);
+    const items = parseUatResultItems(clean);
+    assert.strictEqual(items.length, 0, 'fake inside nested fence must not leak through');
+  });
+
+  test('evaluateUatPassed → passed:false + no_uat_artifacts:true for nested-fence-only file', () => {
+    const raw = [
+      '```',
+      '~~~',
+      '### 1. Fake',
+      'expected: X',
+      'result: passed',
+      '~~~',
+      '```',
+    ].join('\n');
+    writeFile(tmpDir, 'phase-UAT.md', raw);
+    const report = evaluateUatPassed(tmpDir);
+    assert.strictEqual(report.passed, false, 'nested-fence fake must not flip passed');
+    assert.strictEqual(report.no_uat_artifacts, true, 'no real items → no_uat_artifacts:true');
+    assert.ok(!report.checks.some(c => c.name === 'Fake'), 'fake must not appear in checks');
+  });
+
+  test('balanced nested fence (``` inside ~~~) is NOT flagged as malformed', () => {
+    // ~~~ outer, ``` inner — properly closed — should not trigger unterminatedFence
+    const raw = [
+      '~~~',
+      '```',
+      'code',
+      '```',
+      '~~~',
+      '',
+      '### 1. Real Test',
+      'expected: Works',
+      'result: passed',
+    ].join('\n');
+    const { unterminatedFence } = analyzeMarkdown(raw);
+    assert.strictEqual(unterminatedFence, false, 'balanced nested fence must not be flagged');
+    const clean = stripFalsePositiveContexts(raw);
+    const items = parseUatResultItems(clean);
+    assert.strictEqual(items.length, 1, 'real test outside fence must still be found');
+    assert.strictEqual(items[0].result, 'passed');
+  });
+
+  test('real result:passed outside ``` that encloses ~~~ → passed:true (no false-block)', () => {
+    const raw = [
+      '---',
+      'status: passed',
+      '---',
+      '',
+      '```',
+      '~~~',
+      '### 1. Fake',
+      'result: passed',
+      '~~~',
+      '```',
+      '',
+      '### 1. Real Test',
+      'expected: Works',
+      'result: passed',
+    ].join('\n');
+    writeFile(tmpDir, 'phase-UAT.md', raw);
+    const report = evaluateUatPassed(tmpDir);
+    assert.strictEqual(report.passed, true, 'real result outside nested fence must still pass');
+    assert.ok(!report.checks.some(c => c.name === 'Fake'), 'fake must not appear in checks');
+  });
+});
+
+// ─── FIX B regression: cross-line result value ────────────────────────────────
+
+describe('FIX B — cross-line result: value must be on the same line', () => {
+  test('result: with value on next line → result:missing (not passed)', () => {
+    const content = [
+      '### 1. Cross-line Test',
+      'expected: Y',
+      'result:',
+      '',
+      'passed',
+    ].join('\n');
+    const items = parseUatResultItems(content);
+    assert.strictEqual(items.length, 1);
+    assert.notStrictEqual(items[0].result, 'passed',
+      'result value on a subsequent line must not be captured as passed');
+    assert.strictEqual(items[0].result, 'missing',
+      'cross-line result must yield missing (blocker)');
+  });
+
+  test('evaluateUatPassed → passed:false for cross-line result:passed', () => {
+    const tmpDir = makeTmpDir();
+    try {
+      const content = [
+        '### 1. Cross-line Test',
+        'expected: Y',
+        'result:',
+        '',
+        'passed',
+      ].join('\n');
+      writeFile(tmpDir, 'phase-UAT.md', content);
+      const report = evaluateUatPassed(tmpDir);
+      assert.strictEqual(report.passed, false);
+      assert.ok(!report.checks.some(c => c.result === 'passed'),
+        'cross-line result must not produce a passing check');
+    } finally {
+      rmDir(tmpDir);
+    }
+  });
+});
+
+// ─── FIX C regression: masked-comment (earlier closed comment + later unterminated) ──
+
+describe('FIX C — dangling comment survives earlier balanced comment', () => {
+  test('analyzeMarkdown detects unterminated comment after a properly closed one', () => {
+    const raw = [
+      '<!-- ok -->',
+      'Some text',
+      '<!--',
+      '### 1. Fake',
+      'result: passed',
+    ].join('\n');
+    const { unterminatedComment } = analyzeMarkdown(raw);
+    assert.strictEqual(unterminatedComment, true,
+      'later unterminated comment must be detected even after a balanced one');
+  });
+
+  test('evaluateUatPassed → passed:false (malformed) when later comment is unterminated', () => {
+    const tmpDir = makeTmpDir();
+    try {
+      const raw = [
+        '### 1. Real Test',
+        'expected: Something',
+        'result: passed',
+        '',
+        '<!-- properly closed -->',
+        '',
+        '<!--',
+        '### 2. Fake',
+        'result: passed',
+      ].join('\n');
+      writeFile(tmpDir, 'phase-UAT.md', raw);
+      const report = evaluateUatPassed(tmpDir);
+      assert.strictEqual(report.passed, false,
+        'unterminated later comment must trigger malformed blocker');
+      assert.ok(report.blockers.some(b => /malformed/i.test(b)),
+        `Expected malformed blocker, got: ${JSON.stringify(report.blockers)}`);
+    } finally {
+      rmDir(tmpDir);
+    }
+  });
+
+  test('analyzeMarkdown does NOT flag a file with only properly balanced comments', () => {
+    const raw = [
+      '<!-- first comment -->',
+      'Some text',
+      '<!-- second comment -->',
+      '',
+      '### 1. Real Test',
+      'result: passed',
+    ].join('\n');
+    const { unterminatedComment } = analyzeMarkdown(raw);
+    assert.strictEqual(unterminatedComment, false,
+      'only balanced comments must not be flagged as unterminated');
+  });
+});
+
+// ─── FIX D regression: balanced mixed fences are NOT flagged ─────────────────
+
+describe('FIX D — odd-fence-count heuristic replaced: balanced mixed fences not flagged', () => {
+  test('analyzeMarkdown: ``` followed by ~~~ (both balanced) → unterminatedFence:false', () => {
+    const raw = [
+      '```',
+      'code',
+      '```',
+      '',
+      '~~~',
+      'more code',
+      '~~~',
+    ].join('\n');
+    const { unterminatedFence } = analyzeMarkdown(raw);
+    assert.strictEqual(unterminatedFence, false,
+      'two separate balanced fences must not trigger unterminatedFence');
+  });
+
+  test('evaluateUatPassed: multiple balanced fences + real passing test → passed:true, no malformed blocker', () => {
+    const tmpDir = makeTmpDir();
+    try {
+      const raw = [
+        '---',
+        'status: passed',
+        '---',
+        '',
+        '```',
+        'result: fake',
+        '```',
+        '',
+        '~~~',
+        'result: also fake',
+        '~~~',
+        '',
+        '### 1. Real Test',
+        'expected: Works',
+        'result: passed',
+      ].join('\n');
+      writeFile(tmpDir, 'phase-UAT.md', raw);
+      const report = evaluateUatPassed(tmpDir);
+      assert.ok(!report.blockers.some(b => /malformed/i.test(b)),
+        `Balanced mixed fences must not produce malformed blocker, got: ${JSON.stringify(report.blockers)}`);
+      assert.strictEqual(report.passed, true,
+        'real test outside balanced fences must still pass');
+    } finally {
+      rmDir(tmpDir);
+    }
+  });
+});
+
+// ─── FIX E extra: fake-not-in-checks assertions for existing mixed tests ──────
+
+describe('FIX E — fake items must NOT appear in checks (absence assertions)', () => {
+  let tmpDir;
+
+  beforeEach(() => { tmpDir = makeTmpDir(); });
+  afterEach(() => { rmDir(tmpDir); });
+
+  test('fake inside fence + real pending: fake NOT in checks', () => {
+    const content = [
+      '---', 'status: partial', '---', '',
+      '```',
+      '### 10. Fake',
+      'expected: Fake',
+      'result: passed',
+      '```',
+      '',
+      '### 1. Real Test',
+      'expected: Something',
+      'result: pending',
+      '',
+    ].join('\n');
+    writeFile(tmpDir, 'phase-UAT.md', content);
+    const report = evaluateUatPassed(tmpDir);
+    assert.strictEqual(report.passed, false);
+    assert.ok(!report.checks.some(c => c.name === 'Fake'),
+      'fake test inside fence must not appear in checks');
+  });
+
+  test('fake inside blockquote + real pending: fake NOT in checks', () => {
+    const content = [
+      '---', 'status: partial', '---', '',
+      '> ### 10. Fake',
+      '> expected: Fake',
+      '> result: passed',
+      '',
+      '### 1. Real Test',
+      'expected: Something',
+      'result: pending',
+      '',
+    ].join('\n');
+    writeFile(tmpDir, 'phase-UAT.md', content);
+    const report = evaluateUatPassed(tmpDir);
+    assert.strictEqual(report.passed, false);
+    assert.ok(!report.checks.some(c => c.name === 'Fake'),
+      'fake test inside blockquote must not appear in checks');
+  });
+
+  test('fake inside HTML comment + real pending: fake NOT in checks', () => {
+    const content = [
+      '---', 'status: partial', '---', '',
+      '<!-- ### 10. Fake',
+      'expected: Fake',
+      'result: passed -->',
+      '',
+      '### 1. Real Test',
+      'expected: Something',
+      'result: pending',
+      '',
+    ].join('\n');
+    writeFile(tmpDir, 'phase-UAT.md', content);
+    const report = evaluateUatPassed(tmpDir);
+    assert.strictEqual(report.passed, false);
+    assert.ok(!report.checks.some(c => c.name === 'Fake'),
+      'fake test inside HTML comment must not appear in checks');
+  });
+});
+
+// ─── Property-based test (fast-check) ─────────────────────────────────────────
+
+describe('evaluateUatPassed — property: wrapping in false-positive context never flips to passed', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+  });
+
+  afterEach(() => {
+    rmDir(tmpDir);
+  });
+
+  test('fc: inserting result:passed inside wrapper context never flips a failing UAT to passed', () => {
+    // A baseline UAT file that has a pending item — it must always evaluate to passed:false
+    // regardless of how many "result: passed" lines we inject inside fenced/blockquote/comment wrappers.
+    const baseFailingBody = [
+      '### 1. Real Test',
+      'expected: It works',
+      'result: pending',
+      '',
+    ].join('\n');
+
+    const wrappers = fc.constantFrom(
+      // backtick fence
+      (inner) => '```\n' + inner + '\n```',
+      // tilde fence
+      (inner) => '~~~\n' + inner + '\n~~~',
+      // HTML comment
+      (inner) => '<!--\n' + inner + '\n-->',
+      // blockquote — prefix each line
+      (inner) => inner.split('\n').map(l => '> ' + l).join('\n'),
+    );
+
+    fc.assert(
+      fc.property(wrappers, fc.nat(3), (wrap, extraCount) => {
+        // Build a "fake passing block" that would fool a naive regex
+        const fakePassingLines = Array.from({ length: extraCount + 1 }, (_, i) =>
+          `### ${i + 10}. Fake Test ${i + 10}\nexpected: Fake\nresult: passed`
+        ).join('\n');
+
+        const fullContent = [
+          '---',
+          'status: partial',
+          '---',
+          '',
+          wrap(fakePassingLines),
+          '',
+          baseFailingBody,
+        ].join('\n');
+
+        // Write to a unique tmp file to avoid cross-test state
+        const fcDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-fc-uat-'));
+        try {
+          fs.writeFileSync(path.join(fcDir, 'feature-UAT.md'), fullContent, 'utf-8');
+          const report = evaluateUatPassed(fcDir);
+          // The pending item must always keep passed:false
+          // AND fake items injected via wrappers must never appear in checks
+          const hasFakeInChecks = report.checks.some(c => c.name.startsWith('Fake Test'));
+          return report.passed === false && !hasFakeInChecks;
+        } finally {
+          cleanup(fcDir);
+        }
+      }),
+      { numRuns: 50 }
+    );
+  });
+});


### PR DESCRIPTION
## Enhancement PR

## Linked Issue

Closes #247

The linked issue carries the `approved-enhancement` label (approved by @trek-e on 2026-06-01).

---

## What this enhancement improves

Adds a runtime-neutral `phase uat-passed <N>` predicate that evaluates **HUMAN-UAT results** with markdown-aware parsing and reports pass **only when every required check passes**. This wires the already-reserved `phase.uat-passed` command alias (subcommand `uat-passed`, `mutation:false`) into the phase command router — the alias existed but had no dispatch bridge, exactly as noted in the issue's approval comment ("the alias is reserved … but the CJS dispatch bridge in phase-command-router.cjs is absent").

This is the post-SDK-retirement (ADR-0174 / #174) successor to the SDK-framed #70: the need to enforce phase-complete using HUMAN-UAT pass results with markdown-safe parsing now lives as a runtime-neutral CLI predicate, with **no SDK-specific API surface**.

## Before / After

**Before:**
There was no runtime-neutral way to ask "did this phase's HUMAN-UAT actually pass?". The closest signal, `cmdPhaseComplete`, scans the whole UAT file with a naive `/result: pending/.test(content)` regex that **false-matches** `result:` lines appearing inside YAML frontmatter, fenced code blocks, HTML comments, and blockquotes — a weak signal that can mark completion without enforcing UAT pass semantics.

**After:**
```
$ gsd-tools phase uat-passed 5 --raw
{
  "phase": "5",
  "passed": false,
  "uat_files": ["05-1-UAT.md"],
  "verification_files": [],
  "checks": [
    { "file": "05-1-UAT.md", "test": 1, "name": "Login flow", "result": "passed", "passing": true },
    { "file": "05-1-UAT.md", "test": 2, "name": "Logout flow", "result": "pending", "passing": false }
  ],
  "blockers": ["05-1-UAT.md: test 2 (pending)"],
  "no_uat_artifacts": false,
  "policy": { "require_verification": false }
}
```
The predicate is **fail-closed**: only a real `### N. Name / expected: / result: passed` test block counts as passing. A `result: passed` line living inside frontmatter, a fenced/`~~~` code block (including a `~~~` nested inside a triple-backtick fence), an HTML comment, or a blockquote is ignored. Absence of evidence (no `*-UAT.md`, unreadable dir, malformed/unterminated fence or comment) yields `passed:false` with `no_uat_artifacts` / a malformed-markdown blocker — never a vacuous pass. An optional `--require-verification` policy hook requires a passing `*-VERIFICATION.md` for sensitive-path integration verification.

## How it was implemented

- **`src/uat-predicate.cts`** (new pure-computation module, mirrors the `phase-lifecycle.cjs` extraction pattern — no `process.exit`/`output`): `stripFalsePositiveContexts` (frontmatter → HTML-comment → CommonMark-style fenced-block state machine tracking delimiter char+length → blockquote, each a small composable step), `parseUatResultItems` (heading-block parser, column-0-anchored `result:`, missing result → fail-closed `missing`), `analyzeMarkdown` (unterminated fence/comment detection), and `evaluateUatPassed` (allowlist-based pass/verification semantics; `passed = no blockers && ≥1 check && all passing`).
- **`src/phase.cts`** — thin `cmdPhaseUatPassed` handler delegating to the predicate, reusing `findPhaseInternal` phase resolution and the existing `output(obj, raw)` convention.
- **`src/phase-command-router.cts`** — `uat-passed` cjsRegistry closure (rejects unknown flags via `makeInvalidArgs`, parses `--require-verification`).
- Registry/docs: `docs/COMMANDS.md`, `docs/FEATURES.md`, `docs/CLI-TOOLS.md`, `docs/INVENTORY.md` (+manifest), `CONTEXT.md` glossary, `.gitignore`, `eslint.config.mjs`.

The design was hardened across two independent Codex adversarial-review passes (vacuous-pass, parser-drops-failing-tests, permissive verification status, nested-fence escape, cross-line `result:` value, masked unterminated comment) — every finding fixed fail-closed.

## Testing

### How I verified the enhancement works

- TDD red→green. New suites: `tests/uat-predicate.test.cjs` (unit: strip contexts, heading-block parser, boundary 0/1/N-1/N, frontmatter + verification status, policy, **isolated false-positive hardening** asserting fakes are absent from `checks`, nested-fence + cross-line + masked-comment regressions, plus a `fast-check` property test that injected fakes never flip `passed`) and `tests/247-phase-uat-passed.test.cjs` (CLI integration via `runGsdTools`).
- 98 tests pass in the two new suites; phase/router/hub/uat regression suites green (240 pass, 1 pre-existing skip).
- `npm run lint`: 0 issues. Docker `gsd-test` (Ubuntu-CI mirror): green.

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux (Docker `gsd-test`)
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (CLI predicate — runtime-neutral by design)

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue — no additions or removals
- [x] If scope changed during implementation, I updated the issue and got re-approval before continuing

---

## Documentation

- [x] Updated the relevant file(s) under `docs/` to reflect this change (`docs/COMMANDS.md`, `docs/FEATURES.md`, `docs/CLI-TOOLS.md`, `docs/INVENTORY.md`)
- [x] All `docs/` content added in this PR is written in English
- [ ] If genuinely no user-facing docs impact, apply `no-docs` / docs-exempt

## Checklist

- [x] Issue linked above with `Closes #247`
- [x] Linked issue has the `approved-enhancement` label
- [x] Changes are scoped to the approved enhancement — nothing extra included
- [x] All existing tests pass
- [x] New or updated tests cover the enhanced behavior
- [x] `.changeset/` fragment added (type `Added`)
- [x] No unnecessary dependencies added

## Breaking changes

None. Adds a new read-only (`mutation:false`) command path; no existing command, output, or API changes. `cmdPhaseComplete` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1063"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783801127&installation_id=134682257&pr_number=1063&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1063&signature=7ec10d7b6b1fd211dcc84ae38c9309277bed7c3bece059bab14e6c37ecb18124"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->