### PR TITLE
refactor(#1558): plan runtime artifact uninstall removal

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -365,6 +365,7 @@ const {
 } = require(path.join(_gsdLibDir, 'runtime-artifact-layout.cjs'));
 const {
   createRuntimeArtifactInstallPlan,
+  createRuntimeArtifactUninstallPlan,
 } = require(path.join(_gsdLibDir, 'runtime-artifact-install-plan.cjs'));
 const {
   planLegacyCleanup,
@@ -7189,9 +7190,14 @@ function uninstallRuntimeArtifacts(runtime, configDir, scope) {
   const savedLegacyArtifacts = _runLegacyUninstallCleanup(runtime, configDir, scope);
 
   const layout = resolveRuntimeArtifactLayout(runtime, configDir, scope);
-  for (const kind of layout.kinds) {
-    const dest = path.join(layout.configDir, kind.destSubpath);
-    _removeGsdEntries(dest, kind);
+  const plan = createRuntimeArtifactUninstallPlan(layout);
+  const kindsByName = new Map(layout.kinds.map((kind) => [kind.kind, kind]));
+  for (const item of plan.items) {
+    const kind = kindsByName.get(item.kind);
+    if (!kind) {
+      throw new Error(`Runtime artifact uninstall plan referenced unknown kind: ${item.kind}`);
+    }
+    _removeGsdEntries(item.destDir, kind);
   }
 
   // Hermes: after removing gsd-* skill dirs from skills/gsd/, also remove

--- a/gsd-core/bin/lib/runtime-artifact-install-plan.cjs
+++ b/gsd-core/bin/lib/runtime-artifact-install-plan.cjs
@@ -66,4 +66,12 @@ function createRuntimeArtifactInstallPlan(args) {
     }
     return { ok: true, plan: { items, cleanupDirs } };
 }
-module.exports = { createRuntimeArtifactInstallPlan };
+function createRuntimeArtifactUninstallPlan(layout) {
+    return {
+        items: layout.kinds.map((kind) => ({
+            kind: kind.kind,
+            destDir: path.join(layout.configDir, kind.destSubpath),
+        })),
+    };
+}
+module.exports = { createRuntimeArtifactInstallPlan, createRuntimeArtifactUninstallPlan };

--- a/src/runtime-artifact-install-plan.cts
+++ b/src/runtime-artifact-install-plan.cts
@@ -24,6 +24,7 @@ interface ResolvedProfile {
 interface ArtifactKind {
   kind: ArtifactKindName;
   destSubpath: string;
+  prefix?: string;
   stage: (resolvedProfile: ResolvedProfile) => string;
 }
 
@@ -62,6 +63,15 @@ interface PlanItem {
 interface InstallPlan {
   items: PlanItem[];
   cleanupDirs: string[];
+}
+
+interface UninstallPlanItem {
+  kind: ArtifactKindName;
+  destDir: string;
+}
+
+interface UninstallPlan {
+  items: UninstallPlanItem[];
 }
 
 type InstallPlanResult =
@@ -143,4 +153,13 @@ function createRuntimeArtifactInstallPlan(args: CreateRuntimeArtifactInstallPlan
   return { ok: true, plan: { items, cleanupDirs } };
 }
 
-export = { createRuntimeArtifactInstallPlan };
+function createRuntimeArtifactUninstallPlan(layout: Layout): UninstallPlan {
+  return {
+    items: layout.kinds.map((kind) => ({
+      kind: kind.kind,
+      destDir: path.join(layout.configDir, kind.destSubpath),
+    })),
+  };
+}
+
+export = { createRuntimeArtifactInstallPlan, createRuntimeArtifactUninstallPlan };

--- a/tests/install-runtime-artifacts.test.cjs
+++ b/tests/install-runtime-artifacts.test.cjs
@@ -47,18 +47,25 @@ const MANIFEST = loadSkillsManifest(REAL_COMMANDS_DIR);
 const RESOLVED_CORE = resolveProfile({ modes: ['core'], manifest: MANIFEST });
 
 function loadFreshInstallerWithInstallPlanStub(stub) {
+  return loadFreshInstallerWithPlanStubs({ installStub: stub });
+}
+
+function loadFreshInstallerWithPlanStubs({ installStub, uninstallStub }) {
   const installPath = require.resolve('../bin/install.js');
   const planPath = require.resolve('../gsd-core/bin/lib/runtime-artifact-install-plan.cjs');
   const planModule = require(planPath);
-  const original = planModule.createRuntimeArtifactInstallPlan;
-  planModule.createRuntimeArtifactInstallPlan = stub;
+  const originalInstall = planModule.createRuntimeArtifactInstallPlan;
+  const originalUninstall = planModule.createRuntimeArtifactUninstallPlan;
+  if (installStub) planModule.createRuntimeArtifactInstallPlan = installStub;
+  if (uninstallStub) planModule.createRuntimeArtifactUninstallPlan = uninstallStub;
   delete require.cache[installPath];
   const installer = require('../bin/install.js');
 
   return {
     installer,
     restore() {
-      planModule.createRuntimeArtifactInstallPlan = original;
+      planModule.createRuntimeArtifactInstallPlan = originalInstall;
+      planModule.createRuntimeArtifactUninstallPlan = originalUninstall;
       delete require.cache[installPath];
     },
   };
@@ -400,6 +407,39 @@ describe('installOpencodeFamilySkills — emits skills/<name>/SKILL.md (#784)', 
 });
 
 // ─── Section 7: uninstallRuntimeArtifacts — all runtimes ─────────────────────
+
+describe('uninstallRuntimeArtifacts — consumes Runtime Artifact Uninstall Plan Module', () => {
+  test('removes returned plan destinations with layout kind metadata', (t) => {
+    const configDir = createTempDir('gsd-uninstall-plan-adapter-');
+    t.after(() => cleanup(configDir));
+
+    const commandsDir = path.join(configDir, 'custom-commands');
+    fs.mkdirSync(commandsDir, { recursive: true });
+    fs.writeFileSync(path.join(commandsDir, 'gsd-help.md'), '# remove\n');
+    fs.writeFileSync(path.join(commandsDir, 'user-custom.md'), '# keep\n');
+
+    let planLayout;
+    const { installer, restore } = loadFreshInstallerWithPlanStubs({
+      uninstallStub(layout) {
+        planLayout = layout;
+        return {
+          items: [
+            { kind: 'commands', destDir: commandsDir },
+          ],
+        };
+      },
+    });
+    t.after(restore);
+
+    installer.uninstallRuntimeArtifacts('gemini', configDir, 'global');
+
+    assert.strictEqual(planLayout.runtime, 'gemini');
+    assert.strictEqual(planLayout.configDir, configDir);
+    assert.strictEqual(planLayout.scope, 'global');
+    assert.ok(!fs.existsSync(path.join(commandsDir, 'gsd-help.md')));
+    assert.ok(fs.existsSync(path.join(commandsDir, 'user-custom.md')));
+  });
+});
 
 describe('uninstallRuntimeArtifacts — removes gsd-owned entries, preserves foreign', () => {
   for (const runtime of ALL_RUNTIMES_LAYOUT) {


### PR DESCRIPTION
## Enhancement PR

> **Using the wrong template?**
> — Bug fix: use [fix.md](?template=fix.md)
> — New feature: use [feature.md](?template=feature.md)

---

## Linked Issue

> **Required.** This PR will be auto-closed if no valid issue link is found.
> The linked issue **must** have the `approved-enhancement` label. If it does not, this PR will be closed without review.

Closes #1558

> ⛔ **No `approved-enhancement` label on the issue = immediate close.**
> Do not open this PR if a maintainer has not yet approved the enhancement proposal.

---

## What this enhancement improves

Runtime artifact uninstallation in `bin/install.js`.

## Before / After

**Before:**
`uninstallRuntimeArtifacts` resolved the layout and derived artifact destination paths directly before deleting GSD-owned entries.

**After:**
`uninstallRuntimeArtifacts` still owns legacy cleanup, metadata-aware deletion, Hermes category cleanup, and migration restoration, but consumes removal destinations from the Runtime Artifact Install Plan Module.

## How it was implemented

- Added `createRuntimeArtifactUninstallPlan` to `src/runtime-artifact-install-plan.cts` and generated CJS output.
- Updated `bin/install.js` to consume uninstall plan items while retaining layout kind metadata for `_removeGsdEntries`.
- Added an adapter seam test proving uninstall uses returned plan destinations and still preserves foreign artifacts.
- Kept existing all-runtime uninstall behavior tests green.

## Testing

### How I verified the enhancement works

- `node --test tests/install-runtime-artifacts.test.cjs`
- `npm run lint:ci`
- `npm run build`
- `npm run test:install`
- Memtrace deterministic code review: no issues returned.
- `gsd-test-summary --both`

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [x] Claude Code
- [x] Gemini CLI
- [x] OpenCode
- [x] Other: Codex, Kilo, all runtime artifact layout matrix via existing tests
- [ ] N/A (not runtime-specific)

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue — no additions or removals
- [ ] If scope changed during implementation, I updated the issue and got re-approval before continuing

---

## Documentation

- [ ] Updated the relevant file(s) under `docs/` to reflect this change
- [x] All `docs/` content added in this PR is written in English
- [x] If genuinely no user-facing docs impact (infrastructure / internal refactor / test-only), apply the `no-docs` label **or** add `<!-- docs-exempt: internal refactor only; no user-facing docs impact -->` inside each triggering changeset fragment and leave a comment explaining why.

## Checklist

- [x] Issue linked above with `Closes #1558` — **PR will be auto-closed if missing**
- [x] Linked issue has the `approved-enhancement` label — **PR will be closed if missing**
- [x] Changes are scoped to the approved enhancement — nothing extra included
- [x] All existing tests pass (`npm test`)
- [x] New or updated tests cover the enhanced behavior
- [x] `.changeset/` fragment added (`npm run changeset -- --type Changed --pr <NNN> --body "..."`) — or `no-changelog` label applied if not user-facing
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1564"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784684621&installation_id=134682257&pr_number=1564&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1564&signature=ee4ccde81baed2ce3835d1293687a4184c0af63ff03558e847182c275b620479"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->