### PR TITLE
fix(#1274): bump ws to ^8.21.0 to clear advisory GHSA-96hv-2xvq-fx4p

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.84",
-        "ws": "8.20.1"
+        "ws": "^8.21.0"
       },
       "bin": {
         "gsd_run": "gsd-core/bin/gsd_run",
@@ -5207,9 +5207,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.84",
-    "ws": "8.20.1"
+    "ws": "^8.21.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",


### PR DESCRIPTION
## Linked Issue

Fixes #1274

> Linked issue carries `confirmed-bug` + `security` (maintainer-confirmed).

---

## What was broken

The direct production dependency `ws` was pinned to `8.20.1`, which falls in the vulnerable range of **GHSA-96hv-2xvq-fx4p** (high — *ws: Memory exhaustion DoS from tiny fragments and data chunks*). The freshly-disclosed advisory turned the `#3588: npm audit --omit=dev reports zero advisories` CI gate red **repo-wide** (on `next` and every open PR — the bad version was already in the committed lockfile).

## What this fix does

Bumps the declared `ws` range to `^8.21.0` (patched, backward-compatible) and refreshes `package-lock.json`. `npm audit --omit=dev` now reports **0 advisories**.

## Root cause

A new CVE was disclosed against a `ws` version already pinned in the lockfile. Nothing in the codebase changed; the audit gate flipped red purely from the advisory-DB update. (`ws` has no direct `require` in source — it is an effectively-transitive runtime dep, so the patch bump carries no functional risk.)

## Testing

### How I verified the fix

- `npm audit --omit=dev` → `found 0 vulnerabilities` (was 1 high).
- `tests/bug-3588-npm-audit-clean.test.cjs` → passes (it was the failing gate).
- `npm run build:lib` green; full `npm test` green on this branch.

### Regression test added?

- [x] No — the existing `tests/bug-3588-npm-audit-clean.test.cjs` **is** the regression guard: it went red on the advisory and greens after the bump. No new test needed.

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [x] N/A (not platform-specific)

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #1274`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — only `package.json` + `package-lock.json` (`ws` version)
- [x] Regression test: the existing `#3588` audit gate covers it
- [x] All existing tests pass (`npm test`)
- [x] `no-changelog` applied (dependency-maintenance bump; `package.json` is not a changeset-gated path)
- [x] No unnecessary dependencies added (version bump only)

## Breaking changes

None. `ws` 8.20.1 → 8.21.0 is a backward-compatible patch; the dependency is not referenced in source.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1275"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784138275&installation_id=134682257&pr_number=1275&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1275&signature=aec1ccdb4645dfc1b4364e0957fe585125dae9777d28c3335cc7442242a555b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->