### PR TITLE
docs(#1010): document projects-sync, the first reference third-party capability

### DIFF
--- a/docs/how-to/import-a-capability-from-a-url.md
+++ b/docs/how-to/import-a-capability-from-a-url.md
@@ -169,6 +169,20 @@ The output shows each installed capability, its version, scope, and enabled stat
 
 ---
 
+## A worked example: projects-sync
+
+[`projects-sync`](https://github.com/The-Artificer-of-Ciphers-LLC/projects-sync-capability) is a reference third-party capability — it mirrors a project's `.planning/ROADMAP.md` to GitHub Issues, Milestones, and Projects v2. Install it the same way as any URL spec:
+
+```bash
+gsd capability install https://github.com/The-Artificer-of-Ciphers-LLC/projects-sync-capability.git#v0.1.0 --scope project
+gsd-tools config-set projects-sync.enabled true   # opt-in, default off
+gsd-tools projects-sync status                     # dry run
+```
+
+It is a `role: feature` capability that registers an `execute:pre` step and a `ship:post` contribution (both `onError: skip`) and contributes the `projects-sync` command family — a concrete model for the manifest shape, hook registration, and command-router conventions described in [Develop a capability](./develop-a-capability.md).
+
+---
+
 ## Next steps
 
 - [Version and update a capability](./version-a-capability.md) — check for updates with `gsd capability outdated` and apply them with `gsd capability update`.


### PR DESCRIPTION
## Summary

Doc-only change. Adds a worked example to `docs/how-to/import-a-capability-from-a-url.md` showing how to install and enable **projects-sync**, the first reference third-party (ADR-1244 ecosystem) capability — it mirrors `.planning/ROADMAP.md` phases to GitHub Issues, Milestones, and Projects v2 (one-way, idempotent, opt-in).

The capability itself ships as an **external installable repo** — [`The-Artificer-of-Ciphers-LLC/projects-sync-capability`](https://github.com/The-Artificer-of-Ciphers-LLC/projects-sync-capability) (`v0.1.0`) — consistent with ADR-1244, under which third-party capabilities are authored/published externally and installed into `.gsd/capabilities/<id>/` via `gsd capability install`, never committed to GSD Core. GSD Core gains only the worked example here.

## Why no code / changeset

Per ADR-1244 the capability-matrix is generated and intentionally **never records third-party capabilities** (they live in the runtime overlay, `gsd capability list`). So there is no in-repo registration artifact — the only appropriate Core change is documentation. This is a doc-only PR (auto-detected, template-exempt) with no user-facing code diff, so no changeset is required; `lint:docs` passes.

## Validation of the linked capability

The external capability was built test-first (188 unit tests) and dogfood-validated end-to-end against the ADR-1244 machinery on `next`: `capability install` (with trust disclosure) → enable via `projects-sync.enabled` → `execute:pre` hook activation → third-party command dispatch → idempotent marker-based sync → fail-open on outage. A Codex adversarial review's findings were all fixed.

Closes #1010

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1470"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784508755&installation_id=134682257&pr_number=1470&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1470&signature=ed51691bd4f921efeb18cf4ba601895dbbd60e8a051588558708ea3b71667fa8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->