### PR TITLE
test(#1139): add phase 6 capstone conformance gate

### DIFF
--- a/.changeset/1139-phase6-capstone-conformance.md
+++ b/.changeset/1139-phase6-capstone-conformance.md
@@ -1,0 +1,8 @@
+---
+"@opengsd/gsd-core": patch
+type: Changed
+issue: 1139
+pr: 1158
+---
+
+Added ADR-857 Phase 6 capstone conformance coverage so migrated Capability activation keys cannot be read directly from host loop workflows, Capability-owned config keys stay out of the central schema, and the host loop workflow size budgets remain documented. The verify-work UI automation preflight now resolves UI activation through the Capability hook registry instead of reading `workflow.ui_phase` directly.

--- a/docs/how-to/develop-a-capability.md
+++ b/docs/how-to/develop-a-capability.md
@@ -225,8 +225,11 @@ Run the smallest affected tests first, then the full suite before opening a read
 ```bash
 node --test tests/capability-registry.test.cjs
 node --test tests/phase6-planning-capabilities.test.cjs
+node --test tests/phase6-capstone-conformance.test.cjs
 npm test
 ```
+
+Run the Phase 6 capstone test whenever a Capability adds a `when` key or moves activation logic in a host workflow. It checks that migrated activation keys are resolved through Capability hooks or state, and that Capability-owned config keys stay out of the central schema. If a host workflow must keep core behaviour behind a `workflow.*` key, document why it is core rather than Capability-owned before adding it.
 
 ## Keep the docs with the slice
 

--- a/gsd-core/workflows/verify-work.md
+++ b/gsd-core/workflows/verify-work.md
@@ -108,16 +108,17 @@ Continue to `create_uat_file`.
 <step name="automated_ui_verification">
 **Automated UI Verification (when Playwright-MCP is available)**
 
-Before running manual UAT, check whether this phase has a UI component and whether
-`mcp__playwright__*` or `mcp__puppeteer__*` tools are available in the current session.
+Before UAT, check UI capability activation and whether Playwright/Puppeteer MCP tools are available.
 
 ```bash
-UI_PHASE_FLAG=$(gsd_run query config-get workflow.ui_phase --raw 2>/dev/null || echo "true")
+PLAN_HOOKS_JSON=$(gsd_run loop render-hooks plan:pre --raw)
 UI_SPEC_FILE=$(ls "${PHASE_DIR}"/*-UI-SPEC.md 2>/dev/null | head -1)
 ```
 
+Set `UI_PHASE_ACTIVE=true` when `PLAN_HOOKS_JSON.activeHooks` contains an active `ui` step hook.
+
 **If Playwright-MCP tools are available in this session (`mcp__playwright__*` tools
-respond to tool calls) AND (`UI_PHASE_FLAG` is `true` OR `UI_SPEC_FILE` is non-empty):**
+respond to tool calls) AND (`UI_PHASE_ACTIVE` is `true` OR `UI_SPEC_FILE` is non-empty):**
 
 For each UI checkpoint listed in the phase's UI-SPEC.md (or inferred from SUMMARY.md):
 

--- a/tests/phase6-capstone-conformance.test.cjs
+++ b/tests/phase6-capstone-conformance.test.cjs
@@ -1,0 +1,108 @@
+// allow-test-rule: source-text-is-the-product
+'use strict';
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.join(__dirname, '..');
+const HOST_LOOP_FILES = [
+  'gsd-core/workflows/plan-phase.md',
+  'gsd-core/workflows/execute-phase.md',
+  'gsd-core/workflows/verify-work.md',
+  'gsd-core/workflows/ship.md',
+];
+
+const CORE_SUBSTRATE_TERMS = [
+  'Verification substrate',
+  'verifier↔predicate contract',
+  'Probe Core Module',
+  'Edge Probe Module',
+];
+
+const registry = require('../gsd-core/bin/lib/capability-registry.cjs');
+const { isCentralConfigKey } = require('../gsd-core/bin/lib/config-schema.cjs');
+
+function readRepoFile(relativePath) {
+  return fs.readFileSync(path.join(ROOT, relativePath), 'utf8');
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function activeWhenKeys() {
+  const keys = new Set();
+  for (const cap of Object.values(registry.capabilities)) {
+    for (const group of ['steps', 'gates', 'contributions']) {
+      for (const hook of cap[group] || []) {
+        if (hook.when) keys.add(hook.when);
+      }
+    }
+  }
+  return [...keys].sort();
+}
+
+describe('ADR-857 Phase 6 capstone conformance (#1139)', () => {
+  test('first-party optional feature capabilities are declared in the generated registry', () => {
+    const expectedFeatureCapabilities = [
+      'ai-integration',
+      'audit',
+      'code-review',
+      'graphify',
+      'intel',
+      'nyquist',
+      'pattern-mapper',
+      'research',
+      'security',
+      'ui',
+    ];
+
+    for (const capId of expectedFeatureCapabilities) {
+      assert.equal(registry.capabilities[capId]?.role, 'feature', `${capId} must be a feature Capability`);
+    }
+  });
+
+  test('core verification substrate is documented as deliberately not capability-owned', () => {
+    const context = readRepoFile('CONTEXT.md');
+    for (const term of CORE_SUBSTRATE_TERMS) {
+      assert.match(context, new RegExp(escapeRegExp(term)), `${term} must be documented in CONTEXT.md`);
+    }
+  });
+
+  test('host loop files do not read capability hook activation keys directly', () => {
+    const forbiddenKeys = activeWhenKeys();
+    assert.ok(forbiddenKeys.length > 0, 'registry must expose hook activation keys');
+
+    for (const relativePath of HOST_LOOP_FILES) {
+      const content = readRepoFile(relativePath);
+      for (const key of forbiddenKeys) {
+        assert.doesNotMatch(
+          content,
+          new RegExp(`\\bconfig-get\\s+${escapeRegExp(key)}\\b`),
+          `${relativePath} must resolve ${key} through Capability hooks/state, not direct config-get`,
+        );
+      }
+    }
+  });
+
+  test('capability-owned config keys are not reintroduced into the central schema', () => {
+    for (const key of Object.keys(registry.configKeys).sort()) {
+      assert.equal(
+        isCentralConfigKey(key),
+        false,
+        `${key} is owned by capability ${registry.configKeys[key]} and must stay out of central config schema`,
+      );
+    }
+  });
+
+  test('host loop workflow files have committed byte budgets', () => {
+    const baseline = JSON.parse(readRepoFile('tests/workflow-size-baseline.json'));
+    for (const relativePath of HOST_LOOP_FILES) {
+      const fileName = path.basename(relativePath);
+      assert.equal(typeof baseline[fileName], 'number', `${fileName} must have a workflow-size baseline`);
+      assert.ok(baseline[fileName] > 0, `${fileName} baseline must be positive`);
+    }
+  });
+});

--- a/tests/workflow-size-baseline.json
+++ b/tests/workflow-size-baseline.json
@@ -86,5 +86,5 @@
   "update.md": 21053,
   "validate-phase.md": 10745,
   "verify-phase.md": 28430,
-  "verify-work.md": 31160
+  "verify-work.md": 31157
 }


