### PR TITLE
fix(#1115): capability-probe codex hook-trust bypass flag in /gsd:review; fail loud on empty output

### DIFF
--- a/.changeset/1115-review-codex-flag-capability-probe.md
+++ b/.changeset/1115-review-codex-flag-capability-probe.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 1122
+---
+**`/gsd:review` no longer produces a silent empty Codex review on codex-cli < 0.137** — the `codex exec` invocation passed `--dangerously-bypass-hook-trust` (added in codex 0.137.0) unconditionally and discarded stderr, so on older CLIs codex exited with `unexpected argument` before reading the prompt and the empty output was treated as a completed review. The flag is now capability-probed (`codex exec --help | grep`) and applied via `$CODEX_BYPASS_FLAG` only when supported, codex stderr is captured to a `.err` file instead of `/dev/null`, and an empty Codex output is replaced with a diagnostic so a broken reviewer is surfaced rather than silently skipped. (#1115)

--- a/gsd-core/workflows/review.md
+++ b/gsd-core/workflows/review.md
@@ -223,6 +223,16 @@ CODEX_MODEL=$(gsd_run query config-get review.models.codex 2>/dev/null | jq -r '
 OPENCODE_MODEL=$(gsd_run query config-get review.models.opencode 2>/dev/null | jq -r '.' 2>/dev/null || true)
 # review.models.agy is reserved for future model-pinning support; agy selects its model internally
 AGY_MODEL=$(gsd_run query config-get review.models.agy 2>/dev/null | jq -r '.' 2>/dev/null || true)
+
+# #1115: `--dangerously-bypass-hook-trust` only exists on codex-cli >= 0.137.0.
+# Capability-probe it so older installs don't fail with "unexpected argument"
+# (which, with stderr suppressed, produced a silent empty review). The codex
+# invocation works fine without the flag on older versions.
+if codex exec --help 2>/dev/null | grep -q -- '--dangerously-bypass-hook-trust'; then
+  CODEX_BYPASS_FLAG="--dangerously-bypass-hook-trust"
+else
+  CODEX_BYPASS_FLAG=""
+fi
 ```
 
 For each selected CLI, invoke in sequence (not parallel — avoid rate limits):
@@ -247,10 +257,17 @@ fi
 
 **Codex:**
 ```bash
+# $CODEX_BYPASS_FLAG is capability-gated above (#1115). Capture stderr to a .err
+# file (not /dev/null) so a non-zero exit — e.g. a flag the installed codex-cli
+# does not support — is diagnosable instead of a silent empty review.
 if [ -n "$CODEX_MODEL" ] && [ "$CODEX_MODEL" != "null" ]; then
-  cat /tmp/gsd-review-prompt-{phase}.md | codex exec --ephemeral --dangerously-bypass-hook-trust --model "$CODEX_MODEL" --skip-git-repo-check - 2>/dev/null > /tmp/gsd-review-codex-{phase}.md
+  cat /tmp/gsd-review-prompt-{phase}.md | codex exec --ephemeral $CODEX_BYPASS_FLAG --model "$CODEX_MODEL" --skip-git-repo-check - 2>/tmp/gsd-review-codex-{phase}.err > /tmp/gsd-review-codex-{phase}.md
 else
-  cat /tmp/gsd-review-prompt-{phase}.md | codex exec --ephemeral --dangerously-bypass-hook-trust --skip-git-repo-check - 2>/dev/null > /tmp/gsd-review-codex-{phase}.md
+  cat /tmp/gsd-review-prompt-{phase}.md | codex exec --ephemeral $CODEX_BYPASS_FLAG --skip-git-repo-check - 2>/tmp/gsd-review-codex-{phase}.err > /tmp/gsd-review-codex-{phase}.md
+fi
+if [ ! -s /tmp/gsd-review-codex-{phase}.md ]; then
+  echo "Codex review failed or returned empty output. stderr:" > /tmp/gsd-review-codex-{phase}.md
+  cat /tmp/gsd-review-codex-{phase}.err >> /tmp/gsd-review-codex-{phase}.md
 fi
 ```
 

--- a/tests/enh-773-codex-exec-automation-flags.test.cjs
+++ b/tests/enh-773-codex-exec-automation-flags.test.cjs
@@ -15,10 +15,12 @@ describe('enh-773: automated codex exec invocations include --ephemeral and --da
     'utf8'
   );
 
-  // Extract all codex exec invocation lines from code fences
+  // Extract codex exec INVOCATION lines from code fences. The #1115 capability
+  // probe (`codex exec --help | grep …`) is not an automation invocation, so it
+  // is excluded from the per-invocation flag assertions below.
   const codexExecLines = workflow
     .split('\n')
-    .filter((line) => line.includes('codex exec'));
+    .filter((line) => line.includes('codex exec') && !line.includes('codex exec --help'));
 
   test('review.md contains at least one codex exec invocation', () => {
     assert.ok(
@@ -36,13 +38,44 @@ describe('enh-773: automated codex exec invocations include --ephemeral and --da
     }
   });
 
-  test('every codex exec invocation includes --dangerously-bypass-hook-trust', () => {
+  test('#1115: the hook-trust bypass is capability-gated, not passed unconditionally', () => {
+    // --dangerously-bypass-hook-trust only exists on codex-cli >= 0.137.0. It must
+    // be probed (`codex exec --help | grep`) and applied via $CODEX_BYPASS_FLAG so
+    // older installs do not fail with "unexpected argument" (a silent empty review).
+    assert.ok(
+      /codex exec --help[^\n]*grep[^\n]*--dangerously-bypass-hook-trust/.test(workflow),
+      'review.md must capability-probe --dangerously-bypass-hook-trust via `codex exec --help | grep`'
+    );
+    assert.ok(
+      workflow.includes('CODEX_BYPASS_FLAG="--dangerously-bypass-hook-trust"'),
+      'the probe must set CODEX_BYPASS_FLAG to the flag when the CLI supports it'
+    );
     for (const line of codexExecLines) {
       assert.ok(
-        line.includes('--dangerously-bypass-hook-trust'),
-        `codex exec invocation is missing --dangerously-bypass-hook-trust:\n  ${line.trim()}`
+        line.includes('$CODEX_BYPASS_FLAG'),
+        `codex exec invocation must apply the capability-gated $CODEX_BYPASS_FLAG, not an unconditional flag:\n  ${line.trim()}`
+      );
+      // …and must NOT also pass the literal flag (that would reintroduce #1115).
+      assert.ok(
+        !line.includes('--dangerously-bypass-hook-trust'),
+        `codex exec invocation must not pass the literal --dangerously-bypass-hook-trust (use the gated $CODEX_BYPASS_FLAG):\n  ${line.trim()}`
       );
     }
+  });
+
+  test('#1115: codex review failures are surfaced, not silently swallowed', () => {
+    // stderr must be captured (not discarded to /dev/null) and an empty output
+    // must be replaced with a diagnostic, so a broken reviewer is reported.
+    for (const line of codexExecLines) {
+      assert.ok(
+        !line.includes('2>/dev/null'),
+        `codex exec must not discard stderr to /dev/null:\n  ${line.trim()}`
+      );
+    }
+    assert.ok(
+      /\[ ! -s \/tmp\/gsd-review-codex-\{phase\}\.md \]/.test(workflow),
+      'review.md must guard against an empty codex review output and surface the failure'
+    );
   });
 
   test('--ephemeral appears before the prompt argument (flag ordering)', () => {

--- a/tests/workflow-size-baseline.json
+++ b/tests/workflow-size-baseline.json
@@ -62,7 +62,7 @@
   "remove-phase.md": 8469,
   "remove-workspace.md": 7507,
   "resume-project.md": 15288,
-  "review.md": 37079,
+  "review.md": 38031,
   "scan.md": 7688,
   "secure-phase.md": 12187,
   "session-report.md": 4044,


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #1115

The linked issue has the `confirmed-bug` label.

---

## What was broken

`/gsd:review` produced an **empty Codex review file with no error** on codex-cli < 0.137.0: the `codex exec` invocation in `review.md` passed `--dangerously-bypass-hook-trust` (a 0.137+ flag) unconditionally and discarded stderr, so older CLIs exited `unexpected argument` before reading the prompt and the empty output was treated as a completed review.

## What this fix does

Capability-probes the flag and applies it only when the installed CLI supports it, and surfaces a Codex failure (captured stderr / empty output) instead of swallowing it.

## Root cause

`#773` added `--ephemeral --dangerously-bypass-hook-trust` to the automated Codex wrappers without a version/capability gate, and the Codex block piped stderr to `/dev/null` with no exit-code or empty-output check. The fix:

- **Capability probe** (once, in the reviewer setup): `codex exec --help | grep -q -- '--dangerously-bypass-hook-trust'` → sets `CODEX_BYPASS_FLAG` to the flag (supported) or `""` (unsupported). The invocation uses `$CODEX_BYPASS_FLAG` unquoted, so it degrades to nothing on older CLIs.
- **Fail loud**: codex stderr is redirected to `/tmp/gsd-review-codex-{phase}.err` (not `/dev/null`), and an empty output is replaced with a diagnostic that includes the captured stderr — mirroring the existing Cursor/OpenCode/Qwen guards.

Scoped to Codex (the reported bug). Gemini/Claude/CodeRabbit also suppress stderr but lack the version-incompatible flag, so broader hardening is left as a separate cleanup.

## Testing

### How I verified the fix

Updated the `enh-773` enforcement test (`tests/enh-773-codex-exec-automation-flags.test.cjs`) — which previously *mandated* the unconditional flag — to instead require: the capability probe exists; every Codex invocation applies the gated `$CODEX_BYPASS_FLAG` and does NOT pass the literal flag; stderr is not sent to `/dev/null`; and an empty-output guard is present. `--ephemeral`, `--skip-git-repo-check`, and flag ordering are still enforced. The updated test fails against the original (buggy) `review.md` and passes against the fix. Full unit suite green; `npm run lint`, `lint-regression-test-names`, and the workflow-size baseline pass. An independent Codex adversarial review confirmed the shell change is sound (safe empty-expansion of the unquoted var, probe degradation when codex is absent) and prompted the literal-flag-absent test hardening.

### Regression test added?

- [x] Yes — `enh-773` updated to enforce the capability gate + fail-loud guard

### Platforms tested

- [x] macOS
- [x] Windows (Git Bash) — the reporter's environment; the change is POSIX shell in the workflow contract, no path handling

### Runtimes tested

- [x] Other: Codex (codex-cli) — the reported runtime; probe verified against a local `codex exec --help`

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (enforcement test updated)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added (`type: Fixed`, #1115)
- [x] `tests/workflow-size-baseline.json` updated for review.md growth (+952 B of probe/guard shell)
- [x] No unnecessary dependencies added

## Breaking changes

None. On codex-cli >= 0.137 the flag is still applied (unchanged behavior); on older CLIs it is now omitted instead of causing a silent failure.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1122"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783885523&installation_id=134682257&pr_number=1122&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1122&signature=09bd0f99e4ae8a3905f18f7ece423b227665189087a1b385a9119cf1e233859b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->