### PR TITLE
test(#1168): honest phase-6 conformance gate (RED by design) + wire dead ship:pre gate (#1167)

### DIFF
--- a/gsd-core/workflows/ship.md
+++ b/gsd-core/workflows/ship.md
@@ -79,6 +79,32 @@ Verify the work is ready to ship:
    which gh && gh auth status 2>&1
    ```
    If `gh` not found or not authenticated: provide setup instructions and exit.
+
+6. **Security ship gate (capability-driven).**
+
+   Resolve active `ship:pre` gate hooks from the capability registry — the registry evaluates each hook's `when` condition, so do **not** read `workflow.security_enforcement` directly:
+
+   ```bash
+   SHIP_PRE_HOOKS_JSON=$(gsd_run loop render-hooks ship:pre --raw)
+   SECURITY_FILE=$(ls "${PHASE_DIR}"/*-SECURITY.md 2>/dev/null | head -1)
+   ```
+
+   Read the `activeHooks` array from `SHIP_PRE_HOOKS_JSON` in-context (do NOT pipe it through a shell parser).
+
+   If an active entry exists with `kind == "gate"`, `capId == "security"`, and `blocking == true`, enforce its predicate (`SECURITY.md` frontmatter `threats_open == 0`) before shipping:
+
+   - **`SECURITY_FILE` is empty** → block with `SECURITY_SHIP_GATE_NO_REVIEW`:
+     ```
+     ⚠ Security enforcement is enabled but no SECURITY.md exists for this phase.
+     Run /gsd:secure-phase {phase} and resolve findings before shipping.
+     ```
+   - **`SECURITY_FILE` exists** → read its frontmatter `threats_open`. The gate passes **only** when `threats_open` is exactly `0`. For any other value — `threats_open` > 0, or a missing / non-numeric / unparsable field — **fail closed and block** with `SECURITY_SHIP_GATE_OPEN_THREATS` (the predicate is strict equality to `0`; never ship on an ambiguous value):
+     ```
+     ⚠ Security ship gate: SECURITY.md does not assert threats_open == 0 (found: {threats_open|unset}).
+     Resolve open threats (or re-run /gsd:secure-phase {phase}) before shipping.
+     ```
+
+   If no active security `ship:pre` gate hook is present (security enforcement off), skip this check silently.
 </step>
 
 <step name="push_branch">

--- a/tests/phase6-capstone-conformance.test.cjs
+++ b/tests/phase6-capstone-conformance.test.cjs
@@ -106,12 +106,17 @@ describe('ADR-857 Phase 6 capstone conformance (#1139)', () => {
     }
   });
 
-  test('every declared capability hook point has a render-hooks call site in the host loop (#1169)', () => {
-    // Points whose host call site is intentionally not yet wired, mapped to the
-    // issue tracking the gap. execute:wave:post (ui.gates / ui_safety_gate) also
-    // needs its `ui.safety-gate` check implemented before it can be wired — #1169.
-    const KNOWN_UNWIRED = { 'execute:wave:post': '#1169' };
+  // ─── Phase-6 conformance: RED BY DESIGN until phase 6 is actually complete ──────
+  //
+  // #1139 closed (via #1158) with a green "capstone conformance gate" while the
+  // ADR-857 phase-6 acceptance criteria were unmet — a false green. The three
+  // tests below assert the real criteria with NO paper-over allowlist, so the
+  // gate stays RED until the work lands. Green here must mean "phase 6 conformant,"
+  // not "no new regression." Fixes tracked in #1167 / #1168 / #1169.
 
+  test('every declared capability hook point has a render-hooks call site in the host loop (#1168)', () => {
+    // No allowlist: every point a capability declares a hook at MUST have a
+    // `render-hooks` call site in the host loop, or those hooks can never fire.
     const declaredPoints = new Set();
     for (const cap of Object.values(registry.capabilities)) {
       for (const group of ['steps', 'gates', 'contributions']) {
@@ -121,8 +126,8 @@ describe('ADR-857 Phase 6 capstone conformance (#1139)', () => {
       }
     }
 
-    // Scan only the host loop files (not every workflow): a `render-hooks`
-    // mention in a non-host workflow must not mask a lost host call site.
+    // Scan only the host loop files (a `render-hooks` mention in a non-host
+    // workflow must not mask a lost host call site).
     const callSites = new Set();
     const reCall = /loop render-hooks\s+([a-z:]+)/g;
     for (const relativePath of HOST_LOOP_FILES) {
@@ -131,18 +136,48 @@ describe('ADR-857 Phase 6 capstone conformance (#1139)', () => {
       while ((m = reCall.exec(content))) callSites.add(m[1]);
     }
 
-    for (const point of [...declaredPoints].sort()) {
-      if (point in KNOWN_UNWIRED) {
-        assert.ok(
-          !callSites.has(point),
-          `${point} is listed in KNOWN_UNWIRED (${KNOWN_UNWIRED[point]}) but now HAS a render-hooks call site — remove it from the allowlist.`,
-        );
-        continue;
+    const orphaned = [...declaredPoints].sort().filter((p) => !callSites.has(p));
+    assert.deepEqual(
+      orphaned, [],
+      `ADR-857 phase 6 is NOT complete: capability hooks declare these extension points ` +
+      `but no host-loop workflow calls \`gsd_run loop render-hooks <point>\`, so the hooks ` +
+      `can never fire: ${orphaned.join(', ')}. Wire each call site (#1167/#1169).`,
+    );
+  });
+
+  test('all ADR-857-named optional features are migrated to Capabilities (#1169)', () => {
+    // ADR-857 §53 + Decision 7 enumerate these optional, non-loop modules as
+    // Capabilities. Until each is a registered feature capability (or documented
+    // as core substrate), phase 6 is incomplete and the capstone is a false green.
+    const REQUIRED = ['tdd', 'schema-gate', 'drift', 'gap-analysis', 'profile-pipeline'];
+    const unmigrated = REQUIRED.filter((id) => registry.capabilities[id]?.role !== 'feature');
+    assert.deepEqual(
+      unmigrated, [],
+      `ADR-857 phase 6 is NOT complete: these ADR-named optional features are not yet ` +
+      `feature Capabilities (still inline in plan-phase.md / execute-phase.md): ` +
+      `${unmigrated.join(', ')}. Migrate each, or document it as core substrate (#1169).`,
+    );
+  });
+
+  test('host loop reads no capability-owned config key inline (#1169)', () => {
+    // Phase 6 requires the loop to resolve capability behavior via render-hooks,
+    // not by reading capability-owned keys directly. Any inline `config-get` of a
+    // registry-owned key is an incomplete migration (the loop still owns the
+    // feature's params).
+    const leaks = [];
+    for (const relativePath of HOST_LOOP_FILES) {
+      const content = readRepoFile(relativePath);
+      for (const key of Object.keys(registry.configKeys)) {
+        if (new RegExp(`\\bconfig-get\\s+${escapeRegExp(key)}\\b`).test(content)) {
+          leaks.push(`${path.basename(relativePath)} → ${key} (owned by ${registry.configKeys[key]})`);
+        }
       }
-      assert.ok(
-        callSites.has(point),
-        `Capability hooks declare point "${point}" but no workflow calls \`gsd_run loop render-hooks ${point}\` — hooks at that point can never fire (#1169). Wire a call site or add the point to KNOWN_UNWIRED with its tracking issue.`,
-      );
     }
+    leaks.sort();
+    assert.deepEqual(
+      leaks, [],
+      `ADR-857 phase 6 is NOT complete: the host loop reads capability-owned config keys ` +
+      `inline:\n  ${leaks.join('\n  ')}\nThe owning capability must render/consume these (#1169).`,
+    );
   });
 });

--- a/tests/phase6-capstone-conformance.test.cjs
+++ b/tests/phase6-capstone-conformance.test.cjs
@@ -105,4 +105,44 @@ describe('ADR-857 Phase 6 capstone conformance (#1139)', () => {
       assert.ok(baseline[fileName] > 0, `${fileName} baseline must be positive`);
     }
   });
+
+  test('every declared capability hook point has a render-hooks call site in the host loop (#1169)', () => {
+    // Points whose host call site is intentionally not yet wired, mapped to the
+    // issue tracking the gap. execute:wave:post (ui.gates / ui_safety_gate) also
+    // needs its `ui.safety-gate` check implemented before it can be wired — #1169.
+    const KNOWN_UNWIRED = { 'execute:wave:post': '#1169' };
+
+    const declaredPoints = new Set();
+    for (const cap of Object.values(registry.capabilities)) {
+      for (const group of ['steps', 'gates', 'contributions']) {
+        for (const hook of cap[group] || []) {
+          if (hook.point) declaredPoints.add(hook.point);
+        }
+      }
+    }
+
+    // Scan only the host loop files (not every workflow): a `render-hooks`
+    // mention in a non-host workflow must not mask a lost host call site.
+    const callSites = new Set();
+    const reCall = /loop render-hooks\s+([a-z:]+)/g;
+    for (const relativePath of HOST_LOOP_FILES) {
+      const content = readRepoFile(relativePath);
+      let m;
+      while ((m = reCall.exec(content))) callSites.add(m[1]);
+    }
+
+    for (const point of [...declaredPoints].sort()) {
+      if (point in KNOWN_UNWIRED) {
+        assert.ok(
+          !callSites.has(point),
+          `${point} is listed in KNOWN_UNWIRED (${KNOWN_UNWIRED[point]}) but now HAS a render-hooks call site — remove it from the allowlist.`,
+        );
+        continue;
+      }
+      assert.ok(
+        callSites.has(point),
+        `Capability hooks declare point "${point}" but no workflow calls \`gsd_run loop render-hooks ${point}\` — hooks at that point can never fire (#1169). Wire a call site or add the point to KNOWN_UNWIRED with its tracking issue.`,
+      );
+    }
+  });
 });

--- a/tests/workflow-size-baseline.json
+++ b/tests/workflow-size-baseline.json
@@ -69,7 +69,7 @@
   "settings-advanced.md": 39621,
   "settings-integrations.md": 15801,
   "settings.md": 32133,
-  "ship.md": 20896,
+  "ship.md": 22534,
   "sketch-wrap-up.md": 14223,
   "sketch.md": 19960,
   "spec-phase.md": 23094,


### PR DESCRIPTION
## Phase-6 honesty enforcement (RED by design) + dead `ship:pre` gate wired

> ⚠️ **This PR intentionally lands a failing CI gate.** Maintainer-authorized admin-merge — the red *is* the deliverable. It does **not** close the phase-6 issues; they stay open as the work to do.

### Background

The ADR-857 "phase 6 capstone conformance gate" (#1139 / #1158) was merged green and #1139 closed, signaling phase-6 conformance. An audit proved that false — the gate could not detect the incompleteness it claimed to guard (a false green). See #1139, #1167.

### What this PR does

1. **`feat(#1169)` — wires the dead `security.gates@ship:pre`** capability gate into `ship.md` via `render-hooks` (fail-closed: ship blocks unless `SECURITY.md.threats_open == 0`). A real down-payment on the migration.
2. **`test(#1168)` — makes the conformance gate honest.** It now asserts the real ADR-857 acceptance criteria with **no paper-over allowlist**, so green means *"phase 6 conformant,"* not *"no new regression."*

### Why CI is red (intentional)

`tests/phase6-capstone-conformance.test.cjs` → **5 pass / 3 fail by design**:

- ❌ orphaned hook point with no `render-hooks` call site: `execute:wave:post`
- ❌ ADR-named optional features not migrated: `tdd`, `schema-gate`, `drift`, `gap-analysis`, `profile-pipeline`
- ❌ capability-owned config keys read inline by the loop: `intel.enabled`, `security_asvs_level`, `security_block_on`

The red is the forcing function: `next` CI stays red until phase 6 is genuinely complete and the gate goes green on its own merits.

Refs #1139, #1167, #1168, #1169.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1174"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783955362&installation_id=134682257&pr_number=1174&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1174&signature=401560680f98cb3a3293dffecf530c8a96003241bcbaefee8f146876cdd918ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->