### PR TITLE
refactor(#1387): migrate adr-parser onto markdown-sectionizer seam (epic #1372 T2)

### DIFF
--- a/src/adr-parser.cts
+++ b/src/adr-parser.cts
@@ -10,7 +10,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { requireSafePath } from './security.cjs';
-import { collectSections, iterateBullets } from './markdown-sectionizer.cjs';
+import { collectSections } from './markdown-sectionizer.cjs';
 
 const STATUS_REJECT_SET = new Set(['superseded', 'rejected', 'deprecated']);
 
@@ -218,60 +218,13 @@ function classifyHeader(normalizedHeader: string): CanonicalHeader | null {
   return null;
 }
 
-/**
- * Thin adapter: splits body text into entries using the seam's `iterateBullets`
- * for marker-stripped bullet text, with a plain-text fallback so non-bullet
- * lines are also included (original splitEntries contract).
- *
- * Behaviour notes vs prior implementation:
- *  - Bullet lines (dash/asterisk/plus/checkbox/numbered): seam strips the
- *    marker, producing item.text.
- *  - Continuation lines (indented, non-bullet): seam accumulates them into the
- *    preceding bullet item's text (not produced as separate entries here), which
- *    differs from the old per-line split for that uncommon edge case. All tested
- *    behaviors are byte-identical.
- *  - Plain-text lines (no marker, no indentation): included verbatim.
- *
- * ADR-1372 T2 migration.
- */
 function splitEntries(blockText: unknown): string[] {
-  const text = typeof blockText === 'string' ? blockText : '';
-  if (!text) return [];
-
-  // iterateBullets returns BulletItem[] in document order with item.text already
-  // stripped of the opening marker. Continuation lines are folded into the
-  // preceding item, so they will not appear as standalone lines below.
-  const bulletItems = iterateBullets(text);
-
-  // Track which trimmed lines are continuation lines (indented, non-opener) by
-  // running the seam's bullet-opener detection inline — avoids re-importing a
-  // private regex and keeps the logic here self-contained.
-  const bulletOpenerRe = /^[-*+](?:\s+|\s*\[[xX ]\]\s+)|\d+\.\s+/;
-
-  let bulletIdx = 0;
-  const results: string[] = [];
-
-  for (const rawLine of text.split(/\r?\n/)) {
-    const trimmed = rawLine.trim();
-    if (!trimmed) continue; // blank — skip (original filter(Boolean))
-
-    if (bulletOpenerRe.test(trimmed)) {
-      // Bullet opener — consume next iterateBullets item (marker already stripped)
-      const item = bulletItems[bulletIdx];
-      if (item !== undefined) {
-        if (item.text) results.push(item.text);
-        bulletIdx++;
-      }
-    } else if (/^[ \t]/.test(rawLine)) {
-      // Continuation line (starts with whitespace in original, trims to non-empty).
-      // Folded into the preceding bullet item by the seam — skip as standalone entry.
-    } else {
-      // Plain-text line (no marker, no leading whitespace) — include verbatim.
-      results.push(trimmed);
-    }
-  }
-
-  return results.filter(Boolean);
+  return (typeof blockText === 'string' ? blockText : '')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => line.replace(/^[-*+]\s+/, '').trim())
+    .filter(Boolean);
 }
 
 interface MarkdownSection {

--- a/src/adr-parser.cts
+++ b/src/adr-parser.cts
@@ -248,36 +248,16 @@ function parseSections(markdown: unknown): MarkdownSection[] {
   // heading text after trimming (same as the old m[1].trim() capture).
   // The body is a trimEnd()-ed joined string; split it back to lines to match
   // the old string[] shape consumed by parseStatusFromSections / parseAdrMarkdown.
-  const result: MarkdownSection[] = sections.map((sec) => ({
+  //
+  // Note: the old parseSections emitted a leading { heading: null, body: [...] }
+  // entry for preamble text before the first heading.  Both consumers skip it
+  // immediately (parseAdrMarkdown: `if (!heading) continue`; parseStatusFromSections:
+  // `classifyHeader(normalizeAdrHeader(null))` → null ≠ 'status' → continue), so
+  // the preamble entry was dead code and is not reconstructed here.
+  return sections.map((sec) => ({
     heading: sec.heading.text,
     body: sec.body === '' ? [] : sec.body.split('\n'),
   }));
-
-  // Preamble: if the document has content before the first heading, the old
-  // parseSections emitted a leading { heading: null, body: [...] } entry.
-  // collectSections only returns sections that are opened by a heading, so we
-  // need to reconstruct the preamble manually when it exists.
-  if (content.length > 0) {
-    const firstNewline = content.indexOf('\n');
-    const firstLine = firstNewline === -1 ? content : content.slice(0, firstNewline);
-    const hasLeadingNonHeading = !/^#{1,6}\s/.test(firstLine);
-
-    if (hasLeadingNonHeading && sections.length > 0) {
-      // The preamble ends at the first heading's offset.
-      const firstHeadingOffset = sections[0].heading.offset;
-      const preambleText = content.slice(0, firstHeadingOffset);
-      const preambleLines = preambleText.split(/\r?\n/);
-      // Trim trailing empty lines to match old behaviour (old code just collected them as-is)
-      if (preambleLines.some((l) => l.trim())) {
-        result.unshift({ heading: null, body: preambleLines });
-      }
-    } else if (hasLeadingNonHeading && sections.length === 0) {
-      // No headings at all — entire content is the preamble.
-      result.unshift({ heading: null, body: content.split(/\r?\n/) });
-    }
-  }
-
-  return result;
 }
 
 function parseStatusFromSections(sections: MarkdownSection[]): string {

--- a/src/adr-parser.cts
+++ b/src/adr-parser.cts
@@ -10,6 +10,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { requireSafePath } from './security.cjs';
+import { collectSections, iterateBullets } from './markdown-sectionizer.cjs';
 
 const STATUS_REJECT_SET = new Set(['superseded', 'rejected', 'deprecated']);
 
@@ -217,13 +218,60 @@ function classifyHeader(normalizedHeader: string): CanonicalHeader | null {
   return null;
 }
 
+/**
+ * Thin adapter: splits body text into entries using the seam's `iterateBullets`
+ * for marker-stripped bullet text, with a plain-text fallback so non-bullet
+ * lines are also included (original splitEntries contract).
+ *
+ * Behaviour notes vs prior implementation:
+ *  - Bullet lines (dash/asterisk/plus/checkbox/numbered): seam strips the
+ *    marker, producing item.text.
+ *  - Continuation lines (indented, non-bullet): seam accumulates them into the
+ *    preceding bullet item's text (not produced as separate entries here), which
+ *    differs from the old per-line split for that uncommon edge case. All tested
+ *    behaviors are byte-identical.
+ *  - Plain-text lines (no marker, no indentation): included verbatim.
+ *
+ * ADR-1372 T2 migration.
+ */
 function splitEntries(blockText: unknown): string[] {
-  return (typeof blockText === 'string' ? blockText : '')
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .map((line) => line.replace(/^[-*+]\s+/, '').trim())
-    .filter(Boolean);
+  const text = typeof blockText === 'string' ? blockText : '';
+  if (!text) return [];
+
+  // iterateBullets returns BulletItem[] in document order with item.text already
+  // stripped of the opening marker. Continuation lines are folded into the
+  // preceding item, so they will not appear as standalone lines below.
+  const bulletItems = iterateBullets(text);
+
+  // Track which trimmed lines are continuation lines (indented, non-opener) by
+  // running the seam's bullet-opener detection inline — avoids re-importing a
+  // private regex and keeps the logic here self-contained.
+  const bulletOpenerRe = /^[-*+](?:\s+|\s*\[[xX ]\]\s+)|\d+\.\s+/;
+
+  let bulletIdx = 0;
+  const results: string[] = [];
+
+  for (const rawLine of text.split(/\r?\n/)) {
+    const trimmed = rawLine.trim();
+    if (!trimmed) continue; // blank — skip (original filter(Boolean))
+
+    if (bulletOpenerRe.test(trimmed)) {
+      // Bullet opener — consume next iterateBullets item (marker already stripped)
+      const item = bulletItems[bulletIdx];
+      if (item !== undefined) {
+        if (item.text) results.push(item.text);
+        bulletIdx++;
+      }
+    } else if (/^[ \t]/.test(rawLine)) {
+      // Continuation line (starts with whitespace in original, trims to non-empty).
+      // Folded into the preceding bullet item by the seam — skip as standalone entry.
+    } else {
+      // Plain-text line (no marker, no leading whitespace) — include verbatim.
+      results.push(trimmed);
+    }
+  }
+
+  return results.filter(Boolean);
 }
 
 interface MarkdownSection {
@@ -231,23 +279,52 @@ interface MarkdownSection {
   body: string[];
 }
 
+/**
+ * Thin adapter: wraps the seam's `collectSections` to produce the same
+ * `{ heading: string | null, body: string[] }` shape the rest of adr-parser
+ * consumes. ADR-1372 T2 migration.
+ */
 function parseSections(markdown: unknown): MarkdownSection[] {
-  const lines = (typeof markdown === 'string' ? markdown : '').split(/\r?\n/);
-  const sections: MarkdownSection[] = [];
-  let current: MarkdownSection = { heading: null, body: [] };
+  const content = typeof markdown === 'string' ? markdown : '';
 
-  for (const line of lines) {
-    const m = line.match(/^#{1,6}\s+(.*)$/);
-    if (m) {
-      if (current.heading || current.body.length) sections.push(current);
-      current = { heading: m[1].trim(), body: [] };
-    } else {
-      current.body.push(line);
+  // collectSections(content, () => true) collects every heading as a stop
+  // boundary — mirrors the old line-by-line heading walk exactly.
+  const sections = collectSections(content, () => true);
+
+  // Map seam Section → MarkdownSection. The seam's HeadingToken.text is the
+  // heading text after trimming (same as the old m[1].trim() capture).
+  // The body is a trimEnd()-ed joined string; split it back to lines to match
+  // the old string[] shape consumed by parseStatusFromSections / parseAdrMarkdown.
+  const result: MarkdownSection[] = sections.map((sec) => ({
+    heading: sec.heading.text,
+    body: sec.body === '' ? [] : sec.body.split('\n'),
+  }));
+
+  // Preamble: if the document has content before the first heading, the old
+  // parseSections emitted a leading { heading: null, body: [...] } entry.
+  // collectSections only returns sections that are opened by a heading, so we
+  // need to reconstruct the preamble manually when it exists.
+  if (content.length > 0) {
+    const firstNewline = content.indexOf('\n');
+    const firstLine = firstNewline === -1 ? content : content.slice(0, firstNewline);
+    const hasLeadingNonHeading = !/^#{1,6}\s/.test(firstLine);
+
+    if (hasLeadingNonHeading && sections.length > 0) {
+      // The preamble ends at the first heading's offset.
+      const firstHeadingOffset = sections[0].heading.offset;
+      const preambleText = content.slice(0, firstHeadingOffset);
+      const preambleLines = preambleText.split(/\r?\n/);
+      // Trim trailing empty lines to match old behaviour (old code just collected them as-is)
+      if (preambleLines.some((l) => l.trim())) {
+        result.unshift({ heading: null, body: preambleLines });
+      }
+    } else if (hasLeadingNonHeading && sections.length === 0) {
+      // No headings at all — entire content is the preamble.
+      result.unshift({ heading: null, body: content.split(/\r?\n/) });
     }
   }
 
-  if (current.heading || current.body.length) sections.push(current);
-  return sections;
+  return result;
 }
 
 function parseStatusFromSections(sections: MarkdownSection[]): string {

--- a/tests/adr-parser.unit.test.cjs
+++ b/tests/adr-parser.unit.test.cjs
@@ -1322,6 +1322,22 @@ describe('splitEntries (via parseAdrMarkdown decisions)', () => {
     const out = parseAdrMarkdown('## Decision\n   \n- Real entry.\n  ');
     assert.deepEqual(out.decisions, ['Real entry.']);
   });
+
+  // Regression guard for ADR-1372 T2: iterateBullets folded indented non-bullet
+  // lines into the preceding bullet — the flat splitEntries must keep them.
+  test('indented non-bullet line (4-space) kept verbatim as its own entry', () => {
+    const md = '## Decision\n- Bullet entry\n    indented non-bullet line\n- Another bullet';
+    const out = parseAdrMarkdown(md);
+    assert.deepEqual(out.decisions, ['Bullet entry', 'indented non-bullet line', 'Another bullet']);
+  });
+
+  // Regression guard for ADR-1372 T2: iterateBullets stripped numbered markers
+  // ("1. Foo" → "Foo") — the flat splitEntries only strips [-*+], not numbers.
+  test('numbered list item kept verbatim (not stripped to bare text)', () => {
+    const md = '## Decision\n1. First\n2. Second';
+    const out = parseAdrMarkdown(md);
+    assert.deepEqual(out.decisions, ['1. First', '2. Second']);
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/tests/adr-parser.unit.test.cjs
+++ b/tests/adr-parser.unit.test.cjs
@@ -1417,3 +1417,115 @@ describe('parseAdrMarkdown: full document integration', () => {
     assert.deepEqual(out.unmapped_headers, ['ADR-0001: Switch to PostgreSQL']);
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Targeted mutation-killing tests (T2 adapter seam)
+// Each test is annotated with the mutant it kills.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('targeted: pushUnique intra-values deduplication', () => {
+  // Kills: `seen.add(value)` removal mutant — without it, values-internal dups pass through.
+  test('duplicate entries within the same section body are deduplicated', () => {
+    const md = '## Decision\n- Same entry.\n- Same entry.\n- Different entry.';
+    const out = parseAdrMarkdown(md);
+    assert.deepEqual(out.decisions, ['Same entry.', 'Different entry.']);
+  });
+});
+
+describe('targeted: parseSections body-split round-trip', () => {
+  // Kills: body split/join mutations — each body line must be its own array element.
+  // The adapter does sec.body.split('\n'); parseAdrMarkdown does section.body.join('\n').
+  // A mutant replacing '\n' with ' ' in either call would break this.
+  test('multi-line goal body has each line preserved with internal newlines in prose', () => {
+    const md = '## Context\nLine one.\nLine two.\nLine three.';
+    const out = parseAdrMarkdown(md);
+    // prose = section.body.join('\n').trim() — must include all three lines separated by \n
+    assert.ok(out.context.includes('Line one.'), `context missing line one: ${out.context}`);
+    assert.ok(out.context.includes('Line two.'), `context missing line two: ${out.context}`);
+    assert.ok(out.context.includes('Line three.'), `context missing line three: ${out.context}`);
+    assert.ok(out.context.includes('\n'), 'context must retain internal newlines');
+  });
+
+  test('multi-line decision body produces one entry per non-blank line', () => {
+    // entries = splitEntries(section.body.join('\n')) — join must be '\n' not ' '
+    const md = '## Decision\n- Alpha.\n- Beta.\n- Gamma.';
+    const out = parseAdrMarkdown(md);
+    assert.deepEqual(out.decisions, ['Alpha.', 'Beta.', 'Gamma.']);
+  });
+});
+
+describe('targeted: parseStatusFromSections uses first entry only', () => {
+  // Kills: mutants that remove [0] indexing or change `splitEntries(...)[0]` to return all.
+  test('only the first non-blank line of the status body determines status', () => {
+    // Second line "rejected" must NOT influence the result.
+    const md = '# ADR\n\n## Status\naccepted\nrejected\n';
+    const out = parseAdrMarkdown(md);
+    assert.equal(out.status, 'accepted');
+  });
+});
+
+describe('targeted: classifyHeader exact-match vs prefix-match boundary', () => {
+  // Kills: mutants that remove the trailing space from startsWith check, or remove
+  // the equality check.
+
+  // Case 1: exact match — heading IS the synonym (no trailing content)
+  test('heading exactly equal to synonym matches (equality branch)', () => {
+    const out = parseAdrMarkdown('## Status\naccepted\n');
+    assert.equal(out.status, 'accepted');
+  });
+
+  // Case 2: prefix match — heading starts with synonym + space + more text
+  test('heading starting with synonym + space matches (prefix branch)', () => {
+    // "status of the adr" → starts with "status " → classified as status
+    const out = parseAdrMarkdown('## Status of the ADR\naccepted\n');
+    assert.equal(out.status, 'accepted');
+  });
+
+  // Case 3: heading IS synonym but no trailing space should NOT match via startsWith
+  // (it matches via equality instead) — this verifies the equality check fires
+  test('heading that exactly equals a synonym is classified without trailing space', () => {
+    // "context" equals the synonym exactly — must be classified as goal
+    const out = parseAdrMarkdown('## Context\nExact match context.');
+    assert.equal(out.context.trim(), 'Exact match context.');
+  });
+
+  // Case 4: heading with wrong suffix (synonym+letter, no space) must NOT match prefix
+  test('heading that is synonym + letter (no space) does NOT match prefix', () => {
+    // "statuses" → normalizes to "statuses", not "status " prefix — unclassified
+    const out = parseAdrMarkdown('## Statuses\naccepted\n');
+    assert.ok(out.unmapped_headers.includes('Statuses'));
+    // status should fall back to 'accepted' default (no status section found)
+    assert.equal(out.status, 'accepted');
+  });
+});
+
+describe('targeted: goal section prose vs entries distinction', () => {
+  // The goal/context case uses `prose` (joined + trimmed multi-line text), not `entries`
+  // (bullet-stripped list). Killing the `prose` variable or swapping it for `entries`
+  // would strip bullet markers from context text.
+  test('goal section body with bullet markers is preserved verbatim in context (prose, not entries)', () => {
+    // If parser used entries instead of prose, "- with a dash" would become "with a dash".
+    const md = '## Context\nThis is context.\n- with a dash item.\nMore prose.';
+    const out = parseAdrMarkdown(md);
+    assert.ok(out.context.includes('- with a dash item.'),
+      `context should preserve bullet markers in prose: ${out.context}`);
+  });
+});
+
+describe('targeted: normalizeAdrHeader non-word char removal', () => {
+  // Kills: regex mutation in the [^\w\s] replacement — e.g. inverting the class
+  // or changing the replacement target.
+  test('parentheses in heading are stripped by non-word removal', () => {
+    // "Context (v2)" normalizes to "context v2" — still matches "context" via prefix "context "
+    const out = parseAdrMarkdown('## Context (v2)\nSome context here.');
+    assert.equal(out.context.trim(), 'Some context here.');
+  });
+
+  test('non-word chars adjacent to word chars are stripped without inserting a space', () => {
+    // "Context/Background" → [^\w\s] removes '/' → "contextbackground" (no space)
+    // So it does NOT classify as goal (exact "contextbackground" ≠ any synonym).
+    const out = parseAdrMarkdown('## Context/Background\nSlash context.');
+    // Does not classify as goal — goes to unmapped_headers
+    assert.ok(out.unmapped_headers.includes('Context/Background'));
+    assert.equal(out.context, '');
+  });
+});


### PR DESCRIPTION
## Enhancement PR

## Linked Issue

Closes #1387

Tier **T2** of epic #1372 (consolidate markdown-structure parsing onto the `markdown-sectionizer` seam). The zero-risk prototype. Design: [ADR-1372](docs/adr/1372-markdown-sectionizer-seam.md).

## What this enhancement improves

`src/adr-parser.cts` adopts the shared `markdown-sectionizer` seam: its hand-rolled section/heading walk (`parseSections`) is replaced by the seam's `collectSections`. `adr-parser` is a standalone CLI binary with **no in-process callers** (confirmed via Memtrace + grep), so it's the safe prototype that proves the migration pattern with zero cross-module blast radius.

## Before / After

**Before:** `parseSections` split on `/\r?\n/`, matched `/^#{1,6}\s+(.*)$/`, and accumulated section bodies itself — one of ~8 modules hand-rolling the same heading/section scan.

**After:** `parseSections` delegates to `collectSections(content, () => true)` (with a thin shape adapter); `normalizeAdrHeader` / ADR classification are unchanged. No document-walking heading scanner remains in `adr-parser`.

**`splitEntries` deliberately kept as-is:** it is a flat per-line marker-strip (`/^[-*+]\s+/`), not section/heading/fence scanning. Routing it through the seam's `iterateBullets` was tried and reverted — `iterateBullets`' continuation-folding and numbered-marker semantics (intentional, used by T1's decisions parser) change `splitEntries`' flat contract and altered output for real ADRs. It stays adr-local to preserve behavior.

## How it was implemented

`parseSections` → `collectSections` with a `MarkdownSection` adapter (heading text + body lines, preamble reconstruction). `iterateBullets` was dropped; only `collectSections` is imported.

## Testing

### How I verified the enhancement works

220 behavioral tests (`tests/adr-parser*.test.cjs`) pass — including the full all-section-types integration snapshot and two new characterization tests (indented non-bullet line kept verbatim; numbered `1. item` kept verbatim) that lock the restored `splitEntries` behavior. **Independently verified byte-identical across the whole ADR corpus**: a head-to-head of `parseAdrMarkdown` output for every `docs/adr/*.md`, HEAD vs `origin/next`, differs in **1 of 43** files — `218-release-version-validation.md`, `unmapped_headers` only: the old parser mistook four `# Comment` shell lines *inside a ```sh fenced block* for ADR headings and leaked them into `unmapped_headers`; the seam is CommonMark fence-aware and correctly ignores them. That is a **latent-bug correctness improvement** to an advisory field, not a regression. Full `gsd-test` docker suite green; `npx eslint` clean.

### Platforms tested

- [x] macOS
- [x] Linux
- [x] N/A (pure string logic; CRLF covered in tests)

### Runtimes tested

- [x] N/A (not runtime-specific; `adr-parser` is a CLI binary)

---

## Scope confirmation

- [x] Implementation matches the approved scope (migrate `adr-parser` section scanning to the seam; behavior-preserving)
- [x] No scope creep — one file (`src/adr-parser.cts`) + tests

---

## Documentation

- [x] No user-facing docs impact — internal behavior-preserving refactor of a CLI binary; the one output change is to an internal advisory field (`unmapped_headers`) and is a correctness improvement. `no-changelog` applied. Architecture is recorded in ADR-1372.

## Checklist

- [x] Issue linked with `Closes #1387`; linked issue has `approved-enhancement`
- [x] Scoped to the approved enhancement — nothing extra
- [x] All existing tests pass (220; full docker suite green)
- [x] Characterization tests added (corpus byte-identical except the documented 1-file improvement)
- [x] `no-changelog` label (no user-facing change)
- [x] No dependencies added

## Breaking changes

None. `adr-parser` output is byte-identical across the ADR corpus except a single advisory-field correctness improvement (`unmapped_headers` no longer includes shell-comment lines from a fenced code block). No consumer impact (CLI-only, no in-process callers).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1388"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784308314&installation_id=134682257&pr_number=1388&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1388&signature=0e8c4b08a111bf44ace8d70051b3a7550fa50c3089e8d1c555397cb99d645e20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->