### PR TITLE
fix: route nested sub_repos by longest prefix, not first array-order match (#391)

### DIFF
--- a/src/commands.cts
+++ b/src/commands.cts
@@ -621,13 +621,12 @@ function cmdCommit(cwd: string, message: string | undefined, files: string[] | u
 /**
  * Route a list of changed files to their sub-repo prefixes.
  *
- * Bucket sub-repos by their first path segment. Any file that matches a
+ * Bucket sub-repos by their first path segment (#311). Any file that matches a
  * sub-repo prefix must share that sub-repo's first segment, so we only scan
- * the (small) bucket for the file's first segment instead of all sub-repos
- * — O(F + R) expected vs the prior O(F*R) find-in-loop. Candidates stay in
- * sub-repo array order, preserving the original first-match semantics
- * (incl. multi-segment sub-repos like "vendor/pkg", which resolve via the
- * inner startsWith). (#311)
+ * the (small) same-first-segment bucket instead of all sub-repos. Within that
+ * bucket all candidates are scanned to find the longest (most-specific)
+ * matching prefix, so nested sub_repos (e.g. ['packages', 'packages/core'])
+ * route to the deepest match regardless of sub_repos array order (#391).
  *
  * @param files    - changed file paths (relative to project root)
  * @param subRepos - sub-repo path prefixes from config.sub_repos
@@ -644,7 +643,23 @@ function groupFilesBySubrepo(files: string[], subRepos: string[]): GroupFilesByS
   const unmatched: string[] = [];
   for (const file of files) {
     const candidates = reposByFirstSeg.get(file.split('/')[0]);
-    const match = candidates ? candidates.find(repo => file.startsWith(repo + '/')) : undefined;
+    // Select the longest (most-specific) matching sub-repo prefix so nested
+    // sub_repos (e.g. ['packages', 'packages/core']) route correctly regardless
+    // of array order. (#391) String() guards the length read so non-string
+    // entries never throw, matching the tolerance of the prior `.find` path.
+    let match: string | undefined;
+    let matchLen = -1;
+    if (candidates) {
+      for (const repo of candidates) {
+        if (file.startsWith(repo + '/')) {
+          const repoLen = String(repo).length;
+          if (repoLen > matchLen) {
+            match = repo;
+            matchLen = repoLen;
+          }
+        }
+      }
+    }
     if (match) {
       (grouped[match] ||= []).push(file);
     } else {

--- a/tests/commands.test.cjs
+++ b/tests/commands.test.cjs
@@ -1481,13 +1481,50 @@ describe('groupFilesBySubrepo (#311)', () => {
     assert.deepStrictEqual(result.unmatched, ['vendor/other.js']);
   });
 
-  test('first-match-in-array-order wins (not longest-prefix)', () => {
-    // 'app' comes before 'app/sub' in subRepos array; 'app/sub/f.js' matches 'app' first
+  test('longest-prefix wins, not first-match-in-array-order (#391)', () => {
+    // 'app' precedes 'app/sub' in array order, but 'app/sub' is the more specific
+    // configured sub-repo, so 'app/sub/f.js' must route to 'app/sub'.
     const result = groupFilesBySubrepo(
       ['app/sub/f.js'],
       ['app', 'app/sub']
     );
-    assert.deepStrictEqual(result.grouped, { app: ['app/sub/f.js'] });
+    assert.deepStrictEqual(result.grouped, { 'app/sub': ['app/sub/f.js'] });
+    assert.deepStrictEqual(result.unmatched, []);
+  });
+
+  test('longest-prefix selection is independent of sub_repos array order (#391)', () => {
+    // Reverse array order: longest-prefix must still win (no array-order workaround).
+    const result = groupFilesBySubrepo(
+      ['app/sub/f.js'],
+      ['app/sub', 'app']
+    );
+    assert.deepStrictEqual(result.grouped, { 'app/sub': ['app/sub/f.js'] });
+    assert.deepStrictEqual(result.unmatched, []);
+  });
+
+  test('nested sub-repos route by specificity; shallow files stay shallow (#391)', () => {
+    // Exact repro from #391 plus a shallow sibling file under the parent sub-repo.
+    const result = groupFilesBySubrepo(
+      ['packages/core/widget.js', 'packages/util.js'],
+      ['packages', 'packages/core']
+    );
+    assert.deepStrictEqual(result.grouped, {
+      'packages/core': ['packages/core/widget.js'],
+      packages: ['packages/util.js'],
+    });
+    assert.deepStrictEqual(result.unmatched, []);
+  });
+
+  test('three-level nesting routes to the deepest matching prefix (#391)', () => {
+    const result = groupFilesBySubrepo(
+      ['a/b/c/f.js', 'a/b/g.js', 'a/h.js'],
+      ['a', 'a/b', 'a/b/c']
+    );
+    assert.deepStrictEqual(result.grouped, {
+      'a/b/c': ['a/b/c/f.js'],
+      'a/b': ['a/b/g.js'],
+      a: ['a/h.js'],
+    });
     assert.deepStrictEqual(result.unmatched, []);
   });
 
@@ -1523,6 +1560,17 @@ describe('groupFilesBySubrepo (#311)', () => {
     });
     assert.deepStrictEqual(result.grouped, { a: ['a/b'] });
     assert.deepStrictEqual(result.unmatched, ['README.md']);
+  });
+
+  test('non-string entry in a matched bucket does not throw (#391)', () => {
+    // A null sub_repos entry shares the 'null' first-segment bucket with a real
+    // multi-segment entry; longest-prefix selection must not throw reading length.
+    let result;
+    assert.doesNotThrow(() => {
+      result = groupFilesBySubrepo(['null/a/f.js'], [null, 'null/a']);
+    });
+    assert.deepStrictEqual(result.grouped, { 'null/a': ['null/a/f.js'] });
+    assert.deepStrictEqual(result.unmatched, []);
   });
 });
 


### PR DESCRIPTION
Closes #391.

## Problem

`groupFilesBySubrepo` (and therefore `cmdCommitToSubrepo`) routed each changed file to the **first** `sub_repos` array-order entry whose prefix matched, via `candidates.find(repo => file.startsWith(repo + '/'))`. When `sub_repos` entries nest, a file under the more-specific sub-repo was mis-routed to the less-specific parent:

```jsonc
// .planning/config.json
{ "sub_repos": ["packages", "packages/core"] }
```

`packages/core/widget.js` → routed to **`packages`**, not `packages/core`. The only workaround was reversing the array order.

## Decision

Per the maintainer ruling on #391 (**option 1 — longest-prefix wins**): select the **longest (most-specific) matching prefix** within each first-segment bucket, making routing **independent of `sub_repos` array order**.

## Change

- `src/commands.cts` — replace the first-match `.find` with a scan that keeps the longest matching prefix. The `#311` first-segment bucketing is retained, so the scan is over the small same-first-segment bucket, not all sub-repos.
- `String()`-guard the length comparison so non-string `sub_repos` entries still never throw (preserves the tolerance the prior `.find` had; surfaced by adversarial review).
- Update the stale doc comment that claimed "first-match semantics".

## ⚠️ Behavior change (Hyrum's Law)

This **intentionally changes observable routing** for nested/overlapping `sub_repos`. Anyone who relied on array-order priority (incl. the reverse-order workaround) will now get longest-prefix routing. The test that encoded the old contract (`first-match-in-array-order wins`) is **rewritten**, not just deleted, to assert the new contract. Non-overlapping `sub_repos` configs are unaffected.

## Tests (TDD: red → green)

Added to the `groupFilesBySubrepo` block in `tests/commands.test.cjs`:
- longest-prefix wins over earlier array entry (the #391 repro)
- selection is independent of `sub_repos` array order (reverse-order)
- nested route-by-specificity with a shallow sibling staying shallow
- three-level nesting routes to the deepest prefix
- non-string entry in a matched bucket does not throw

All existing `groupFilesBySubrepo` cases (single/multi-segment, no-slash, empty lists, non-string-tolerance) still pass. Owning test file: **118 passing**. `tsc` (`build:lib`) clean, `eslint src/commands.cts` clean.

## Review

Independent adversarial review (Codex, read-only) run on the diff: confirmed the core longest-prefix logic sound (siblings can't collide, ties impossible except duplicates). It flagged the non-string `.length` throw and a stale comment — both fixed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1130"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783888946&installation_id=134682257&pr_number=1130&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1130&signature=8913d514d7e24a8b406b0bc5dfc077dd062102d6bdb09ab9e5b8b0bab8385542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->