### PR TITLE
refactor(#1283): T3 — migrate 9 multi-leaf callers off the core spine (batch 2)

### DIFF
--- a/scripts/lint-core-spine-imports.allowlist.json
+++ b/scripts/lint-core-spine-imports.allowlist.json
@@ -5,19 +5,10 @@
     "src/audit-command-router.cts",
     "src/check-command-router.cts",
     "src/commands.cts",
-    "src/config.cts",
-    "src/docs.cts",
-    "src/gap-checker.cts",
-    "src/graphify-command-router.cts",
-    "src/init.cts",
     "src/intel-command-router.cts",
     "src/phase.cts",
-    "src/profile-output.cts",
     "src/roadmap.cts",
     "src/state.cts",
-    "src/template.cts",
-    "src/uat.cts",
-    "src/verification.cts",
-    "src/workstream.cts"
+    "src/template.cts"
   ]
 }

--- a/src/config.cts
+++ b/src/config.cts
@@ -10,8 +10,11 @@ import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-import core = require('./core.cjs');
-const { output, error, ERROR_REASON, CONFIG_DEFAULTS } = core;
+import io = require('./io.cjs');
+const { output, error, ERROR_REASON } = io;
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import configLoader = require('./config-loader.cjs');
+const { CONFIG_DEFAULTS } = configLoader;
 import { platformWriteSync, platformEnsureDir } from './shell-command-projection.cjs';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import planningWorkspace = require('./planning-workspace.cjs');

--- a/src/docs.cts
+++ b/src/docs.cts
@@ -13,8 +13,17 @@
 import fs from 'node:fs';
 import path from 'node:path';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-import core = require('./core.cjs');
-const { output, loadConfig, resolveModelInternal, pathExistsInternal, toPosixPath } = core;
+import io = require('./io.cjs');
+const { output } = io;
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import configLoader = require('./config-loader.cjs');
+const { loadConfig } = configLoader;
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import modelResolver = require('./model-resolver.cjs');
+const { resolveModelInternal } = modelResolver;
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import coreUtils = require('./core-utils.cjs');
+const { pathExistsInternal, toPosixPath } = coreUtils;
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import agentInstallCheck = require('./agent-install-check.cjs');
 const { checkAgentsInstalled } = agentInstallCheck;

--- a/src/gap-checker.cts
+++ b/src/gap-checker.cts
@@ -19,8 +19,11 @@
 import fs from 'node:fs';
 import path from 'node:path';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-import core = require('./core.cjs');
-const { escapeRegex, output, error } = core;
+import io = require('./io.cjs');
+const { output, error } = io;
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import phaseId = require('./phase-id.cjs');
+const { escapeRegex } = phaseId;
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import planningWorkspace = require('./planning-workspace.cjs');
 const { planningPaths, planningDir, findContextMdIn } = planningWorkspace;

--- a/src/graphify-command-router.cts
+++ b/src/graphify-command-router.cts
@@ -26,11 +26,9 @@
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import graphify = require('./graphify.cjs');
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-import core = require('./core.cjs');
-// eslint-disable-next-line @typescript-eslint/no-require-imports
 import io = require('./io.cjs');
 
-const { ERROR_REASON } = io;
+const { output, ERROR_REASON } = io;
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -73,16 +71,16 @@ function routeGraphifyCommand({ args, cwd, raw, error, _graphify }: RouteGraphif
       }
       budget = parseInt(rawBudget, 10);
     }
