### PR TITLE
docs(#1553): document issue-number scope convention for commit titles

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -834,7 +834,7 @@ Defensive normalization at trust boundaries must validate both the value's type 
 
 - **CommonJS** (`.cjs`) — the project uses `require()`, not ESM `import`
 - **No external dependencies in core** — `gsd-tools.cjs` and all lib files use only Node.js built-ins
-- **Conventional commits** — `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `ci:`
+- **Conventional commits** — `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `ci:`. The full grammar is `<type>(<scope>): <subject>` (enforced by `hooks/gsd-validate-commit.sh`; subject ≤72 chars, lowercase, imperative mood, no trailing period). When the work resolves a tracked issue, put the issue number in the scope: `fix(#1520): randomize mktemp temp paths on BSD/macOS`. The same convention applies to PR titles — release notes are grouped by the title's type prefix (`feat` → Feature, `fix` → Fix, everything else → Enhancement).
 
 ## File Structure
 


### PR DESCRIPTION
## Enhancement PR

## Linked Issue

Closes #1553

The linked issue carries the `approved-enhancement` label.

---

## What this enhancement improves

Documents the project's `<type>(#<issue>):` title convention in `CONTRIBUTING.md` (Code Style → "Conventional commits"). The issue-number-in-scope pattern was used everywhere in practice but documented nowhere.

## Before / After

**Before:**
```
- **Conventional commits** — `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `ci:`
```
Only the type prefix was documented; the `(<scope>)` grammar and the convention of putting the issue number in the scope were undocumented, discoverable only by reading existing commits/PRs (e.g. PR #1550 `fix(#1520): …`, ADR 415 `fix(#160)`).

**After:**
The bullet now documents the full `<type>(<scope>): <subject>` grammar (enforced by `hooks/gsd-validate-commit.sh`), the issue-number-in-scope convention with a worked example, and that PR titles follow the same rule (release notes group by type prefix).

## How it was implemented

Single-line expansion of the existing "Conventional commits" bullet in `CONTRIBUTING.md`. No code or behavior change.

## Testing

### How I verified the enhancement works

Docs-only change; rendered Markdown reviewed. No test surface.

### Platforms tested

- [x] N/A (not platform-specific)

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue — no additions or removals
- [x] If scope changed during implementation, I updated the issue and got re-approval before continuing

---

## Documentation

- [x] If genuinely no user-facing docs impact — `CONTRIBUTING.md` is contributor guidance, not a `docs/`-gated changeset path, so no changeset/`docs/` update is required. `no-changelog` label applied.

## Checklist

- [x] Issue linked above with `Closes #NNN`
- [x] Linked issue has the `approved-enhancement` label
- [x] Changes are scoped to the approved enhancement — nothing extra included
- [x] All existing tests pass (no test surface — docs only)
- [ ] New or updated tests cover the enhanced behavior (N/A — docs only)
- [x] `no-changelog` label applied (CONTRIBUTING.md is not a changeset-gated path)
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1554"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784665391&installation_id=134682257&pr_number=1554&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1554&signature=073cdfa31f2c0e7c78233191cc6b74fc1eda2c26b1205756164466ccc3710202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->