### PR TITLE
chore: align LICENSE copyright with open-gsd ownership (match gsd-pi)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Lex Christopherson
+Copyright (c) 2026 Open GSD
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
<!-- pr-template-exempt: chore — single-line LICENSE copyright correction; no fix/enhancement/feature template applies; non-code, non-user-facing, no changeset -->

## Chore PR — align LICENSE copyright with open-gsd ownership

Closes #1331

`gsd-core`'s `LICENSE` still carried the original individual author and an outdated year. This aligns it with the sibling repo `open-gsd/gsd-pi` and the repository's actual owner (the **`open-gsd`** GitHub organization).

```diff
-Copyright (c) 2025 Lex Christopherson
+Copyright (c) 2026 Open GSD
```

The rest of the MIT text is unchanged; `gsd-core/LICENSE` is now **byte-identical** to [`open-gsd/gsd-pi/LICENSE`](https://github.com/open-gsd/gsd-pi/blob/main/LICENSE) (verified with `diff`).

### Verification
- No code, test, README, or `package.json` metadata depends on the copyright holder/year (zero `Lex Christopherson` references in `tests/`/`scripts/`/`src/`; README's License section only links to the file; the SPDX `MIT` identifier is untouched).
- Gates: changeset-lint → `ok_no_user_facing_changes`; docs-lint → `ok_no_triggering_fragments`.

### Scope
One concern: correcting the LICENSE copyright line. No behavioral change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1334"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784206152&installation_id=134682257&pr_number=1334&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1334&signature=18ec4ef69caa4f341791b32fc03ea8dbe26304b2aca199cbfff317cd36ccb658"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->