### PR TITLE
feat: add MiMoCode and Command Code runtime installer support

### DIFF
--- a/.changeset/mimocode-runtime-support.md
+++ b/.changeset/mimocode-runtime-support.md
@@ -2,4 +2,4 @@
 "@opengsd/gsd-core": minor
 ---
 
-Add MiMoCode runtime installer support with valid subagent frontmatter conversion (`tools` record + `#RRGGBB` colors), XDG config at `~/.config/mimocode`, and `--mimo` CLI flag.
+Add MiMoCode and Command Code runtime installer support with valid subagent frontmatter conversion (`tools` record + `#RRGGBB` colors), config at `~/.config/mimocode` and `~/.commandcode`, and `--mimo` / `--commandcode` CLI flags.

--- a/.changeset/mimocode-runtime-support.md
+++ b/.changeset/mimocode-runtime-support.md
@@ -1,0 +1,5 @@
+---
+"@opengsd/gsd-core": minor
+---
+
+Add MiMoCode runtime installer support with valid subagent frontmatter conversion (`tools` record + `#RRGGBB` colors), XDG config at `~/.config/mimocode`, and `--mimo` CLI flag.

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ commands.html
 # Local test installs
 .claude/
 .mimocode/
+.commandcode/
 
 # Cursor IDE — local agents/skills bundle (never commit)
 .cursor/

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ commands.html
 
 # Local test installs
 .claude/
+.mimocode/
 
 # Cursor IDE — local agents/skills bundle (never commit)
 .cursor/

