### PR TITLE
fix(#1374): surface diagnostic when configured agent skills all fail to resolve

### DIFF
--- a/.changeset/wise-zebras-run.md
+++ b/.changeset/wise-zebras-run.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 1376
 ---
-**Misconfigured agent skills no longer fail silently** — when an agent's configured `agent_skills` paths all fail to resolve (e.g. a missing `SKILL.md`), `gsd-tools query agent-skills` now emits an aggregate warning to stderr and adds a `warnings[]` field to its `--json` output, instead of returning an empty block with no signal. (#0)
+**Misconfigured agent skills no longer fail silently** — when an agent's configured `agent_skills` paths all fail to resolve (e.g. a missing `SKILL.md`), `gsd-tools query agent-skills` now emits an aggregate warning to stderr and adds a `warnings[]` field to its `--json` output, instead of returning an empty block with no signal. (#1376)

--- a/.changeset/wise-zebras-run.md
+++ b/.changeset/wise-zebras-run.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**Misconfigured agent skills no longer fail silently** — when an agent's configured `agent_skills` paths all fail to resolve (e.g. a missing `SKILL.md`), `gsd-tools query agent-skills` now emits an aggregate warning to stderr and adds a `warnings[]` field to its `--json` output, instead of returning an empty block with no signal. (#0)

--- a/docs/CLI-TOOLS.md
+++ b/docs/CLI-TOOLS.md
@@ -425,11 +425,11 @@ Emit the skill block for a given agent type.
 # Emit raw XML skill block (default — safe for shell expansion)
 node gsd-tools.cjs agent-skills <agent-type>
 
-# Emit typed JSON surface (#455) — { agent_type, block, skills_count }
+# Emit typed JSON surface (#455) — { agent_type, block, skills_count, warnings }
 node gsd-tools.cjs agent-skills <agent-type> --json
 ```
 
-The `--json` flag returns a typed IR object suitable for structured consumption and test assertions, while the default (no flag) preserves the raw XML output that workflow shell expansions rely on.
+The `--json` flag returns a typed IR object suitable for structured consumption and test assertions, while the default (no flag) preserves the raw XML output that workflow shell expansions rely on. The IR also includes a `warnings` array naming any configured skill paths that were skipped (for example a missing `SKILL.md`); it is empty when every configured skill resolved.
 
 ---
 

--- a/src/init.cts
+++ b/src/init.cts
@@ -1876,7 +1876,13 @@ function buildAgentSkillsBlock(
   config: Record<string, unknown>,
   agentType: string,
   projectRoot: string,
+  diagnostics?: { warnings: string[] },
 ): string {
+  const warn = (message: string): void => {
+    process.stderr.write(message);
+    if (diagnostics) diagnostics.warnings.push(message.replace(/\n+$/, ''));
+  };
+
   const runtime = (config && (config['runtime'] as string)) || 'claude';
   const globalSkillsBase = getGlobalSkillsBase(runtime);
 
@@ -1886,7 +1892,13 @@ function buildAgentSkillsBlock(
   if (!skillPaths) return '';
 
   if (typeof skillPaths === 'string') skillPaths = [skillPaths];
-  if (!Array.isArray(skillPaths) || skillPaths.length === 0) return '';
+  if (!Array.isArray(skillPaths)) {
+    warn(
+      `[agent-skills] WARNING: Agent "${agentType}" has a malformed agent_skills value (expected string or array, got ${typeof skillPaths}) — ignoring\n`,
+    );
+    return '';
+  }
+  if (skillPaths.length === 0) return '';
 
   // Hoist trusted roots computation before the loop: loadTrustedGlobalRoots does
   // realpathSync I/O and should run at most once per call, not once per failing skill.
@@ -1898,12 +1910,15 @@ function buildAgentSkillsBlock(
   // Skill-tool directive ({ kind: 'directive', name }) for plugin-provided namespaced skills.
   const validEntries: Array<{ kind: 'include'; ref: string; display: string } | { kind: 'directive'; name: string }> = [];
   for (const skillPath of skillPaths) {
-    if (typeof skillPath !== 'string') continue;
+    if (typeof skillPath !== 'string') {
+      warn(`[agent-skills] WARNING: Ignoring non-string skill entry (${typeof skillPath}) — skipping\n`);
+      continue;
+    }
 
     if (skillPath.startsWith('global:')) {
       const skillName = skillPath.slice(7);
       if (!skillName) {
-        process.stderr.write(
+        warn(
           `[agent-skills] WARNING: "global:" prefix with empty skill name — skipping\n`,
         );
         continue;
@@ -1911,7 +1926,7 @@ function buildAgentSkillsBlock(
       // Accept: one or more [A-Za-z0-9_-]+ segments joined by single colons.
       // Rejects: empty segments (::), leading/trailing colon, dots, slashes, backslashes.
       if (!/^[A-Za-z0-9_-]+(:[A-Za-z0-9_-]+)*$/.test(skillName)) {
-        process.stderr.write(
+        warn(
           `[agent-skills] WARNING: Invalid global skill name "${skillName}" — skipping\n`,
         );
         continue;
@@ -1923,7 +1938,7 @@ function buildAgentSkillsBlock(
           // Emit a natural-language Skill-tool directive (not a @-include).
           validEntries.push({ kind: 'directive', name: skillName });
         } else {
-          process.stderr.write(
+          warn(
             `[agent-skills] WARNING: Plugin-namespaced skill "global:${skillName}" requires a Skill-tool-capable runtime (claude) — skipping on runtime "${runtime}"\n`,
           );
         }
@@ -1931,7 +1946,7 @@ function buildAgentSkillsBlock(
       }
       // Non-namespaced bare name: attempt filesystem resolution as before.
       if (globalSkillsBase === null) {
-        process.stderr.write(
+        warn(
           `[agent-skills] WARNING: Runtime "${runtime}" does not use a skills directory — "global:${skillName}" is not supported on this runtime\n`,
         );
         continue;
@@ -1940,7 +1955,7 @@ function buildAgentSkillsBlock(
       const globalSkillMd = path.join(globalSkillDir, 'SKILL.md');
       const displayPath = getGlobalSkillDisplayPath(runtime, skillName);
       if (!fs.existsSync(globalSkillMd)) {
-        process.stderr.write(
+        warn(
           `[agent-skills] WARNING: Global skill not found at "${displayPath}/SKILL.md" — skipping\n`,
         );
         continue;
@@ -1952,11 +1967,13 @@ function buildAgentSkillsBlock(
           return Boolean(rootCheck['safe']);
         });
         if (!acceptedViaTrustedRoot) {
-          process.stderr.write(
+          warn(
             `[agent-skills] WARNING: Global skill "${skillName}" failed path check (symlink escape?) — skipping\n`,
           );
           continue;
         }
+        // Intentionally a direct stderr write, NOT warn(): this is an acceptance
+        // trace, not a skip, so it must not land in the diagnostics warnings[].
         process.stderr.write(`[agent-skills] NOTE: Global skill "${skillName}" accepted via trusted_global_roots (resolves outside the default skills dir)\n`);
       }
       validEntries.push({ kind: 'include', ref: `${globalSkillDir}/SKILL.md`, display: displayPath });
@@ -1965,7 +1982,7 @@ function buildAgentSkillsBlock(
 
     const pathCheck = validatePath(skillPath, projectRoot) as unknown as Record<string, unknown>;
     if (!pathCheck['safe']) {
-      process.stderr.write(
+      warn(
         `[agent-skills] WARNING: Skipping unsafe path "${skillPath}": ${pathCheck['error'] as string}\n`,
       );
       continue;
@@ -1973,7 +1990,7 @@ function buildAgentSkillsBlock(
 
     const skillMdPath = path.join(projectRoot, skillPath, 'SKILL.md');
     if (!fs.existsSync(skillMdPath)) {
-      process.stderr.write(
+      warn(
         `[agent-skills] WARNING: Skill not found at "${skillPath}/SKILL.md" — skipping\n`,
       );
       continue;
@@ -1982,7 +1999,12 @@ function buildAgentSkillsBlock(
     validEntries.push({ kind: 'include', ref: `${skillPath}/SKILL.md`, display: skillPath });
   }
 
-  if (validEntries.length === 0) return '';
+  if (validEntries.length === 0) {
+    warn(
+      `[agent-skills] WARNING: Agent "${agentType}" has ${skillPaths.length} configured skill path(s) but none resolved to a valid skill — all were skipped (see warnings above)\n`,
+    );
+    return '';
+  }
 
   const lines = validEntries.map((entry) => {
     if (entry.kind === 'directive') {
@@ -2005,10 +2027,12 @@ function cmdAgentSkills(
   }
 
   const config = loadConfig(cwd);
+  const diagnostics = { warnings: [] as string[] };
   const block = buildAgentSkillsBlock(
     config,
     agentType,
     cwd,
+    diagnostics,
   );
 
   if (jsonMode) {
@@ -2019,7 +2043,7 @@ function cmdAgentSkills(
       : skillPaths
         ? [skillPaths]
         : [];
-    output({ agent_type: agentType, block: block || '', skills_count: normalizedPaths.length }, raw);
+    output({ agent_type: agentType, block: block || '', skills_count: normalizedPaths.length, warnings: diagnostics.warnings }, raw);
     return;
   }
 

--- a/tests/agent-skills.test.cjs
+++ b/tests/agent-skills.test.cjs
@@ -234,6 +234,140 @@ describe('agent-skills command', () => {
   });
 });
 
+// ─── empty-resolution diagnostics (silent-drop visibility) ────────────────────
+//
+// When an agent is CONFIGURED with skill paths but every path fails to resolve
+// (missing SKILL.md, unsafe path, invalid global name), buildAgentSkillsBlock
+// previously returned '' with only per-path stderr warnings and no aggregate
+// signal — so `query agent-skills --json` reported skills_count > 0 with an
+// empty block and no indication the configured skills were dropped.
+//
+// Fix: emit an aggregate stderr WARNING when configured paths all resolve to
+// zero skills, and surface every skip reason in a `warnings[]` field on the
+// --json IR.
+describe('agent-skills empty-resolution diagnostics', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempProject();
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('configured agent whose only skill is missing → warnings[] names the path and the aggregate drop', () => {
+    writeConfig(tmpDir, {
+      agent_skills: { 'gsd-phase-researcher': ['references/other-skill'] },
+    });
+
+    const r = runAgentSkillsJson(['agent-skills', 'gsd-phase-researcher'], tmpDir);
+    assert.ok(r.success, `Command failed: ${r.error}`);
+    assert.strictEqual(r.ir.block, '', 'block must be empty when the only configured skill is missing');
+    assert.strictEqual(r.ir.skills_count, 1, 'skills_count still reflects the configured path count');
+    assert.ok(Array.isArray(r.ir.warnings), 'IR must include a warnings array');
+    assert.ok(r.ir.warnings.length >= 1, `warnings must be non-empty, got: ${JSON.stringify(r.ir.warnings)}`);
+    assert.ok(
+      r.ir.warnings.some((w) => w.includes('references/other-skill')),
+      `warnings must name the skipped path, got: ${JSON.stringify(r.ir.warnings)}`,
+    );
+    assert.ok(
+      r.ir.warnings.some((w) => /none resolved to a valid skill/.test(w)),
+      `warnings must include the aggregate empty-resolution diagnostic, got: ${JSON.stringify(r.ir.warnings)}`,
+    );
+  });
+
+  test('configured agent with all skills missing → aggregate WARNING on stderr naming the agent', () => {
+    writeConfig(tmpDir, {
+      agent_skills: { 'gsd-planner': ['references/a', 'references/b'] },
+    });
+
+    const r = runGsdToolsWithStderr(['agent-skills', '--json', 'gsd-planner'], tmpDir, {
+      HOME: tmpDir,
+      USERPROFILE: tmpDir,
+    });
+    assert.ok(r.success, `Command failed (exit ${r.exitCode}): ${r.stderr}`);
+    assert.ok(
+      r.stderr.includes('[agent-skills] WARNING') &&
+        r.stderr.includes('gsd-planner') &&
+        r.stderr.includes('none resolved to a valid skill'),
+      `stderr must carry the aggregate empty-resolution warning naming the agent, got: ${r.stderr}`,
+    );
+    const ir = JSON.parse(r.stdout);
+    assert.strictEqual(ir.block, '');
+    assert.ok(ir.warnings.length >= 2, `warnings must list both skipped paths, got: ${JSON.stringify(ir.warnings)}`);
+  });
+
+  test('partial resolution: one valid + one missing → block present, NO aggregate warning, skipped path still listed', () => {
+    const skillDir = path.join(tmpDir, 'skills', 'present');
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(path.join(skillDir, 'SKILL.md'), '# present\n');
+
+    writeConfig(tmpDir, {
+      agent_skills: { 'gsd-executor': ['skills/present', 'skills/absent'] },
+    });
+
+    const r = runAgentSkillsJson(['agent-skills', 'gsd-executor'], tmpDir);
+    assert.ok(r.success, `Command failed: ${r.error}`);
+    assert.ok(r.ir.block.includes('skills/present/SKILL.md'), 'block must include the resolvable skill');
+    assert.strictEqual(r.ir.skills_count, 2, 'skills_count reflects both configured paths');
+    assert.ok(Array.isArray(r.ir.warnings), 'IR must include a warnings array');
+    assert.ok(
+      r.ir.warnings.some((w) => w.includes('skills/absent')),
+      `warnings must list the one skipped path, got: ${JSON.stringify(r.ir.warnings)}`,
+    );
+    assert.ok(
+      !r.ir.warnings.some((w) => /none resolved to a valid skill/.test(w)),
+      `aggregate empty-resolution warning must NOT fire when at least one skill resolved, got: ${JSON.stringify(r.ir.warnings)}`,
+    );
+  });
+
+  test('all skills resolve → warnings[] is empty', () => {
+    const skillDir = path.join(tmpDir, 'skills', 'only');
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(path.join(skillDir, 'SKILL.md'), '# only\n');
+
+    writeConfig(tmpDir, {
+      agent_skills: { 'gsd-executor': ['skills/only'] },
+    });
+
+    const r = runAgentSkillsJson(['agent-skills', 'gsd-executor'], tmpDir);
+    assert.ok(r.success, `Command failed: ${r.error}`);
+    assert.ok(r.ir.block.includes('skills/only/SKILL.md'), 'block must include the resolved skill');
+    assert.ok(Array.isArray(r.ir.warnings), 'IR must include a warnings array');
+    assert.strictEqual(r.ir.warnings.length, 0, `warnings must be empty when all skills resolve, got: ${JSON.stringify(r.ir.warnings)}`);
+  });
+
+  test('unconfigured agent → warnings[] empty (no skills configured is not a drop)', () => {
+    writeConfig(tmpDir, {
+      agent_skills: { 'gsd-executor': ['skills/whatever'] },
+    });
+
+    const r = runAgentSkillsJson(['agent-skills', 'gsd-planner'], tmpDir);
+    assert.ok(r.success, `Command failed: ${r.error}`);
+    assert.strictEqual(r.ir.block, '');
+    assert.ok(Array.isArray(r.ir.warnings), 'IR must include a warnings array');
+    assert.strictEqual(r.ir.warnings.length, 0, 'an agent with no configured skills is not a drop — warnings must be empty');
+  });
+
+  test('malformed (non-array, non-string) configured value → flagged in warnings[], not a silent drop', () => {
+    // A hand-edited config.json could carry a scalar instead of an array.
+    // cmdAgentSkills still counts it as a configured path, so it must be surfaced.
+    writeConfig(tmpDir, {
+      agent_skills: { 'gsd-executor': 42 },
+    });
+
+    const r = runAgentSkillsJson(['agent-skills', 'gsd-executor'], tmpDir);
+    assert.ok(r.success, `Command failed: ${r.error}`);
+    assert.strictEqual(r.ir.block, '', 'block must be empty for a malformed value');
+    assert.ok(Array.isArray(r.ir.warnings), 'IR must include a warnings array');
+    assert.ok(
+      r.ir.warnings.some((w) => /malformed agent_skills value/.test(w)),
+      `malformed scalar config must be flagged in warnings[], got: ${JSON.stringify(r.ir.warnings)}`,
+    );
+  });
+});
+
 // ─── config-ensure-section includes agent_skills ────────────────────────────
 
 describe('config-ensure-section with agent_skills', () => {


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #1374

> The linked issue has the `confirmed-bug` label.

---

## What was broken

When an agent was **configured** with `agent_skills` paths that all failed to resolve (missing `SKILL.md`, unsafe path, invalid `global:` name, or a malformed scalar value), `buildAgentSkillsBlock` returned an empty string with only ad-hoc per-path stderr warnings. `query agent-skills --json` reported `skills_count > 0` with `block: ""` and **no machine-readable signal** — a fully-dropped configuration was indistinguishable from a correctly-resolved one.

## What this fix does

Routes every per-path skip warning through a `warn()` helper that writes to stderr **and** records the reason into an optional diagnostics collector, emits an **aggregate** warning when configured paths all resolve to zero skills, flags truthy-but-malformed config values, and surfaces the collected reasons in a new **`warnings[]`** field on the `query agent-skills --json` IR. Empty arrays and falsy values stay silent (their `skills_count` is honestly `0`). `skills_count` semantics are unchanged.

## Root cause

`buildAgentSkillsBlock` returned `''` at the `validEntries.length === 0` guard without any aggregate diagnostic, and `cmdAgentSkills` reported `skills_count` = configured-path count with no `warnings` channel — so the dropped-config case left no signal in machine-readable output.

## Testing

### How I verified the fix

- Added 6 behavioral regression tests in `tests/agent-skills.test.cjs` (written **fail-first**: confirmed RED against the pre-fix build, GREEN after).
- Boundary coverage: 1-configured/0-valid, N-configured/0-valid (stderr + IR), partial (some valid → no aggregate but skipped path still listed), all-valid (empty `warnings[]`), unconfigured (silent), and malformed scalar value.
- End-to-end on the rebuilt binary against the exact reproduction from #1374 (and a control agent with a valid skill — no false-positive warnings).
- Full `tests/agent-skills.test.cjs` green (65/65); full suite green under Docker (mirrors Ubuntu CI).

### Regression test added?

- [x] Yes — added a test that would have caught this bug

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

> The change is pure config/path-resolution logic with no platform-specific branches; verified on macOS (local) and Linux (Docker). CI covers Windows.

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #1374`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass
- [x] `.changeset/` fragment added (`type: Fixed`)
- [x] No unnecessary dependencies added

## Breaking changes

None — the `warnings` field is purely **additive** to the `--json` IR. The `block` output string is byte-identical for resolving cases and `skills_count` semantics are unchanged, so existing consumers (the ~22 workflow `block` readers and tolerant JSON consumers) are unaffected.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1376"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784297150&installation_id=134682257&pr_number=1376&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1376&signature=1131df536e3fb73cd68332789867af86a776994a074e59b50ce327cf39c7c78a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->