-    core.output(g.graphifyQuery(cwd, term, { budget }), raw);
+    output(g.graphifyQuery(cwd, term, { budget }), raw);
   } else if (subcommand === 'status') {
-    core.output(g.graphifyStatus(cwd), raw);
+    output(g.graphifyStatus(cwd), raw);
   } else if (subcommand === 'diff') {
-    core.output(g.graphifyDiff(cwd), raw);
+    output(g.graphifyDiff(cwd), raw);
   } else if (subcommand === 'build') {
     if (args[2] === 'snapshot') {
-      core.output(g.writeSnapshot(cwd), raw);
+      output(g.writeSnapshot(cwd), raw);
     } else {
-      core.output(g.graphifyBuild(cwd), raw);
+      output(g.graphifyBuild(cwd), raw);
     }
   } else {
     error(

--- a/src/init.cts
+++ b/src/init.cts
@@ -10,8 +10,22 @@ import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import { execGit, platformWriteSync, platformReadSync } from './shell-command-projection.cjs';
-// eslint-disable-next-line @typescript-eslint/no-require-imports -- core.cjs is an export= CommonJS module
-import core = require('./core.cjs');
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- io.cjs is an export= CommonJS module
+import io = require('./io.cjs');
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- config-loader.cjs is an export= CommonJS module
+import configLoader = require('./config-loader.cjs');
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- model-resolver.cjs is an export= CommonJS module
+import modelResolver = require('./model-resolver.cjs');
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- phase-locator.cjs is an export= CommonJS module
+import phaseLocator = require('./phase-locator.cjs');
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- roadmap-parser.cjs is an export= CommonJS module
+import roadmapParser = require('./roadmap-parser.cjs');
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- core-utils.cjs is an export= CommonJS module
+import coreUtils = require('./core-utils.cjs');
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- phase-id.cjs is an export= CommonJS module
+import phaseId = require('./phase-id.cjs');
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- worktree-safety.cjs is an export= CommonJS module
+import worktreeSafety = require('./worktree-safety.cjs');
 // eslint-disable-next-line @typescript-eslint/no-require-imports -- planning-workspace.cjs is an export= CommonJS module
 import planningWorkspace = require('./planning-workspace.cjs');
 import { maskIfSecret } from './secrets.cjs';
@@ -32,25 +46,20 @@ const { checkAgentsInstalled } = agentInstallCheck;
 import gitBaseBranch = require('./git-base-branch.cjs');
 const { gitWorktreeInfoInternal } = gitBaseBranch;
 
+const { output, error } = io;
+const { loadConfig } = configLoader;
+const { resolveModelInternal, resolveGranularityInternal, assertValidGranularityOverride } = modelResolver;
+const { findPhaseInternal } = phaseLocator;
 const {
-  loadConfig,
-  resolveModelInternal,
-  resolveGranularityInternal,
-  assertValidGranularityOverride,
-  findPhaseInternal,
   getRoadmapPhaseInternal,
-  pathExistsInternal,
-  generateSlugInternal,
   getMilestoneInfo,
   getMilestonePhaseFilter,
   stripShippedMilestones,
   extractCurrentMilestone,
-  normalizePhaseName,
-  toPosixPath,
-  output,
-  error,
-  phaseTokenMatches,
-} = core;
+} = roadmapParser;
+const { pathExistsInternal, generateSlugInternal, toPosixPath } = coreUtils;
+const { normalizePhaseName, phaseTokenMatches } = phaseId;
+const { pruneOrphanedWorktrees } = worktreeSafety;
 
 const {
   planningPaths,
@@ -1517,7 +1526,6 @@ function cmdInitManager(cwd: string, raw: boolean): void {
 
 function cmdInitProgress(cwd: string, raw: boolean): void {
   try {
-    const { pruneOrphanedWorktrees } = core;
     (pruneOrphanedWorktrees as (cwd: string) => void)(cwd);
   } catch {
     /* intentionally empty */

--- a/src/profile-output.cts
+++ b/src/profile-output.cts
@@ -17,8 +17,11 @@ import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-import core = require('./core.cjs');
-const { output, error, loadConfig } = core;
+import io = require('./io.cjs');
+const { output, error } = io;
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import configLoader = require('./config-loader.cjs');
+const { loadConfig } = configLoader;
 import { platformReadSync as safeReadFile, platformWriteSync, platformEnsureDir } from './shell-command-projection.cjs';
 import { getGlobalSkillDir, getGlobalConfigDir } from './runtime-homes.cjs';
 import { formatGsdSlash, resolveRuntime } from './runtime-slash.cjs';

--- a/src/uat.cts
+++ b/src/uat.cts
@@ -12,8 +12,14 @@
 import fs from 'node:fs';
 import path from 'node:path';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-import core = require('./core.cjs');
-const { output, error, getMilestonePhaseFilter, toPosixPath } = core;
+import io = require('./io.cjs');
+const { output, error } = io;
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import roadmapParser = require('./roadmap-parser.cjs');
+const { getMilestonePhaseFilter } = roadmapParser;
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import coreUtils = require('./core-utils.cjs');
+const { toPosixPath } = coreUtils;
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import planningWorkspace = require('./planning-workspace.cjs');
 const { planningDir } = planningWorkspace;

--- a/src/verification.cts
+++ b/src/verification.cts
@@ -18,12 +18,15 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-// eslint-disable-next-line @typescript-eslint/no-require-imports -- core.cjs is an export= CommonJS module
-import core = require('./core.cjs');
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- io.cjs is an export= CommonJS module
+import io = require('./io.cjs');
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- phase-id.cjs is an export= CommonJS module
+import phaseId = require('./phase-id.cjs');
 // eslint-disable-next-line @typescript-eslint/no-require-imports -- frontmatter.cjs is an export= CommonJS module
 import frontmatterMod = require('./frontmatter.cjs');
 
-const { output, extractPhaseToken } = core;
+const { output, error } = io;
+const { extractPhaseToken } = phaseId;
 const { extractFrontmatter } = frontmatterMod;
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -210,7 +213,7 @@ function readVerificationStatus(
 
 /**
  * CLI command handler: resolve phaseDir against cwd, call readVerificationStatus,
- * emit via core.output().
+ * emit via io.output().
  *
  * @param cwd         - Current working directory (used to resolve phaseDirArg).
  * @param phaseDirArg - Phase directory path (absolute or relative to cwd).
@@ -218,7 +221,7 @@ function readVerificationStatus(
  */
 function cmdVerificationStatus(cwd: string, phaseDirArg: string | undefined, raw: boolean): void {
   if (!phaseDirArg) {
-    core.error('phase directory required for verification.status');
+    error('phase directory required for verification.status');
     return;
   }
   const phaseDir = path.resolve(cwd, phaseDirArg);

--- a/src/workstream.cts
+++ b/src/workstream.cts
@@ -15,8 +15,14 @@
 import fs from 'node:fs';
 import path from 'node:path';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-import core = require('./core.cjs');
-const { output, error, toPosixPath, getMilestoneInfo, generateSlugInternal } = core;
+import io = require('./io.cjs');
+const { output, error } = io;
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import coreUtils = require('./core-utils.cjs');
+const { toPosixPath, generateSlugInternal } = coreUtils;
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import roadmapParser = require('./roadmap-parser.cjs');
+const { getMilestoneInfo } = roadmapParser;
 import { platformWriteSync, platformEnsureDir } from './shell-command-projection.cjs';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import planningWorkspace = require('./planning-workspace.cjs');


### PR DESCRIPTION
## Linked Issue

Closes #1283

> `approved-enhancement`. Tranche **T3** of epic #1267 (retire the `core.cjs` re-export spine) — second file-batch.

## What this enhancement improves

The `core.cjs` re-export spine. Continues the per-file migration (batch by file so the convergence-lint allowlist drops each tranche). T3 migrates 9 multi-leaf files completely off `core`.

## Before / After

**Before:** 9 files imported their symbols via `core`; allowlist = 18.
**After:** each imports from the leaf module(s) directly; allowlist = **9**.
- `config`, `docs`, `gap-checker`, `graphify-command-router` (namespace `core.output` → `io.output`), `init` (17 core symbols → 8 leaves), `profile-output`, `uat`, `verification`, `workstream`.

`core.cts` re-exports untouched (they still serve the remaining 9 files); spine teardown is T-final.

## How it was implemented

Pure import-path migration — leaf modules export the same objects `core` re-exports by reference, so behaviour is identical. Each file's entire core surface (destructures, aliases, namespace `core.output`, lazy in-function imports) routed to the owning leaf; `core` import removed; stale `core.*` docstrings corrected.

## Testing

### How I verified the enhancement works

- Full `npm test` green on this branch.
- `npm run lint:ci` green; convergence lint `9 allowlisted importer(s), 0 new` (down from 18).
- Independent grep: the 9 files have zero `core` references.
- Targeted tests (config/docs/gap-checker/graphify/init/profile/uat/verification/workstream + core) pass.

### Regression test added?

- [x] No — pure import-path relocation; existing leaf behaviour tests + the convergence lint cover it.

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [x] N/A (not platform-specific)

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue — no additions or removals
- [x] If scope changed during implementation, I updated the issue and got re-approval before continuing

---

## Documentation

- [ ] Updated the relevant file(s) under `docs/`
- [x] All `docs/` content added in this PR is written in English
- [x] Genuinely no user-facing docs impact (internal refactor) → `no-changelog` label applied.

## Checklist

- [x] Issue linked above with `Closes #1283`
- [x] Linked issue has the `approved-enhancement` label
- [x] Changes are scoped to the approved enhancement
- [x] All existing tests pass (`npm test`)
- [x] New or updated tests cover the change (behaviour covered by leaf tests)
- [x] `no-changelog` applied (internal refactor)
- [x] No unnecessary dependencies added

## Breaking changes

None. Symbols are still exported by their leaf modules (callers import them there now); `core` still re-exports them for the remaining files. Behaviour identical.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1285"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784147617&installation_id=134682257&pr_number=1285&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1285&signature=25638fed95c8cfc06360526e370ccff62782765037a6d5eecf2e716664f2c407"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->