### PR TITLE
fix(#1406): guard setGsdConfig test helper against prototype pollution (CodeQL #40)

### DIFF
--- a/tests/git-base-branch.test.cjs
+++ b/tests/git-base-branch.test.cjs
@@ -67,14 +67,25 @@ function setGsdConfig(dir, key, value) {
   const cfgPath = path.join(cfgDir, 'config.json');
   let cfg = {};
   try { cfg = JSON.parse(fs.readFileSync(cfgPath, 'utf8')); } catch (_) { /* new file */ }
-  // Set nested key (dot notation)
+  // Set nested key (dot notation). Guard every segment against prototype
+  // pollution with inline literal checks at each write site — mirrors the
+  // production guard in src/config.cts. A Set/pre-loop guard is NOT recognised
+  // by CodeQL's js/prototype-pollution-utility query (see PR #752 / alert #40).
   const parts = key.split('.');
   let obj = cfg;
   for (let i = 0; i < parts.length - 1; i++) {
-    if (typeof obj[parts[i]] !== 'object' || obj[parts[i]] === null) obj[parts[i]] = {};
-    obj = obj[parts[i]];
+    const k = parts[i];
+    if (k === '__proto__' || k === 'prototype' || k === 'constructor') {
+      throw new Error(`setGsdConfig: unsafe config key segment '${k}'`);
+    }
+    if (typeof obj[k] !== 'object' || obj[k] === null) obj[k] = {};
+    obj = obj[k];
   }
-  obj[parts[parts.length - 1]] = value;
+  const lastKey = parts[parts.length - 1];
+  if (lastKey === '__proto__' || lastKey === 'prototype' || lastKey === 'constructor') {
+    throw new Error(`setGsdConfig: unsafe config key segment '${lastKey}'`);
+  }
+  obj[lastKey] = value;
   fs.writeFileSync(cfgPath, JSON.stringify(cfg, null, 2) + '\n');
 }
 
@@ -287,5 +298,43 @@ describe('#1268 gitWorktreeInfoInternal: relocation to git-base-branch', () => {
     const dir = createTempDir('gsd-wt-info-nothrow-');
     t.after(() => cleanup(dir));
     assert.doesNotThrow(() => gitBaseBranch.gitWorktreeInfoInternal(dir));
+  });
+});
+
+// ─── setGsdConfig prototype-pollution guard (#1406) ───────────────────────────
+
+describe('#1406: setGsdConfig prototype-pollution guard', () => {
+  test('rejects __proto__ as a key segment', (t) => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-1406-'));
+    t.after(() => cleanup(dir));
+    assert.throws(() => setGsdConfig(dir, '__proto__', 'x'), /unsafe config key segment/);
+    assert.throws(() => setGsdConfig(dir, '__proto__.polluted', true), /unsafe config key segment/);
+  });
+
+  test('rejects constructor / prototype chain segments', (t) => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-1406-'));
+    t.after(() => cleanup(dir));
+    assert.throws(() => setGsdConfig(dir, 'constructor.prototype.polluted', true), /unsafe config key segment/);
+    assert.throws(() => setGsdConfig(dir, 'safe.__proto__', true), /unsafe config key segment/);
+    assert.throws(() => setGsdConfig(dir, 'a.prototype.b', true), /unsafe config key segment/);
+  });
+
+  test('does not pollute Object.prototype after rejected attempts', (t) => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-1406-'));
+    t.after(() => cleanup(dir));
+    try { setGsdConfig(dir, '__proto__.polluted', true); } catch (_) { /* expected */ }
+    try { setGsdConfig(dir, 'constructor.prototype.polluted', true); } catch (_) { /* expected */ }
+    try { setGsdConfig(dir, 'a.__proto__.polluted', true); } catch (_) { /* expected */ }
+    assert.strictEqual(({}).polluted, undefined);
+    assert.strictEqual(Object.prototype.polluted, undefined);
+  });
+
+  test('still writes a normal nested key', (t) => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-1406-'));
+    t.after(() => cleanup(dir));
+    setGsdConfig(dir, 'git.base_branch', 'develop');
+    const cfgPath = path.join(dir, '.planning', 'config.json');
+    const cfg = JSON.parse(fs.readFileSync(cfgPath, 'utf8'));
+    assert.strictEqual(cfg.git.base_branch, 'develop');
   });
 });


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #1406

## What was broken

The `setGsdConfig` test helper in `tests/git-base-branch.test.cjs` deep-assigned a dot-notation config key through a `.`-split chain with **no prototype-pollution guard** — CodeQL alert [#40](https://github.com/open-gsd/gsd-core/security/code-scanning/40) (`js/prototype-pollution-utility`, medium, CWE-915).

## What this fix does

Adds inline literal `__proto__` / `prototype` / `constructor` checks immediately before **both** write sites (the chain-walk `obj[k] = {}` and the final `obj[lastKey] = value`), throwing on a forbidden segment — mirroring the production guard in `src/config.cts`.

## Root cause

The helper is a re-implementation of the production set-nested-key logic in `src/config.cts`, which carries the guard (added in PR #752). The test copy silently dropped it. Not exploitable in practice (non-exported, single call site with the constant key `'git.base_branch'`), but it trips CodeQL over `tests/` and is a latent footgun — so it's fixed inline rather than dismissed.

## Testing

### How I verified the fix

- `node --test tests/git-base-branch.test.cjs` → **16/16 pass** (12 existing + 4 new guard tests), after `npm ci` + `npm run build:lib`.
- `npm run lint` → clean, no warnings.
- Independent Codex adversarial review (`gpt-5.5`, read-only) → **no blockers**; confirmed the guard covers both write sites, preserves behavior for the valid call, and matches the `src/config.cts` precedent.

### Regression test added?

- [x] Yes — added the `#1406` suite asserting the guard throws on `__proto__` / `constructor.prototype` / `safe.__proto__` keys and does not pollute `Object.prototype`, while a normal nested key still writes.

### Platforms tested

- [x] N/A (not platform-specific — pure JS guard; CI runs the full matrix)

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #1406`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass (affected file 16/16; CI runs full suite)
- [x] `.changeset/` fragment **N/A** — test-only, non-user-facing change → `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1407"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784338755&installation_id=134682257&pr_number=1407&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1407&signature=bbc60d3e42c67a4f3d8fb8e1123ca5b577b6f5f994600f335829b8a0772566a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->