### PR TITLE
fix(#1389): exempt auto-backmerge PRs from the Require Issue Link gate

### DIFF
--- a/.github/workflows/require-issue-link.yml
+++ b/.github/workflows/require-issue-link.yml
@@ -29,7 +29,16 @@ jobs:
           fi
 
       - name: Comment and fail if no issue link
-        if: steps.check.outputs.found == 'false'
+        # Exempt auto-backmerge PRs (chore/backmerge-main-to-next-*): they map to
+        # no issue and a `Closes #N` would pollute the released CHANGELOG. Keyed on
+        # the workflow-authored branch name AND same-repo identity so a fork PR
+        # cannot forge the exemption. Step-level (not job-level) so the required
+        # "Issue link required" check still reports SUCCESS rather than a
+        # branch-protection-blocking "skipped". See #1389.
+        if: >-
+          steps.check.outputs.found == 'false' &&
+          !(startsWith(github.head_ref, 'chore/backmerge-main-to-next-') &&
+            github.event.pull_request.head.repo.full_name == github.repository)
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           # Uses GitHub API SDK — no shell string interpolation of untrusted input

--- a/tests/workflow-maintainer-skip.test.cjs
+++ b/tests/workflow-maintainer-skip.test.cjs
@@ -79,3 +79,27 @@ describe('PR policy workflow maintainer carve-outs', () => {
     assert.match(workflow, /CONTRIBUTING\.md#pull-request-guidelines/);
   });
 });
+
+describe('Require Issue Link back-merge automation carve-out', () => {
+  test('the fail step is skipped for same-repo auto-backmerge PRs', () => {
+    const workflow = readWorkflow('.github/workflows/require-issue-link.yml');
+
+    // Auto-backmerge PRs (chore/backmerge-main-to-next-*) map to no issue, and a
+    // `Closes #N` would pollute the released CHANGELOG. The fail step must carve
+    // them out — keyed on the workflow-authored branch name AND same-repo
+    // identity so a fork PR cannot forge the exemption (#1389).
+    assert.match(
+      workflow,
+      /startsWith\(github\.head_ref, 'chore\/backmerge-main-to-next-'\)/
+    );
+    assert.match(
+      workflow,
+      /github\.event\.pull_request\.head\.repo\.full_name == github\.repository/
+    );
+
+    // The carve-out must live on the failing step's `if:` alongside the
+    // found=='false' check (step-level, so the required check still reports
+    // SUCCESS rather than a branch-protection-blocking "skipped").
+    assert.match(workflow, /steps\.check\.outputs\.found == 'false'/);
+  });
+});


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #1389

---

## What was broken

The required **Issue link required** check (`.github/workflows/require-issue-link.yml`) had no exemption for automated back-merge PRs (`chore/backmerge-main-to-next-<sha>`). When such a PR parked for manual review (`needs_review`), the maintainer could only merge it via `--admin`, because these bot PRs legitimately map to no issue and adding a `Closes #N` would pollute the released CHANGELOG. Hit live on #1379.

## What this fix does

Adds a carve-out on the failing step's `if:` so the gate does not fail same-repo auto-back-merge PRs, while still enforcing for every normal PR.

```yaml
if: >-
  steps.check.outputs.found == 'false' &&
  !(startsWith(github.head_ref, 'chore/backmerge-main-to-next-') &&
    github.event.pull_request.head.repo.full_name == github.repository)
```

Two deliberate design choices:
- **Step-level, not job-level** — a skipped *job* reports the required check as "skipped", which leaves branch protection pending (the original symptom). Keeping the job running so it reports **SUCCESS** is correct.
- **Branch-pattern + same-repo guard, not the `backmerge` label** — the label is applied *after* PR creation and `labeled` is not a trigger (race). `github.head_ref` is known at `opened`, and `head.repo.full_name == github.repository` makes it **fork-proof** (a fork cannot forge same-repo identity).

## Root cause

`require-issue-link.yml` gated its fail step solely on `steps.check.outputs.found == 'false'` with no automation/back-merge carve-out, while `auto-backmerge.yml` only self-merges (`--admin`) when `needs_review != 'true'` — so any back-merge with main-only drops parked onto the manual path where this gate is a hard red required check.

## Testing

### How I verified the fix

- Strict TDD: added a lock test to `tests/workflow-maintainer-skip.test.cjs` that asserts the back-merge + same-repo carve-out is present on the fail step. Confirmed it **fails** before the workflow edit and **passes** after.
- `node -e` with `js-yaml` confirms the folded-scalar `if:` parses into one valid boolean expression.
- `npm run lint` clean; 106 workflow-validation tests (`ci-test-scope`, `adr-230-pr-target-policy`) + naming-guard tests pass; `lint-test-file-count` clean.
- Adversarial Codex review of the diff: **no blocking findings**. One accepted LOW — a trusted same-repo collaborator could name a branch `chore/backmerge-main-to-next-*` to skip this (process, non-security) gate; forks are blocked by the same-repo guard, same-repo push requires write access, and such a PR still hits the other gates.

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [x] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass — lint + workflow-validation + naming-guard suites green locally; full cross-platform matrix runs in CI
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1391"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784311779&installation_id=134682257&pr_number=1391&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1391&signature=05c523f4d5c1ae3b9c33cde31954cd136f58cac7f39234280c122938cc16ebff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->