### PR TITLE
fix(#1145): implement query user-story.validate handler

### DIFF
--- a/.changeset/brave-lions-revolt.md
+++ b/.changeset/brave-lions-revolt.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 1193
 ---
-**`query user-story.validate` now works** — `mvp-phase` and `verify-work` workflows both invoked this command to validate "As a / I want to / so that" user stories, but no CJS handler existed; every call errored with "Unknown command: user-story". (#0)
+**`query user-story.validate` now works** — `mvp-phase` and `verify-work` workflows both invoked this command to validate "As a / I want to / so that" user stories, but no CJS handler existed; every call errored with "Unknown command: user-story". (#1193)

--- a/.changeset/brave-lions-revolt.md
+++ b/.changeset/brave-lions-revolt.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`query user-story.validate` now works** — `mvp-phase` and `verify-work` workflows both invoked this command to validate "As a / I want to / so that" user stories, but no CJS handler existed; every call errored with "Unknown command: user-story". (#0)

--- a/gsd-core/bin/gsd-tools.cjs
+++ b/gsd-core/bin/gsd-tools.cjs
@@ -58,6 +58,11 @@
  *     [--name <name>]
  *     [--archive-phases]               Move phase dirs to milestones/vX.Y-phases/
  *
+ * User Story Validation:
+ *   user-story validate --story "..."  Validate "As a / I want to / so that" format
+ *                                      Returns JSON { valid, errors[], slots: {role,capability,outcome} | null }
+ *                                      --pick valid  Emit bare boolean (for workflow boolean checks)
+ *
  * Validation:
  *   validate consistency               Check phase numbering, disk/roadmap sync
  *   validate health [--repair]         Check .planning/ integrity, optionally repair
@@ -508,7 +513,7 @@ async function main() {
     'generate-dev-preferences, generate-slug, graphify, history-digest, init, intel, ' +
     'capability, classify-confidence, learnings, list-todos, loop, milestone, package-legitimacy, phase, phase-plan-index, phases, profile-questionnaire, ' +
     'profile-sample, progress, prompt-budget, requirements, research-plan, research-store, resolve-granularity, resolve-model, roadmap, scaffold, state, ' +
-    'task, template, validate, verify, verify-path-exists, verify-summary, workstream, worktree\n\n' +
+    'task, template, user-story, validate, verify, verify-path-exists, verify-summary, workstream, worktree\n\n' +
     'Global flags:\n' +
     '  --raw              Emit raw output without post-processing\n' +
     '  --pick <field>     Extract a single field from JSON output (dot/bracket notation)\n' +
@@ -557,6 +562,7 @@ async function main() {
     'verify-summary', 'template', 'frontmatter', 'detect-custom-files',
     'worktree', 'prompt-budget',
     'research-store', 'research-plan', 'package-legitimacy', 'classify-confidence',
+    'user-story', // pure string validation — no .planning/ access needed
   ]);
   if (!SKIP_ROOT_RESOLUTION.has(command)) {
     cwd = findProjectRoot(cwd);
@@ -1923,6 +1929,76 @@ async function runCommand(command, args, cwd, raw, defaultValue, originalCommand
       } else {
         error('Unknown effort subcommand. Available: sync', ERROR_REASON.SDK_UNKNOWN_COMMAND);
       }
+      break;
+    }
+
+    // ─── User Story Validation (bug #1145) ────────────────────────────────────
+    //
+    // Invocation shapes (from mvp-phase.md and verify-work.md):
+    //   gsd_run query user-story.validate --story "$USER_STORY"
+    //   gsd_run query user-story.validate --story "$PHASE_GOAL" --pick valid
+    //
+    // Returns JSON: { valid: boolean, errors: string[], slots: { role, capability, outcome } | null }
+    //   - valid: true only when the story fully matches the canonical format
+    //   - errors: per-slot diagnostic strings (empty on success)
+    //   - slots: extracted role/capability/outcome on success; null on failure
+    //
+    // Canonical format (user-story-template.md):
+    //   "As a [user role], I want to [capability], so that [outcome]."
+    //   Each slot must be non-empty and contain non-whitespace content.
+    //
+    // No .planning/ access needed — pure string validation.
+    case 'user-story': {
+      const subcommand = args[1];
+      if (subcommand !== 'validate') {
+        error(`Unknown user-story subcommand: ${subcommand || '(none)'}. Available: validate`, ERROR_REASON.SDK_UNKNOWN_COMMAND);
+        break;
+      }
+
+      const storyIdx = args.indexOf('--story');
+      const story = (storyIdx !== -1 && args[storyIdx + 1] && !args[storyIdx + 1].startsWith('--'))
+        ? args[storyIdx + 1]
+        : '';
+
+      // Canonical extraction regex — requires non-whitespace content in each slot
+      // (\S.*? ensures the slot isn't whitespace-only).
+      // Named groups: role / capability / outcome.
+      const USER_STORY_RE = /^As a (\S.*?), I want to (\S.*?), so that (\S.*?)\.$/;
+
+      const errors = [];
+      const trimmed = story.trim();
+      let slots = null;
+
+      if (!trimmed) {
+        errors.push('Story is empty. Required format: "As a [role], I want to [capability], so that [outcome]."');
+      } else {
+        // Per-clause guards produce targeted, actionable error messages before
+        // attempting the full regex. Guards are ordered: role → capability → outcome → period.
+        if (!/^As a \S/i.test(trimmed)) {
+          errors.push('Story must start with "As a [user role]," (role must be non-empty).');
+        }
+        if (!/, I want to \S/i.test(trimmed)) {
+          errors.push('Story must include ", I want to [capability]," (capability must be non-empty).');
+        }
+        if (!/, so that \S/i.test(trimmed)) {
+          errors.push('Story must include ", so that [outcome]." (outcome must be non-empty).');
+        }
+        if (!trimmed.endsWith('.')) {
+          errors.push('Story must end with a period (.).');
+        }
+        // Full-regex check only when per-clause guards all passed — avoids
+        // redundant "format mismatch" noise on top of specific error messages.
+        if (errors.length === 0) {
+          const m = USER_STORY_RE.exec(trimmed);
+          if (!m) {
+            errors.push('Story does not match the canonical format: "As a [role], I want to [capability], so that [outcome]."');
+          } else {
+            slots = { role: m[1], capability: m[2], outcome: m[3] };
+          }
+        }
+      }
+
+      core.output({ valid: errors.length === 0, errors, slots }, raw);
       break;
     }
 

--- a/tests/commands.test.cjs
+++ b/tests/commands.test.cjs
@@ -2223,3 +2223,145 @@ describe('_wsParseRetryAfter (#308)', () => {
     assert.strictEqual(_wsParseRetryAfter(null), null);
   });
 });
+
+// ─── Regressions: bug #1145 — query user-story.validate phantom command ────
+//
+// `query user-story.validate` was invoked by mvp-phase.md and verify-work.md
+// but had no CJS handler (phantom command). Every invocation errored with
+// "Unknown command: user-story — did you mean: user-story validate?".
+//
+// Calls the CLI via runGsdTools; no readFileSync source-grep.
+
+describe('user-story validate command (bug #1145)', () => {
+  // Helper: call `query user-story.validate --story <story>` and parse JSON.
+  function validateStory(story) {
+    const result = runGsdTools(['query', 'user-story.validate', '--story', story]);
+    assert.equal(result.success, true, `user-story.validate exited non-zero: ${result.error || result.output}`);
+    let parsed;
+    try { parsed = JSON.parse(result.output); } catch {
+      assert.fail(`output was not valid JSON: ${result.output}`);
+    }
+    return parsed;
+  }
+
+  // Helper: call with --pick valid, return trimmed output string.
+  function validateStoryPickValid(story) {
+    const result = runGsdTools(['query', 'user-story.validate', '--story', story, '--pick', 'valid']);
+    assert.equal(result.success, true, `user-story.validate --pick valid exited non-zero: ${result.error || result.output}`);
+    return result.output.trim();
+  }
+
+  test('command is reachable — not a phantom (negative proof of bug #1145)', () => {
+    // Before the fix: exit 1 with "Unknown command: user-story"
+    const result = runGsdTools(['query', 'user-story.validate', '--story', 'As a user, I want to log in, so that I can access my account.']);
+    assert.equal(result.success, true, `Expected exit 0 but got: ${result.error || result.output}`);
+  });
+
+  test('canonical well-formed story returns { valid: true, errors: [], slots }', () => {
+    const out = validateStory('As a new user, I want to register and log in, so that I can access my account.');
+    assert.equal(typeof out, 'object');
+    assert.equal(out.valid, true, `expected valid:true, got: ${JSON.stringify(out)}`);
+    assert.ok(!out.errors || out.errors.length === 0, `unexpected errors: ${JSON.stringify(out.errors)}`);
+    // Slot extraction (see verify-work.md: "returns slot extractions")
+    assert.ok(out.slots && typeof out.slots === 'object', `expected slots object, got: ${JSON.stringify(out.slots)}`);
+    assert.equal(out.slots.role, 'new user');
+    assert.equal(out.slots.capability, 'register and log in');
+    assert.equal(out.slots.outcome, 'I can access my account');
+  });
+
+  test('whitespace-only role slot returns { valid: false } (Codex finding: .+ accepted spaces)', () => {
+    // "As a  ," — role is whitespace-only; must be rejected
+    const out = validateStory('As a  , I want to build reports, so that I can share status.');
+    assert.equal(out.valid, false, `whitespace role must be invalid: ${JSON.stringify(out)}`);
+    assert.ok(Array.isArray(out.errors) && out.errors.length > 0);
+    assert.equal(out.slots, null, 'slots must be null on invalid story');
+  });
+
+  test('whitespace-only capability slot returns { valid: false }', () => {
+    // ", I want to  ," — capability is whitespace-only
+    const out = validateStory('As a user, I want to  , so that I can share status.');
+    assert.equal(out.valid, false, `whitespace capability must be invalid: ${JSON.stringify(out)}`);
+    assert.ok(Array.isArray(out.errors) && out.errors.length > 0);
+  });
+
+  test('whitespace-only outcome slot returns { valid: false }', () => {
+    // ", so that  ." — outcome is whitespace-only
+    const out = validateStory('As a user, I want to build reports, so that  .');
+    assert.equal(out.valid, false, `whitespace outcome must be invalid: ${JSON.stringify(out)}`);
+    assert.ok(Array.isArray(out.errors) && out.errors.length > 0);
+  });
+
+  test('empty string returns { valid: false } with non-empty errors array', () => {
+    const out = validateStory('');
+    assert.equal(out.valid, false);
+    assert.ok(Array.isArray(out.errors) && out.errors.length > 0);
+  });
+
+  test('story missing "As a" prefix returns { valid: false }', () => {
+    const out = validateStory('I want to register so that I can log in.');
+    assert.equal(out.valid, false);
+    assert.ok(Array.isArray(out.errors) && out.errors.length > 0);
+  });
+
+  test('story missing ", I want to" clause returns { valid: false }', () => {
+    const out = validateStory('As a user, so that I can log in.');
+    assert.equal(out.valid, false);
+    assert.ok(Array.isArray(out.errors) && out.errors.length > 0);
+  });
+
+  test('story missing ", so that" clause returns { valid: false }', () => {
+    const out = validateStory('As a user, I want to register and log in.');
+    assert.equal(out.valid, false);
+    assert.ok(Array.isArray(out.errors) && out.errors.length > 0);
+  });
+
+  test('story missing trailing period returns { valid: false }', () => {
+    const out = validateStory('As a user, I want to register, so that I can log in');
+    assert.equal(out.valid, false);
+    assert.ok(Array.isArray(out.errors) && out.errors.length > 0);
+  });
+
+  test('whitespace-only story returns { valid: false }', () => {
+    const out = validateStory('   ');
+    assert.equal(out.valid, false);
+    assert.ok(Array.isArray(out.errors) && out.errors.length > 0);
+  });
+
+  test('--pick valid returns bare "true" for valid story (verify-work.md call shape)', () => {
+    const out = validateStoryPickValid('As a developer, I want to run tests, so that I can catch regressions.');
+    assert.equal(out, 'true', `expected bare "true" but got: ${JSON.stringify(out)}`);
+  });
+
+  test('--pick valid returns bare "false" for invalid story (verify-work.md call shape)', () => {
+    const out = validateStoryPickValid('Not a user story at all.');
+    assert.equal(out, 'false', `expected bare "false" but got: ${JSON.stringify(out)}`);
+  });
+
+  test('mvp-phase.md call shape: result has .valid boolean, .errors array, and .slots', () => {
+    // gsd_run query user-story.validate --story "$USER_STORY"
+    // mvp-phase.md uses: jq -r '.valid' and jq -r '.errors[]'
+    const out = validateStory('As a product manager, I want to export reports, so that I can share progress with stakeholders.');
+    assert.ok(Object.prototype.hasOwnProperty.call(out, 'valid'), 'missing "valid" field');
+    assert.ok(Object.prototype.hasOwnProperty.call(out, 'errors'), 'missing "errors" field');
+    assert.ok(Object.prototype.hasOwnProperty.call(out, 'slots'), 'missing "slots" field');
+    assert.equal(typeof out.valid, 'boolean');
+    assert.ok(Array.isArray(out.errors));
+    // slots is object on success, null on failure
+    assert.equal(out.valid, true);
+    assert.equal(typeof out.slots, 'object');
+    assert.notEqual(out.slots, null);
+  });
+
+  test('dotted-form (user-story.validate) works identically to spaced form', () => {
+    // Canonical dotted invocation used by workflows
+    const result = runGsdTools(['query', 'user-story.validate', '--story', 'As a user, I want to log in, so that I can see my dashboard.']);
+    assert.equal(result.success, true, `dotted form failed: ${result.error}`);
+    const out = JSON.parse(result.output);
+    assert.equal(out.valid, true);
+  });
+
+  test('boundary — minimal valid story passes', () => {
+    const out = validateStory('As a X, I want to Y, so that Z.');
+    assert.equal(out.valid, true, `minimal valid story should pass: ${JSON.stringify(out)}`);
+  });
+});


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #1145

---

## What was broken

`query user-story.validate` was a phantom command: both `mvp-phase.md` (line 102) and `verify-work.md` (line 170) call it to validate "As a / I want to / so that" user stories, but no CJS handler existed. Every invocation exited with `Error: Unknown command: user-story — did you mean: "user-story validate"?` (the suggestion itself was also dead), breaking the MVP mode flow and the user-story format guard in verify-work.

## What this fix does

Implements a `case 'user-story':` handler directly in `gsd-core/bin/gsd-tools.cjs` (following the same pattern as the #1140 fix in PR #1148). The handler:

- Validates "As a [role], I want to [capability], so that [outcome]." format
- Requires non-whitespace content in each slot (not just structural keywords)
- Returns `{ valid: boolean, errors: string[], slots: { role, capability, outcome } | null }`
- `--pick valid` emits a bare `true`/`false` string (used by verify-work.md)
- Added `user-story` to `SKIP_ROOT_RESOLUTION` (pure string validation — no `.planning/` access)

## Root cause

The command was documented and invoked by workflows but never implemented in CJS after the SDK retirement (ADR-0174). The dotted-form dispatcher routes `query user-story.validate` → strips `query` prefix → splits on `.` → `command='user-story'`, which fell through to the `default:` case with no registered capability handler.

## Testing

### How I verified the fix

- Confirmed bug reproduction: `node gsd-core/bin/gsd-tools.cjs query user-story.validate --story "..."` → exit 1 "Unknown command: user-story" before fix
- Both exact workflow call shapes verified working after fix:
  - `query user-story.validate --story "$USER_STORY"` → JSON with `.valid`, `.errors`, `.slots`
  - `query user-story.validate --story "$PHASE_GOAL" --pick valid` → bare `"true"` or `"false"`
- Adversarial Codex review identified high-severity issue (whitespace-only slots passing as valid); fixed by using `\S` anchors in per-clause guards and extraction regex

### Regression test added?

- [x] Yes — added a test that would have caught this bug

Tests added to `tests/commands.test.cjs` (in a `describe('user-story validate command (bug #1145)')` block) covering: command reachability, valid story, whitespace-only slots (per Codex finding), each missing clause, missing period, whitespace-only input, `--pick valid` bare boolean output, mvp-phase.md and verify-work.md exact call shapes, slot extraction, dotted-form, minimal boundary case.

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None — `{ valid, errors }` shape is extended with `slots` (additive). All existing consumers only read `.valid` and `.errors[]`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1193"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783997470&installation_id=134682257&pr_number=1193&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1193&signature=b579f624abed1180a6c11e0085e40c25b4773339e11a5b9a4234d0ae1ab894fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->