### PR TITLE
chore(#1465): add @davesienkowski to CODEOWNERS reviewer pool

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # CODEOWNERS is advisory only — the main-protection ruleset does not require
 # CODEOWNERS approval (required_approving_review_count: 0).
-# All paths: active reviewer pool as of 2026-05.
-*  @trek-e @Solvely-Colin @jeremymcs
+# All paths: active reviewer pool as of 2026-06.
+*  @trek-e @Solvely-Colin @jeremymcs @davesienkowski


### PR DESCRIPTION
<!-- pr-template-exempt: config-only change to .github/CODEOWNERS (tooling path) -->

## Summary

Adds `@davesienkowski` (existing write/maintain collaborator) to the all-paths reviewer pool in `.github/CODEOWNERS` so they are auto-requested for review on PRs.

CODEOWNERS in this repo is **advisory only** — the main-protection ruleset has `required_approving_review_count: 0`, so this auto-requests reviews without making them merge-blocking.

## Changes

- `.github/CODEOWNERS`: add `@davesienkowski` to the `*` owner line; bump the "as of" comment to 2026-06.

## Gates

Config-only change to a tooling path (`.github/**`):
- Template gate: auto-exempt (tooling-paths carve-out in `pr-template-policy.cjs`).
- Changeset gate: not user-facing → no changeset required.
- `npm run lint`: clean.
- No test/script/workflow references CODEOWNERS, so the docker test suite and code/security/adversarial reviews have no code surface to evaluate.

Closes #1465

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1466"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784493017&installation_id=134682257&pr_number=1466&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1466&signature=f4764e22c436811a4f34608588dc8ad2171941034816015dd98aad7a47159c31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->