### PR TITLE
fix(#1300): resume UAT checkpoint from paused placeholder

### DIFF
--- a/.changeset/1300-uat-paused-checkpoint.md
+++ b/.changeset/1300-uat-paused-checkpoint.md
@@ -1,0 +1,6 @@
+---
+type: Fixed
+pr: 1350
+---
+
+**UAT resume now accepts paused checkpoints** — `uat render-checkpoint` treats a non-structured paused `Current Test` placeholder as a resume signal and derives the checkpoint from the first pending UAT test instead of failing as malformed. (#1300)

--- a/src/uat.cts
+++ b/src/uat.cts
@@ -200,6 +200,13 @@ function parseCurrentTest(content: string): CurrentTest {
   const expectedInlineMatch = section.match(/^expected:\s*(.+)\s*$/m);
 
   if (!numberMatch || !nameMatch || (!expectedBlockMatch && !expectedInlineMatch)) {
+    if (!numberMatch && !nameMatch && !expectedBlockMatch && !expectedInlineMatch) {
+      const pendingTest = parseFirstPendingTest(content);
+      if (pendingTest) {
+        return pendingTest;
+      }
+      error('Current Test section is non-structured and no pending UAT test remains to resume');
+    }
     error('Current Test section is malformed');
   }
 
@@ -220,6 +227,63 @@ function parseCurrentTest(content: string): CurrentTest {
     name: sanitizeForDisplay(nameMatch![1].trim()),
     expected: sanitizeForDisplay(expected),
   };
+}
+
+function parseFirstPendingTest(content: string): CurrentTest | null {
+  const testsMatch = content.match(/##\s*Tests\s*\n([\s\S]*?)(?=\n##\s|$)/i);
+  if (!testsMatch) {
+    return null;
+  }
+
+  const testsSection = testsMatch[1];
+  const headingPattern = /^###\s*(\d+)\.\s*([^\n]+)\s*$/gm;
+  const headings: Array<{ index: number; number: number; name: string }> = [];
+  let headingMatch: RegExpExecArray | null;
+  while ((headingMatch = headingPattern.exec(testsSection)) !== null) {
+    headings.push({
+      index: headingMatch.index,
+      number: parseInt(headingMatch[1], 10),
+      name: headingMatch[2].trim(),
+    });
+  }
+
+  for (let i = 0; i < headings.length; i += 1) {
+    const current = headings[i];
+    const next = headings[i + 1];
+    const block = testsSection.slice(current.index, next ? next.index : undefined);
+    if (!/^result:\s*\[?pending\]?\s*$/im.test(block)) {
+      continue;
+    }
+
+    const expected = parseExpectedFromTestBlock(block);
+    if (!expected) {
+      error(`Pending UAT test ${current.number} is missing an expected field`);
+    }
+
+    return {
+      complete: false,
+      number: current.number,
+      name: sanitizeForDisplay(current.name),
+      expected: sanitizeForDisplay(expected),
+    };
+  }
+
+  return null;
+}
+
+function parseExpectedFromTestBlock(block: string): string | null {
+  const expectedBlockMatch = block.match(/^expected:\s*\|\n([\s\S]*?)(?=^\w[\w-]*:\s)/m)
+    || block.match(/^expected:\s*\|\n([\s\S]+)/m);
+  if (expectedBlockMatch) {
+    return expectedBlockMatch[1]
+      .split('\n')
+      .map((line: string) => line.replace(/^ {2}/, ''))
+      .join('\n')
+      .trim();
+  }
+
+  const expectedInlineMatch = block.match(/^expected:\s*(.+)\s*$/m);
+  return expectedInlineMatch ? expectedInlineMatch[1].trim() : null;
 }
 
 // ─── buildCheckpoint ──────────────────────────────────────────────────────────

--- a/tests/uat.test.cjs
+++ b/tests/uat.test.cjs
@@ -533,6 +533,99 @@ expected: |
     assert.ok(result.output.includes('It ends at the section boundary.'));
   });
 
+  test('resumes paused Current Test placeholder from first pending test (#1300)', () => {
+    fs.writeFileSync(uatPath, [
+      '---',
+      'status: partial',
+      'phase: 01-test-phase',
+      'started: 2026-06-15T00:00:00Z',
+      'updated: 2026-06-15T00:00:00Z',
+      '---',
+      '',
+      '## Current Test',
+      '',
+      '[testing paused — 2 items outstanding]',
+      '',
+      '## Tests',
+      '',
+      '### 1. First test',
+      'expected: something observable',
+      'result: pass',
+      '',
+      '### 2. Second test',
+      'expected: another observable thing',
+      'result: [pending]',
+      '',
+      '## Summary',
+      '',
+      'total: 2',
+      'passed: 1',
+      'issues: 0',
+      'pending: 1',
+      'skipped: 0',
+      'blocked: 0',
+      '',
+      '## Gaps',
+      '',
+      '[none yet]',
+    ].join('\n'));
+
+    const result = runGsdTools(['uat', 'render-checkpoint', '--file', '.planning/phases/01-test-phase/01-UAT.md'], tmpDir);
+    assert.strictEqual(result.success, true, `render-checkpoint failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.test_number, 2);
+    assert.strictEqual(output.test_name, 'Second test');
+    assert.strictEqual(output.file_path, '.planning/phases/01-test-phase/01-UAT.md');
+  });
+
+  test('raw checkpoint mode accepts paused Current Test placeholder (#1300)', () => {
+    fs.writeFileSync(uatPath, [
+      '---',
+      'status: partial',
+      'phase: 01-test-phase',
+      '---',
+      '',
+      '## Current Test',
+      '',
+      '[testing paused — 1 item outstanding]',
+      '',
+      '## Tests',
+      '',
+      '### 1. First pending test',
+      'expected: raw mode checkpoint is available',
+      'result: [pending]',
+    ].join('\n'));
+
+    const result = runGsdTools(['uat', 'render-checkpoint', '--file', '.planning/phases/01-test-phase/01-UAT.md', '--raw'], tmpDir);
+    assert.strictEqual(result.success, true, `render-checkpoint failed: ${result.error}`);
+    assert.ok(result.output.length > 0, 'raw mode must emit a checkpoint');
+  });
+
+  test('non-structured Current Test with no pending tests reports actionable resume error (#1300)', () => {
+    fs.writeFileSync(uatPath, [
+      '---',
+      'status: partial',
+      'phase: 01-test-phase',
+      '---',
+      '',
+      '## Current Test',
+      '',
+      '[testing paused — 0 items outstanding]',
+      '',
+      '## Tests',
+      '',
+      '### 1. Already handled test',
+      'expected: completed behavior',
+      'result: pass',
+    ].join('\n'));
+
+    const result = runGsdTools(['uat', 'render-checkpoint', '--file', '.planning/phases/01-test-phase/01-UAT.md'], tmpDir);
+    assert.strictEqual(result.success, false, 'Should fail when a paused placeholder has no pending test to resume');
+    assert.ok(result.error.includes('no pending UAT test remains'));
+    assert.ok(!result.error.includes('Current Test section is malformed'));
+  });
+
   test('fails when testing is already complete', () => {
     fs.writeFileSync(uatPath, `---
 status: complete


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #1300

## What was broken

`uat render-checkpoint` treated the documented `[testing paused — N items outstanding]` `## Current Test` placeholder as malformed because the parser only accepted `[testing complete]` or a structured `number`/`name`/`expected` block. That broke resume-after-pause for UAT files produced by GSD's own lifecycle.

## What this fix does

Non-structured, non-complete `Current Test` sections now derive the checkpoint from the first test with `result: [pending]` in the `## Tests` section. Partially structured `Current Test` blocks still fail as malformed, and a paused placeholder with no pending test now gets an actionable no-pending resume error.

## Root cause

`parseCurrentTest()` had no third state for paused/resume placeholders. It fell through to structured-field parsing and emitted `Current Test section is malformed` before the renderer could use the resume semantics already documented in the UAT template and verify-work workflow.

## Testing

### How I verified the fix

- RED: `node --test tests/uat.test.cjs` failed on the paused-placeholder regression before the parser change.
- `npm run build:lib`
- `node --test tests/uat.test.cjs`
- `npm run lint:ci`
- `npm test`

### Regression test added?

- [x] Yes — added tests that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [x] Other: `gsd-tools uat render-checkpoint` via node:test
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — PR will be auto-closed if missing
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None

## Standards followed

Follows the UAT template contract and the verify-work resume semantics documented in the repository; no ADR is revisited.