### PR DESCRIPTION
## Linked Issue

Closes #1139

## What this enhancement improves

Adds the ADR-857 Phase 6 capstone conformance gate for Capability migration. The gate covers first-party optional feature Capability declarations, direct host-loop activation reads, Capability-owned config-key ownership, workflow byte-budget baselines, and documented core verification substrate.

## Before / After

**Before:**

The remaining capstone checks were implicit: host workflows could reintroduce direct `workflow.*` activation reads or central-schema ownership for Capability-owned config keys without a focused Phase 6 conformance test catching the regression.

**After:**

`tests/phase6-capstone-conformance.test.cjs` fails if Capability hook activation keys are read directly from host loop files, if Capability-owned config keys move back into the central schema, if expected first-party feature Capabilities disappear, or if the host loop files lose committed size baselines. `verify-work.md` now resolves UI activation through rendered Capability hooks instead of direct `workflow.ui_phase` lookup.

## How it was implemented

- Added `tests/phase6-capstone-conformance.test.cjs` for the ADR-857 capstone invariants.
- Updated `gsd-core/workflows/verify-work.md` so UI automation preflight uses `loop render-hooks plan:pre` activation state.
- Ratcheted `tests/workflow-size-baseline.json` after the host workflow shrink.
- Updated `docs/how-to/develop-a-capability.md` with the capstone test in the Capability developer workflow.
- Added `.changeset/1139-phase6-capstone-conformance.md` for the user-facing conformance/debugging change.

## Testing

### How I verified the enhancement works

- RED: `node --test tests/phase6-capstone-conformance.test.cjs` failed before the workflow cleanup on the direct `workflow.ui_phase` read in `verify-work.md`.
- GREEN: `node --test tests/phase6-capstone-conformance.test.cjs`
- `node --test tests/workflow-size-budget.test.cjs tests/phase6-capstone-conformance.test.cjs`
- `npm run lint:docs`
- `npm run lint:changeset`
- `git diff --check`
- `npm run build:lib`
- `node scripts/gen-capability-registry.cjs --check`
- `npm test` — 594 tests passed, 0 failed.

Full-suite warning scan was reviewed. The matches are existing tests and fixtures that intentionally assert warning behavior, not new capstone warnings.

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue — no additions or removals
- [ ] If scope changed during implementation, I updated the issue and got re-approval before continuing

---

## Documentation

- [x] Updated the relevant file(s) under `docs/` to reflect this change
  - Behavior or output change → `docs/USER-GUIDE.md` and/or `docs/COMMANDS.md`
  - Configuration / schema change → `docs/CONFIGURATION.md`
  - Architectural change → `docs/ARCHITECTURE.md` and/or `docs/adr/`
  - Agent or skill change → `docs/AGENTS.md`
- [x] All `docs/` content added in this PR is written in English
- [ ] If genuinely no user-facing docs impact (infrastructure / internal refactor / test-only), apply the `no-docs` label **or** add `<!-- docs-exempt: <reason> -->` inside each triggering changeset fragment and leave a comment explaining why.

## Checklist

- [x] Issue linked above with `Closes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `approved-enhancement` label — **PR will be closed if missing**
- [x] Changes are scoped to the approved enhancement — nothing extra included
- [x] All existing tests pass (`npm test`)
- [x] New or updated tests cover the enhanced behavior
- [x] `.changeset/` fragment added (`npm run changeset -- --type Changed --pr <NNN> --body "..."`) — or `no-changelog` label applied if not user-facing
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1158"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783922733&installation_id=134682257&pr_number=1158&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1158&signature=9e74c33e89b732fb1be97ebad2b20e7254047eb86129db77b0c9ad82bf376574"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->