### PR TITLE
feat(#323): fish-shell support in installer PATH suggestion + coverage detection

### DIFF
--- a/.changeset/lively-tunas-squeak.md
+++ b/.changeset/lively-tunas-squeak.md
@@ -1,0 +1,5 @@
+---
+type: Changed
+pr: 1444
+---
+Installer PATH suggestion now supports fish: it offers a fish-native `fish_add_path` command and no longer prints a spurious "not on your PATH" warning when fish's fish_user_paths / config.fish already covers the npm global bin (#323).

--- a/bin/install.js
+++ b/bin/install.js
@@ -11808,6 +11808,200 @@ function homePathCoveredByRc(globalBin, homeDir, rcFileNames) {
 }
 
 /**
+ * Detect whether fish already has globalBin on PATH. Fish persists PATH
+ * additions outside the sh-style rc files homePathCoveredByRc scans, so a fish
+ * user whose npm global bin is already covered would otherwise see a spurious
+ * "not on your PATH" warning on every install (#323). Two detection routes:
+ *
+ *   1. The universal-variable store ~/.config/fish/fish_variables — a
+ *      `SETUVAR [--flags] fish_user_paths:<dir>\x1e<dir>…` line. fish serializes
+ *      the list separator and special bytes as escaped TEXT, not raw bytes:
+ *      entries are delimited by the literal four characters `\x1e` and bytes
+ *      such as space appear as `\x20` (verified against fish 4.x output), so the
+ *      value must be split on the `\x1e` text and then fish-unescaped. Values
+ *      are stored absolute (fish does NOT expand HOME in this format).
+ *   2. ~/.config/fish/config.fish — `fish_add_path <dir>…`, `set … PATH <dir>…`,
+ *      or `set … fish_user_paths <dir>…` lines, after $HOME / ~ expansion.
+ *      Arguments are tokenized honoring single/double quotes, backslash escapes,
+ *      and start-of-word `#` comments, so quoted/escaped paths containing spaces
+ *      are matched (the same quoted form the installer itself suggests) while a
+ *      trailing inline comment is ignored. For the colon-joined path-list
+ *      variables (`PATH` / `fish_user_paths`), tokens are split on `:` so
+ *      `set -gx PATH /dir:$PATH` is recognized.
+ *
+ * Mirrors homePathCoveredByRc's normalise/expand/compare contract so write and
+ * read agree; relative or still-unexpanded entries are skipped (no false match).
+ *
+ * @param {string} globalBin  Absolute path to npm's global bin directory.
+ * @param {string} homeDir    Absolute HOME path.
+ * @returns {boolean} true when fish already has globalBin on PATH.
+ */
+function homePathCoveredByFishConfig(globalBin, homeDir) {
+  if (!globalBin || !homeDir) return false;
+  const path = require('path');
+  const fs = require('fs');
+
+  const normalise = (p) => {
+    if (!p) return '';
+    let n = p.replace(/[\\/]+$/g, '');
+    if (n === '') n = p.startsWith('/') ? '/' : p;
+    return n;
+  };
+
+  const homeAbs = path.resolve(homeDir);
+  const targetAbs = normalise(path.resolve(globalBin));
+  const fishDir = path.join(homeAbs, '.config', 'fish');
+
+  const matchesTarget = (raw) => {
+    if (!raw) return false;
+    let s = raw.replace(/\$\{HOME\}/g, homeAbs).replace(/\$HOME/g, homeAbs);
+    if (s === '~') s = homeAbs;
+    else if (s.startsWith('~/')) s = path.join(homeAbs, s.slice(2));
+    if (s.includes('$')) return false;        // unresolved variable — skip
+    if (!path.isAbsolute(s)) return false;     // relative entry: cwd-dependent
+    try {
+      return normalise(path.resolve(s)) === targetAbs;
+    } catch {
+      return false;
+    }
+  };
+
+  // Decode fish's escaped serialization. fish's full_escape emits `\xHH` for
+  // bytes < 0x80 (e.g. space -> `\x20`), `\uHHHH` for codepoints <= 0xFFFF
+  // (e.g. café -> `café`), and `\UHHHHHHHH` for higher codepoints (e.g.
+  // 😀 -> `\U0001f600`) — all verified against fish 4.x output. `\xHH` is a raw
+  // byte; `\u`/`\U` are codepoints (their UTF-8 bytes are pushed). Bytes are
+  // assembled then UTF-8 decoded so multi-byte sequences round-trip correctly.
+  const pushCodePoint = (bytes, cp) => {
+    if (cp <= 0x10ffff) bytes.push(...Buffer.from(String.fromCodePoint(cp), 'utf8'));
+  };
+  const fishUnescape = (v) => {
+    const bytes = [];
+    const named = { n: 0x0a, r: 0x0d, t: 0x09, e: 0x1b, f: 0x0c, v: 0x0b, a: 0x07, '\\': 0x5c };
+    for (let i = 0; i < v.length; i += 1) {
+      if (v[i] === '\\' && i + 1 < v.length) {
+        const n = v[i + 1];
+        if ((n === 'x' || n === 'X') && /^[0-9A-Fa-f]{2}$/.test(v.slice(i + 2, i + 4))) {
+          bytes.push(parseInt(v.slice(i + 2, i + 4), 16));
+          i += 3;
+          continue;
+        }
+        if (n === 'u' && /^[0-9A-Fa-f]{4}$/.test(v.slice(i + 2, i + 6))) {
+          pushCodePoint(bytes, parseInt(v.slice(i + 2, i + 6), 16));
+          i += 5;
+          continue;
+        }
+        if (n === 'U' && /^[0-9A-Fa-f]{8}$/.test(v.slice(i + 2, i + 10))) {
+          pushCodePoint(bytes, parseInt(v.slice(i + 2, i + 10), 16));
+          i += 9;
+          continue;
+        }
+        if (Object.prototype.hasOwnProperty.call(named, n)) {
+          bytes.push(named[n]);
+          i += 1;
+          continue;
+        }
+        bytes.push(...Buffer.from(n, 'utf8')); // `\<char>` -> literal char
+        i += 1;
+        continue;
+      }
+      bytes.push(...Buffer.from(v[i], 'utf8'));
+    }
+    return Buffer.from(bytes).toString('utf8');
+  };
+
+  // Tokenize a fish argument list, honoring single/double quotes and backslash
+  // escapes so quoted/escaped paths containing spaces survive as one token.
+  const tokenizeFishArgs = (input) => {
+    const out = [];
+    let cur = '';
+    let has = false;
+    let i = 0;
+    while (i < input.length) {
+      const c = input[i];
+      if (c === ' ' || c === '\t') {
+        if (has) { out.push(cur); cur = ''; has = false; }
+        i += 1;
+      } else if (c === '#' && !has) {
+        break; // a `#` at the start of a word begins a fish comment
+      } else if (c === "'") {
+        has = true; i += 1;
+        while (i < input.length && input[i] !== "'") {
+          if (input[i] === '\\' && (input[i + 1] === "'" || input[i + 1] === '\\')) {
+            cur += input[i + 1]; i += 2;
+          } else { cur += input[i]; i += 1; }
+        }
+        i += 1; // skip closing quote
+      } else if (c === '"') {
+        has = true; i += 1;
+        while (i < input.length && input[i] !== '"') {
+          if (input[i] === '\\' && '"\\$'.includes(input[i + 1])) {
+            cur += input[i + 1]; i += 2;
+          } else { cur += input[i]; i += 1; }
+        }
+        i += 1;
+      } else if (c === '\\') {
+        has = true;
+        if (i + 1 < input.length) { cur += input[i + 1]; i += 2; } else { i += 1; }
+      } else {
+        has = true; cur += c; i += 1;
+      }
+    }
+    if (has) out.push(cur);
+    return out;
+  };
+
+  // Route 1: universal-variable store (fish_user_paths is stored absolute).
+  try {
+    const content = fs.readFileSync(path.join(fishDir, 'fish_variables'), 'utf8');
+    for (const line of content.split(/\r?\n/)) {
+      const m = /^SETUVAR\s+(?:--\S+\s+)*fish_user_paths:(.*)$/.exec(line.trim());
+      if (!m) continue;
+      for (const rawEntry of m[1].split('\\x1e')) {
+        if (matchesTarget(fishUnescape(rawEntry))) return true;
+      }
+    }
+  } catch {
+    // no fish_variables — fall through to config.fish
+  }
+
+  // Route 2: config.fish (fish_add_path / set -gx PATH / set -Ux fish_user_paths).
+  try {
+    const content = fs.readFileSync(path.join(fishDir, 'config.fish'), 'utf8');
+    for (const rawLine of content.split(/\r?\n/)) {
+      const line = rawLine.replace(/^\s+/, '');
+      if (line.startsWith('#')) continue;
+      let m;
+      let argText = null;
+      // PATH and fish_user_paths are path-list variables: fish colon-splits
+      // their values, so `set -gx PATH /x:$PATH` puts `/x` on PATH as its own
+      // entry (verified against fish 4.x). fish_add_path takes literal directory
+      // arguments and does NOT colon-split, so leave those tokens intact.
+      let colonSplit = false;
+      if ((m = /^fish_add_path\s+(.+)$/.exec(line))) {
+        argText = m[1];
+      } else if ((m = /^set\s+(?:-\S+\s+)*PATH\s+(.+)$/.exec(line))) {
+        argText = m[1];
+        colonSplit = true;
+      } else if ((m = /^set\s+(?:-\S+\s+)*fish_user_paths\s+(.+)$/.exec(line))) {
+        argText = m[1];
+        colonSplit = true;
+      }
+      if (!argText) continue;
+      for (const tok of tokenizeFishArgs(argText)) {
+        for (const seg of (colonSplit ? tok.split(':') : [tok])) {
+          if (matchesTarget(seg)) return true;
+        }
+      }
+    }
+  } catch {
+    // no config.fish — fall through
+  }
+
+  return false;
+}
+
+/**
  * Emit a PATH-export suggestion if globalBin is not already on PATH AND
  * the user's shell rc files do not already cover it via a HOME-relative
  * entry (#2620).
@@ -11839,12 +12033,15 @@ function maybeSuggestPathExport(globalBin, homeDir) {
   });
   if (onPath) return;
 
-  // Already added to PATH via an rc file, but the current shell predates that
+  // Already added to PATH via a shell config (sh-style rc file, or fish's
+  // fish_user_paths / config.fish #323), but the current shell predates that
   // edit — tell the user to reopen rather than (wrongly) suggesting they add it
   // again. Applies to whatever bin dir we install into (retained shim-agnostic).
-  if (homePathCoveredByRc(globalBin, homeDir)) {
+  const coveredByRc = homePathCoveredByRc(globalBin, homeDir);
+  if (coveredByRc || homePathCoveredByFishConfig(globalBin, homeDir)) {
+    const sourceHint = coveredByRc ? ` (or ${cyan}source ~/.zshrc${reset})` : '';
     console.log('');
-    console.log(`  ${yellow}⚠${reset} ${bold}${globalBin}${reset}'s directory is already on your PATH via an rc file entry — try reopening your shell (or ${cyan}source ~/.zshrc${reset}).`);
+    console.log(`  ${yellow}⚠${reset} ${bold}${globalBin}${reset}'s directory is already on your PATH via a shell config entry — try reopening your shell${sourceHint}.`);
     console.log('');
     return;
   }
@@ -12184,6 +12381,7 @@ module.exports = {
     USER_OWNED_ARTIFACTS,
     finishInstall,
     homePathCoveredByRc,
+    homePathCoveredByFishConfig,
     maybeSuggestPathExport,
     runtimeMap,
     allRuntimes,

--- a/docs/how-to/install-on-your-runtime.md
+++ b/docs/how-to/install-on-your-runtime.md
@@ -24,6 +24,8 @@ npx @opengsd/gsd-core@latest
 
 That is the only command you need for a fresh install or to re-run the installer after switching runtimes.
 
+> **PATH suggestion (POSIX shells).** If the npm global bin directory is not on your `PATH`, the installer prints a copy-paste command to add it. Alongside the `zsh` and `bash` lines it now offers a fish-native `fish_add_path …` command. fish users whose `fish_user_paths` (or `config.fish`) already covers the directory no longer see a spurious "not on your PATH" warning — the installer detects fish's universal-variable store and tells you to reopen your shell instead.
+
 ---
 
 ## Per-runtime instructions

--- a/src/shell-command-projection.cts
+++ b/src/shell-command-projection.cts
@@ -376,6 +376,17 @@ export function projectPathActionProjection({
         shell: 'bash',
         command: `echo 'export PATH="${bashTargetDir}:$PATH"' >> ~/.bashrc`,
       },
+      {
+        // fish has no `export` and uses `$PATH` differently in list contexts,
+        // so the zsh/bash echo line is invalid fish syntax. `fish_add_path`
+        // (fish >= 3.2, 2021) is the fish-native persistent API; it writes to
+        // the universal-variable store. Single-quoted for parity with the
+        // zsh/bash siblings — fish treats the POSIX `'\''` idiom as a literal
+        // single quote, so escapeSingleQuotedShellLiteral stays correct here.
+        label: 'fish',
+        shell: 'fish',
+        command: `fish_add_path '${bashTargetDir}'`,
+      },
     ];
   } else {
     const posixTargetDir = escapePosixDoubleQuoted(targetDir);

--- a/tests/bug-3441-path-action-projection.test.cjs
+++ b/tests/bug-3441-path-action-projection.test.cjs
@@ -39,11 +39,17 @@ describe('bug #3441: PATH guidance is projected from typed shell action IR', () 
       platform: 'linux',
     });
     assert.ok(Array.isArray(posix.shellActions));
-    assert.equal(posix.shellActions.length, 2);
+    assert.equal(posix.shellActions.length, 3);
     assert.equal(posix.shellActions[0].label, 'zsh');
     assert.equal(posix.shellActions[1].label, 'bash');
+    assert.equal(posix.shellActions[2].label, 'fish');
     assert.ok(posix.shellActions[0].command.includes('~/.zshrc'));
     assert.ok(posix.shellActions[1].command.includes('~/.bashrc'));
+    // #323: fish gets a fish-native command (no `export`/`>> rc`), not the
+    // invalid zsh/bash echo line.
+    assert.ok(posix.shellActions[2].command.startsWith('fish_add_path '));
+    assert.ok(!posix.shellActions[2].command.includes('export PATH'));
+    assert.ok(!posix.shellActions[2].command.includes('>>'));
   });
 
   test('POSIX repair mode escapes double-quoted shell metacharacters', () => {
@@ -67,6 +73,12 @@ describe('bug #3441: PATH guidance is projected from typed shell action IR', () 
     });
     assert.equal(projected.shellActions[0].command.includes("/tmp/O'\\''Neil/bin"), true);
     assert.equal(projected.shellActions[1].command.includes("/tmp/O'\\''Neil/bin"), true);
+    // #323: the fish entry single-quotes the same escaped literal — fish reads
+    // the POSIX `'\''` idiom as a literal single quote, so the path round-trips.
+    assert.equal(
+      projected.shellActions[2].command,
+      "fish_add_path '/tmp/O'\\''Neil/bin'",
+    );
   });
 
   test('maybeSuggestPathExport renders commands projected by path-action seam', () => {

--- a/tests/install-path-detection.test.cjs
+++ b/tests/install-path-detection.test.cjs
@@ -318,3 +318,258 @@ describe('installer HOME-relative PATH detection (#2620)',
     }
   });
 });
+
+describe('#323 regression: fish-shell PATH coverage detection',
+  { skip: isWindows ? 'POSIX-only: parses ~/.config/fish; fish on Windows is uncommon and uses no rc files here' : false },
+  () => {
+  let installer;
+  before(() => { installer = loadInstaller(); });
+
+  // Writes a fish config file under <home>/.config/fish, returning globalBin.
+  function withFish(home, { variables, config } = {}) {
+    const globalBin = path.join(home, '.nvm', 'versions', 'node', 'v24', 'bin');
+    fs.mkdirSync(path.join(home, '.config', 'fish'), { recursive: true });
+    fs.mkdirSync(globalBin, { recursive: true });
+    if (variables !== undefined) {
+      fs.writeFileSync(path.join(home, '.config', 'fish', 'fish_variables'), variables);
+    }
+    if (config !== undefined) {
+      fs.writeFileSync(path.join(home, '.config', 'fish', 'config.fish'), config);
+    }
+    return globalBin;
+  }
+
+  test('homePathCoveredByFishConfig is exported', () => {
+    assert.strictEqual(typeof installer.homePathCoveredByFishConfig, 'function',
+      'bin/install.js must export homePathCoveredByFishConfig for #323');
+  });
+
+  test('fish_variables SETUVAR fish_user_paths covers globalBin', () => {
+    const home = createTempHome();
+    try {
+      const globalBin = withFish(home, { variables: '' });
+      // Real fish format: the list separator is the literal TEXT `\x1e` (four
+      // chars), NOT a raw 0x1e byte — verified against fish 4.x output. The `\\`
+      // in this template literal produces that text. Values are stored absolute.
+      fs.writeFileSync(path.join(home, '.config', 'fish', 'fish_variables'),
+        `# This file contains fish universal variable definitions.\n# VERSION: 3.0\nSETUVAR fish_user_paths:/usr/local/bin\\x1e${globalBin}\n`);
+      assert.strictEqual(installer.homePathCoveredByFishConfig(globalBin, home), true);
+    } finally {
+      cleanup(home);
+    }
+  });
+
+  test('fish_variables with a path whose space is escaped as \\x20 is matched', () => {
+    const home = createTempHome();
+    try {
+      // fish escapes the space byte as the TEXT `\x20` (verified against fish 4.x).
+      const globalBin = path.join(home, 'node bin');
+      fs.mkdirSync(path.join(home, '.config', 'fish'), { recursive: true });
+      fs.mkdirSync(globalBin, { recursive: true });
+      const escaped = globalBin.replace(/ /g, '\\x20');
+      fs.writeFileSync(path.join(home, '.config', 'fish', 'fish_variables'),
+        `SETUVAR fish_user_paths:/usr/local/bin\\x1e${escaped}\n`);
+      assert.strictEqual(installer.homePathCoveredByFishConfig(globalBin, home), true);
+    } finally {
+      cleanup(home);
+    }
+  });
+
+  test('fish_variables SETUVAR with --path flag is still parsed', () => {
+    const home = createTempHome();
+    try {
+      const globalBin = withFish(home, { variables: '' });
+      fs.writeFileSync(path.join(home, '.config', 'fish', 'fish_variables'),
+        `SETUVAR --path fish_user_paths:${globalBin}\n`);
+      assert.strictEqual(installer.homePathCoveredByFishConfig(globalBin, home), true);
+    } finally {
+      cleanup(home);
+    }
+  });
+
+  test('config.fish fish_add_path covers globalBin', () => {
+    const home = createTempHome();
+    try {
+      const globalBin = withFish(home, { config: '' });
+      fs.writeFileSync(path.join(home, '.config', 'fish', 'config.fish'),
+        `fish_add_path ${globalBin}\n`);
+      assert.strictEqual(installer.homePathCoveredByFishConfig(globalBin, home), true);
+    } finally {
+      cleanup(home);
+    }
+  });
+
+  test('config.fish single-quoted fish_add_path with a space is matched', () => {
+    const home = createTempHome();
+    try {
+      // This is the exact quoted form the installer itself suggests for spaced
+      // paths, so detection must agree with the suggestion it emits.
+      const globalBin = path.join(home, 'node bin');
+      fs.mkdirSync(path.join(home, '.config', 'fish'), { recursive: true });
+      fs.mkdirSync(globalBin, { recursive: true });
+      fs.writeFileSync(path.join(home, '.config', 'fish', 'config.fish'),
+        `fish_add_path '${globalBin}'\n`);
+      assert.strictEqual(installer.homePathCoveredByFishConfig(globalBin, home), true);
+    } finally {
+      cleanup(home);
+    }
+  });
+
+  test('config.fish double-quoted $HOME path with a space is matched', () => {
+    const home = createTempHome();
+    try {
+      const globalBin = path.join(home, 'node bin');
+      fs.mkdirSync(path.join(home, '.config', 'fish'), { recursive: true });
+      fs.mkdirSync(globalBin, { recursive: true });
+      fs.writeFileSync(path.join(home, '.config', 'fish', 'config.fish'),
+        'fish_add_path "$HOME/node bin"\n');
+      assert.strictEqual(installer.homePathCoveredByFishConfig(globalBin, home), true);
+    } finally {
+      cleanup(home);
+    }
+  });
+
+  test('config.fish set -gx PATH with $HOME expansion covers globalBin', () => {
+    const home = createTempHome();
+    try {
+      const globalBin = withFish(home, {
+        config: 'set -gx PATH $HOME/.nvm/versions/node/v24/bin $PATH\n',
+      });
+      assert.strictEqual(installer.homePathCoveredByFishConfig(globalBin, home), true);
+    } finally {
+      cleanup(home);
+    }
+  });
+
+  test('config.fish set -gx PATH /dir:$PATH (colon-joined) covers globalBin', () => {
+    const home = createTempHome();
+    try {
+      // PATH is a path-list variable; fish colon-splits it, so `/dir:$PATH`
+      // puts /dir on PATH as its own entry (verified against fish 4.x).
+      const globalBin = withFish(home, { config: '' });
+      fs.writeFileSync(path.join(home, '.config', 'fish', 'config.fish'),
+        `set -gx PATH ${globalBin}:$PATH\n`);
+      assert.strictEqual(installer.homePathCoveredByFishConfig(globalBin, home), true);
+    } finally {
+      cleanup(home);
+    }
+  });
+
+  test('fish_variables with a non-ASCII path escaped as \\u00e9 is matched', () => {
+    const home = createTempHome();
+    try {
+      // fish escapes codepoints <= 0xFFFF as the TEXT `\uHHHH` (café -> café,
+      // verified against fish 4.x). The value must be codepoint-decoded.
+      const globalBin = path.join(home, 'café', 'bin');
+      fs.mkdirSync(path.join(home, '.config', 'fish'), { recursive: true });
+      fs.mkdirSync(globalBin, { recursive: true });
+      const escaped = `${home}/caf\\u00e9/bin`;
+      fs.writeFileSync(path.join(home, '.config', 'fish', 'fish_variables'),
+        `SETUVAR fish_user_paths:${escaped}\n`);
+      assert.strictEqual(installer.homePathCoveredByFishConfig(globalBin, home), true);
+    } finally {
+      cleanup(home);
+    }
+  });
+
+  test('config.fish trailing inline # comment is not treated as a path', () => {
+    const home = createTempHome();
+    try {
+      // fish ignores a start-of-word `#` to end-of-line; the commented path must
+      // NOT suppress the warning.
+      const globalBin = path.join(home, 'node-bin');
+      fs.mkdirSync(path.join(home, '.config', 'fish'), { recursive: true });
+      fs.mkdirSync(globalBin, { recursive: true });
+      fs.writeFileSync(path.join(home, '.config', 'fish', 'config.fish'),
+        `fish_add_path /some/other/bin # ${globalBin}\n`);
+      assert.strictEqual(installer.homePathCoveredByFishConfig(globalBin, home), false);
+    } finally {
+      cleanup(home);
+    }
+  });
+
+  test('returns false when fish config covers only an unrelated directory', () => {
+    const home = createTempHome();
+    try {
+      const globalBin = withFish(home, { config: 'fish_add_path /some/other/bin\n' });
+      assert.strictEqual(installer.homePathCoveredByFishConfig(globalBin, home), false);
+    } finally {
+      cleanup(home);
+    }
+  });
+
+  test('returns false when no fish files exist (and does not throw)', () => {
+    const home = createTempHome();
+    try {
+      const globalBin = path.join(home, '.nvm', 'versions', 'node', 'v24', 'bin');
+      fs.mkdirSync(globalBin, { recursive: true });
+      assert.doesNotThrow(() => installer.homePathCoveredByFishConfig(globalBin, home));
+      assert.strictEqual(installer.homePathCoveredByFishConfig(globalBin, home), false);
+    } finally {
+      cleanup(home);
+    }
+  });
+
+  test('relative fish_add_path entry is not treated as covering globalBin', () => {
+    const home = createTempHome();
+    try {
+      // A bare `bin` is cwd-dependent — must NOT be resolved against HOME.
+      const globalBin = withFish(home, { config: 'fish_add_path bin\n' });
+      assert.strictEqual(installer.homePathCoveredByFishConfig(globalBin, home), false);
+    } finally {
+      cleanup(home);
+    }
+  });
+
+  test('maybeSuggestPathExport suppresses the add-PATH warning for a covered fish user', () => {
+    const home = createTempHome();
+    try {
+      const globalBin = withFish(home, { config: '' });
+      fs.writeFileSync(path.join(home, '.config', 'fish', 'config.fish'),
+        `fish_add_path ${globalBin}\n`);
+
+      const logs = [];
+      const origLog = console.log;
+      console.log = (...args) => { logs.push(args.join(' ')); };
+      try {
+        installer.maybeSuggestPathExport(globalBin, home);
+      } finally {
+        console.log = origLog;
+      }
+
+      const joined = logs.join('\n');
+      assert.ok(!/is not on your PATH/.test(joined),
+        `fish-covered user should not see the add-PATH warning; got:\n${joined}`);
+      assert.ok(!/fish_add_path/.test(joined),
+        `fish-covered user should not be told to add the path again; got:\n${joined}`);
+      assert.ok(/already on your PATH/.test(joined),
+        `expected the "already covered, reopen your shell" note; got:\n${joined}`);
+    } finally {
+      cleanup(home);
+    }
+  });
+
+  test('maybeSuggestPathExport still warns (with a fish suggestion) when fish does not cover globalBin', () => {
+    const home = createTempHome();
+    try {
+      const globalBin = withFish(home, { config: 'fish_add_path /some/other/bin\n' });
+
+      const logs = [];
+      const origLog = console.log;
+      console.log = (...args) => { logs.push(args.join(' ')); };
+      try {
+        installer.maybeSuggestPathExport(globalBin, home);
+      } finally {
+        console.log = origLog;
+      }
+
+      const joined = logs.join('\n');
+      assert.ok(/is not on your PATH/.test(joined),
+        `uncovered user should see the add-PATH warning; got:\n${joined}`);
+      assert.ok(joined.includes(`fish_add_path '${globalBin}'`),
+        `the warning should include a fish-native suggestion; got:\n${joined}`);
+    } finally {
+      cleanup(home);
+    }
+  });
+});


### PR DESCRIPTION
## Enhancement PR

---

## Linked Issue

Closes #323

> The linked issue #323 carries the `approved-enhancement` label. **This PR needs `approved-enhancement` applied to the PR itself** — I'm an external fork contributor and cannot self-apply labels (403). @maintainers, could you add it? Thanks.

---

## What this enhancement improves

The installer's post-install PATH suggestion (`bin/install.js` `maybeSuggestPathExport` / `homePathCoveredByRc`, and the persist projection in `src/shell-command-projection.cts`). Two fish-shell defects, both confined to the existing PATH-suggestion seam:

1. The persistent suggestion offered only `zsh`/`bash` `echo 'export PATH=...' >> rc` lines — invalid fish syntax (fish has no `export`, and uses `$PATH` differently in list contexts).
2. `homePathCoveredByRc` only inspected `.zshrc`/`.bashrc`/`.bash_profile`/`.profile`, never fish's universal-variable store (`~/.config/fish/fish_variables`) or `~/.config/fish/config.fish`. So a fish user whose `fish_user_paths` already covered the npm global bin saw a spurious "not on your PATH" warning on **every** install.

## Before / After

**Before:**
```
⚠ /home/u/.nvm/versions/node/v24/bin is not on your PATH.
  Add it with one of:
    zsh: echo 'export PATH="…:$PATH"' >> ~/.zshrc
    bash: echo 'export PATH="…:$PATH"' >> ~/.bashrc
```
A fish user already on PATH via `fish_user_paths` still got this warning; neither suggested command is valid fish.

**After:**
- The suggestion list adds a fish-native entry: `fish: fish_add_path '/home/u/.nvm/versions/node/v24/bin'` (`fish_add_path`, fish ≥ 3.2).
- A fish user whose `fish_user_paths` / `config.fish` already covers the directory no longer sees the add-PATH warning — they get the "already covered, reopen your shell" note instead.

## How it was implemented

- **`src/shell-command-projection.cts`** — the `persist` branch of `projectPathActionProjection` appends a `fish` `ShellAction` (`fish_add_path '<single-quoted dir>'`; the POSIX `'\''` escape idiom is valid in fish, so the existing escaper is reused).
- **`bin/install.js`** — new `homePathCoveredByFishConfig(globalBin, homeDir)`, mirroring `homePathCoveredByRc`'s normalise/expand/compare contract:
  - **Route 1** parses `fish_variables` `SETUVAR [--flags] fish_user_paths:…`, splitting on the literal **text** `\x1e` separator and decoding fish's `\xHH` / `\uHHHH` / `\UHHHHHHHH` / named escapes (byte-assembled, UTF-8 decoded).
  - **Route 2** parses `config.fish` `fish_add_path` / `set … PATH` / `set … fish_user_paths`, with quote-, backslash-, and start-of-word-`#`-comment-aware tokenization, plus `:` colon-splitting for the path-list variables (`PATH` / `fish_user_paths`).
  - Wired into `maybeSuggestPathExport` (`coveredByRc || homePathCoveredByFishConfig`); the "already covered" message wording is generalized ("shell config entry"), with the `source ~/.zshrc` hint shown only for the rc case.
- **`docs/how-to/install-on-your-runtime.md`** — documents the new fish PATH behavior.

## Testing

### How I verified the enhancement works

- **Empirically reproduced both bugs first** against the live `bin/install.js`, then confirmed the fixes.
- **Validated against the real `fish` 4.7.1 binary** (not just docs): drove `set -U fish_user_paths …` and inspected the on-disk `fish_variables` to confirm the escaped `\x1e` separator, `\x20` space escape, `é` (café) / `\U0001f600` (emoji) codepoint escaping, and that `set -gx PATH /x:$PATH` colon-splits so `/x` is a standalone entry; confirmed fish's `#` comment rules. Pointed `homePathCoveredByFishConfig` at the genuine fish-written files — correct matches.
- **Automated tests:** `tests/install-path-detection.test.cjs` gains a `#323 regression` block (fish_variables real escaped format incl. `\x1e`/`\x20`/`\u`, `--path` flag, `fish_add_path`, `set -gx PATH` with `$HOME` and colon-join, single/double-quoted + escaped spaced paths, inline-comment ignored, relative-entry guard, no-files, plus `maybeSuggestPathExport` suppress/warn). `tests/bug-3441-path-action-projection.test.cjs` updated for the new fish projection entry.
- `npm test` green; `npm run lint:ci` green.

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [x] N/A (not platform-specific) — POSIX-shell behavior; the fish tests are POSIX-only (skipped on Windows, consistent with the existing rc tests)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific) — installer/shell behavior, independent of AI runtime

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue — no additions or removals
- [x] If scope changed during implementation, I updated the issue and got re-approval before continuing

---

## Documentation

- [x] Updated the relevant file(s) under `docs/` to reflect this change (`docs/how-to/install-on-your-runtime.md`)
- [x] All `docs/` content added in this PR is written in English
- [ ] If genuinely no user-facing docs impact … (N/A — docs updated)

## Checklist

- [x] Issue linked above with `Closes #323`
- [x] Linked issue has the `approved-enhancement` label
- [x] Changes are scoped to the approved enhancement — nothing extra included
- [x] All existing tests pass (`npm test`)
- [x] New or updated tests cover the enhanced behavior
- [ ] `.changeset/` fragment added — added in a follow-up commit once the PR number is known
- [x] No unnecessary dependencies added

## Breaking changes

None — additive. The fish suggestion is a new list entry; the coverage check only suppresses a previously-spurious warning. zsh/bash behavior is unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1444"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784405272&installation_id=134682257&pr_number=1444&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1444&signature=9ee3f18700a679923ce19a4f782f51c9de72131a3fa950124ec5e57f2f87ddb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->