### PR TITLE
docs(#793): disambiguate Trae IDE vs trae-agent in runtime notes

### DIFF
--- a/src/runtime-artifact-layout.cts
+++ b/src/runtime-artifact-layout.cts
@@ -333,6 +333,7 @@ function convertedCommandsKind(
 //                  (single-level subdir probe of the tap path)
 //     augment    — https://docs.augmentcode.com/cli/skills (flat single-level)
 //     trae       — docs.trae.ai/ide/skills + Trae-AI/TRAE#2253 (flat; nesting errors)
+//                  Trae IDE (trae.ai), not trae-agent — see runtime-homes.cts header note
 //     antigravity— discuss.ai.google.dev/t/more-antigravity-issues/145875 ("will not recursive scan")
 //
 //   FLAT (recursive loader → nesting gives no saving):

--- a/src/runtime-homes.cts
+++ b/src/runtime-homes.cts
@@ -19,6 +19,15 @@
  *             with Kimi selecting the first existing generic skills directory.
  *             ~/.kimi-code/skills is brand-specific and can be selected as a
  *             GSD write target with --config-dir or KIMI_CONFIG_DIR.
+ *   trae    — Targets Trae IDE (trae.ai), the Electron-based IDE — NOT
+ *             trae-agent (github.com/bytedance/trae-agent), a Python CLI that
+ *             uses trae_config.yaml, has no ~/.trae directory, and has no
+ *             skills system. Both are ByteDance "Trae" products; they are
+ *             entirely distinct. The global ~/.trae/skills/ path is
+ *             community-soft-confirmed: docs.trae.ai/ide/skills documents the
+ *             SKILL.md format and project-level .trae/skills/, but does NOT
+ *             publish the global on-disk path; ~/.trae/skills/ rests on
+ *             community evidence incl. Trae-AI/TRAE#2253. Best-effort only.
  */
 
 import os from 'node:os';


### PR DESCRIPTION
## Enhancement PR

## Linked Issue

Closes #793

> The linked issue carries the `approved-enhancement` label.

---

## What this enhancement improves

The Trae runtime's in-code documentation. gsd targets **Trae IDE** (trae.ai, the Electron IDE) for the `trae` runtime, but the code did not record *which* "Trae" product is meant — leaving a trap for future contributors, since ByteDance ships two distinct products under the name: Trae IDE and `trae-agent` (a Python CLI).

## Before / After

**Before:** `src/runtime-homes.cts` had no note disambiguating Trae IDE from `trae-agent`, and the community-soft-confirmed status of the global `~/.trae/skills/` path lived only implicitly in one layout comment.

**After:** The runtime-homes header "Runtime-specific notes" block (the file's established convention, alongside the `hermes`/`cline`/`kimi` notes) now records that the `trae` runtime:
- targets **Trae IDE (trae.ai)** — explicitly **not** `trae-agent` (github.com/bytedance/trae-agent — a Python CLI using `trae_config.yaml`, with no `~/.trae` and no skills system), and
- uses a global `~/.trae/skills/` path that is **community-soft-confirmed** (`docs.trae.ai/ide/skills` documents the SKILL.md format + project-level `.trae/skills/` but not the global on-disk path; `~/.trae/skills/` rests on community evidence incl. `Trae-AI/TRAE#2253`) — best-effort, not officially documented.

A one-line cross-reference was added to the `trae` entry in `src/runtime-artifact-layout.cts` pointing to that header note.

## How it was implemented

Comment-only change to two `.cts` source files. `runtime-homes.cts` is fully data-driven (the actual config home `.trae` / `TRAE_CONFIG_DIR` is declared in `capabilities/trae/capability.json`), so the durable disambiguation lives in the header notes block where the resolver convention documents each runtime. No runtime path, layout, alias, or behavior changes. Compiled output (`bin/lib/*.cjs`) is byte-identical since tsc strips comments.

## Testing

### How I verified the enhancement works

- `npm run build:lib` — compiles clean.
- `npm run lint` — clean.
- `node --test tests/runtime-homes-descriptor-drive.test.cjs tests/runtime-artifact-layout.test.cjs` — 121 tests pass (comment-only, paths unchanged).
- `gsd-test --both` (Mac + Linux Docker) — green.

No new tests — per the issue's acceptance criteria, this is a comment-only change with no behavior to assert.

### Platforms tested

- [x] macOS
- [x] Linux
- [ ] Windows
- [x] N/A (comment-only, not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [x] Other: Trae IDE (documentation only — no path change)
- [x] N/A (not runtime-behavior-specific)

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue — no additions or removals (comment-only, exactly the actionable item from the 2026-06-10 verification; path/hook/alias changes were explicitly out of scope and not made)

---

## Documentation

- [x] If genuinely no user-facing docs impact (infrastructure / internal refactor / test-only), apply the `no-changelog` label — this is an in-code comment with no user-facing behavior; `no-changelog` applied.

## Checklist

- [x] Issue linked above with `Closes #793`
- [x] Linked issue has the `approved-enhancement` label
- [x] Changes are scoped to the approved enhancement
- [x] All existing tests pass
- [x] No new tests required (comment-only — per issue acceptance criteria)
- [x] `no-changelog` label applied (not user-facing)
- [x] No unnecessary dependencies added

## Breaking changes

None. Comment-only; compiled output is unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1083"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783816708&installation_id=134682257&pr_number=1083&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1083&signature=fac832630ca603a8dfd5eb3adf20bc042d711c48155d0378ba5843b48915c7a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->