### PR TITLE
fix(#1238): keep node resolvable in bug-891 PATH isolation (home-fallback subtests false-fail when node co-locates with global gsd-tools)

### DIFF
--- a/tests/bug-891-non-claude-runtime-home-fallback.test.cjs
+++ b/tests/bug-891-non-claude-runtime-home-fallback.test.cjs
@@ -121,17 +121,46 @@ function extractShellBlocks(content) {
 }
 
 /**
- * Build a PATH with no gsd-tools binary so the PATH fallback branch is skipped.
- * Returns the isolated PATH string (system paths minus any dir containing gsd-tools).
+ * Build a PATH with no gsd-tools binary so the PATH fallback branch is skipped,
+ * while guaranteeing that a bare `node` lookup still resolves regardless of whether
+ * the real node binary co-locates with a global gsd-tools shim (e.g. fnm/nvm/Homebrew).
+ *
+ * Strategy (POSIX only): create a temp dir containing only a `node` symlink →
+ * process.execPath, prepend it to the gsd-tools-filtered PATH.  The filtered
+ * PATH excludes any directory that contains an executable `gsd-tools`.
+ *
+ * On Windows the co-location bug does not apply (gsd-tools resolves via .cmd/.ps1,
+ * not the bare binary probed here), and symlinks may require elevated privileges,
+ * so we skip the symlink step entirely on that platform.
+ *
+ * The caller is responsible for cleaning up `result.nodeBinDir` when non-null
+ * (pass it to `cleanup()` in a `t.after` or `finally` block).
+ *
+ * @returns {{ isolatedPath: string, nodeBinDir: string|null }}
  */
 function buildIsolatedPath() {
-  return (process.env.PATH || '/usr/bin:/bin')
+  const filteredPath = (process.env.PATH || '/usr/bin:/bin')
     .split(path.delimiter)
     .filter((p) => {
       try { fs.accessSync(path.join(p, 'gsd-tools'), fs.constants.X_OK); return false; }
       catch { return true; }
     })
     .join(path.delimiter);
+
+  // Windows: no symlink (see JSDoc above); callers must handle nodeBinDir === null.
+  if (process.platform === 'win32') {
+    return { isolatedPath: filteredPath, nodeBinDir: null };
+  }
+
+  const nodeBinDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-891-node-'));
+  try {
+    fs.symlinkSync(process.execPath, path.join(nodeBinDir, 'node'));
+  } catch (err) {
+    cleanup(nodeBinDir);
+    throw err;
+  }
+
+  return { isolatedPath: nodeBinDir + path.delimiter + filteredPath, nodeBinDir };
 }
 
 describe('bug-891: non-Claude runtime home fallback arms', () => {
@@ -179,11 +208,83 @@ describe('bug-891: non-Claude runtime home fallback arms', () => {
     }
   });
 
+  // ── (B0) Regression: buildIsolatedPath keeps node resolvable when node and ──
+  //        gsd-tools co-locate in the same PATH directory.                     ─
+  //
+  // Machine-independence guarantee: PATH is set to ONLY two controlled dirs —
+  // fakeBinDir (holds both fake gsd-tools AND a node symlink) plus a fresh
+  // empty dir (no executables at all). The real system PATH is NOT appended.
+  //
+  //   Old logic: filters out fakeBinDir → only the empty dir remains → node
+  //              UNresolvable → assertion (ii) FAILS (true-red on any machine).
+  //   New logic: prepends its own nodeBinDir → node resolvable despite fakeBinDir
+  //              being filtered → both assertions pass.
+  test(
+    '(B0) buildIsolatedPath: node is resolvable and gsd-tools is not when they share a PATH dir',
+    { skip: process.platform === 'win32' ? 'POSIX-only co-location scenario' : false },
+    (t) => {
+      // Build a fake bin dir that contains BOTH a gsd-tools executable and a node
+      // symlink, simulating a dev setup (fnm/nvm/Homebrew) where both land in the
+      // same bin directory.
+      const fakeBinDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-891-colocated-'));
+      // A second fresh empty dir — contains neither gsd-tools nor node.
+      const emptyDir   = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-891-empty-'));
+      t.after(() => cleanup(fakeBinDir));
+      t.after(() => cleanup(emptyDir));
+
+      // Fake gsd-tools shim (executable file)
+      const fakeGsdTools = path.join(fakeBinDir, 'gsd-tools');
+      fs.writeFileSync(fakeGsdTools, '#!/bin/sh\necho fake-gsd-tools\n');
+      fs.chmodSync(fakeGsdTools, 0o755);
+
+      // node symlink pointing at the real interpreter (co-located with gsd-tools)
+      fs.symlinkSync(process.execPath, path.join(fakeBinDir, 'node'));
+
+      // Set PATH to ONLY the two controlled dirs (no real system dirs).
+      // This makes the test machine-independent: on any machine, the only place
+      // node *could* come from before the fix is fakeBinDir — which gets filtered.
+      const origPath = process.env.PATH;
+      process.env.PATH = fakeBinDir + path.delimiter + emptyDir;
+      let result;
+      try {
+        result = buildIsolatedPath();
+      } finally {
+        process.env.PATH = origPath;
+      }
+      t.after(() => cleanup(result.nodeBinDir));
+
+      const returnedDirs = result.isolatedPath.split(path.delimiter);
+
+      // (i) gsd-tools must NOT be resolvable on the returned PATH
+      const gsdToolsResolvable = returnedDirs.some((dir) => {
+        try { fs.accessSync(path.join(dir, 'gsd-tools'), fs.constants.X_OK); return true; }
+        catch { return false; }
+      });
+      assert.equal(
+        gsdToolsResolvable,
+        false,
+        'gsd-tools must not be resolvable on the isolated PATH (home-fallback would be bypassed)',
+      );
+
+      // (ii) node must BE resolvable on the returned PATH (the new nodeBinDir makes it so)
+      const nodeResolvable = returnedDirs.some((dir) => {
+        try { fs.accessSync(path.join(dir, 'node'), fs.constants.X_OK); return true; }
+        catch { return false; }
+      });
+      assert.equal(
+        nodeResolvable,
+        true,
+        'node must be resolvable on the isolated PATH (launcher runs: node "$GSD_TOOLS" "$@")',
+      );
+    },
+  );
+
   // ── (B) Behavioral: HERMES_HOME stub is resolved ──────────────────────────
   test('(B) gsd_run resolves ${HERMES_HOME}/gsd-core/bin/ stub when set and local+PATH both miss', () => {
     const fakeHome       = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-891-home-b-'));
     const fakeHermesHome = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-891-hermes-'));
     const fakeRuntime    = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-891-rt-'));
+    const { isolatedPath, nodeBinDir } = buildIsolatedPath();
     try {
       const hermesBinDir = path.join(fakeHermesHome, 'gsd-core', 'bin');
       fs.mkdirSync(hermesBinDir, { recursive: true });
@@ -212,7 +313,7 @@ describe('bug-891: non-Claude runtime home fallback arms', () => {
 
       const stdout = execFileSync('bash', [scriptPath], {
         encoding: 'utf8',
-        env: { ...process.env, PATH: buildIsolatedPath(), HOME: fakeHome, HERMES_HOME: fakeHermesHome },
+        env: { ...process.env, PATH: isolatedPath, HOME: fakeHome, HERMES_HOME: fakeHermesHome },
       });
 
       const normStdout = stdout.replace(/\\/g, '/');
@@ -228,6 +329,7 @@ describe('bug-891: non-Claude runtime home fallback arms', () => {
       cleanup(fakeHome);
       cleanup(fakeHermesHome);
       cleanup(fakeRuntime);
+      if (nodeBinDir) cleanup(nodeBinDir);
     }
   });
 
@@ -235,6 +337,7 @@ describe('bug-891: non-Claude runtime home fallback arms', () => {
   test('(C) gsd_run resolves $HOME/.hermes/gsd-core/bin/ stub when HERMES_HOME is unset', () => {
     const fakeHome    = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-891-home-'));
     const fakeRuntime = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-891-rt2-'));
+    const { isolatedPath, nodeBinDir } = buildIsolatedPath();
     try {
       const hermesBinDir = path.join(fakeHome, '.hermes', 'gsd-core', 'bin');
       fs.mkdirSync(hermesBinDir, { recursive: true });
@@ -260,7 +363,7 @@ describe('bug-891: non-Claude runtime home fallback arms', () => {
 
       const stdout = execFileSync('bash', [scriptPath], {
         encoding: 'utf8',
-        env: { ...process.env, PATH: buildIsolatedPath(), HOME: fakeHome },
+        env: { ...process.env, PATH: isolatedPath, HOME: fakeHome },
       });
 
       const normStdout = stdout.replace(/\\/g, '/');
@@ -275,6 +378,7 @@ describe('bug-891: non-Claude runtime home fallback arms', () => {
     } finally {
       cleanup(fakeHome);
       cleanup(fakeRuntime);
+      if (nodeBinDir) cleanup(nodeBinDir);
     }
   });
 


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #1238

> The linked issue carries the `confirmed-bug` label.

---

## What was broken

`tests/bug-891-non-claude-runtime-home-fallback.test.cjs` subtests **B** and **C** failed **Mac-local only** (`node: command not found`, exit 127); the same suite was green in Docker and CI.

## What this fix does

Makes the test's `buildIsolatedPath()` helper guarantee a bare `node` lookup still resolves while keeping `gsd-tools` unresolvable, so the launcher's home-fallback detection is exercised without breaking the interpreter the launcher snippet invokes.

## Root cause

`buildIsolatedPath()` removed **every** PATH directory containing a `gsd-tools` executable. The launcher snippet `_runtime-launcher.snippet.sh` runs `gsd_run() { node "$GSD_TOOLS" "$@"; }` — a **bare `node`** PATH lookup. On a dev machine where the real `node` binary and a global `gsd-tools` shim live in the **same** directory (fnm/nvm/Homebrew/global-npm bin), that directory was stripped along with `gsd-tools`, so bare `node` resolved to nothing → exit 127. CI/Docker place `node` in a directory without `gsd-tools`, so it survived the filter — hence the Mac-local-only false failure.

## Testing

### How I verified the fix

- The bug reproduces on this machine (`node` and `gsd-tools` both in `/opt/homebrew/bin`): subtests B/C failed with exit 127 before the fix, pass after.
- New regression subtest **(B0)** is machine-independent: it sets PATH to only a controlled fake co-located dir (holding both `gsd-tools` and a `node` symlink) plus a fresh empty dir, then asserts via `fs.accessSync` that the returned isolated PATH resolves `node` but **not** `gsd-tools`. Proven to fail against the pre-fix logic (node unresolvable) and pass after.
- `node --test tests/bug-891-non-claude-runtime-home-fallback.test.cjs` → 7 pass / 0 fail. Full `npm test` → exit 0. `npm run lint` → clean.

`buildIsolatedPath()` now (POSIX) prepends a temp dir containing only a `node` symlink → `process.execPath` to the gsd-tools-filtered PATH, with error-recovery cleanup if the symlink fails. On Windows the co-location bug does not apply (`gsd-tools` resolves via `.cmd`/`.ps1`, not the bare binary probed here) and symlinks may need elevated privileges, so the symlink step is skipped there and B0 is skipped on Windows.

### Regression test added?

- [x] Yes — added subtest (B0); proven to fail without the fix.

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [x] N/A (POSIX-only workaround; Windows path is gated and unchanged in behavior)

### Runtimes tested

- [x] N/A (test-suite hermeticity fix, not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #1238`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (subtest B0, proven red before fix)
- [x] All existing tests pass (`npm test`)
- [x] `no-changelog` applies — test-only change, no user-facing impact (no `.changeset/` fragment)
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1247"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784063192&installation_id=134682257&pr_number=1247&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1247&signature=368480ad71beebc4b7361da944cc9b191aa900789daa424e8269aba48810f56c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->