### PR TITLE
fix(#1324): resolve glued phase tokens

### DIFF
--- a/.changeset/1324-glued-phase-token.md
+++ b/.changeset/1324-glued-phase-token.md
@@ -1,0 +1,6 @@
+---
+type: Fixed
+pr: 1353
+---
+
+**Glued letter-prefix phase directories now resolve correctly** -- phase lookup now recognizes tokens like `P0.3` and `M1-2` from directory names, so phase commands can find their plans instead of reporting none found. (#1324)

--- a/src/phase-id.cts
+++ b/src/phase-id.cts
@@ -174,7 +174,7 @@ function extractPhaseToken(dirName: string): string {
   const tokenSegments: string[] = [];
   for (let i = 0; i < segments.length; i++) {
     const seg = segments[i];
-    if (/^\d/.test(seg)) {
+    if (/^\d/.test(seg) || (i === 0 && /^[A-Za-z]{1,3}\d/.test(seg))) {
       tokenSegments.push(seg);
     } else {
       break;

--- a/tests/phase-id.test.cjs
+++ b/tests/phase-id.test.cjs
@@ -185,9 +185,17 @@ describe('extractPhaseToken', () => {
     assert.strictEqual(phaseId.extractPhaseToken('PROJ-12-feature'), 'PROJ-12');
   });
 
+  test('extracts glued letter-prefix phase tokens (#1324)', () => {
+    assert.strictEqual(phaseId.extractPhaseToken('P0.3-tenant-primitives'), 'P0.3');
+    assert.strictEqual(phaseId.extractPhaseToken('P0.0-foundation'), 'P0.0');
+    assert.strictEqual(phaseId.extractPhaseToken('P0.16-gate'), 'P0.16');
+    assert.strictEqual(phaseId.extractPhaseToken('M1-2-brain'), 'M1-2');
+  });
+
   test('returns the full dirName when no numeric token found', () => {
     assert.strictEqual(phaseId.extractPhaseToken('no-numeric'), 'no-numeric');
     assert.strictEqual(phaseId.extractPhaseToken('alpha'), 'alpha');
+    assert.strictEqual(phaseId.extractPhaseToken('phase-name-01'), 'phase-name-01');
   });
 
   test('stops at first non-numeric-starting segment', () => {
@@ -207,6 +215,12 @@ describe('phaseTokenMatches', () => {
   test('matches with project_code prefix stripped', () => {
     assert.ok(phaseId.phaseTokenMatches('CK-01-phase', '01'));
     assert.ok(phaseId.phaseTokenMatches('PROJ-12-feature', '12'));
+  });
+
+  test('matches glued letter-prefix phase dirs (#1324)', () => {
+    assert.ok(phaseId.phaseTokenMatches('P0.3-tenant-primitives', 'P0.3'));
+    assert.ok(phaseId.phaseTokenMatches('M1-2-brain', 'M1-2'));
+    assert.ok(!phaseId.phaseTokenMatches('P0.3-tenant-primitives', 'P0.4'));
   });
 
   test('does not match when token differs', () => {
@@ -386,4 +400,3 @@ describe('getPhaseDirFromPhaseId', () => {
     assert.ok(!result.endsWith('-'));
   });
 });
-


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

Fixes #1324

---

## What was broken

Phase lookup could not resolve directory names where a short letter prefix is glued to the numeric phase token, such as `P0.3-tenant-primitives` or `M1-2-brain`. Those directories fell back to the full directory name and phase commands reported that no plans were found.

## What this fix does

`extractPhaseToken` now accepts a first token segment shaped like a short letter prefix followed by a digit while preserving the existing numeric, milestone, and project-code-prefixed behavior. Regression tests cover both direct token extraction and `phaseTokenMatches`.

## Root cause

The extractor only collected hyphen-delimited token segments that started with a digit. Glued letter-prefix forms start with a letter, so the parser returned the full directory name instead of the phase token.

## Testing

### How I verified the fix

- RED: `node --test --test-name-pattern "#1324" tests/phase-id.test.cjs` failed before the source fix.
- GREEN: `npm run build:lib`
- GREEN: `node --test --test-name-pattern "#1324" tests/phase-id.test.cjs`
- GREEN: `node --test tests/phase-id.test.cjs`
- GREEN: `node --test tests/phase-locator.test.cjs`
- GREEN: `npm run lint:ci`
- GREEN: `npm test` (1344 passed, 0 failed)

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why: <!-- e.g., environment-specific, non-deterministic -->

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None
