### PR TITLE
fix(#1186): guard hotfix version regex against leading zeros (ADR-218)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
             if echo "$VERSION" | grep -qE '^(0|[1-9][0-9]*)\.0\.0$'; then
               IS_MAJOR="true"
             fi
-          elif echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[1-9][0-9]*$'; then
+          elif echo "$VERSION" | grep -qE '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.[1-9][0-9]*$'; then
             # Patch / hotfix release (X.Y.Z, Z>0)
             IS_HOTFIX="true"
             if [ "$ACTION" = "rc" ]; then

--- a/tests/adr-218-release-version-validation.test.cjs
+++ b/tests/adr-218-release-version-validation.test.cjs
@@ -254,12 +254,21 @@ describe('ADR-218 — leading-zero rejection regex (behavioral)', () => {
     // Patch = 0 must be rejected (that is the minor/major form)
     assert.equal(re.test('1.2.0'), false, 'Hotfix pattern must not match X.Y.0 (Z must be >0)');
 
-    // NOTE: The hotfix regex in release.yml currently permits leading zeros on
-    // the major and minor segments (e.g. `1.01.3` and `01.2.3` both pass).
-    // This is a known gap tracked in issue #1186.  The assertions below are
-    // intentionally absent for those cases: this test documents CURRENT
-    // behavior, not ideal behavior.  Fix #1186 will harden the pattern and
-    // add leading-zero rejection assertions here.
+    // ADR-218 / #1186: hotfix pattern must also reject leading zeros on major
+    // and minor segments.  The old `[0-9]+` form allowed e.g. `01.2.3` and
+    // `1.02.3`.  The corrected pattern uses `(0|[1-9][0-9]*)` for both.
+    const shouldRejectLeadingZero = [
+      '01.2.3',   // leading zero in major
+      '1.02.3',   // leading zero in minor
+    ];
+    for (const v of shouldRejectLeadingZero) {
+      assert.equal(
+        re.test(v), false,
+        `Hotfix version "${v}" should be REJECTED (leading zero) but was accepted.\n` +
+        `Pattern: ${hotfixPatterns[0]}\n` +
+        `ADR-218 / #1186: restore (0|[1-9][0-9]*) on major and minor segments.`
+      );
+    }
   });
 
   test('extracted patterns use strict leading-zero guard, not the old [0-9]+ form', () => {


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

> **Required.** This PR will be auto-closed if no valid issue link is found.

Fixes #1186

> The linked issue must have the `confirmed-bug` label. If it doesn't, ask a maintainer to confirm the bug before continuing.

---

## What was broken

The hotfix version validation regex in `.github/workflows/release.yml` used `^[0-9]+\.[0-9]+\.[1-9][0-9]*$`, which allowed leading zeros on the major and minor segments (e.g. `01.2.3` and `1.02.3` both matched), violating ADR-218's strict-semver guard.

## What this fix does

Replaces the unguarded `[0-9]+` segments with `(0|[1-9][0-9]*)` on both major and minor, producing `^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.[1-9][0-9]*$` — consistent with the two sibling patterns already in the same `validate-version` step.

## Root cause

When the hotfix branch was added to `validate-version`, the `(0|[1-9][0-9]*)` leading-zero guard used by the minor/major and major-only patterns was not carried over. The oversight left `[0-9]+` in place for both the major and minor segments of the hotfix path.

## Testing

### How I verified the fix

TDD regression-first approach per CONTRIBUTING.md:

1. **Fail-first proof** — replaced the `#1186` placeholder comment in `tests/adr-218-release-version-validation.test.cjs` with real assertions: `01.2.3` → false, `1.02.3` → false. Running against the **buggy** regex produced:

   ```
   ✖ hotfix pattern (X.Y.Z, Z>0) is present and uses digit anchors (2.056875ms)
     AssertionError: Hotfix version "01.2.3" should be REJECTED (leading zero) but was accepted.
     Pattern: ^[0-9]+\.[0-9]+\.[1-9][0-9]*$
     true !== false
   ```

2. **Green after fix** — applied the corrected regex; all 12 tests pass:

   ```
   ✔ ADR-218 — leading-zero rejection regex (behavioral) (6.111708ms)
   ✔ ADR-218 — structural wiring of release.yml (4.126125ms)
   ℹ pass 12
   ℹ fail 0
   ```

3. **Full suite (gsd-test-summary docker)** — exit 0, 15427 passed / 0 failed / 12 skipped.

### Regression test added?

- [x] Yes — added a test that would have caught this bug

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [x] N/A (not platform-specific — CI-workflow regex only)

### Runtimes tested

- [x] N/A (not runtime-specific — GitHub Actions workflow validation only)

---

## Checklist

- [x] Issue linked above with `Fixes #1186` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `no-changelog` label applied — diff touches only `.github/workflows/` and `tests/`, which are not changeset-trigger paths
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784037098&installation_id=134682257&pr_number=1214&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1214&signature=bb9bb6941d092c3707a61925f4173eb09e720c6d00ec3be27e5e479ad2f9935b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->