### PR TITLE
refactor(#1556): wire installRuntimeArtifacts to install plan

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -364,6 +364,9 @@ const {
   resolveRuntimeArtifactLayout,
 } = require(path.join(_gsdLibDir, 'runtime-artifact-layout.cjs'));
 const {
+  createRuntimeArtifactInstallPlan,
+} = require(path.join(_gsdLibDir, 'runtime-artifact-install-plan.cjs'));
+const {
   planLegacyCleanup,
   applyLegacyCleanup,
 } = require(path.join(__dirname, '..', 'gsd-core', 'bin', 'lib', 'legacy-cleanup.cjs'));
@@ -7008,36 +7011,25 @@ function installRuntimeArtifacts(runtime, configDir, scope, resolvedProfile) {
   _runLegacyInstallMigrations(runtime, configDir, scope);
 
   const layout = resolveRuntimeArtifactLayout(runtime, configDir, scope);
-
-  // Compute pathPrefix once for the rewrite step (same derivation as the
-  // top-level install() function).
-  const _resolvedTarget = path.resolve(configDir).replace(/\\/g, '/');
-  const _homeDir = os.homedir().replace(/\\/g, '/');
-  const pathPrefix = computePathPrefix({
-    isGlobal: scope === 'global',
-    isOpencode: runtime === 'opencode',
-    isWindowsHost: process.platform === 'win32',
-    resolvedTarget: _resolvedTarget,
-    homeDir: _homeDir,
+  const planResult = createRuntimeArtifactInstallPlan({
+    layout,
+    resolvedProfile,
+    homedir: () => os.homedir(),
+    platform: process.platform,
+    resolveAttribution: getCommitAttribution,
   });
 
-  for (const kind of layout.kinds) {
-    const staged = kind.stage(resolvedProfile);
-    // stagedForCopy: the directory to copy from (may differ from staged if rewrites
-    // produce a temp copy — see applyRuntimeContentRewritesForCommandsInPlace).
-    let stagedForCopy = staged;
-    const isGlobal = scope === 'global';
-    if (kind.kind === 'skills' || kind.kind === 'kimi-agents') {
-      applyRuntimeContentRewritesInPlace(staged, runtime, pathPrefix, isGlobal, getCommitAttribution(runtime));
-    } else if (kind.kind === 'commands') {
-      // Returns a temp dir with rewritten content so source files are never mutated.
-      stagedForCopy = applyRuntimeContentRewritesForCommandsInPlace(staged, runtime, pathPrefix, isGlobal, getCommitAttribution(runtime));
+  const cleanupDirs = planResult.ok ? planResult.plan.cleanupDirs : planResult.cleanupDirs;
+  try {
+    if (!planResult.ok) {
+      throw new Error(planResult.message);
     }
-    // applyRuntimeContentRewritesForCommandsInPlace() returns a fresh mkdtemp dir under
-    // os.tmpdir() (gsd-cmd-rewrites-*); remove it once copied so it does not accumulate (#856).
-    const tempToClean = stagedForCopy !== staged ? stagedForCopy : null;
-    try {
-      const dest = path.join(layout.configDir, kind.destSubpath);
+
+    const kindsByName = new Map(layout.kinds.map((kind) => [kind.kind, kind]));
+    for (const item of planResult.plan.items) {
+      const kind = kindsByName.get(item.kind);
+      if (!kind) throw new Error(`Install plan returned unknown artifact kind: ${item.kind}`);
+      const dest = item.destDir;
       fs.mkdirSync(dest, { recursive: true });
       if (kind.kind === 'skills' && fs.existsSync(dest)) {
         // Pre-prune: snapshot user-owned content before _removeGsdEntries wipes it,
@@ -7064,7 +7056,7 @@ function installRuntimeArtifacts(runtime, configDir, scope, resolvedProfile) {
         }
 
         _removeGsdEntries(dest, kind);
-        _copyStaged(stagedForCopy, dest, kind);
+        _copyStaged(item.sourceDir, dest, kind);
 
         // Restore user-owned dirs after the prune+copy
         for (const [dirName, snap] of toPreserve) {
@@ -7074,12 +7066,12 @@ function installRuntimeArtifacts(runtime, configDir, scope, resolvedProfile) {
         // For non-skills kinds (commands, agents): no user content to preserve;
         // just prune stale gsd-* entries and copy new ones.
         _removeGsdEntries(dest, kind);
-        _copyStaged(stagedForCopy, dest, kind);
+        _copyStaged(item.sourceDir, dest, kind);
       }
-    } finally {
-      if (tempToClean) {
-        try { fs.rmSync(tempToClean, { recursive: true, force: true }); } catch { /* best-effort */ }
-      }
+    }
+  } finally {
+    for (const dir of cleanupDirs) {
+      try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* best-effort */ }
     }
   }
 

--- a/tests/install-runtime-artifacts.test.cjs
+++ b/tests/install-runtime-artifacts.test.cjs
@@ -46,7 +46,90 @@ const REAL_COMMANDS_DIR = path.join(__dirname, '..', 'commands', 'gsd');
 const MANIFEST = loadSkillsManifest(REAL_COMMANDS_DIR);
 const RESOLVED_CORE = resolveProfile({ modes: ['core'], manifest: MANIFEST });
 
+function loadFreshInstallerWithInstallPlanStub(stub) {
+  const installPath = require.resolve('../bin/install.js');
+  const planPath = require.resolve('../gsd-core/bin/lib/runtime-artifact-install-plan.cjs');
+  const planModule = require(planPath);
+  const original = planModule.createRuntimeArtifactInstallPlan;
+  planModule.createRuntimeArtifactInstallPlan = stub;
+  delete require.cache[installPath];
+  const installer = require('../bin/install.js');
+
+  return {
+    installer,
+    restore() {
+      planModule.createRuntimeArtifactInstallPlan = original;
+      delete require.cache[installPath];
+    },
+  };
+}
+
 // ─── Section 6: installRuntimeArtifacts — parameterised layout loop ──────────
+
+describe('installRuntimeArtifacts — consumes Runtime Artifact Install Plan Module', () => {
+  test('executes returned copy items and cleanup obligations', (t) => {
+    const configDir = createTempDir('gsd-install-plan-adapter-');
+    const sourceDir = createTempDir('gsd-install-plan-source-');
+    const cleanupDir = createTempDir('gsd-install-plan-cleanup-');
+    t.after(() => {
+      cleanup(configDir);
+      cleanup(sourceDir);
+      cleanup(cleanupDir);
+    });
+
+    fs.writeFileSync(path.join(sourceDir, 'proof.md'), '# proof\n');
+    fs.writeFileSync(path.join(cleanupDir, 'temp.md'), '# cleanup\n');
+    let planArgs;
+    const { installer, restore } = loadFreshInstallerWithInstallPlanStub((args) => {
+      planArgs = args;
+      return {
+        ok: true,
+        plan: {
+          cleanupDirs: [cleanupDir],
+          items: [
+            { kind: 'commands', sourceDir, destDir: path.join(configDir, 'commands', 'gsd') },
+          ],
+        },
+      };
+    });
+    t.after(restore);
+
+    installer.installRuntimeArtifacts('gemini', configDir, 'global', RESOLVED_CORE);
+
+    assert.strictEqual(planArgs.layout.runtime, 'gemini');
+    assert.strictEqual(planArgs.layout.configDir, configDir);
+    assert.strictEqual(planArgs.layout.scope, 'global');
+    assert.strictEqual(planArgs.resolvedProfile, RESOLVED_CORE);
+    assert.strictEqual(planArgs.resolveAttribution('gemini'), undefined);
+    assert.ok(fs.existsSync(path.join(configDir, 'commands', 'gsd', 'proof.md')));
+    assert.ok(!fs.existsSync(cleanupDir), 'returned cleanup dir must be removed after copy');
+  });
+
+  test('cleans returned obligations when planning fails', (t) => {
+    const configDir = createTempDir('gsd-install-plan-fail-');
+    const cleanupDir = createTempDir('gsd-install-plan-fail-cleanup-');
+    t.after(() => {
+      cleanup(configDir);
+      cleanup(cleanupDir);
+    });
+
+    fs.writeFileSync(path.join(cleanupDir, 'temp.md'), '# cleanup\n');
+    const { installer, restore } = loadFreshInstallerWithInstallPlanStub(() => ({
+      ok: false,
+      kind: 'rewrite_failed',
+      failedKind: 'commands',
+      message: 'planned failure',
+      cleanupDirs: [cleanupDir],
+    }));
+    t.after(restore);
+
+    assert.throws(
+      () => installer.installRuntimeArtifacts('gemini', configDir, 'global', RESOLVED_CORE),
+      /planned failure/,
+    );
+    assert.ok(!fs.existsSync(cleanupDir), 'failure cleanup dir must be removed');
+  });
+});
 
 const SKILLS_RUNTIMES_LAYOUT = [
   'claude', 'cursor', 'codex', 'copilot', 'antigravity',


### PR DESCRIPTION
## Enhancement PR

> **Using the wrong template?**
> — Bug fix: use [fix.md](?template=fix.md)
> — New feature: use [feature.md](?template=feature.md)

---

## Linked Issue

> **Required.** This PR will be auto-closed if no valid issue link is found.
> The linked issue **must** have the `approved-enhancement` label. If it does not, this PR will be closed without review.

Closes #1556

> ⛔ **No `approved-enhancement` label on the issue = immediate close.**
> Do not open this PR if a maintainer has not yet approved the enhancement proposal.

---

## What this enhancement improves

Installer runtime artifact installation execution in `bin/install.js`.

## Before / After

**Before:**
`installRuntimeArtifacts` directly staged layout kinds, selected rewrite behaviour, tracked temporary rewrite cleanup, and then copied artifacts.

**After:**
`installRuntimeArtifacts` still runs migrations and executes prune/copy/preservation behaviour, but consumes copy items and cleanup obligations from the Runtime Artifact Install Plan Module.

## How it was implemented

- Imported `createRuntimeArtifactInstallPlan` in `bin/install.js`.
- Passed the resolved runtime artifact layout, resolved profile, platform, homedir, and attribution resolver into the plan module.
- Reused the existing layout kind metadata for prefix-aware prune/copy while taking source and destination paths from returned plan items.
- Centralised cleanup execution for successful and failed plan results.
- Added installer tests that stub the plan seam and verify copy execution plus cleanup on success and failure.

## Testing

### How I verified the enhancement works

- `node --test tests/install-runtime-artifacts.test.cjs`
- `npm run lint:ci`
- `npm run build`
- `npm run test:install`
- `gsd-test-summary --both`
- Memtrace deterministic code review: no issues returned.

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [x] Claude Code
- [x] Gemini CLI
- [x] OpenCode
- [x] Other: Codex, Kilo, installer layout matrix via existing tests
- [ ] N/A (not runtime-specific)

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue — no additions or removals
- [ ] If scope changed during implementation, I updated the issue and got re-approval before continuing

---

## Documentation

- [ ] Updated the relevant file(s) under `docs/` to reflect this change
- [x] All `docs/` content added in this PR is written in English
- [x] If genuinely no user-facing docs impact (infrastructure / internal refactor / test-only), apply the `no-docs` label **or** add `<!-- docs-exempt: internal refactor only; no user-facing docs impact -->` inside each triggering changeset fragment and leave a comment explaining why.

## Checklist

- [x] Issue linked above with `Closes #1556` — **PR will be auto-closed if missing**
- [x] Linked issue has the `approved-enhancement` label — **PR will be closed if missing**
- [x] Changes are scoped to the approved enhancement — nothing extra included
- [x] All existing tests pass (`npm test`)
- [x] New or updated tests cover the enhanced behavior
- [x] `.changeset/` fragment added (`npm run changeset -- --type Changed --pr <NNN> --body "..."`) — or `no-changelog` label applied if not user-facing
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1563"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784682143&installation_id=134682257&pr_number=1563&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1563&signature=5e55cd1640eb9e1fb1adee8e6d6054ff9b5bc8203aa9d7d92a1e8b88d4579033"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->