### PR TITLE
fix(agent-skills): deterministic config resolution across cwd/workstream drift (#1366)

### DIFF
--- a/.changeset/curious-voles-tumble.md
+++ b/.changeset/curious-voles-tumble.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 1408
+---
+**`gsd-tools query agent-skills` no longer silently drops a configured agent's skills under cwd/workstream drift** — resolution is now anchored to the nearest ancestor `.planning/` (so it works from any descendant subdirectory), `loadConfig` falls back to the project-root config when `GSD_WORKSTREAM` points at a missing workstream, and a configured agent that resolves to no skills now emits a stderr warning plus `configured`/`reason` fields in the `--json` output instead of returning an empty block with no signal. (#1408)

--- a/src/config-loader.cts
+++ b/src/config-loader.cts
@@ -645,13 +645,19 @@ function loadConfig(cwd: string, options: Record<string, unknown> = {}): Record<
     }
     return _baseConfig;
   } catch {
+    // #1366 — a workstream was requested (CLI --ws / GSD_WORKSTREAM env /
+    // stored pointer) but its scoped config.json is absent or unreadable.
+    // Whether or not the workstream directory itself exists, fall back to the
+    // project-root config we already loaded above instead of silently degrading
+    // to bare defaults — that fall-through dropped agent_skills and every other
+    // root-level mapping, so configured agents resolved EMPTY with no signal.
+    if (rootParsed) {
+      // Re-parse with the workstream cleared so the project-root config.json is
+      // the sole source. (The federated overlay is applied in the re-entrant call.)
+      return loadConfig(cwd, { workstream: null });
+    }
     // Fall back to ~/.gsd/defaults.json only for truly pre-project contexts (#1683)
     if (fs.existsSync(planningDir(cwd, ws))) {
-      if (rootParsed) {
-        // Workstream has no config.json: re-parse using root config as the sole source.
-        // (FIX 2: overlay is applied recursively in the re-entrant loadConfig call)
-        return loadConfig(cwd, { workstream: null });
-      }
       // FIX 2: Apply the federated overlay on the no-config path.
       // Migrated Capability keys are surfaced from the generated registry even
       // when the project has no config.json, so schema defaults still apply.

--- a/src/init.cts
+++ b/src/init.cts
@@ -1872,33 +1872,116 @@ function cmdInitRemoveWorkspace(cwd: string, name: string | undefined, raw: bool
   output(result, raw);
 }
 
+// #1366 — why an empty agent-skills block was returned. Lets the verb's output
+// contract distinguish "no mapping configured" (silent, expected) from "mapping
+// configured but resolved to nothing" (a misconfiguration that must be visible).
+type AgentSkillsReason =
+  | 'resolved'
+  | 'not_configured'
+  | 'configured_empty'
+  | 'configured_unresolved';
+
+interface AgentSkillsDiagnostics {
+  warnings: string[];
+  configured?: boolean;
+  reason?: AgentSkillsReason;
+}
+
+/**
+ * Resolve the project root for `agent-skills` config resolution by walking
+ * upward from `cwd` to the nearest ancestor that contains a `.planning/`
+ * directory (#1366).
+ *
+ * The verb is frequently invoked from a descendant subdirectory (e.g. a
+ * subagent running inside its own worktree or a nested package). Anchoring to
+ * the nearest `.planning/` makes resolution deterministic w.r.t. the invoking
+ * cwd instead of silently degrading to bare defaults when the immediate cwd has
+ * no `.planning/`. Falls back to the original `cwd` when no ancestor qualifies,
+ * preserving the pre-existing behaviour for genuinely project-less contexts.
+ */
+function resolvePlanningCwd(cwd: string): string {
+  let dir: string;
+  try {
+    dir = path.resolve(cwd);
+  } catch {
+    return cwd;
+  }
+  const fsRoot = path.parse(dir).root;
+  // Bound the walk so a pathological symlink loop or deep tree can't spin.
+  for (let depth = 0; depth < 40; depth += 1) {
+    try {
+      const planning = path.join(dir, '.planning');
+      if (fs.existsSync(planning) && fs.statSync(planning).isDirectory()) return dir;
+    } catch {
+      // Unreadable ancestor — keep walking upward.
+    }
+    if (dir === fsRoot) break;
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return cwd;
+}
+
 function buildAgentSkillsBlock(
   config: Record<string, unknown>,
   agentType: string,
   projectRoot: string,
-  diagnostics?: { warnings: string[] },
+  diagnostics?: AgentSkillsDiagnostics,
 ): string {
   const warn = (message: string): void => {
     process.stderr.write(message);
     if (diagnostics) diagnostics.warnings.push(message.replace(/\n+$/, ''));
   };
+  const setReason = (reason: AgentSkillsReason): void => {
+    if (diagnostics) diagnostics.reason = reason;
+  };
 
   const runtime = (config && (config['runtime'] as string)) || 'claude';
   const globalSkillsBase = getGlobalSkillsBase(runtime);
 
-  if (!config || !config['agent_skills'] || !agentType) return '';
+  const agentSkills =
+    config && typeof config['agent_skills'] === 'object' && config['agent_skills'] !== null
+      ? (config['agent_skills'] as Record<string, unknown>)
+      : null;
+  // "Configured" = this agent has an explicit key in agent_skills, regardless of
+  // whether that entry resolves to any valid skill. Surfacing this lets callers
+  // tell "not configured" apart from "configured but resolved empty" (#1366).
+  const isConfigured =
+    !!agentSkills && !!agentType && Object.prototype.hasOwnProperty.call(agentSkills, agentType);
+  if (diagnostics) diagnostics.configured = isConfigured;
 
-  let skillPaths = (config['agent_skills'] as Record<string, unknown>)[agentType];
-  if (!skillPaths) return '';
+  if (!agentSkills || !agentType) {
+    setReason('not_configured');
+    return '';
+  }
+
+  let skillPaths = agentSkills[agentType];
+  if (skillPaths === undefined || skillPaths === null) {
+    setReason(isConfigured ? 'configured_empty' : 'not_configured');
+    if (isConfigured) {
+      warn(
+        `[agent-skills] WARNING: Agent "${agentType}" is configured in agent_skills but its value is empty (${skillPaths === null ? 'null' : 'undefined'}) — resolved to no skills\n`,
+      );
+    }
+    return '';
+  }
 
   if (typeof skillPaths === 'string') skillPaths = [skillPaths];
   if (!Array.isArray(skillPaths)) {
+    setReason('configured_empty');
     warn(
       `[agent-skills] WARNING: Agent "${agentType}" has a malformed agent_skills value (expected string or array, got ${typeof skillPaths}) — ignoring\n`,
     );
     return '';
   }
-  if (skillPaths.length === 0) return '';
+  if (skillPaths.length === 0) {
+    setReason('configured_empty');
+    warn(
+      `[agent-skills] WARNING: Agent "${agentType}" is configured with an empty skill list — resolved to no skills\n`,
+    );
+    return '';
+  }
 
   // Hoist trusted roots computation before the loop: loadTrustedGlobalRoots does
   // realpathSync I/O and should run at most once per call, not once per failing skill.
@@ -2000,12 +2083,14 @@ function buildAgentSkillsBlock(
   }
 
   if (validEntries.length === 0) {
+    setReason('configured_unresolved');
     warn(
       `[agent-skills] WARNING: Agent "${agentType}" has ${skillPaths.length} configured skill path(s) but none resolved to a valid skill — all were skipped (see warnings above)\n`,
     );
     return '';
   }
 
+  setReason('resolved');
   const lines = validEntries.map((entry) => {
     if (entry.kind === 'directive') {
       return `- Load the \`${entry.name}\` skill via the Skill tool before proceeding (plugin-provided).`;
@@ -2026,12 +2111,21 @@ function cmdAgentSkills(
     return;
   }
 
-  const config = loadConfig(cwd);
-  const diagnostics = { warnings: [] as string[] };
+  // #1366 — anchor config resolution to the project root (nearest ancestor with
+  // a .planning/) so resolution is deterministic regardless of which descendant
+  // subdirectory the verb was invoked from. loadConfig additionally falls back
+  // to the project-root config when GSD_WORKSTREAM points at a missing workstream.
+  const projectRoot = resolvePlanningCwd(cwd);
+  const config = loadConfig(projectRoot);
+  const diagnostics: AgentSkillsDiagnostics = {
+    warnings: [],
+    configured: false,
+    reason: 'not_configured',
+  };
   const block = buildAgentSkillsBlock(
     config,
     agentType,
-    cwd,
+    projectRoot,
     diagnostics,
   );
 
@@ -2043,7 +2137,16 @@ function cmdAgentSkills(
       : skillPaths
         ? [skillPaths]
         : [];
-    output({ agent_type: agentType, block: block || '', skills_count: normalizedPaths.length, warnings: diagnostics.warnings }, raw);
+    output({
+      agent_type: agentType,
+      block: block || '',
+      skills_count: normalizedPaths.length,
+      // #1366 — output contract: distinguish "no mapping configured" from
+      // "mapping configured but resolved empty" so callers can detect a silent drop.
+      configured: diagnostics.configured === true,
+      reason: diagnostics.reason,
+      warnings: diagnostics.warnings,
+    }, raw);
     return;
   }
 

--- a/tests/agent-skills.test.cjs
+++ b/tests/agent-skills.test.cjs
@@ -377,6 +377,166 @@ describe('agent-skills empty-resolution diagnostics', () => {
   });
 });
 
+// ─── #1366: deterministic cwd/workstream resolution ─────────────────────────
+// `query agent-skills` resolved config relative to the invoking process's cwd
+// and active GSD_WORKSTREAM. Two invocation-context drifts made a CONFIGURED
+// agent fall open to an EMPTY block with no signal:
+//   (1) invoked from a descendant subdirectory with no .planning/ → config fell
+//       through to bare defaults → agent_skills = {} → empty block.
+//   (2) GSD_WORKSTREAM pointing at a workstream with no scoped config → same
+//       fall-through to defaults → empty block.
+// The fix anchors resolution to the nearest ancestor .planning/ (project root)
+// and falls back to the project-root config when the workstream is absent, and
+// makes "configured but resolved empty" distinguishable from "not configured".
+
+describe('agent-skills cwd/workstream resolution determinism (#1366)', () => {
+  let tmpDir;
+
+  // Parse the --json IR from an explicit cwd (the helper runAgentSkillsJson
+  // always runs at the project root, which cannot exercise the cwd-drift vector).
+  function agentSkillsJsonFromCwd(agentType, cwd, env) {
+    const r = runGsdTools(
+      ['agent-skills', '--json', agentType],
+      cwd,
+      env || { HOME: tmpDir, USERPROFILE: tmpDir },
+    );
+    if (!r.success) return { success: false, error: r.error, ir: null };
+    try {
+      return { success: true, ir: JSON.parse(r.output) };
+    } catch (e) {
+      return { success: false, error: `JSON parse failed: ${e.message} output=${r.output}`, ir: null };
+    }
+  }
+
+  beforeEach(() => {
+    tmpDir = createTempProject();
+    const skillDir = path.join(tmpDir, 'skills', 'shared-skill');
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(path.join(skillDir, 'SKILL.md'), '# Shared Skill\n');
+    // Identical project-root mapping for all three plan-phase agents.
+    writeConfig(tmpDir, {
+      agent_skills: {
+        'gsd-phase-researcher': ['skills/shared-skill'],
+        'gsd-planner': ['skills/shared-skill'],
+        'gsd-plan-checker': ['skills/shared-skill'],
+      },
+    });
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  // ── Vector 1: cwd drift ──────────────────────────────────────────────────
+  test('CWD-DRIFT: resolves the configured block from a descendant subdirectory with no .planning/', () => {
+    const nested = path.join(tmpDir, 'src', 'deep', 'nested');
+    fs.mkdirSync(nested, { recursive: true });
+
+    for (const agent of ['gsd-phase-researcher', 'gsd-planner', 'gsd-plan-checker']) {
+      const r = agentSkillsJsonFromCwd(agent, nested);
+      assert.ok(r.success, `Command failed for ${agent}: ${r.error}`);
+      assert.ok(
+        r.ir.block.includes('<agent_skills>') && r.ir.block.includes('shared-skill/SKILL.md'),
+        `${agent} must resolve the configured block from a descendant cwd, got: ${JSON.stringify(r.ir.block)}`,
+      );
+      assert.strictEqual(r.ir.skills_count, 1, `${agent} skills_count must be 1 from a descendant cwd`);
+      assert.strictEqual(r.ir.configured, true, `${agent} must report configured=true`);
+      assert.strictEqual(r.ir.reason, 'resolved', `${agent} reason must be 'resolved'`);
+    }
+  });
+
+  test('CWD-DRIFT: resolution is identical whether invoked from the project root or a descendant', () => {
+    const nested = path.join(tmpDir, 'packages', 'inner');
+    fs.mkdirSync(nested, { recursive: true });
+    const atRoot = agentSkillsJsonFromCwd('gsd-planner', tmpDir);
+    const atNested = agentSkillsJsonFromCwd('gsd-planner', nested);
+    assert.ok(atRoot.success && atNested.success, 'both invocations must succeed');
+    assert.strictEqual(
+      atNested.ir.block,
+      atRoot.ir.block,
+      'descendant-cwd resolution must be byte-identical to root-cwd resolution (deterministic)',
+    );
+  });
+
+  // ── Vector 2: workstream drift ───────────────────────────────────────────
+  test('WORKSTREAM: an unset GSD_WORKSTREAM resolves the configured block', () => {
+    const r = agentSkillsJsonFromCwd('gsd-plan-checker', tmpDir, {
+      HOME: tmpDir,
+      USERPROFILE: tmpDir,
+      GSD_WORKSTREAM: '',
+    });
+    assert.ok(r.success, `Command failed: ${r.error}`);
+    assert.strictEqual(r.ir.configured, true);
+    assert.strictEqual(r.ir.reason, 'resolved');
+    assert.ok(r.ir.block.includes('shared-skill/SKILL.md'), 'unset workstream must resolve the project-root mapping');
+  });
+
+  test('WORKSTREAM: a nonexistent GSD_WORKSTREAM no longer drops a configured agent to an empty block', () => {
+    for (const agent of ['gsd-planner', 'gsd-plan-checker']) {
+      const r = agentSkillsJsonFromCwd(agent, tmpDir, {
+        HOME: tmpDir,
+        USERPROFILE: tmpDir,
+        GSD_WORKSTREAM: 'does-not-exist',
+      });
+      assert.ok(r.success, `Command failed for ${agent}: ${r.error}`);
+      assert.ok(
+        r.ir.block.includes('shared-skill/SKILL.md'),
+        `${agent} must fall back to the project-root config for a missing workstream, got: ${JSON.stringify(r.ir.block)}`,
+      );
+      assert.strictEqual(r.ir.skills_count, 1, `${agent} skills_count must be 1 under a missing workstream`);
+      assert.strictEqual(r.ir.configured, true);
+      assert.strictEqual(r.ir.reason, 'resolved');
+    }
+  });
+
+  test('WORKSTREAM + CWD-DRIFT combined: descendant cwd AND nonexistent workstream still resolves', () => {
+    const nested = path.join(tmpDir, 'a', 'b', 'c');
+    fs.mkdirSync(nested, { recursive: true });
+    const r = agentSkillsJsonFromCwd('gsd-planner', nested, {
+      HOME: tmpDir,
+      USERPROFILE: tmpDir,
+      GSD_WORKSTREAM: 'ghost',
+    });
+    assert.ok(r.success, `Command failed: ${r.error}`);
+    assert.ok(r.ir.block.includes('shared-skill/SKILL.md'), 'combined drift must still resolve the configured block');
+    assert.strictEqual(r.ir.reason, 'resolved');
+  });
+
+  // ── Diagnostic visibility: configured-but-empty vs not-configured ─────────
+  test('DIAGNOSTIC: a configured agent that resolves empty is distinguishable from an unconfigured one', () => {
+    writeConfig(tmpDir, {
+      agent_skills: {
+        'gsd-planner': [], // configured, but empty → must be visible, not silent
+      },
+    });
+
+    const configuredEmpty = runGsdToolsWithStderr(['agent-skills', '--json', 'gsd-planner'], tmpDir, {
+      HOME: tmpDir,
+      USERPROFILE: tmpDir,
+    });
+    assert.ok(configuredEmpty.success, `Command failed: ${configuredEmpty.stderr}`);
+    const emptyIr = JSON.parse(configuredEmpty.stdout);
+    assert.strictEqual(emptyIr.block, '', 'configured-but-empty still yields an empty block');
+    assert.strictEqual(emptyIr.configured, true, 'configured-but-empty must report configured=true');
+    assert.strictEqual(emptyIr.reason, 'configured_empty', "reason must be 'configured_empty'");
+    assert.ok(
+      configuredEmpty.stderr.includes('[agent-skills] WARNING') && configuredEmpty.stderr.includes('gsd-planner'),
+      `configured-but-empty must emit a visible stderr diagnostic, got: ${configuredEmpty.stderr}`,
+    );
+
+    // Contrast: an agent with no mapping at all stays silent and reports not_configured.
+    const notConfigured = runGsdToolsWithStderr(['agent-skills', '--json', 'gsd-executor'], tmpDir, {
+      HOME: tmpDir,
+      USERPROFILE: tmpDir,
+    });
+    assert.ok(notConfigured.success, `Command failed: ${notConfigured.stderr}`);
+    const ncIr = JSON.parse(notConfigured.stdout);
+    assert.strictEqual(ncIr.configured, false, 'unconfigured agent must report configured=false');
+    assert.strictEqual(ncIr.reason, 'not_configured', "reason must be 'not_configured'");
+    assert.strictEqual(ncIr.warnings.length, 0, 'not-configured must stay silent (no warnings)');
+  });
+});
+
 // ─── config-ensure-section includes agent_skills ────────────────────────────
 
 describe('config-ensure-section with agent_skills', () => {


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #1366

The linked issue carries the `bug` + `confirmed-bug` labels.

## What was broken

`gsd-tools query agent-skills <agent>` silently resolved to an **empty** skill set (failed open) when config resolution was thrown off by the invoking context, dropping a *configured* agent's skill/rule block with no warning, so a planner/checker subagent planned or verified without its configured context and the gap was invisible. Two drift vectors triggered it: invocation from a descendant subdirectory with no `.planning/`, and `GSD_WORKSTREAM` pointing at a workstream that has no scoped config — both fell through to bare defaults (`agent_skills = {}`).

## What this fix does

Anchors `agent-skills` resolution to the project root (nearest ancestor `.planning/`) so it is deterministic regardless of the invoking cwd, falls back to the project-root config when a requested workstream is missing, and makes the output contract distinguish "not configured" from "configured but resolved empty" (with a stderr warning + `configured`/`reason` fields) so the silent drop can no longer happen unnoticed.

## Root cause

Resolution is uniform across agent types (`config.agent_skills[agentType]`, no per-agent branch), so the divergence was upstream in config loading. `cmdAgentSkills` called `loadConfig(cwd)` with the raw invoking cwd, and `loadConfig`'s catch path degraded to bare defaults when the cwd had no `.planning/` or when a requested workstream's scoped `config.json` was absent — discarding the project-root `agent_skills` mapping.

Fix, by seam:

1. **Deterministic project-root anchoring** (`src/init.cts`, new `resolvePlanningCwd`) — `cmdAgentSkills` walks upward from the invoking cwd to the nearest ancestor containing `.planning/` and resolves config there. Falls back to the original cwd for genuinely project-less contexts (behaviour preserved).
2. **Workstream fallback** (`src/config-loader.cts`, `loadConfig`) — when a workstream is requested (CLI `--ws` / `GSD_WORKSTREAM` / stored pointer) but its scoped config is absent/unreadable, fall back to the already-loaded project-root config instead of bare defaults. The valid-config and no-workstream paths are unchanged.
3. **Visible diagnostic + output contract** (`src/init.cts`, `buildAgentSkillsBlock`) — records a `configured` flag and a `reason` (`resolved` | `not_configured` | `configured_empty` | `configured_unresolved`), both surfaced in the `--json` IR, and emits a stderr `WARNING` whenever a *configured* agent resolves to no skills. A genuinely-unconfigured agent stays silent. Builds on the `warnings[]` field from #1376.

## Testing

### How I verified the fix

- Reproduced all three vectors against the built CLI pre-fix (descendant cwd → empty; nonexistent `GSD_WORKSTREAM` → empty) and confirmed each resolves the configured block post-fix.
- Added automated regression coverage (below).
- `npm run build` (full pipeline) clean; diff limited to `src/*.cts`, the test file, and a changeset (compiled `gsd-core/bin/lib/*.cjs` is gitignored).
- Lint: `npm run lint`, `lint:skill-deps`, `lint-regression-test-names`, `lint-windows-test-portability`, `lint-test-file-count`, `lint-allow-test-rule-refs` all pass.
- Suites: `agent-skills`, `config-loader`, `workstream`, `planning-workspace`, `config`, `init`, capability/precedence suites, plus full **unit** (1137) and **integration** (101) — all green.

New `describe('agent-skills cwd/workstream resolution determinism (#1366)')` block in `tests/agent-skills.test.cjs` (folded into the owning module's test file per the regression-test placement policy; no new `bug-NNNN` file) covers:

- **cwd-drift** — configured block resolves from a descendant subdirectory for `gsd-phase-researcher` / `gsd-planner` / `gsd-plan-checker`; root vs descendant resolution is byte-identical.
- **workstream** — unset, nonexistent, and combined cwd+workstream drift all resolve the project-root mapping.
- **diagnostic** — configured-but-empty yields `configured: true` / `reason: "configured_empty"` + a stderr warning, while not-configured stays silent (`configured: false`, `reason: "not_configured"`, no warnings).

Maps to the issue's acceptance criteria:
- [x] Configured block resolves from a descendant subdirectory (not only project root).
- [x] Unset/nonexistent `GSD_WORKSTREAM` no longer yields an empty block.
- [x] Configured-but-empty emits a diagnostic; the silent empty path is gone.
- [x] Regression test exercises BOTH the cwd-drift and workstream vectors.

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [x] N/A (not platform-specific)

> Path handling uses `path.join` / `path.dirname` / `path.parse().root` throughout; `lint-windows-test-portability` passes. Not manually run on Windows/Linux.

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (full unit + integration suites green)
- [x] `.changeset/` fragment added (`curious-voles-tumble.md`, type Fixed)
- [x] No unnecessary dependencies added

## Out of scope

- How subagents receive context beyond this verb's resolution + visibility (the `plan-phase` injection channel itself is fine).
- #991 (code-review never calling the verb) and #502 (file-backed-stdout capture).

## Breaking changes

None. The `--json` output gains additive `configured` and `reason` fields; existing fields (`agent_type`, `block`, `skills_count`, `warnings`) are unchanged, and a configured agent that previously resolved correctly still produces a byte-identical block.