### PR TITLE
enhance(spec-phase): edge-probe `precision` probe should name tie-breaking / rounding-mode

### DIFF
--- a/.changeset/graceful-zebras-munch.md
+++ b/.changeset/graceful-zebras-munch.md
@@ -1,0 +1,5 @@
+---
+type: Changed
+pr: 1108
+---
+Edge-probe `precision` probe text now names tie-breaking / rounding-mode (half-up vs half-to-even, ceil/floor/truncate), so a surfaced precision edge cues the most common rounding failure mode. Prose-only; firing rule and the 8-category core unchanged.

--- a/docs/how-to/resolve-edge-coverage-findings.md
+++ b/docs/how-to/resolve-edge-coverage-findings.md
@@ -12,7 +12,7 @@ For the category taxonomy and the reasoning behind front-of-pipeline edge analys
 
 Each finding is one **applicable** edge for one requirement — a boundary the probe's relevance filter decided is in scope for that requirement's shape, and that you have not yet addressed. A finding is phrased as a probe question, for example:
 
-> **R3 · precision** — Where can precision loss or overflow occur, and what is the contract?
+> **R3 · precision** — Where can precision loss, overflow, or rounding/tie-breaking occur — and what is the exact contract (e.g. half-up vs half-to-even, ceil/floor/truncate)?
 
 You must resolve each finding into exactly one of four states. Claude presents them as a numbered choice (or an `AskUserQuestion` menu).
 

--- a/gsd-core/references/edge-probe-fixtures/01-round-half-even/expected-coverage.json
+++ b/gsd-core/references/edge-probe-fixtures/01-round-half-even/expected-coverage.json
@@ -1,7 +1,7 @@
 {
   "items": [
     { "requirement_id": "R1", "category": "boundary", "status": "unresolved", "verification": null, "resolution": null, "reason": null, "probe": "What happens exactly at each min/max/threshold — and one step either side?" },
-    { "requirement_id": "R1", "category": "precision", "status": "unresolved", "verification": null, "resolution": null, "reason": null, "probe": "Where can precision loss or overflow occur, and what is the contract?" }
+    { "requirement_id": "R1", "category": "precision", "status": "unresolved", "verification": null, "resolution": null, "reason": null, "probe": "Where can precision loss, overflow, or rounding/tie-breaking occur — and what is the exact contract (e.g. half-up vs half-to-even, ceil/floor/truncate)?" }
   ],
   "coverage": { "applicable": 2, "resolved": 0, "unresolved": 2, "byVerification": { "explicit": 0, "backstop": 0 } }
 }

--- a/gsd-core/references/edge-probe-fixtures/04-money-rounding/expected-coverage.json
+++ b/gsd-core/references/edge-probe-fixtures/04-money-rounding/expected-coverage.json
@@ -1,7 +1,7 @@
 {
   "items": [
     { "requirement_id": "R1", "category": "boundary", "status": "unresolved", "verification": null, "resolution": null, "reason": null, "probe": "What happens exactly at each min/max/threshold — and one step either side?" },
-    { "requirement_id": "R1", "category": "precision", "status": "unresolved", "verification": null, "resolution": null, "reason": null, "probe": "Where can precision loss or overflow occur, and what is the contract?" }
+    { "requirement_id": "R1", "category": "precision", "status": "unresolved", "verification": null, "resolution": null, "reason": null, "probe": "Where can precision loss, overflow, or rounding/tie-breaking occur — and what is the exact contract (e.g. half-up vs half-to-even, ceil/floor/truncate)?" }
   ],
   "coverage": { "applicable": 2, "resolved": 0, "unresolved": 2, "byVerification": { "explicit": 0, "backstop": 0 } }
 }

--- a/gsd-core/references/edge-probe.md
+++ b/gsd-core/references/edge-probe.md
@@ -62,7 +62,7 @@ truncation). Growth happens via optional domain packs, not by bloating the core.
 | empty | Empty / degenerate | collection, text | What is the result for empty, single-element, or null input? |
 | encoding | Encoding / representation | text | Whose definition of length/equality applies — bytes, code points, grapheme clusters, or normalized form? |
 | ordering | Ordering / stability | collection | When elements compare equal, is output order specified and stable? |
