### PR TITLE
refactor(#1286): T4 — migrate 5 large destructure callers off the core spine (batch 3)

### DIFF
--- a/scripts/lint-core-spine-imports.allowlist.json
+++ b/scripts/lint-core-spine-imports.allowlist.json
@@ -4,11 +4,6 @@
     "gsd-core/bin/gsd-tools.cjs",
     "src/audit-command-router.cts",
     "src/check-command-router.cts",
-    "src/commands.cts",
-    "src/intel-command-router.cts",
-    "src/phase.cts",
-    "src/roadmap.cts",
-    "src/state.cts",
-    "src/template.cts"
+    "src/intel-command-router.cts"
   ]
 }

--- a/src/commands.cts
+++ b/src/commands.cts
@@ -10,32 +10,26 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { execGit, platformWriteSync, platformReadSync, platformEnsureDir } from './shell-command-projection.cjs';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-import core = require('./core.cjs');
-const {
-  loadConfig,
-  isGitIgnored,
-  normalizePhaseName,
-  comparePhaseNum,
-  getArchivedPhaseDirs,
-  generateSlugInternal,
-  getMilestoneInfo,
-  getMilestonePhaseFilter,
-  resolveModelInternal,
-  resolveEffortInternal,
-  resolveFastModeInternal,
-  resolveEffortForTier,
-  stripShippedMilestones: _stripShippedMilestones,
-  extractCurrentMilestone,
-  toPosixPath,
-  output,
-  error,
-  findPhaseInternal,
-  extractOneLinerFromBody,
-  getRoadmapPhaseInternal,
-  extractPhaseToken,
-  resolveGranularityInternal,
-  assertValidGranularityOverride,
-} = core;
+import ioMod = require('./io.cjs');
+const { output, error } = ioMod;
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import configLoaderMod = require('./config-loader.cjs');
+const { loadConfig, isGitIgnored } = configLoaderMod;
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import coreUtilsMod = require('./core-utils.cjs');
+const { toPosixPath, generateSlugInternal, extractOneLinerFromBody } = coreUtilsMod;
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import phaseIdMod = require('./phase-id.cjs');
+const { normalizePhaseName, comparePhaseNum, extractPhaseToken } = phaseIdMod;
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import phaseLocatorMod = require('./phase-locator.cjs');
+const { getArchivedPhaseDirs, findPhaseInternal } = phaseLocatorMod;
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import roadmapParserMod = require('./roadmap-parser.cjs');
+const { extractCurrentMilestone, stripShippedMilestones: _stripShippedMilestones, getMilestoneInfo, getMilestonePhaseFilter, getRoadmapPhaseInternal } = roadmapParserMod;
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import modelResolverMod = require('./model-resolver.cjs');
+const { resolveModelInternal, resolveEffortInternal, resolveFastModeInternal, resolveEffortForTier, resolveGranularityInternal, assertValidGranularityOverride } = modelResolverMod;
 import { renderEffortForRuntime, RUNTIMES_WITH_FAST_MODE } from './model-catalog.cjs';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import planningWorkspace = require('./planning-workspace.cjs');

--- a/src/phase.cts
+++ b/src/phase.cts
@@ -18,8 +18,24 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-// eslint-disable-next-line @typescript-eslint/no-require-imports -- core.cjs is an export= CommonJS module
-import core = require('./core.cjs');
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- io.cjs is an export= CommonJS module
+import ioMod = require('./io.cjs');
+const { output, error, ERROR_REASON } = ioMod;
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- config-loader.cjs is an export= CommonJS module
+import configLoaderMod = require('./config-loader.cjs');
+const { loadConfig } = configLoaderMod;
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- core-utils.cjs is an export= CommonJS module
+import coreUtilsMod = require('./core-utils.cjs');
+const { toPosixPath, generateSlugInternal, readSubdirectories } = coreUtilsMod;
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- phase-id.cjs is an export= CommonJS module
+import phaseIdMod = require('./phase-id.cjs');
+const { escapeRegex, normalizePhaseName, phaseMarkdownRegexSource, comparePhaseNum, phaseTokenMatches } = phaseIdMod;
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- phase-locator.cjs is an export= CommonJS module
+import phaseLocatorMod = require('./phase-locator.cjs');
+const { findPhaseInternal, getArchivedPhaseDirs } = phaseLocatorMod;
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- roadmap-parser.cjs is an export= CommonJS module
+import roadmapParserMod = require('./roadmap-parser.cjs');
+const { stripShippedMilestones, extractCurrentMilestone, getMilestonePhaseFilter } = roadmapParserMod;
 // eslint-disable-next-line @typescript-eslint/no-require-imports -- planning-workspace.cjs is an export= CommonJS module
 import planningWorkspace = require('./planning-workspace.cjs');
 // eslint-disable-next-line @typescript-eslint/no-require-imports -- frontmatter.cjs is an export= CommonJS module
