### PR TITLE
fix(#1223): install scripts/fix-slash-commands.cjs so gsd-tools loads

### DIFF
--- a/.changeset/graceful-wasps-bark.md
+++ b/.changeset/graceful-wasps-bark.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 1232
+---
+**`gsd-tools` CLI no longer crashes at load on installed runtimes** — the installer now copies `scripts/fix-slash-commands.cjs` into the runtime config dir, where `command-roster` hard-requires it via `../../../scripts/`. Previously the file shipped in the npm tarball but was never installed, so every `gsd_run` invocation died at module load with `MODULE_NOT_FOUND` and no GSD workflow could run. `readCmdNames()` also now degrades to `[]` when no `commands/gsd` directory exists.

--- a/bin/install.js
+++ b/bin/install.js
@@ -8365,6 +8365,15 @@ function uninstall(isGlobal, runtime = 'claude') {
       console.log(`  ${green}✓${reset} Removed scripts/lib/ GSD files`);
     }
   }
+  // Remove scripts/fix-slash-commands.cjs (command-roster runtime dep, #1223)
+  const fixSlashUninstallPath = path.join(targetDir, 'scripts', 'fix-slash-commands.cjs');
+  if (fs.existsSync(fixSlashUninstallPath)) {
+    try {
+      fs.unlinkSync(fixSlashUninstallPath);
+      removedCount++;
+      console.log(`  ${green}✓${reset} Removed scripts/fix-slash-commands.cjs`);
+    } catch (_) { /* best-effort */ }
+  }
   // If scripts/ dir is now empty, remove it too
   const scriptsUninstallDir = path.join(targetDir, 'scripts');
   if (fs.existsSync(scriptsUninstallDir)) {
@@ -9078,6 +9087,11 @@ function writeManifest(configDir, runtime = 'claude', options = {}) {
         manifest.files['scripts/lib/' + file] = fileHash(path.join(scriptsLibInstallDir, file));
       }
     }
+  }
+  // Track scripts/fix-slash-commands.cjs (command-roster runtime dep, #1223)
+  const fixSlashInstallPath = path.join(configDir, 'scripts', 'fix-slash-commands.cjs');
+  if (fs.existsSync(fixSlashInstallPath)) {
+    manifest.files['scripts/fix-slash-commands.cjs'] = fileHash(fixSlashInstallPath);
   }
 
   fs.writeFileSync(path.join(configDir, MANIFEST_NAME), JSON.stringify(manifest, null, 2));
@@ -10469,6 +10483,30 @@ function install(isGlobal, runtime = 'claude', options = {}) {
       console.log(`  ${green}✓${reset} Installed scripts/changeset/ (changelog preview CLI)`);
     } else {
       failures.push('scripts/changeset/cli.cjs');
+    }
+  }
+
+  // Install scripts/fix-slash-commands.cjs into <configDir>/scripts/ (#1223).
+  //
+  // gsd-core/bin/lib/command-roster.cjs hard-requires this file at module load
+  // via require('../../../scripts/fix-slash-commands.cjs'), which resolves to
+  // <install-root>/scripts/fix-slash-commands.cjs (a sibling of gsd-core/). It
+  // ships in the npm tarball root but was never copied to the runtime config
+  // dir, so every gsd-tools invocation crashed at load with MODULE_NOT_FOUND
+  // (the entire CLI unusable — same defect class as #935 / #606). All runtimes
+  // load the roster through gsd-tools, so copy unconditionally, same scope as
+  // gsd-core/ itself.
+  const fixSlashSrc = path.join(src, 'scripts', 'fix-slash-commands.cjs');
+  if (!fs.existsSync(fixSlashSrc)) {
+    failures.push('scripts/fix-slash-commands.cjs (source missing from package — reinstall from npm)');
+  } else {
+    const scriptsDest = path.join(targetDir, 'scripts');
+    fs.mkdirSync(scriptsDest, { recursive: true });
+    fs.copyFileSync(fixSlashSrc, path.join(scriptsDest, 'fix-slash-commands.cjs'));
+    if (verifyFileInstalled(path.join(scriptsDest, 'fix-slash-commands.cjs'), 'scripts/fix-slash-commands.cjs')) {
+      console.log(`  ${green}✓${reset} Installed scripts/fix-slash-commands.cjs (command-roster runtime dep)`);
+    } else {
+      failures.push('scripts/fix-slash-commands.cjs');
     }
   }
 

--- a/scripts/fix-slash-commands.cjs
+++ b/scripts/fix-slash-commands.cjs
@@ -92,7 +92,12 @@ function transformContentToHyphen(src, cmdNames) {
 }
 
 function readCmdNames() {
-  return fs.readdirSync(COMMANDS_DIR)
+  // Skill-based runtimes register GSD commands as skills and have no
+  // commands/gsd directory, so the readdir would throw ENOENT. Degrade to an
+  // empty roster — same try/catch no-op contract as processFile/processDir below.
+  let entries;
+  try { entries = fs.readdirSync(COMMANDS_DIR); } catch { return []; }
+  return entries
     .filter(f => f.endsWith('.md'))
     .map(f => f.replace(/\.md$/, ''));
 }

