### PR TITLE
chore(#1175): remove dead tool-name converters + fix unused-arg lint

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -2335,22 +2335,6 @@ const claudeToCursorTools = {
   SlashCommand: null,    // No equivalent — skills are auto-discovered
 };
 
-/**
- * Convert a Claude Code tool name to Cursor CLI format
- * @returns {string|null} Cursor tool name, or null if tool should be excluded
- */
-function convertCursorToolName(claudeTool) {
-  if (claudeTool in claudeToCursorTools) {
-    return claudeToCursorTools[claudeTool];
-  }
-  // MCP tools keep their format (Cursor supports MCP)
-  if (claudeTool.startsWith('mcp__')) {
-    return claudeTool;
-  }
-  // Most tools share the same name (Read, Write, Glob, Grep, Task, WebSearch, WebFetch, TodoWrite)
-  return claudeTool;
-}
-
 function convertSlashCommandsToCursorSkillMentions(content) {
   // Keep leading "/" for slash commands; only normalize gsd: -> gsd-.
   // This preserves rendered "next step" commands like "/gsd-execute-phase 17".
@@ -2477,22 +2461,6 @@ const claudeToWindsurfTools = {
   SlashCommand: null,    // No equivalent — skills are auto-discovered
 };
 
-/**
- * Convert a Claude Code tool name to Windsurf Cascade format
- * @returns {string|null} Windsurf tool name, or null if tool should be excluded
- */
-function convertWindsurfToolName(claudeTool) {
-  if (claudeTool in claudeToWindsurfTools) {
-    return claudeToWindsurfTools[claudeTool];
-  }
-  // MCP tools keep their format (Windsurf supports MCP)
-  if (claudeTool.startsWith('mcp__')) {
-    return claudeTool;
-  }
-  // Most tools share the same name (Read, Write, Glob, Grep, Task, WebSearch, WebFetch, TodoWrite)
-  return claudeTool;
-}
-
 function convertSlashCommandsToWindsurfSkillMentions(content) {
   // Keep leading "/" for slash commands; only normalize gsd: -> gsd-.
   return content.replace(/gsd:/gi, 'gsd-');
@@ -2604,25 +2572,6 @@ const claudeToAugmentTools = {
   SlashCommand: null,
   TodoWrite: 'add_tasks',
 };
-
-function convertAugmentToolName(claudeTool) {
-  if (claudeTool in claudeToAugmentTools) {
-    return claudeToAugmentTools[claudeTool];
-  }
-  if (claudeTool.startsWith('mcp__')) {
-    return claudeTool;
-  }
-  const toolMapping = {
-    Read: 'view',
-    Write: 'save-file',
-    Glob: 'view',
-    Grep: 'grep',
-    Task: null,
-    WebSearch: 'web-search',
-    WebFetch: 'web-fetch',
-  };
-  return toolMapping[claudeTool] || claudeTool;
-}
 
 function convertSlashCommandsToAugmentSkillMentions(content) {
   return content.replace(/gsd:/gi, 'gsd-');


### PR DESCRIPTION
## Enhancement PR

---

## Linked Issue

Closes #1175

---

## What this enhancement improves

Removes three dead tool-name converter functions from `bin/install.js` that were extracted to `src/runtime-artifact-conversion.cts` in prior work but never deleted from the committed installer source.

## Before / After

**Before:**
`bin/install.js` contained three unreferenced functions:
- `convertCursorToolName` (lines ~2342–2352)
- `convertWindsurfToolName` (lines ~2484–2494)
- `convertAugmentToolName` (lines ~2608–2625)

**After:**
All three functions removed. 51 lines of dead code eliminated. Zero behavior change.

## How it was implemented

Grepped the entire repo (`src/`, `bin/`, `scripts/`, `tests/`) for each candidate function name:

```
convertCursorToolName  — 0 callers (definition only in bin/install.js)
convertWindsurfToolName — 0 callers (definition only in bin/install.js)
convertAugmentToolName  — 0 callers (definition only in bin/install.js)
```

All three were also absent from `src/runtime-artifact-conversion.cts` exports, confirming they are not surfaced anywhere. Removed the definition blocks (including JSDoc comments for the first two) from `bin/install.js` directly.

The issue also mentioned fixing unused-arg lint warnings in `src/runtime-artifact-conversion.cts`. After audit, all parameters in that file that are intentionally unused already carry the `_` prefix convention (e.g., `_runtime`, `_cmdNames`, `_commandName`). The used parameter `runtime` in `convertClaudeCommandToClaudeSkill` is legitimately consumed (lines 388, 392 for `hermes`/`qwen` branching). ESLint `npm run lint` confirmed: **0 issues**.

## Testing

### How I verified the enhancement works

- `npm run build` — clean (tsc + build:lib + hooks)
- `npm run lint` — 0 issues
- `gsd-test-summary --both` — Docker (Linux): **18155 passed, 0 failed**; 3 Mac-only failures in `bug-891-non-claude-runtime-home-fallback.test.cjs` are pre-existing environmental (bash subprocess `node: command not found` due to stripped PATH in sandbox, passes in Docker)

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [x] N/A (not runtime-specific — dead-code removal only)

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue — no additions or removals
- [x] If scope changed during implementation, I updated the issue and got re-approval before continuing

---

## Documentation

- [x] If genuinely no user-facing docs impact (infrastructure / internal refactor / test-only),
      apply the `no-docs` label **or** add `<!-- docs-exempt: <reason> -->` inside each
      triggering changeset fragment and leave a comment explaining why.

(No changeset fragment — `no-changelog` label applied. Dead-code removal, no user-facing change.)

## Checklist

- [x] Issue linked above with `Closes #NNN`
- [x] Linked issue has the `approved-enhancement` label
- [x] Changes are scoped to the approved enhancement — nothing extra included
- [x] All existing tests pass (`npm test`)
- [x] New or updated tests cover the enhanced behavior — N/A (dead-code removal, behavior unchanged)
- [x] `.changeset/` fragment added — not needed; `no-changelog` label applied (internal dead-code removal)
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1234"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784054541&installation_id=134682257&pr_number=1234&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1234&signature=2ef5cd1bfb62432e886c43309c97e1b8b48ea592568151c1db87ff0eb7cad83e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->