@@ -34,27 +50,6 @@ import { realClock } from './clock.cjs';
 import uatPredicate = require('./uat-predicate.cjs');
 const { evaluateUatPassed } = uatPredicate;
 
-const {
-  escapeRegex,
-  loadConfig,
-  normalizePhaseName,
-  phaseMarkdownRegexSource,
-  comparePhaseNum,
-  findPhaseInternal,
-  getArchivedPhaseDirs,
-  generateSlugInternal,
-  getMilestonePhaseFilter,
-  stripShippedMilestones,
-  extractCurrentMilestone,
-  replaceInCurrentMilestone,
-  toPosixPath,
-  output,
-  error,
-  readSubdirectories,
-  phaseTokenMatches,
-  ERROR_REASON,
-} = core;
-
 const { planningDir, withPlanningLock } = planningWorkspace;
 const { extractFrontmatter } = frontmatterMod;
 const {
@@ -66,11 +61,6 @@ const {
   withStateLock,
   updatePerformanceMetricsSection,
 } = stateMod;
-
-// Unused import silences TS — keep for structural parity with .cjs (stripShippedMilestones,
-// replaceInCurrentMilestone are exported from core but only used in phase.cjs as-is).
-void stripShippedMilestones;
-void replaceInCurrentMilestone;
 
 // #2893 — strict canonical filter: `{padded_phase}-{NN}-PLAN.md` or `PLAN.md`.
 const isCanonicalPlanFile = (f: string): boolean => f.endsWith('-PLAN.md') || f === 'PLAN.md';

--- a/src/roadmap.cts
+++ b/src/roadmap.cts
@@ -10,8 +10,14 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { realClock } from './clock.cjs';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-import core = require('./core.cjs');
-const { escapeRegex, normalizePhaseName, phaseMarkdownRegexSource, phaseMarkdownRegexSourceExact, output, error, findPhaseInternal, phaseTokenMatches } = core;
+import ioMod = require('./io.cjs');
+const { output, error } = ioMod;
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import phaseIdMod = require('./phase-id.cjs');
+const { escapeRegex, normalizePhaseName, phaseMarkdownRegexSource, phaseMarkdownRegexSourceExact, phaseTokenMatches } = phaseIdMod;
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import phaseLocatorMod = require('./phase-locator.cjs');
+const { findPhaseInternal } = phaseLocatorMod;
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import roadmapParserModule = require('./roadmap-parser.cjs');
 const { stripShippedMilestones, extractCurrentMilestone, replaceInCurrentMilestone } = roadmapParserModule;
@@ -98,8 +104,7 @@ function countPhasePlansAndSummaries(phaseDir: string): PhasePlansAndSummaries {
   };
 }
 
-// `phaseMarkdownRegexSource` moved to core.cjs (#3537) so phase.cjs and
-// core.cjs itself can consume it without circular deps. Imported above.
+// `phaseMarkdownRegexSource` lives in phase-id.cjs (#3537) and is imported above.
 
 // ─── searchPhaseInContent ─────────────────────────────────────────────────────
 

--- a/src/state.cts
+++ b/src/state.cts
@@ -9,8 +9,17 @@
 import fs from 'node:fs';
 import path from 'node:path';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-import core = require('./core.cjs');