--- a/tests/bug-376-claude-js-hook-gsd-rewriter.test.cjs
+++ b/tests/bug-376-claude-js-hook-gsd-rewriter.test.cjs
@@ -248,6 +248,12 @@ describe('bug #376 — Suite 2: Cursor install still rewrites /gsd: → /gsd- (r
 
     const offenders = [];
     for (const { rel, full } of jsFiles) {
+      // scripts/fix-slash-commands.cjs IS the namespace transformer (#1223).
+      // Its `/gsd:` occurrences are transform-rule literals and template code
+      // (e.g. `/gsd:${cmd}`), not user-facing command refs — rewriting them
+      // would corrupt the module, so the installer ships it verbatim (same
+      // contract as the unmutated hook sources in Suite 3).
+      if (path.basename(rel) === 'fix-slash-commands.cjs') continue;
       const content = fs.readFileSync(full, 'utf-8');
       const badLines = colonRefs(content);
       if (badLines.length > 0) {

--- a/tests/install.test.cjs
+++ b/tests/install.test.cjs
@@ -947,6 +947,117 @@ describe('install — changeset CLI lands at scripts/changeset/cli.cjs (#935)', 
   });
 });
 
+// ─── Section N: fix-slash-commands.cjs install regression (#1223) ────────────
+
+describe('install — scripts/fix-slash-commands.cjs lands for command-roster (#1223)', () => {
+  // Regression guard: gsd-core/bin/lib/command-roster.cjs hard-requires
+  // ../../../scripts/fix-slash-commands.cjs at module load. The installer copied
+  // scripts/changeset/ and scripts/lib/ but never this top-level file, so every
+  // gsd-tools invocation crashed with MODULE_NOT_FOUND — the entire CLI unusable.
+  let tmpDir;
+  let previousCwd;
+
+  beforeEach(() => {
+    tmpDir = createTempDir('gsd-fix-slash-1223-');
+    previousCwd = process.cwd();
+    process.chdir(tmpDir);
+  });
+
+  afterEach(() => {
+    process.chdir(previousCwd);
+    cleanup(tmpDir);
+  });
+
+  test('install() copies scripts/fix-slash-commands.cjs to <configDir>/scripts/', () => {
+    install(false, 'claude');
+    const claudeDir = path.join(tmpDir, '.claude');
+    const filePath = path.join(claudeDir, 'scripts', 'fix-slash-commands.cjs');
+    assert.ok(
+      fs.existsSync(filePath),
+      `scripts/fix-slash-commands.cjs must exist at ${path.relative(tmpDir, filePath)} after install (#1223)`,
+    );
+  });
+
+  test('installed gsd-tools loads without MODULE_NOT_FOUND and emits JSON (#1223)', () => {
+    // End-to-end proof of the reported crash: from the installed gsd-core/, the
+    // command-roster require chain must resolve so `gsd-tools query` runs.
+    install(false, 'claude');
+    const claudeDir = path.join(tmpDir, '.claude');
+    const gsdTools = path.join(claudeDir, 'gsd-core', 'bin', 'gsd-tools.cjs');
+    assert.ok(fs.existsSync(gsdTools), 'gsd-tools.cjs must be installed under gsd-core/bin/');
+    const { spawnSync } = require('node:child_process');
+    const result = spawnSync(process.execPath, [gsdTools, 'query', 'init.new-project'], { encoding: 'utf8' });
+    assert.ok(
+      !result.stderr.includes('MODULE_NOT_FOUND') && !result.stderr.includes('Cannot find module'),
+      `gsd-tools query must resolve all modules; stderr=${result.stderr}`,
+    );
+    assert.strictEqual(result.status, 0, `gsd-tools query must exit 0; got ${result.status}; stderr=${result.stderr}`);
+    assert.doesNotThrow(() => JSON.parse(result.stdout), 'gsd-tools query must emit valid JSON');
+  });
+
+  test('command-roster require resolves from the installed layout (#1223)', () => {
+    // Direct guard against a manifest that omits the file: load command-roster
+    // from the installed gsd-core/ and confirm it does not throw at module load.
+    install(false, 'claude');
+    const claudeDir = path.join(tmpDir, '.claude');
+    const roster = path.join(claudeDir, 'gsd-core', 'bin', 'lib', 'command-roster.cjs');
+    const { spawnSync } = require('node:child_process');
+    const result = spawnSync(process.execPath, ['-e', `require(${JSON.stringify(roster)})`], { encoding: 'utf8' });
+    assert.ok(
+      !result.stderr.includes("Cannot find module '../../../scripts/fix-slash-commands.cjs'"),
+      `command-roster must resolve fix-slash-commands.cjs from the install; stderr=${result.stderr}`,
+    );
+    assert.strictEqual(result.status, 0, `requiring command-roster must not throw; stderr=${result.stderr}`);
+  });
+
+  test('readCmdNames() returns [] when commands/gsd is absent (#1223)', () => {
+    // Latent second failure: runtimes that register GSD as skills have no
+    // commands/gsd directory, so readCmdNames()'s readdirSync would throw ENOENT.
+    // Copy the shipped module into an isolated scripts/ dir with no sibling
+    // commands/gsd and confirm it degrades to [] rather than crashing.
+    const isolatedScripts = path.join(tmpDir, 'isolated', 'scripts');
+    fs.mkdirSync(isolatedScripts, { recursive: true });
+    const target = path.join(isolatedScripts, 'fix-slash-commands.cjs');
+    fs.copyFileSync(path.join(__dirname, '..', 'scripts', 'fix-slash-commands.cjs'), target);
+    assert.ok(
+      !fs.existsSync(path.join(tmpDir, 'isolated', 'commands', 'gsd')),
+      'pre-condition: isolated layout has no commands/gsd directory',
+    );
+    const { spawnSync } = require('node:child_process');
+    const result = spawnSync(
+      process.execPath,
+      ['-e', `const m=require(${JSON.stringify(target)}); process.stdout.write(JSON.stringify(m.readCmdNames()))`],
+      { encoding: 'utf8' },
+    );
+    assert.strictEqual(result.status, 0, `readCmdNames() must not throw; stderr=${result.stderr}`);
+    assert.deepStrictEqual(JSON.parse(result.stdout), [], 'readCmdNames() must return [] when commands/gsd is absent');
+  });
+
+  test('writeManifest() tracks scripts/fix-slash-commands.cjs', () => {
+    install(false, 'claude');
+    const claudeDir = path.join(tmpDir, '.claude');
+    const manifest = writeManifest(claudeDir, 'claude');
+    assert.ok(
+      Object.keys(manifest.files).includes('scripts/fix-slash-commands.cjs'),
+      'manifest must track scripts/fix-slash-commands.cjs',
+    );
+  });
+
+  test('uninstall() removes scripts/fix-slash-commands.cjs', () => {
+    install(false, 'claude');
+    const claudeDir = path.join(tmpDir, '.claude');
+    assert.ok(
+      fs.existsSync(path.join(claudeDir, 'scripts', 'fix-slash-commands.cjs')),
+      'pre-condition: fix-slash-commands.cjs must be installed before uninstall',
+    );
+    uninstall(false, 'claude');
+    assert.ok(
+      !fs.existsSync(path.join(claudeDir, 'scripts', 'fix-slash-commands.cjs')),
+      'scripts/fix-slash-commands.cjs must be removed on uninstall',
+    );
+  });
+});
+
 // ─── Section N: Antigravity .agents canonical workspace dir (#791) ─────────────
 // allow-test-rule: runtime-contract-is-the-product
 // Reads deployed agent .md files whose text IS the product surface the


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #1223

