### PR TITLE
fix(#1342): scope worktree-path-guard to GSD executor runs; fail open for no-repo targets

### DIFF
--- a/.changeset/1342-worktree-guard-gsd-gate.md
+++ b/.changeset/1342-worktree-guard-gsd-gate.md
@@ -1,0 +1,6 @@
+---
+type: Fixed
+pr: 1361
+---
+
+**The worktree path guard no longer blocks ordinary writes in non-GSD git worktrees** — the `gsd-worktree-path-guard` PreToolUse hook fired for every `Write`/`Edit` in any linked git worktree, so Claude Code plan-mode writing its plan to `~/.claude/plans/<slug>.md` from a manually-created worktree was hard-blocked. The hook now only enforces inside a GSD isolated-executor worktree (branch `worktree-agent-*`) and fails open when a target resolves to no git repository, while still blocking writes that escape to a different git root (the #260 protection) or into a repository's `.git` internals. (#1342)

--- a/hooks/gsd-worktree-path-guard.js
+++ b/hooks/gsd-worktree-path-guard.js
@@ -71,6 +71,17 @@ process.stdin.on('end', () => {
       process.exit(0); // main repo, submodule, or separate-git-dir — no-op
     }
 
+    // #1342: Only enforce inside a GSD-managed isolated executor worktree. Those
+    // are always on a `worktree-agent-*` branch (the positive allow-list enforced
+    // by worktree-branch-check.md, #2924). A manually-created linked worktree (plain
+    // non-GSD work, e.g. Claude Code plan-mode) is on the user's own branch, so the
+    // guard must be a no-op there. Detached HEAD / error → not GSD-managed → no-op.
+    const branchResult = git(['symbolic-ref', '--short', 'HEAD'], cwd);
+    const branch = branchResult.status === 0 && branchResult.stdout ? branchResult.stdout.trim() : '';
+    if (!/^worktree-agent-[A-Za-z0-9._/-]+$/.test(branch)) {
+      process.exit(0); // not a GSD-managed executor worktree — no-op
+    }
+
     // Get the raw --show-toplevel output for the worktree (cwd).
     // We keep it raw (not path.resolve'd) to compare directly with the
     // file's toplevel — same git binary, same format, no normalization needed.
@@ -110,15 +121,9 @@ process.stdin.on('end', () => {
 
     if (!checkDir) {
       // Walked to root without finding any directory — path is synthetic.
-      // Block conservatively.
-      const output = {
-        decision: 'block',
-        reason:
-          `Worktree path guard: '${filePath}' has no existing ancestor directory — ` +
-          `cannot verify it is inside the worktree '${wtTopRaw}'. Use a relative path instead.`,
-      };
-      process.stdout.write(JSON.stringify(output));
-      process.exit(2);
+      // A path with no existing ancestor is not the #260 main-repo vector;
+      // #260 is caught by the different-git-root branch below. Fail open. (#1342)
+      process.exit(0);
     }
 
     // Ask git for the toplevel of the file's location.
@@ -130,15 +135,26 @@ process.stdin.on('end', () => {
     const fileTopResult = git(['rev-parse', '--show-toplevel'], checkDir);
 
     if (fileTopResult.status !== 0 || !fileTopResult.stdout) {
-      // checkDir is not inside any git repo → cannot be inside the worktree.
-      const output = {
-        decision: 'block',
-        reason:
-          `Worktree path guard: '${filePath}' is not inside any git repository — ` +
-          `it cannot be inside the worktree at '${wtTopRaw}'. Use a relative path instead.`,
-      };
-      process.stdout.write(JSON.stringify(output));
-      process.exit(2);
+      // The target's location is not a git work tree. Two sub-cases:
+      //  - Inside a .git directory (e.g. /main-repo/.git/config or .git/hooks/*)
+      //    → an absolute write into a repository's internals; still a #260-class
+      //    escape (and dangerous) → BLOCK.
+      //  - Truly outside all git repositories (e.g. ~/.claude/plans/) → not the
+      //    main-repo vector → fail open. (#1342)
+      const insideGitDir = git(['rev-parse', '--is-inside-git-dir'], checkDir);
+      if (insideGitDir.status === 0 && insideGitDir.stdout && insideGitDir.stdout.trim() === 'true') {
+        const output = {
+          decision: 'block',
+          reason:
+            `Worktree path guard: '${filePath}' is inside a git internal (.git) directory, ` +
+            `not the active worktree at '${wtTopRaw}'. Writing to repository internals via an ` +
+            `absolute path is not permitted from an isolated executor worktree. Use a relative path.`,
+        };
+        process.stdout.write(JSON.stringify(output));
+        process.exit(2);
+      }
+      // Outside all git repositories — fail open (#1342).
+      process.exit(0);
     }
 
     const fileTopRaw = fileTopResult.stdout.trim();

--- a/tests/bug-260-worktree-path-guard.test.cjs
+++ b/tests/bug-260-worktree-path-guard.test.cjs
@@ -388,15 +388,15 @@ describe('bug #260: gsd-worktree-path-guard.js', () => {
         // We compute the number of segments needed to reach the filesystem root
         // from worktreeDir so the traversal always lands at the right level
         // regardless of how deep the worktree path is.
-        const depthFromRoot = worktreeDir.split(path.sep).filter(Boolean).length;
-        const upSegments = Array(depthFromRoot + 1).fill('..').join(path.sep);
-        // Strip the leading separator from externalDir so path.join treats it
-        // as relative segments when appended after the .. chain.
-        // Note: externalDir is the root of a different git repo, so path.resolve()
-        // normalises the traversal to externalDir/file.ts, which hits the
-        // different-git-root block (the genuine #260 hard block).
-        const externalRelative = externalDir.replace(/^[/\\]+/, '');
-        const traversalPath = path.join(worktreeDir, upSegments, externalRelative, 'file.ts');
+        // Build a file_path containing literal `..` segments that climb out of the
+        // worktree into externalDir. path.relative() yields a ..-laden relative path
+        // between two same-drive absolute paths (both live under os.tmpdir()); we
+        // re-anchor it at worktreeDir via STRING CONCAT (NOT path.join, which would
+        // normalise the `..` away) so the hook's path.resolve() must collapse it.
+        // Windows-safe: avoids the drive-letter doubling that
+        // path.join(worktreeDir, '..', absolutePath) produces on win32 (#1342).
+        const externalTarget = path.join(externalDir, 'file.ts');
+        const traversalPath = worktreeDir + path.sep + path.relative(worktreeDir, externalTarget);
 
         // Confirm the resolved path is truly outside the worktree (test integrity guard).
         const resolved = path.resolve(traversalPath);

--- a/tests/bug-260-worktree-path-guard.test.cjs
+++ b/tests/bug-260-worktree-path-guard.test.cjs
@@ -66,11 +66,14 @@ function makeMainRepo() {
 /**
  * Create a worktree off mainRepo and return its path.
  * In the worktree, .git is a FILE (the gitdir pointer).
+ * @param {string} mainRepo - path to the main repo
+ * @param {string} [branchName] - branch name to use (default: 'worktree-agent-test')
  */
-function makeWorktree(mainRepo) {
+function makeWorktree(mainRepo, branchName) {
+  const branch = branchName || 'worktree-agent-test';
   const wtDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-260-wt-'));
   fs.rmdirSync(wtDir); // git worktree add creates the dir itself
-  git(mainRepo, ['worktree', 'add', '-q', '-b', 'wt-test-branch', wtDir]);
+  git(mainRepo, ['worktree', 'add', '-q', '-b', branch, wtDir]);
   return wtDir;
 }
 
@@ -261,25 +264,67 @@ describe('bug #260: gsd-worktree-path-guard.js', () => {
     });
   });
 
-  // 6. Sibling directory path is BLOCKED (validates the '/' boundary check)
+  // 6. Sibling directory path is BLOCKED (validates the '/' boundary check AND prefix-overlap)
   describe('sibling path is blocked', () => {
     test('path that shares prefix with worktree root but is a sibling exits 2', () => {
-      // e.g. worktreeDir = /tmp/gsd-260-wt-XXXXX
-      // sibling       = /tmp/gsd-260-wt-XXXXXsibling/file.ts
-      // This would pass a naive startsWith(wtRoot) check without the '/' suffix.
-      const siblingPath = worktreeDir + '-sibling/file.ts';
-      const payload = {
-        cwd: worktreeDir,
-        tool_name: 'Edit',
-        tool_input: { file_path: siblingPath },
-      };
-      const result = runHook(worktreeDir, payload);
-      assert.strictEqual(result.status, 2,
-        `Sibling path "${siblingPath}" must be blocked (exit 2), got ${result.status}. ` +
-        `This validates the '/' boundary check in startsWith(wtRoot + '/'). stderr: ${result.stderr}`
-      );
-      const parsed = JSON.parse(result.stdout);
-      assert.strictEqual(parsed.decision, 'block');
+      // This test exercises BOTH the prefix-overlap boundary check AND the different-git-root block:
+      //   worktree  = <base>/wt
+      //   sibling   = <base>/wt-sibling   ← shares "wt" prefix with the worktree root
+      //   target    = <base>/wt-sibling/file.ts
+      //
+      // A naive startsWith(wtRoot) check would wrongly classify "<base>/wt-sibling/..." as inside
+      // the worktree (it doesn't include the '/' boundary). The hook resolves the sibling's git
+      // toplevel (a different repo) so the different-git-root block fires regardless.
+      // (#1342: paths outside all git repos now fail open; only different-git-root blocks.)
+      const base = realp(fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-260-sib-base-')));
+      const wtDir = path.join(base, 'wt');
+      const siblingRepoDir = path.join(base, 'wt-sibling');
+      // We need a genuine linked worktree at <base>/wt and a separate git repo at <base>/wt-sibling.
+      // Create a fresh main repo to host this worktree (the fixture worktree is already allocated).
+      const sibMainRepo = realp(makeMainRepo());
+      try {
+        fs.mkdirSync(base, { recursive: true });
+        // Create linked worktree at <base>/wt (using sibMainRepo as its host).
+        git(sibMainRepo, ['worktree', 'add', '-q', '-b', 'worktree-agent-sib-test', wtDir]);
+        // Create a separate git repo at <base>/wt-sibling (shares "wt" prefix).
+        fs.mkdirSync(siblingRepoDir, { recursive: true });
+        git(siblingRepoDir, ['init', '-q']);
+        git(siblingRepoDir, ['config', 'user.email', 'test@example.com']);
+        git(siblingRepoDir, ['config', 'user.name', 'Test User']);
+        git(siblingRepoDir, ['config', 'commit.gpgsign', 'false']);
+        fs.writeFileSync(path.join(siblingRepoDir, 'README.md'), '# sibling\n');
+        git(siblingRepoDir, ['add', 'README.md']);
+        git(siblingRepoDir, ['commit', '-q', '-m', 'chore: sibling init']);
+
+        // Confirm prefix-overlap: siblingRepoDir starts with wtDir (without trailing sep).
+        assert.ok(
+          siblingRepoDir.startsWith(wtDir),
+          `Sibling "${siblingRepoDir}" must share a string prefix with worktree "${wtDir}" for this test to be meaningful`
+        );
+        // Confirm they are genuinely distinct (different toplevel).
+        assert.notStrictEqual(
+          realp(siblingRepoDir), realp(wtDir),
+          'sibling and worktree must be different directories'
+        );
+
+        const siblingPath = path.join(realp(siblingRepoDir), 'file.ts');
+        const payload = {
+          cwd: realp(wtDir),
+          tool_name: 'Edit',
+          tool_input: { file_path: siblingPath },
+        };
+        const result = runHook(realp(wtDir), payload);
+        assert.strictEqual(result.status, 2,
+          `Path inside a prefix-sibling git repo "${siblingPath}" must be blocked (exit 2), got ${result.status}. ` +
+          `This validates both the prefix-overlap boundary and the different-git-root block. stderr: ${result.stderr}`
+        );
+        const parsed = JSON.parse(result.stdout);
+        assert.strictEqual(parsed.decision, 'block');
+      } finally {
+        try { git(sibMainRepo, ['worktree', 'remove', '--force', wtDir]); } catch { /* ignore */ }
+        cleanup(sibMainRepo);
+        cleanup(base);
+      }
     });
   });
 
@@ -323,14 +368,13 @@ describe('bug #260: gsd-worktree-path-guard.js', () => {
   // 8. Adversarial: `..` traversal is normalised before the containment check (Codex finding #1)
   describe('dot-dot traversal is blocked', () => {
     test('path with .. that escapes the worktree is blocked', () => {
-      // Construct the traversal target inside a SEPARATE tmpdir that is
+      // Construct the traversal target inside a SEPARATE git repo that is
       // guaranteed to be outside the worktree on every platform (no symlink
-      // ambiguity).  We create the directory so that the hook's
-      // nearestExistingDir() walk finds it and dispatches git --show-toplevel
-      // on it — which will either fail (not a git repo → block) or return a
-      // different toplevel (different repo → block).  Either path through the
-      // hook exits 2.
-      const externalDir = realp(fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-260-ext-')));
+      // ambiguity).  The hook finds the external dir's git toplevel (a different
+      // repo → different-git-root block).
+      // (#1342: paths outside all git repos now fail open; only different-git-root blocks,
+      // so externalDir must be inside a real different git repo to exercise the block.)
+      const externalDir = realp(makeMainRepo());
       try {
         // Sanity: the external directory must not be inside the worktree.
         assert.ok(
@@ -348,6 +392,9 @@ describe('bug #260: gsd-worktree-path-guard.js', () => {
         const upSegments = Array(depthFromRoot + 1).fill('..').join(path.sep);
         // Strip the leading separator from externalDir so path.join treats it
         // as relative segments when appended after the .. chain.
+        // Note: externalDir is the root of a different git repo, so path.resolve()
+        // normalises the traversal to externalDir/file.ts, which hits the
+        // different-git-root block (the genuine #260 hard block).
         const externalRelative = externalDir.replace(/^[/\\]+/, '');
         const traversalPath = path.join(worktreeDir, upSegments, externalRelative, 'file.ts');
 
@@ -408,6 +455,156 @@ describe('bug #260: gsd-worktree-path-guard.js', () => {
     });
   });
 
+});
+
+// ---------------------------------------------------------------------------
+// #1342 — GSD-activity gate + fail-open for no-repo targets
+// ---------------------------------------------------------------------------
+
+describe('#1342 — GSD-activity gate + fail-open for no-repo targets', () => {
+  // Fixtures: one non-agent linked worktree (plain user branch) + one agent worktree
+  let mainRepo1342;
+  let nonAgentWorktree;   // on branch 'feature-x' — non-GSD
+  let agentWorktree;       // on branch 'worktree-agent-foo' — GSD-managed
+
+  before(() => {
+    mainRepo1342 = realp(makeMainRepo());
+    nonAgentWorktree = realp(makeWorktree(mainRepo1342, 'feature-x'));
+    agentWorktree    = realp(makeWorktree(mainRepo1342, 'worktree-agent-foo'));
+  });
+
+  after(() => {
+    try { git(mainRepo1342, ['worktree', 'remove', '--force', nonAgentWorktree]); } catch { /* ignore */ }
+    try { git(mainRepo1342, ['worktree', 'remove', '--force', agentWorktree]); } catch { /* ignore */ }
+    cleanup(mainRepo1342);
+    cleanup(nonAgentWorktree);
+    cleanup(agentWorktree);
+  });
+
+  // Test 1 — reporter repro: non-agent worktree writing outside all git repos → exit 0
+  test('(1) non-agent linked worktree: Write to a path outside all git repos exits 0 (no block)', () => {
+    // Simulates Claude Code plan-mode writing ~/.claude/plans/<slug>.md from a
+    // manually-created linked worktree that is NOT on a worktree-agent-* branch.
+    const plansDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-1342-plans-'));
+    try {
+      const targetPath = path.join(plansDir, 'my-plan.md');
+      const payload = {
+        cwd: nonAgentWorktree,
+        tool_name: 'Write',
+        tool_input: { file_path: targetPath },
+      };
+      const result = runHook(nonAgentWorktree, payload);
+      assert.strictEqual(result.status, 0,
+        `Non-agent linked worktree writing outside git repos must exit 0 (reporter repro). ` +
+        `Got exit ${result.status}. stderr: ${result.stderr}`
+      );
+      assert.strictEqual(result.stdout, '', 'Expected no block output');
+    } finally {
+      cleanup(plansDir);
+    }
+  });
+
+  // Test 2 — non-agent linked worktree: Edit targeting MAIN repo root → exit 0 (gate no-op)
+  test('(2) non-agent linked worktree: Edit targeting main repo root exits 0 (gate no-op, not #260 block)', () => {
+    const payload = {
+      cwd: nonAgentWorktree,
+      tool_name: 'Edit',
+      tool_input: { file_path: path.join(mainRepo1342, 'src', 'index.ts') },
+    };
+    const result = runHook(nonAgentWorktree, payload);
+    assert.strictEqual(result.status, 0,
+      `Non-agent linked worktree must exit 0 (GSD-activity gate fires before #260 check). ` +
+      `Got exit ${result.status}. stderr: ${result.stderr}`
+    );
+    assert.strictEqual(result.stdout, '', 'Expected no block output');
+  });
+
+  // Test 3 — GSD-managed worktree (worktree-agent-foo): Edit targeting main repo root → exit 2 (block)
+  test('(3) GSD-managed worktree: Edit targeting main repo root exits 2 with block decision', () => {
+    const payload = {
+      cwd: agentWorktree,
+      tool_name: 'Edit',
+      tool_input: { file_path: path.join(mainRepo1342, 'src', 'index.ts') },
+    };
+    const result = runHook(agentWorktree, payload);
+    assert.strictEqual(result.status, 2,
+      `GSD-managed worktree targeting main repo root must be blocked (exit 2). ` +
+      `Got exit ${result.status}. stderr: ${result.stderr}`
+    );
+    let parsed;
+    assert.doesNotThrow(() => { parsed = JSON.parse(result.stdout); }, 'stdout must be valid JSON');
+    assert.strictEqual(parsed.decision, 'block', 'Expected decision:"block" in output');
+  });
+
+  // Test 4 — GSD-managed worktree: absolute target INSIDE the active worktree → exit 0
+  test('(4) GSD-managed worktree: absolute target inside the active worktree exits 0', () => {
+    const payload = {
+      cwd: agentWorktree,
+      tool_name: 'Edit',
+      tool_input: { file_path: path.join(agentWorktree, 'src', 'foo.ts') },
+    };
+    const result = runHook(agentWorktree, payload);
+    assert.strictEqual(result.status, 0,
+      `GSD-managed worktree targeting its own subtree must pass. ` +
+      `Got exit ${result.status}. stderr: ${result.stderr}`
+    );
+    assert.strictEqual(result.stdout, '', 'Expected no block output');
+  });
+
+  // Test 5 — GSD-managed worktree: target OUTSIDE all git repos (tmpdir) → exit 0 (fail open)
+  test('(5) GSD-managed worktree: target outside all git repos exits 0 (fail open, not #260 vector)', () => {
+    // Create a temp dir that is NOT a git repository (no .git).
+    // This is the ~/.claude/plans/ scenario — a path that has a real ancestor
+    // directory but is outside every git repo.
+    // IMPORTANT: this dir must NOT be inside any .git directory — it must be a plain tempdir
+    // so the fail-open path (truly outside all repos) is exercised, not the .git-internals block.
+    const externalDir = realp(fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-1342-ext-')));
+    try {
+      const targetPath = path.join(externalDir, 'notes.md');
+      const payload = {
+        cwd: agentWorktree,
+        tool_name: 'Write',
+        tool_input: { file_path: targetPath },
+      };
+      const result = runHook(agentWorktree, payload);
+      assert.strictEqual(result.status, 0,
+        `GSD-managed worktree writing to a path outside all git repos must fail open (exit 0). ` +
+        `Only the different-git-root vector (#260) blocks; no-repo targets are not that vector. ` +
+        `Got exit ${result.status}. stderr: ${result.stderr}`
+      );
+      assert.strictEqual(result.stdout, '', 'Expected no block output');
+    } finally {
+      cleanup(externalDir);
+    }
+  });
+
+  // Test 6 — GSD-managed worktree: Write to .git/config of the MAIN repo → exit 2 (block)
+  test('(6) blocks absolute writes into the main repo .git internals from a GSD worktree (#1342)', () => {
+    // A target like /main-repo/.git/config or /main-repo/.git/hooks/pre-commit causes
+    // `git rev-parse --show-toplevel` to FAIL (a .git dir is not a work tree), so the
+    // "file not in any git repo" branch fires. Previously that branch failed open — but
+    // writing into repository internals via an absolute path is still a #260-class escape
+    // (and dangerous, e.g. injecting a git hook). The fix checks --is-inside-git-dir and
+    // blocks when true.
+    const gitConfigPath = path.join(mainRepo1342, '.git', 'config');
+    const payload = {
+      cwd: agentWorktree,
+      tool_name: 'Write',
+      tool_input: { file_path: gitConfigPath },
+    };
+    const result = runHook(agentWorktree, payload);
+    assert.strictEqual(result.status, 2,
+      `GSD-managed worktree targeting .git/config of another repo must be blocked (exit 2). ` +
+      `Got exit ${result.status}. stderr: ${result.stderr}`
+    );
+    let parsed;
+    assert.doesNotThrow(() => { parsed = JSON.parse(result.stdout); }, 'stdout must be valid JSON');
+    assert.strictEqual(parsed.decision, 'block', 'Expected decision:"block" in output');
+    assert.ok(
+      parsed.reason && parsed.reason.includes('.git'),
+      `Block reason should mention .git internals. Got: ${parsed.reason}`
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #1342

## What was broken

`gsd-worktree-path-guard.js` is a global `PreToolUse(Write|Edit|MultiEdit)` hook whose job is the #260 protection: stop a GSD isolated-executor agent from writing, via an absolute path, into the **main** repository instead of its worktree. But it keyed **only** on "cwd is a linked git worktree", with no check for whether a GSD workflow is actually running. So it fired for *any* Write/Edit in *any* linked worktree — including plain non-GSD work. Concretely, Claude Code plan-mode writing its plan to the canonical `~/.claude/plans/<slug>.md` from a manually-created `git worktree` was hard-blocked (exit 2), because that target resolves to **no** git repository and the hook treated "no repo" the same as "the main repo".

## What this fix does

1. **GSD-activity gate.** After detecting a linked worktree, the hook now no-ops unless the worktree's branch matches `^worktree-agent-[A-Za-z0-9._/-]+$` — GSD's isolated-executor branch namespace (the same positive allow-list enforced by `worktree-branch-check.md`, #2924). A user's manual worktree is on their own branch, so the guard is a no-op there.
2. **Fail open for no-repo targets.** A target that resolves to **no** git repository (e.g. `~/.claude/plans/`) now exits 0 instead of blocking — it is not the #260 "main repo" vector. **Exception:** a target inside a `.git` directory (e.g. `<main>/.git/config`, `<main>/.git/hooks/*`) still **blocks** (`git rev-parse --is-inside-git-dir`), since that is an absolute write into a repository's internals.

The genuine #260 hard block — a target resolving to a **different git root** than the active worktree (i.e. the main checkout) — is unchanged.

## Root cause

The hook inferred GSD-executor isolation purely from "`git rev-parse --git-dir` contains `.git/worktrees/`", with no GSD-activity marker, and its "target is not inside any git repository" branch blocked conservatively — but that branch was conflating "outside all repos" (harmless) with the #260 "main repo absolute path" failure mode (which is actually caught by the separate different-git-root branch).

## Testing

### How I verified the fix

Behavioral matrix (direct hook invocation) + 27 tests in `tests/bug-260-worktree-path-guard.test.cjs`:

| cwd | target | result |
|---|---|---|
| GSD `worktree-agent-*` worktree | main repo working file | **block (exit 2)** — #260 intact |
| GSD `worktree-agent-*` worktree | main repo `.git/config` | **block (exit 2)** — internals escape |
| GSD `worktree-agent-*` worktree | inside the worktree | allow (exit 0) |
| GSD `worktree-agent-*` worktree | outside all git repos | allow (exit 0) — fail open |
| user `feature-x` worktree | main repo / `~/.claude/plans/` | allow (exit 0) — gate no-op |

The existing #260 enforcement tests were updated to create their worktrees on a `worktree-agent-*` branch (so enforcement still runs), and the prefix-sibling / `..`-traversal escape tests were kept as different-git-root blocks.

### Regression test added?

- [x] Yes — added a `#1342` test block (GSD gate + fail-open + `.git`-internals block) and updated #260 tests

### Platforms tested

- [x] macOS
- [x] Linux (remote host, full hook test file)
- [x] Windows (including backslash path handling) — the hook's `[/\\]` git-dir detection + `lint:windows-test-portability` pass; no OS-specific logic added

### Runtimes tested

- [x] Claude Code

---

## Checklist

- [x] Issue linked above with `Fixes #1342`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added
- [x] No unnecessary dependencies added

## Breaking changes

None. The guard still enforces the #260 protection for GSD isolated-executor worktrees; it simply stops firing for non-GSD work in unrelated linked worktrees.

## Known limitation (accepted)

The gate keys on the worktree branch (`worktree-agent-*`). If a GSD executor worktree were in a **detached-HEAD** state, `git symbolic-ref` fails and the guard no-ops. This is acceptable because GSD executors run on attached `worktree-agent-*` branches and a detached executor is independently **fail-closed** by `worktree-branch-check.md` (exit 42) before it can commit; the #260 backstop targets non-adversarial model error, not a harness that has detached HEAD. A future hardening could add an explicit executor env-marker as a second signal.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1361"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784251990&installation_id=134682257&pr_number=1361&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1361&signature=957ed83fe5d34cd958f0e95d952f3e82580ea24bbf22f9d23c1397b0eef53e31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->