### PR TITLE
fix(#1114): write-profile resolves the active runtime config home for USER-PROFILE.md

### DIFF
--- a/.changeset/1114-write-profile-runtime-home.md
+++ b/.changeset/1114-write-profile-runtime-home.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 1119
+---
+**`write-profile` now writes `USER-PROFILE.md` to the active runtime's config home instead of always `~/.claude`** — under Codex, `gsd-tools query write-profile` wrote `~/.claude/gsd-core/USER-PROFILE.md` while Codex `discuss-phase` advisor-mode (installed under `~/.codex`) checked the Codex home and never found it, so advisor-mode silently stayed disabled. The default output path is now resolved via the runtime-aware `getGlobalConfigDir` (`GSD_RUNTIME` / `config.runtime` → e.g. `~/.codex` for Codex), matching how the runtime's own workflows resolve it — mirroring `generate-dev-preferences`. Claude is unchanged (`~/.claude`); an explicit `--output` still wins. (#1114)

--- a/src/profile-output.cts
+++ b/src/profile-output.cts
@@ -20,7 +20,7 @@ import os from 'node:os';
 import core = require('./core.cjs');
 const { output, error, loadConfig } = core;
 import { platformReadSync as safeReadFile, platformWriteSync, platformEnsureDir } from './shell-command-projection.cjs';
-import { getGlobalSkillDir } from './runtime-homes.cjs';
+import { getGlobalSkillDir, getGlobalConfigDir } from './runtime-homes.cjs';
 import { formatGsdSlash, resolveRuntime } from './runtime-slash.cjs';
 import { resolveRuntimeNameFromCandidates } from './runtime-name-policy.cjs';
 
@@ -729,7 +729,27 @@ function cmdWriteProfile(cwd: string, options: CmdWriteProfileOptions, raw: bool
 
   let outputPath = options.output;
   if (!outputPath) {
-    outputPath = path.join(os.homedir(), '.claude', 'gsd-core', 'USER-PROFILE.md');
+    // #1114: resolve the ACTIVE runtime's config home so the profile is written
+    // where the runtime's own workflows look for it. Previously this hardcoded the
+    // Claude home, so a Codex run wrote the profile under the Claude config dir
+    // while Codex advisor-mode (installed under the Codex home) checked the Codex
+    // dir and never found it. Mirrors cmdGenerateDevPreferences' runtime resolution.
+    let effectiveRuntime = 'claude';
+    try {
+      const config = loadConfig(cwd);
+      effectiveRuntime = resolveRuntimeNameFromCandidates(
+        process.env['GSD_RUNTIME'],
+        config['runtime'],
+        'claude'
+      ) || 'claude';
+    } catch {
+      effectiveRuntime = resolveRuntimeNameFromCandidates(
+        process.env['GSD_RUNTIME'],
+        'claude'
+      ) || 'claude';
+    }
+    // path.join (not a string literal) keeps the cline-install leaked-path lint quiet.
+    outputPath = path.join(getGlobalConfigDir(effectiveRuntime), 'gsd-core', 'USER-PROFILE.md');
   } else if (!path.isAbsolute(outputPath)) {
     outputPath = path.join(cwd, outputPath);
   }

--- a/tests/profile-output.test.cjs
+++ b/tests/profile-output.test.cjs
@@ -117,6 +117,73 @@ describe('write-profile command', () => {
     assert.ok(out.dimensions_scored > 0, 'should have scored dimensions');
   });
 
+  test('#1114: default output resolves the active runtime config home (codex)', () => {
+    const analysis = {
+      profile_version: '1.0',
+      dimensions: { communication_style: { rating: 'terse-direct', confidence: 'HIGH' } },
+    };
+    const analysisPath = path.join(tmpDir, 'analysis.json');
+    const codexHome = path.join(tmpDir, 'codex-home');
+    fs.writeFileSync(analysisPath, JSON.stringify(analysis));
+
+    const result = runGsdTools(
+      ['write-profile', '--input', analysisPath, '--raw'],
+      tmpDir,
+      { CODEX_HOME: codexHome, GSD_RUNTIME: 'codex' }
+    );
+    assert.ok(result.success, `Failed: ${result.error}`);
+    const out = JSON.parse(result.output);
+    // Must land in the Codex home (so Codex advisor-mode finds it), NOT .claude.
+    assert.strictEqual(out.profile_path, path.join(codexHome, 'gsd-core', 'USER-PROFILE.md'));
+    assert.ok(!out.profile_path.includes(`${path.sep}.claude${path.sep}`),
+      `codex profile must not be written under .claude; got ${out.profile_path}`);
+    assert.ok(fs.existsSync(out.profile_path), 'runtime-aware profile should be written to disk');
+  });
+
+  test('#1114: default output is the .claude config home for the claude runtime', () => {
+    const analysis = {
+      profile_version: '1.0',
+      dimensions: { communication_style: { rating: 'terse-direct', confidence: 'HIGH' } },
+    };
+    const analysisPath = path.join(tmpDir, 'analysis.json');
+    fs.writeFileSync(analysisPath, JSON.stringify(analysis));
+
+    // Clear ambient runtime vars so the test is hermetic regardless of the
+    // developer's shell (a stray GSD_RUNTIME/CLAUDE_CONFIG_DIR would redirect it).
+    const result = runGsdTools(['write-profile', '--input', analysisPath, '--raw'], tmpDir,
+      { HOME: tmpDir, GSD_RUNTIME: '', CLAUDE_CONFIG_DIR: '', CODEX_HOME: '' });
+    assert.ok(result.success, `Failed: ${result.error}`);
+    const out = JSON.parse(result.output);
+    // os.homedir() returns HOME verbatim, so assert on the suffix to stay
+    // robust against macOS /var → /private/var symlink normalization.
+    assert.ok(
+      out.profile_path.endsWith(path.join('.claude', 'gsd-core', 'USER-PROFILE.md')),
+      `claude profile must be under .claude/gsd-core; got ${out.profile_path}`
+    );
+    assert.ok(fs.existsSync(out.profile_path), 'profile should be written to disk');
+  });
+
+  test('#1114: config.runtime=codex (no GSD_RUNTIME) also resolves the Codex home', () => {
+    const analysis = {
+      profile_version: '1.0',
+      dimensions: { communication_style: { rating: 'terse-direct', confidence: 'HIGH' } },
+    };
+    const analysisPath = path.join(tmpDir, 'analysis.json');
+    const codexHome = path.join(tmpDir, 'codex-home');
+    fs.writeFileSync(analysisPath, JSON.stringify(analysis));
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'config.json'), JSON.stringify({ runtime: 'codex' }));
+
+    // No GSD_RUNTIME — the runtime must be read from config.runtime.
+    const result = runGsdTools(
+      ['write-profile', '--input', analysisPath, '--raw'],
+      tmpDir,
+      { CODEX_HOME: codexHome, GSD_RUNTIME: '' }
+    );
+    assert.ok(result.success, `Failed: ${result.error}`);
+    const out = JSON.parse(result.output);
+    assert.strictEqual(out.profile_path, path.join(codexHome, 'gsd-core', 'USER-PROFILE.md'));
+  });
+
   test('errors when --input is missing', () => {
     const result = runGsdTools('write-profile --raw', tmpDir);
     assert.ok(!result.success, 'should fail without --input');


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #1114

The linked issue has the `confirmed-bug` label.

---

## What was broken

`gsd-tools query write-profile` always wrote `USER-PROFILE.md` to `~/.claude/gsd-core/`, even under Codex. Codex `discuss-phase` advisor-mode (installed under `~/.codex`) checks the Codex home, so it never saw the generated profile and silently stayed disabled.

## What this fix does

The default output path is now resolved via the runtime-aware `getGlobalConfigDir`, so the profile is written to the **active runtime's** config home (`~/.codex/gsd-core/USER-PROFILE.md` under Codex), matching where that runtime's own workflows look for it.

## Root cause

`cmdWriteProfile` (`src/profile-output.cts`) hardcoded `path.join(os.homedir(), '.claude', 'gsd-core', 'USER-PROFILE.md')` with no runtime detection — unlike `cmdGenerateDevPreferences`, which already resolves the runtime via `resolveRuntimeNameFromCandidates(GSD_RUNTIME, config.runtime, 'claude')`. The fix mirrors that pattern and uses `getGlobalConfigDir(runtime)` to build the path. Only the writer changes — the installed workflow checkers are already runtime-home-aware (the reporter's workaround, copying the profile into `~/.codex`, proves the checker resolves the runtime home).

## Testing

### How I verified the fix

Regression cases added to the `write-profile` block in `tests/profile-output.test.cjs`: default output lands in the Codex home under `GSD_RUNTIME=codex` + `CODEX_HOME` (and explicitly NOT under `.claude`); `config.runtime=codex` (no `GSD_RUNTIME`) resolves the Codex home via the config precedence path; and the Claude default stays under `.claude/gsd-core` (hermetic — ambient runtime vars cleared). The codex case fails pre-fix and passes post-fix; full unit suite green; `npm run lint` and `lint-regression-test-names` clean. An independent Codex adversarial review confirmed the implementation is sound and prompted the hermeticity + config.runtime test additions.

### Regression test added?

- [x] Yes — runtime-home resolution regression tests in the owning test file

### Platforms tested

- [x] macOS
- [x] N/A (not platform-specific) — path resolution via `path.join` / `getGlobalConfigDir`

### Runtimes tested

- [x] Claude Code (default `~/.claude`, unchanged)
- [x] Other: Codex (`~/.codex` via `CODEX_HOME` / descriptor) — the reported case

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added (`type: Fixed`, #1114)
- [x] No unnecessary dependencies added

## Breaking changes

None for Claude. Under non-Claude runtimes the default `USER-PROFILE.md` location now correctly follows the runtime home instead of `~/.claude` — which is the fix. `--output` and an explicit path are unaffected.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1119"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783884853&installation_id=134682257&pr_number=1119&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1119&signature=4bedbe035265c04437d5018402b0e8c8501a69f235b9a6c3a0ff4b303bdab6f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->