### PR TITLE
fix(#1498): regenerate capability-registry.cjs in npm version lifecycle hook

### DIFF
--- a/.changeset/patient-tunas-jump.md
+++ b/.changeset/patient-tunas-jump.md
@@ -1,6 +1,6 @@
 ---
 type: Fixed
-pr: 0
+pr: 1499
 ---
 **`npm version` no longer leaves `capability-registry.cjs` stale** — the `version` npm lifecycle script now regenerates and stages the capability registry after stamping new version strings into all capability manifests, preventing the 1.6.0-rc regression where `gen-capability-registry.cjs --check` failed. (#1498)
 

--- a/.changeset/patient-tunas-jump.md
+++ b/.changeset/patient-tunas-jump.md
@@ -1,0 +1,7 @@
+---
+type: Fixed
+pr: 0
+---
+**`npm version` no longer leaves `capability-registry.cjs` stale** — the `version` npm lifecycle script now regenerates and stages the capability registry after stamping new version strings into all capability manifests, preventing the 1.6.0-rc regression where `gen-capability-registry.cjs --check` failed. (#1498)
+
+<!-- docs-exempt: internal release-tooling fix; no user-facing command or API change -->

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "gen:capability-registry": "node scripts/gen-capability-registry.cjs --write",
     "prepack": "npm run build:lib",
     "prepare": "npm run build:lib",
-    "version": "node scripts/sync-manifest-versions.cjs --stage",
+    "version": "node scripts/sync-manifest-versions.cjs --stage && node scripts/gen-capability-registry.cjs --write && git add gsd-core/bin/lib/capability-registry.cjs",
     "prepublishOnly": "npm run build:lib && npm run build:hooks",
     "pretest": "npm run build:lib && npm run lint:skill-deps",
     "pretest:coverage": "npm run build:lib && npm run lint:skill-deps",

--- a/tests/issue-844-manifest-version-sync.test.cjs
+++ b/tests/issue-844-manifest-version-sync.test.cjs
@@ -341,3 +341,33 @@ describe('D: CLI --check exits 0 when manifests are in sync', () => {
     );
   });
 });
+
+// ─── F: version script includes capability-registry regen (#1498) ─────────────
+//
+// Regression guard for #1498: the `npm version` lifecycle script must regenerate
+// capability-registry.cjs after stamping capability manifests. Without this,
+// `npm version X.Y.Z` leaves the committed registry stale (capability JSONs get
+// new version strings but the registry still has the old ones), causing the
+// `gen-capability-registry.cjs --check` test to fail in the RC workflow.
+describe('F: npm version script includes gen-capability-registry --write (#1498)', () => {
+
+  test('package.json "version" script regenerates capability-registry.cjs after syncing manifests', () => {
+    const pkg = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8'));
+    const versionScript = pkg.scripts && pkg.scripts.version;
+    assert.ok(
+      typeof versionScript === 'string',
+      'package.json must have a "version" script',
+    );
+    assert.ok(
+      versionScript.includes('gen-capability-registry.cjs --write'),
+      'package.json "version" script must include "gen-capability-registry.cjs --write" to keep the registry in sync after npm version bumps capability manifests. ' +
+      'Got: ' + JSON.stringify(versionScript),
+    );
+    assert.ok(
+      versionScript.includes('git add') && versionScript.includes('capability-registry.cjs'),
+      'package.json "version" script must stage capability-registry.cjs with "git add" so it is included in the version-bump commit. ' +
+      'Got: ' + JSON.stringify(versionScript),
+    );
+  });
+
+});


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #1498

---

## What was broken

The `npm version` lifecycle script (`package.json` `"version"` key) stamped all `capabilities/*/capability.json` files with the new version number (via `scripts/sync-manifest-versions.cjs --stage`) but did **not** regenerate `gsd-core/bin/lib/capability-registry.cjs`. The registry embeds the full capability objects including their `version` fields, so after `npm version X.Y.Z-rc.N`, the committed registry still contained old version strings while all the capability JSONs had the new version — making `gen-capability-registry.cjs --check` fail.

This caused the 1.6.0-rc.1 "Install and test" CI step to fail with:
```
AssertionError [ERR_ASSERTION]: gen-capability-registry.cjs --check failed — committed capability-registry.cjs is stale.
```

## What this fix does

Extends `package.json`'s `"version"` lifecycle script to also:
1. Regenerate `capability-registry.cjs` with the new version strings embedded
2. Stage the updated registry with `git add` so it lands in the same version-bump commit

The new version script is:
```
node scripts/sync-manifest-versions.cjs --stage && node scripts/gen-capability-registry.cjs --write && git add gsd-core/bin/lib/capability-registry.cjs
```

## Root cause

The `"version"` npm lifecycle hook was added in #844 to keep runtime-integration manifests in sync during `npm version`. ADR-1244 D6 extended it to also sweep `capabilities/*/capability.json` files. However, `capability-registry.cjs` (which embeds all capability versions) was not added to this sweep. Every release bump produced a stale registry.

## Testing

### How I verified the fix

1. Checked out the version-bump commit `e0c674f02a` (the first RC's failing state)
2. Confirmed `gen-capability-registry.cjs --check` exits 1 (stale)
3. Applied the fix and confirmed the check exits 0

The new `describe F` test in `tests/issue-844-manifest-version-sync.test.cjs` asserts that `package.json`'s `"version"` script includes both `gen-capability-registry.cjs --write` and the corresponding `git add` for the registry file.

### Regression test added?

- [x] Yes — added `describe F` to `tests/issue-844-manifest-version-sync.test.cjs` (test verifies the `package.json` `"version"` script contains the registry regen command)

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #1498` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (describe F in tests/issue-844-manifest-version-sync.test.cjs)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/patient-tunas-jump.md` fragment added (type: Fixed, with docs-exempt marker)
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1499"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784573520&installation_id=134682257&pr_number=1499&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1499&signature=4b011a84e63abd0e5d85708399bf4dc4c3b8296acb3ab3dc866ea767a0ffe42a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->