### PR TITLE
fix(#1416): add resolution.cjs to ESLint ignore list (ADR-457) — repair next

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -39,6 +39,7 @@ export default tseslint.config(
       '**/*.generated.cjs',
       // ADR-457: tsc-generated runtime artifact — lint the src/*.cts source, not the emitted .cjs.
       'gsd-core/bin/lib/semver-compare.cjs',
+      'gsd-core/bin/lib/resolution.cjs',
       'gsd-core/bin/lib/plan-drift-guard.cjs',
       'gsd-core/bin/lib/cli-exit.cjs',
       'gsd-core/bin/lib/edge-probe.cjs',


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #1427

> The linked issue has the `confirmed-bug` label.

---

## What was broken

`next` CI was red: the `551-eslint-bin-lib-coverage` test (`ESLint coverage tracks the bin/lib TS migration`) failed because `gsd-core/bin/lib/resolution.cjs` was not in the ESLint ignore list.

## What this fix does

Adds `gsd-core/bin/lib/resolution.cjs` to the ESLint ignore list in `eslint.config.mjs` (ADR-457: lint the `src/*.cts` source, not the emitted `.cjs`).

## Root cause

PR #1425 (epic #1411 P3) added `src/resolution.cts` → `gsd-core/bin/lib/resolution.cjs`. The ADR-457 ripple for a new TS-migrated module is three parts — `.gitignore` allowlist, `docs/INVENTORY-MANIFEST.json`, and the ESLint ignore list. #1425 handled the first two but missed the third, and the `551` shard isn't in the scoped pre-merge suite, so it merged red.

## Testing

### How I verified the fix

`node --test tests/551-eslint-bin-lib-coverage.test.cjs` -> 3/3 pass after the change (failed before). `npm run lint` (full eslint) clean.

### Regression test added?

- [x] Yes — the existing `551-eslint-bin-lib-coverage` test is the regression guard: it failed before this change (`actual: ['resolution.cjs']`) and passes after. No new test needed.

### Platforms tested

- [x] N/A (lint-config-only; not platform-specific)

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (the existing `551` migration-coverage test)
- [x] All existing tests pass (affected suites)
- [x] Build-tooling only — `lint:changeset` reports `ok_no_user_facing_changes` (no changeset required)
- [x] No unnecessary dependencies added

## Breaking changes

None
