### PR TITLE
fix(#1297): have executor self-report worktree metadata

### DIFF
--- a/.changeset/1297-worktree-metadata.md
+++ b/.changeset/1297-worktree-metadata.md
@@ -1,0 +1,6 @@
+---
+type: Fixed
+pr: 1349
+---
+
+**Parallel worktree execution now has executor-authored cleanup metadata** — executor agents capture their worktree path, branch, and expected base before task commits and return a parseable metadata block for execute-phase to prefer over runtime harness metadata. (#1297)

--- a/agents/gsd-executor.md
+++ b/agents/gsd-executor.md
@@ -103,6 +103,24 @@ PLAN_START_EPOCH=$(date +%s)
 ```
 </step>
 
+<worktree_metadata_capture>
+If running inside a git worktree, capture authoritative worktree identity before
+any task commit changes HEAD. The execute-phase orchestrator consumes this from
+your final `<worktree_metadata>` return block to build the wave cleanup manifest
+without relying on runtime harness metadata (#1297).
+
+```bash
+GSD_WORKTREE_PATH=""
+GSD_WORKTREE_BRANCH=""
+GSD_WORKTREE_EXPECTED_BASE=""
+if [ -f .git ]; then
+  GSD_WORKTREE_PATH=$(git rev-parse --show-toplevel)
+  GSD_WORKTREE_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+  GSD_WORKTREE_EXPECTED_BASE=$(git rev-parse HEAD)
+fi
+```
+</worktree_metadata_capture>
+
 <step name="determine_execution_pattern">
 ```bash
 grep -n "type=\"checkpoint" [plan-path]
@@ -760,6 +778,10 @@ into the user's project history.
 **Plan:** {phase}-{plan}
 **Tasks:** {completed}/{total}
 **SUMMARY:** {path to SUMMARY.md}
+
+<worktree_metadata>
+{"agent_id":"{phase}-{plan}","worktree_path":"${GSD_WORKTREE_PATH:-}","branch":"${GSD_WORKTREE_BRANCH:-}","expected_base":"${GSD_WORKTREE_EXPECTED_BASE:-}"}
+</worktree_metadata>
 
 **Commits:**
 - {hash}: {message}

--- a/gsd-core/workflows/execute-phase.md
+++ b/gsd-core/workflows/execute-phase.md
@@ -635,6 +635,7 @@ increases monotonically across waves. `{status}` is `complete` (success),
        this commit — the orchestrator force-removes the worktree after you return, and
        any uncommitted SUMMARY.md will be permanently lost (#2070).
        REQUIRED ORDER: Write SUMMARY.md → commit → only then any narration. No text between Write and commit (truncation risk; #2070 rescue is not primary defense).
+
        </parallel_execution>
 
        <execution_context>
@@ -682,7 +683,7 @@ increases monotonically across waves. `{status}` is `complete` (success),
    )
    ```
 
-   Immediately after each worktree `Agent()` spawn returns metadata, atomically append `{agent_id, worktree_path, branch, expected_base}` to `WAVE_WORKTREE_MANIFEST`. If any field is missing, stop and ask for recovery instead of scanning all agent worktrees.
+   After each `Agent()` returns, parse executor-returned worktree metadata (`<worktree_metadata>`) before harness metadata, then atomically append `{agent_id, worktree_path, branch, expected_base}` to `WAVE_WORKTREE_MANIFEST`. Missing: stop and ask for recovery instead of scanning worktrees.
 
    > **Worktree recovery policy (#48 + #1292):** See `execute-phase/steps/worktree-recovery-policy.md` — FAIL-CLOSED rule for base/HEAD-namespace mismatches AND isolated-run fail-safe recovery.
 

--- a/tests/agent-size-baseline.json
+++ b/tests/agent-size-baseline.json
@@ -14,7 +14,7 @@
   "gsd-domain-researcher.md": 6938,
   "gsd-eval-auditor.md": 7761,
   "gsd-eval-planner.md": 7008,
-  "gsd-executor.md": 42519,
+  "gsd-executor.md": 43343,
   "gsd-framework-selector.md": 6778,
   "gsd-integration-checker.md": 15148,
   "gsd-intel-updater.md": 18122,

--- a/tests/workflow-size-baseline.json
+++ b/tests/workflow-size-baseline.json
@@ -24,7 +24,7 @@
   "docs-update.md": 54770,
   "edit-phase.md": 12883,
   "eval-review.md": 9923,
-  "execute-phase.md": 93122,
+  "execute-phase.md": 93157,
   "execute-plan.md": 31365,
   "explore.md": 10497,
   "extract-learnings.md": 12849,

--- a/tests/worktree-cleanup.test.cjs
+++ b/tests/worktree-cleanup.test.cjs
@@ -684,6 +684,29 @@ describe('bug #3384: worktree cleanup workflow contracts', () => {
     assert.doesNotMatch(content, /done < <\(git worktree list --porcelain \| grep "\^worktree " \| grep "\\\.claude\/worktrees\/agent-"/);
   });
 
+  test('#1297 gsd-executor self-reports authoritative worktree metadata', () => {
+    const content = fs.readFileSync(EXECUTOR_AGENT_PATH, 'utf8');
+    assert.match(content, /<worktree_metadata_capture>/);
+    assert.match(content, /git rev-parse --show-toplevel/);
+    assert.match(content, /git rev-parse --abbrev-ref HEAD/);
+    assert.match(content, /GSD_WORKTREE_EXPECTED_BASE=\$\(git rev-parse HEAD\)/);
+    assert.match(content, /<worktree_metadata>/);
+    assert.match(content, /"worktree_path":/);
+    assert.match(content, /"branch":/);
+    assert.match(content, /"expected_base":/);
+  });
+
+  test('#1297 execute-phase consumes executor-returned worktree metadata before harness metadata', () => {
+    const content = fs.readFileSync(EXECUTE_PHASE_PATH, 'utf8');
+    assert.match(content, /<worktree_metadata>/);
+    assert.match(content, /executor-returned worktree metadata/i);
+    assert.match(content, /harness metadata/i);
+    assert.ok(
+      content.indexOf('executor-returned worktree metadata') < content.indexOf('harness metadata'),
+      'execute-phase must prefer executor-returned worktree metadata before runtime harness metadata (#1297)'
+    );
+  });
+
   test('quick contract requires a cleanup manifest instead of global worktree discovery', () => {
     const content = fs.readFileSync(QUICK_PATH, 'utf8');
     assert.match(content, /WAVE_WORKTREE_MANIFEST|QUICK_WORKTREE_MANIFEST/);


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #1297

## What was broken

Parallel execute-phase worktree cleanup depended on runtime harness metadata from each `Agent(isolation="worktree")` result. The executor itself did not return its own worktree path, branch, or expected base, so runtimes that omitted or reshaped harness metadata could leave `WAVE_WORKTREE_MANIFEST` without required entries and force fail-closed cleanup/degraded execution.

## What this fix does

`gsd-executor` now captures its worktree path, branch, and pre-task expected base from inside the worktree before task commits. Its completion response includes a parseable `<worktree_metadata>` JSON block, and execute-phase now prefers that executor-returned worktree metadata before falling back to runtime harness metadata.

## Root cause

The worktree cleanup manifest contract required `{agent_id, worktree_path, branch, expected_base}`, but the authoritative process running inside the worktree never self-reported those fields. The orchestrator therefore relied on runtime-specific metadata instead of a stable executor return contract.

## Testing

### How I verified the fix

- RED: `node --test tests/worktree-cleanup.test.cjs` failed on missing executor worktree metadata capture/return and execute-phase consumption contract.
- `node --test tests/phase6-capstone-conformance.test.cjs tests/worktree-cleanup.test.cjs tests/agent-size-budget.test.cjs tests/workflow-size-budget.test.cjs`
- `npm run lint:ci`
- `npm test`

### Regression test added?

- [x] Yes — added tests that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [x] Other: workflow and executor contract tests via node:test
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — PR will be auto-closed if missing
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None

## Standards followed

Follows the Worktree Safety Policy Module and Worktree Lifecycle contracts in CONTEXT.md; no ADR is revisited.
