### PR TITLE
refactor(#1277): T1 — decouple agent-install-check + git-base-branch from the core spine

### DIFF
--- a/src/core.cts
+++ b/src/core.cts
@@ -51,10 +51,6 @@ const {
 import phaseLocatorModule = require('./phase-locator.cjs');
 const { searchPhaseInDir, findPhaseInternal, getArchivedPhaseDirs } = phaseLocatorModule;
 import { findProjectRoot } from './project-root.cjs';
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-import agentInstallCheck = require('./agent-install-check.cjs');
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-import gitBaseBranch = require('./git-base-branch.cjs');
 
 // ─── Config Loader Module (extracted from core, ADR-857 phase 2e / #885) ─────
 // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -123,8 +119,7 @@ const {
 
 // ─── Agent installation validation (#1371) ───────────────────────────────────
 // getAgentsDir and checkAgentsInstalled moved to agent-install-check.cjs (T0 #1268).
-// The destructured bindings above (from agentInstallCheck) make them available to
-// core-internal callers; core.cjs re-exports both symbols by reference for back-compat.
+// Re-exports removed in T1 (#1277); callers import directly from agent-install-check.cjs.
 
 // ─── Model alias resolution ───────────────────────────────────────────────────
 // RUNTIME_OVERRIDE_TIERS, _warnedConfigKeys, _warnUnknownProfileOverrides, and
@@ -192,7 +187,6 @@ export = {
   resolveModelPolicy,
   KNOWN_PROVIDERS,
   pathExistsInternal,
-  gitWorktreeInfoInternal: gitBaseBranch.gitWorktreeInfoInternal,
   generateSlugInternal,
   getMilestoneInfo,
   getMilestonePhaseFilter,
@@ -219,8 +213,6 @@ export = {
   filterSummaryFiles,
   getPhaseFileStats,
   readSubdirectories,
-  getAgentsDir: agentInstallCheck.getAgentsDir,
-  checkAgentsInstalled: agentInstallCheck.checkAgentsInstalled,
   timeAgo,
   pruneOrphanedWorktrees: worktreeSafety.pruneOrphanedWorktrees,
   inspectWorktreeHealth,

--- a/src/docs.cts
+++ b/src/docs.cts
@@ -14,7 +14,10 @@ import fs from 'node:fs';
 import path from 'node:path';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import core = require('./core.cjs');
-const { output, loadConfig, resolveModelInternal, pathExistsInternal, toPosixPath, checkAgentsInstalled } = core;
+const { output, loadConfig, resolveModelInternal, pathExistsInternal, toPosixPath } = core;
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import agentInstallCheck = require('./agent-install-check.cjs');
+const { checkAgentsInstalled } = agentInstallCheck;
 import { platformReadSync } from './shell-command-projection.cjs';
 
 // ─── Constants ────────────────────────────────────────────────────────────────

--- a/src/init.cts
+++ b/src/init.cts
@@ -25,6 +25,12 @@ import { validatePath, loadTrustedGlobalRoots } from './security.cjs';
 import { getGlobalSkillDir, getGlobalSkillDisplayPath, getGlobalSkillsBase } from './runtime-homes.cjs';
 // eslint-disable-next-line @typescript-eslint/no-require-imports -- frontmatter.cjs is an export= CommonJS module
 import frontmatterMod = require('./frontmatter.cjs');
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- agent-install-check.cjs is an export= CommonJS module
+import agentInstallCheck = require('./agent-install-check.cjs');
+const { checkAgentsInstalled } = agentInstallCheck;
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- git-base-branch.cjs is an export= CommonJS module
+import gitBaseBranch = require('./git-base-branch.cjs');
+const { gitWorktreeInfoInternal } = gitBaseBranch;
 
 const {
   loadConfig,
@@ -34,7 +40,6 @@ const {
   findPhaseInternal,
   getRoadmapPhaseInternal,
   pathExistsInternal,
-  gitWorktreeInfoInternal,
   generateSlugInternal,
   getMilestoneInfo,
   getMilestonePhaseFilter,
@@ -44,7 +49,6 @@ const {
   toPosixPath,
   output,
   error,
-  checkAgentsInstalled,
   phaseTokenMatches,
 } = core;
 

--- a/src/verify.cts
+++ b/src/verify.cts
@@ -28,6 +28,9 @@ import { PACKAGE_NAME } from './package-identity.cjs';
 import { formatGsdSlash, resolveRuntime } from './runtime-slash.cjs';
 import { detectSchemaFiles, checkSchemaDrift } from './schema-detect.cjs';
 import { isCanonicalPlanningFile } from './artifacts.cjs';
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- agent-install-check.cjs is an export= CommonJS module
+import agentInstallCheck = require('./agent-install-check.cjs');
+const { checkAgentsInstalled } = agentInstallCheck;
 
 const {
   loadConfig,
@@ -40,7 +43,6 @@ const {
   extractCurrentMilestone,
   output,
   error,
-  checkAgentsInstalled,
   CONFIG_DEFAULTS,
   inspectWorktreeHealth,
 } = core;

--- a/tests/agent-install-check.test.cjs
+++ b/tests/agent-install-check.test.cjs
@@ -1,15 +1,14 @@
 'use strict';
 
 /**
- * Agent Install Check Module — relocation tests (#1268 T0)
+ * Agent Install Check Module — behaviour tests (#1268 T0, T1 #1277)
  *
  * Seam: gsd-core/bin/lib/agent-install-check.cjs
  * Interface: getAgentsDir, checkAgentsInstalled
  *
  * Verifies:
- *   1. Object identity — core re-exports by reference (not re-wrapped)
- *   2. getAgentsDir behaviour: GSD_AGENTS_DIR override, claude path, non-claude path
- *   3. checkAgentsInstalled behaviour against temp dirs via GSD_AGENTS_DIR:
+ *   1. getAgentsDir behaviour: GSD_AGENTS_DIR override, claude path, non-claude path
+ *   2. checkAgentsInstalled behaviour against temp dirs via GSD_AGENTS_DIR:
  *      - missing dir → agents_installed:false, missing_agents = all expected
  *      - existing-but-empty dir → installed_agents:[], agents_installed:false
  *      - no manifest → completeness skipped (incomplete_agents empty)
@@ -26,15 +25,11 @@ const { createTempDir, cleanup } = require('./helpers.cjs');
 const AGENT_INSTALL_CHECK_PATH = path.join(
   __dirname, '..', 'gsd-core', 'bin', 'lib', 'agent-install-check.cjs'
 );
-const CORE_PATH = path.join(
-  __dirname, '..', 'gsd-core', 'bin', 'lib', 'core.cjs'
-);
 const RUNTIME_HOMES_PATH = path.join(
   __dirname, '..', 'gsd-core', 'bin', 'lib', 'runtime-homes.cjs'
 );
 
 const agentInstallCheck = require(AGENT_INSTALL_CHECK_PATH);
-const core = require(CORE_PATH);
 const { getGlobalConfigDir } = require(RUNTIME_HOMES_PATH);
 
 // Get EXPECTED_AGENTS from model-profiles (same source of truth)
@@ -66,27 +61,7 @@ afterEach(() => {
   }
 });
 
-// ─── 1. Object identity ───────────────────────────────────────────────────────
-
-describe('agent-install-check: object identity with core re-exports', () => {
-  test('core.getAgentsDir === agentInstallCheck.getAgentsDir (by reference)', () => {
-    assert.strictEqual(
-      core.getAgentsDir,
-      agentInstallCheck.getAgentsDir,
-      'core.getAgentsDir must be the same function reference as agentInstallCheck.getAgentsDir'
-    );
-  });
-
-  test('core.checkAgentsInstalled === agentInstallCheck.checkAgentsInstalled (by reference)', () => {
-    assert.strictEqual(
-      core.checkAgentsInstalled,
-      agentInstallCheck.checkAgentsInstalled,
-      'core.checkAgentsInstalled must be the same function reference as agentInstallCheck.checkAgentsInstalled'
-    );
-  });
-});
-
-// ─── 2. getAgentsDir behaviour ────────────────────────────────────────────────
+// ─── 1. getAgentsDir behaviour ────────────────────────────────────────────────
 
 describe('getAgentsDir', () => {
   test('GSD_AGENTS_DIR override takes priority', () => {
@@ -96,10 +71,7 @@ describe('getAgentsDir', () => {
   });
 
   test('claude runtime returns __dirname-relative path', () => {
-    // getAgentsDir('claude') from both module and core must agree
     const fromModule = agentInstallCheck.getAgentsDir('claude');
-    const fromCore = core.getAgentsDir('claude');
-    assert.strictEqual(fromModule, fromCore);
     // Should end with /agents
     assert.ok(fromModule.endsWith(path.sep + 'agents') || fromModule.endsWith('/agents'),
       `Expected path to end with /agents, got: ${fromModule}`);
@@ -124,7 +96,7 @@ describe('getAgentsDir', () => {
   });
 });
 
-// ─── 3. checkAgentsInstalled behaviour ───────────────────────────────────────
+// ─── 2. checkAgentsInstalled behaviour ───────────────────────────────────────
 
 describe('checkAgentsInstalled', () => {
   let tmpDir;

--- a/tests/git-base-branch.test.cjs
+++ b/tests/git-base-branch.test.cjs
@@ -260,21 +260,12 @@ describe('#1146: git.base-branch resolver', () => {
   });
 });
 
-// ─── gitWorktreeInfoInternal: relocation identity + behaviour (#1268 T0) ─────
+// ─── gitWorktreeInfoInternal: behaviour (#1268 T0, T1 #1277) ─────────────────
 
 const gitBaseBranch = require(path.join(__dirname, '..', 'gsd-core', 'bin', 'lib', 'git-base-branch.cjs'));
-const core = require(path.join(__dirname, '..', 'gsd-core', 'bin', 'lib', 'core.cjs'));
 const { createTempGitProject, createTempDir } = require('./helpers.cjs');
 
 describe('#1268 gitWorktreeInfoInternal: relocation to git-base-branch', () => {
-  test('core.gitWorktreeInfoInternal === gitBaseBranch.gitWorktreeInfoInternal (by reference)', () => {
-    assert.strictEqual(
-      core.gitWorktreeInfoInternal,
-      gitBaseBranch.gitWorktreeInfoInternal,
-      'core.gitWorktreeInfoInternal must be the same function reference as gitBaseBranch.gitWorktreeInfoInternal'
-    );
-  });
-
   test('gitWorktreeInfoInternal(createTempGitProject()) returns {inside:true, worktreeRoot:<non-empty string>}', (t) => {
     const dir = createTempGitProject('gsd-wt-info-');
     t.after(() => cleanup(dir));


### PR DESCRIPTION
## Linked Issue

Closes #1277

> `approved-enhancement`. Tranche **T1** of epic #1267 (retire the `core.cjs` re-export spine), after T0 (#1268).

---

## What this enhancement improves

The `core.cjs` re-export spine — first leaf-migration tranche. Finishes decoupling the two leaves T0 created (`agent-install-check`, the broadened `git-base-branch` / Git Query Module) from `core`, so their callers import the leaf directly and `core` stops re-exporting their symbols.

## Before / After

**Before:** `core` re-exported `getAgentsDir`, `checkAgentsInstalled`, `gitWorktreeInfoInternal` (by reference, from T0), and callers reached them via `core`.

**After:** callers import from the leaf modules directly; `core` no longer re-exports the three; their shim-identity assertions are deleted.
- `checkAgentsInstalled`: `docs.cts`, `verify.cts`, `init.cts` → `agent-install-check.cjs`
- `gitWorktreeInfoInternal`: `init.cts` → `git-base-branch.cjs`
- `getAgentsDir`: no external via-`core` caller (internal to the leaf) — re-export simply removed

## How it was implemented

Pure import-path migration. Grep-verified ALL via-`core` callers (destructured + `core.X` namespace) of the three symbols, repointed each to the leaf, then removed the re-exports from `src/core.cts` (and the now-unused `agent-install-check` / `git-base-branch` requires in core). Deleted the `core.X === leaf.X` shim-identity assertions in `tests/agent-install-check.test.cjs` + `tests/git-base-branch.test.cjs` (behaviour tests retained — they import the leaves directly).

## Testing

### How I verified the enhancement works

- Full `npm test` green on this branch.
- `npm run lint:ci` green; the migration-convergence lint reports `30 allowlisted importer(s), 0 new` (the three migrated files are multi-leaf, so they stay in the allowlist — no shrink this tranche).
- Independent grep confirms zero `core.getAgentsDir` / `core.checkAgentsInstalled` / `core.gitWorktreeInfoInternal` references remain.
- Regression: `agent-install-validation.test.cjs` (deep `checkAgentsInstalled` suite) + `core` / `docs` / `init` / `git-base-branch` tests pass.

### Regression test added?

- [x] No — pure relocation of import paths; existing leaf behaviour tests + the convergence lint cover it. The deleted assertions were wiring-only (object identity of re-exports that no longer exist).

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [x] N/A (not platform-specific)

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue — no additions or removals
- [x] If scope changed during implementation, I updated the issue and got re-approval before continuing

> Note: the approved issue estimated `checkAgentsInstalled` had one caller; grep-verification found three (`docs`, `verify`, `init`) — all migrated. Same scope (decouple the two leaves), fuller execution.

---

## Documentation

- [ ] Updated the relevant file(s) under `docs/`
- [x] All `docs/` content added in this PR is written in English
- [x] Genuinely no user-facing docs impact (internal refactor) → `no-changelog` label applied.

## Checklist

- [x] Issue linked above with `Closes #1277`
- [x] Linked issue has the `approved-enhancement` label
- [x] Changes are scoped to the approved enhancement
- [x] All existing tests pass (`npm test`)
- [x] New or updated tests cover the change (shim-identity assertions removed; behaviour tests retained)
- [x] `no-changelog` applied (internal refactor)
- [x] No unnecessary dependencies added

## Breaking changes

None. The three symbols are still exported by their leaf modules (callers now import them there); only the redundant `core` re-exports are removed. No caller loses access; observable behaviour is identical.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784144080&installation_id=134682257&pr_number=1280&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1280&signature=1ea5ccf655e004720da7659c654e784563ae6669d4b7e7100b5f45d5418315ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->