### PR TITLE
fix(#1103): preserve newline before Plans: header in roadmap.annotate-dependencies

### DIFF
--- a/.changeset/1103-annotate-deps-missing-newline.md
+++ b/.changeset/1103-annotate-deps-missing-newline.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 1111
+---
+**`roadmap annotate-dependencies` no longer fuses the preceding summary line onto the `Plans:` header** — when the match regex's `(?:^|\n)` anchor consumed a leading newline (mid-string match), the replacement dropped it, producing corrupted output like `**Plans:** 3 plansPlans:`. The replacement now re-emits the leading newline when present. (#1103)

--- a/src/roadmap.cts
+++ b/src/roadmap.cts
@@ -730,9 +730,12 @@ function cmdRoadmapAnnotateDependencies(cwd: string, phaseNum: string | null | u
     }
 
     const newListBlock = annotatedLines.join('\n') + '\n';
+    // #1103: when `(?:^|\n)` consumed a leading `\n` (mid-string match), re-emit it
+    // so the line preceding the Plans: header is not fused onto it.
+    const leadingNewline = plansBlockMatch[0].startsWith('\n') ? '\n' : '';
     const newPhaseSection = phaseSection.replace(
       plansBlockMatch[0],
-      plansHeader + newListBlock
+      leadingNewline + plansHeader + newListBlock
     );
 
     const nextContent = content.slice(0, phaseStart) + newPhaseSection + content.slice(phaseEnd);

--- a/tests/bug-3691-annotate-deps-plans-block-variants.test.cjs
+++ b/tests/bug-3691-annotate-deps-plans-block-variants.test.cjs
@@ -387,3 +387,121 @@ describe('review fix F4 — adversarial test gaps', () => {
       'wave assignment must resolve correctly from planData for bare-bold variant');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Bug #1103 — leading newline dropped in replace, fusing adjacent lines
+//
+// On the SUCCESSFUL mutation path, the block matcher anchors with `(?:^|\n)`.
+// On a mid-string match (a `**Plans:** N plans` bold summary line directly above
+// a bare `Plans:` block) `plansBlockMatch[0]` begins with the consumed `\n`. The
+// replacement did not re-emit it, fusing the summary line onto the header →
+// `**Plans:** 3 plansPlans:`. Distinct from #3691's silent-no-op detection bugs;
+// #3691's Bug 1 fix is what let this two-line layout be matched and exposed it.
+// ---------------------------------------------------------------------------
+
+describe('bug #1103 — annotate-dependencies preserves newline before Plans: header', () => {
+  let tmpDir;
+  afterEach(() => cleanup(tmpDir));
+
+  test('bold **Plans:** summary line followed by bare Plans: header are not fused', (_t) => {
+    const roadmap = [
+      '# Roadmap',
+      '',
+      '### Phase 1: Foundation',
+      '',
+      '**Goal:** Set up project',
+      '',
+      '**Plans:** 3 plans',
+      'Plans:',
+      '- [ ] 01-01-PLAN.md — Task A',
+      '- [ ] 01-02-PLAN.md — Task B',
+      '- [ ] 01-03-PLAN.md — Task C',
+      '',
+    ].join('\n');
+
+    tmpDir = makePlanProject({
+      '.planning/ROADMAP.md': roadmap,
+      '.planning/phases/01-foundation/01-01-PLAN.md': makePlan({ phase: '1', plan: '01-01', wave: 1 }),
+      '.planning/phases/01-foundation/01-02-PLAN.md': makePlan({ phase: '1', plan: '01-02', wave: 1 }),
+      '.planning/phases/01-foundation/01-03-PLAN.md': makePlan({ phase: '1', plan: '01-03', wave: 2, dependsOn: ['01-01'] }),
+    });
+
+    const result = runGsdTools('roadmap annotate-dependencies 1', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+    const out = JSON.parse(result.output);
+    assert.strictEqual(out.updated, true, 'annotation must succeed and write back');
+
+    const written = fs.readFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), 'utf-8');
+
+    // Core assertion: the malformed fusion string must NOT appear.
+    assert.ok(
+      !written.includes('plansPlans:'),
+      `ROADMAP must not contain the fused string "plansPlans:"; got:\n${written}`
+    );
+    // The bold summary line must keep its line boundary before Plans:.
+    assert.ok(
+      written.includes('**Plans:** 3 plans\nPlans:'),
+      `**Plans:** 3 plans must be followed by a newline before Plans:; got:\n${written}`
+    );
+    assert.ok(written.includes('Wave'), 'wave annotation must appear in ROADMAP.md');
+  });
+
+  test('inline Plans: header (no bold summary prefix) still annotates after fix', (_t) => {
+    const roadmap = [
+      '# Roadmap',
+      '',
+      '### Phase 1: Foundation',
+      '',
+      'Plans: 2 plans',
+      '- [ ] 01-01-PLAN.md — Task A',
+      '- [ ] 01-02-PLAN.md — Task B',
+      '',
+    ].join('\n');
+
+    tmpDir = makePlanProject({
+      '.planning/ROADMAP.md': roadmap,
+      '.planning/phases/01-foundation/01-01-PLAN.md': makePlan({ phase: '1', plan: '01-01', wave: 1 }),
+      '.planning/phases/01-foundation/01-02-PLAN.md': makePlan({ phase: '1', plan: '01-02', wave: 2, dependsOn: ['01-01'] }),
+    });
+
+    const result = runGsdTools('roadmap annotate-dependencies 1', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+    const out = JSON.parse(result.output);
+    assert.strictEqual(out.updated, true, 'inline Plans: header must still be annotated after fix');
+  });
+
+  test('mid-string Plans: header keeps exact heading→header spacing (no extra newline)', (_t) => {
+    // `phaseSection` always begins with the `### Phase` heading, so the `Plans:`
+    // match is always mid-string and `(?:^|\n)` matches a `\n` (the start-of-string
+    // `^` branch is unreachable through the handler). This guards the inverse of the
+    // bug: the re-emitted newline must restore EXACTLY the one `\n` the regex
+    // consumed — not a doubled blank line and not a fusion.
+    const roadmap = [
+      '### Phase 1: Foundation',
+      '',
+      'Plans:',
+      '- [ ] 01-01-PLAN.md — Task A',
+      '- [ ] 01-02-PLAN.md — Task B',
+      '',
+    ].join('\n');
+
+    tmpDir = makePlanProject({
+      '.planning/ROADMAP.md': roadmap,
+      '.planning/phases/01-foundation/01-01-PLAN.md': makePlan({ phase: '1', plan: '01-01', wave: 1 }),
+      '.planning/phases/01-foundation/01-02-PLAN.md': makePlan({ phase: '1', plan: '01-02', wave: 2, dependsOn: ['01-01'] }),
+    });
+
+    const result = runGsdTools('roadmap annotate-dependencies 1', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+    const out = JSON.parse(result.output);
+    assert.strictEqual(out.updated, true, 'Plans: must still be detected and annotated');
+
+    const written = fs.readFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), 'utf-8');
+    assert.ok(
+      written.includes('### Phase 1: Foundation\n\nPlans:'),
+      `heading→Plans spacing must be preserved exactly; got:\n${written}`
+    );
+    assert.ok(!written.includes('FoundationPlans:'), 'heading must not fuse onto Plans:');
+    assert.ok(!written.includes('Foundation\n\n\nPlans:'), 'no doubled blank line before Plans:');
+  });
+});


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #1103

The linked issue has the `confirmed-bug` label.

---

## What was broken

`roadmap.annotate-dependencies` could emit malformed markdown — `**Plans:** 3 plansPlans:` — by fusing the existing bold plans-summary line onto the inserted `Plans:` header, requiring a manual one-line repair before the ROADMAP would pass `roadmap.analyze` / `roadmap validate`.

## What this fix does

Re-emits the leading newline that the match regex's `(?:^|\n)` anchor consumes on a mid-string match, so the line preceding the `Plans:` header keeps its line boundary.

## Root cause

In `cmdRoadmapAnnotateDependencies` (`src/roadmap.cts`), the block matcher anchors with `(?:^|\n)`. When the `Plans:` block is not at the start of the phase section — the common case, where a `**Plans:** N plans` summary line sits directly above a bare `Plans:` block — the alternation matches a `\n`, so `plansBlockMatch[0]` begins with that newline. The replacement `phaseSection.replace(plansBlockMatch[0], plansHeader + newListBlock)` did not re-emit the consumed newline, so the preceding line fused onto the header. The fix prepends the newline back when `plansBlockMatch[0]` starts with one (the start-of-string `^` path is preserved unchanged).

This is on the successful-mutation path and is distinct from #42 (silent no-op detection of inline/bold/decimal Plans variants); the #3691 work that let this two-line layout be matched is what exposed the previously-unreachable missing-newline bug.

## Testing

### How I verified the fix

Regression cases were added to the owning annotate-dependencies test file `tests/bug-3691-annotate-deps-plans-block-variants.test.cjs` (per the repo's regression-test-naming policy — new `bug-NNNN-*.test.cjs` files are not accepted). They reproduce the bold-summary + bare-`Plans:` two-line layout (fails pre-fix with `**Plans:** 3 plansPlans:`, passes post-fix), plus guard the inline-only variant and exact heading→header spacing. That suite passes 12/12. Full unit suite green; `npm run lint` and `lint-regression-test-names` clean.

### Regression test added?

- [x] Yes — added a test that would have caught this bug

### Platforms tested

- [x] macOS
- [x] N/A (not platform-specific) — pure string transformation, no path handling

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added (`type: Fixed`, #1103)
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1111"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783877150&installation_id=134682257&pr_number=1111&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1111&signature=ad065a820bbbbe719b1ef8d0887a4060cf04c9cc5d73a07edb78eee47849eb69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->