### PR TITLE
docs(#1209): map ready-for-agent to confirmed-bug in triage-labels

### DIFF
--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -6,7 +6,7 @@ Maps the five canonical triage roles to the actual label strings in `open-gsd/gs
 |-------------------|--------------------------|----------------------------------------------------------------|
 | `needs-triage`    | `needs-triage`           | Auto-applied by GitHub Action on every new issue               |
 | `needs-info`      | `needs-reproduction`     | Waiting on reporter — cannot reproduce, more info required     |
-| `ready-for-agent` | `confirmed`              | Bug verified + fully specified — AFK agent can pick up         |
+| `ready-for-agent` | `confirmed-bug`          | Bug verified + fully specified — AFK agent can pick up. This is the fix gate (`RULESET.CONTRIB.CLASSIFY.fix`); bug-remediation workflows scope on it. |
 | `ready-for-human` | `approved-enhancement` / `approved-feature` | Enhancement/feature approved by maintainer — human codes it |
 | `wontfix`         | `wontfix`                | Will not be actioned                                           |
 | `possible-duplicate` | `possible-duplicate` | Applied by the Duplicate check workflow when a new issue's title closely matches existing open issues. The reporter (or a maintainer) replies justifying why it is not a duplicate within 24h, or the Duplicate auto-close sweep closes it. A reply clears this label and applies needs-maintainer-review for human adjudication. React 👎 to the bot comment to veto auto-close. |
@@ -15,7 +15,7 @@ Maps the five canonical triage roles to the actual label strings in `open-gsd/gs
 
 ## Notes on this repo's label model
 
-- `confirmed` is the AFK-agent-ready signal for **bugs**. It means "verified to exist and reproducible."
+- `confirmed-bug` is the AFK-agent-ready signal for **bugs**. It means "verified reproducible bug" and is the gate the fix workflow requires before any code is written. Apply it (in addition to `bug`) when triage reproduces/verifies a bug. The legacy `confirmed` label ("bug verified to exist") is retained only for back-compat in the duplicate-sweep exempt list — use `confirmed-bug` for new triage.
 - For **enhancements** and **features**, maintainer approval is `approved-enhancement` / `approved-feature` respectively. A contributor (human or agent) may not write code until one of these is applied.
 - There is no separate "ready-for-human" vs "ready-for-agent" distinction for enhancements — both flow through the same `approved-*` labels. If the work requires human judgment (design decisions, external access), note it in the issue body.
 - `needs-triage` is removed when any other state label is applied.


### PR DESCRIPTION
<!-- pr-template-exempt: doc-only correction (single mapping file under docs/); auto-detected doc-only PR -->

## Summary

`docs/agents/triage-labels.md` mapped the canonical `ready-for-agent` role to the **stale `confirmed`** label. The live verified-bug gate in this repo is **`confirmed-bug`**, so a `/triage` run that follows the doc applies the wrong (or no) gate label — leaving reproduced bugs invisible to the `confirmed-bug`-scoped fix/remediation workflow.

## Change

- Map `ready-for-agent` (bugs) → **`confirmed-bug`** (was `confirmed`), and note it is the fix gate per `RULESET.CONTRIB.CLASSIFY.fix`.
- Update the label-model note to describe `confirmed-bug` as the AFK-ready / verified-bug signal and mark `confirmed` as legacy/back-compat (still in the duplicate-sweep exempt list, but not for new triage).
- No change to `needs-info → needs-reproduction` or `ready-for-human → approved-enhancement/approved-feature`.

## Why

- `RULESET.CONTRIB.CLASSIFY.fix=requires confirmed/confirmed-bug before implementation`.
- 200+ issues and every recent closed bug carry `confirmed-bug`; bug-remediation workflows scope on it.

## Verification

- `node scripts/lint-docs-required.cjs` → `ok_no_triggering_fragments`.
- `node --test tests/lint-docs-required.test.cjs` → 31/31 pass.
- Doc-only diff (2 lines, one markdown file); no code, fences, or test fixtures touched. Per `ci-test-scope` this is the inert path — the product test matrix does not run for docs-only changes.

## Scope / type

Doc-only, no user-facing product change → `no-changelog` (changeset gate does not trigger for `docs/`). Template-exempt (auto-detected doc-only PR).

Closes #1209

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1210"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784035577&installation_id=134682257&pr_number=1210&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1210&signature=4b7fce3f8c92c9fed26b05708ac25b0e514ece9d9acb9f7f93f996fc277adf4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->