-const { escapeRegex, loadConfig, getMilestoneInfo, getMilestonePhaseFilter, extractCurrentMilestone, output, error } = core;
+import ioMod = require('./io.cjs');
+const { output, error } = ioMod;
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import configLoaderMod = require('./config-loader.cjs');
+const { loadConfig } = configLoaderMod;
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import phaseIdMod = require('./phase-id.cjs');
+const { escapeRegex } = phaseIdMod;
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import roadmapParserMod = require('./roadmap-parser.cjs');
+const { getMilestoneInfo, getMilestonePhaseFilter, extractCurrentMilestone } = roadmapParserMod;
 import { platformWriteSync, platformReadSync, platformEnsureDir } from './shell-command-projection.cjs';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import planningWorkspace = require('./planning-workspace.cjs');

--- a/src/template.cts
+++ b/src/template.cts
@@ -9,8 +9,17 @@
 import fs from 'node:fs';
 import path from 'node:path';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-import core = require('./core.cjs');
-const { normalizePhaseName, findPhaseInternal, generateSlugInternal, toPosixPath, output, error } = core;
+import ioMod = require('./io.cjs');
+const { output, error } = ioMod;
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import coreUtilsMod = require('./core-utils.cjs');
+const { toPosixPath, generateSlugInternal } = coreUtilsMod;
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import phaseIdMod = require('./phase-id.cjs');
+const { normalizePhaseName } = phaseIdMod;
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import phaseLocatorMod = require('./phase-locator.cjs');
+const { findPhaseInternal } = phaseLocatorMod;
 import { platformWriteSync } from './shell-command-projection.cjs';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import planningWorkspace = require('./planning-workspace.cjs');


### PR DESCRIPTION
## Linked Issue

Closes #1286

> `approved-enhancement`. Tranche **T4** of epic #1267 (retire the `core.cjs` re-export spine) — third file-batch (large destructure callers).

## What this enhancement improves

The `core.cjs` re-export spine. Migrates the 5 largest destructure callers completely off `core`, leaving only the 4 idiom-hard files (T5) before teardown.

## Before / After

**Before:** allowlist = 9.
**After:** allowlist = **4**. Migrated `commands` (~23 symbols), `phase` (~17), `roadmap`, `state`, `template` to import from the leaf modules directly.

`core.cts` re-exports untouched (still serve the remaining 4 files: `gsd-tools.cjs`, `audit/intel-command-router`, `check-command-router`); spine teardown is T-final.

## How it was implemented

Pure import-path migration — leaf modules export the same objects `core` re-exports by reference. Each file's symbols grouped by owning leaf into direct `import X = require('./<leaf>.cjs')` imports (the leaves use `export =`, so named ESM imports don't apply); `core` import removed; a dead `void replaceInCurrentMilestone` dropped from `phase.cts`; stale `core.*` docstrings fixed.

## Testing

### How I verified the fix

- Full `npm test` green on this branch.
- `npm run lint:ci` green; convergence lint `4 allowlisted importer(s), 0 new` (down from 9).
- Independent grep: the 5 files have zero `core` references.
- Targeted tests (commands/phase/roadmap/state/template + core) pass.

### Regression test added?

- [x] No — pure import-path relocation; existing leaf behaviour tests + the convergence lint cover it.

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [x] N/A (not platform-specific)

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue — no additions or removals
- [x] If scope changed during implementation, I updated the issue and got re-approval before continuing

---

## Documentation

- [ ] Updated the relevant file(s) under `docs/`
- [x] All `docs/` content added in this PR is written in English
- [x] Genuinely no user-facing docs impact (internal refactor) → `no-changelog` label applied.

## Checklist

- [x] Issue linked above with `Closes #1286`
- [x] Linked issue has the `approved-enhancement` label
- [x] Changes are scoped to the approved enhancement
- [x] All existing tests pass (`npm test`)
- [x] New or updated tests cover the change (behaviour covered by leaf tests)
- [x] `no-changelog` applied (internal refactor)
- [x] No unnecessary dependencies added

## Breaking changes

None. Symbols still exported by their leaf modules; `core` still re-exports them for the remaining 4 files. Behaviour identical.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1287"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784148943&installation_id=134682257&pr_number=1287&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1287&signature=25ab6ffae72357c5baff5ad9b82d9a65abc1673c320907233e623186a4db9dc0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->