### PR TITLE
fix(#1467): honor .gsd-source marker in install-exports loader for relocated installs

### DIFF
--- a/src/runtime-artifact-layout.cts
+++ b/src/runtime-artifact-layout.cts
@@ -45,15 +45,47 @@ interface InstallExports {
 }
 
 /**
+ * Resolve the install package root implied by a .gsd-source marker, if present.
+ *
+ * The marker (written by callers that relocate the runtime away from the install
+ * source, e.g. a runtime mirror) points at <root>/commands/gsd; the package root
+ * is its grandparent. This mirrors the marker derivation in findAgentsSourceRoot,
+ * keeping all three source-locating paths (commands, agents, install.js) consistent.
+ *
+ * @returns the package root, or null when no usable marker is found.
+ */
+function resolveMarkerInstallRoot(runtimeConfigDir?: string): string | null {
+  if (!runtimeConfigDir) return null;
+  const markerPath = path.join(runtimeConfigDir, '.gsd-source');
+  if (!fs.existsSync(markerPath)) return null;
+  try {
+    const src = fs.readFileSync(markerPath, 'utf8').trim();
+    // Marker points to commands/gsd; the package root is dirname(commands)/.. .
+    if (src && fs.existsSync(src)) return path.resolve(path.dirname(src), '..');
+  } catch { /* fall through */ }
+  return null;
+}
+
+/**
  * Load bin/install.js exports in a test-safe way.
  * Sets GSD_TEST_MODE only for the duration of the require() call and only if
  * it was not already set, restoring the original value in a finally block so
  * the module-level environment is never permanently mutated.
+ *
+ * Resolution order for install.js, mirroring findInstallSourceRoot/findAgentsSourceRoot:
+ * 1. If a usable <runtimeConfigDir>/.gsd-source marker exists, load
+ *    <markerRoot>/bin/install.js (relocated / runtime-mirror installs).
+ * 2. Otherwise fall back to the package-relative path (normal npm install).
  */
-function loadInstallExports(): InstallExports {
+function loadInstallExports(runtimeConfigDir?: string): InstallExports {
   const savedTestMode = process.env['GSD_TEST_MODE'];
   if (savedTestMode === undefined) process.env['GSD_TEST_MODE'] = '1';
   try {
+    const markerRoot = resolveMarkerInstallRoot(runtimeConfigDir);
+    if (markerRoot) {
+      const candidate = path.join(markerRoot, 'bin', 'install.js');
+      if (fs.existsSync(candidate)) return _require(candidate) as InstallExports;
+    }
     return _require('../../../bin/install.js') as InstallExports;
   } finally {
     if (savedTestMode === undefined) delete process.env['GSD_TEST_MODE'];
@@ -63,8 +95,8 @@ function loadInstallExports(): InstallExports {
 
 /** Cache after first successful load. */
 let _installExports: InstallExports | null = null;
-function getInstallExports(): InstallExports {
-  if (!_installExports) _installExports = loadInstallExports();
+function getInstallExports(runtimeConfigDir?: string): InstallExports {
+  if (!_installExports) _installExports = loadInstallExports(runtimeConfigDir);
   return _installExports;
 }
 
@@ -494,4 +526,4 @@ function resolveRuntimeArtifactLayoutFromRegistry(
   return { runtime, configDir, scope, kinds };
 }
 
-export = { resolveRuntimeArtifactLayout, resolveRuntimeArtifactLayoutFromRegistry, findInstallSourceRoot, getInstallExports };
+export = { resolveRuntimeArtifactLayout, resolveRuntimeArtifactLayoutFromRegistry, findInstallSourceRoot, getInstallExports, loadInstallExports };

--- a/src/runtime-artifact-layout.cts
+++ b/src/runtime-artifact-layout.cts
@@ -93,11 +93,25 @@ function loadInstallExports(runtimeConfigDir?: string): InstallExports {
   }
 }
 
-/** Cache after first successful load. */
-let _installExports: InstallExports | null = null;
+/**
+ * Cache of loaded install exports, keyed by the resolved install source.
+ *
+ * Keying matters: the cache must not let a no-marker (package-relative) load
+ * mask a later marker-aware load, or vice-versa. The key is the .gsd-source
+ * marker root when one resolves, else a fixed sentinel for the package-relative
+ * path. Marker roots and the sentinel never collide, so each distinct source
+ * memoizes independently — a fallback is never cached as if it were the marker
+ * resolution.
+ */
+const _installExportsCache = new Map<string, InstallExports>();
 function getInstallExports(runtimeConfigDir?: string): InstallExports {
-  if (!_installExports) _installExports = loadInstallExports(runtimeConfigDir);
-  return _installExports;
+  const cacheKey = resolveMarkerInstallRoot(runtimeConfigDir) ?? '__package_relative__';
+  let exports = _installExportsCache.get(cacheKey);
+  if (!exports) {
+    exports = loadInstallExports(runtimeConfigDir);
+    _installExportsCache.set(cacheKey, exports);
+  }
+  return exports;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/surface.cts
+++ b/src/surface.cts
@@ -311,7 +311,9 @@ function applySurface(runtimeConfigDir: string, layout: Layout, manifest: Map<st
   for (const kind of layout.kinds) {
     const staged = kind.stage(resolved);
     if (kind.kind === 'skills') {
-      const installExports = getInstallExports();
+      // Pass configDir so a .gsd-source marker (relocated / runtime-mirror installs)
+      // resolves bin/install.js, consistent with findInstallSourceRoot below.
+      const installExports = getInstallExports(layout.configDir);
       if (pathPrefix === null) {
         const scope = layout.scope ?? 'global';
         const resolvedTarget = path.resolve(layout.configDir).replace(/\\/g, '/');

--- a/tests/runtime-artifact-layout-install-marker.test.cjs
+++ b/tests/runtime-artifact-layout-install-marker.test.cjs
@@ -1,0 +1,105 @@
+'use strict';
+/**
+ * loadInstallExports honors the .gsd-source marker (relocated / runtime-mirror installs).
+ *
+ * Regression: findInstallSourceRoot and findAgentsSourceRoot honor a
+ * <runtimeConfigDir>/.gsd-source marker so the commands/ and agents/ source can live
+ * apart from the runtime lib. loadInstallExports did NOT — it hard-required
+ * ../../../bin/install.js with no marker fallback. Any install that relocates
+ * gsd-core/bin/lib away from the package root (e.g. a runtime mirror at
+ * ~/.claude/gsd-core/, where only the inner gsd-core/ subtree is copied) could
+ * resolve commands+agents via the marker but hard-failed the write path
+ * (applySurface -> getInstallExports) on a MODULE_NOT_FOUND for bin/install.js.
+ *
+ * The marker points at <root>/commands/gsd; bin/install.js is a sibling of commands/
+ * at the package root, mirroring findAgentsSourceRoot's <root>/agents derivation.
+ */
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const { loadInstallExports } = require('../gsd-core/bin/lib/runtime-artifact-layout.cjs');
+const { createTempDir, cleanup } = require('./helpers.cjs');
+
+// A stub bin/install.js carrying a sentinel so we can prove WHICH install.js was loaded.
+function writeStubInstall(binDir, sentinel) {
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(binDir, 'install.js'),
+    `module.exports = { __sentinel: ${JSON.stringify(sentinel)}, ` +
+      `computePathPrefix: () => '', applyRuntimeContentRewritesInPlace: () => {}, ` +
+      `readGsdCommandNames: () => [] };\n`,
+  );
+}
+
+// Build a relocated install: a package root with commands/gsd + bin/install.js (stub),
+// and a separate runtime config dir whose .gsd-source marker points at <root>/commands/gsd.
+function makeRelocatedInstall(sentinel, { withInstallJs = true } = {}) {
+  const pkgRoot = createTempDir('gsd-fake-pkg-');
+  const commandsGsd = path.join(pkgRoot, 'commands', 'gsd');
+  fs.mkdirSync(commandsGsd, { recursive: true });
+  if (withInstallJs) writeStubInstall(path.join(pkgRoot, 'bin'), sentinel);
+  const configDir = createTempDir('gsd-relocated-cfg-');
+  fs.writeFileSync(path.join(configDir, '.gsd-source'), commandsGsd);
+  return { pkgRoot, commandsGsd, configDir };
+}
+
+describe('loadInstallExports — .gsd-source marker resolution', () => {
+  test('honors the marker: loads bin/install.js from the marker-implied package root', () => {
+    const { configDir, pkgRoot } = makeRelocatedInstall('from-marker-root');
+    try {
+      const exp = loadInstallExports(configDir);
+      assert.equal(
+        exp.__sentinel,
+        'from-marker-root',
+        'expected install.js to be loaded from <markerRoot>/bin/install.js',
+      );
+    } finally {
+      cleanup(configDir);
+      cleanup(pkgRoot);
+    }
+  });
+
+  test('falls back to the package-relative path when no marker is present', () => {
+    const configDir = createTempDir('gsd-nomarker-cfg-');
+    try {
+      const exp = loadInstallExports(configDir);
+      assert.ok(exp && typeof exp === 'object', 'expected real install.js exports');
+      assert.equal(exp.__sentinel, undefined, 'must not be the marker stub');
+    } finally {
+      cleanup(configDir);
+    }
+  });
+
+  test('falls back when the marker resolves but bin/install.js is absent at that root', () => {
+    const { configDir, pkgRoot } = makeRelocatedInstall('unused', { withInstallJs: false });
+    try {
+      const exp = loadInstallExports(configDir);
+      assert.ok(exp && typeof exp === 'object');
+      assert.equal(exp.__sentinel, undefined, 'guard must fall through to the real install.js');
+    } finally {
+      cleanup(configDir);
+      cleanup(pkgRoot);
+    }
+  });
+
+  test('no runtimeConfigDir → package-relative path (unchanged behavior)', () => {
+    const exp = loadInstallExports();
+    assert.ok(exp && typeof exp === 'object');
+    assert.equal(exp.__sentinel, undefined);
+  });
+
+  test('marker file present but pointing at a non-existent dir → fallback', () => {
+    const configDir = createTempDir('gsd-stalemarker-cfg-');
+    fs.writeFileSync(path.join(configDir, '.gsd-source'), path.join(configDir, 'does', 'not', 'exist'));
+    try {
+      const exp = loadInstallExports(configDir);
+      assert.ok(exp && typeof exp === 'object');
+      assert.equal(exp.__sentinel, undefined, 'stale marker must not break resolution');
+    } finally {
+      cleanup(configDir);
+    }
+  });
+});

--- a/tests/runtime-artifact-layout-install-marker.test.cjs
+++ b/tests/runtime-artifact-layout-install-marker.test.cjs
@@ -20,7 +20,7 @@ const assert = require('node:assert/strict');
 const fs = require('fs');
 const path = require('path');
 
-const { loadInstallExports } = require('../gsd-core/bin/lib/runtime-artifact-layout.cjs');
+const { loadInstallExports, getInstallExports } = require('../gsd-core/bin/lib/runtime-artifact-layout.cjs');
 const { createTempDir, cleanup } = require('./helpers.cjs');
 
 // A stub bin/install.js carrying a sentinel so we can prove WHICH install.js was loaded.
@@ -100,6 +100,48 @@ describe('loadInstallExports — .gsd-source marker resolution', () => {
       assert.equal(exp.__sentinel, undefined, 'stale marker must not break resolution');
     } finally {
       cleanup(configDir);
+    }
+  });
+});
+
+describe('getInstallExports — keyed memoization (no-marker must not mask marker-aware)', () => {
+  // Regression for the memoized accessor: getInstallExports caches the loaded
+  // exports. With a single unkeyed slot, the FIRST call wins and a no-marker
+  // (package-relative) load would mask a later marker-aware load — the exact
+  // poisoning the surface write path (applySurface -> getInstallExports) hits
+  // when an earlier call already primed the cache. The cache is keyed by the
+  // resolved install source so the two memoize independently.
+  test('a no-marker call does not poison a later marker-aware call', () => {
+    // Prime the cache with the package-relative (no-marker) resolution first.
+    const pkg = getInstallExports();
+    assert.equal(pkg.__sentinel, undefined, 'no-arg call resolves the real package-relative install.js');
+
+    // A subsequent marker-aware call MUST resolve the marker root, not return
+    // the cached package-relative exports.
+    const { configDir, pkgRoot } = makeRelocatedInstall('from-marker-memo');
+    try {
+      const viaMarker = getInstallExports(configDir);
+      assert.equal(
+        viaMarker.__sentinel,
+        'from-marker-memo',
+        'marker-aware getInstallExports must not be masked by an earlier no-marker load',
+      );
+    } finally {
+      cleanup(configDir);
+      cleanup(pkgRoot);
+    }
+  });
+
+  test('marker resolution is memoized per source (same configDir returns the cached instance)', () => {
+    const { configDir, pkgRoot } = makeRelocatedInstall('memoized-marker');
+    try {
+      const first = getInstallExports(configDir);
+      const second = getInstallExports(configDir);
+      assert.equal(first.__sentinel, 'memoized-marker');
+      assert.equal(second, first, 'second call with the same source returns the cached instance');
+    } finally {
+      cleanup(configDir);
+      cleanup(pkgRoot);
     }
   });
 });


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #1467

The linked issue carries the `confirmed-bug` label. This PR supersedes #1468, which was auto-closed (the issue was still `needs-triage` at the time); the branch is unchanged plus one follow-up commit hardening the memoization path called out in the triage brief.

## What was broken

On a relocated / runtime-mirror install — where the runtime lib lives apart from the package root and a `<runtimeConfigDir>/.gsd-source` marker points at the real source tree — every surface **write** subcommand (`profile` / `enable` / `disable` / `reset`) failed with `MODULE_NOT_FOUND` for `bin/install.js`, even with a correct marker. The **read** subcommands (`list` / `status`) resolved fine via the marker-aware finders, masking the defect until a write was attempted.

## What this fix does

`loadInstallExports` now honors the `.gsd-source` marker — mirroring `findInstallSourceRoot` / `findAgentsSourceRoot` — resolving `<markerRoot>/bin/install.js`, with the package-relative path as the fallback. `applySurface` threads its `runtimeConfigDir` down to the loader. The memoized accessor `getInstallExports` is keyed by the resolved install source, so a no-marker (package-relative) load can never mask a later marker-aware one, and vice-versa.

Normal npm installs (no marker) resolve exactly as before.

## Root cause

`findInstallSourceRoot` and `findAgentsSourceRoot` were both marker-aware; `loadInstallExports` was the one source-locating function never wired to the marker — it hard-required the package-relative `../../../bin/install.js`. This is the `bin/install.js` analog of #1223 (relocated install dropped `scripts/fix-slash-commands.cjs`; accepted and fixed).

A second, subtler leg: `getInstallExports` memoized into a single unkeyed slot. Even after threading the marker through, an earlier package-relative load could cache a fallback that then masked a later marker-aware resolution (the surface write path reaches the loader after read paths may already have primed the cache). The cache is now keyed by the resolved install source — the marker root when one resolves, else a fixed package-relative sentinel — which never collide.

## Testing

### How I verified the fix

Automated — `tests/runtime-artifact-layout-install-marker.test.cjs`, 7 cases:

- **`loadInstallExports` resolution (5):** marker honored; no-marker fallback; marker-resolves-but-`install.js`-absent fallback; no-`runtimeConfigDir` unchanged; stale-marker (path missing) fallback.
- **`getInstallExports` memoization (2):** a no-marker call must not poison a later marker-aware call; per-source memoization returns the cached instance.

The two memoization cases fail against an unkeyed single-slot cache and pass with the keyed cache. All 7 green; the broader surface/layout suite (195 tests across 10 files) stays green.

### Regression test added?

- [x] Yes — added a test that would have caught this bug

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

> Resolution is `path`-module based (`path.join` / `path.resolve` / `fs.existsSync`) and portable; the marker test writes a real platform path into the marker, so the macOS/Windows CI jobs exercise the cross-platform behavior.

### Runtimes tested

- [x] N/A (not runtime-specific) — install/surface plumbing, runtime-agnostic.

---

## Checklist

- [x] Issue linked above with `Fixes #1467`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass (`npm test`) — surface/layout + install-marker suites green; no new failures introduced
- [x] No unnecessary dependencies added

> `.changeset/` fragment: not required — the diff touches only `src/` and `tests/`, neither of which is in the changeset-lint user-facing set (the compiled `gsd-core/bin/lib/*.cjs` artifacts are gitignored). The lint returns `ok_no_user_facing_changes`.

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1476"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784538346&installation_id=134682257&pr_number=1476&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1476&signature=f4060821ba4771819ed09f851e2e6d45e8a6dff582316238c25fe76b2d9e7eaa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->