### PR TITLE
fix(#1493): read workflow.drift_action/drift_threshold from nested config shape in verify.cts

### DIFF
--- a/.changeset/lively-orcas-roam.md
+++ b/.changeset/lively-orcas-roam.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 1504
+---
+`verify codebase-drift` now reads `workflow.drift_action` and `workflow.drift_threshold` from the correct nested config shape — previously both keys silently no-oped because `loadConfig()` returns a flattened object and `config?.workflow` was always `undefined`.

--- a/src/verify.cts
+++ b/src/verify.cts
@@ -2210,8 +2210,18 @@ function cmdVerifyCodebaseDrift(cwd: string, raw: boolean): void {
       else if (status === 'D') deleted.push(file);
     }
 
-    const config = loadConfig(cwd);
-    const wf = config?.workflow as Record<string, unknown> | undefined;
+    // loadConfig() returns a flattened object — there is no nested `workflow`
+    // key. Read the raw config.json directly to access workflow-scoped keys,
+    // matching the pattern used in check-command-router.cts:readWorkflowConfig.
+    let wf: Record<string, unknown> | undefined;
+    try {
+      const rawCfg = JSON.parse(
+        fs.readFileSync(path.join(planningDir(cwd), 'config.json'), 'utf-8'),
+      ) as Record<string, unknown>;
+      wf = rawCfg['workflow'] as Record<string, unknown> | undefined;
+    } catch {
+      wf = undefined;
+    }
     const threshold =
       Number.isInteger(wf?.drift_threshold) && (wf?.drift_threshold as number) >= 1
         ? (wf?.drift_threshold as number)

--- a/tests/drift-detection.test.cjs
+++ b/tests/drift-detection.test.cjs
@@ -720,3 +720,77 @@ describe('verify codebase-drift CLI', () => {
     }
   });
 });
+
+// ─── Regression #1493 — workflow.drift_action / drift_threshold read from nested config shape ───
+//
+// loadConfig() returns a flattened object; config?.workflow was always undefined,
+// making drift_action permanently 'warn' and drift_threshold always 3 regardless
+// of .planning/config.json contents. Fix reads the raw nested JSON directly.
+
+describe('verify codebase-drift — workflow config read from nested shape (#1493)', () => {
+  let tmp;
+  beforeEach(() => {
+    tmp = createTempGitProject('gsd-drift-1493-');
+    fs.mkdirSync(path.join(tmp, '.planning', 'codebase'), { recursive: true });
+  });
+  afterEach(() => cleanup(tmp));
+
+  test('workflow.drift_action=auto-remap in config.json is honored (not always warn) (#1493)', () => {
+    // Write config with nested workflow shape — the flat loadConfig() path would
+    // have silently dropped this, leaving action === 'warn'.
+    fs.writeFileSync(
+      path.join(tmp, '.planning', 'config.json'),
+      JSON.stringify({ workflow: { drift_action: 'auto-remap', drift_threshold: 1 } }, null, 2),
+    );
+
+    // Map codebase to current HEAD so anything committed next is "new" drift.
+    const structure = path.join(tmp, '.planning', 'codebase', 'STRUCTURE.md');
+    fs.writeFileSync(structure, '# Codebase Structure\n\n- `src/`\n');
+    writeMappedCommit(structure, git(tmp, 'rev-parse', 'HEAD'), '2026-04-22');
+    git(tmp, 'add', '-A');
+    git(tmp, 'commit', '-m', 'map codebase');
+
+    // Add one structural barrel file — enough to exceed drift_threshold of 1.
+    const dir = path.join(tmp, 'packages', 'ui', 'src');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'index.ts'), 'export {};\n');
+    git(tmp, 'add', '-A');
+    git(tmp, 'commit', '-m', 'add package barrel');
+
+    const r = runGsdTools(['verify', 'codebase-drift'], tmp);
+    assert.strictEqual(r.success, true, r.error);
+    const data = JSON.parse(r.output);
+    assert.strictEqual(
+      data.action, 'auto-remap',
+      'workflow.drift_action=auto-remap must flow through from nested config; "warn" means the flat-shape bug is still active',
+    );
+  });
+
+  test('workflow.drift_threshold in config.json gates triggering (#1493)', () => {
+    // Threshold of 100 — 1 structural file should not trigger action_required.
+    fs.writeFileSync(
+      path.join(tmp, '.planning', 'config.json'),
+      JSON.stringify({ workflow: { drift_action: 'auto-remap', drift_threshold: 100 } }, null, 2),
+    );
+
+    const structure = path.join(tmp, '.planning', 'codebase', 'STRUCTURE.md');
+    fs.writeFileSync(structure, '# Codebase Structure\n\n- `src/`\n');
+    writeMappedCommit(structure, git(tmp, 'rev-parse', 'HEAD'), '2026-04-22');
+    git(tmp, 'add', '-A');
+    git(tmp, 'commit', '-m', 'map codebase');
+
+    const dir = path.join(tmp, 'packages', 'ui', 'src');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'index.ts'), 'export {};\n');
+    git(tmp, 'add', '-A');
+    git(tmp, 'commit', '-m', 'add one package barrel');
+
+    const r = runGsdTools(['verify', 'codebase-drift'], tmp);
+    assert.strictEqual(r.success, true, r.error);
+    const data = JSON.parse(r.output);
+    assert.strictEqual(data.threshold, 100,
+      'workflow.drift_threshold=100 must be read from nested config; 3 means the flat-shape bug is still active');
+    assert.strictEqual(data.action_required, false,
+      '1 structural file must not exceed threshold of 100');
+  });
+});


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #1493

