### PR TITLE
fix(#1477): write .gsd-source marker during Claude global install (fixes gsd-surface)

### DIFF
--- a/.changeset/humble-mice-snooze.md
+++ b/.changeset/humble-mice-snooze.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 1477
+---
+Write .gsd-source marker and ship bin/install.js on Claude global install so gsd surface subcommands resolve the skill source directory correctly

--- a/bin/install.js
+++ b/bin/install.js
@@ -9792,6 +9792,20 @@ function install(isGlobal, runtime = 'claude', options = {}) {
     const scope = isGlobal ? 'global' : 'local';
     installRuntimeArtifacts(runtime, targetDir, scope, _resolvedProfile);
 
+    // #1477 — Claude global only: write .gsd-source marker so findInstallSourceRoot
+    // can locate commands/gsd/ at runtime without requiring a repo checkout.
+    // The marker lives at <runtimeConfigDir>/.gsd-source and points at the
+    // canonical commands/gsd/ source tree inside the package (src/, not deployed).
+    if (runtime === 'claude' && isGlobal) {
+      const gsdSourcePath = path.join(src, 'commands', 'gsd');
+      fs.writeFileSync(
+        path.join(targetDir, '.gsd-source'),
+        gsdSourcePath + '\n',
+        'utf8',
+      );
+      console.log(`  ${green}✓${reset} Wrote .gsd-source marker`);
+    }
+
     // #1326 — Codex only: remove stale agents/openai.yaml sidecars from managed
     // gsd-* skill dirs. Prior installs wrote these files so Codex would show a
     // display name and description in the /skills TUI popup. Recent Codex builds
@@ -10223,6 +10237,24 @@ function install(isGlobal, runtime = 'claude', options = {}) {
     console.log(`  ${green}✓${reset} Wrote VERSION (${pkg.version})`);
   } else {
     failures.push('VERSION');
+  }
+
+  // #1477 — Claude global only: copy bin/install.js into gsd-core/bin/install.js so that
+  // loadInstallExports() in runtime-artifact-layout.cjs resolves correctly when called
+  // from the deployed skill tree (~/.claude/gsd-core/bin/lib/).
+  // Resolution order (see loadInstallExports in runtime-artifact-layout.cts):
+  //   1. co-located: ~/.claude/gsd-core/bin/install.js  ← shipped here
+  //   2. repo fallback: ../../../bin/install.js (gsd-core checkout, tests)
+  if (runtime === 'claude' && isGlobal) {
+    const installJsSrc = path.join(src, 'bin', 'install.js');
+    const installJsDest = path.join(targetDir, 'gsd-core', 'bin', 'install.js');
+    fs.mkdirSync(path.dirname(installJsDest), { recursive: true });
+    fs.copyFileSync(installJsSrc, installJsDest);
+    if (verifyFileInstalled(installJsDest, 'gsd-core/bin/install.js')) {
+      console.log(`  ${green}✓${reset} Installed gsd-core/bin/install.js`);
+    } else {
+      failures.push('gsd-core/bin/install.js');
+    }
   }
 
   if (!isCodex && !isCopilot && !isCursor && !isWindsurf && !isTrae && !isCline && !isKimi) {

--- a/src/runtime-artifact-layout.cts
+++ b/src/runtime-artifact-layout.cts
@@ -54,7 +54,14 @@ function loadInstallExports(): InstallExports {
   const savedTestMode = process.env['GSD_TEST_MODE'];
   if (savedTestMode === undefined) process.env['GSD_TEST_MODE'] = '1';
   try {
-    return _require('../../../bin/install.js') as InstallExports;
+    // #1477: Try the co-located copy first (gsd-core/bin/install.js — shipped by the
+    // installer into the deployed skill tree at ~/.claude/gsd-core/bin/install.js).
+    // Fall back to the repo-root path (../../../bin/install.js) which works when
+    // running inside the gsd-core package checkout (tests, local development).
+    const coLocated = path.join(__dirname, '..', 'install.js');
+    const repoRoot = path.join(__dirname, '..', '..', '..', 'bin', 'install.js');
+    const resolved = fs.existsSync(coLocated) ? coLocated : repoRoot;
+    return _require(resolved) as InstallExports;
   } finally {
     if (savedTestMode === undefined) delete process.env['GSD_TEST_MODE'];
     else process.env['GSD_TEST_MODE'] = savedTestMode;

--- a/tests/bug-1477-global-install-gsd-source-marker.test.cjs
+++ b/tests/bug-1477-global-install-gsd-source-marker.test.cjs
@@ -1,0 +1,172 @@
+/**
+ * Regression test for #1477: `gsd surface` broken on Claude Code global installs.
+ *
+ * Two bugs:
+ *
+ * 1. findInstallSourceRoot() never found commands/gsd/ on global Claude installs
+ *    because the installer never wrote the .gsd-source marker.
+ *    Fix: bin/install.js now writes <runtimeConfigDir>/.gsd-source pointing at
+ *    the source commands/gsd/ directory.
+ *
+ * 2. loadInstallExports() resolved '../../../bin/install.js' from the deployed
+ *    gsd-core/bin/lib/ path, which resolves to ~/.claude/bin/install.js —
+ *    a path that never exists. The installed copy lives at gsd-core/bin/install.js.
+ *    Fix: loadInstallExports() now tries the co-located path first
+ *    (gsd-core/bin/install.js) before the repo-root fallback.
+ */
+
+'use strict';
+
+process.env.GSD_TEST_MODE = '1';
+
+const { describe, test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const ROOT = path.join(__dirname, '..');
+const { install } = require('../bin/install.js');
+const { findInstallSourceRoot } = require('../gsd-core/bin/lib/runtime-artifact-layout.cjs');
+const { createTempDir, cleanup } = require('./helpers.cjs');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function silenceConsole(fn) {
+  const orig = { log: console.log, warn: console.warn, error: console.error };
+  console.log = () => {};
+  console.warn = () => {};
+  console.error = () => {};
+  try {
+    return fn();
+  } finally {
+    console.log = orig.log;
+    console.warn = orig.warn;
+    console.error = orig.error;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('bug-1477: Claude global install writes .gsd-source and ships install.js', () => {
+  let tmpRoot;
+  let claudeDir;
+  let savedHome;
+  let savedUserProfile;
+  let savedExplicitConfigDir;
+  let savedExit;
+
+  beforeEach(() => {
+    tmpRoot = createTempDir('gsd-1477-');
+    claudeDir = path.join(tmpRoot, '.claude');
+    fs.mkdirSync(claudeDir, { recursive: true });
+
+    // Redirect HOME so install() targets our temp dir.
+    savedHome = process.env.HOME;
+    savedUserProfile = process.env.USERPROFILE;
+    savedExplicitConfigDir = process.env.GSD_EXPLICIT_CONFIG_DIR;
+    process.env.HOME = tmpRoot;
+    process.env.USERPROFILE = tmpRoot;
+    delete process.env.GSD_EXPLICIT_CONFIG_DIR;
+
+    // Prevent install() from killing the test process on error.
+    savedExit = process.exit;
+    process.exit = (code) => {
+      throw new Error(`process.exit(${code}) called during install — unexpected`);
+    };
+
+    silenceConsole(() => {
+      install(true /* isGlobal */, 'claude');
+    });
+  });
+
+  afterEach(() => {
+    process.exit = savedExit;
+    process.env.HOME = savedHome;
+    if (savedUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = savedUserProfile;
+    if (savedExplicitConfigDir === undefined) delete process.env.GSD_EXPLICIT_CONFIG_DIR;
+    else process.env.GSD_EXPLICIT_CONFIG_DIR = savedExplicitConfigDir;
+    try { cleanup(tmpRoot); } catch { /* best-effort */ }
+  });
+
+  // ── Failure 1: .gsd-source marker ─────────────────────────────────────────
+
+  test('installer writes .gsd-source to runtimeConfigDir (~/.claude)', () => {
+    const markerPath = path.join(claudeDir, '.gsd-source');
+    assert.ok(
+      fs.existsSync(markerPath),
+      `.gsd-source must exist at ${markerPath} after Claude global install`,
+    );
+  });
+
+  test('.gsd-source contains a valid path to commands/gsd/', () => {
+    const markerPath = path.join(claudeDir, '.gsd-source');
+    const content = fs.readFileSync(markerPath, 'utf8').trim();
+    assert.ok(content.length > 0, '.gsd-source must not be empty');
+    assert.ok(
+      fs.existsSync(content),
+      `.gsd-source content must point to an existing directory: ${content}`,
+    );
+    // Must point at commands/gsd/ (the source skill directory)
+    assert.ok(
+      content.endsWith(path.join('commands', 'gsd')) || content.endsWith(`commands${path.sep}gsd`),
+      `.gsd-source must end with commands/gsd, got: ${content}`,
+    );
+  });
+
+  test('findInstallSourceRoot(claudeDir) resolves via .gsd-source without throwing', () => {
+    let resolved;
+    assert.doesNotThrow(() => {
+      resolved = findInstallSourceRoot(claudeDir);
+    }, 'findInstallSourceRoot must not throw after global Claude install');
+    assert.ok(fs.existsSync(resolved), `findInstallSourceRoot returned non-existent path: ${resolved}`);
+  });
+
+  // ── Failure 2: install.js co-located copy ─────────────────────────────────
+
+  test('installer copies bin/install.js to gsd-core/bin/install.js', () => {
+    const installJsDest = path.join(claudeDir, 'gsd-core', 'bin', 'install.js');
+    assert.ok(
+      fs.existsSync(installJsDest),
+      `gsd-core/bin/install.js must exist at ${installJsDest} after Claude global install`,
+    );
+  });
+
+  test('deployed gsd-core/bin/install.js is a valid JS file (has exports)', () => {
+    const installJsDest = path.join(claudeDir, 'gsd-core', 'bin', 'install.js');
+    const content = fs.readFileSync(installJsDest, 'utf8');
+    // install.js must export `install` and `installRuntimeArtifacts`
+    assert.ok(
+      content.includes('installRuntimeArtifacts') || content.includes('module.exports'),
+      'deployed install.js must contain installRuntimeArtifacts or module.exports',
+    );
+  });
+
+  test('deployed gsd-core/bin/install.js path is co-located so loadInstallExports() resolves it', () => {
+    // loadInstallExports() in runtime-artifact-layout.cjs resolves the co-located
+    // path first: path.join(__dirname, '..', 'install.js') where __dirname is the
+    // deployed gsd-core/bin/lib/. That resolves to gsd-core/bin/install.js.
+    // The file must exist and be the canonical gsd-core install.js (same inode/content).
+    const coLocatedInstallJs = path.join(claudeDir, 'gsd-core', 'bin', 'install.js');
+    const repoInstallJs = path.join(ROOT, 'bin', 'install.js');
+
+    assert.ok(
+      fs.existsSync(coLocatedInstallJs),
+      `co-located install.js must exist at ${coLocatedInstallJs} for loadInstallExports() to resolve`,
+    );
+
+    // File sizes must match — ensures it's a real copy, not a stub.
+    const deployedSize = fs.statSync(coLocatedInstallJs).size;
+    const sourceSize = fs.statSync(repoInstallJs).size;
+    assert.strictEqual(
+      deployedSize,
+      sourceSize,
+      `deployed gsd-core/bin/install.js size (${deployedSize}) must match source bin/install.js (${sourceSize})`,
+    );
+  });
+});


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #1477

---

## What was broken

`gsd surface` (all subcommands: `list`, `status`, `profile`, `disable`, `enable`, `reset`) was completely broken on Claude Code global installs. Two distinct failures:

1. `findInstallSourceRoot()` could not locate `commands/gsd/` because the installer never wrote the `.gsd-source` marker to `~/.claude/`. The walk-up fallback also failed because the deployed skill tree (`~/.claude/gsd-core/`) has no `commands/gsd/` subtree.

2. `loadInstallExports()` in `runtime-artifact-layout.cjs` resolved `../../../bin/install.js` relative to the deployed `~/.claude/gsd-core/bin/lib/`, which pointed to `~/.claude/bin/install.js` — a path that never exists.

## What this fix does

**Failure 1:** `bin/install.js` now writes `<runtimeConfigDir>/.gsd-source` (i.e. `~/.claude/.gsd-source`) containing the absolute path to the source `commands/gsd/` directory during every Claude global install. `findInstallSourceRoot()` checks this marker as step 1, so it resolves correctly on all global installs.

**Failure 2:** `bin/install.js` now copies itself to `~/.claude/gsd-core/bin/install.js` during Claude global installs. `loadInstallExports()` in `runtime-artifact-layout.cts` now tries the co-located path (`path.join(__dirname, '..', 'install.js')` = `gsd-core/bin/install.js`) first, falling back to the repo-root path (`../../../bin/install.js`) for tests and local development.

## Root cause

PR #1476 added the `.gsd-source` reader in `findInstallSourceRoot` (step 1) but did not add the corresponding writer in the install path. The walk-up fallback (step 2) cannot succeed on global installs because the deployed `~/.claude/gsd-core/` subtree only contains `bin/`, `contexts/`, `references/`, `templates/`, `workflows/` — no `commands/gsd/`. Similarly, `loadInstallExports` was written assuming the caller always runs from the package source tree, but this is not true for the deployed `gsd-core/bin/lib/*.cjs` modules.

This PR is the writer-side complement to PR #1476 (reader side).

## Testing

### How I verified the fix

Added regression tests in `tests/bug-1477-global-install-gsd-source-marker.test.cjs` that simulate a real Claude global install to a temp dir and assert:

- `.gsd-source` marker is written to `~/.claude/`
- The marker content is a valid path pointing to `commands/gsd/`
- `findInstallSourceRoot(claudeDir)` resolves without throwing
- `gsd-core/bin/install.js` is present in the install output
- The deployed `install.js` is a full copy of the source (size matches)

All 6 tests pass.

### Regression test added?

- [x] Yes — added a test that would have caught this bug

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1486"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784557073&installation_id=134682257&pr_number=1486&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1486&signature=c44c65b87624a5c801c3a2f93e981e933f32a1bc6f829ef3de4e37b63ef41746"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->