--- a/bin/install.js
+++ b/bin/install.js
@@ -395,7 +395,7 @@ if (hasMinimal && _profileArgRaw) {
 
 function selectRuntimesFromArgs(runtimeArgs) {
   if (runtimeArgs.includes('--all')) {
-    return ['claude', 'kimi', 'kilo', 'opencode', 'gemini', 'codex', 'copilot', 'antigravity', 'cursor', 'windsurf', 'augment', 'trae', 'qwen', 'hermes', 'codebuddy', 'cline'];
+    return ['claude', 'kimi', 'kilo', 'mimo', 'opencode', 'gemini', 'codex', 'copilot', 'antigravity', 'cursor', 'windsurf', 'augment', 'trae', 'qwen', 'hermes', 'codebuddy', 'cline'];
   }
   if (runtimeArgs.includes('--both')) {
     return ['claude', 'opencode'];
@@ -416,6 +416,7 @@ function selectRuntimesFromArgs(runtimeArgs) {
   if (runtimeArgs.includes('--qwen')) selected.push('qwen');
   if (runtimeArgs.includes('--hermes')) selected.push('hermes');
   if (runtimeArgs.includes('--kimi')) selected.push('kimi');
+  if (runtimeArgs.includes('--mimo')) selected.push('mimo');
   if (runtimeArgs.includes('--codebuddy')) selected.push('codebuddy');
   if (runtimeArgs.includes('--cline')) selected.push('cline');
   return selected;
@@ -473,6 +474,7 @@ function getDirName(runtime) {
   if (runtime === 'qwen') return '.qwen';
   if (runtime === 'hermes') return '.hermes';
   if (runtime === 'kimi') return '.kimi-code';
+  if (runtime === 'mimo') return '.mimocode';
   if (runtime === 'codebuddy') return '.codebuddy';
   if (runtime === 'cline') return '.cline';
   return '.claude';
@@ -520,6 +522,7 @@ function getConfigDirFromHome(runtime, isGlobal) {
   if (runtime === 'codebuddy') return "'.codebuddy'";
   if (runtime === 'cline') return "'.cline'";
   if (runtime === 'kimi') return "'.config', 'agents'";
+  if (runtime === 'mimo') return "'.config', 'mimocode'";
   return "'.claude'";
 }
 
@@ -541,7 +544,7 @@ const banner = '\n' +
   '  GSD Core ' + dim + 'v' + pkg.version + reset + '\n' +
   '  Git. Ship. Done.\n' +
   '  A meta-prompting, context engineering and spec-driven\n' +
-  '  development workflows for Claude Code, OpenCode, Gemini, Kimi CLI, Kilo, Codex, Copilot, Antigravity, Cursor, Windsurf, Augment, Trae, Qwen Code, Hermes Agent, Cline and CodeBuddy.\n';
+  '  development workflows for Claude Code, OpenCode, Gemini, Kimi CLI, MiMoCode, Kilo, Codex, Copilot, Antigravity, Cursor, Windsurf, Augment, Trae, Qwen Code, Hermes Agent, Cline and CodeBuddy.\n';
 
 // Pure seam: parse --config-dir / -c from an arbitrary args array.
 // Returns the path string, '' for an empty equals-form value, or null when the
@@ -598,7 +601,7 @@ if (hasUninstall) {
 
 // Show help if requested
 if (hasHelp) {
-  console.log(`  ${yellow}Usage:${reset} npx ${pkg.name} [options]\n\n  ${yellow}Options:${reset}\n    ${cyan}-g, --global${reset}              Install globally (to config directory)\n    ${cyan}-l, --local${reset}               Install locally (to current directory)\n    ${cyan}--claude${reset}                  Install for Claude Code only\n    ${cyan}--opencode${reset}                Install for OpenCode only\n    ${cyan}--gemini${reset}                  Install for Gemini only\n    ${cyan}--kilo${reset}                    Install for Kilo only\n    ${cyan}--codex${reset}                   Install for Codex only\n    ${cyan}--kimi${reset}                    Install for Kimi CLI only\n    ${cyan}--copilot${reset}                 Install for Copilot only\n    ${cyan}--antigravity${reset}             Install for Antigravity only\n    ${cyan}--cursor${reset}                  Install for Cursor only\n    ${cyan}--windsurf${reset}                Install for Windsurf only\n    ${cyan}--augment${reset}                 Install for Augment only\n    ${cyan}--trae${reset}                    Install for Trae only\n    ${cyan}--qwen${reset}                    Install for Qwen Code only\n    ${cyan}--hermes${reset}                  Install for Hermes Agent only\n    ${cyan}--cline${reset}                   Install for Cline only\n    ${cyan}--codebuddy${reset}              Install for CodeBuddy only\n    ${cyan}--all${reset}                     Install for all runtimes\n    ${cyan}-u, --uninstall${reset}           Uninstall GSD (remove all GSD files)\n    ${cyan}-c, --config-dir <path>${reset}   Specify custom config directory\n    ${cyan}-h, --help${reset}                Show this help message\n    ${cyan}--force-statusline${reset}        Replace existing statusline config\n    ${cyan}--portable-hooks${reset}          Emit \$HOME-relative hook paths in settings.json\n                              (for WSL/Docker bind-mount setups; also GSD_PORTABLE_HOOKS=1)\n    ${cyan}--profile=<name>${reset}         Install a named skill profile. Profiles:\n                              core     — ${PROFILES.core.length} main-loop skills incl. phase (~130 desc tokens)\n                              standard — ${PROFILES.standard.length} skills incl. phase, review, config (~700)\n                              full     — all skills (default)\n                              Composable: --profile=core,audit installs union of closures.\n                              Profile is persisted and respected by \`gsd update\`.\n    ${cyan}--minimal${reset}                 Alias for --profile=core (back-compat).\n                              Cuts cold-start overhead from ~12k tokens to ~700.\n                              Alias: --core-only.\n\n  ${yellow}Examples:${reset}\n    ${dim}# Interactive install (prompts for runtime and location)${reset}\n    npx ${pkg.name}\n\n    ${dim}# Install for Claude Code globally${reset}\n    npx ${pkg.name} --claude --global\n\n    ${dim}# Install for Gemini globally${reset}\n    npx ${pkg.name} --gemini --global\n\n    ${dim}# Install for Kilo globally${reset}\n    npx ${pkg.name} --kilo --global\n\n    ${dim}# Install for Codex globally${reset}\n    npx ${pkg.name} --codex --global\n\n    ${dim}# Install for Kimi CLI globally${reset}\n    npx ${pkg.name} --kimi --global\n\n    ${dim}# Install for Kimi CLI under ~/.kimi-code${reset}\n    npx ${pkg.name} --kimi --global --config-dir ~/.kimi-code\n\n    ${dim}# Install for Copilot globally${reset}\n    npx ${pkg.name} --copilot --global\n\n    ${dim}# Install for Copilot locally${reset}\n    npx ${pkg.name} --copilot --local\n\n    ${dim}# Install for Antigravity globally${reset}\n    npx ${pkg.name} --antigravity --global\n\n    ${dim}# Install for Antigravity locally${reset}\n    npx ${pkg.name} --antigravity --local\n\n    ${dim}# Install for Cursor globally${reset}\n    npx ${pkg.name} --cursor --global\n\n    ${dim}# Install for Cursor locally${reset}\n    npx ${pkg.name} --cursor --local\n\n    ${dim}# Install for Windsurf globally${reset}\n    npx ${pkg.name} --windsurf --global\n\n    ${dim}# Install for Windsurf locally${reset}\n    npx ${pkg.name} --windsurf --local\n\n    ${dim}# Install for Augment globally${reset}\n    npx ${pkg.name} --augment --global\n\n    ${dim}# Install for Augment locally${reset}\n    npx ${pkg.name} --augment --local\n\n    ${dim}# Install for Trae globally${reset}\n    npx ${pkg.name} --trae --global\n\n    ${dim}# Install for Trae locally${reset}\n    npx ${pkg.name} --trae --local\n\n    ${dim}# Install for Hermes Agent globally${reset}\n    npx ${pkg.name} --hermes --global\n\n    ${dim}# Install for Hermes Agent locally${reset}\n    npx ${pkg.name} --hermes --local\n\n    ${dim}# Install for Cline globally${reset}\n    npx ${pkg.name} --cline --global\n\n    ${dim}# Install for Cline locally${reset}\n    npx ${pkg.name} --cline --local\n\n    ${dim}# Install for CodeBuddy globally${reset}\n    npx ${pkg.name} --codebuddy --global\n\n    ${dim}# Install for CodeBuddy locally${reset}\n    npx ${pkg.name} --codebuddy --local\n\n    ${dim}# Install for all runtimes globally${reset}\n    npx ${pkg.name} --all --global\n\n    ${dim}# Install to custom config directory${reset}\n    npx ${pkg.name} --kilo --global --config-dir ~/.kilo-work\n\n    ${dim}# Install to current project only${reset}\n    npx ${pkg.name} --claude --local\n\n    ${dim}# Uninstall GSD from Cursor globally${reset}\n    npx ${pkg.name} --cursor --global --uninstall\n\n  ${yellow}Notes:${reset}\n    The --config-dir option is useful when you have multiple configurations.\n    It takes priority over CLAUDE_CONFIG_DIR / OPENCODE_CONFIG_DIR / GEMINI_CONFIG_DIR / KILO_CONFIG_DIR / CODEX_HOME / KIMI_CONFIG_DIR / COPILOT_CONFIG_DIR / COPILOT_HOME / ANTIGRAVITY_CONFIG_DIR / CURSOR_CONFIG_DIR / WINDSURF_CONFIG_DIR / AUGMENT_CONFIG_DIR / TRAE_CONFIG_DIR / QWEN_CONFIG_DIR / HERMES_HOME / CLINE_CONFIG_DIR / CODEBUDDY_CONFIG_DIR environment variables.\n    Kimi CLI defaults to the first existing generic skills root: ${cyan}~/.config/agents/skills${reset}, then ${cyan}~/.agents/skills${reset}; if neither exists, GSD creates ${cyan}~/.config/agents${reset}.\n    Use ${cyan}--config-dir ~/.kimi-code${reset} or ${cyan}KIMI_CONFIG_DIR=~/.kimi-code${reset} for brand-specific Kimi installs.\n`);
+  console.log(`  ${yellow}Usage:${reset} npx ${pkg.name} [options]\n\n  ${yellow}Options:${reset}\n    ${cyan}-g, --global${reset}              Install globally (to config directory)\n    ${cyan}-l, --local${reset}               Install locally (to current directory)\n    ${cyan}--claude${reset}                  Install for Claude Code only\n    ${cyan}--opencode${reset}                Install for OpenCode only\n    ${cyan}--gemini${reset}                  Install for Gemini only\n    ${cyan}--kilo${reset}                    Install for Kilo only\n    ${cyan}--codex${reset}                   Install for Codex only\n    ${cyan}--kimi${reset}                    Install for Kimi CLI only\n    ${cyan}--copilot${reset}                 Install for Copilot only\n    ${cyan}--antigravity${reset}             Install for Antigravity only\n    ${cyan}--cursor${reset}                  Install for Cursor only\n    ${cyan}--windsurf${reset}                Install for Windsurf only\n    ${cyan}--augment${reset}                 Install for Augment only\n    ${cyan}--trae${reset}                    Install for Trae only\n    ${cyan}--qwen${reset}                    Install for Qwen Code only\n    ${cyan}--hermes${reset}                  Install for Hermes Agent only\n    ${cyan}--mimo${reset}                    Install for MiMoCode only\n    ${cyan}--cline${reset}                   Install for Cline only\n    ${cyan}--codebuddy${reset}              Install for CodeBuddy only\n    ${cyan}--all${reset}                     Install for all runtimes\n    ${cyan}-u, --uninstall${reset}           Uninstall GSD (remove all GSD files)\n    ${cyan}-c, --config-dir <path>${reset}   Specify custom config directory\n    ${cyan}-h, --help${reset}                Show this help message\n    ${cyan}--force-statusline${reset}        Replace existing statusline config\n    ${cyan}--portable-hooks${reset}          Emit \$HOME-relative hook paths in settings.json\n                              (for WSL/Docker bind-mount setups; also GSD_PORTABLE_HOOKS=1)\n    ${cyan}--profile=<name>${reset}         Install a named skill profile. Profiles:\n                              core     — ${PROFILES.core.length} main-loop skills incl. phase (~130 desc tokens)\n                              standard — ${PROFILES.standard.length} skills incl. phase, review, config (~700)\n                              full     — all skills (default)\n                              Composable: --profile=core,audit installs union of closures.\n                              Profile is persisted and respected by \`gsd update\`.\n    ${cyan}--minimal${reset}                 Alias for --profile=core (back-compat).\n                              Cuts cold-start overhead from ~12k tokens to ~700.\n                              Alias: --core-only.\n\n  ${yellow}Examples:${reset}\n    ${dim}# Interactive install (prompts for runtime and location)${reset}\n    npx ${pkg.name}\n\n    ${dim}# Install for Claude Code globally${reset}\n    npx ${pkg.name} --claude --global\n\n    ${dim}# Install for Gemini globally${reset}\n    npx ${pkg.name} --gemini --global\n\n    ${dim}# Install for Kilo globally${reset}\n    npx ${pkg.name} --kilo --global\n\n    ${dim}# Install for Codex globally${reset}\n    npx ${pkg.name} --codex --global\n\n    ${dim}# Install for Kimi CLI globally${reset}\n    npx ${pkg.name} --kimi --global\n\n    ${dim}# Install for Kimi CLI under ~/.kimi-code${reset}\n    npx ${pkg.name} --kimi --global --config-dir ~/.kimi-code\n\n    ${dim}# Install for Copilot globally${reset}\n    npx ${pkg.name} --copilot --global\n\n    ${dim}# Install for Copilot locally${reset}\n    npx ${pkg.name} --copilot --local\n\n    ${dim}# Install for Antigravity globally${reset}\n    npx ${pkg.name} --antigravity --global\n\n    ${dim}# Install for Antigravity locally${reset}\n    npx ${pkg.name} --antigravity --local\n\n    ${dim}# Install for Cursor globally${reset}\n    npx ${pkg.name} --cursor --global\n\n    ${dim}# Install for Cursor locally${reset}\n    npx ${pkg.name} --cursor --local\n\n    ${dim}# Install for Windsurf globally${reset}\n    npx ${pkg.name} --windsurf --global\n\n    ${dim}# Install for Windsurf locally${reset}\n    npx ${pkg.name} --windsurf --local\n\n    ${dim}# Install for Augment globally${reset}\n    npx ${pkg.name} --augment --global\n\n    ${dim}# Install for Augment locally${reset}\n    npx ${pkg.name} --augment --local\n\n    ${dim}# Install for Trae globally${reset}\n    npx ${pkg.name} --trae --global\n\n    ${dim}# Install for Trae locally${reset}\n    npx ${pkg.name} --trae --local\n\n    ${dim}# Install for Hermes Agent globally${reset}\n    npx ${pkg.name} --hermes --global\n\n    ${dim}# Install for Hermes Agent locally${reset}\n    npx ${pkg.name} --hermes --local\n\n    ${dim}# Install for MiMoCode globally${reset}\n    npx ${pkg.name} --mimo --global\n\n    ${dim}# Install for MiMoCode locally${reset}\n    npx ${pkg.name} --mimo --local\n\n    ${dim}# Install for Cline globally${reset}\n    npx ${pkg.name} --cline --global\n\n    ${dim}# Install for Cline locally${reset}\n    npx ${pkg.name} --cline --local\n\n    ${dim}# Install for CodeBuddy globally${reset}\n    npx ${pkg.name} --codebuddy --global\n\n    ${dim}# Install for CodeBuddy locally${reset}\n    npx ${pkg.name} --codebuddy --local\n\n    ${dim}# Install for all runtimes globally${reset}\n    npx ${pkg.name} --all --global\n\n    ${dim}# Install to custom config directory${reset}\n    npx ${pkg.name} --kilo --global --config-dir ~/.kilo-work\n\n    ${dim}# Install to current project only${reset}\n    npx ${pkg.name} --claude --local\n\n    ${dim}# Uninstall GSD from Cursor globally${reset}\n    npx ${pkg.name} --cursor --global --uninstall\n\n  ${yellow}Notes:${reset}\n    The --config-dir option is useful when you have multiple configurations.\n    It takes priority over CLAUDE_CONFIG_DIR / OPENCODE_CONFIG_DIR / GEMINI_CONFIG_DIR / KILO_CONFIG_DIR / CODEX_HOME / KIMI_CONFIG_DIR / COPILOT_CONFIG_DIR / COPILOT_HOME / ANTIGRAVITY_CONFIG_DIR / CURSOR_CONFIG_DIR / WINDSURF_CONFIG_DIR / AUGMENT_CONFIG_DIR / TRAE_CONFIG_DIR / QWEN_CONFIG_DIR / HERMES_HOME / CLINE_CONFIG_DIR / CODEBUDDY_CONFIG_DIR environment variables.\n    Kimi CLI defaults to the first existing generic skills root: ${cyan}~/.config/agents/skills${reset}, then ${cyan}~/.agents/skills${reset}; if neither exists, GSD creates ${cyan}~/.config/agents${reset}.\n    Use ${cyan}--config-dir ~/.kimi-code${reset} or ${cyan}KIMI_CONFIG_DIR=~/.kimi-code${reset} for brand-specific Kimi installs.\n`);
   process.exit(0);
 }
 
@@ -1842,6 +1845,163 @@ function convertClaudeCommandToClaudeSkill(content, skillName, runtime = null, c
   fm += '---';
 
   return `${fm}\n${normalizedBody}`;
+}
+
+const claudeToMimoAgentTools = {
+  Read: 'read',
+  Write: 'write',
+  Edit: 'edit',
+  Bash: 'bash',
+  Glob: 'glob',
+  Grep: 'grep',
+  WebFetch: 'webfetch',
+  WebSearch: 'webfetch',
+  Task: 'task',
+  Agent: 'task',
+};
+
+function convertClaudeToMimoAgentTool(claudeTool) {
+  if (claudeTool.startsWith('mcp__')) {
+    return null;
+  }
+  if (claudeToMimoAgentTools[claudeTool]) {
+    return claudeToMimoAgentTools[claudeTool];
+  }
+  return null;
+}
+
+function normalizeMimoHexColor(colorValue) {
+  const value = colorValue.replace(/^["']|["']$/g, '').trim();
+  if (/^#[0-9a-fA-F]{6}$/.test(value)) {
+    return value.toUpperCase();
+  }
+  const named = colorNameToHex[value.toLowerCase()];
+  if (named) {
+    return named.toUpperCase();
+  }
+  if (/^#[0-9a-fA-F]{3}$/.test(value)) {
+    const hex = value.slice(1);
+    return ('#' + hex.split('').map((ch) => ch + ch).join('')).toUpperCase();
+  }
+  return null;
+}
+
+function buildMimoAgentToolsBlock(claudeTools) {
+  const allowedTools = new Set();
+  for (const tool of claudeTools) {
+    const mapped = convertClaudeToMimoAgentTool(tool);
+    if (mapped) {
+      allowedTools.add(mapped);
+    }
+  }
+  const lines = ['tools:'];
+  for (const tool of [...allowedTools].sort()) {
+    lines.push(`  ${tool}: true`);
+  }
+  return lines;
+}
+
+/**
+ * Convert Claude Code agent frontmatter to MiMoCode format.
+ * MiMoCode expects tools as a record (tool: true) and color as #RRGGBB.
+ */
+function convertClaudeToMimoAgentFrontmatter(content) {
+  if (!content.startsWith('---')) {
+    return content;
+  }
+
+  const endIndex = content.indexOf('---', 3);
+  if (endIndex === -1) {
+    return content;
+  }
+
+  const frontmatter = content.substring(3, endIndex).trim();
+  const body = content.substring(endIndex + 3);
+  const lines = frontmatter.split('\n');
+  const newLines = [];
+  let inAllowedTools = false;
+  let inAgentTools = false;
+  let inSkippedArray = false;
+  const agentTools = [];
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    if (trimmed.startsWith('#')) {
+      continue;
+    }
+
+    if (trimmed.startsWith('allowed-tools:')) {
+      inAllowedTools = true;
+      continue;
+    }
+
+    if (inAgentTools) {
+      if (trimmed.startsWith('- ')) {
+        agentTools.push(trimmed.substring(2).trim());
+        continue;
+      }
+      if (trimmed && !trimmed.startsWith('-')) {
+        inAgentTools = false;
+      }
+    }
+
+    if (trimmed.startsWith('tools:')) {
+      const toolsValue = trimmed.substring(6).trim();
+      if (toolsValue) {
+        agentTools.push(...toolsValue.split(',').map((t) => t.trim()).filter(Boolean));
+      } else {
+        inAgentTools = true;
+      }
+      continue;
+    }
+
+    if (/^(skills|memory|maxTurns|permissionMode|disallowedTools):/.test(trimmed)) {
+      inSkippedArray = true;
+      continue;
+    }
+
+    if (inSkippedArray) {
+      if (trimmed.startsWith('- ') || trimmed.startsWith('#') || /^\s/.test(line)) {
+        continue;
+      }
+      inSkippedArray = false;
+    }
+
+    if (trimmed.startsWith('color:')) {
+      const hexColor = normalizeMimoHexColor(trimmed.substring(6).trim());
+      if (hexColor) {
+        newLines.push(`color: "${hexColor}"`);
+      }
+      continue;
+    }
+
+    if (trimmed.startsWith('model:') || trimmed.startsWith('mode:')) {
+      continue;
+    }
+
+    if (inAllowedTools) {
+      if (trimmed.startsWith('- ')) {
+        agentTools.push(trimmed.substring(2).trim());
+        continue;
+      }
+      if (trimmed && !trimmed.startsWith('-')) {
+        inAllowedTools = false;
+      }
+    }
+
+    if (!inAllowedTools) {
+      newLines.push(line);
+    }
+  }
+
+  const descIdx = newLines.findIndex((l) => l.trim().startsWith('description:'));
+  const insertAt = descIdx >= 0 ? descIdx + 1 : newLines.length;
+  newLines.splice(insertAt, 0, ...buildMimoAgentToolsBlock(agentTools));
+  newLines.push('mode: subagent');
+
+  const newFrontmatter = newLines.join('\n').trim();
+  return `---\n${newFrontmatter}\n---${body}`;
 }
 
 function normalizeKimiSkillName(skillName) {
@@ -6945,6 +7105,19 @@ function _applyRuntimeRewrites(content, runtime, pathPrefix) {
       content = processAttribution(content, getCommitAttribution(runtime));
       break;
 
+    case 'mimo':
+      content = content.replace(/CLAUDE\.md/g, 'MIMOCODE.md');
+      content = content.replace(/\bClaude Code\b/g, 'MiMoCode');
+      content = content.replace(/~\/\.claude\//g, pathPrefix);
+      content = content.replace(/\$HOME\/\.claude\//g, pathPrefix);
+      content = content.replace(/~\/\.mimocode\//g, pathPrefix);
+      content = content.replace(/\$HOME\/\.mimocode\//g, pathPrefix);
+      content = content.replace(/\.claude\//g, '.mimocode/');
+      content = content.replace(/\.\/\.claude\//g, `./${dirName}/`);
+      content = content.replace(/\.\/\.mimocode\//g, `./${dirName}/`);
+      content = processAttribution(content, getCommitAttribution(runtime));
+      break;
+
     default:
       // Unknown runtime — no rewrites.
       // OpenCode/Kilo are intentionally absent: their skills are written by
@@ -7501,6 +7674,7 @@ function copyWithPathReplacement(srcDir, destDir, pathPrefix, runtime, isCommand
   const isTrae = runtime === 'trae';
   const isQwen = runtime === 'qwen';
   const isHermes = runtime === 'hermes';
+  const isMiMo = runtime === 'mimo';
   const isCline = runtime === 'cline';
   const dirName = getDirName(runtime);
 
@@ -7595,6 +7769,11 @@ function copyWithPathReplacement(srcDir, destDir, pathPrefix, runtime, isCommand
         content = content.replace(/\bClaude Code\b/g, 'Hermes Agent');
         content = content.replace(/\.claude\//g, '.hermes/');
         fs.writeFileSync(destPath, content);
+      } else if (isMiMo) {
+        content = content.replace(/CLAUDE\.md/g, 'MIMOCODE.md');
+        content = content.replace(/\bClaude Code\b/g, 'MiMoCode');
+        content = content.replace(/\.claude\//g, '.mimocode/');
+        fs.writeFileSync(destPath, content);
       } else {
         fs.writeFileSync(destPath, content);
       }
@@ -7652,6 +7831,13 @@ function copyWithPathReplacement(srcDir, destDir, pathPrefix, runtime, isCommand
       jsContent = jsContent.replace(/\.claude\//g, '.hermes/');
       jsContent = jsContent.replace(/CLAUDE\.md/g, 'HERMES.md');
       jsContent = jsContent.replace(/\bClaude Code\b/g, 'Hermes Agent');
+      fs.writeFileSync(destPath, jsContent);
+    } else if (isMiMo && (entry.name.endsWith('.cjs') || entry.name.endsWith('.js'))) {
+      let jsContent = fs.readFileSync(srcPath, 'utf8');
+      jsContent = jsContent.replace(/\.claude\/skills\//g, '.mimocode/skills/');
+      jsContent = jsContent.replace(/\.claude\//g, '.mimocode/');
+      jsContent = jsContent.replace(/CLAUDE\.md/g, 'MIMOCODE.md');
+      jsContent = jsContent.replace(/\bClaude Code\b/g, 'MiMoCode');
       fs.writeFileSync(destPath, jsContent);
     } else {
       fs.copyFileSync(srcPath, destPath);
@@ -9328,6 +9514,7 @@ function install(isGlobal, runtime = 'claude', options = {}) {
   const isTrae = runtime === 'trae';
   const isQwen = runtime === 'qwen';
   const isHermes = runtime === 'hermes';
+  const isMiMo = runtime === 'mimo';
   const isCodebuddy = runtime === 'codebuddy';
   const isCline = runtime === 'cline';
   const configIntent = resolveRuntimeConfigIntent(runtime);
@@ -9485,6 +9672,7 @@ function install(isGlobal, runtime = 'claude', options = {}) {
   if (isQwen) runtimeLabel = 'Qwen Code';
   if (isHermes) runtimeLabel = 'Hermes Agent';
   if (isKimi) runtimeLabel = 'Kimi';
+  if (isMiMo) runtimeLabel = 'MiMoCode';
   if (isCodebuddy) runtimeLabel = 'CodeBuddy';
   if (isCline) runtimeLabel = 'Cline';
 
@@ -9773,7 +9961,7 @@ function install(isGlobal, runtime = 'claude', options = {}) {
   // handles per-runtime path + branding rewrites, including Qwen/Hermes.
   // Cline global: emit skills to ~/.cline/skills/ (Cline >= v3.48.0 — #782).
   const _isSkillsRuntime = isCodex || isCopilot || isAntigravity || isCursor || isWindsurf ||
-    isAugment || isTrae || isCodebuddy || isQwen || isHermes ||
+    isAugment || isTrae || isCodebuddy || isQwen || isHermes || isMiMo ||
     isKimi ||
     (runtime === 'claude' && isGlobal) ||
     (isCline && isGlobal);
@@ -10160,6 +10348,11 @@ function install(isGlobal, runtime = 'claude', options = {}) {
           content = content.replace(/CLAUDE\.md/g, 'HERMES.md');
           content = content.replace(/\bClaude Code\b/g, 'Hermes Agent');
           content = content.replace(/\.claude\//g, '.hermes/');
+        } else if (isMiMo) {
+          content = content.replace(/CLAUDE\.md/g, 'MIMOCODE.md');
+          content = content.replace(/\bClaude Code\b/g, 'MiMoCode');
+          content = content.replace(/\.claude\//g, '.mimocode/');
+          content = convertClaudeToMimoAgentFrontmatter(content);
         }
         // #443 — Inject `effort:` into the Claude .md frontmatter ONLY.
         // Gemini/OpenCode/Qwen/Hermes also produce .md files but break on
@@ -10214,7 +10407,7 @@ function install(isGlobal, runtime = 'claude', options = {}) {
     failures.push('VERSION');
   }
 
-  if (!isCodex && !isCopilot && !isCursor && !isWindsurf && !isTrae && !isCline && !isKimi) {
+  if (!isCodex && !isCopilot && !isCursor && !isWindsurf && !isTrae && !isCline && !isKimi && !isMiMo) {
     // Write package.json to force CommonJS mode for GSD scripts
     // Prevents "require is not defined" errors when project has "type": "module"
     // Node.js walks up looking for package.json - this stops inheritance from project
@@ -10310,7 +10503,7 @@ function install(isGlobal, runtime = 'claude', options = {}) {
   // the hooks/lib/ helpers — otherwise the Codex comment downstream
   // ("we deliberately do *not* copy hooks/lib/ for Codex") is contradicted in practice.
   const hooksLibSrc = path.join(src, 'hooks', 'lib');
-  if (!isCodex && !isCopilot && !isCursor && !isWindsurf && !isTrae && !isCline && !isKimi && fs.existsSync(hooksLibSrc)) {
+  if (!isCodex && !isCopilot && !isCursor && !isWindsurf && !isTrae && !isCline && !isKimi && !isMiMo && fs.existsSync(hooksLibSrc)) {
     const hooksLibDest = path.join(targetDir, 'hooks', 'lib');
     fs.mkdirSync(hooksLibDest, { recursive: true });
     copyLibDir(hooksLibSrc, hooksLibDest, GSD_HOOK_LIB_FILES);
@@ -11794,6 +11987,7 @@ function finishInstall(settingsPath, settings, statuslineCommand, shouldInstallS
   if (runtime === 'qwen') program = 'Qwen Code';
   if (runtime === 'hermes') program = 'Hermes Agent';
   if (runtime === 'kimi') program = 'Kimi CLI';
+  if (runtime === 'mimo') program = 'MiMoCode';
 
   let command = '/gsd-new-project';
   if (runtime === 'opencode') command = '/gsd-new-project';
@@ -11810,6 +12004,7 @@ function finishInstall(settingsPath, settings, statuslineCommand, shouldInstallS
   if (runtime === 'qwen') command = '/gsd-new-project';
   if (runtime === 'hermes') command = '/gsd-new-project';
   if (runtime === 'kimi') command = '/skill:gsd-new-project';
+  if (runtime === 'mimo') command = '/gsd-new-project';
 
   // Claude Code global installs use the skills/ format (CC 2.1.88+).
   // Restart is required for CC to pick up newly-installed skills, and the
@@ -11915,10 +12110,11 @@ const runtimeMap = {
   '13': 'opencode',
   '14': 'qwen',
   '15': 'trae',
-  '16': 'windsurf'
+  '16': 'windsurf',
+  '17': 'mimo'
 };
-const allRuntimes = ['claude', 'antigravity', 'augment', 'cline', 'codebuddy', 'codex', 'copilot', 'cursor', 'gemini', 'hermes', 'kimi', 'kilo', 'opencode', 'qwen', 'trae', 'windsurf'];
-const ALL_RUNTIMES_OPTION = '17';
+const allRuntimes = ['claude', 'antigravity', 'augment', 'cline', 'codebuddy', 'codex', 'copilot', 'cursor', 'gemini', 'hermes', 'kimi', 'kilo', 'mimo', 'opencode', 'qwen', 'trae', 'windsurf'];
+const ALL_RUNTIMES_OPTION = '18';
 
 /**
  * Build the runtime-selection prompt text shown by the interactive installer.
@@ -11942,7 +12138,8 @@ function buildRuntimePromptText() {
   ${cyan}14${reset}) Qwen Code    ${dim}(~/.qwen)${reset}
   ${cyan}15${reset}) Trae         ${dim}(~/.trae)${reset}
   ${cyan}16${reset}) Windsurf     ${dim}(~/.codeium/windsurf)${reset}
-  ${cyan}17${reset}) All
+  ${cyan}17${reset}) MiMoCode     ${dim}(~/.config/mimocode)${reset}
+  ${cyan}18${reset}) All
 
   ${dim}Select multiple: 1,2,6 or 1 2 6${reset}
 `;
@@ -12557,6 +12754,7 @@ module.exports = {
     convertClaudeCommandToAntigravitySkill,
     convertClaudeAgentToAntigravityAgent,
     convertClaudeCommandToClaudeSkill,
+    convertClaudeToMimoAgentFrontmatter,
     skillFrontmatterName,
     convertClaudeToWindsurfMarkdown,
     convertClaudeCommandToWindsurfSkill,

--- a/bin/install.js
+++ b/bin/install.js
@@ -395,7 +395,7 @@ if (hasMinimal && _profileArgRaw) {
 
 function selectRuntimesFromArgs(runtimeArgs) {
   if (runtimeArgs.includes('--all')) {
-    return ['claude', 'kimi', 'kilo', 'mimo', 'opencode', 'gemini', 'codex', 'copilot', 'antigravity', 'cursor', 'windsurf', 'augment', 'trae', 'qwen', 'hermes', 'codebuddy', 'cline'];
+    return ['claude', 'kimi', 'kilo', 'mimo', 'commandcode', 'opencode', 'gemini', 'codex', 'copilot', 'antigravity', 'cursor', 'windsurf', 'augment', 'trae', 'qwen', 'hermes', 'codebuddy', 'cline'];
   }
   if (runtimeArgs.includes('--both')) {
     return ['claude', 'opencode'];
@@ -417,6 +417,7 @@ function selectRuntimesFromArgs(runtimeArgs) {
   if (runtimeArgs.includes('--hermes')) selected.push('hermes');
   if (runtimeArgs.includes('--kimi')) selected.push('kimi');
   if (runtimeArgs.includes('--mimo')) selected.push('mimo');
+  if (runtimeArgs.includes('--commandcode')) selected.push('commandcode');
   if (runtimeArgs.includes('--codebuddy')) selected.push('codebuddy');
   if (runtimeArgs.includes('--cline')) selected.push('cline');
   return selected;
@@ -475,6 +476,7 @@ function getDirName(runtime) {
   if (runtime === 'hermes') return '.hermes';
   if (runtime === 'kimi') return '.kimi-code';
   if (runtime === 'mimo') return '.mimocode';
+  if (runtime === 'commandcode') return '.commandcode';
   if (runtime === 'codebuddy') return '.codebuddy';
   if (runtime === 'cline') return '.cline';
   return '.claude';
@@ -523,6 +525,7 @@ function getConfigDirFromHome(runtime, isGlobal) {
   if (runtime === 'cline') return "'.cline'";
   if (runtime === 'kimi') return "'.config', 'agents'";
   if (runtime === 'mimo') return "'.config', 'mimocode'";
+  if (runtime === 'commandcode') return "'.commandcode'";
   return "'.claude'";
 }
 
@@ -544,7 +547,7 @@ const banner = '\n' +
   '  GSD Core ' + dim + 'v' + pkg.version + reset + '\n' +
   '  Git. Ship. Done.\n' +
   '  A meta-prompting, context engineering and spec-driven\n' +
-  '  development workflows for Claude Code, OpenCode, Gemini, Kimi CLI, MiMoCode, Kilo, Codex, Copilot, Antigravity, Cursor, Windsurf, Augment, Trae, Qwen Code, Hermes Agent, Cline and CodeBuddy.\n';
+  '  development workflows for Claude Code, OpenCode, Gemini, Kimi CLI, MiMoCode, Command Code, Kilo, Codex, Copilot, Antigravity, Cursor, Windsurf, Augment, Trae, Qwen Code, Hermes Agent, Cline and CodeBuddy.\n';
 
 // Pure seam: parse --config-dir / -c from an arbitrary args array.
 // Returns the path string, '' for an empty equals-form value, or null when the
@@ -601,7 +604,7 @@ if (hasUninstall) {
 
 // Show help if requested
 if (hasHelp) {
-  console.log(`  ${yellow}Usage:${reset} npx ${pkg.name} [options]\n\n  ${yellow}Options:${reset}\n    ${cyan}-g, --global${reset}              Install globally (to config directory)\n    ${cyan}-l, --local${reset}               Install locally (to current directory)\n    ${cyan}--claude${reset}                  Install for Claude Code only\n    ${cyan}--opencode${reset}                Install for OpenCode only\n    ${cyan}--gemini${reset}                  Install for Gemini only\n    ${cyan}--kilo${reset}                    Install for Kilo only\n    ${cyan}--codex${reset}                   Install for Codex only\n    ${cyan}--kimi${reset}                    Install for Kimi CLI only\n    ${cyan}--copilot${reset}                 Install for Copilot only\n    ${cyan}--antigravity${reset}             Install for Antigravity only\n    ${cyan}--cursor${reset}                  Install for Cursor only\n    ${cyan}--windsurf${reset}                Install for Windsurf only\n    ${cyan}--augment${reset}                 Install for Augment only\n    ${cyan}--trae${reset}                    Install for Trae only\n    ${cyan}--qwen${reset}                    Install for Qwen Code only\n    ${cyan}--hermes${reset}                  Install for Hermes Agent only\n    ${cyan}--mimo${reset}                    Install for MiMoCode only\n    ${cyan}--cline${reset}                   Install for Cline only\n    ${cyan}--codebuddy${reset}              Install for CodeBuddy only\n    ${cyan}--all${reset}                     Install for all runtimes\n    ${cyan}-u, --uninstall${reset}           Uninstall GSD (remove all GSD files)\n    ${cyan}-c, --config-dir <path>${reset}   Specify custom config directory\n    ${cyan}-h, --help${reset}                Show this help message\n    ${cyan}--force-statusline${reset}        Replace existing statusline config\n    ${cyan}--portable-hooks${reset}          Emit \$HOME-relative hook paths in settings.json\n                              (for WSL/Docker bind-mount setups; also GSD_PORTABLE_HOOKS=1)\n    ${cyan}--profile=<name>${reset}         Install a named skill profile. Profiles:\n                              core     — ${PROFILES.core.length} main-loop skills incl. phase (~130 desc tokens)\n                              standard — ${PROFILES.standard.length} skills incl. phase, review, config (~700)\n                              full     — all skills (default)\n                              Composable: --profile=core,audit installs union of closures.\n                              Profile is persisted and respected by \`gsd update\`.\n    ${cyan}--minimal${reset}                 Alias for --profile=core (back-compat).\n                              Cuts cold-start overhead from ~12k tokens to ~700.\n                              Alias: --core-only.\n\n  ${yellow}Examples:${reset}\n    ${dim}# Interactive install (prompts for runtime and location)${reset}\n    npx ${pkg.name}\n\n    ${dim}# Install for Claude Code globally${reset}\n    npx ${pkg.name} --claude --global\n\n    ${dim}# Install for Gemini globally${reset}\n    npx ${pkg.name} --gemini --global\n\n    ${dim}# Install for Kilo globally${reset}\n    npx ${pkg.name} --kilo --global\n\n    ${dim}# Install for Codex globally${reset}\n    npx ${pkg.name} --codex --global\n\n    ${dim}# Install for Kimi CLI globally${reset}\n    npx ${pkg.name} --kimi --global\n\n    ${dim}# Install for Kimi CLI under ~/.kimi-code${reset}\n    npx ${pkg.name} --kimi --global --config-dir ~/.kimi-code\n\n    ${dim}# Install for Copilot globally${reset}\n    npx ${pkg.name} --copilot --global\n\n    ${dim}# Install for Copilot locally${reset}\n    npx ${pkg.name} --copilot --local\n\n    ${dim}# Install for Antigravity globally${reset}\n    npx ${pkg.name} --antigravity --global\n\n    ${dim}# Install for Antigravity locally${reset}\n    npx ${pkg.name} --antigravity --local\n\n    ${dim}# Install for Cursor globally${reset}\n    npx ${pkg.name} --cursor --global\n\n    ${dim}# Install for Cursor locally${reset}\n    npx ${pkg.name} --cursor --local\n\n    ${dim}# Install for Windsurf globally${reset}\n    npx ${pkg.name} --windsurf --global\n\n    ${dim}# Install for Windsurf locally${reset}\n    npx ${pkg.name} --windsurf --local\n\n    ${dim}# Install for Augment globally${reset}\n    npx ${pkg.name} --augment --global\n\n    ${dim}# Install for Augment locally${reset}\n    npx ${pkg.name} --augment --local\n\n    ${dim}# Install for Trae globally${reset}\n    npx ${pkg.name} --trae --global\n\n    ${dim}# Install for Trae locally${reset}\n    npx ${pkg.name} --trae --local\n\n    ${dim}# Install for Hermes Agent globally${reset}\n    npx ${pkg.name} --hermes --global\n\n    ${dim}# Install for Hermes Agent locally${reset}\n    npx ${pkg.name} --hermes --local\n\n    ${dim}# Install for MiMoCode globally${reset}\n    npx ${pkg.name} --mimo --global\n\n    ${dim}# Install for MiMoCode locally${reset}\n    npx ${pkg.name} --mimo --local\n\n    ${dim}# Install for Cline globally${reset}\n    npx ${pkg.name} --cline --global\n\n    ${dim}# Install for Cline locally${reset}\n    npx ${pkg.name} --cline --local\n\n    ${dim}# Install for CodeBuddy globally${reset}\n    npx ${pkg.name} --codebuddy --global\n\n    ${dim}# Install for CodeBuddy locally${reset}\n    npx ${pkg.name} --codebuddy --local\n\n    ${dim}# Install for all runtimes globally${reset}\n    npx ${pkg.name} --all --global\n\n    ${dim}# Install to custom config directory${reset}\n    npx ${pkg.name} --kilo --global --config-dir ~/.kilo-work\n\n    ${dim}# Install to current project only${reset}\n    npx ${pkg.name} --claude --local\n\n    ${dim}# Uninstall GSD from Cursor globally${reset}\n    npx ${pkg.name} --cursor --global --uninstall\n\n  ${yellow}Notes:${reset}\n    The --config-dir option is useful when you have multiple configurations.\n    It takes priority over CLAUDE_CONFIG_DIR / OPENCODE_CONFIG_DIR / GEMINI_CONFIG_DIR / KILO_CONFIG_DIR / CODEX_HOME / KIMI_CONFIG_DIR / COPILOT_CONFIG_DIR / COPILOT_HOME / ANTIGRAVITY_CONFIG_DIR / CURSOR_CONFIG_DIR / WINDSURF_CONFIG_DIR / AUGMENT_CONFIG_DIR / TRAE_CONFIG_DIR / QWEN_CONFIG_DIR / HERMES_HOME / CLINE_CONFIG_DIR / CODEBUDDY_CONFIG_DIR environment variables.\n    Kimi CLI defaults to the first existing generic skills root: ${cyan}~/.config/agents/skills${reset}, then ${cyan}~/.agents/skills${reset}; if neither exists, GSD creates ${cyan}~/.config/agents${reset}.\n    Use ${cyan}--config-dir ~/.kimi-code${reset} or ${cyan}KIMI_CONFIG_DIR=~/.kimi-code${reset} for brand-specific Kimi installs.\n`);
+  console.log(`  ${yellow}Usage:${reset} npx ${pkg.name} [options]\n\n  ${yellow}Options:${reset}\n    ${cyan}-g, --global${reset}              Install globally (to config directory)\n    ${cyan}-l, --local${reset}               Install locally (to current directory)\n    ${cyan}--claude${reset}                  Install for Claude Code only\n    ${cyan}--opencode${reset}                Install for OpenCode only\n    ${cyan}--gemini${reset}                  Install for Gemini only\n    ${cyan}--kilo${reset}                    Install for Kilo only\n    ${cyan}--codex${reset}                   Install for Codex only\n    ${cyan}--kimi${reset}                    Install for Kimi CLI only\n    ${cyan}--copilot${reset}                 Install for Copilot only\n    ${cyan}--antigravity${reset}             Install for Antigravity only\n    ${cyan}--cursor${reset}                  Install for Cursor only\n    ${cyan}--windsurf${reset}                Install for Windsurf only\n    ${cyan}--augment${reset}                 Install for Augment only\n    ${cyan}--trae${reset}                    Install for Trae only\n    ${cyan}--qwen${reset}                    Install for Qwen Code only\n    ${cyan}--hermes${reset}                  Install for Hermes Agent only\n    ${cyan}--mimo${reset}                    Install for MiMoCode only\n    ${cyan}--commandcode${reset}             Install for Command Code only\n    ${cyan}--cline${reset}                   Install for Cline only\n    ${cyan}--codebuddy${reset}              Install for CodeBuddy only\n    ${cyan}--all${reset}                     Install for all runtimes\n    ${cyan}-u, --uninstall${reset}           Uninstall GSD (remove all GSD files)\n    ${cyan}-c, --config-dir <path>${reset}   Specify custom config directory\n    ${cyan}-h, --help${reset}                Show this help message\n    ${cyan}--force-statusline${reset}        Replace existing statusline config\n    ${cyan}--portable-hooks${reset}          Emit \$HOME-relative hook paths in settings.json\n                              (for WSL/Docker bind-mount setups; also GSD_PORTABLE_HOOKS=1)\n    ${cyan}--profile=<name>${reset}         Install a named skill profile. Profiles:\n                              core     — ${PROFILES.core.length} main-loop skills incl. phase (~130 desc tokens)\n                              standard — ${PROFILES.standard.length} skills incl. phase, review, config (~700)\n                              full     — all skills (default)\n                              Composable: --profile=core,audit installs union of closures.\n                              Profile is persisted and respected by \`gsd update\`.\n    ${cyan}--minimal${reset}                 Alias for --profile=core (back-compat).\n                              Cuts cold-start overhead from ~12k tokens to ~700.\n                              Alias: --core-only.\n\n  ${yellow}Examples:${reset}\n    ${dim}# Interactive install (prompts for runtime and location)${reset}\n    npx ${pkg.name}\n\n    ${dim}# Install for Claude Code globally${reset}\n    npx ${pkg.name} --claude --global\n\n    ${dim}# Install for Gemini globally${reset}\n    npx ${pkg.name} --gemini --global\n\n    ${dim}# Install for Kilo globally${reset}\n    npx ${pkg.name} --kilo --global\n\n    ${dim}# Install for Codex globally${reset}\n    npx ${pkg.name} --codex --global\n\n    ${dim}# Install for Kimi CLI globally${reset}\n    npx ${pkg.name} --kimi --global\n\n    ${dim}# Install for Kimi CLI under ~/.kimi-code${reset}\n    npx ${pkg.name} --kimi --global --config-dir ~/.kimi-code\n\n    ${dim}# Install for Copilot globally${reset}\n    npx ${pkg.name} --copilot --global\n\n    ${dim}# Install for Copilot locally${reset}\n    npx ${pkg.name} --copilot --local\n\n    ${dim}# Install for Antigravity globally${reset}\n    npx ${pkg.name} --antigravity --global\n\n    ${dim}# Install for Antigravity locally${reset}\n    npx ${pkg.name} --antigravity --local\n\n    ${dim}# Install for Cursor globally${reset}\n    npx ${pkg.name} --cursor --global\n\n    ${dim}# Install for Cursor locally${reset}\n    npx ${pkg.name} --cursor --local\n\n    ${dim}# Install for Windsurf globally${reset}\n    npx ${pkg.name} --windsurf --global\n\n    ${dim}# Install for Windsurf locally${reset}\n    npx ${pkg.name} --windsurf --local\n\n    ${dim}# Install for Augment globally${reset}\n    npx ${pkg.name} --augment --global\n\n    ${dim}# Install for Augment locally${reset}\n    npx ${pkg.name} --augment --local\n\n    ${dim}# Install for Trae globally${reset}\n    npx ${pkg.name} --trae --global\n\n    ${dim}# Install for Trae locally${reset}\n    npx ${pkg.name} --trae --local\n\n    ${dim}# Install for Hermes Agent globally${reset}\n    npx ${pkg.name} --hermes --global\n\n    ${dim}# Install for Hermes Agent locally${reset}\n    npx ${pkg.name} --hermes --local\n\n    ${dim}# Install for MiMoCode globally${reset}\n    npx ${pkg.name} --mimo --global\n\n    ${dim}# Install for MiMoCode locally${reset}\n    npx ${pkg.name} --mimo --local\n\n    ${dim}# Install for Command Code globally${reset}\n    npx ${pkg.name} --commandcode --global\n\n    ${dim}# Install for Command Code locally${reset}\n    npx ${pkg.name} --commandcode --local\n\n    ${dim}# Install for Cline globally${reset}\n    npx ${pkg.name} --cline --global\n\n    ${dim}# Install for Cline locally${reset}\n    npx ${pkg.name} --cline --local\n\n    ${dim}# Install for CodeBuddy globally${reset}\n    npx ${pkg.name} --codebuddy --global\n\n    ${dim}# Install for CodeBuddy locally${reset}\n    npx ${pkg.name} --codebuddy --local\n\n    ${dim}# Install for all runtimes globally${reset}\n    npx ${pkg.name} --all --global\n\n    ${dim}# Install to custom config directory${reset}\n    npx ${pkg.name} --kilo --global --config-dir ~/.kilo-work\n\n    ${dim}# Install to current project only${reset}\n    npx ${pkg.name} --claude --local\n\n    ${dim}# Uninstall GSD from Cursor globally${reset}\n    npx ${pkg.name} --cursor --global --uninstall\n\n  ${yellow}Notes:${reset}\n    The --config-dir option is useful when you have multiple configurations.\n    It takes priority over CLAUDE_CONFIG_DIR / OPENCODE_CONFIG_DIR / GEMINI_CONFIG_DIR / KILO_CONFIG_DIR / CODEX_HOME / KIMI_CONFIG_DIR / COPILOT_CONFIG_DIR / COPILOT_HOME / ANTIGRAVITY_CONFIG_DIR / CURSOR_CONFIG_DIR / WINDSURF_CONFIG_DIR / AUGMENT_CONFIG_DIR / TRAE_CONFIG_DIR / QWEN_CONFIG_DIR / HERMES_HOME / CLINE_CONFIG_DIR / CODEBUDDY_CONFIG_DIR environment variables.\n    Kimi CLI defaults to the first existing generic skills root: ${cyan}~/.config/agents/skills${reset}, then ${cyan}~/.agents/skills${reset}; if neither exists, GSD creates ${cyan}~/.config/agents${reset}.\n    Use ${cyan}--config-dir ~/.kimi-code${reset} or ${cyan}KIMI_CONFIG_DIR=~/.kimi-code${reset} for brand-specific Kimi installs.\n`);
   process.exit(0);
 }
 
@@ -2003,6 +2006,9 @@ function convertClaudeToMimoAgentFrontmatter(content) {
   const newFrontmatter = newLines.join('\n').trim();
   return `---\n${newFrontmatter}\n---${body}`;
 }
+
+/** Command Code shares MiMoCode's subagent frontmatter schema (tools record + hex color). */
+const convertClaudeToCommandcodeAgentFrontmatter = convertClaudeToMimoAgentFrontmatter;
 
 function normalizeKimiSkillName(skillName) {
   let text = String(skillName || '').trim().toLowerCase();
@@ -7118,6 +7124,19 @@ function _applyRuntimeRewrites(content, runtime, pathPrefix) {
       content = processAttribution(content, getCommitAttribution(runtime));
       break;
 
+    case 'commandcode':
+      content = content.replace(/CLAUDE\.md/g, 'COMMANDCODE.md');
+      content = content.replace(/\bClaude Code\b/g, 'Command Code');
+      content = content.replace(/~\/\.claude\//g, pathPrefix);
+      content = content.replace(/\$HOME\/\.claude\//g, pathPrefix);
+      content = content.replace(/~\/\.commandcode\//g, pathPrefix);
+      content = content.replace(/\$HOME\/\.commandcode\//g, pathPrefix);
+      content = content.replace(/\.claude\//g, '.commandcode/');
+      content = content.replace(/\.\/\.claude\//g, `./${dirName}/`);
+      content = content.replace(/\.\/\.commandcode\//g, `./${dirName}/`);
+      content = processAttribution(content, getCommitAttribution(runtime));
+      break;
+
     default:
       // Unknown runtime — no rewrites.
       // OpenCode/Kilo are intentionally absent: their skills are written by
@@ -7675,6 +7694,7 @@ function copyWithPathReplacement(srcDir, destDir, pathPrefix, runtime, isCommand
   const isQwen = runtime === 'qwen';
   const isHermes = runtime === 'hermes';
   const isMiMo = runtime === 'mimo';
+  const isCommandcode = runtime === 'commandcode';
   const isCline = runtime === 'cline';
   const dirName = getDirName(runtime);
 
@@ -7774,6 +7794,11 @@ function copyWithPathReplacement(srcDir, destDir, pathPrefix, runtime, isCommand
         content = content.replace(/\bClaude Code\b/g, 'MiMoCode');
         content = content.replace(/\.claude\//g, '.mimocode/');
         fs.writeFileSync(destPath, content);
+      } else if (isCommandcode) {
+        content = content.replace(/CLAUDE\.md/g, 'COMMANDCODE.md');
+        content = content.replace(/\bClaude Code\b/g, 'Command Code');
+        content = content.replace(/\.claude\//g, '.commandcode/');
+        fs.writeFileSync(destPath, content);
       } else {
         fs.writeFileSync(destPath, content);
       }
@@ -7838,6 +7863,13 @@ function copyWithPathReplacement(srcDir, destDir, pathPrefix, runtime, isCommand
       jsContent = jsContent.replace(/\.claude\//g, '.mimocode/');
       jsContent = jsContent.replace(/CLAUDE\.md/g, 'MIMOCODE.md');
       jsContent = jsContent.replace(/\bClaude Code\b/g, 'MiMoCode');
+      fs.writeFileSync(destPath, jsContent);
+    } else if (isCommandcode && (entry.name.endsWith('.cjs') || entry.name.endsWith('.js'))) {
+      let jsContent = fs.readFileSync(srcPath, 'utf8');
+      jsContent = jsContent.replace(/\.claude\/skills\//g, '.commandcode/skills/');
+      jsContent = jsContent.replace(/\.claude\//g, '.commandcode/');
+      jsContent = jsContent.replace(/CLAUDE\.md/g, 'COMMANDCODE.md');
+      jsContent = jsContent.replace(/\bClaude Code\b/g, 'Command Code');
       fs.writeFileSync(destPath, jsContent);
     } else {
       fs.copyFileSync(srcPath, destPath);
@@ -9515,6 +9547,7 @@ function install(isGlobal, runtime = 'claude', options = {}) {
   const isQwen = runtime === 'qwen';
   const isHermes = runtime === 'hermes';
   const isMiMo = runtime === 'mimo';
+  const isCommandcode = runtime === 'commandcode';
   const isCodebuddy = runtime === 'codebuddy';
   const isCline = runtime === 'cline';
   const configIntent = resolveRuntimeConfigIntent(runtime);
@@ -9673,6 +9706,7 @@ function install(isGlobal, runtime = 'claude', options = {}) {
   if (isHermes) runtimeLabel = 'Hermes Agent';
   if (isKimi) runtimeLabel = 'Kimi';
   if (isMiMo) runtimeLabel = 'MiMoCode';
+  if (isCommandcode) runtimeLabel = 'Command Code';
   if (isCodebuddy) runtimeLabel = 'CodeBuddy';
   if (isCline) runtimeLabel = 'Cline';
 
@@ -9961,7 +9995,7 @@ function install(isGlobal, runtime = 'claude', options = {}) {
   // handles per-runtime path + branding rewrites, including Qwen/Hermes.
   // Cline global: emit skills to ~/.cline/skills/ (Cline >= v3.48.0 — #782).
   const _isSkillsRuntime = isCodex || isCopilot || isAntigravity || isCursor || isWindsurf ||
-    isAugment || isTrae || isCodebuddy || isQwen || isHermes || isMiMo ||
+    isAugment || isTrae || isCodebuddy || isQwen || isHermes || isMiMo || isCommandcode ||
     isKimi ||
     (runtime === 'claude' && isGlobal) ||
     (isCline && isGlobal);
@@ -10353,6 +10387,11 @@ function install(isGlobal, runtime = 'claude', options = {}) {
           content = content.replace(/\bClaude Code\b/g, 'MiMoCode');
           content = content.replace(/\.claude\//g, '.mimocode/');
           content = convertClaudeToMimoAgentFrontmatter(content);
+        } else if (isCommandcode) {
+          content = content.replace(/CLAUDE\.md/g, 'COMMANDCODE.md');
+          content = content.replace(/\bClaude Code\b/g, 'Command Code');
+          content = content.replace(/\.claude\//g, '.commandcode/');
+          content = convertClaudeToCommandcodeAgentFrontmatter(content);
         }
         // #443 — Inject `effort:` into the Claude .md frontmatter ONLY.
         // Gemini/OpenCode/Qwen/Hermes also produce .md files but break on
@@ -10407,7 +10446,7 @@ function install(isGlobal, runtime = 'claude', options = {}) {
     failures.push('VERSION');
   }
 
-  if (!isCodex && !isCopilot && !isCursor && !isWindsurf && !isTrae && !isCline && !isKimi && !isMiMo) {
+  if (!isCodex && !isCopilot && !isCursor && !isWindsurf && !isTrae && !isCline && !isKimi && !isMiMo && !isCommandcode) {
     // Write package.json to force CommonJS mode for GSD scripts
     // Prevents "require is not defined" errors when project has "type": "module"
     // Node.js walks up looking for package.json - this stops inheritance from project
@@ -10503,7 +10542,7 @@ function install(isGlobal, runtime = 'claude', options = {}) {
   // the hooks/lib/ helpers — otherwise the Codex comment downstream
   // ("we deliberately do *not* copy hooks/lib/ for Codex") is contradicted in practice.
   const hooksLibSrc = path.join(src, 'hooks', 'lib');
-  if (!isCodex && !isCopilot && !isCursor && !isWindsurf && !isTrae && !isCline && !isKimi && !isMiMo && fs.existsSync(hooksLibSrc)) {
+  if (!isCodex && !isCopilot && !isCursor && !isWindsurf && !isTrae && !isCline && !isKimi && !isMiMo && !isCommandcode && fs.existsSync(hooksLibSrc)) {
     const hooksLibDest = path.join(targetDir, 'hooks', 'lib');
     fs.mkdirSync(hooksLibDest, { recursive: true });
     copyLibDir(hooksLibSrc, hooksLibDest, GSD_HOOK_LIB_FILES);
@@ -11988,6 +12027,7 @@ function finishInstall(settingsPath, settings, statuslineCommand, shouldInstallS
   if (runtime === 'hermes') program = 'Hermes Agent';
   if (runtime === 'kimi') program = 'Kimi CLI';
   if (runtime === 'mimo') program = 'MiMoCode';
+  if (runtime === 'commandcode') program = 'Command Code';
 
   let command = '/gsd-new-project';
   if (runtime === 'opencode') command = '/gsd-new-project';
@@ -12005,6 +12045,7 @@ function finishInstall(settingsPath, settings, statuslineCommand, shouldInstallS
   if (runtime === 'hermes') command = '/gsd-new-project';
   if (runtime === 'kimi') command = '/skill:gsd-new-project';
   if (runtime === 'mimo') command = '/gsd-new-project';
+  if (runtime === 'commandcode') command = '/gsd-new-project';
 
   // Claude Code global installs use the skills/ format (CC 2.1.88+).
   // Restart is required for CC to pick up newly-installed skills, and the
@@ -12111,10 +12152,11 @@ const runtimeMap = {
   '14': 'qwen',
   '15': 'trae',
   '16': 'windsurf',
-  '17': 'mimo'
+  '17': 'mimo',
+  '18': 'commandcode'
 };
-const allRuntimes = ['claude', 'antigravity', 'augment', 'cline', 'codebuddy', 'codex', 'copilot', 'cursor', 'gemini', 'hermes', 'kimi', 'kilo', 'mimo', 'opencode', 'qwen', 'trae', 'windsurf'];
-const ALL_RUNTIMES_OPTION = '18';
+const allRuntimes = ['claude', 'antigravity', 'augment', 'cline', 'codebuddy', 'codex', 'commandcode', 'copilot', 'cursor', 'gemini', 'hermes', 'kimi', 'kilo', 'mimo', 'opencode', 'qwen', 'trae', 'windsurf'];
+const ALL_RUNTIMES_OPTION = '19';
 
 /**
  * Build the runtime-selection prompt text shown by the interactive installer.
@@ -12139,7 +12181,8 @@ function buildRuntimePromptText() {
   ${cyan}15${reset}) Trae         ${dim}(~/.trae)${reset}
   ${cyan}16${reset}) Windsurf     ${dim}(~/.codeium/windsurf)${reset}
   ${cyan}17${reset}) MiMoCode     ${dim}(~/.config/mimocode)${reset}
-  ${cyan}18${reset}) All
+  ${cyan}18${reset}) Command Code ${dim}(~/.commandcode)${reset}
+  ${cyan}19${reset}) All
 
   ${dim}Select multiple: 1,2,6 or 1 2 6${reset}
 `;
@@ -12755,6 +12798,7 @@ module.exports = {
     convertClaudeAgentToAntigravityAgent,
     convertClaudeCommandToClaudeSkill,
     convertClaudeToMimoAgentFrontmatter,
+    convertClaudeToCommandcodeAgentFrontmatter,
     skillFrontmatterName,
     convertClaudeToWindsurfMarkdown,
     convertClaudeCommandToWindsurfSkill,

--- a/capabilities/commandcode/capability.json
+++ b/capabilities/commandcode/capability.json
@@ -1,0 +1,42 @@
+{
+  "id": "commandcode",
+  "role": "runtime",
+  "title": "Command Code",
+  "description": "Command Code — dot-home config at ~/.commandcode; Claude-style flat skills layout; subagent frontmatter conversion; no lifecycle hook registration; tier-2 support.",
+  "tier": "core",
+  "requires": [],
+  "runtime": {
+    "configHome": {
+      "kind": "dot-home",
+      "name": ".commandcode",
+      "env": ["COMMANDCODE_CONFIG_DIR"]
+    },
+    "configFormat": "none",
+    "artifactLayout": {
+      "global": [
+        {
+          "kind": "skills",
+          "destSubpath": "skills",
+          "prefix": "gsd-",
+          "nesting": "flat",
+          "recursive": false,
+          "converter": "convertClaudeCommandToClaudeSkill"
+        }
+      ],
+      "local": [
+        {
+          "kind": "skills",
+          "destSubpath": "skills",
+          "prefix": "gsd-",
+          "nesting": "flat",
+          "recursive": false,
+          "converter": "convertClaudeCommandToClaudeSkill"
+        }
+      ]
+    },
+    "commandStyle": "slash-hyphen",
+    "hooksSurface": "none",
+    "sandboxTier": "none",
+    "supportTier": 2
+  }
+}

--- a/capabilities/mimo/capability.json
+++ b/capabilities/mimo/capability.json
@@ -1,0 +1,42 @@
+{
+  "id": "mimo",
+  "role": "runtime",
+  "title": "MiMoCode",
+  "description": "MiMoCode — XDG-based config dir at ~/.config/mimocode; Claude-style flat skills layout; subagent frontmatter conversion; no lifecycle hook registration; tier-2 support.",
+  "tier": "core",
+  "requires": [],
+  "runtime": {
+    "configHome": {
+      "kind": "xdg",
+      "name": "mimocode",
+      "env": ["MIMOCODE_CONFIG_DIR", "XDG_CONFIG_HOME"]
+    },
+    "configFormat": "none",
+    "artifactLayout": {
+      "global": [
+        {
+          "kind": "skills",
+          "destSubpath": "skills",
+          "prefix": "gsd-",
+          "nesting": "flat",
+          "recursive": false,
+          "converter": "convertClaudeCommandToClaudeSkill"
+        }
+      ],
+      "local": [
+        {
+          "kind": "skills",
+          "destSubpath": "skills",
+          "prefix": "gsd-",
+          "nesting": "flat",
+          "recursive": false,
+          "converter": "convertClaudeCommandToClaudeSkill"
+        }
+      ]
+    },
+    "commandStyle": "slash-hyphen",
+    "hooksSurface": "none",
+    "sandboxTier": "none",
+    "supportTier": 2
+  }
+}

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1006,7 +1006,7 @@ fix(03-01): correct auth token expiry
 **Purpose:** Run GSD across multiple AI coding agent runtimes.
 
 **Requirements:**
-- REQ-RUNTIME-01: System MUST support Claude Code, OpenCode, Gemini CLI, Kimi CLI, MiMoCode, Kilo, Codex, Copilot, Antigravity, Trae, Cline, Augment Code, CodeBuddy, Qwen Code, Hermes Agent
+- REQ-RUNTIME-01: System MUST support Claude Code, OpenCode, Gemini CLI, Kimi CLI, MiMoCode, Command Code, Kilo, Codex, Copilot, Antigravity, Trae, Cline, Augment Code, CodeBuddy, Qwen Code, Hermes Agent
 - REQ-RUNTIME-02: Installer MUST transform content per runtime (tool names, paths, frontmatter)
 - REQ-RUNTIME-03: Installer MUST support interactive and non-interactive (`--claude --global`) modes
 - REQ-RUNTIME-04: Installer MUST support both global and local installation

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1006,7 +1006,7 @@ fix(03-01): correct auth token expiry
 **Purpose:** Run GSD across multiple AI coding agent runtimes.
 
 **Requirements:**
-- REQ-RUNTIME-01: System MUST support Claude Code, OpenCode, Gemini CLI, Kilo, Codex, Copilot, Antigravity, Trae, Cline, Augment Code, CodeBuddy, Qwen Code
+- REQ-RUNTIME-01: System MUST support Claude Code, OpenCode, Gemini CLI, Kimi CLI, MiMoCode, Kilo, Codex, Copilot, Antigravity, Trae, Cline, Augment Code, CodeBuddy, Qwen Code, Hermes Agent
 - REQ-RUNTIME-02: Installer MUST transform content per runtime (tool names, paths, frontmatter)
 - REQ-RUNTIME-03: Installer MUST support interactive and non-interactive (`--claude --global`) modes
 - REQ-RUNTIME-04: Installer MUST support both global and local installation

--- a/docs/how-to/install-on-your-runtime.md
+++ b/docs/how-to/install-on-your-runtime.md
@@ -269,6 +269,54 @@ Avoid arbitrary `KIMI_CONFIG_DIR` roots unless your Kimi configuration also adds
 
 ---
 
+### MiMoCode
+
+```bash
+npx @opengsd/gsd-core@latest --mimo --global
+```
+
+Skills land in `~/.config/mimocode/skills/gsd-*/SKILL.md`. Subagents land in `~/.config/mimocode/agents/gsd-*.md` with MiMoCode-native frontmatter (`tools:` as a YAML record, `#RRGGBB` colors, `mode: subagent`). Hooks are not installed — MiMoCode has no lifecycle hook surface.
+
+**Project-local install** (when you run `mimo` from a specific repo):
+
+```bash
+cd /path/to/your/project
+npx @opengsd/gsd-core@latest --mimo --local
+```
+
+This writes `.mimocode/` in the project root. From a source checkout, use `node /path/to/gsd-core/bin/install.js --mimo --local` instead of `npx` until the release is published.
+
+**Override the install directory:**
+
+```bash
+npx @opengsd/gsd-core@latest --mimo --global --config-dir ~/.mimocode-work
+```
+
+---
+
+### Command Code
+
+```bash
+npx @opengsd/gsd-core@latest --commandcode --global
+```
+
+Skills land in `~/.commandcode/skills/gsd-*/SKILL.md`. Subagents land in `~/.commandcode/agents/gsd-*.md` with the same subagent frontmatter schema as MiMoCode. Hooks are not installed.
+
+**Project-local install:**
+
+```bash
+cd /path/to/your/project
+npx @opengsd/gsd-core@latest --commandcode --local
+```
+
+**Override the install directory:**
+
+```bash
+COMMANDCODE_CONFIG_DIR=~/.commandcode-alt npx @opengsd/gsd-core@latest --commandcode --global
+```
+
+---
+
 ### GitHub Copilot
 
 ```bash

--- a/gsd-core/bin/lib/capability-registry.cjs
+++ b/gsd-core/bin/lib/capability-registry.cjs
@@ -340,6 +340,50 @@ const capabilities = {
       "supportTier": 1
     }
   },
+  "commandcode": {
+    "id": "commandcode",
+    "role": "runtime",
+    "title": "Command Code",
+    "description": "Command Code — dot-home config at ~/.commandcode; Claude-style flat skills layout; subagent frontmatter conversion; no lifecycle hook registration; tier-2 support.",
+    "tier": "core",
+    "requires": [],
+    "runtime": {
+      "configHome": {
+        "kind": "dot-home",
+        "name": ".commandcode",
+        "env": [
+          "COMMANDCODE_CONFIG_DIR"
+        ]
+      },
+      "configFormat": "none",
+      "artifactLayout": {
+        "global": [
+          {
+            "kind": "skills",
+            "destSubpath": "skills",
+            "prefix": "gsd-",
+            "nesting": "flat",
+            "recursive": false,
+            "converter": "convertClaudeCommandToClaudeSkill"
+          }
+        ],
+        "local": [
+          {
+            "kind": "skills",
+            "destSubpath": "skills",
+            "prefix": "gsd-",
+            "nesting": "flat",
+            "recursive": false,
+            "converter": "convertClaudeCommandToClaudeSkill"
+          }
+        ]
+      },
+      "commandStyle": "slash-hyphen",
+      "hooksSurface": "none",
+      "sandboxTier": "none",
+      "supportTier": 2
+    }
+  },
   "copilot": {
     "id": "copilot",
     "role": "runtime",
@@ -1513,6 +1557,50 @@ const runtimes = {
       "supportTier": 1
     }
   },
+  "commandcode": {
+    "id": "commandcode",
+    "role": "runtime",
+    "title": "Command Code",
+    "description": "Command Code — dot-home config at ~/.commandcode; Claude-style flat skills layout; subagent frontmatter conversion; no lifecycle hook registration; tier-2 support.",
+    "tier": "core",
+    "requires": [],
+    "runtime": {
+      "configHome": {
+        "kind": "dot-home",
+        "name": ".commandcode",
+        "env": [
+          "COMMANDCODE_CONFIG_DIR"
+        ]
+      },
+      "configFormat": "none",
+      "artifactLayout": {
+        "global": [
+          {
+            "kind": "skills",
+            "destSubpath": "skills",
+            "prefix": "gsd-",
+            "nesting": "flat",
+            "recursive": false,
+            "converter": "convertClaudeCommandToClaudeSkill"
+          }
+        ],
+        "local": [
+          {
+            "kind": "skills",
+            "destSubpath": "skills",
+            "prefix": "gsd-",
+            "nesting": "flat",
+            "recursive": false,
+            "converter": "convertClaudeCommandToClaudeSkill"
+          }
+        ]
+      },
+      "commandStyle": "slash-hyphen",
+      "hooksSurface": "none",
+      "sandboxTier": "none",
+      "supportTier": 2
+    }
+  },
   "copilot": {
     "id": "copilot",
     "role": "runtime",
@@ -2123,6 +2211,7 @@ const _requiresGraph = {
   "cline": [],
   "codebuddy": [],
   "codex": [],
+  "commandcode": [],
   "copilot": [],
   "cursor": [],
   "gemini": [],

--- a/gsd-core/bin/lib/capability-registry.cjs
+++ b/gsd-core/bin/lib/capability-registry.cjs
@@ -709,6 +709,51 @@ const capabilities = {
       "supportTier": 2
     }
   },
+  "mimo": {
+    "id": "mimo",
+    "role": "runtime",
+    "title": "MiMoCode",
+    "description": "MiMoCode — XDG-based config dir at ~/.config/mimocode; Claude-style flat skills layout; subagent frontmatter conversion; no lifecycle hook registration; tier-2 support.",
+    "tier": "core",
+    "requires": [],
+    "runtime": {
+      "configHome": {
+        "kind": "xdg",
+        "name": "mimocode",
+        "env": [
+          "MIMOCODE_CONFIG_DIR",
+          "XDG_CONFIG_HOME"
+        ]
+      },
+      "configFormat": "none",
+      "artifactLayout": {
+        "global": [
+          {
+            "kind": "skills",
+            "destSubpath": "skills",
+            "prefix": "gsd-",
+            "nesting": "flat",
+            "recursive": false,
+            "converter": "convertClaudeCommandToClaudeSkill"
+          }
+        ],
+        "local": [
+          {
+            "kind": "skills",
+            "destSubpath": "skills",
+            "prefix": "gsd-",
+            "nesting": "flat",
+            "recursive": false,
+            "converter": "convertClaudeCommandToClaudeSkill"
+          }
+        ]
+      },
+      "commandStyle": "slash-hyphen",
+      "hooksSurface": "none",
+      "sandboxTier": "none",
+      "supportTier": 2
+    }
+  },
   "opencode": {
     "id": "opencode",
     "role": "runtime",
@@ -1779,6 +1824,51 @@ const runtimes = {
       "supportTier": 2
     }
   },
+  "mimo": {
+    "id": "mimo",
+    "role": "runtime",
+    "title": "MiMoCode",
+    "description": "MiMoCode — XDG-based config dir at ~/.config/mimocode; Claude-style flat skills layout; subagent frontmatter conversion; no lifecycle hook registration; tier-2 support.",
+    "tier": "core",
+    "requires": [],
+    "runtime": {
+      "configHome": {
+        "kind": "xdg",
+        "name": "mimocode",
+        "env": [
+          "MIMOCODE_CONFIG_DIR",
+          "XDG_CONFIG_HOME"
+        ]
+      },
+      "configFormat": "none",
+      "artifactLayout": {
+        "global": [
+          {
+            "kind": "skills",
+            "destSubpath": "skills",
+            "prefix": "gsd-",
+            "nesting": "flat",
+            "recursive": false,
+            "converter": "convertClaudeCommandToClaudeSkill"
+          }
+        ],
+        "local": [
+          {
+            "kind": "skills",
+            "destSubpath": "skills",
+            "prefix": "gsd-",
+            "nesting": "flat",
+            "recursive": false,
+            "converter": "convertClaudeCommandToClaudeSkill"
+          }
+        ]
+      },
+      "commandStyle": "slash-hyphen",
+      "hooksSurface": "none",
+      "sandboxTier": "none",
+      "supportTier": 2
+    }
+  },
   "opencode": {
     "id": "opencode",
     "role": "runtime",
@@ -2041,6 +2131,7 @@ const _requiresGraph = {
   "intel": [],
   "kilo": [],
   "kimi": [],
+  "mimo": [],
   "opencode": [],
   "qwen": [],
   "trae": [],

--- a/gsd-core/bin/shared/model-catalog.json
+++ b/gsd-core/bin/shared/model-catalog.json
@@ -57,6 +57,11 @@
       "sonnet": null,
       "haiku": null
     },
+    "mimo": {
+      "opus": null,
+      "sonnet": null,
+      "haiku": null
+    },
     "cursor": {
       "opus": null,
       "sonnet": null,

--- a/gsd-core/bin/shared/model-catalog.json
+++ b/gsd-core/bin/shared/model-catalog.json
@@ -62,6 +62,11 @@
       "sonnet": null,
       "haiku": null
     },
+    "commandcode": {
+      "opus": null,
+      "sonnet": null,
+      "haiku": null
+    },
     "cursor": {
       "opus": null,
       "sonnet": null,

--- a/src/runtime-artifact-layout.cts
+++ b/src/runtime-artifact-layout.cts
@@ -173,7 +173,7 @@ function findAgentsSourceRoot(runtimeConfigDir?: string): string {
 const ALLOWED_RUNTIMES = new Set([
   'claude', 'cursor', 'gemini', 'codex', 'copilot', 'antigravity',
   'windsurf', 'augment', 'trae', 'qwen', 'hermes', 'codebuddy',
-  'cline', 'kimi', 'mimo', 'opencode', 'kilo',
+  'cline', 'kimi', 'mimo', 'commandcode', 'opencode', 'kilo',
 ]);
 
 // ---------------------------------------------------------------------------

--- a/src/runtime-artifact-layout.cts
+++ b/src/runtime-artifact-layout.cts
@@ -173,7 +173,7 @@ function findAgentsSourceRoot(runtimeConfigDir?: string): string {
 const ALLOWED_RUNTIMES = new Set([
   'claude', 'cursor', 'gemini', 'codex', 'copilot', 'antigravity',
   'windsurf', 'augment', 'trae', 'qwen', 'hermes', 'codebuddy',
-  'cline', 'kimi', 'opencode', 'kilo',
+  'cline', 'kimi', 'mimo', 'opencode', 'kilo',
 ]);
 
 // ---------------------------------------------------------------------------

--- a/src/runtime-config-adapter-registry.cts
+++ b/src/runtime-config-adapter-registry.cts
@@ -70,13 +70,14 @@ const REGISTRY: Record<string, Readonly<RegistryEntry>> = Object.freeze({
   windsurf:    Object.freeze({ installSurface: 'profile-marker-only',  writesSharedSettings: false, finishPermissionWriter: null       } as const),
   trae:        Object.freeze({ installSurface: 'profile-marker-only',  writesSharedSettings: false, finishPermissionWriter: null       } as const),
   kimi:        Object.freeze({ installSurface: 'profile-marker-only',  writesSharedSettings: false, finishPermissionWriter: null       } as const),
+  mimo:        Object.freeze({ installSurface: 'profile-marker-only',  writesSharedSettings: false, finishPermissionWriter: null       } as const),
 });
 
 // ---------------------------------------------------------------------------
 // Exports
 // ---------------------------------------------------------------------------
 
-/** The complete set of 16 supported runtimes for config-adapter dispatch. */
+/** The complete set of 17 supported runtimes for config-adapter dispatch. */
 const ALLOWED_CONFIG_RUNTIMES: ReadonlySet<string> = new Set(Object.keys(REGISTRY));
 
 /** All valid installSurface values. */

--- a/src/runtime-config-adapter-registry.cts
+++ b/src/runtime-config-adapter-registry.cts
@@ -71,13 +71,14 @@ const REGISTRY: Record<string, Readonly<RegistryEntry>> = Object.freeze({
   trae:        Object.freeze({ installSurface: 'profile-marker-only',  writesSharedSettings: false, finishPermissionWriter: null       } as const),
   kimi:        Object.freeze({ installSurface: 'profile-marker-only',  writesSharedSettings: false, finishPermissionWriter: null       } as const),
   mimo:        Object.freeze({ installSurface: 'profile-marker-only',  writesSharedSettings: false, finishPermissionWriter: null       } as const),
+  commandcode: Object.freeze({ installSurface: 'profile-marker-only',  writesSharedSettings: false, finishPermissionWriter: null       } as const),
 });
 
 // ---------------------------------------------------------------------------
 // Exports
 // ---------------------------------------------------------------------------
 
-/** The complete set of 17 supported runtimes for config-adapter dispatch. */
+/** The complete set of 18 supported runtimes for config-adapter dispatch. */
 const ALLOWED_CONFIG_RUNTIMES: ReadonlySet<string> = new Set(Object.keys(REGISTRY));
 
 /** All valid installSurface values. */

--- a/tests/capability-registry.test.cjs
+++ b/tests/capability-registry.test.cjs
@@ -2523,7 +2523,7 @@ const {
 const RUNTIME_IDS = [
   'claude', 'codex', 'antigravity', 'gemini', 'cursor', 'opencode',
   'kilo', 'copilot', 'augment', 'trae', 'qwen', 'hermes',
-  'codebuddy', 'cline', 'kimi', 'windsurf',
+  'codebuddy', 'cline', 'kimi', 'mimo', 'windsurf',
 ];
 
 // Helper: build a minimal valid runtime capability object for fixture-based tests
@@ -2552,16 +2552,16 @@ function makeRuntimeCap(overrides) {
 
 // ── 24a. All 16 runtime ids appear in the runtimes index ─────────────────────
 
-describe('ADR-1016 phase 5a: all 16 runtimes in registry index', () => {
+describe('ADR-1016 phase 5a: all 17 runtimes in registry index', () => {
   let registry;
 
-  test('loadAndValidate + buildRegistry produces runtimes index with 16 entries', () => {
+  test('loadAndValidate + buildRegistry produces runtimes index with 17 entries', () => {
     const { capMap, errors } = loadAndValidate(new Set());
     const hardErrors = errors.filter((e) => !e.includes('pending-migration'));
     assert.deepEqual(hardErrors, [], 'Expected no hard errors: ' + JSON.stringify(hardErrors));
     registry = buildRegistry(capMap);
     const runtimeKeys = Object.keys(registry.runtimes).sort();
-    assert.strictEqual(runtimeKeys.length, 16, 'Expected 16 runtime entries, got: ' + runtimeKeys.join(', '));
+    assert.strictEqual(runtimeKeys.length, 17, 'Expected 17 runtime entries, got: ' + runtimeKeys.join(', '));
     for (const id of RUNTIME_IDS) {
       assert.ok(
         Object.prototype.hasOwnProperty.call(registry.runtimes, id),

--- a/tests/capability-registry.test.cjs
+++ b/tests/capability-registry.test.cjs
@@ -2523,7 +2523,7 @@ const {
 const RUNTIME_IDS = [
   'claude', 'codex', 'antigravity', 'gemini', 'cursor', 'opencode',
   'kilo', 'copilot', 'augment', 'trae', 'qwen', 'hermes',
-  'codebuddy', 'cline', 'kimi', 'mimo', 'windsurf',
+  'codebuddy', 'cline', 'kimi', 'mimo', 'commandcode', 'windsurf',
 ];
 
 // Helper: build a minimal valid runtime capability object for fixture-based tests
@@ -2552,16 +2552,16 @@ function makeRuntimeCap(overrides) {
 
 // ── 24a. All 16 runtime ids appear in the runtimes index ─────────────────────
 
-describe('ADR-1016 phase 5a: all 17 runtimes in registry index', () => {
+describe('ADR-1016 phase 5a: all 18 runtimes in registry index', () => {
   let registry;
 
-  test('loadAndValidate + buildRegistry produces runtimes index with 17 entries', () => {
+  test('loadAndValidate + buildRegistry produces runtimes index with 18 entries', () => {
     const { capMap, errors } = loadAndValidate(new Set());
     const hardErrors = errors.filter((e) => !e.includes('pending-migration'));
     assert.deepEqual(hardErrors, [], 'Expected no hard errors: ' + JSON.stringify(hardErrors));
     registry = buildRegistry(capMap);
     const runtimeKeys = Object.keys(registry.runtimes).sort();
-    assert.strictEqual(runtimeKeys.length, 17, 'Expected 17 runtime entries, got: ' + runtimeKeys.join(', '));
+    assert.strictEqual(runtimeKeys.length, 18, 'Expected 18 runtime entries, got: ' + runtimeKeys.join(', '));
     for (const id of RUNTIME_IDS) {
       assert.ok(
         Object.prototype.hasOwnProperty.call(registry.runtimes, id),

--- a/tests/commandcode-runtime-install.test.cjs
+++ b/tests/commandcode-runtime-install.test.cjs
@@ -1,0 +1,84 @@
+'use strict';
+
+process.env.GSD_TEST_MODE = '1';
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const os = require('node:os');
+
+const {
+  getDirName,
+  getGlobalDir,
+  getConfigDirFromHome,
+  runtimeMap,
+  allRuntimes,
+  parseRuntimeInput,
+  buildRuntimePromptText,
+  convertClaudeToCommandcodeAgentFrontmatter,
+  selectRuntimesFromArgs,
+} = require('../bin/install.js');
+
+describe('Command Code runtime directory mapping', () => {
+  test('getDirName returns .commandcode for local installs', () => {
+    assert.strictEqual(getDirName('commandcode'), '.commandcode');
+  });
+
+  test('getGlobalDir returns ~/.commandcode for global installs', () => {
+    assert.strictEqual(getGlobalDir('commandcode'), path.join(os.homedir(), '.commandcode'));
+  });
+
+  test('getConfigDirFromHome returns .commandcode fragment', () => {
+    assert.strictEqual(getConfigDirFromHome('commandcode', false), "'.commandcode'");
+    assert.strictEqual(getConfigDirFromHome('commandcode', true), "'.commandcode'");
+  });
+});
+
+describe('Command Code in runtime selection', () => {
+  test('option 18 selects commandcode', () => {
+    assert.deepStrictEqual(parseRuntimeInput('18'), ['commandcode']);
+  });
+
+  test('--commandcode flag selects commandcode', () => {
+    assert.deepStrictEqual(selectRuntimesFromArgs(['--commandcode']), ['commandcode']);
+  });
+
+  test('--all includes commandcode exactly once', () => {
+    const selected = selectRuntimesFromArgs(['--all']);
+    assert.ok(selected.includes('commandcode'));
+    assert.strictEqual(selected.filter((runtime) => runtime === 'commandcode').length, 1);
+  });
+
+  test('runtimeMap maps 18 to commandcode', () => {
+    assert.strictEqual(runtimeMap['18'], 'commandcode');
+  });
+
+  test('buildRuntimePromptText includes Command Code', () => {
+    const text = buildRuntimePromptText();
+    assert.ok(text.includes('Command Code'));
+    assert.ok(text.includes('commandcode'));
+  });
+
+  test('allRuntimes includes commandcode', () => {
+    assert.ok(allRuntimes.includes('commandcode'));
+  });
+});
+
+describe('convertClaudeToCommandcodeAgentFrontmatter', () => {
+  test('converts Claude agent frontmatter to Command Code schema', () => {
+    const input = `---
+name: gsd-planner
+description: Creates executable phase plans.
+tools: Read, Write, Bash, Glob, Grep, WebFetch
+color: green
+---
+
+<body>`;
+
+    const result = convertClaudeToCommandcodeAgentFrontmatter(input);
+    assert.match(result, /  read: true/);
+    assert.match(result, /color: "#00FF00"/);
+    assert.match(result, /mode: subagent/);
+    assert.match(result, /<body>/);
+  });
+});

--- a/tests/install-runtime-artifacts.test.cjs
+++ b/tests/install-runtime-artifacts.test.cjs
@@ -50,13 +50,13 @@ const RESOLVED_CORE = resolveProfile({ modes: ['core'], manifest: MANIFEST });
 
 const SKILLS_RUNTIMES_LAYOUT = [
   'claude', 'cursor', 'codex', 'copilot', 'antigravity',
-  'windsurf', 'augment', 'trae', 'qwen', 'kimi', 'codebuddy',
+  'windsurf', 'augment', 'trae', 'qwen', 'kimi', 'mimo', 'codebuddy',
 ];
 
 const ALL_RUNTIMES_LAYOUT = [
   'claude', 'cursor', 'gemini', 'codex', 'copilot', 'antigravity',
   'windsurf', 'augment', 'trae', 'qwen', 'hermes', 'codebuddy',
-  'cline', 'kimi', 'opencode', 'kilo',
+  'cline', 'kimi', 'mimo', 'opencode', 'kilo',
 ];
 
 function countPrefixedEntries(destDir, prefix) {

--- a/tests/install-runtime-artifacts.test.cjs
+++ b/tests/install-runtime-artifacts.test.cjs
@@ -50,13 +50,13 @@ const RESOLVED_CORE = resolveProfile({ modes: ['core'], manifest: MANIFEST });
 
 const SKILLS_RUNTIMES_LAYOUT = [
   'claude', 'cursor', 'codex', 'copilot', 'antigravity',
-  'windsurf', 'augment', 'trae', 'qwen', 'kimi', 'mimo', 'codebuddy',
+  'windsurf', 'augment', 'trae', 'qwen', 'kimi', 'mimo', 'commandcode', 'codebuddy',
 ];
 
 const ALL_RUNTIMES_LAYOUT = [
   'claude', 'cursor', 'gemini', 'codex', 'copilot', 'antigravity',
   'windsurf', 'augment', 'trae', 'qwen', 'hermes', 'codebuddy',
-  'cline', 'kimi', 'mimo', 'opencode', 'kilo',
+  'cline', 'kimi', 'mimo', 'commandcode', 'opencode', 'kilo',
 ];
 
 function countPrefixedEntries(destDir, prefix) {

--- a/tests/mimo-runtime-install.test.cjs
+++ b/tests/mimo-runtime-install.test.cjs
@@ -1,0 +1,155 @@
+'use strict';
+
+process.env.GSD_TEST_MODE = '1';
+
+const { test, describe, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const { createTempDir, cleanup } = require('./helpers.cjs');
+
+const {
+  getDirName,
+  getGlobalDir,
+  getConfigDirFromHome,
+  runtimeMap,
+  allRuntimes,
+  parseRuntimeInput,
+  buildRuntimePromptText,
+  convertClaudeToMimoAgentFrontmatter,
+  selectRuntimesFromArgs,
+} = require('../bin/install.js');
+
+describe('MiMoCode runtime directory mapping', () => {
+  test('getDirName returns .mimocode for local installs', () => {
+    assert.strictEqual(getDirName('mimo'), '.mimocode');
+  });
+
+  test('getGlobalDir returns ~/.config/mimocode for global installs', () => {
+    assert.strictEqual(getGlobalDir('mimo'), path.join(os.homedir(), '.config', 'mimocode'));
+  });
+
+  test('getConfigDirFromHome returns .config/mimocode fragment', () => {
+    assert.strictEqual(getConfigDirFromHome('mimo', false), "'.mimocode'");
+    assert.strictEqual(getConfigDirFromHome('mimo', true), "'.config', 'mimocode'");
+  });
+});
+
+describe('getGlobalDir (MiMoCode)', () => {
+  test('returns ~/.config/mimocode with no explicit dir', () => {
+    const result = getGlobalDir('mimo');
+    assert.strictEqual(result, path.join(os.homedir(), '.config', 'mimocode'));
+  });
+
+  test('returns explicit dir when provided', () => {
+    const result = getGlobalDir('mimo', '/custom/mimocode-path');
+    assert.strictEqual(result, '/custom/mimocode-path');
+  });
+
+  test('does not break other runtimes', () => {
+    assert.strictEqual(getGlobalDir('claude'), path.join(os.homedir(), '.claude'));
+    assert.strictEqual(getGlobalDir('codex'), path.join(os.homedir(), '.codex'));
+  });
+});
+
+describe('MiMoCode in runtime selection', () => {
+  test('option 17 selects mimo', () => {
+    assert.deepStrictEqual(parseRuntimeInput('17'), ['mimo']);
+  });
+
+  test('--mimo flag selects mimo without interactive prompt', () => {
+    assert.deepStrictEqual(selectRuntimesFromArgs(['--mimo']), ['mimo']);
+  });
+
+  test('--all includes mimo exactly once', () => {
+    const selected = selectRuntimesFromArgs(['--all']);
+    assert.ok(selected.includes('mimo'), '--all includes mimo');
+    assert.strictEqual(selected.filter((runtime) => runtime === 'mimo').length, 1);
+  });
+
+  test('runtimeMap maps 17 to mimo', () => {
+    assert.strictEqual(runtimeMap['17'], 'mimo');
+  });
+
+  test('buildRuntimePromptText includes MiMoCode', () => {
+    const text = buildRuntimePromptText();
+    assert.ok(text.includes('MiMoCode'), 'prompt should mention MiMoCode');
+    assert.ok(text.includes('mimocode'), 'prompt should show mimocode path');
+  });
+});
+
+describe('convertClaudeToMimoAgentFrontmatter', () => {
+  test('converts comma-separated tools and named colors to MiMoCode schema', () => {
+    const input = `---
+name: gsd-planner
+description: Creates executable phase plans.
+tools: Read, Write, Bash, Glob, Grep, WebFetch, mcp__context7__*
+color: green
+# hooks:
+#   PostToolUse:
+#     - matcher: "Write|Edit"
+---
+
+<body>`;
+
+    const result = convertClaudeToMimoAgentFrontmatter(input);
+    for (const tool of ['bash', 'glob', 'grep', 'read', 'write', 'webfetch']) {
+      assert.match(result, new RegExp(`  ${tool}: true`));
+    }
+    assert.match(result, /color: "#00FF00"/);
+    assert.match(result, /mode: subagent/);
+    assert.doesNotMatch(result, /mcp__context7__/);
+    assert.doesNotMatch(result, /# hooks:/);
+    assert.match(result, /<body>/);
+  });
+
+  test('converts YAML list tools and preserves six-digit hex colors', () => {
+    const input = `---
+name: gsd-security-auditor
+description: Security audit agent.
+tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+color: "#EF4444"
+---
+
+<body>`;
+
+    const result = convertClaudeToMimoAgentFrontmatter(input);
+    assert.match(result, /tools:\n  bash: true\n  edit: true\n  read: true\n  write: true/);
+    assert.match(result, /color: "#EF4444"/);
+  });
+});
+
+describe('MiMoCode install artifact layout', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempDir('mimo-test');
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('getDirName returns .mimocode which is the correct local dir', () => {
+    const dirName = getDirName('mimo');
+    assert.strictEqual(dirName, '.mimocode');
+    const localDir = path.join(tmpDir, dirName);
+    fs.mkdirSync(localDir, { recursive: true });
+    assert.ok(fs.existsSync(localDir), 'local .mimocode dir should exist');
+  });
+
+  test('getGlobalDir with explicit dir returns the custom path', () => {
+    const customDir = path.join(tmpDir, 'custom-global');
+    const result = getGlobalDir('mimo', customDir);
+    assert.strictEqual(result, customDir);
+  });
+
+  test('allRuntimes includes mimo', () => {
+    assert.ok(allRuntimes.includes('mimo'));
+  });
+});

--- a/tests/multi-runtime-select.test.cjs
+++ b/tests/multi-runtime-select.test.cjs
@@ -85,19 +85,23 @@ describe('multi-runtime selection parsing', () => {
     assert.deepStrictEqual(parseRuntimeInput('17'), ['mimo']);
   });
 
+  test('single choice for commandcode', () => {
+    assert.deepStrictEqual(parseRuntimeInput('18'), ['commandcode']);
+  });
+
   test('single choice for kimi', () => {
     assert.deepStrictEqual(parseRuntimeInput('11'), ['kimi']);
   });
 
-  test('choice 18 returns all runtimes', () => {
-    assert.deepStrictEqual(parseRuntimeInput('18'), allRuntimes);
+  test('choice 19 returns all runtimes', () => {
+    assert.deepStrictEqual(parseRuntimeInput('19'), allRuntimes);
   });
 
-  test('choice 18 returns all runtimes when mixed with separators or other tokens', () => {
-    assert.deepStrictEqual(parseRuntimeInput('18,'), allRuntimes);
-    assert.deepStrictEqual(parseRuntimeInput('18 1'), allRuntimes);
-    assert.deepStrictEqual(parseRuntimeInput('1,18'), allRuntimes);
-    assert.deepStrictEqual(parseRuntimeInput('  18  '), allRuntimes);
+  test('choice 19 returns all runtimes when mixed with separators or other tokens', () => {
+    assert.deepStrictEqual(parseRuntimeInput('19,'), allRuntimes);
+    assert.deepStrictEqual(parseRuntimeInput('19 1'), allRuntimes);
+    assert.deepStrictEqual(parseRuntimeInput('1,19'), allRuntimes);
+    assert.deepStrictEqual(parseRuntimeInput('  19  '), allRuntimes);
   });
 
   test('empty input defaults to claude', () => {
@@ -106,13 +110,13 @@ describe('multi-runtime selection parsing', () => {
   });
 
   test('invalid choices are ignored, falls back to claude if all invalid', () => {
-    assert.deepStrictEqual(parseRuntimeInput('19'), ['claude']);
+    assert.deepStrictEqual(parseRuntimeInput('20'), ['claude']);
     assert.deepStrictEqual(parseRuntimeInput('0'), ['claude']);
     assert.deepStrictEqual(parseRuntimeInput('abc'), ['claude']);
   });
 
   test('invalid choices mixed with valid are filtered out', () => {
-    assert.deepStrictEqual(parseRuntimeInput('1,19,7'), ['claude', 'copilot']);
+    assert.deepStrictEqual(parseRuntimeInput('1,20,7'), ['claude', 'copilot']);
     assert.deepStrictEqual(parseRuntimeInput('abc 3 xyz'), ['augment']);
   });
 
@@ -146,9 +150,10 @@ describe('install.js exports multi-select runtime metadata', () => {
     '15': 'trae',
     '16': 'windsurf',
     '17': 'mimo',
+    '18': 'commandcode',
   };
   const expectedRuntimes = [
-    'claude', 'antigravity', 'augment', 'cline', 'codebuddy', 'codex',
+    'claude', 'antigravity', 'augment', 'cline', 'codebuddy', 'codex', 'commandcode',
     'copilot', 'cursor', 'gemini', 'hermes', 'kimi', 'kilo', 'mimo', 'opencode',
     'qwen', 'trae', 'windsurf',
   ];
@@ -167,8 +172,8 @@ describe('install.js exports multi-select runtime metadata', () => {
       'allRuntimes has no duplicates');
   });
 
-  test('"All" shortcut (option 18) selects every runtime', () => {
-    assert.deepStrictEqual(parseRuntimeInput('18'), allRuntimes);
+  test('"All" shortcut (option 19) selects every runtime', () => {
+    assert.deepStrictEqual(parseRuntimeInput('19'), allRuntimes);
   });
 
   test('--kimi flag selects Kimi without interactive prompt', () => {
@@ -182,7 +187,7 @@ describe('install.js exports multi-select runtime metadata', () => {
       '--all includes kimi exactly once');
   });
 
-  test('prompt lists Hermes Agent (10), Kimi (11), Qwen Code (14), Trae (15), MiMoCode (17), and All (18)', () => {
+  test('prompt lists Hermes Agent (10), Kimi (11), Qwen Code (14), Trae (15), MiMoCode (17), Command Code (18), and All (19)', () => {
     const prompt = stripAnsi(buildRuntimePromptText());
     assert.ok(/\b10\)\s*Hermes Agent\b/.test(prompt),
       'prompt lists Hermes Agent as option 10');
@@ -196,8 +201,10 @@ describe('install.js exports multi-select runtime metadata', () => {
       'prompt lists Trae as option 15');
     assert.ok(/\b17\)\s*MiMoCode\b/.test(prompt),
       'prompt lists MiMoCode as option 17');
-    assert.ok(/\b18\)\s*All\b/.test(prompt),
-      'prompt lists All as option 18');
+    assert.ok(/\b18\)\s*Command Code\b/.test(prompt),
+      'prompt lists Command Code as option 18');
+    assert.ok(/\b19\)\s*All\b/.test(prompt),
+      'prompt lists All as option 19');
   });
 
   test('prompt text shows multi-select hint', () => {

--- a/tests/multi-runtime-select.test.cjs
+++ b/tests/multi-runtime-select.test.cjs
@@ -81,23 +81,23 @@ describe('multi-runtime selection parsing', () => {
     assert.deepStrictEqual(parseRuntimeInput('16'), ['windsurf']);
   });
 
+  test('single choice for mimo', () => {
+    assert.deepStrictEqual(parseRuntimeInput('17'), ['mimo']);
+  });
+
   test('single choice for kimi', () => {
     assert.deepStrictEqual(parseRuntimeInput('11'), ['kimi']);
   });
 
-  test('choice 17 returns all runtimes', () => {
-    assert.deepStrictEqual(parseRuntimeInput('17'), allRuntimes);
+  test('choice 18 returns all runtimes', () => {
+    assert.deepStrictEqual(parseRuntimeInput('18'), allRuntimes);
   });
 
-  test('choice 17 returns all runtimes when mixed with separators or other tokens', () => {
-    // CR feedback: tokenized inputs that include 17 (e.g. trailing comma, or
-    // alongside other choices) must still expand to all-runtimes — previously
-    // only the bare all-runtimes option matched, so "17," or "17 1" silently installed a
-    // subset.
-    assert.deepStrictEqual(parseRuntimeInput('17,'), allRuntimes);
-    assert.deepStrictEqual(parseRuntimeInput('17 1'), allRuntimes);
-    assert.deepStrictEqual(parseRuntimeInput('1,17'), allRuntimes);
-    assert.deepStrictEqual(parseRuntimeInput('  17  '), allRuntimes);
+  test('choice 18 returns all runtimes when mixed with separators or other tokens', () => {
+    assert.deepStrictEqual(parseRuntimeInput('18,'), allRuntimes);
+    assert.deepStrictEqual(parseRuntimeInput('18 1'), allRuntimes);
+    assert.deepStrictEqual(parseRuntimeInput('1,18'), allRuntimes);
+    assert.deepStrictEqual(parseRuntimeInput('  18  '), allRuntimes);
   });
 
   test('empty input defaults to claude', () => {
@@ -106,13 +106,13 @@ describe('multi-runtime selection parsing', () => {
   });
 
   test('invalid choices are ignored, falls back to claude if all invalid', () => {
-    assert.deepStrictEqual(parseRuntimeInput('18'), ['claude']);
+    assert.deepStrictEqual(parseRuntimeInput('19'), ['claude']);
     assert.deepStrictEqual(parseRuntimeInput('0'), ['claude']);
     assert.deepStrictEqual(parseRuntimeInput('abc'), ['claude']);
   });
 
   test('invalid choices mixed with valid are filtered out', () => {
-    assert.deepStrictEqual(parseRuntimeInput('1,18,7'), ['claude', 'copilot']);
+    assert.deepStrictEqual(parseRuntimeInput('1,19,7'), ['claude', 'copilot']);
     assert.deepStrictEqual(parseRuntimeInput('abc 3 xyz'), ['augment']);
   });
 
@@ -145,10 +145,11 @@ describe('install.js exports multi-select runtime metadata', () => {
     '14': 'qwen',
     '15': 'trae',
     '16': 'windsurf',
+    '17': 'mimo',
   };
   const expectedRuntimes = [
     'claude', 'antigravity', 'augment', 'cline', 'codebuddy', 'codex',
-    'copilot', 'cursor', 'gemini', 'hermes', 'kimi', 'kilo', 'opencode',
+    'copilot', 'cursor', 'gemini', 'hermes', 'kimi', 'kilo', 'mimo', 'opencode',
     'qwen', 'trae', 'windsurf',
   ];
 
@@ -166,8 +167,8 @@ describe('install.js exports multi-select runtime metadata', () => {
       'allRuntimes has no duplicates');
   });
 
-  test('"All" shortcut (option 17) selects every runtime', () => {
-    assert.deepStrictEqual(parseRuntimeInput('17'), allRuntimes);
+  test('"All" shortcut (option 18) selects every runtime', () => {
+    assert.deepStrictEqual(parseRuntimeInput('18'), allRuntimes);
   });
 
   test('--kimi flag selects Kimi without interactive prompt', () => {
@@ -181,7 +182,7 @@ describe('install.js exports multi-select runtime metadata', () => {
       '--all includes kimi exactly once');
   });
 
-  test('prompt lists Hermes Agent (10), Kimi (11), Qwen Code (14), Trae (15), and All (17)', () => {
+  test('prompt lists Hermes Agent (10), Kimi (11), Qwen Code (14), Trae (15), MiMoCode (17), and All (18)', () => {
     const prompt = stripAnsi(buildRuntimePromptText());
     assert.ok(/\b10\)\s*Hermes Agent\b/.test(prompt),
       'prompt lists Hermes Agent as option 10');
@@ -193,8 +194,10 @@ describe('install.js exports multi-select runtime metadata', () => {
       'prompt lists Qwen Code as option 14');
     assert.ok(/\b15\)\s*Trae\b/.test(prompt),
       'prompt lists Trae as option 15');
-    assert.ok(/\b17\)\s*All\b/.test(prompt),
-      'prompt lists All as option 17');
+    assert.ok(/\b17\)\s*MiMoCode\b/.test(prompt),
+      'prompt lists MiMoCode as option 17');
+    assert.ok(/\b18\)\s*All\b/.test(prompt),
+      'prompt lists All as option 18');
   });
 
   test('prompt text shows multi-select hint', () => {

--- a/tests/runtime-artifact-layout-descriptor-drive.test.cjs
+++ b/tests/runtime-artifact-layout-descriptor-drive.test.cjs
@@ -195,6 +195,15 @@ const GOLDEN = {
     { kind: 'commands', destSubpath: 'command', prefix: 'gsd-' },
     { kind: 'skills',   destSubpath: 'skills',  prefix: 'gsd-' },
   ],
+
+  // ── mimo ─────────────────────────────────────────────────────────────────────
+  // Descriptor: flat Claude-style skills; local == global.
+  'mimo/global': [
+    { kind: 'skills', destSubpath: 'skills', prefix: 'gsd-' },
+  ],
+  'mimo/local': [
+    { kind: 'skills', destSubpath: 'skills', prefix: 'gsd-' },
+  ],
 };
 
 // ── Parametrized tests ────────────────────────────────────────────────────────
@@ -202,7 +211,7 @@ const GOLDEN = {
 const RUNTIMES = [
   'claude', 'cursor', 'gemini', 'codex', 'copilot',
   'antigravity', 'windsurf', 'augment', 'trae', 'qwen',
-  'hermes', 'codebuddy', 'cline', 'kimi', 'opencode', 'kilo',
+  'hermes', 'codebuddy', 'cline', 'kimi', 'mimo', 'opencode', 'kilo',
 ];
 
 for (const runtime of RUNTIMES) {

--- a/tests/runtime-artifact-layout-descriptor-drive.test.cjs
+++ b/tests/runtime-artifact-layout-descriptor-drive.test.cjs
@@ -204,6 +204,14 @@ const GOLDEN = {
   'mimo/local': [
     { kind: 'skills', destSubpath: 'skills', prefix: 'gsd-' },
   ],
+
+  // ── commandcode ──────────────────────────────────────────────────────────────
+  'commandcode/global': [
+    { kind: 'skills', destSubpath: 'skills', prefix: 'gsd-' },
+  ],
+  'commandcode/local': [
+    { kind: 'skills', destSubpath: 'skills', prefix: 'gsd-' },
+  ],
 };
 
 // ── Parametrized tests ────────────────────────────────────────────────────────
@@ -211,7 +219,7 @@ const GOLDEN = {
 const RUNTIMES = [
   'claude', 'cursor', 'gemini', 'codex', 'copilot',
   'antigravity', 'windsurf', 'augment', 'trae', 'qwen',
-  'hermes', 'codebuddy', 'cline', 'kimi', 'mimo', 'opencode', 'kilo',
+  'hermes', 'codebuddy', 'cline', 'kimi', 'mimo', 'commandcode', 'opencode', 'kilo',
 ];
 
 for (const runtime of RUNTIMES) {

--- a/tests/runtime-config-adapter-registry.test.cjs
+++ b/tests/runtime-config-adapter-registry.test.cjs
@@ -210,15 +210,15 @@ describe('resolveRuntimeConfigIntent — fresh object each call', () => {
 // ---------------------------------------------------------------------------
 
 describe('ALLOWED_CONFIG_RUNTIMES completeness', () => {
-  const EXPECTED_17 = new Set([
+  const EXPECTED_18 = new Set([
     'claude', 'gemini', 'antigravity', 'augment', 'qwen', 'hermes', 'codebuddy',
     'opencode', 'kilo', 'codex', 'copilot', 'cline', 'cursor', 'windsurf', 'trae',
-    'kimi', 'mimo',
+    'kimi', 'mimo', 'commandcode',
   ]);
 
-  test('ALLOWED_CONFIG_RUNTIMES contains exactly the 17 expected runtimes', () => {
+  test('ALLOWED_CONFIG_RUNTIMES contains exactly the 18 expected runtimes', () => {
     const runtimeSet = new Set(ALLOWED_CONFIG_RUNTIMES);
-    assert.deepStrictEqual(runtimeSet, EXPECTED_17);
+    assert.deepStrictEqual(runtimeSet, EXPECTED_18);
   });
 
   test('every member of ALLOWED_CONFIG_RUNTIMES resolves without throwing', () => {
@@ -227,8 +227,8 @@ describe('ALLOWED_CONFIG_RUNTIMES completeness', () => {
     }
   });
 
-  test('ALLOWED_CONFIG_RUNTIMES has exactly 17 entries', () => {
-    assert.strictEqual([...ALLOWED_CONFIG_RUNTIMES].length, 17);
+  test('ALLOWED_CONFIG_RUNTIMES has exactly 18 entries', () => {
+    assert.strictEqual([...ALLOWED_CONFIG_RUNTIMES].length, 18);
   });
 });
 

--- a/tests/runtime-config-adapter-registry.test.cjs
+++ b/tests/runtime-config-adapter-registry.test.cjs
@@ -210,15 +210,15 @@ describe('resolveRuntimeConfigIntent — fresh object each call', () => {
 // ---------------------------------------------------------------------------
 
 describe('ALLOWED_CONFIG_RUNTIMES completeness', () => {
-  const EXPECTED_16 = new Set([
+  const EXPECTED_17 = new Set([
     'claude', 'gemini', 'antigravity', 'augment', 'qwen', 'hermes', 'codebuddy',
     'opencode', 'kilo', 'codex', 'copilot', 'cline', 'cursor', 'windsurf', 'trae',
-    'kimi',
+    'kimi', 'mimo',
   ]);
 
-  test('ALLOWED_CONFIG_RUNTIMES contains exactly the 16 expected runtimes', () => {
+  test('ALLOWED_CONFIG_RUNTIMES contains exactly the 17 expected runtimes', () => {
     const runtimeSet = new Set(ALLOWED_CONFIG_RUNTIMES);
-    assert.deepStrictEqual(runtimeSet, EXPECTED_16);
+    assert.deepStrictEqual(runtimeSet, EXPECTED_17);
   });
 
   test('every member of ALLOWED_CONFIG_RUNTIMES resolves without throwing', () => {
@@ -227,8 +227,8 @@ describe('ALLOWED_CONFIG_RUNTIMES completeness', () => {
     }
   });
 
-  test('ALLOWED_CONFIG_RUNTIMES has exactly 16 entries', () => {
-    assert.strictEqual([...ALLOWED_CONFIG_RUNTIMES].length, 16);
+  test('ALLOWED_CONFIG_RUNTIMES has exactly 17 entries', () => {
+    assert.strictEqual([...ALLOWED_CONFIG_RUNTIMES].length, 17);
   });
 });
 


### PR DESCRIPTION
## Feature PR

> **Using the wrong template?**
> — Bug fix: use [fix.md](?template=fix.md)
> — Enhancement to existing behavior: use [enhancement.md](?template=enhancement.md)

---

## Linked Issue

Closes #1071

> Implementation was developed on fork branch `feat/mimocode-runtime` and validated locally before this issue was filed. Awaiting `approved-feature` on #1071 per CONTRIBUTING.md.

---

## Feature summary

Adds first-class GSD installer support for **MiMoCode** (`--mimo`) and **Command Code** (`--commandcode`), including capability-registry wiring, flat skills layout, subagent frontmatter conversion (tools record + hex colors), and interactive menu entries.

## What changed

### New files

| File | Purpose |
|------|---------|
| `capabilities/mimo/capability.json` | MiMoCode runtime descriptor (`~/.config/mimocode`, skills, no hooks) |
| `capabilities/commandcode/capability.json` | Command Code runtime descriptor (`~/.commandcode`, skills, no hooks) |
| `tests/mimo-runtime-install.test.cjs` | Directory mapping, menu flags, frontmatter conversion tests |
| `tests/commandcode-runtime-install.test.cjs` | Same for Command Code |
| `.changeset/mimocode-runtime-support.md` | User-facing changelog fragment |

### Modified files

| File | What changed |
|------|-------------|
| `bin/install.js` | `--mimo` / `--commandcode`, agent frontmatter converter, branding/path rewrites, menu options 17–19 |
| `src/runtime-artifact-layout.cts` | Allowlist `mimo`, `commandcode` |
| `src/runtime-config-adapter-registry.cts` | `profile-marker-only` entries for both runtimes |
| `gsd-core/bin/lib/capability-registry.cjs` | Generated registry (via `npm run gen:capability-registry`) |
| `gsd-core/bin/shared/model-catalog.json` | Null-tier model entries |
| `docs/FEATURES.md` | Runtime support list |
| `docs/how-to/install-on-your-runtime.md` | Per-runtime install instructions |
| `.gitignore` | Ignore `.mimocode/`, `.commandcode/` local installs |
| Multiple `tests/*.test.cjs` | Menu, registry, layout, drift guards updated for 18 runtimes |

## Implementation notes

- Command Code reuses `convertClaudeToMimoAgentFrontmatter` via alias — both runtimes share the same subagent schema (`tools:` record, `#RRGGBB` color, `mode: subagent`).
- MiMoCode uses XDG `~/.config/mimocode`; Command Code uses dot-home `~/.commandcode` (matches each CLI's native layout).
- Neither runtime receives hooks or `settings.json` (hooks surface: none).
- Source `agents/*.md` in the repo remain Claude-native; conversion happens only at install time.

## Spec compliance

- [x] `--mimo --global` installs skills/agents under `~/.config/mimocode` with valid frontmatter
- [x] `--mimo --local` installs to `.mimocode/` in cwd
- [x] `--commandcode --global` installs under `~/.commandcode`
- [x] `--commandcode --local` installs to `.commandcode/` in cwd
- [x] Claude `tools:` / `color:` converted; `mcp__*` stripped; `mode: subagent` added
- [x] Both runtimes in `--all`, registry, and drift guards
- [x] No hooks written
- [x] Tests added; docs updated

## Testing

### Test coverage

- `tests/mimo-runtime-install.test.cjs` — `getDirName`, `getGlobalDir`, `parseRuntimeInput('17')`, frontmatter conversion
- `tests/commandcode-runtime-install.test.cjs` — same for option 18 / `--commandcode`
- `tests/multi-runtime-select.test.cjs` — menu option 19 = All, runtime map consistency
- `tests/runtime-config-adapter-registry.test.cjs` — 18 `ALLOWED_CONFIG_RUNTIMES`
- `tests/runtime-artifact-layout-descriptor-drive.test.cjs` — layout golden entries
- `tests/issue-57-runtime-install-no-drift.test.cjs` — registry / `allRuntimes` parity

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Codex
- [ ] Copilot
- [x] Other: MiMoCode — global + local install; `mimo debug agent gsd-planner` passes
- [x] Other: Command Code — global + local install; agent frontmatter verified

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue exactly
- [x] No additional features, commands, or behaviors were added beyond what was approved
- [ ] If scope changed during implementation, I updated the issue spec and received re-approval

---

## Documentation

- [x] Updated the relevant file(s) under `docs/` to reflect this feature
  - `docs/FEATURES.md` — runtime list
  - `docs/how-to/install-on-your-runtime.md` — MiMoCode + Command Code install sections
- [x] All `docs/` content added in this PR is written in English

## Checklist

- [x] Issue linked above with `Closes #1071`
- [ ] Linked issue has the `approved-feature` label — awaiting maintainer triage on #1071
- [x] All acceptance criteria from the issue are met (listed above)
- [x] Implementation scope matches the approved spec exactly
- [x] Focused runtime install tests pass (`node --test tests/mimo-runtime-install.test.cjs tests/commandcode-runtime-install.test.cjs tests/multi-runtime-select.test.cjs`)
- [x] New tests cover the happy path, error cases, and edge cases
- [x] `.changeset/` fragment added
- [x] No unnecessary external dependencies added
- [ ] Works on Windows (backslash paths handled) — not yet verified

## Breaking changes

None

## Screenshots / recordings

N/A — CLI installer only. Example valid MiMoCode agent frontmatter after install:

```yaml
tools:
  read: true
  write: true
  bash: true
color: "#00FF00"
mode: subagent
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1072"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783807846&installation_id=134682257&pr_number=1072&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1072&signature=8695f325aeb3d2828214bbfca38850d12bfb0d433629a90c26d62f1d22cdd418"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->