### PR TITLE
feat(#1188): branch-coverage floors + promote no-source-grep to error on tests/**

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -236,6 +236,8 @@ export default tseslint.config(
       'local/no-raw-rmsync-in-tests': 'error',
       // Ban tautological assertions (always-truthy arg or identical-literal equality)
       'local/no-tautological-assert': 'error',
+      // Ban source-grep pattern in tests — use require() + behavior assertions instead
+      'local/no-source-grep': 'error',
       // Ban raw setTimeout sync + elapsed/duration-style assertions via no-restricted-syntax
       'no-restricted-syntax': [
         'error',

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "test:affected": "node scripts/run-affected-tests.cjs",
     "test:coverage": "c8 --check-coverage --lines 70 --branches 60 --reporter text --include 'gsd-core/bin/lib/*.cjs' --exclude 'tests/**' --all node scripts/run-tests.cjs",
     "test:coverage:scripts-floor": "c8 check-coverage --lines 55 --include 'scripts/**/*.cjs' --exclude 'tests/**' --all",
-    "test:coverage:unit": "c8 --check-coverage --lines 70 --branches 60 --reporter text --include 'gsd-core/bin/lib/*.cjs' --exclude 'tests/**' --all node scripts/run-tests.cjs --suite unit && c8 check-coverage --per-file --branches 70 --include 'gsd-core/bin/lib/state.cjs' --include 'gsd-core/bin/lib/phase.cjs' --include 'gsd-core/bin/lib/verify.cjs' --include 'gsd-core/bin/lib/init.cjs' --exclude 'tests/**'",
+    "test:coverage:unit": "c8 --check-coverage --lines 70 --branches 60 --reporter text --include 'gsd-core/bin/lib/*.cjs' --exclude 'tests/**' --all node scripts/run-tests.cjs --suite unit && c8 check-coverage --per-file --lines 0 --functions 0 --statements 0 --branches 70 --include 'gsd-core/bin/lib/state.cjs' --include 'gsd-core/bin/lib/phase.cjs' --include 'gsd-core/bin/lib/verify.cjs' --include 'gsd-core/bin/lib/init.cjs' --exclude 'tests/**'",
     "test:coverage:all": "npm run test:coverage",
     "test:mutation": "stryker run",
     "test:mutation:since": "stryker run --incremental --since origin/next"

--- a/package.json
+++ b/package.json
@@ -114,9 +114,9 @@
     "test:security": "node scripts/run-tests.cjs --suite security",
     "test:slow": "node scripts/run-tests.cjs --suite slow",
     "test:affected": "node scripts/run-affected-tests.cjs",
-    "test:coverage": "c8 --check-coverage --lines 70 --reporter text --include 'gsd-core/bin/lib/*.cjs' --exclude 'tests/**' --all node scripts/run-tests.cjs",
+    "test:coverage": "c8 --check-coverage --lines 70 --branches 60 --reporter text --include 'gsd-core/bin/lib/*.cjs' --exclude 'tests/**' --all node scripts/run-tests.cjs",
     "test:coverage:scripts-floor": "c8 check-coverage --lines 55 --include 'scripts/**/*.cjs' --exclude 'tests/**' --all",
-    "test:coverage:unit": "c8 --check-coverage --lines 70 --reporter text --include 'gsd-core/bin/lib/*.cjs' --exclude 'tests/**' --all node scripts/run-tests.cjs --suite unit",
+    "test:coverage:unit": "c8 --check-coverage --lines 70 --branches 60 --reporter text --include 'gsd-core/bin/lib/*.cjs' --exclude 'tests/**' --all node scripts/run-tests.cjs --suite unit && c8 check-coverage --per-file --branches 70 --include 'gsd-core/bin/lib/state.cjs' --include 'gsd-core/bin/lib/phase.cjs' --include 'gsd-core/bin/lib/verify.cjs' --include 'gsd-core/bin/lib/init.cjs' --exclude 'tests/**'",
     "test:coverage:all": "npm run test:coverage",
     "test:mutation": "stryker run",
     "test:mutation:since": "stryker run --incremental --since origin/next"

--- a/tests/repo-layout.test.cjs
+++ b/tests/repo-layout.test.cjs
@@ -1,4 +1,5 @@
 'use strict';
+// allow-test-rule: structural guard-placement verification in bin/install.js requires source-text analysis; install.js is a non-exportable CLI script and the guard must be in a specific lexical scope which require()+behavior cannot verify #1188
 
 /**
  * Governance tests for the gsd-core repository root layout.


### PR DESCRIPTION
## Enhancement PR

## Linked Issue

Closes #1188

## What this enhancement improves

Two test-rigor gates were weaker than ADR-456 intends:
1. **No branch-coverage floor** — c8 enforced line floors only (lib 70%, scripts 55%), so untested branches in high-risk modules were invisible.
2. **`no-source-grep` was `warn` and not applied to `tests/**`** — source-text-grep test smells could slip into the test suite.

## Before / After

**Before:** coverage gate checked only lines; `local/no-source-grep` ran as `warn` on `gsd-core/bin/**` + `scripts/**` only.

**After:** the lib coverage gate also enforces a **60% global branch floor** plus a **70% per-file branch floor** on the high-risk UNMUTATED modules (`state`/`phase`/`verify`/`init`); `no-source-grep` is an **error on `tests/**`**, so a test reading `.cjs/.ts` source text and grepping it now fails the lint unless it carries a justified `// allow-test-rule:` marker.

## How it was implemented

**Branch floors (package.json):**
- Added `--branches 60` to `test:coverage` and `test:coverage:unit`. Current global branch coverage is **82.52%** (measured from a green CI run), so 60 is a safe start — the ~22-point margin mirrors the existing lines floor (70 vs 91% actual). Ratchet up over time.
- Appended a chained `c8 check-coverage --per-file --branches 70 --include state/phase/verify/init` to `test:coverage:unit`. It **reuses the coverage data the suite run just produced** (the same `c8 check-coverage` data-reuse pattern as the existing `test:coverage:scripts-floor`), so it adds **no second suite run**. Current branch coverage of those modules: init 85.9, phase 78.5, state 85.4, verify 78.3 — all safely above the 70 per-file floor.

**no-source-grep promotion (eslint.config.mjs):**
- Added `'local/no-source-grep': 'error'` to the `tests/**/*.test.cjs` config block. (Left `bin/**`/`scripts/**` at `warn` — those have ~33 legitimate tooling-grep cases; promoting them is a separate, larger effort.)
- The rule already distinguishes **allowed** product/config reads (`.md`/`.json`/`.yml`) from **blocked** source reads (`.cjs`/`.js`/`.ts` under `bin|lib|gsd-core|src`), so the issue's "split" is inherent.
- **Surfaced violations: exactly 2**, both in `tests/repo-layout.test.cjs` (asserting a security guard's lexical placement in the non-exportable `bin/install.js` CLI). Both are legitimate source-text-as-product (require()+behavior can't verify lexical scope), so marked with a specific `// allow-test-rule: … #1188` reason rather than rewritten. (The audit's earlier cleanup + existing markers covered the rest.)

## Testing

- `npm run lint` clean; full `lint-tests` chain (skill-deps, test-file-count, command-contract, allow-test-rule-refs, windows-portability) green.
- `eslint-rules` 49/49, `repo-layout` 2/2, `release-coverage-scope` 1/1.
- **Rule-fires proof:** stripping the `repo-layout` marker makes `npx eslint` report the `no-source-grep` error → the rule is genuinely active on `tests/**`.
- Branch floors are validated by CI's coverage job (c8 can't run locally here — a yargs/Node-26 ESM bug; the floor values were set from the actual percentages in a green CI coverage run, with comfortable margins).

## Scope confirmation

Test-platform tooling only (`package.json` coverage scripts + `eslint.config.mjs` + one test marker) — no user-facing files, so no changeset/docs (gates confirm `ok_no_user_facing_changes` / `ok_no_triggering_fragments`). `bin/scripts` no-source-grep promotion is deliberately deferred (large, separate). Floors are conservative "start" values to ratchet up.

## Checklist

- [x] Linked issue approved (`approved-enhancement` on #1188)
- [x] Tests pass locally (lint chain + eslint-rules/repo-layout/release-coverage green)
- [x] `no-source-grep` rule-fires proof confirmed
- [x] Branch floors set from real CI numbers with safe margins (CI coverage job validates)
- [x] No changeset/docs required (tooling-only)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1250"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784065390&installation_id=134682257&pr_number=1250&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1250&signature=020e08ae022aff8c5a3a351efb322c4b9def45d3bad064d12d6cf9f404da943a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->