> Linked issue carries `confirmed-bug` (and `priority: high`, `ready-for-agent`).

---

## What was broken

Every `gsd-tools` invocation crashed at module load with `Cannot find module '../../../scripts/fix-slash-commands.cjs'` on installed runtimes (regression since 1.5.0-rc.1), so no GSD workflow could run.

## What this fix does

The installer now copies `scripts/fix-slash-commands.cjs` into `<install-root>/scripts/` (where `command-roster` requires it), tracks it in the file manifest, and removes it on uninstall. `readCmdNames()` also degrades to `[]` when no `commands/gsd` directory exists.

## Root cause

`gsd-core/bin/lib/command-roster.cjs` hard-requires `../../../scripts/fix-slash-commands.cjs` at module load, resolving to `<install-root>/scripts/fix-slash-commands.cjs` (a sibling of `gsd-core/`). The file ships in the npm tarball root but the installer copy manifest deployed `scripts/changeset/` and `scripts/lib/` while omitting this top-level file. Because the throw is at load of a core dependency in the `gsd-tools` require chain, every `gsd_run query ...` failed identically. Same defect class as #935 (`scripts/changeset/cli.cjs`) and #606 (`hooks/managed-hooks-registry.cjs`).

A second, latent failure: `readCmdNames()` did an unguarded `fs.readdirSync(commands/gsd)`, which throws `ENOENT` on skill-based installs lacking that directory — now guarded.

## Testing

### How I verified the fix

Added regression guards in `tests/install.test.cjs` that drive a real `install()` into a temp config dir and assert:
- `scripts/fix-slash-commands.cjs` lands at `<configDir>/scripts/`
- the installed `gsd-tools query init.new-project` exits 0, emits valid JSON, and produces no `MODULE_NOT_FOUND`
- requiring the installed `command-roster.cjs` resolves cleanly
- the manifest tracks the file and `uninstall()` removes it
- `readCmdNames()` returns `[]` when `commands/gsd` is absent

All 123 install tests pass; the namespace-transformer suites that consume the module (bug-2543/2808/3683/3677) stay green.

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No

### Platforms tested

- [ ] macOS
- [x] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] N/A

---

## Checklist

- [x] Issue linked above with `Fixes #1223`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added (`Fixed`)
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1232"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784053693&installation_id=134682257&pr_number=1232&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1232&signature=d549f64413361b78766065f9180890c14b98d67be7eeb3ffaa8c38e58fc701c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->