### PR TITLE
fix(#1364): parse decisions under markdown headers, not only <decisions> blocks

### DIFF
--- a/.changeset/steady-wolves-greet.md
+++ b/.changeset/steady-wolves-greet.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 1382
+---
+**`check.decision-coverage-plan` no longer reports a false pass when a CONTEXT.md records its decisions under markdown `## … decisions` headers instead of a `<decisions>` block** — `parseDecisions` previously returned an empty set for any CONTEXT.md without a `<decisions>` XML wrapper, so the blocking coverage gate green-lit phases whose markdown-header decisions were never checked. The parser now falls back to the body under markdown decision headers (nested category sub-headings preserved); the `<decisions>` block path is unchanged and still takes precedence when both shapes are present. (#1364)

--- a/src/decisions.cts
+++ b/src/decisions.cts
@@ -33,8 +33,65 @@ function stripFencedCode(content: string): string {
 }
 
 /**
+ * #1364: Fallback for a CONTEXT.md that records its decisions under markdown
+ * headers (`## Locked decisions`, `## Implementation decisions`,
+ * `### Decisions`, …) instead of a `<decisions>...</decisions>` wrapper.
+ *
+ * Without this, `extractDecisionsBlock` returned null for such a file, so
+ * `parseDecisions` yielded `[]` and `check.decision-coverage-plan` — a BLOCKING
+ * gate — reported a vacuous `covered 0/0, passed: true`, never coverage-checking
+ * decisions that were actually present.
+ *
+ * Returns the body under every markdown heading whose title contains the word
+ * "decision"/"decisions", joined by `\n\n`, or null when none is found. A
+ * section runs from its heading to the next heading of equal-or-higher level,
+ * so nested category sub-headings (e.g. `### Claude's Discretion`) inside a
+ * `## … decisions` block are preserved for the bullet parser.
+ */
+function extractMarkdownDecisionSections(content: string): string | null {
+  const lines = content.split(/\r?\n/);
+  const sections: string[] = [];
+  let buf: string[] = [];
+  let capturing = false;
+  let headerLevel = 0;
+  const flush = (): void => {
+    if (buf.length > 0) {
+      sections.push(buf.join('\n'));
+      buf = [];
+    }
+  };
+  for (const line of lines) {
+    const heading = line.match(/^(#{1,6})\s+(.*\S)\s*$/);
+    if (heading) {
+      const level = heading[1].length;
+      const isDecisionHeading = /\bdecisions?\b/i.test(heading[2]);
+      // A heading at the same or higher level closes the active section.
+      if (capturing && level <= headerLevel) {
+        flush();
+        capturing = false;
+      }
+      // Start (or restart) capture at a decision heading; the heading line
+      // itself is not part of the body. Deeper headings inside an active
+      // section fall through below and are kept as category sub-headings.
+      if (!capturing && isDecisionHeading) {
+        capturing = true;
+        headerLevel = level;
+        continue;
+      }
+    }
+    if (capturing)
+      buf.push(line);
+  }
+  flush();
+  return sections.length > 0 ? sections.join('\n\n') : null;
+}
+
+/**
  * Extract the inner text of EVERY `<decisions>...</decisions>` block in
- * order, concatenated by `\n\n`. Returns null when no block is present.
+ * order, concatenated by `\n\n`. When no `<decisions>` wrapper exists, fall
+ * back to markdown decision-header sections (#1364) so a CONTEXT.md that
+ * records decisions under `## … decisions` headings is still parsed. Returns
+ * null when neither shape is present.
  *
  * CONTEXT.md may legitimately contain more than one block (for example, a
  * "current decisions" block plus a "carry-over from prior phase" block);
@@ -44,7 +101,7 @@ function extractDecisionsBlock(content: string): string | null {
   const cleaned = stripFencedCode(content);
   const matches = [...cleaned.matchAll(/<decisions>([\s\S]*?)<\/decisions>/g)];
   if (matches.length === 0)
-    return null;
+    return extractMarkdownDecisionSections(cleaned);
   return matches.map((m) => m[1]).join('\n\n');
 }
 

--- a/tests/post-planning-gaps-2493.test.cjs
+++ b/tests/post-planning-gaps-2493.test.cjs
@@ -623,3 +623,93 @@ describe('#1343 — parseDecisions tolerates freeform text before the colon (reg
     assert.strictEqual(ds[1].trackable, false);
   });
 });
+
+describe('#1364 — parseDecisions falls back to markdown decision headers (regressions)', () => {
+  // A CONTEXT.md that records its decisions under markdown headers (no
+  // `<decisions>` XML wrapper) used to extract nothing, so the BLOCKING
+  // `check.decision-coverage-plan` gate reported a vacuous `covered 0/0,
+  // passed: true` and never coverage-checked decisions that were present.
+
+  test('bullets under a `## Locked decisions` header are extracted', () => {
+    const md =
+      '# Phase Context\n\n' +
+      '## Locked decisions\n' +
+      '- **D-1:** first decision\n' +
+      '- **D-2:** second decision\n';
+    const ds = parseDecisions(md);
+    assert.deepStrictEqual(
+      ds.map(d => d.id),
+      ['D-1', 'D-2'],
+      'markdown-header decisions must be extracted, not silently dropped'
+    );
+  });
+
+  test('singular `### Decision` heading is recognized', () => {
+    const ds = parseDecisions('### Implementation decision\n- **D-7:** only one\n');
+    assert.deepStrictEqual(ds.map(d => d.id), ['D-7']);
+  });
+
+  test('a following non-decision heading bounds the section', () => {
+    const md =
+      '### Implementation decisions\n' +
+      '- **D-7:** kept\n' +
+      '## Next steps\n' +
+      '- **D-99:** outside the decisions section\n';
+    const ds = parseDecisions(md);
+    assert.deepStrictEqual(
+      ds.map(d => d.id),
+      ['D-7'],
+      'D-99 lives under a non-decision heading and must not be captured'
+    );
+  });
+
+  test('nested category sub-heading inside a decisions section still drives trackability', () => {
+    const md =
+      '## Locked decisions\n' +
+      '- **D-1:** tracked\n' +
+      "### Claude's Discretion\n" +
+      '- **D-2:** discretionary\n';
+    const ds = parseDecisions(md);
+    const d1 = ds.find(d => d.id === 'D-1');
+    const d2 = ds.find(d => d.id === 'D-2');
+    assert.ok(d1 && d1.trackable === true, 'D-1 must be trackable');
+    assert.ok(d2 && d2.trackable === false, 'D-2 under Claude\'s Discretion must be non-trackable');
+  });
+
+  test('an explicit `<decisions>` block still takes precedence over markdown headers', () => {
+    const md =
+      '## Decisions\n' +
+      '- **D-1:** markdown copy (must be ignored)\n' +
+      '<decisions>\n- **D-9:** canonical xml\n</decisions>\n';
+    const ds = parseDecisions(md);
+    assert.deepStrictEqual(
+      ds.map(d => d.id),
+      ['D-9'],
+      'when both shapes exist the `<decisions>` block wins (existing behavior)'
+    );
+  });
+
+  test('a D-bullet NOT under a decisions heading is not captured', () => {
+    const ds = parseDecisions('## Summary\n- **D-1:** prose that is not a decisions section\n');
+    assert.deepStrictEqual(ds, [], 'only sections under a decisions heading are parsed');
+  });
+
+  test('a malformed bullet under a decisions heading warns rather than silently passing', () => {
+    // No `:**` terminator → bulletRe fails → the parse-miss guard must surface it
+    // loudly instead of letting the blocking gate report a vacuous 0/0 pass.
+    const md = '## Locked decisions\n- **D-1 — missing the closing colon** body\n';
+    const warnMessages = [];
+    const origWarn = console.warn;
+    try {
+      console.warn = (...args) => { warnMessages.push(args.join(' ')); };
+      const ds = parseDecisions(md);
+      assert.strictEqual(ds.length, 0, 'unparseable bullet must be excluded');
+    } finally {
+      console.warn = origWarn;
+    }
+    assert.ok(
+      warnMessages.some(m => m.includes('D-1')),
+      `expected a console.warn mentioning D-1, got: ${JSON.stringify(warnMessages)}`
+    );
+  });
+});


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #1364

The linked issue carries the `confirmed-bug` label.

## What was broken

`gsd-tools query check.decision-coverage-plan` (a **BLOCKING** gate) reported a vacuous `covered 0/0, passed: true` for any phase `CONTEXT.md` that recorded its decisions under markdown headers (`## Locked decisions`, `## Implementation decisions`) instead of a `<decisions>…</decisions>` XML wrapper — so decisions that were actually present were never coverage-checked, and a dropped decision in such a file slipped through silently.

## What this fix does

When no `<decisions>` wrapper is present, `extractDecisionsBlock` now falls back to the body under every markdown heading whose title contains "decision"/"decisions" and runs the existing bullet parser over it. The blocking gate now sees the real decisions; a malformed bullet under such a heading hits the existing parse-miss `console.warn` guard, so the gate fails loud instead of passing silently.

## Root cause

`extractDecisionsBlock` (`src/decisions.cts`) matched only `/<decisions>([\s\S]*?)<\/decisions>/g` and returned `null` for any other shape. `parseDecisions` short-circuits to `[]` on `null`, and the coverage gate treats `total === covered === 0` as a pass.

## Testing

### How I verified the fix

- Rebuilt the lib (`tsc -p tsconfig.build.json`) and exercised `parseDecisions` against the issue repro plus a behavior matrix: markdown `## Locked decisions` and singular `### … decision` headings now extract; a following non-decision heading bounds the section; nested `### Claude's Discretion` sub-headings still drive `trackable:false`; an explicit `<decisions>` block still takes precedence when both shapes are present; a markdown D-bullet outside a decisions heading is not captured; a malformed (no-colon) bullet warns instead of silently passing.
- Regression tests added to the `decisions.cjs` parser suite in `tests/post-planning-gaps-2493.test.cjs` (the `lint-regression-test-names` gate bans new top-level `bug-*.test.cjs` files, so they are folded into the module suite as a `#1364 … (regressions)` block).
- `node --test` on the decisions suite + downstream gap/coverage/discuss consumers (`bug-2492`, `bug-3739`, `bug-447`, `check-gap-analysis-plan-post-e2e`, `bug-2549…`, `discuss-mode`, `validate-context`): all green. `eslint` and `lint-regression-test-names` clean.

### Regression test added?

- [x] Yes — added a test that would have caught this bug

### Platforms tested

- [x] macOS
- [x] N/A (pure in-memory string parsing — no path/OS-specific behavior)

### Runtimes tested

- [x] N/A (not runtime-specific)

## Checklist

- [x] Issue linked above with `Fixes #1364`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass (decisions suite + downstream consumers)
- [x] `.changeset/` fragment added (follow-up commit on this branch)
- [x] No unnecessary dependencies added

## Breaking changes

None. The `<decisions>`-wrapper path is unchanged and still takes precedence when both shapes are present; only the previously-`null` (no-wrapper) branch gains behavior.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1382"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784302211&installation_id=134682257&pr_number=1382&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1382&signature=0600eb8d6816cb5fa85e3da7f657a43b34daa9d8a54bcdb53dc9bbda8dcfaeb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->