-| precision | Precision / overflow | numeric-range | Where can precision loss or overflow occur, and what is the contract? |
+| precision | Precision / overflow | numeric-range | Where can precision loss, overflow, or rounding/tie-breaking occur — and what is the exact contract (e.g. half-up vs half-to-even, ceil/floor/truncate)? |
 | idempotency | Idempotency / repetition | stateful | What happens if this runs twice on the same input? |
 | concurrency | Concurrency / effect ordering | stateful, io | If interrupted or run in parallel, what is guaranteed? |
 
@@ -170,7 +170,7 @@ rule, the requirement classifies as `numeric-range`, which raises `boundary` and
 {
   "items": [
     { "requirement_id": "R1", "category": "boundary", "status": "unresolved", "verification": null, "resolution": null, "reason": null, "probe": "What happens exactly at each min/max/threshold — and one step either side?" },
-    { "requirement_id": "R1", "category": "precision", "status": "unresolved", "verification": null, "resolution": null, "reason": null, "probe": "Where can precision loss or overflow occur, and what is the contract?" }
+    { "requirement_id": "R1", "category": "precision", "status": "unresolved", "verification": null, "resolution": null, "reason": null, "probe": "Where can precision loss, overflow, or rounding/tie-breaking occur — and what is the exact contract (e.g. half-up vs half-to-even, ceil/floor/truncate)?" }
   ],
   "coverage": { "applicable": 2, "resolved": 0, "unresolved": 2, "byVerification": { "explicit": 0, "backstop": 0 } }
 }
@@ -209,7 +209,7 @@ classifies as `numeric-range`, which raises `boundary` and `precision`:
 {
   "items": [
     { "requirement_id": "R1", "category": "boundary", "status": "unresolved", "verification": null, "resolution": null, "reason": null, "probe": "What happens exactly at each min/max/threshold — and one step either side?" },
-    { "requirement_id": "R1", "category": "precision", "status": "unresolved", "verification": null, "resolution": null, "reason": null, "probe": "Where can precision loss or overflow occur, and what is the contract?" }
+    { "requirement_id": "R1", "category": "precision", "status": "unresolved", "verification": null, "resolution": null, "reason": null, "probe": "Where can precision loss, overflow, or rounding/tie-breaking occur — and what is the exact contract (e.g. half-up vs half-to-even, ceil/floor/truncate)?" }
   ],
   "coverage": { "applicable": 2, "resolved": 0, "unresolved": 2, "byVerification": { "explicit": 0, "backstop": 0 } }
 }

--- a/src/edge-probe.cts
+++ b/src/edge-probe.cts
@@ -88,7 +88,7 @@ export const TAXONOMY: TaxonomyEntry[] = [
   { id: 'empty', name: 'Empty / degenerate', shapes: ['collection', 'text'], probe: 'What is the result for empty, single-element, or null input?' },
   { id: 'encoding', name: 'Encoding / representation', shapes: ['text'], probe: 'Whose definition of length/equality applies — bytes, code points, grapheme clusters, or normalized form?' },
   { id: 'ordering', name: 'Ordering / stability', shapes: ['collection'], probe: 'When elements compare equal, is output order specified and stable?' },
-  { id: 'precision', name: 'Precision / overflow', shapes: ['numeric-range'], probe: 'Where can precision loss or overflow occur, and what is the contract?' },
+  { id: 'precision', name: 'Precision / overflow', shapes: ['numeric-range'], probe: 'Where can precision loss, overflow, or rounding/tie-breaking occur — and what is the exact contract (e.g. half-up vs half-to-even, ceil/floor/truncate)?' },
   { id: 'idempotency', name: 'Idempotency / repetition', shapes: ['stateful'], probe: 'What happens if this runs twice on the same input?' },
   { id: 'concurrency', name: 'Concurrency / effect ordering', shapes: ['stateful', 'io'], probe: 'If interrupted or run in parallel, what is guaranteed?' },
 ];


### PR DESCRIPTION
## Enhancement PR

> Sharpens an existing edge-probe taxonomy probe's text — no new command, workflow, category, or concept.

---

## Linked Issue

Closes #1102

> Linked issue carries the `approved-enhancement` label.

---

## What this enhancement improves

