### PR TITLE
test(#1189): cover ADR-0006 planningPaths() consumption in init handlers

### DIFF
--- a/tests/init.test.cjs
+++ b/tests/init.test.cjs
@@ -1655,5 +1655,228 @@ describe('withProjectRoot project identity', () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
+// ADR-0006: init handlers honor GSD_WORKSTREAM (planningPaths/planningDir consumption)
+// Issue #1189 — regression guard: workstream-scoped paths must be resolved
+// through planningDir(cwd) which picks up GSD_WORKSTREAM from env.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('init handlers honor GSD_WORKSTREAM (ADR-0006 planningPaths consumption)', () => {
+  const { seedWorkstream } = require('./fixtures/index.cjs');
+
+  /**
+   * Build a workstream-scoped fixture under tmpDir.
+   * Only workstream-scoped files exist; flat .planning/ has only the phases dir.
+   */
+  function buildWsFixture(tmpDir, ws = 'wsx') {
+    const wsDir = seedWorkstream(tmpDir, { name: ws });
+    // Write the planning files ONLY under the workstream path
+    fs.writeFileSync(
+      path.join(wsDir, 'STATE.md'),
+      '# State\n'
+    );
+    fs.writeFileSync(
+      path.join(wsDir, 'ROADMAP.md'),
+      '# Roadmap\n\n### Phase 1: Setup\n**Goal:** Bootstrap\n**Requirements**: R-01\n**Plans:** 1 plans\n'
+    );
+    fs.writeFileSync(
+      path.join(wsDir, 'config.json'),
+      JSON.stringify({})
+    );
+    // Create a phase plan under the workstream
+    fs.mkdirSync(path.join(wsDir, 'phases', '01-setup'), { recursive: true });
+    fs.writeFileSync(path.join(wsDir, 'phases', '01-setup', '01-01-PLAN.md'), '# Plan\n');
+    return wsDir;
+  }
+
+  // ── Test 1: execute-phase — workstream-scoped path fields (happy) ─────────
+
+  describe('execute-phase — workstream-scoped path fields', () => {
+    let tmpDir;
+
+    beforeEach(() => {
+      tmpDir = createFixture();
+      buildWsFixture(tmpDir, 'wsx');
+    });
+
+    afterEach(() => {
+      cleanup(tmpDir);
+    });
+
+    test('execute-phase emits workstream-scoped state/roadmap/config paths (ADR-0006)', () => {
+      const result = runGsdTools('init execute-phase 1', tmpDir, { GSD_WORKSTREAM: 'wsx', GSD_PROJECT: '' });
+      assert.ok(result.success, `Command failed: ${result.error}`);
+
+      const output = JSON.parse(result.output);
+      // Positive: paths must be workstream-scoped
+      assert.strictEqual(output.state_path, '.planning/workstreams/wsx/STATE.md');
+      assert.strictEqual(output.roadmap_path, '.planning/workstreams/wsx/ROADMAP.md');
+      assert.strictEqual(output.config_path, '.planning/workstreams/wsx/config.json');
+      // Goodhart both-directions: must NOT be the flat form
+      assert.notStrictEqual(output.state_path, '.planning/STATE.md');
+      assert.notStrictEqual(output.roadmap_path, '.planning/ROADMAP.md');
+      assert.notStrictEqual(output.config_path, '.planning/config.json');
+      // phase_dir is emitted and must be workstream-scoped
+      assert.ok(
+        output.phase_dir && output.phase_dir.includes('workstreams/wsx'),
+        `phase_dir should include workstreams/wsx, got: ${output.phase_dir}`
+      );
+    });
+
+    test('execute-phase WITHOUT GSD_WORKSTREAM resolves flat paths (boundary control)', () => {
+      // Flat fixture: the workstream fixture exists but we do NOT pass GSD_WORKSTREAM.
+      // Handler should resolve flat .planning/ → state/roadmap/config are flat,
+      // and the workstream phase is NOT found (flat phases/ is empty).
+      const result = runGsdTools('init execute-phase 1', tmpDir, { GSD_WORKSTREAM: '', GSD_PROJECT: '' });
+      assert.ok(result.success, `Command failed: ${result.error}`);
+
+      const output = JSON.parse(result.output);
+      // Flat paths must be returned when no workstream is active
+      assert.strictEqual(output.state_path, '.planning/STATE.md');
+      assert.strictEqual(output.roadmap_path, '.planning/ROADMAP.md');
+      assert.strictEqual(output.config_path, '.planning/config.json');
+      // Phase is NOT found in flat .planning/phases/ (only exists under workstream)
+      assert.strictEqual(output.phase_found, false,
+        'phase should not be found in flat path when only workstream fixture exists');
+    });
+  });
+
+  // ── Test 2: milestone-op — reads workstream-scoped roadmap/state/phases ───
+
+  describe('milestone-op — reads workstream-scoped planning files', () => {
+    let tmpDir;
+
+    beforeEach(() => {
+      // Do NOT call createFixture (which would add flat .planning/phases/).
+      // Create a bare temp dir so files only exist under the workstream path.
+      const os = require('os');
+      tmpDir = fs.mkdtempSync(require('path').join(os.tmpdir(), 'gsd-test-'));
+      buildWsFixture(tmpDir, 'wsx');
+    });
+
+    afterEach(() => {
+      cleanup(tmpDir);
+    });
+
+    test('milestone-op with GSD_WORKSTREAM finds roadmap/state/phases in workstream scope (ADR-0006)', () => {
+      const result = runGsdTools('init milestone-op', tmpDir, { GSD_WORKSTREAM: 'wsx', GSD_PROJECT: '' });
+      assert.ok(result.success, `Command failed: ${result.error}`);
+
+      const output = JSON.parse(result.output);
+      assert.strictEqual(output.roadmap_exists, true,
+        'roadmap_exists must be true: ROADMAP.md exists only under workstream path');
+      assert.strictEqual(output.state_exists, true,
+        'state_exists must be true: STATE.md exists only under workstream path');
+      assert.strictEqual(output.phases_dir_exists, true,
+        'phases_dir_exists must be true: phases/ exists under workstream path');
+    });
+
+    test('milestone-op WITHOUT GSD_WORKSTREAM misses workstream-only files (negative discrimination)', () => {
+      const result = runGsdTools('init milestone-op', tmpDir, { GSD_WORKSTREAM: '', GSD_PROJECT: '' });
+      assert.ok(result.success, `Command failed: ${result.error}`);
+
+      const output = JSON.parse(result.output);
+      // Handler looked at flat .planning/ — no files there → all false
+      assert.strictEqual(output.roadmap_exists, false,
+        'roadmap_exists must be false: ROADMAP.md is only under workstream, not flat .planning/');
+      assert.strictEqual(output.state_exists, false,
+        'state_exists must be false: STATE.md is only under workstream, not flat .planning/');
+    });
+  });
+
+  // ── Test 3: plan-phase — workstream-scoped resolution ────────────────────
+
+  describe('plan-phase — workstream-scoped path resolution', () => {
+    let tmpDir;
+
+    beforeEach(() => {
+      tmpDir = createFixture();
+      buildWsFixture(tmpDir, 'wsx');
+    });
+
+    afterEach(() => {
+      cleanup(tmpDir);
+    });
+
+    test('plan-phase emits workstream-scoped state/roadmap/requirements paths (ADR-0006)', () => {
+      const result = runGsdTools('init plan-phase 1', tmpDir, { GSD_WORKSTREAM: 'wsx', GSD_PROJECT: '' });
+      assert.ok(result.success, `Command failed: ${result.error}`);
+
+      const output = JSON.parse(result.output);
+      // Path fields must be scoped to the workstream
+      assert.strictEqual(output.state_path, '.planning/workstreams/wsx/STATE.md');
+      assert.strictEqual(output.roadmap_path, '.planning/workstreams/wsx/ROADMAP.md');
+      assert.strictEqual(output.requirements_path, '.planning/workstreams/wsx/REQUIREMENTS.md');
+      // Must NOT be flat
+      assert.notStrictEqual(output.state_path, '.planning/STATE.md');
+      assert.notStrictEqual(output.roadmap_path, '.planning/ROADMAP.md');
+      // phase_dir is workstream-scoped and phase is found
+      assert.strictEqual(output.phase_found, true);
+      assert.ok(
+        output.phase_dir && output.phase_dir.includes('workstreams/wsx'),
+        `phase_dir should include workstreams/wsx, got: ${output.phase_dir}`
+      );
+    });
+
+    test('plan-phase WITHOUT GSD_WORKSTREAM resolves flat paths (boundary control)', () => {
+      const result = runGsdTools('init plan-phase 1', tmpDir, { GSD_WORKSTREAM: '', GSD_PROJECT: '' });
+      assert.ok(result.success, `Command failed: ${result.error}`);
+
+      const output = JSON.parse(result.output);
+      assert.strictEqual(output.state_path, '.planning/STATE.md');
+      assert.strictEqual(output.roadmap_path, '.planning/ROADMAP.md');
+      assert.strictEqual(output.requirements_path, '.planning/REQUIREMENTS.md');
+      // Phase only exists under workstream, so not found via flat path
+      assert.strictEqual(output.phase_found, false);
+    });
+  });
+
+  // ── Test 4: phase-op — workstream-scoped phase resolution ────────────────
+
+  describe('phase-op — workstream-scoped phase resolution', () => {
+    let tmpDir;
+
+    beforeEach(() => {
+      tmpDir = createFixture();
+      buildWsFixture(tmpDir, 'wsx');
+    });
+
+    afterEach(() => {
+      cleanup(tmpDir);
+    });
+
+    test('phase-op with GSD_WORKSTREAM finds phase in workstream scope and emits scoped paths (ADR-0006)', () => {
+      const result = runGsdTools('init phase-op 1', tmpDir, { GSD_WORKSTREAM: 'wsx', GSD_PROJECT: '' });
+      assert.ok(result.success, `Command failed: ${result.error}`);
+
+      const output = JSON.parse(result.output);
+      // Phase is found via workstream-scoped phases dir
+      assert.strictEqual(output.phase_found, true,
+        'phase_found must be true: phase exists under workstream path');
+      assert.ok(
+        output.phase_dir && output.phase_dir.includes('workstreams/wsx'),
+        `phase_dir should include workstreams/wsx, got: ${output.phase_dir}`
+      );
+      // Path fields are workstream-scoped
+      assert.strictEqual(output.state_path, '.planning/workstreams/wsx/STATE.md');
+      assert.strictEqual(output.roadmap_path, '.planning/workstreams/wsx/ROADMAP.md');
+      assert.notStrictEqual(output.state_path, '.planning/STATE.md');
+    });
+
+    test('phase-op WITHOUT GSD_WORKSTREAM does not find workstream-only phase (negative discrimination)', () => {
+      const result = runGsdTools('init phase-op 1', tmpDir, { GSD_WORKSTREAM: '', GSD_PROJECT: '' });
+      assert.ok(result.success, `Command failed: ${result.error}`);
+
+      const output = JSON.parse(result.output);
+      // Phase only exists under workstream path — flat path has no matching phase dir
+      assert.strictEqual(output.phase_found, false,
+        'phase_found must be false: phase only exists under workstream path');
+      // Flat paths are emitted
+      assert.strictEqual(output.state_path, '.planning/STATE.md');
+      assert.strictEqual(output.roadmap_path, '.planning/ROADMAP.md');
+    });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
 // roadmap analyze command
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Enhancement PR

## Linked Issue

Closes #1189

## What this enhancement improves

ADR-0006 (Planning Path Projection Module) has its central invariant covered only at the **helper** level — `tests/planning-workspace.test.cjs` exercises `planningDir`/`planningPaths` directly. The **consumption** of those helpers by the `init` handlers was untested: nothing asserted that `execute-phase` / `plan-phase` / `phase-op` / `milestone-op` actually route their planning paths through `planningPaths()` and therefore resolve **workstream-scoped** paths under `GSD_WORKSTREAM` (`.planning/workstreams/<ws>/…`) instead of the flat `.planning/…` form.

Consequence: a regression that bypassed `planningPaths()` inside any handler (reverting to flat `.planning` joins) would have passed CI silently. This PR closes that gap with a black-box regression guard over all four init subcommands.

## Before / After

**Before:** `planningDir`/`planningPaths` unit-tested in isolation; zero coverage of whether the init handlers route through them. A flat-`.planning` regression in any handler ships green.

**After:** 8 tests in `tests/init.test.cjs` assert, through the CLI, that under `GSD_WORKSTREAM=wsx` each handler emits workstream-scoped paths and, in the control cases, the flat form when no workstream is set. A handler reverting to flat joins now turns the suite red — verified by mutation (forcing `planningDir` to ignore the workstream fails exactly the 4 positive assertions).

## How it was implemented

- New `describe('init handlers honor GSD_WORKSTREAM (ADR-0006 planningPaths consumption)', …)` block in `tests/init.test.cjs`.
- Black-box via the existing `runGsdTools(args, cwd, env)` CLI-spawn harness + `createFixture`/`seedPhase`/`seedWorkstream`; fixtures seeded into the workstream-scoped `.planning/workstreams/wsx/` location (not flat — otherwise the handler finds nothing and the test is vacuously green).
- Observables are the handlers' emitted JSON: `state_path`/`roadmap_path`/`config_path` (execute-phase, plan-phase), `roadmap_exists`/`state_exists`/`phases_dir_exists` (milestone-op), `phase_found`/`phase_dir` (phase-op).
- Each positive case asserts **both** the workstream-scoped value **and** not-equal-to-flat (a genuine guard, not coverage credit). Assertions are limited to invariant-bearing fields — no pinning of incidental output (`agents_installed`, `project_root`, model/config values).
- Hermeticity: every CLI call pins `GSD_WORKSTREAM` and `GSD_PROJECT` explicitly (child-scoped env), so an ambient `GSD_*` in the test runner cannot make a flat-control test run scoped (or vice-versa).

No source changes — `git diff src/` is empty.

## Testing

- `node --test tests/init.test.cjs` → **102/102 pass** (8 new, no regressions).
- Targeted: `node --test --test-name-pattern='ADR-0006' tests/init.test.cjs` → **8/8**.
- **Mutation (red→green):** forcing `planningDir` to ignore the workstream turns the 4 positive assertions red; revert → 8/8 green.
- **Hermeticity:** `GSD_WORKSTREAM=ambientws GSD_PROJECT=ambientproj node --test --test-name-pattern='ADR-0006' tests/init.test.cjs` → **8/8 pass** (polluted parent env has no effect).
- `npm run lint` clean. Independent Codex adversarial review run; its one finding (flat-control calls inheriting ambient `GSD_*`) fixed and re-verified.

## Scope confirmation

Test-only. No runtime/user-facing behavior change, no new command/flag/output, no module or seam added (so no CONTEXT.md glossary change). Adds coverage for an existing, already-documented (ADR-0006) invariant. Sibling **source-seam** work (clock/reset determinism) is tracked separately in #1191.

## Checklist

- [x] Linked issue is approved (`approved-enhancement` on #1189)
- [x] Tests pass locally (102/102 in the touched file; 8 new)
- [x] Lint passes
- [x] No changeset required — test-only; `changeset-required` lint returns `ok_no_user_facing_changes`
- [x] No docs required — test-only, no user-facing surface
- [x] `src/` unmodified (test-only change)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1226"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784048725&installation_id=134682257&pr_number=1226&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1226&signature=1f99e395ed022f0d4a931cc28fb76f2b1d5c259c0bee5db141ac79093ea51bee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->