### PR TITLE
fix(#1545): make no-phantom-issue-refs walk() robust to broken symlinks

### DIFF
--- a/tests/no-phantom-issue-refs.test.cjs
+++ b/tests/no-phantom-issue-refs.test.cjs
@@ -11,6 +11,7 @@ const { test } = require('node:test');
 const assert = require('node:assert');
 const fs = require('node:fs');
 const path = require('node:path');
+const os = require('node:os');
 
 const ROOT = path.resolve(__dirname, '..');
 
@@ -32,7 +33,10 @@ function walk(dir, acc) {
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
     if (entry.isDirectory()) {
       if (!SKIP_DIRS.has(entry.name)) walk(path.join(dir, entry.name), acc);
-    } else if (SCAN_EXT.has(path.extname(entry.name))) {
+    // entry.isFile() excludes symlinks (and other non-regular dirents) so a broken symlink like
+    // a gitignored CLAUDE.md worktree symlink is skipped deterministically on every platform —
+    // it can't be read and isn't shipped repo text (#1545).
+    } else if (entry.isFile() && SCAN_EXT.has(path.extname(entry.name))) {
       acc.push(path.join(dir, entry.name));
     }
   }
@@ -55,4 +59,42 @@ test('no phantom pre-migration issue references remain in repo text (#1073)', ()
     `Phantom issue refs (${PHANTOM.map((n) => '#' + n).join('/')}) found — repoint to a real ` +
       `successor (#717/#720) or rewrite as prose (see #1073):\n` + offenders.join('\n'),
   );
+});
+
+test('walk() skips broken symlinks and does not throw ENOENT (#1545)', (t) => {
+  const fixture = fs.mkdtempSync(path.join(os.tmpdir(), 'nophantom-symlink-'));
+  let symlinkCreated = false;
+  try {
+    fs.writeFileSync(path.join(fixture, 'real.md'), '# real, no phantom refs\n');
+    try {
+      fs.symlinkSync(
+        path.join(fixture, 'does-not-exist-target'),
+        path.join(fixture, 'broken.md'),
+      );
+      // Verify the symlink actually exists (lstat succeeds even for dangling symlinks)
+      fs.lstatSync(path.join(fixture, 'broken.md'));
+      symlinkCreated = true;
+    } catch (e) {
+      // Windows without symlink privilege — genuine skip
+    }
+
+    if (!symlinkCreated) {
+      t.skip('platform cannot create symlinks unprivileged');
+      return;
+    }
+
+    const found = walk(fixture, []).map((f) => path.basename(f));
+
+    assert.ok(found.includes('real.md'), 'walk() must include real.md');
+    assert.ok(!found.includes('broken.md'), 'walk() must NOT include broken.md (broken symlink)');
+
+    // Mirror the production read loop — must not throw ENOENT
+    assert.doesNotThrow(
+      () => found.length && walk(fixture, []).forEach((fp) => fs.readFileSync(fp, 'utf8')),
+      'readFileSync on every walk() result must not throw (no broken symlinks returned)',
+    );
+  } finally {
+    // eslint-disable-next-line local/no-raw-rmsync-in-tests -- local cleanup in standalone guard test; no helpers import available (would introduce a test-dep cycle)
+    fs.rmSync(fixture, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #1545

## What was broken

`tests/no-phantom-issue-refs.test.cjs` (the #1073 phantom-ref guard) crashed with `ENOENT` under `gsd-test` Docker when run from a worktree. `walk()` collected dirents by extension only and `readFileSync`'d each, so a broken `*.md` symlink — the gitignored `CLAUDE.md` worktree symlink whose target is absent inside the container — threw on read.

## What this fix does

Guards `walk()`'s collection with `entry.isFile()`, so symlinks (and other non-regular dirents) are skipped deterministically on every platform. Gitignored files are not shipped repo text, so excluding `CLAUDE.md` is correct.

## Root cause

`Dirent` from `readdirSync({ withFileTypes: true })` reports the dirent type **without** following symlinks; the old extension-only filter collected the broken symlink, and the unguarded `readFileSync` followed it → `ENOENT`. It passed on a developer Mac (the symlink resolves) and in GitHub CI (`CLAUDE.md` is gitignored/absent), failing **only** on the gsd-test-docker-from-worktree path — a real error hiding behind the local environment, not a flake (it reproduced deterministically on two consecutive full runs).

## Testing

### How I verified the fix

- Strict TDD: the new regression test fails before the fix (`walk() must NOT include broken.md`) and passes after.
- Full `gsd-test` Docker (Linux) suite green after the fix — the single `ENOENT` failure is gone, no new failures.
- `npm run lint` clean; `node --test tests/no-phantom-issue-refs.test.cjs` → 2/2 pass.

### Regression test added?

- [x] Yes — a deterministic dangling-`*.md`-symlink fixture asserts `walk()` excludes the broken symlink and the production read loop never throws. Windows-symlink-unprivileged is a genuine `t.skip` (not a silent pass); the fix itself is platform-agnostic.

### Platforms tested

- [x] macOS (local `node --test`)
- [x] Linux (`gsd-test` Docker)
- [ ] Windows (regression test self-skips where symlink creation is unprivileged; `entry.isFile()` is platform-agnostic)

### Runtimes tested

- [x] N/A (test-suite robustness, not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #1545`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass (full `gsd-test` Docker)
- [x] `no-changelog` label applied (test-only, no user-facing change)
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1546"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784660409&installation_id=134682257&pr_number=1546&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1546&signature=44512764c247bffbf2363cd82c8501dda56499bd19a8f06e03ff116c6d01f1d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->