### PR TITLE
fix(#1203): gate free-form ROADMAP deprecation warning on phase_id_convention

### DIFF
--- a/.changeset/brave-cats-leap.md
+++ b/.changeset/brave-cats-leap.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 1218
 ---
-**Legacy ROADMAP projects no longer get deprecation-warning spam** — the free-form ROADMAP warning fired on every command regardless of phase_id_convention; it now only warns when the milestone-prefixed convention is explicitly set and unmet. (#1203)
+**Legacy ROADMAP projects no longer get deprecation-warning spam** — the free-form ROADMAP warning fired on every command regardless of phase_id_convention; it now only warns when the milestone-prefixed convention is explicitly set and unmet. (#1218)

--- a/.changeset/brave-cats-leap.md
+++ b/.changeset/brave-cats-leap.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**Legacy ROADMAP projects no longer get deprecation-warning spam** — the free-form ROADMAP warning fired on every command regardless of phase_id_convention; it now only warns when the milestone-prefixed convention is explicitly set and unmet. (#1203)

--- a/src/roadmap-parser.cts
+++ b/src/roadmap-parser.cts
@@ -402,7 +402,7 @@ function getMilestonePhaseFilter(cwd: string, versionOverride?: string | null, p
       console.warn(
         '[gsd] Deprecated: free-form ROADMAP.md detected (no versioned milestone headings). ' +
         'The project has phase_id_convention set to "milestone-prefixed" in config.json but the ' +
-        'ROADMAP does not use versioned milestone headings. Run `gsd roadmap upgrade --apply` to migrate.'
+        'ROADMAP does not use versioned milestone headings. Run `gsd-tools roadmap upgrade --convention milestone-prefixed` to migrate (dry-run by default).'
       );
     }
 

--- a/src/roadmap-parser.cts
+++ b/src/roadmap-parser.cts
@@ -377,8 +377,17 @@ type MilestonePhaseFilter = ((dirName: string) => boolean) & {
 /**
  * Returns a filter function that checks whether a phase directory belongs
  * to the current milestone based on ROADMAP.md phase headings.
+ *
+ * @param cwd - Project working directory.
+ * @param versionOverride - Optional version string to scope the phase filter
+ *   to a specific milestone (e.g. 'v1.2').
+ * @param phaseIdConvention - The resolved `phase_id_convention` config value.
+ *   When `'milestone-prefixed'`, a deprecation warning is emitted for
+ *   free-form ROADMAPs that lack versioned milestone headings. When absent or
+ *   any other value, the warning is suppressed — legacy/default projects must
+ *   never see spurious warnings.
  */
-function getMilestonePhaseFilter(cwd: string, versionOverride?: string | null): MilestonePhaseFilter {
+function getMilestonePhaseFilter(cwd: string, versionOverride?: string | null, phaseIdConvention?: string | null): MilestonePhaseFilter {
   const milestonePhaseNums = new Set<string>();
   let missingExplicitVersion = false;
   try {
@@ -389,10 +398,11 @@ function getMilestonePhaseFilter(cwd: string, versionOverride?: string | null): 
 
     const hasVersionedMilestonesGlobal = /^#{1,3}\s+.*v\d+\.\d+/mi.test(roadmapContent);
     const hasPhaseHeadings = /#{2,4}\s*(?:\[[^\]]+\]\s*)?Phase\s+[\w]/i.test(roadmapContent);
-    if (!hasVersionedMilestonesGlobal && hasPhaseHeadings) {
+    if (!hasVersionedMilestonesGlobal && hasPhaseHeadings && phaseIdConvention === 'milestone-prefixed') {
       console.warn(
         '[gsd] Deprecated: free-form ROADMAP.md detected (no versioned milestone headings). ' +
-        'Set phase_id_convention in config.json to suppress this warning.'
+        'The project has phase_id_convention set to "milestone-prefixed" in config.json but the ' +
+        'ROADMAP does not use versioned milestone headings. Run `gsd roadmap upgrade --apply` to migrate.'
       );
     }
 

--- a/tests/backwards-compat-phase-id.test.cjs
+++ b/tests/backwards-compat-phase-id.test.cjs
@@ -4,7 +4,10 @@
  * Covers:
  *   1. Legacy 'Phase N' ROADMAP entries still work when phase_id_convention
  *      is null (the default — no config key set).
- *   2. Deprecated warning fires for free-form roadmaps (non-fatal).
+ *   2a. Deprecated warning is SUPPRESSED when phase_id_convention is not set
+ *       (legacy/default projects must see ZERO warnings). [regression guard]
+ *   2b. Deprecated warning FIRES when phase_id_convention is explicitly
+ *       'milestone-prefixed' and the roadmap doesn't conform (non-fatal).
  *   3. No automatic migration happens when a free-form roadmap is loaded.
  *   4. isDirInMilestone still works for old-style dirs ('02-setup') against
  *      ROADMAP entries 'Phase 2:'.
@@ -13,8 +16,8 @@
  *   6. Heading regex matches both '### Phase 2-01: Setup' and
  *      '### [GSD] Phase 2-01: Setup'.
  *
- * Tests 1-3 exercise new behavior and will FAIL until implemented.
- * Tests 4-6 exercise existing/new behavior and should pass once wired.
+ * Tests 1-3 exercise new/regression behavior.
+ * Tests 4-6 exercise existing/new behavior.
  */
 
 'use strict';
@@ -73,10 +76,14 @@ describe('backwards-compat: legacy Phase N roadmap entries', () => {
     assert.strictEqual(filter('03-deploy'), false, 'unlisted phase must not match');
   });
 
-  // ── test 2: deprecated warning fires for free-form roadmaps ───────────────
+  // ── test 2a: NO warning for legacy/default projects (regression guard) ───────
+  // This is the PRIMARY regression guard: a project with no phase_id_convention
+  // must never receive the deprecation warning. Before the fix this test FAILS
+  // because the warning fires unconditionally.
 
-  test('deprecated warning fires (non-fatal) when roadmap has no versioned milestone headings', () => {
-    // A "free-form" roadmap: phase headings but no ## vX.Y milestone section.
+  test('no deprecation warning when phase_id_convention is not set (legacy default)', () => {
+    // Free-form roadmap (no versioned milestone headings) AND no config file at
+    // all — the warning must be fully suppressed.
     writeRoadmap(tmpDir, [
       '### Phase 1: Setup',
       '**Goal:** setup',
@@ -89,11 +96,35 @@ describe('backwards-compat: legacy Phase N roadmap entries', () => {
       getMilestonePhaseFilter(tmpDir);
     });
 
+    assert.strictEqual(
+      stderr,
+      '',
+      'no deprecation warning must be emitted when phase_id_convention is not set'
+    );
+  });
+
+  // ── test 2b: deprecated warning fires when convention is milestone-prefixed ──
+
+  test('deprecated warning fires (non-fatal) when phase_id_convention is milestone-prefixed and roadmap lacks versioned milestones', () => {
+    // A "free-form" roadmap (no ## vX.Y milestone section) combined with the
+    // explicit milestone-prefixed convention — the warning is actionable here.
+    writeRoadmap(tmpDir, [
+      '### Phase 1: Setup',
+      '**Goal:** setup',
+      '',
+      '### Phase 2: Build',
+      '**Goal:** build',
+    ].join('\n'));
+
+    const { stderr } = captureConsole(() => {
+      getMilestonePhaseFilter(tmpDir, null, 'milestone-prefixed');
+    });
+
     // Warning must fire but must not throw — non-fatal.
     assert.match(
       stderr,
       /deprecated|free.form|phase_id_convention/i,
-      'a deprecation warning must be emitted for free-form roadmaps'
+      'a deprecation warning must be emitted when milestone-prefixed convention is set but roadmap is free-form'
     );
   });
 


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #1203

---

## What was broken

`getMilestonePhaseFilter` in `src/roadmap-parser.cts` emitted a `console.warn` deprecation warning on every invocation whenever the ROADMAP had no versioned milestone headings — regardless of whether `phase_id_convention` was set in config. The warning told users to "set phase_id_convention in config.json to suppress this warning," but the function never read that key, making suppression impossible. Legacy/default projects (the vast majority) received this spurious warning on essentially every GSD command.

## What this fix does

Gates the deprecation warning behind a new optional `phaseIdConvention` parameter. The warning is now only emitted when `phaseIdConvention === 'milestone-prefixed'` — i.e., when the project has explicitly opted into the milestone-prefixed convention but the ROADMAP doesn't conform. Legacy/default projects (no `phase_id_convention` set) see zero warnings.

## Root cause

The `getMilestonePhaseFilter` function lacked any mechanism to receive the resolved `phase_id_convention` config value. Its signature only accepted `cwd` and `versionOverride`, so the condition `!hasVersionedMilestonesGlobal && hasPhaseHeadings` fired unconditionally for all free-form ROADMAPs, even though the warning was only actionable for milestone-prefixed projects.

## Testing

### How I verified the fix

- Added a regression test (test 2a) that asserts the warning is **suppressed** when `phase_id_convention` is not set — confirmed this test **failed** against the unfixed code (proving it's a real guard).
- Existing test (now 2b) confirms the warning still fires when `phase_id_convention === 'milestone-prefixed'` and the ROADMAP is free-form.
- Full unit suite: `npm test` — 975 tests, 975 pass, 0 fail.

### Fail-first excerpt

```
✖ no deprecation warning when phase_id_convention is not set (legacy default) (22.686917ms)
  AssertionError [ERR_ASSERTION]: no deprecation warning must be emitted when phase_id_convention is not set
  + actual - expected
  + '[gsd] Deprecated: free-form ROADMAP.md detected (no versioned milestone headings). Set phase_id_convention in config.json to suppress this warning.'
  - ''
```

### Regression test added?

- [x] Yes — added a test that would have caught this bug

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [x] N/A (not platform-specific)

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #1203` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1218"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784042304&installation_id=134682257&pr_number=1218&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1218&signature=730c3946856e5d94602404571218527bb68004fd638bb313f87c400a05770e2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->