## What was broken

`workflow.drift_action` and `workflow.drift_threshold` silently no-op for all users — `verify codebase-drift` always defaulted to `action: 'warn'` and `threshold: 3` regardless of `.planning/config.json` contents.

## What this fix does

Replaces the `loadConfig(cwd)` + `config?.workflow` read in `cmdVerifyCodebaseDrift` with a direct raw JSON parse of `.planning/config.json`, then accesses `['workflow']` on the nested object. This matches the established pattern in `check-command-router.cts:readWorkflowConfig`.

## Root cause

`loadConfig()` returns a **flattened** object — there is no nested `workflow` key. `config?.workflow` was therefore always `undefined`, making every downstream guard (`wf?.drift_action === 'auto-remap'`, `wf?.drift_threshold`) permanently false. The consumer branch existed in source but was structurally unreachable.

## Testing

### How I verified the fix

Two behavioral regression tests added to `tests/drift-detection.test.cjs` in the new `verify codebase-drift — workflow config read from nested shape (#1493)` describe block:

1. **`workflow.drift_action=auto-remap` is honored** — writes `{ workflow: { drift_action: 'auto-remap', drift_threshold: 1 } }` to config, adds a structural barrel file past threshold, asserts `data.action === 'auto-remap'`. Would return `'warn'` under the old code.
2. **`workflow.drift_threshold` gates triggering** — sets threshold to 100, adds 1 file, asserts `data.threshold === 100` and `data.action_required === false`. Would return `threshold: 3` under the old code.

Both tests pass. Full `drift-detection.test.cjs` suite: 58/58 pass.

### Regression test added?

- [x] Yes — added two behavioral tests that would have caught this bug

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [x] N/A (not platform-specific — pure JSON read, no path divergence)

### Runtimes tested

- [x] N/A (not runtime-specific — `verify codebase-drift` is a CLI subcommand, not a workflow step)

---

## Checklist

- [x] Issue linked above with `Fixes #1493`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (two behavioral tests)
- [x] All existing tests pass (58/58 in `drift-detection.test.cjs`)
- [x] `.changeset/lively-orcas-roam.md` added (Fixed, PR 1504)
- [x] No unnecessary dependencies added

## Breaking changes

None — this restores documented behavior; the old code silently ignored the configured values.