### PR TITLE
refactor(#1393): migrate roadmap-parser onto markdown-sectionizer seam (epic #1372 T4)

### DIFF
--- a/src/roadmap-parser.cts
+++ b/src/roadmap-parser.cts
@@ -24,6 +24,7 @@ const { escapeRegex, phaseMarkdownRegexSource } = phaseIdModule;
 import planningWorkspace = require('./planning-workspace.cjs');
 const { planningDir } = planningWorkspace;
 import { platformReadSync } from './shell-command-projection.cjs';
+import { tokenizeHeadings } from './markdown-sectionizer.cjs';
 
 // ─── Roadmap milestone scoping ───────────────────────────────────────────────
 
@@ -109,35 +110,20 @@ function extractCurrentMilestone(content: string, cwd?: string): string {
 
   const computeSectionEnd = (headingText: string, headingStart: number): number => {
     const level = (headingText.match(/^(#{1,3})\s/) ?? ['', '#'])[1].length;
-    const rest = content.slice(headingStart + headingText.length);
-    const stopPattern = new RegExp(
-      `^#{1,${level}}\\s+(?!Phase\\s+\\S)(?:.*v\\d+\\.\\d+|✅|📋|🚧)`,
-      'i',
-    );
-    let end = content.length;
-    let fc: string | null = null;
-    let fl = 0;
-    let off = 0;
-    for (const line of rest.split('\n')) {
-      const fm = line.match(/^\s{0,3}((?:`{3,}|~{3,}))(.*)/);
-      if (fm) {
-        const ch = fm[1][0];
-        const ln = fm[1].length;
-        const trailing = fm[2] || '';
-        if (!fc) {
-          fc = ch;
-          fl = ln;
-        } else if (ch === fc && ln >= fl && /^\s*$/.test(trailing)) {
-          fc = null;
-          fl = 0;
-        }
-      } else if (!fc && stopPattern.test(line)) {
-        end = headingStart + headingText.length + off;
-        break;
-      }
-      off += line.length + 1;
+    const afterHeading = headingStart + headingText.length;
+    // Use tokenizeHeadings (fence-aware, offsets into original content) to find
+    // the next stop boundary without re-implementing fence detection. T4 seam migration.
+    const headings = tokenizeHeadings(content);
+    for (const h of headings) {
+      if (h.offset <= headingStart) continue;
+      if (h.offset < afterHeading) continue;
+      if (h.level > level) continue;
+      // Mirrors old stopPattern: level-bounded, not a Phase heading, milestone marker
+      if (/^Phase\s+\S/i.test(h.text)) continue;
+      if (!/v\d+\.\d+|✅|📋|🚧/i.test(h.text)) continue;
+      return h.offset;
     }
-    return end;
+    return content.length;
   };
 
   const sectionEnd = computeSectionEnd(selected[0], sectionStart);
@@ -331,46 +317,6 @@ function getMilestoneInfo(cwd: string): MilestoneInfo {
   }
 }
 
-// ─── Fence-aware text helper ──────────────────────────────────────────────────
-
-/**
- * Return a copy of `text` with every line that lies inside a fenced code block
- * replaced by an empty string, using the same fence semantics as
- * `computeSectionEnd` (backtick/tilde, ≥3 chars, indent ≤3 spaces, toggle;
- * an unclosed fence treats remaining content as fenced).
- */
-function stripFencedLines(text: string): string {
-  let fenceChar: string | null = null;
-  let fenceLen = 0;
-  const lines = text.split('\n');
-  const result: string[] = [];
-  for (const line of lines) {
-    const fm = line.match(/^\s{0,3}((?:`{3,}|~{3,}))(.*)/);
-    if (fm) {
-      const ch = fm[1][0];
-      const ln = fm[1].length;
-      const trailing = fm[2] || '';
-      if (!fenceChar) {
-        fenceChar = ch;
-        fenceLen = ln;
-        // The fence-open line itself is not a content line — blank it.
-        result.push('');
-      } else if (ch === fenceChar && ln >= fenceLen && /^\s*$/.test(trailing)) {
-        fenceChar = null;
-        fenceLen = 0;
-        // The fence-close line — blank it.
-        result.push('');
-      } else {
-        // A fence marker that doesn't close the current fence (different char or shorter) — keep treating as fenced content.
-        result.push(fenceChar ? '' : line);
-      }
-    } else {
-      result.push(fenceChar ? '' : line);
-    }
-  }
-  return result.join('\n');
-}
-
 // ─── Milestone phase filter ───────────────────────────────────────────────────
 
 type MilestonePhaseFilter = ((dirName: string) => boolean) & {
@@ -437,31 +383,18 @@ function getMilestonePhaseFilter(cwd: string, versionOverride?: string | null, p
       } else {
         const sectionStart = sectionMatch.index!;
         const headingLevel = (sectionMatch[1].match(/^(#{1,3})\s/) ?? ['', '#'])[1].length;
-        const restContent = roadmapContent.slice(sectionStart + sectionMatch[0].length);
-        const nextMilestonePattern = new RegExp(`^#{1,${headingLevel}}\\s+(?!Phase\\s+\\S)(?:.*v\\d+\\.\\d+|✅|📋|🚧)`, 'i');
-
+        const afterHeading = sectionStart + sectionMatch[0].length;
+        // Use tokenizeHeadings (fence-aware, offsets into original content) to find
+        // the next milestone-boundary heading. T4 seam migration.
+        const allHeadings = tokenizeHeadings(roadmapContent);
         let sectionEnd = roadmapContent.length;
-        let fenceChar: string | null = null;
-        let fenceLen = 0;
-        let charOffset = 0;
-        for (const line of restContent.split('\n')) {
-          const fenceMatch = line.match(/^\s{0,3}((?:`{3,}|~{3,}))(.*)/);
-          if (fenceMatch) {
-            const char = fenceMatch[1][0];
-            const len = fenceMatch[1].length;
-            const trailing = fenceMatch[2] || '';
-            if (!fenceChar) {
-              fenceChar = char;
-              fenceLen = len;
-            } else if (char === fenceChar && len >= fenceLen && /^\s*$/.test(trailing)) {
-              fenceChar = null;
-              fenceLen = 0;
-            }
-          } else if (!fenceChar && nextMilestonePattern.test(line)) {
-            sectionEnd = sectionStart + sectionMatch[0].length + charOffset;
-            break;
-          }
-          charOffset += line.length + 1;
+        for (const h of allHeadings) {
+          if (h.offset < afterHeading) continue;
+          if (h.level > headingLevel) continue;
+          if (/^Phase\s+\S/i.test(h.text)) continue;
+          if (!/v\d+\.\d+|✅|📋|🚧/i.test(h.text)) continue;
+          sectionEnd = h.offset;
+          break;
         }
 
         const currentSection = roadmapContent.slice(sectionStart, sectionEnd);
@@ -469,11 +402,13 @@ function getMilestonePhaseFilter(cwd: string, versionOverride?: string | null, p
       }
     }
 
-    const phasePattern = /#{2,4}\s*(?:\[[^\]]+\]\s*)?Phase\s+([\w][\w.-]*)\s*:/gi;
-    const roadmapUnfenced = stripFencedLines(roadmap);
-    let m: RegExpExecArray | null;
-    while ((m = phasePattern.exec(roadmapUnfenced)) !== null) {
-      milestonePhaseNums.add(m[1]);
+    // Use tokenizeHeadings (fence-aware) instead of stripFencedLines + regex.
+    // T4 seam migration: phase headings inside fences are excluded automatically.
+    const phaseHeadingPattern = /^(?:\[[^\]]+\]\s*)?Phase\s+([\w][\w.-]*)\s*:/i;
+    for (const h of tokenizeHeadings(roadmap)) {
+      if (h.level < 2 || h.level > 4) continue;
+      const pm = phaseHeadingPattern.exec(h.text);
+      if (pm) milestonePhaseNums.add(pm[1]);
     }
   } catch { /* intentionally empty */ }
 


### PR DESCRIPTION
## Enhancement PR

## Linked Issue

Closes #1393

Tier **T4** of epic #1372 (consolidate markdown-structure parsing onto the `markdown-sectionizer` seam). Design: [ADR-1372](docs/adr/1372-markdown-sectionizer-seam.md).

## What this enhancement improves

`src/roadmap-parser.cts` loses **all three** of its duplicated inline fenced-code state machines (the standalone `stripFencedLines` + the inline copies in `computeSectionEnd` and `getMilestonePhaseFilter`) and adopts the shared seam's fence-aware `tokenizeHeadings`. Net **−65 lines** (32 added, 97 removed).

## Before / After

**Before:** roadmap-parser blanked fenced lines (3 separate fence loops) then scanned for milestone/phase headings with line-by-line offset arithmetic.

**After:** `tokenizeHeadings(content)` (fence-aware, headings-in-fences already excluded) provides the milestone/phase heading positions directly. `computeSectionEnd` and the `getMilestonePhaseFilter` version-override path use `heading.offset` — **a character index into the original content** — as the section boundary.

## How it was implemented — offset preservation

The critical constraint: roadmap-parser slices milestone sections by **character offset into the original content**, so the seam's `stripFencedCode` (which *removes* fenced lines, shifting offsets) was deliberately **not** used. Instead `tokenizeHeadings` returns `offset` = the index of the `#` in the unmodified content (verified `content[h.offset] === '#'`), so section slicing stays byte-identical. `<details>` handling, frontmatter-in-section logic, and milestone-selection stay caller-side.

## Testing

### How I verified the enhancement works

165 roadmap/milestone/phase tests pass (roadmap-parser, feat-3594 adversarial, the milestone suite, roadmap-phase-fallback, milestones-drift). Independently verified the offset invariant — every `tokenizeHeadings` offset points at `#`, and both fenced (` ```md / ## Phase `) and HTML-commented (`<!-- ## Phase -->`) headings are correctly excluded. **Corpus head-to-head** (every ROADMAP fixture, this branch vs `origin/next`): **1 of 84 output slots differs** — `markdown-headings-inside-html-comment.md` `phaseCount` 3→2, because the old unanchored regex matched `## Phase 998:` *inside* an inline HTML comment while ATX-anchored `tokenizeHeadings` correctly rejects it (a **correctness improvement**, no test asserts that count). Not in the Stryker mutation matrix. Full `gsd-test` docker suite green; `npx eslint` clean.

### Platforms tested

- [x] macOS
- [x] Linux
- [x] N/A (pure string logic; CRLF covered)

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Scope confirmation

- [x] Matches the approved scope (collapse the 3 fence loops + heading scanning onto the seam, offset-preserving, behavior-preserving)
- [x] No scope creep — `src/roadmap-parser.cts` + tests only

---

## Documentation

- [x] No user-facing docs impact — internal behavior-preserving refactor of milestone/phase parsing; the one output change is a correctness improvement (commented-out phase no longer mis-counted). `no-changelog` applied. Architecture in ADR-1372.

## Checklist

- [x] `Closes #1393`; issue has `approved-enhancement`
- [x] Scoped — nothing extra
- [x] All existing tests pass (165 roadmap/milestone/phase; full docker suite green)
- [x] Characterization tests + corpus head-to-head (byte-identical except the documented improvement); offset invariant independently verified
- [x] `no-changelog`
- [x] No dependencies added

## Breaking changes

None. Milestone/phase parsing and section character-offset slicing are byte-identical except one correctness improvement: a `## Phase` line inside an inline HTML comment is no longer counted as a phase.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1395"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784315079&installation_id=134682257&pr_number=1395&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1395&signature=ac7042695a3fc9bf0072f6b8b3923c1e1ac3478ef0806b334a56eea809eda50a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->