The `spec-phase` edge-probe's **`precision`** edge category (`src/edge-probe.cts` `TAXONOMY`). The probe fires correctly on `numeric-range` requirements, but its question text never named the most common real failure mode in that class — **tie-breaking / rounding mode**. This sharpens that one probe string so a surfaced-unresolved precision edge actually cues the omitted rule.

## Before / After

**Before:**
> Where can precision loss or overflow occur, and what is the contract?

**After:**
> Where can precision loss, overflow, or rounding/tie-breaking occur — and what is the exact contract (e.g. half-up vs half-to-even, ceil/floor/truncate)?

Validated by a runnable A/B experiment (n=24, opus/sonnet/haiku × 2 reps × {old,new}): deterministic recall **MISS → HIT** on rounding tasks; downstream honest abstention **83% → 100%** (false-pass 17% → 0%). The entire old-probe failure was the weak tier — **haiku false-pass 50% → 0%**; opus/sonnet already abstained. No category regression (precision still fires only on `numeric-range`).

## How it was implemented

A one-line change to the single `precision` probe string in `src/edge-probe.cts`. Because that string is global (one `TAXONOMY` entry rendered in several surfaces), every rendering is updated **in the same commit** so the doc↔fixture↔machine contract test (`tests/edge-probe-docs-fixtures.test.cjs`) stays green:

- `src/edge-probe.cts` — the `TAXONOMY` `precision` probe text.
- `gsd-core/references/edge-probe.md` — taxonomy table + the two worked-example JSON blocks.
- `gsd-core/references/edge-probe-fixtures/01-round-half-even/expected-coverage.json` and `…/04-money-rounding/expected-coverage.json` — the contract fixtures.
- `docs/how-to/resolve-edge-coverage-findings.md` — the quoted precision example, kept consistent.

> **Scope note:** the approved issue listed `src/edge-probe.cts` + the two fixtures + `edge-probe.md`. Because the probe string also renders in the `edge-probe.md` taxonomy table (not just one example) and in the `resolve-edge-coverage` how-to, those are updated in the same commit purely for rendering consistency — same one-line change, no new behavior. Prose-only: nothing keys on the probe text, and `SHAPE_CUES` (the firing rule) is unchanged.

## Testing

### How I verified the enhancement works
- Rebuilt the generated `edge-probe.cjs` (`npm run build:lib`) and confirmed the CLI emits the new text (byte-identical em dash between source and fixtures, so the golden-fixture byte-match holds).
- `tests/edge-probe*.test.cjs` (incl. the doc↔fixture parity contract) — **82/82**.
- Full suite green (unit + integration, 0 fail); `eslint --max-warnings=0` clean.
- Proved the parity contract is non-vacuous: mutating one fixture's probe text fails `edge-probe-docs-fixtures.test.cjs`; restoring returns it to green.

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [x] N/A (not platform-specific — prose-only change, exercised on all CI legs)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [x] N/A (not runtime-specific — runtime-agnostic reference/taxonomy text)

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue — no additions or removals
- [x] If scope changed during implementation, I updated the issue and got re-approval before continuing — N/A (no scope change; the extra renderings are consistency-only updates of the same one-line string, noted above)

---

## Documentation

- [x] Updated the relevant file(s) under `docs/` to reflect this change (`docs/how-to/resolve-edge-coverage-findings.md` — the quoted precision probe example)
- [x] All `docs/` content added in this PR is written in English
- [ ] If genuinely no user-facing docs impact, apply `no-docs` / `docs-exempt` — N/A (docs updated)

## Checklist

- [x] Issue linked above with `Closes #1102`
- [x] Linked issue has the `approved-enhancement` label
- [x] Changes are scoped to the approved enhancement — nothing extra included
- [x] All existing tests pass (`npm test`)
- [x] New or updated tests cover the enhanced behavior — the doc↔fixture contract fixtures are updated and proven non-vacuous
- [x] `.changeset/` fragment added (`type: Changed`, `pr: 1108`)
- [x] No unnecessary dependencies added

## Breaking changes

None. Same category, same `numeric-range` firing rule, same JSON schema — only the human-facing probe **string** changes (contract-tested against the fixtures, updated in the same commit). Fully backward compatible.
