### PR TITLE
fix(#1264): preserve curated progress during state patch

### DIFF
--- a/.changeset/fair-lions-patch.md
+++ b/.changeset/fair-lions-patch.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 1345
+---
+Preserve curated STATE.md progress frontmatter when `state patch` updates non-progress fields, while still allowing progress-related fields to resync from disk-derived project state.

--- a/src/state.cts
+++ b/src/state.cts
@@ -114,6 +114,21 @@ interface PrunedSection {
   lines: string[];
 }
 
+const STATE_PROGRESS_RESYNC_FIELDS = new Set([
+  'Progress',
+  'Total Plans in Phase',
+  'Total Phases',
+]);
+
+function shouldResyncStateProgress(fields: Iterable<string>): boolean {
+  for (const field of fields) {
+    if (STATE_PROGRESS_RESYNC_FIELDS.has(field)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 // ─── Cache ────────────────────────────────────────────────────────────────────
 
 // Cache disk scan results from buildStateFrontmatter per cwd per process (#1967).
@@ -258,6 +273,7 @@ function cmdStatePatch(cwd: string, patches: Record<string, string>, raw: boolea
   const statePath = planningPaths(cwd).state;
   try {
     const results: { updated: string[]; failed: string[] } = { updated: [], failed: [] };
+    const shouldResync = shouldResyncStateProgress(Object.keys(patches));
 
     // Use atomic read-modify-write to prevent lost updates from concurrent agents
     readModifyWriteStateMd(statePath, (content) => {
@@ -271,7 +287,7 @@ function cmdStatePatch(cwd: string, patches: Record<string, string>, raw: boolea
         }
       }
       return content;
-    }, cwd);
+    }, cwd, { resync: shouldResync });
 
     output(results, raw, results.updated.length > 0 ? 'true' : 'false');
   } catch {
@@ -295,7 +311,7 @@ function cmdStateUpdate(cwd: string, field: string | undefined, value: string | 
   const statePath = planningPaths(cwd).state;
   try {
     let updated = false;
-    const shouldResync = ['Progress', 'Total Plans in Phase', 'Total Phases'].includes(field as string);
+    const shouldResync = shouldResyncStateProgress([field as string]);
     // Preserve curated progress for body-only updates, but allow fields that
     // directly project into progress.* frontmatter to rebuild after mutation.
     readModifyWriteStateMd(statePath, (content) => {

--- a/tests/bug-3242-state-update-progress-trample.test.cjs
+++ b/tests/bug-3242-state-update-progress-trample.test.cjs
@@ -18,6 +18,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 
 const { runGsdTools, createTempProject, cleanup } = require('./helpers.cjs');
+const { extractFrontmatter } = require('../gsd-core/bin/lib/frontmatter.cjs');
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Helpers
@@ -86,6 +87,32 @@ function createPhaseDirs(phasesDir, count) {
     fs.mkdirSync(dir, { recursive: true });
     fs.writeFileSync(path.join(dir, `01-PLAN.md`), `# Plan\n`);
     fs.writeFileSync(path.join(dir, `01-SUMMARY.md`), `# Summary\n`);
+  }
+}
+
+function createPhasePlanOnlyDirs(phasesDir, count) {
+  for (let i = 1; i <= count; i++) {
+    const dir = path.join(phasesDir, String(i).padStart(2, '0'));
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, `01-PLAN.md`), `# Plan\n`);
+  }
+}
+
+function readPersistedProgress(statePath) {
+  const fm = extractFrontmatter(fs.readFileSync(statePath, 'utf-8'));
+  assert.ok(fm.progress, 'persisted frontmatter must have a progress block');
+  return Object.fromEntries(
+    Object.entries(fm.progress).map(([key, value]) => [key, Number(value)]),
+  );
+}
+
+function assertProgressEquals(actual, expected) {
+  for (const [key, value] of Object.entries(expected)) {
+    assert.strictEqual(
+      actual[key],
+      value,
+      `persisted progress.${key} expected ${value}, got ${actual[key]}`,
+    );
   }
 }
 
@@ -202,6 +229,88 @@ describe('#3242 Bug A: body-only state.update preserves curated progress frontma
     assert.ok(jsonResult.success, `state json failed: ${jsonResult.error}`);
     const fm = JSON.parse(jsonResult.output);
     assert.strictEqual(fm.progress.percent, 80);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #1264: state.patch must apply the same progress preservation policy
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#1264: state.patch preserves curated progress frontmatter for non-progress fields', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempProject();
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('query state.patch of Current Phase preserves persisted progress.* values', () => {
+    const statePath = path.join(tmpDir, '.planning', 'STATE.md');
+    const curatedProgress = {
+      total_phases: 4,
+      completed_phases: 3,
+      total_plans: 11,
+      completed_plans: 11,
+      percent: 75,
+    };
+    fs.writeFileSync(statePath, buildStateWithCuratedProgress({
+      completedPlans: curatedProgress.completed_plans,
+      totalPlans: curatedProgress.total_plans,
+      completedPhases: curatedProgress.completed_phases,
+      totalPhases: curatedProgress.total_phases,
+      percent: curatedProgress.percent,
+    }));
+
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      buildRoadmap(5),
+    );
+    createPhasePlanOnlyDirs(path.join(tmpDir, '.planning', 'phases'), 5);
+
+    const patchResult = runGsdTools([
+      'query',
+      'state.patch',
+      JSON.stringify({ 'Current Phase': '08.2' }),
+    ], tmpDir);
+    assert.ok(patchResult.success, `state patch failed: ${patchResult.error}`);
+
+    const output = JSON.parse(patchResult.output);
+    assert.deepEqual(output.updated, ['Current Phase']);
+
+    const progress = readPersistedProgress(statePath);
+    assertProgressEquals(progress, curatedProgress);
+  });
+
+  test('query state.patch of Total Plans in Phase still resyncs persisted progress.* from the updated body', () => {
+    const statePath = path.join(tmpDir, '.planning', 'STATE.md');
+    fs.writeFileSync(statePath, buildStateWithCuratedProgress({
+      completedPlans: 22,
+      totalPlans: 22,
+      completedPhases: 6,
+      totalPhases: 12,
+      percent: 50,
+    }));
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      buildRoadmap(8),
+    );
+    createPhasePlanOnlyDirs(path.join(tmpDir, '.planning', 'phases'), 8);
+
+    const patchResult = runGsdTools([
+      'query',
+      'state.patch',
+      JSON.stringify({ 'Total Plans in Phase': '8' }),
+    ], tmpDir);
+    assert.ok(patchResult.success, `state patch failed: ${patchResult.error}`);
+
+    const output = JSON.parse(patchResult.output);
+    assert.deepEqual(output.updated, ['Total Plans in Phase']);
+
+    const progress = readPersistedProgress(statePath);
+    assert.strictEqual(progress.total_plans, 8);
   });
 });
 


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #1264

---

## What was broken

`state patch` always ran a full STATE.md frontmatter resync after any successful field update. Patching an unrelated field such as `Current Phase` could overwrite curated `progress.*` counters with disk-derived values.

## What this fix does

`state patch` now uses the same progress-resync policy as `state update`: non-progress fields preserve the existing persisted `progress` block, while fields that project into progress still resync.

## Root cause

`cmdStateUpdate` already passed `{ resync: false }` for body-only fields, but `cmdStatePatch` called `readModifyWriteStateMd()` without options, so it used the default full resync path for every patch.

## Testing

### How I verified the fix

- Added #1264 regression coverage in `tests/bug-3242-state-update-progress-trample.test.cjs`.
- Verified persisted frontmatter with `extractFrontmatter`, not `state json`.
- Ran focused and full local checks listed below.

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None

## Local validation

- `node --test tests/bug-3242-state-update-progress-trample.test.cjs tests/issue-766-plugin-manifest.test.cjs`
- `npm run lint:ci`
- `node scripts/changeset/lint.cjs`
- `npm run test:unit`
- `npm test`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1345"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784216470&installation_id=134682257&pr_number=1345&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1345&signature=2329f160db425f5889f3a4e4807522bdc5edd135234604c296086bf6fb7f9013"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->