### PR TITLE
fix(#1404): version-only manifest bumps no longer park the back-merge

### DIFF
--- a/.github/workflows/auto-backmerge.yml
+++ b/.github/workflows/auto-backmerge.yml
@@ -108,6 +108,27 @@ jobs:
           NEXT_CODE=$(git diff --name-only "$BASE" origin/next -- . ':(exclude)CHANGELOG.md' ':(exclude).changeset' | sort)
           DROPPED=$(comm -23 <(printf '%s\n' "$MAIN_CODE") <(printf '%s\n' "$NEXT_CODE") | grep -v '^$' || true)
 
+          # The version-bearing manifests diverge every release by design (next
+          # runs a -dev version). A drop whose main-vs-base diff touches ONLY
+          # "version" lines is just the release stamp, not a straight-to-main
+          # fix — parking on it is what lets the back-merge sit and go stale, so
+          # filter those out. A substantive change still parks: it leaves
+          # non-"version" lines (deps in package.json; resolved/integrity in the
+          # lockfile when a dependency actually changes).
+          VERSION_STAMP_MANIFESTS='package.json package-lock.json .claude-plugin/plugin.json gemini-extension.json'
+          DROPPED=$(printf '%s\n' "$DROPPED" | while IFS= read -r f; do
+            [ -n "$f" ] || continue
+            case " $VERSION_STAMP_MANIFESTS " in
+              *" $f "*)
+                changed=$(git diff "$BASE" origin/main -- "$f" | grep -E '^[+-]' | grep -vE '^[+-]{3} ' || true)
+                if [ -z "$(printf '%s\n' "$changed" | grep -vE '^[+-][[:space:]]*"version":' || true)" ]; then
+                  continue
+                fi
+                ;;
+            esac
+            printf '%s\n' "$f"
+          done | grep -v '^$' || true)
+
           git commit -m "chore: back-merge main into next (${SHORT_SHA})"
           git push --force origin "$BR"
 

--- a/tests/workflow-maintainer-skip.test.cjs
+++ b/tests/workflow-maintainer-skip.test.cjs
@@ -103,3 +103,33 @@ describe('Require Issue Link back-merge automation carve-out', () => {
     assert.match(workflow, /steps\.check\.outputs\.found == 'false'/);
   });
 });
+
+describe('Auto-backmerge needs_review version-manifest carve-out (#1404)', () => {
+  const workflow = readWorkflow('.github/workflows/auto-backmerge.yml');
+
+  test('all four version manifests are filtered via version-only detection', () => {
+    // package.json / package-lock.json / plugin.json / gemini-extension.json
+    // diverge every release; a drop that is ONLY "version" lines must not park
+    // (parking is what lets the back-merge go stale). A substantive change still
+    // parks. (#1404)
+    assert.ok(
+      workflow.includes("VERSION_STAMP_MANIFESTS='package.json package-lock.json .claude-plugin/plugin.json gemini-extension.json'"),
+      'auto-backmerge.yml must version-only-filter all four version manifests'
+    );
+    assert.ok(
+      workflow.includes(`grep -vE '^[+-][[:space:]]*"version":'`),
+      'auto-backmerge.yml must filter version-only diffs via the "version" grep'
+    );
+  });
+
+  test('package-lock.json is NOT blindly excluded (lockfile-only changes still park)', () => {
+    // A lockfile-only substantive change (e.g. npm audit fix) rewrites
+    // resolved/integrity lines, so version-only filtering lets it through to
+    // review rather than dropping it silently. Guard against regression to a
+    // blanket exclude. (#1404)
+    assert.ok(
+      !workflow.includes(":(exclude)package-lock.json"),
+      'package-lock.json must not be globally excluded; rely on version-only filtering'
+    );
+  });
+});


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #1404

---

## What was broken

`auto-backmerge.yml`'s `needs_review` safety net parked the back-merge for manual review whenever a code file existed only on `main`. But the version-bearing manifests (`package.json`, `package-lock.json`, `.claude-plugin/plugin.json`, `gemini-extension.json`) diverge **every release** by design (`next` runs a `-dev` version), so the net misfired on every release. That manual-review park is what let the back-merge sit and go **stale** — #1379 parked ~3h, then collected a modify/delete conflict when #1385 (#1777 purity gate) re-touched `.changeset` fragments the back-merge had deleted.

## What this fix does

Makes the safety net **version-aware** so routine release stamps don't park, while a genuine straight-to-main change still does:

- For all four version manifests, ignore a drop whose `main`-vs-base diff touches **only** `"version"` lines (the release stamp).
- A substantive change still parks because it leaves non-`"version"` lines: dependency edits in `package.json` (`"name": "range"`), and `resolved`/`integrity` rewrites in `package-lock.json` when a dependency actually changes.

Result: routine release back-merges get `needs_review=false` → auto-merge within seconds of branch creation → no park, no staleness window. Genuine straight-to-main fixes still park for review.

## Root cause

The safety net's exclusion list (lines 104–109) was only `CHANGELOG.md` + `.changeset/`. The version manifests weren't accounted for, so `DROPPED` was non-empty on every release → `needs_review=true` → the auto-merge step (`if: ... needs_review != 'true'`) was skipped.

## Testing

### How I verified the fix

- Strict TDD: added lock tests to `tests/workflow-maintainer-skip.test.cjs` (red before the workflow edit, green after) asserting the four-manifest version-only filter exists and that `package-lock.json` is **not** blindly excluded.
- **Logic proof** of the exact version-only classifier on synthetic diffs: `package.json` version-bump → *version-only* (skip); `package.json` dep-bump → *substantive* (park); lockfile version-bump → *version-only*; lockfile dep-change (`resolved`/`integrity`) → *substantive*. All correct.
- `js-yaml` parse OK; `npm run lint` clean; workflow-validation (`ci-test-scope`, naming guards, `lint-test-file-count`) all green.
- **Adversarial Codex review** (two rounds): the first flagged a MED — fully excluding `package-lock.json` was a blind spot for lockfile-only substantive changes. Fixed by version-only-filtering it instead of excluding. Re-review (Codex empirically confirmed registry deps carry `resolved`/`integrity`): **no blocking findings**.

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [x] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass — lint + workflow-validation + naming-guard + classifier proof green locally; full cross-platform matrix runs in CI
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1405"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784335110&installation_id=134682257&pr_number=1405&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1405&signature=1659f689213f0ce0356f808702dfe4371ce0afe2e0bace661bf70f14c1b04b3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->