### PR TITLE
fix(#1501): build:lib before npm version in release workflow (capability-registry hook)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,7 @@ jobs:
     needs: validate-version
     if: inputs.action == 'create'
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     permissions:
       contents: write
     steps:
@@ -118,6 +118,10 @@ jobs:
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+
+      - name: Install dependencies and build
+        run: npm ci --silent && npm run build:lib
 
       - name: Check branch doesn't already exist
         env:
@@ -358,6 +362,9 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+      - name: Install dependencies and build
+        run: npm ci --silent && npm run build:lib
+
       - name: Bump to pre-release version
         env:
           PRE_VERSION: ${{ steps.prerelease.outputs.pre_version }}
@@ -522,6 +529,9 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Install dependencies and build
+        run: npm ci --silent && npm run build:lib
 
       - name: Set final version
         env:


### PR DESCRIPTION
## Description

The `npm version` lifecycle hook (added in #1499) runs `gen-capability-registry.cjs --write`, which requires `gsd-core/bin/lib/capability-ledger.cjs` — a gitignored `build:lib` / `tsc` output artifact. In the release workflow, `npm version` was running **before** any `npm ci` or `build:lib`, so `capability-ledger.cjs` didn't exist and all fragment reads silently failed (the fail-closed fallback from #1459 returns `null` for every missing bounded-reader, producing `"could not be read"` errors for every fragment).

This fix adds `npm ci --silent && npm run build:lib` as a step before `npm version` in all three affected jobs (`create`, `rc`, `finalize`). The hotfix path inside `create` is covered by the same step.

## Root cause

`capability-validator.cjs` lazily requires `capability-ledger.cjs` inside `materializeHookFragments()`. When `capability-ledger.cjs` is absent (not yet built), the fallback in `capability-validator.cjs` returns `null` for every fragment path instead of throwing, causing 100% of fragment validation to report failure even though the fragment files themselves exist on disk.

## Fix

`.github/workflows/release.yml` changes:

- **`create` job**: added `cache: 'npm'` to `setup-node`; added `Install dependencies and build` step (`npm ci --silent && npm run build:lib`) before the existing `Check branch doesn't already exist` step; bumped `timeout-minutes` from 5 to 10
- **`rc` job**: added `Install dependencies and build` step between `Configure git identity` and `Bump to pre-release version`
- **`finalize` job**: added `Install dependencies and build` step between `Configure git identity` and `Set final version`

The `rc` and `finalize` jobs retain their existing `npm ci` inside `Install and test` — that run is still needed post-version-bump to pick up any `package-lock.json` changes.

## Test plan

- [ ] Verify `node scripts/gen-capability-registry.cjs --write` succeeds after `npm ci && npm run build:lib` (confirmed locally — outputs `Wrote .../capability-registry.cjs` with no fragment errors)
- [ ] Trigger an RC run of the release workflow and confirm the `Bump to pre-release version` step does not produce `capability validation failed` errors
- [ ] Confirm the `create` and `finalize` jobs pass with the new pre-build step

Closes #1501

<!-- docs-exempt: internal release workflow change, no user-visible behavior -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1502"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784575880&installation_id=134682257&pr_number=1502&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1502&signature=92f23018f53d0c4ae3def24404e6979f5246e28cf2a9ba846c40b84b944a9ee0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->