### PR TITLE
fix(#1182): extract agent converters + tool-name tables into conversion module

### DIFF
--- a/src/runtime-artifact-conversion.cts
+++ b/src/runtime-artifact-conversion.cts
@@ -1755,6 +1755,277 @@ function convertClaudeToKiloFrontmatter(content, { isAgent = false } = {}) {
   return `---\n${newFrontmatter}\n---${body}`;
 }
 
+// ── Agent converters — #1182 extraction ─────────────────────────────────────
+// These were previously only in bin/install.js. Extracted here so the module
+// is self-contained and #1173 descriptor-driven dispatch can call them without
+// reaching through the Installer Module.
+// NOTE: Do NOT remove the inline copies from bin/install.js in this PR —
+// that is #1175. This PR only adds them to the module's export surface.
+
+// Copilot tool name mapping — Claude Code tools to GitHub Copilot tools
+// Tool mapping applies ONLY to agents, NOT to skills (per CONTEXT.md decision)
+const claudeToCopilotTools = {
+  Read: 'read',
+  Write: 'edit',
+  Edit: 'edit',
+  Bash: 'execute',
+  Grep: 'search',
+  Glob: 'search',
+  Task: 'agent',
+  WebSearch: 'web',
+  WebFetch: 'web',
+  TodoWrite: 'todo',
+  AskUserQuestion: 'ask_user',
+  SlashCommand: 'skill',
+};
+
+// Tool name mapping from Claude Code to Gemini CLI
+// Gemini CLI uses snake_case built-in tool names
+const claudeToGeminiTools = {
+  Read: 'read_file',
+  Write: 'write_file',
+  Edit: 'replace',
+  Bash: 'run_shell_command',
+  Glob: 'glob',
+  Grep: 'search_file_content',
+  WebSearch: 'google_web_search',
+  WebFetch: 'web_fetch',
+  TodoWrite: 'write_todos',
+};
+
+/**
+ * Convert a Claude Code tool name to Gemini CLI format
+ * - Applies Claude→Gemini mapping (Read→read_file, Bash→run_shell_command, etc.)
+ * - Filters out MCP tools (mcp__*) — they are auto-discovered at runtime in Gemini
+ * - Filters out Task/Agent — agents are auto-registered as tools in Gemini
+ * @returns {string|null} Gemini tool name, or null if tool should be excluded
+ */
+function convertGeminiToolName(claudeTool) {
+  // MCP tools: exclude — auto-discovered from mcpServers config at runtime
+  if (claudeTool.startsWith('mcp__')) {
+    return null;
+  }
+  // Task/Agent: exclude — agents are auto-registered as callable tools.
+  // AskUserQuestion: exclude — Gemini CLI does not expose an ask_user tool;
+  // emitting it causes frontmatter validation errors (#3362).
+  if (
+    claudeTool === 'Task' ||
+    claudeTool === 'Agent' ||
+    claudeTool === 'AskUserQuestion' ||
+    claudeTool === 'ask_user'
+  ) {
+    return null;
+  }
+  // Check for explicit mapping
+  if (claudeToGeminiTools[claudeTool]) {
+    return claudeToGeminiTools[claudeTool];
+  }
+  // Default: lowercase
+  return claudeTool.toLowerCase();
+}
+
+/**
+ * Convert a Claude Code tool name to GitHub Copilot format.
+ * - Applies explicit mapping from claudeToCopilotTools
+ * - Handles mcp__context7__* prefix → io.github.upstash/context7/*
+ * - Falls back to lowercase for unknown tools
+ */
+function convertCopilotToolName(claudeTool) {
+  // mcp__context7__* wildcard → io.github.upstash/context7/*
+  if (claudeTool.startsWith('mcp__context7__')) {
+    return 'io.github.upstash/context7/' + claudeTool.slice('mcp__context7__'.length);
+  }
+  // Check explicit mapping
+  if (claudeToCopilotTools[claudeTool]) {
+    return claudeToCopilotTools[claudeTool];
+  }
+  // mcp__{tavily,ref,jina,exa,firecrawl}__* use the generic MCP passthrough like exa/firecrawl;
+  // add explicit Copilot registry mappings when the io.github ids are confirmed (#657 follow-up)
+  // Default: lowercase
+  return claudeTool.toLowerCase();
+}
+
+/**
+ * Convert a Claude agent (.md) to a GitHub Copilot agent.
+ * CONV-04: JSON array format. CONV-05: Tool name mapping.
+ */
+function convertClaudeAgentToCopilotAgent(content, isGlobal = false) {
+  const converted = convertClaudeToCopilotContent(content, isGlobal);
+  const { frontmatter, body } = extractFrontmatterAndBody(converted);
+  if (!frontmatter) return converted;
+
+  const name = extractFrontmatterField(frontmatter, 'name') || 'unknown';
+  const description = extractFrontmatterField(frontmatter, 'description') || '';
+  const color = extractFrontmatterField(frontmatter, 'color');
+  const toolsRaw = extractFrontmatterField(frontmatter, 'tools') || '';
+
+  // CONV-04 + CONV-05: Map tools, deduplicate, format as JSON array
+  const claudeTools = toolsRaw.split(',').map(t => t.trim()).filter(Boolean);
+  const mappedTools = claudeTools.map(t => convertCopilotToolName(t));
+  const uniqueTools = [...new Set(mappedTools)];
+  const toolsArray = uniqueTools.length > 0
+    ? "['" + uniqueTools.join("', '") + "']"
+    : '[]';
+
+  // Reconstruct frontmatter in Copilot format. Quote description (#2876)
+  // so a leading YAML flow indicator (`[BETA] …`, `{ … }`, etc.) doesn't
+  // crash the Copilot frontmatter loader.
+  let fm = `---\nname: ${name}\ndescription: ${yamlQuote(description)}\ntools: ${toolsArray}\n`;
+  if (color) fm += `color: ${color}\n`;
+  fm += '---';
+
+  return `${fm}\n${body}`;
+}
+
+/**
+ * Convert a Claude agent (.md) to an Antigravity agent.
+ * Uses Gemini tool names since Antigravity runs on Gemini 3 backend.
+ */
+function convertClaudeAgentToAntigravityAgent(content, isGlobal = false) {
+  const converted = convertClaudeToAntigravityContent(content, isGlobal);
+  const { frontmatter, body } = extractFrontmatterAndBody(converted);
+  if (!frontmatter) return converted;
+
+  const name = extractFrontmatterField(frontmatter, 'name') || 'unknown';
+  const description = extractFrontmatterField(frontmatter, 'description') || '';
+  const color = extractFrontmatterField(frontmatter, 'color');
+  const toolsRaw = extractFrontmatterField(frontmatter, 'tools') || '';
+
+  // Map tools to Gemini equivalents (reuse existing convertGeminiToolName)
+  const claudeTools = toolsRaw.split(',').map(t => t.trim()).filter(Boolean);
+  const mappedTools = claudeTools.map(t => convertGeminiToolName(t)).filter(Boolean);
+
+  // #2876: quote description for the same reason as the skill variant.
+  let fm = `---\nname: ${name}\ndescription: ${yamlQuote(description)}\ntools: ${mappedTools.join(', ')}\n`;
+  if (color) fm += `color: ${color}\n`;
+  fm += '---';
+
+  return `${fm}\n${body}`;
+}
+
+/**
+ * Convert Claude Code agent markdown to Cursor agent format.
+ * Strips frontmatter fields Cursor doesn't support (color, skills),
+ * converts tool references, and adds a role context header.
+ */
+function convertClaudeAgentToCursorAgent(content) {
+  const converted = convertClaudeToCursorMarkdown(content);
+
+  const { frontmatter, body } = extractFrontmatterAndBody(converted);
+  if (!frontmatter) return converted;
+
+  const name = extractFrontmatterField(frontmatter, 'name') || 'unknown';
+  const description = extractFrontmatterField(frontmatter, 'description') || '';
+
+  const cleanFrontmatter = `---\nname: ${yamlIdentifier(name)}\ndescription: ${yamlQuote(toSingleLine(description))}\n---`;
+
+  return `${cleanFrontmatter}\n${body}`;
+}
+
+/**
+ * Convert Claude Code agent markdown to Windsurf agent format.
+ * Strips frontmatter fields Windsurf doesn't support (color, skills),
+ * converts tool references, and adds a role context header.
+ */
+function convertClaudeAgentToWindsurfAgent(content) {
+  const converted = convertClaudeToWindsurfMarkdown(content);
+
+  const { frontmatter, body } = extractFrontmatterAndBody(converted);
+  if (!frontmatter) return converted;
+
+  const name = extractFrontmatterField(frontmatter, 'name') || 'unknown';
+  const description = extractFrontmatterField(frontmatter, 'description') || '';
+
+  const cleanFrontmatter = `---\nname: ${yamlIdentifier(name)}\ndescription: ${yamlQuote(toSingleLine(description))}\n---`;
+
+  return `${cleanFrontmatter}\n${body}`;
+}
+
+/**
+ * Convert Claude Code agent markdown to Augment agent format.
+ * Strips frontmatter fields Augment doesn't support (color, skills),
+ * converts tool references, and cleans up for Augment agents.
+ */
+function convertClaudeAgentToAugmentAgent(content) {
+  const converted = convertClaudeToAugmentMarkdown(content);
+
+  const { frontmatter, body } = extractFrontmatterAndBody(converted);
+  if (!frontmatter) return converted;
+
+  const name = extractFrontmatterField(frontmatter, 'name') || 'unknown';
+  const description = extractFrontmatterField(frontmatter, 'description') || '';
+
+  const cleanFrontmatter = `---\nname: ${yamlIdentifier(name)}\ndescription: ${yamlQuote(toSingleLine(description))}\n---`;
+
+  return `${cleanFrontmatter}\n${body}`;
+}
+
+function convertClaudeAgentToTraeAgent(content) {
+  const converted = convertClaudeToTraeMarkdown(content);
+
+  const { frontmatter, body } = extractFrontmatterAndBody(converted);
+  if (!frontmatter) return converted;
+
+  const name = extractFrontmatterField(frontmatter, 'name') || 'unknown';
+  const description = extractFrontmatterField(frontmatter, 'description') || '';
+
+  const cleanFrontmatter = `---\nname: ${yamlIdentifier(name)}\ndescription: ${yamlQuote(toSingleLine(description))}\n---`;
+
+  return `${cleanFrontmatter}\n${body}`;
+}
+
+function convertClaudeAgentToCodebuddyAgent(content) {
+  const converted = convertClaudeToCodebuddyMarkdown(content);
+
+  const { frontmatter, body } = extractFrontmatterAndBody(converted);
+  if (!frontmatter) return converted;
+
+  const name = extractFrontmatterField(frontmatter, 'name') || 'unknown';
+  const description = extractFrontmatterField(frontmatter, 'description') || '';
+
+  const cleanFrontmatter = `---\nname: ${yamlIdentifier(name)}\ndescription: ${yamlQuote(toSingleLine(description))}\n---`;
+
+  return `${cleanFrontmatter}\n${body}`;
+}
+
+function convertClaudeAgentToClineAgent(content) {
+  const converted = convertClaudeToCliineMarkdown(content);
+  const { frontmatter, body } = extractFrontmatterAndBody(converted);
+  if (!frontmatter) return converted;
+  const name = extractFrontmatterField(frontmatter, 'name') || 'unknown';
+  const description = extractFrontmatterField(frontmatter, 'description') || '';
+  const cleanFrontmatter = `---\nname: ${yamlIdentifier(name)}\ndescription: ${yamlQuote(toSingleLine(description))}\n---`;
+  return `${cleanFrontmatter}\n${body}`;
+}
+
+/**
+ * Convert Claude Code agent markdown to Codex agent format.
+ * Applies base markdown conversions, then adds a <codex_agent_role> header
+ * and cleans up frontmatter (removes tools/color fields).
+ */
+function convertClaudeAgentToCodexAgent(content) {
+  const converted = convertClaudeToCodexMarkdown(content);
+
+  const { frontmatter, body } = extractFrontmatterAndBody(converted);
+  if (!frontmatter) return converted;
+
+  const name = extractFrontmatterField(frontmatter, 'name') || 'unknown';
+  const description = extractFrontmatterField(frontmatter, 'description') || '';
+  const tools = extractFrontmatterField(frontmatter, 'tools') || '';
+
+  const roleHeader = `<codex_agent_role>
+role: ${name}
+tools: ${tools}
+purpose: ${toSingleLine(description)}
+</codex_agent_role>`;
+
+  const cleanFrontmatter = `---\nname: ${yamlQuote(name)}\ndescription: ${yamlQuote(toSingleLine(description))}\n---`;
+
+  return `${cleanFrontmatter}\n\n${roleHeader}\n${body}`;
+}
+
+// ── End agent converters #1182 ───────────────────────────────────────────────
+
 /**
  * Shared SKILL.md writer for the OpenCode-family runtimes (OpenCode + Kilo),
  * which share a config schema (Kilo derives from OpenCode). OpenCode discovers
@@ -1857,4 +2128,18 @@ export = {
   convertClaudeCommandToKiloSkill,
   readGsdCommandNames,
   transformContentToHyphen,
+  // #1182: agent converters + tool-name table dependency closure
+  claudeToCopilotTools,
+  convertCopilotToolName,
+  claudeToGeminiTools,
+  convertGeminiToolName,
+  convertClaudeAgentToCopilotAgent,
+  convertClaudeAgentToAntigravityAgent,
+  convertClaudeAgentToCursorAgent,
+  convertClaudeAgentToWindsurfAgent,
+  convertClaudeAgentToAugmentAgent,
+  convertClaudeAgentToTraeAgent,
+  convertClaudeAgentToCodebuddyAgent,
+  convertClaudeAgentToClineAgent,
+  convertClaudeAgentToCodexAgent,
 };

--- a/tests/copilot-install.test.cjs
+++ b/tests/copilot-install.test.cjs
@@ -1808,3 +1808,61 @@ describe('Claude uninstall preserves user-generated files (#1423)', () => {
     assert.ok(!fs.existsSync(cmdDir), 'commands/gsd/ should not exist after clean uninstall');
   });
 });
+
+// ─── #1182 regression: agent converters accessible via module path ────────────
+// These tests require convertClaudeAgentToCopilotAgent and its dependency closure
+// (claudeToCopilotTools, convertCopilotToolName) THROUGH the runtime-artifact-conversion
+// module export — not via bin/install.js. Before the fix, the module returned
+// undefined for all three, causing ReferenceError when called.
+
+describe('#1182 convertClaudeAgentToCopilotAgent exported from runtime-artifact-conversion module', () => {
+  const _gsdLibDirModule = path.join(__dirname, '..', 'gsd-core', 'bin', 'lib');
+  const conversionModule = require(path.join(_gsdLibDirModule, 'runtime-artifact-conversion.cjs'));
+
+  test('module exports claudeToCopilotTools table', () => {
+    assert.strictEqual(typeof conversionModule.claudeToCopilotTools, 'object', 'claudeToCopilotTools must be exported');
+    assert.ok(conversionModule.claudeToCopilotTools !== null, 'not null');
+    assert.strictEqual(conversionModule.claudeToCopilotTools['Read'], 'read', 'Read maps to read');
+    assert.strictEqual(conversionModule.claudeToCopilotTools['Bash'], 'execute', 'Bash maps to execute');
+  });
+
+  test('module exports convertCopilotToolName function', () => {
+    assert.strictEqual(typeof conversionModule.convertCopilotToolName, 'function', 'convertCopilotToolName must be exported');
+    assert.strictEqual(conversionModule.convertCopilotToolName('Read'), 'read', 'maps Read -> read');
+    assert.strictEqual(conversionModule.convertCopilotToolName('Bash'), 'execute', 'maps Bash -> execute');
+    assert.strictEqual(conversionModule.convertCopilotToolName('mcp__context7__resolve-library-id'), 'io.github.upstash/context7/resolve-library-id', 'mcp__context7__ prefix mapped');
+  });
+
+  test('module exports convertClaudeAgentToCopilotAgent function', () => {
+    assert.strictEqual(typeof conversionModule.convertClaudeAgentToCopilotAgent, 'function', 'convertClaudeAgentToCopilotAgent must be exported');
+  });
+
+  test('convertClaudeAgentToCopilotAgent via module produces correct output (local mode)', () => {
+    const input = `---\nname: gsd-executor\ndescription: Executes GSD plans\ntools: Read, Write, Edit, Bash, Grep, Glob\ncolor: yellow\n---\n\nAgent body.`;
+    const result = conversionModule.convertClaudeAgentToCopilotAgent(input);
+    // Tools must be mapped and deduplicated
+    assert.ok(result.includes("tools: ['read', 'edit', 'execute', 'search']"), `expected mapped tools in: ${result}`);
+    assert.ok(result.includes('name: gsd-executor'), 'name preserved');
+    assert.ok(result.includes('color: yellow'), 'color preserved');
+  });
+
+  test('convertClaudeAgentToCopilotAgent via module applies path/command conversions (global mode)', () => {
+    const input = `---\nname: gsd-test\ndescription: Test\ntools: Read\n---\n\nCheck ~/.claude/settings and run gsd:health.`;
+    const result = conversionModule.convertClaudeAgentToCopilotAgent(input, true);
+    assert.ok(result.includes('~/.copilot/settings'), 'CONV-06 applied in global mode');
+    assert.ok(result.includes('gsd-health'), 'CONV-07 applied');
+  });
+
+  // Parity assertion: claudeToCopilotTools in module matches the table in bin/install.js
+  // Per DEFECT.GENERATIVE-FIX: shared constant across two surfaces needs a parity guard.
+  test('claudeToCopilotTools parity: module table matches bin/install.js table', () => {
+    const installJs = require('../bin/install.js');
+    const moduleTable = conversionModule.claudeToCopilotTools;
+    const installTable = installJs.claudeToCopilotTools;
+    assert.deepStrictEqual(
+      moduleTable,
+      installTable,
+      'claudeToCopilotTools must be identical in module and bin/install.js',
+    );
+  });
+});


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Closes #1182

---

## What was broken

`convertClaudeAgentToCopilotAgent` (and the other 8 `convertClaudeAgentTo*` converters) plus their tool-name table dependencies (`claudeToCopilotTools`, `convertCopilotToolName`, `claudeToGeminiTools`, `convertGeminiToolName`) existed only in `bin/install.js` and were NOT in `src/runtime-artifact-conversion.cts`'s `export =` block. If the module copy is invoked (which #1173 wants to do via descriptor-driven install dispatch), it throws `ReferenceError: claudeToCopilotTools is not defined`.

## What this fix does

Extracts the 9 `convertClaudeAgentTo*` functions together with their full dependency closure (`claudeToCopilotTools`, `claudeToGeminiTools`, `convertCopilotToolName`, `convertGeminiToolName`) into `src/runtime-artifact-conversion.cts` and adds them all to the module's `export =` block.

The inline copies in `bin/install.js` are intentionally NOT removed in this PR — that is #1175. This PR only makes the module self-contained.

## Root cause

When `src/runtime-artifact-conversion.cts` was extracted from `bin/install.js` (PR #1100), only the *skill* converters were migrated. The *agent* converters and their tool-name lookup tables remained in `bin/install.js` only. They were never added to the module's `export =`, making the module incomplete for the descriptor-driven dispatch path planned in #1173.

## Testing

### How I verified the fix

**Fail-first proof:** Before this fix, `require('bin/lib/runtime-artifact-conversion.cjs').convertClaudeAgentToCopilotAgent` returned `undefined`. All 6 new `#1182` tests failed.

**After the fix:** All 6 new tests pass, and all 148 tests in `tests/copilot-install.test.cjs` pass (0 failures).

### Regression test added?

- [x] Yes — added a test that would have caught this bug

New `describe` block in `tests/copilot-install.test.cjs`:

- `module exports claudeToCopilotTools table` — asserts table is exported and correct
- `module exports convertCopilotToolName function` — asserts fn exported and maps correctly
- `module exports convertClaudeAgentToCopilotAgent function` — asserts fn exported
- `convertClaudeAgentToCopilotAgent via module produces correct output (local mode)` — behavioral
- `convertClaudeAgentToCopilotAgent via module applies path/command conversions (global mode)` — behavioral
- `claudeToCopilotTools parity: module table matches bin/install.js table` — DEFECT.GENERATIVE-FIX parity guard ensuring the two copies stay in sync

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [x] N/A (not platform-specific) — string transforms, no filesystem I/O

### Runtimes tested

- [x] N/A — this is an internal module extraction, converters not yet wired into dispatch (#1173)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `no-changelog` label applied — this is a pure internal extraction with no user-facing behavior change (converters are not yet wired into the descriptor-driven dispatch path; that is #1173)
- [x] No unnecessary dependencies added

## Breaking changes

None — the converters are not yet called from any new path. This PR only adds them to the module export surface.

## Unblocks

- #1173 (descriptor-driven install dispatch can now call agent converters via module)
- #1175 (remove now-redundant inline copies from `bin/install.js`)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1220"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784042637&installation_id=134682257&pr_number=1220&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1220&signature=f74097776c4c7c4379a8e3078bf3d0a9be910cf4621bbb7eb97ec8c2537be5e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->