### PR TITLE
fix(#1329): existence-filter scoped-CI fallback so a deleted test can't crash the lane

### DIFF
--- a/scripts/ci-prepare-test-scope.cjs
+++ b/scripts/ci-prepare-test-scope.cjs
@@ -16,13 +16,37 @@ const path = require('path');
 
 const { ExitError, runMain } = require('./lib/cli-exit.cjs');
 
-const scope = process.env.TEST_SCOPE || '';
-const targeted = process.env.TARGETED_TESTS || '';
-const windows = process.env.WINDOWS_TESTS || '';
+// Suite sentinels understood by run-tests.cjs (scripts/run-tests.cjs SUITES).
+// A sentinel resolves to its live file set at run time, so — unlike an explicit
+// filename — it can never reference a since-deleted test file.
+const SUITE_SENTINELS = ['all', 'unit', 'integration', 'install', 'security', 'slow'];
 
-const FALLBACK = 'tests/command-contract.test.cjs tests/commands.test.cjs tests/core.test.cjs tests/package-manifest.test.cjs';
+// Fast smoke set used when scope detection yields no targeted tests. Each entry
+// MUST resolve via run-tests.cjs: an existing repo-relative test file or a
+// SUITE_SENTINELS token. A stale filename here (a test deleted by a refactor)
+// is exactly what broke CI in #1329 — `tests/core.test.cjs`, deleted in #1291,
+// was still listed and crashed every scoped lane that hit this fallback. The
+// parity guard in tests/bug-641-files-from-suite-token.test.cjs fails the
+// moment an entry stops resolving; resolveSelection() filters at write time so
+// a stale entry degrades instead of crashing the lane.
+const FALLBACK = [
+  'tests/command-contract.test.cjs',
+  'tests/commands.test.cjs',
+  'tests/package-manifest.test.cjs',
+];
 
-function main() {
+// Last-resort selector when every FALLBACK entry has been deleted: the whole
+// unit suite, resolved live by run-tests.cjs (the #408/#641 sentinel path).
+const FALLBACK_SENTINEL = 'unit';
+
+// An entry is runnable if it is a suite sentinel or an existing file under root.
+function isResolvable(entry, root) {
+  return SUITE_SENTINELS.includes(entry) || fs.existsSync(path.join(root, entry));
+}
+
+// Resolve the scoped test selection for the lane. Pure (no I/O beyond the
+// existence probe under `root`) so it can be unit-tested directly.
+function resolveSelection({ scope, targeted, windows, root }) {
   let selected;
   if (scope === 'windows') {
     selected = windows;
@@ -32,20 +56,38 @@ function main() {
     throw new ExitError(1, `::error::Unknown test scope: ${scope}`);
   }
 
-  // Trim and fall back to default set if empty.
-  if (!selected.trim()) {
-    selected = FALLBACK;
+  // Detected list passes through verbatim: affected-tests-lib.cjs already filters
+  // deleted files, and the list may legitimately carry a suite sentinel.
+  const detected = (selected || '').split(/\s+/).filter(Boolean);
+  if (detected.length > 0) {
+    return detected;
   }
 
-  // Split on whitespace, filter blanks, join with newlines.
-  const lines = selected.split(/\s+/).filter(Boolean);
-  const content = lines.join('\n') + '\n';
+  // Empty detection → smoke fallback, existence-filtered so a stale entry can
+  // never crash the scoped lane (#1329). If nothing survives, use the unit
+  // sentinel, which run-tests.cjs always resolves.
+  const survivors = FALLBACK.filter((f) => isResolvable(f, root));
+  return survivors.length > 0 ? survivors : [FALLBACK_SENTINEL];
+}
 
-  const outPath = path.join(process.cwd(), '.ci-selected-tests.txt');
-  fs.writeFileSync(outPath, content, 'utf-8');
+function main() {
+  const root = process.cwd();
+  const lines = resolveSelection({
+    scope: process.env.TEST_SCOPE || '',
+    targeted: process.env.TARGETED_TESTS || '',
+    windows: process.env.WINDOWS_TESTS || '',
+    root,
+  });
+
+  const content = lines.join('\n') + '\n';
+  fs.writeFileSync(path.join(root, '.ci-selected-tests.txt'), content, 'utf-8');
 
   process.stdout.write('Scoped tests:\n');
   process.stdout.write(content);
 }
 
-runMain(main);
+if (require.main === module) {
+  runMain(main);
+}
+
+module.exports = { FALLBACK, FALLBACK_SENTINEL, SUITE_SENTINELS, resolveSelection, main };

--- a/tests/bug-641-files-from-suite-token.test.cjs
+++ b/tests/bug-641-files-from-suite-token.test.cjs
@@ -147,3 +147,103 @@ describe('bug #641 — --files-from with bare suite token', () => {
     assert.ok(r.stderr.includes('a.test.cjs'), `unit test must run.\nstderr: ${r.stderr}`);
   });
 });
+
+// Regression test for issue #1329:
+// ci-prepare-test-scope's empty-detection FALLBACK hardcoded an explicit file
+// list that included tests/core.test.cjs — a file deleted in #1291. Every
+// scoped lane (scope=targeted|windows) that hit the fallback wrote the stale
+// path into .ci-selected-tests.txt and crashed run-tests with
+// "requested test file(s) not found: core.test.cjs". The fix: existence-filter
+// the fallback at write time, fall back to the 'unit' suite sentinel when
+// nothing survives, and guard the FALLBACK constant against disk reality.
+describe('bug #1329 — ci-prepare-test-scope fallback never emits a deleted file', () => {
+  const { FALLBACK, FALLBACK_SENTINEL, SUITE_SENTINELS, resolveSelection } =
+    require('../scripts/ci-prepare-test-scope.cjs');
+  const REPO_ROOT = path.join(__dirname, '..');
+
+  // Generative parity guard (DEFECT.GENERATIVE-FIX): the FALLBACK constant and
+  // the test files on disk are two surfaces that must stay in sync. This fails
+  // the instant a refactor deletes a file still named in FALLBACK — which is
+  // precisely what #1291 did and CI did not catch.
+  test('every FALLBACK entry resolves on disk or is a known suite sentinel', () => {
+    for (const entry of FALLBACK) {
+      const isSentinel = SUITE_SENTINELS.includes(entry);
+      const exists = fs.existsSync(path.join(REPO_ROOT, entry));
+      assert.ok(
+        isSentinel || exists,
+        `FALLBACK entry "${entry}" is neither an existing test file nor a suite sentinel — stale reference will crash scoped CI lanes (see #1329).`,
+      );
+    }
+  });
+
+  let tmpDir;
+  beforeEach(() => {
+    tmpDir = createTempDir('gsd-1329-fallback-');
+    fs.mkdirSync(path.join(tmpDir, 'tests'), { recursive: true });
+  });
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('empty detection drops a non-existent fallback entry instead of emitting it', () => {
+    // Create all but the last FALLBACK file under a controlled root, simulating
+    // a since-deleted test (the #1329 mechanism), independent of which files
+    // FALLBACK happens to name today.
+    const present = FALLBACK.slice(0, -1);
+    const absent = FALLBACK[FALLBACK.length - 1];
+    for (const f of present) {
+      fs.writeFileSync(path.join(tmpDir, f), PASS_BODY, 'utf8');
+    }
+
+    const lines = resolveSelection({ scope: 'targeted', targeted: '', windows: '', root: tmpDir });
+
+    assert.ok(!lines.includes(absent), `absent file "${absent}" must be filtered out, got: ${lines.join(', ')}`);
+    for (const f of present) {
+      assert.ok(lines.includes(f), `present file "${f}" must survive, got: ${lines.join(', ')}`);
+    }
+  });
+
+  test('empty detection with no surviving fallback files falls back to the unit sentinel', () => {
+    // tmpDir/tests exists but contains none of the FALLBACK files.
+    const lines = resolveSelection({ scope: 'windows', targeted: '', windows: '', root: tmpDir });
+    assert.deepStrictEqual(lines, [FALLBACK_SENTINEL]);
+  });
+
+  test('detected list passes through verbatim — files and suite sentinels preserved, not existence-filtered', () => {
+    // The detected list is already filtered by affected-tests-lib and may carry
+    // a suite sentinel; ci-prepare-test-scope must not touch it.
+    const lines = resolveSelection({
+      scope: 'targeted',
+      targeted: 'tests/does-not-exist.test.cjs unit',
+      windows: '',
+      root: tmpDir,
+    });
+    assert.deepStrictEqual(lines, ['tests/does-not-exist.test.cjs', 'unit']);
+  });
+
+  test('end-to-end: the real script writes a fallback list whose every entry resolves', () => {
+    // Run the real script (subprocess) with empty detection inside an isolated
+    // root that holds the FALLBACK files, then verify every line it wrote into
+    // .ci-selected-tests.txt resolves — the exact scoped-lane path that crashed
+    // in #1329. Hermetic: the temp root is removed by afterEach's cleanup().
+    for (const f of FALLBACK) {
+      fs.writeFileSync(path.join(tmpDir, f), PASS_BODY, 'utf8');
+    }
+    const prep = spawnSync(
+      process.execPath,
+      [path.join(REPO_ROOT, 'scripts', 'ci-prepare-test-scope.cjs')],
+      { cwd: tmpDir, env: { ...process.env, TEST_SCOPE: 'targeted', TARGETED_TESTS: '', WINDOWS_TESTS: '' }, encoding: 'utf8' },
+    );
+    assert.strictEqual(prep.status, 0, `prepare step failed: ${prep.stderr}`);
+
+    const selected = fs.readFileSync(path.join(tmpDir, '.ci-selected-tests.txt'), 'utf8');
+    for (const line of selected.split('\n').filter(Boolean)) {
+      const isSentinel = SUITE_SENTINELS.includes(line);
+      assert.ok(
+        isSentinel || fs.existsSync(path.join(tmpDir, line)),
+        `selected entry "${line}" does not resolve — would crash run-tests (#1329)`,
+      );
+    }
+    assert.doesNotMatch(selected, /core\.test\.cjs/, 'deleted core.test.cjs must never be selected');
+  });
+});


### PR DESCRIPTION
## Linked Issue

Fixes #1329

## What was broken

Scoped CI lanes (`scope: targeted` and `scope: windows` in `.github/workflows/test.yml`) crashed with `run-tests: requested test file(s) not found: core.test.cjs` whenever the diff produced an empty detected test set — e.g. [run 27599149212](https://github.com/open-gsd/gsd-core/actions/runs/27599149212) (push of #1308 to `next`).

## What this fix does

`ci-prepare-test-scope.cjs` now existence-filters its empty-detection fallback at write time and falls back to the `unit` suite sentinel (resolved live by `run-tests.cjs`) when nothing survives, so a stale reference degrades instead of crashing the lane. Detected lists still pass through verbatim.

## Root cause

The hardcoded `FALLBACK` smoke list still named `tests/core.test.cjs`, deleted in **#1291/#1293** (`c76827afb`). That refactor scrubbed references everywhere — it even added a guard in `tests/ci-test-scope.test.cjs` — but missed this constant. The fallback was written verbatim with no existence check (unlike the sibling `affected-tests-lib.cjs:298`, which filters deleted files). Only `scope != 'full'` lanes route through this path; the `full`/sharded lanes glob the suite and were immune, which is why only the scoped lanes went red. This is the same fallback-path fragility class as #641.

## Testing

### How I verified the fix

- Reproduced the exact CI signal against the real `next` tree (worktree): empty-scope fallback → `run-tests: requested test file(s) not found: core.test.cjs`. After the fix, the fallback emits only resolvable entries and `run-tests` no longer errors.
- New regression tests in `tests/bug-641-files-from-suite-token.test.cjs`: a **generative parity guard** asserting every `FALLBACK` entry resolves on disk or is a suite sentinel (would have failed the moment #1291 deleted the file), `resolveSelection` unit tests (filter-survivors, `unit`-sentinel backstop, verbatim detected-list passthrough), and an end-to-end subprocess test.
- `npm run lint:ci` (all 8 linters) — exit 0.
- Codex adversarial review — no material findings.
- Full suite in Linux Docker (mirrors ubuntu CI) — **15822 tests, 0 failed**.

### Regression test added?

- [x] Yes — added a test that would have caught this bug (parity guard fails the instant a `FALLBACK` entry stops resolving)

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [x] N/A (not platform-specific — `path.join`/`fs.existsSync`; `lint-windows-test-portability` passes)

### Runtimes tested

- [x] N/A (CI tooling, not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #1329`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass (full Docker suite: 15822 passed, 0 failed)
- [x] `no-changelog` label applied (CI-tooling change, no user-facing impact; outside the changeset-gated paths)
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1332"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784205585&installation_id=134682257&pr_number=1332&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1332&signature=8096c3c6611daddab5df0947bbab54b200cb623e9cfcea02695de818fa76b6b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->