### PR TITLE
fix(#1356): rewrite bare ~/.claude paths in the Cursor install branch

### DIFF
--- a/.changeset/1356-cursor-bare-claude-paths.md
+++ b/.changeset/1356-cursor-bare-claude-paths.md
@@ -1,0 +1,6 @@
+---
+type: Fixed
+pr: 1368
+---
+
+**`gsd install --cursor` no longer leaves bare `~/.claude` paths in installed artifacts** — the Cursor install branch only rewrote the trailing-slash `.claude` forms, so bare `~/.claude` / `$HOME/.claude` references survived into installed skills and workflows (e.g. `gsd-surface`, `gsd-graphify`, `plan-phase`, `autonomous`) and tripped the post-install "unreplaced .claude path reference(s)" warning, pointing at a directory that doesn't exist on a Cursor-only install. The Cursor branch now rewrites bare forms too (mirroring the Trae/Augment/Copilot branches), using a `(?![\w-])` lookahead so `.claude-plugin` / `.claudeignore` are not corrupted. (#1356)

--- a/bin/install.js
+++ b/bin/install.js
@@ -6792,6 +6792,12 @@ function _applyRuntimeRewrites(content, runtime, pathPrefix, isGlobal = false) {
       content = content.replace(/~\/\.claude\//g, pathPrefix);
       content = content.replace(/\$HOME\/\.claude\//g, pathPrefix);
       content = content.replace(/\.\/\.claude\//g, `./${dirName}/`);
+      // Bare forms (no trailing slash) — use (?![\w-]) instead of \b so that
+      // .claude-plugin / .claudeignore are NOT corrupted (the \b word-boundary
+      // fires between 'e' and '-', which rewrites .claude-plugin → .cursor-plugin).
+      content = content.replace(/~\/\.claude(?![\w-])/g, normalizedPathPrefix);
+      content = content.replace(/\$HOME\/\.claude(?![\w-])/g, normalizedPathPrefix);
+      content = content.replace(/\.\/\.claude(?![\w-])/g, `./${dirName}`);
       content = content.replace(/~\/\.cursor\//g, pathPrefix);
       content = processAttribution(content, getCommitAttribution(runtime));
       break;

--- a/tests/cursor-conversion.test.cjs
+++ b/tests/cursor-conversion.test.cjs
@@ -18,6 +18,7 @@ const {
   convertClaudeCommandToCursorSkill,
   convertClaudeAgentToCursorAgent,
   convertClaudeCommandToCursorCommand,
+  _applyRuntimeRewrites,
 } = require('../bin/install.js');
 
 describe('convertClaudeCommandToCursorSkill', () => {
@@ -149,5 +150,114 @@ Some body content.
   test('is exported from install.js', () => {
     assert.strictEqual(typeof convertClaudeCommandToCursorCommand, 'function',
       'convertClaudeCommandToCursorCommand must be exported from install.js');
+  });
+});
+
+// ─── _applyRuntimeRewrites(cursor) — bare-form regression (#1356) ────────────
+//
+// Prior to this fix the cursor branch only rewrote trailing-slash ~/.claude/
+// and $HOME/.claude/ forms.  Bare end-of-token references (end of line,
+// inside backtick spans, before punctuation) survived and triggered the
+// post-install audit "Found N unreplaced .claude path reference(s)".
+//
+// Fix: add three bare-form rewrites (mirroring augment/windsurf/trae) using
+// (?![\w-]) to avoid corrupting .claude-plugin / .claudeignore.
+//
+// TDD proof: these assertions FAIL before the fix and PASS after.
+
+describe('_applyRuntimeRewrites(cursor) — bare-form ~/.claude regression (#1356)', () => {
+  const CURSOR_PATH_PREFIX = '~/.cursor/';
+
+  // Compound input that exercises every bare and slash ~/.claude / $HOME/.claude
+  // form the fix must handle.  .claude-plugin is intentionally excluded here
+  // because \b fires before the hyphen — its preservation is tested separately.
+  const COMPOUND_INPUT = [
+    'Config dir: ~/.claude',
+    'Also: $HOME/.claude',
+    'Slash form: ~/.claude/gsd-core/foo.md',
+    'Inline: paths `~/.claude`, `~/.cursor`',
+  ].join('\n');
+
+  // Input for the preservation test only — includes .claude-plugin.
+  const COMPOUND_INPUT_WITH_PLUGIN = COMPOUND_INPUT + '\nPlugin installed at: ~/.claude-plugin/plugin.json';
+
+  test('bare ~/.claude at end of line is rewritten (no trailing slash)', () => {
+    const result = _applyRuntimeRewrites(COMPOUND_INPUT, 'cursor', CURSOR_PATH_PREFIX);
+    assert.ok(
+      !/~\/\.claude\b/.test(result),
+      `bare ~/.claude must be gone; got:\n${result}`,
+    );
+    assert.ok(result.includes('~/.cursor'), `cursor prefix must appear; got:\n${result}`);
+  });
+
+  test('bare $HOME/.claude at end of line is rewritten', () => {
+    const result = _applyRuntimeRewrites(COMPOUND_INPUT, 'cursor', CURSOR_PATH_PREFIX);
+    assert.ok(
+      !/\$HOME\/\.claude\b/.test(result),
+      `bare $HOME/.claude must be gone; got:\n${result}`,
+    );
+  });
+
+  test('bare ~/.claude inside a code span (before punctuation) is rewritten', () => {
+    const input = 'paths: `~/.claude`, `~/.cursor`';
+    const result = _applyRuntimeRewrites(input, 'cursor', CURSOR_PATH_PREFIX);
+    assert.ok(
+      !/~\/\.claude\b/.test(result),
+      `bare ~/.claude before punctuation must be gone; got:\n${result}`,
+    );
+  });
+
+  test('trailing-slash ~/.claude/gsd-core/foo.md is rewritten exactly once (no doubling)', () => {
+    const input = '~/.claude/gsd-core/foo.md';
+    const result = _applyRuntimeRewrites(input, 'cursor', CURSOR_PATH_PREFIX);
+    assert.ok(result.includes('~/.cursor/gsd-core/foo.md'), `slash form must be rewritten; got: ${result}`);
+    assert.ok(!result.includes('cursor/cursor'), `path must not be doubled; got: ${result}`);
+    assert.ok(!result.includes('.claude'), `no .claude must survive; got: ${result}`);
+  });
+
+  test('zero surviving bare ~/.claude or $HOME/.claude refs in compound input', () => {
+    const result = _applyRuntimeRewrites(COMPOUND_INPUT, 'cursor', CURSOR_PATH_PREFIX);
+    const bareClaudePattern = /(?:~|\$HOME)\/\.claude\b/;
+    assert.ok(
+      !bareClaudePattern.test(result),
+      `no bare ~/.claude / $HOME/.claude must survive; got:\n${result}`,
+    );
+  });
+
+  test('~/.claude-plugin is NOT corrupted — (?![\\w-]) lookahead preserves it', () => {
+    const result = _applyRuntimeRewrites(COMPOUND_INPUT_WITH_PLUGIN, 'cursor', CURSOR_PATH_PREFIX);
+    assert.ok(
+      result.includes('~/.claude-plugin'),
+      `~/.claude-plugin must be preserved; got:\n${result}`,
+    );
+    assert.ok(
+      !result.includes('~/.cursor-plugin'),
+      `~/.cursor-plugin must NOT appear; got:\n${result}`,
+    );
+  });
+
+  test('bare relative ./.claude (end-of-token) is rewritten to ./.cursor', () => {
+    // The relative bare form ./.claude (no trailing slash) must also be caught.
+    // End-of-line, inside a code span, and before punctuation variants.
+    // The cursor dir name derived from pathPrefix '~/.cursor/' is '.cursor',
+    // so ./.claude → ./.cursor (the ./${dotDirName} form).
+    const pathPrefix = '~/.cursor/';
+    const isGlobal = false;
+
+    const input = [
+      'see ./.claude for config',
+      'also `./.claude` in a code span',
+    ].join('\n');
+
+    const result = _applyRuntimeRewrites(input, 'cursor', pathPrefix, isGlobal);
+
+    assert.ok(
+      result.includes('./.cursor'),
+      `bare ./.claude must be rewritten to ./.cursor; got:\n${result}`,
+    );
+    assert.ok(
+      !/\/\.claude\b/.test(result),
+      `no bare ./.claude (end-of-token) must survive; got:\n${result}`,
+    );
   });
 });


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #1356

## What was broken

`gsd install --cursor` left bare `~/.claude` / `$HOME/.claude` references in installed Cursor artifacts (`skills/gsd-surface/SKILL.md`, `skills/gsd-graphify/SKILL.md`, `workflows/plan-phase.md`, `workflows/autonomous.md`), tripping the post-install audit `Found N unreplaced .claude path reference(s)`. Those paths point at a directory that doesn't exist on a Cursor-only install. This is the same regression class as #983 (Trae/Windsurf), #2418 (Antigravity), and #2545 (Copilot) — every other affected branch got a bare-form rewrite; the Cursor branch of `_applyRuntimeRewrites` was never patched.

## What this fix does

Adds the three bare-form rewrites (`~/.claude`, `$HOME/.claude`, `./.claude` with no trailing slash) to the Cursor branch, mirroring the `cline`/`trae`/`augment`/`codebuddy` branches. They run after the trailing-slash rewrites (so `~/.claude/foo` is not double-replaced) and use the `(?![\w-])` negative-lookahead form rather than `\b` so `.claude-plugin` / `.claudeignore` are not corrupted to `.cursor-plugin`.

Verified empirically: the four real leaking source files contained **40** bare `~/.claude` references between them; after the Cursor rewrite, **0** survive.

## Root cause

The Cursor branch only rewrote the slash-suffix forms (`~/.claude/`, `$HOME/.claude/`, `./.claude/`); bare end-of-token forms were left untouched. The stage-1 markdown converter (`convertClaudeToCursorMarkdown`) only normalizes `.claude/skills/`, but installed SKILL.md content also passes through stage-2 `_applyRuntimeRewrites('cursor', …)`, so the single-branch fix covers both workflows and skills (confirmed — no stage-1 change needed, avoiding double-rewrite).

## Testing

### How I verified the fix

- New `_applyRuntimeRewrites(cursor) — bare-form ~/.claude (#1356)` suite in `tests/cursor-conversion.test.cjs` (patterned on the Copilot test `bug-2545`): bare `~/.claude` / `$HOME/.claude` / `./.claude` at end-of-line, before punctuation, and in code spans all rewrite to the Cursor prefix; the trailing-slash form is not double-replaced; `.claude-plugin` is preserved. The "no survivor" assertions use the **production audit regex** `/(?:~|\$HOME)\/\.claude\b/`.
- TDD: the bare-form assertions fail before the fix and pass after.
- Ground truth: ran the Cursor rewriter over the actual leaking source files — 40 bare refs → 0.
- Sibling-runtime tests (`bug-983`, `bug-2545`) still green (no regression).

### Regression test added?

- [x] Yes

### Platforms tested

- [x] macOS
- [x] Linux (remote host)
- [x] N/A platform-specific — string rewrites on markdown content (no fs path logic); `lint:windows-test-portability` passes

### Runtimes tested

- [x] Other: Cursor (the affected runtime); sibling runtimes unaffected

---

## Checklist

- [x] Issue linked above with `Fixes #1356`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added
- [x] No unnecessary dependencies added

## Breaking changes

None. Cursor installs now rewrite bare `.claude` references the way every other runtime already does.

## Follow-up (out of scope, per the issue)

Whether the dense bare `~/.claude` mentions in `commands/gsd/surface.md` / `graphify.md` sources should be made runtime-agnostic at the source (rather than relied on to rewrite per-runtime) is captured as a separate follow-up, not part of this fix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1368"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784258959&installation_id=134682257&pr_number=1368&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1368&signature=c7e27dc033d81d3e6e058f57e5884adee7853a343831c868914d6f59676b54ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->