### PR TITLE
fix: reduce workflow verification noise

### DIFF
--- a/src/roadmap-parser.cts
+++ b/src/roadmap-parser.cts
@@ -29,6 +29,31 @@ import { platformReadSync } from './shell-command-projection.cjs';
 
 // ─── Roadmap milestone scoping ───────────────────────────────────────────────
 
+function readPhaseIdConvention(cwd: string, roadmapContent: string): string | null {
+  const configPath = path.join(planningDir(cwd), 'config.json');
+  const configRaw = platformReadSync(configPath);
+  if (configRaw !== null) {
+    try {
+      const config = JSON.parse(configRaw) as Record<string, unknown>;
+      const value = config['phase_id_convention'];
+      return typeof value === 'string' && value.trim() ? value.trim() : null;
+    } catch {
+      return null;
+    }
+  }
+
+  const fmMatch = roadmapContent.match(/^---\r?\n([\s\S]+?)\r?\n---/);
+  if (fmMatch) {
+    const kvMatch = fmMatch[1].match(/^phase_id_convention:\s*(.*)$/m);
+    if (kvMatch) {
+      const raw = kvMatch[1].trim().replace(/^["']|["']$/g, '');
+      return raw && raw !== 'null' ? raw : null;
+    }
+  }
+
+  return null;
+}
+
 /**
  * Strip shipped milestone content wrapped in <details> blocks.
  */
@@ -389,10 +414,11 @@ function getMilestonePhaseFilter(cwd: string, versionOverride?: string | null): 
 
     const hasVersionedMilestonesGlobal = /^#{1,3}\s+.*v\d+\.\d+/mi.test(roadmapContent);
     const hasPhaseHeadings = /#{2,4}\s*(?:\[[^\]]+\]\s*)?Phase\s+[\w]/i.test(roadmapContent);
-    if (!hasVersionedMilestonesGlobal && hasPhaseHeadings) {
+    const phaseIdConvention = readPhaseIdConvention(cwd, roadmapContent);
+    if (phaseIdConvention !== null && !hasVersionedMilestonesGlobal && hasPhaseHeadings) {
       console.warn(
         '[gsd] Deprecated: free-form ROADMAP.md detected (no versioned milestone headings). ' +
-        'Set phase_id_convention in config.json to suppress this warning.'
+        'Set phase_id_convention to null for legacy free-form ROADMAP.md, or migrate to versioned milestone headings.'
       );
     }
 

--- a/src/verify.cts
+++ b/src/verify.cts
@@ -52,6 +52,49 @@ const { MODEL_PROFILES } = modelProfilesMod;
 void stripShippedMilestones;
 void detectSchemaFiles;
 
+function normalizePlanRelPath(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (!trimmed || path.isAbsolute(trimmed)) return null;
+  return trimmed.replace(/\\/g, '/').replace(/^\.\//, '');
+}
+
+function frontmatterStringList(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.flatMap((item) => (typeof item === 'string' ? [item] : []));
+  }
+  return typeof value === 'string' && value.trim() ? [value] : [];
+}
+
+function collectCurrentOrFuturePlanFiles(phaseDir: string, currentPlanPath: string, currentWave: number | null): Set<string> {
+  const planned = new Set<string>();
+
+  let entries: string[] = [];
+  try {
+    entries = fs.readdirSync(phaseDir).filter((file) => file.endsWith('-PLAN.md') || file === 'PLAN.md');
+  } catch {
+    entries = [path.basename(currentPlanPath)];
+  }
+
+  for (const entry of entries) {
+    const planPath = path.join(phaseDir, entry);
+    const planContent = safeReadFile(planPath);
+    if (!planContent) continue;
+    const fm = extractFrontmatter(planContent) as Record<string, unknown>;
+    const waveValue = Number(fm['wave']);
+    const planWave = Number.isFinite(waveValue) ? waveValue : null;
+    if (currentWave !== null && planWave !== null && planWave < currentWave) continue;
+    if (currentWave !== null && planWave === null && planPath !== currentPlanPath) continue;
+
+    for (const file of frontmatterStringList(fm['files_modified'])) {
+      const normalized = normalizePlanRelPath(file);
+      if (normalized) planned.add(normalized);
+    }
+  }
+
+  return planned;
+}
+
 function cmdVerifySummary(
   cwd: string,
   summaryPath: string,
@@ -542,20 +585,41 @@ function cmdVerifyKeyLinks(cwd: string, planFilePath: string, raw: boolean): voi
     return;
   }
 
+  const currentFm = extractFrontmatter(content) as Record<string, unknown>;
+  const currentWaveValue = Number(currentFm['wave']);
+  const currentWave = Number.isFinite(currentWaveValue) ? currentWaveValue : null;
+  const plannedCurrentOrFutureFiles = collectCurrentOrFuturePlanFiles(
+    path.dirname(fullPath),
+    fullPath,
+    currentWave,
+  );
+
   const results: Record<string, unknown>[] = [];
   for (const link of keyLinks) {
     if (typeof link === 'string') continue;
+    const fromPath = normalizePlanRelPath(link['from']);
+    const toPath = normalizePlanRelPath(link['to']);
+    const linkTouchesCurrentOrFuturePlan = Boolean(
+      (fromPath && plannedCurrentOrFutureFiles.has(fromPath)) ||
+      (toPath && plannedCurrentOrFutureFiles.has(toPath)),
+    );
     const check: Record<string, unknown> = {
       from: link['from'],
       to: link['to'],
       via: link['via'] || '',
       verified: false,
+      pending: false,
       detail: '',
     };
 
     const sourceContent = safeReadFile(path.join(cwd, (link['from'] as string) || ''));
     if (!sourceContent) {
-      check['detail'] = 'Source file not found (from: must be a relative file path; describe components/endpoints in via:)';
+      if (linkTouchesCurrentOrFuturePlan) {
+        check['pending'] = true;
+        check['detail'] = 'Pending current/upcoming wave file; skipped before execution';
+      } else {
+        check['detail'] = 'Source file not found (from: must be a relative file path; describe components/endpoints in via:)';
+      }
     } else if (link['pattern']) {
       try {
         const regex = new RegExp(link['pattern'] as string);
@@ -567,6 +631,9 @@ function cmdVerifyKeyLinks(cwd: string, planFilePath: string, raw: boolean): voi
           if (targetContent && regex.test(targetContent)) {
             check['verified'] = true;
             check['detail'] = 'Pattern found in target';
+          } else if (!targetContent && linkTouchesCurrentOrFuturePlan) {
+            check['pending'] = true;
+            check['detail'] = 'Pending current/upcoming wave target; skipped before execution';
           } else {
             check['detail'] = `Pattern "${link['pattern'] as string}" not found in source or target`;
           }
@@ -578,6 +645,9 @@ function cmdVerifyKeyLinks(cwd: string, planFilePath: string, raw: boolean): voi
       if (sourceContent.includes((link['to'] as string) || '')) {
         check['verified'] = true;
         check['detail'] = 'Target referenced in source';
+      } else if (linkTouchesCurrentOrFuturePlan) {
+        check['pending'] = true;
+        check['detail'] = 'Pending current/upcoming wave link; skipped before execution';
       } else {
         check['detail'] = 'Target not referenced in source';
       }
@@ -587,15 +657,18 @@ function cmdVerifyKeyLinks(cwd: string, planFilePath: string, raw: boolean): voi
   }
 
   const verified = results.filter((r) => r['verified']).length;
+  const pending = results.filter((r) => r['pending']).length;
+  const passedOrPending = verified + pending;
   output(
     {
-      all_verified: verified === results.length,
+      all_verified: passedOrPending === results.length,
       verified,
+      pending,
       total: results.length,
       links: results,
     },
     raw,
-    verified === results.length ? 'valid' : 'invalid',
+    passedOrPending === results.length ? 'valid' : 'invalid',
   );
 }
 

--- a/tests/backwards-compat-phase-id.test.cjs
+++ b/tests/backwards-compat-phase-id.test.cjs
@@ -4,7 +4,7 @@
  * Covers:
  *   1. Legacy 'Phase N' ROADMAP entries still work when phase_id_convention
  *      is null (the default — no config key set).
- *   2. Deprecated warning fires for free-form roadmaps (non-fatal).
+ *   2. Default/null convention does not spam warnings for free-form roadmaps.
  *   3. No automatic migration happens when a free-form roadmap is loaded.
  *   4. isDirInMilestone still works for old-style dirs ('02-setup') against
  *      ROADMAP entries 'Phase 2:'.
@@ -73,9 +73,9 @@ describe('backwards-compat: legacy Phase N roadmap entries', () => {
     assert.strictEqual(filter('03-deploy'), false, 'unlisted phase must not match');
   });
 
-  // ── test 2: deprecated warning fires for free-form roadmaps ───────────────
+  // ── test 2: default/null convention does not warn for free-form roadmaps ──
 
-  test('deprecated warning fires (non-fatal) when roadmap has no versioned milestone headings', () => {
+  test('deprecated warning does NOT fire when phase_id_convention is null/default for free-form roadmaps', () => {
     // A "free-form" roadmap: phase headings but no ## vX.Y milestone section.
     writeRoadmap(tmpDir, [
       '### Phase 1: Setup',
@@ -89,11 +89,34 @@ describe('backwards-compat: legacy Phase N roadmap entries', () => {
       getMilestonePhaseFilter(tmpDir);
     });
 
-    // Warning must fire but must not throw — non-fatal.
+    assert.doesNotMatch(
+      stderr,
+      /deprecated|free.form|phase_id_convention/i,
+      'default legacy/free-form ROADMAP mode must not spam deprecation warnings'
+    );
+  });
+
+  test('deprecated warning fires when milestone-prefixed convention is explicit but ROADMAP is free-form', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({ phase_id_convention: 'milestone-prefixed' }, null, 2),
+    );
+    writeRoadmap(tmpDir, [
+      '### Phase 1: Setup',
+      '**Goal:** setup',
+      '',
+      '### Phase 2: Build',
+      '**Goal:** build',
+    ].join('\n'));
+
+    const { stderr } = captureConsole(() => {
+      getMilestonePhaseFilter(tmpDir);
+    });
+
     assert.match(
       stderr,
       /deprecated|free.form|phase_id_convention/i,
-      'a deprecation warning must be emitted for free-form roadmaps'
+      'explicit milestone-prefixed convention should warn on free-form roadmaps',
     );
   });
 

--- a/tests/verify.test.cjs
+++ b/tests/verify.test.cjs
@@ -980,6 +980,60 @@ describe('verify key-links command', () => {
     );
   });
 
+  test('skips missing source file when key link points to current wave planned file', () => {
+    writePlanWithKeyLinks(tmpDir, [
+      '- from: "src/a.js"',
+      '  to: "src/b.js"',
+      '  pattern: "exports\\.newThing"',
+    ]);
+
+    const result = runGsdTools('verify key-links .planning/phases/01-test/01-01-PLAN.md', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.all_verified, true, `Expected pending current-wave link not to fail: ${JSON.stringify(output)}`);
+    assert.strictEqual(output.pending, 1, 'one key link should be pending');
+    assert.strictEqual(output.links[0].pending, true, 'link should be marked pending');
+    assert.ok(
+      output.links[0].detail.includes('current/upcoming wave'),
+      `Expected current/upcoming wave detail: ${output.links[0].detail}`,
+    );
+  });
+
+  test('skips missing source file when key link points to a later-wave planned file', () => {
+    writePlanWithKeyLinks(tmpDir, [
+      '- from: "src/future-wave.js"',
+      '  to: "src/b.js"',
+      '  pattern: "exports\\.futureThing"',
+    ]);
+
+    const laterPlan = [
+      '---',
+      'phase: 01-test',
+      'plan: 02',
+      'type: execute',
+      'wave: 2',
+      'depends_on: ["01-01"]',
+      'files_modified: [src/future-wave.js]',
+      'autonomous: true',
+      '---',
+      '',
+      '<tasks></tasks>',
+    ].join('\n');
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'phases', '01-test', '01-02-PLAN.md'),
+      laterPlan,
+    );
+
+    const result = runGsdTools('verify key-links .planning/phases/01-test/01-01-PLAN.md', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.all_verified, true, `Expected pending later-wave link not to fail: ${JSON.stringify(output)}`);
+    assert.strictEqual(output.pending, 1, 'one key link should be pending');
+    assert.strictEqual(output.links[0].pending, true, 'link should be marked pending');
+  });
+
   test('returns error when no key_links in frontmatter', () => {
     const content = [
       '---',


### PR DESCRIPTION
## Summary

- Treat `verify key-links` references to current/upcoming wave planned files as pending instead of missing-file failures.
- Suppress free-form `ROADMAP.md` deprecation warning for default/null `phase_id_convention`, while preserving it for explicit stricter conventions.

Closes #1202.
Closes #1203.

## Testing

- `npm run build:lib`
- `node --test tests/verify.test.cjs tests/bug-967-verify-key-links-strict-paths.test.cjs tests/backwards-compat-phase-id.test.cjs tests/roadmap-parser.test.cjs`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1204"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784014396&installation_id=134682257&pr_number=1204&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1204&signature=1d194f73b6de302ed7ec8992ca93df1d0a7c10911f1113a59162466c83ffb3f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->