### PR TITLE
test(#1377): pin real agent-skills IR contracts in two vacuous tests

### DIFF
--- a/tests/agent-skills.test.cjs
+++ b/tests/agent-skills.test.cjs
@@ -211,6 +211,14 @@ describe('agent-skills command', () => {
     const r = runAgentSkillsJson(['agent-skills', 'gsd-executor'], tmpDir);
     assert.ok(r.success, 'Command should succeed even with missing skill paths');
     assert.strictEqual(r.ir.block, '', 'block must be empty when all skill paths are missing');
+    // The --json IR carries a warnings[] field (#1374): a skipped path must not
+    // be dropped silently. Assert it names the missing path so this test guards
+    // the silent-drop regression, not merely the empty block.
+    assert.ok(Array.isArray(r.ir.warnings), 'IR must include a warnings array');
+    assert.ok(
+      r.ir.warnings.some((w) => w.includes('skills/nonexistent')),
+      `warnings must name the skipped path, got: ${JSON.stringify(r.ir.warnings)}`,
+    );
   });
 
   test('validates path safety — rejects traversal attempts', () => {
@@ -226,11 +234,12 @@ describe('agent-skills command', () => {
 
   test('returns typed empty IR when no agent type argument provided', () => {
     const r = runAgentSkillsJson(['agent-skills'], tmpDir);
-    // With --json and no agent type, the command outputs the empty-string IR
     assert.ok(r.success, 'Command should succeed');
-    // Output is JSON, either empty string or empty object
-    const parsed = JSON.parse(r.success ? JSON.stringify(r.ir) : '""');
-    assert.ok(parsed === '' || (typeof parsed === 'object'), 'Should return empty or empty-agent IR');
+    // With --json and no agent type, cmdAgentSkills calls output('', raw, ''),
+    // so the IR is the JSON-encoded empty string "" which parses to ''. Pin that
+    // exact contract: the old assertion (=== '' || typeof === 'object') passed
+    // even for a null IR because typeof null === 'object', so it guarded nothing.
+    assert.strictEqual(r.ir, '', 'empty IR must be the empty string when no agent type is provided');
   });
 });
 


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #1377

---

## What was broken

Two tests in `tests/agent-skills.test.cjs` had vacuous-truth assertions that passed regardless of what `agent-skills --json` emitted, so they guarded nothing (violating `RULESET.TESTS.delete-bad-tests`).

## What this fix does

Replaces both assertions with ones that pin the real `--json` IR contract:
- **`'returns typed empty IR when no agent type argument provided'`** — now `assert.strictEqual(r.ir, '')`.
- **`'warns for nonexistent skill path but does not error'`** — keeps `block === ''` and additionally asserts `Array.isArray(r.ir.warnings)` and that `warnings[]` names the skipped path (`skills/nonexistent`).

## Root cause

- The empty-IR test asserted `parsed === '' || typeof parsed === 'object'`. `typeof null === 'object'`, so it passed even for a `null`/object IR. The real contract: with no agent type, `cmdAgentSkills` calls `output('', raw, '')`, so the `--json` IR is the JSON string `""` which parses to `''`.
- The nonexistent-path test asserted only `block === ''`. The `warnings[]` field added to the IR by #1376 (for #1374) made it possible to guard the actual silent-drop behavior the test is named for, but the test was never updated.

## Testing

### How I verified the fix

- `node --test tests/agent-skills.test.cjs` → 65 tests, 0 failures.
- Docker `gsd-test tests/agent-skills.test.cjs` (Linux container) → all pass, exit 0.
- Verified the real IR shapes against the built CLI: `agent-skills --json` (no agent type) emits `""`; the single-nonexistent-path case emits `warnings[]` whose first entry names `skills/nonexistent/SKILL.md`.
- **Fail-first proof:** the old empty-IR assertion accepts a `null` IR (vacuous); `assert.strictEqual(r.ir, '')` rejects it. The old nonexistent-path test passes against a pre-#1376 IR with no `warnings` field; the new `Array.isArray(r.ir.warnings)` assertion rejects it.

### Regression test added?

- [x] Yes — these *are* the regression tests; the change tightens them from vacuous to contract-pinning.
- [ ] No

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [x] N/A (not platform-specific) — the asserted warning string uses a literal `/` (`` `${skillPath}/SKILL.md` ``), not `path.join`, so `skills/nonexistent` appears verbatim on all OSes.

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (the tests themselves)
- [x] All existing tests pass (`tests/agent-skills.test.cjs` green on Mac + Linux Docker)
- [x] Test-only change → `no-changelog` label applied (no `bin/`/`gsd-core/`/`agents/`/`commands/`/`hooks/`/`sdk/src/` paths touched)
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1380"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784298656&installation_id=134682257&pr_number=1380&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1380&signature=3622cd819395dbfe25fd9041527712322e9335ddb8a0bf47aa011c2b02a5f9b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->