### PR TITLE
fix(#1467): honor .gsd-source marker in loadInstallExports for relocated runtimes

### DIFF
--- a/src/runtime-artifact-layout.cts
+++ b/src/runtime-artifact-layout.cts
@@ -45,15 +45,47 @@ interface InstallExports {
 }
 
 /**
+ * Resolve the install package root implied by a .gsd-source marker, if present.
+ *
+ * The marker (written by callers that relocate the runtime away from the install
+ * source, e.g. a runtime mirror) points at <root>/commands/gsd; the package root
+ * is its grandparent. This mirrors the marker derivation in findAgentsSourceRoot,
+ * keeping all three source-locating paths (commands, agents, install.js) consistent.
+ *
+ * @returns the package root, or null when no usable marker is found.
+ */
+function resolveMarkerInstallRoot(runtimeConfigDir?: string): string | null {
+  if (!runtimeConfigDir) return null;
+  const markerPath = path.join(runtimeConfigDir, '.gsd-source');
+  if (!fs.existsSync(markerPath)) return null;
+  try {
+    const src = fs.readFileSync(markerPath, 'utf8').trim();
+    // Marker points to commands/gsd; the package root is dirname(commands)/.. .
+    if (src && fs.existsSync(src)) return path.resolve(path.dirname(src), '..');
+  } catch { /* fall through */ }
+  return null;
+}
+
+/**
  * Load bin/install.js exports in a test-safe way.
  * Sets GSD_TEST_MODE only for the duration of the require() call and only if
  * it was not already set, restoring the original value in a finally block so
  * the module-level environment is never permanently mutated.
+ *
+ * Resolution order for install.js, mirroring findInstallSourceRoot/findAgentsSourceRoot:
+ * 1. If a usable <runtimeConfigDir>/.gsd-source marker exists, load
+ *    <markerRoot>/bin/install.js (relocated / runtime-mirror installs).
+ * 2. Otherwise fall back to the package-relative path (normal npm install).
  */
-function loadInstallExports(): InstallExports {
+function loadInstallExports(runtimeConfigDir?: string): InstallExports {
   const savedTestMode = process.env['GSD_TEST_MODE'];
   if (savedTestMode === undefined) process.env['GSD_TEST_MODE'] = '1';
   try {
+    const markerRoot = resolveMarkerInstallRoot(runtimeConfigDir);
+    if (markerRoot) {
+      const candidate = path.join(markerRoot, 'bin', 'install.js');
+      if (fs.existsSync(candidate)) return _require(candidate) as InstallExports;
+    }
     return _require('../../../bin/install.js') as InstallExports;
   } finally {
     if (savedTestMode === undefined) delete process.env['GSD_TEST_MODE'];
@@ -63,8 +95,8 @@ function loadInstallExports(): InstallExports {
 
 /** Cache after first successful load. */
 let _installExports: InstallExports | null = null;
-function getInstallExports(): InstallExports {
-  if (!_installExports) _installExports = loadInstallExports();
+function getInstallExports(runtimeConfigDir?: string): InstallExports {
+  if (!_installExports) _installExports = loadInstallExports(runtimeConfigDir);
   return _installExports;
 }
 
@@ -494,4 +526,4 @@ function resolveRuntimeArtifactLayoutFromRegistry(
   return { runtime, configDir, scope, kinds };
 }
 
-export = { resolveRuntimeArtifactLayout, resolveRuntimeArtifactLayoutFromRegistry, findInstallSourceRoot, getInstallExports };
+export = { resolveRuntimeArtifactLayout, resolveRuntimeArtifactLayoutFromRegistry, findInstallSourceRoot, getInstallExports, loadInstallExports };

--- a/src/surface.cts
+++ b/src/surface.cts
@@ -311,7 +311,9 @@ function applySurface(runtimeConfigDir: string, layout: Layout, manifest: Map<st
   for (const kind of layout.kinds) {
     const staged = kind.stage(resolved);
     if (kind.kind === 'skills') {
-      const installExports = getInstallExports();
+      // Pass configDir so a .gsd-source marker (relocated / runtime-mirror installs)
+      // resolves bin/install.js, consistent with findInstallSourceRoot below.
+      const installExports = getInstallExports(layout.configDir);
       if (pathPrefix === null) {
         const scope = layout.scope ?? 'global';
         const resolvedTarget = path.resolve(layout.configDir).replace(/\\/g, '/');

--- a/tests/runtime-artifact-layout-install-marker.test.cjs
+++ b/tests/runtime-artifact-layout-install-marker.test.cjs
@@ -1,0 +1,105 @@
+'use strict';
+/**
+ * loadInstallExports honors the .gsd-source marker (relocated / runtime-mirror installs).
+ *
+ * Regression: findInstallSourceRoot and findAgentsSourceRoot honor a
+ * <runtimeConfigDir>/.gsd-source marker so the commands/ and agents/ source can live
+ * apart from the runtime lib. loadInstallExports did NOT — it hard-required
+ * ../../../bin/install.js with no marker fallback. Any install that relocates
+ * gsd-core/bin/lib away from the package root (e.g. a runtime mirror at
+ * ~/.claude/gsd-core/, where only the inner gsd-core/ subtree is copied) could
+ * resolve commands+agents via the marker but hard-failed the write path
+ * (applySurface -> getInstallExports) on a MODULE_NOT_FOUND for bin/install.js.
+ *
+ * The marker points at <root>/commands/gsd; bin/install.js is a sibling of commands/
+ * at the package root, mirroring findAgentsSourceRoot's <root>/agents derivation.
+ */
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const { loadInstallExports } = require('../gsd-core/bin/lib/runtime-artifact-layout.cjs');
+const { createTempDir, cleanup } = require('./helpers.cjs');
+
+// A stub bin/install.js carrying a sentinel so we can prove WHICH install.js was loaded.
+function writeStubInstall(binDir, sentinel) {
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(binDir, 'install.js'),
+    `module.exports = { __sentinel: ${JSON.stringify(sentinel)}, ` +
+      `computePathPrefix: () => '', applyRuntimeContentRewritesInPlace: () => {}, ` +
+      `readGsdCommandNames: () => [] };\n`,
+  );
+}
+
+// Build a relocated install: a package root with commands/gsd + bin/install.js (stub),
+// and a separate runtime config dir whose .gsd-source marker points at <root>/commands/gsd.
+function makeRelocatedInstall(sentinel, { withInstallJs = true } = {}) {
+  const pkgRoot = createTempDir('gsd-fake-pkg-');
+  const commandsGsd = path.join(pkgRoot, 'commands', 'gsd');
+  fs.mkdirSync(commandsGsd, { recursive: true });
+  if (withInstallJs) writeStubInstall(path.join(pkgRoot, 'bin'), sentinel);
+  const configDir = createTempDir('gsd-relocated-cfg-');
+  fs.writeFileSync(path.join(configDir, '.gsd-source'), commandsGsd);
+  return { pkgRoot, commandsGsd, configDir };
+}
+
+describe('loadInstallExports — .gsd-source marker resolution', () => {
+  test('honors the marker: loads bin/install.js from the marker-implied package root', () => {
+    const { configDir, pkgRoot } = makeRelocatedInstall('from-marker-root');
+    try {
+      const exp = loadInstallExports(configDir);
+      assert.equal(
+        exp.__sentinel,
+        'from-marker-root',
+        'expected install.js to be loaded from <markerRoot>/bin/install.js',
+      );
+    } finally {
+      cleanup(configDir);
+      cleanup(pkgRoot);
+    }
+  });
+
+  test('falls back to the package-relative path when no marker is present', () => {
+    const configDir = createTempDir('gsd-nomarker-cfg-');
+    try {
+      const exp = loadInstallExports(configDir);
+      assert.ok(exp && typeof exp === 'object', 'expected real install.js exports');
+      assert.equal(exp.__sentinel, undefined, 'must not be the marker stub');
+    } finally {
+      cleanup(configDir);
+    }
+  });
+
+  test('falls back when the marker resolves but bin/install.js is absent at that root', () => {
+    const { configDir, pkgRoot } = makeRelocatedInstall('unused', { withInstallJs: false });
+    try {
+      const exp = loadInstallExports(configDir);
+      assert.ok(exp && typeof exp === 'object');
+      assert.equal(exp.__sentinel, undefined, 'guard must fall through to the real install.js');
+    } finally {
+      cleanup(configDir);
+      cleanup(pkgRoot);
+    }
+  });
+
+  test('no runtimeConfigDir → package-relative path (unchanged behavior)', () => {
+    const exp = loadInstallExports();
+    assert.ok(exp && typeof exp === 'object');
+    assert.equal(exp.__sentinel, undefined);
+  });
+
+  test('marker file present but pointing at a non-existent dir → fallback', () => {
+    const configDir = createTempDir('gsd-stalemarker-cfg-');
+    fs.writeFileSync(path.join(configDir, '.gsd-source'), path.join(configDir, 'does', 'not', 'exist'));
+    try {
+      const exp = loadInstallExports(configDir);
+      assert.ok(exp && typeof exp === 'object');
+      assert.equal(exp.__sentinel, undefined, 'stale marker must not break resolution');
+    } finally {
+      cleanup(configDir);
+    }
+  });
+});


### PR DESCRIPTION
Fixes #1467.

## Problem

`loadInstallExports` is the only source-locating function in `runtime-artifact-layout.cts` that ignores the `<runtimeConfigDir>/.gsd-source` marker. `findInstallSourceRoot` and `findAgentsSourceRoot` both honor it, so a relocated/mirror install (where only the inner `gsd-core/` subtree lives under the config dir, away from the package root) can resolve `commands/` and `agents/` via the marker — but `loadInstallExports` hard-requires `../../../bin/install.js` with no marker fallback. The result: the surface **write** path (`applySurface` → `getInstallExports` → `loadInstallExports`, i.e. the gsd-surface `profile` / `enable` / `disable` / `reset` subcommands) hard-fails with `MODULE_NOT_FOUND` even when the marker is set correctly. The read path (`list` / `status`) works, masking the defect until a write is attempted.

This is the `bin/install.js` analog of #1223 (`scripts/fix-slash-commands.cjs` dropped from a relocated install).

## Fix

Mirror the existing `findAgentsSourceRoot` marker derivation:

1. `resolveMarkerInstallRoot(runtimeConfigDir)` returns the package root implied by the marker (`path.resolve(path.dirname(markerValue), '..')`).
2. `loadInstallExports(runtimeConfigDir?)` honors it — loads `<root>/bin/install.js` when the marker resolves and that file exists; otherwise falls back to the package-relative path.
3. `runtimeConfigDir` is threaded from the single call site (`applySurface` in `surface.cts`).

`loadInstallExports` is exported for testing. **No behavior change for normal npm installs** — with no marker, resolution is byte-for-behaviour identical to before.

## Tests

- New `tests/runtime-artifact-layout-install-marker.test.cjs` — 5 cases: marker honored, no-marker fallback, marker-resolves-but-no-`install.js` fallback, no-`configDir` unchanged, stale-marker fallback. All green.
- Existing surface/layout suites green, no regressions: `runtime-artifact-layout-surface` (42), `runtime-artifact-layout` (39), `bug-3659-applysurface-prune-skill-dirs` (5), `runtime-artifact-layout-install-profiles` (54).
- End-to-end against a faithful relocated mirror: without the marker, both paths fail with `findInstallSourceRoot: could not locate commands/gsd`; with the marker set, `listSurface` and `applySurface` (staging 69 skill dirs) both succeed. Isolation check: with the marker present, old `loadInstallExports()` still fails on `../../../bin/install.js` while `loadInstallExports(configDir)` succeeds — confirming the `configDir` threading is the load-bearing change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1468"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784501326&installation_id=134682257&pr_number=1468&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1468&signature=f86de715f9d3f228055c398b55aa2d6b4d9255d5b46ad6af4feee13296f181c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->