### PR TITLE
fix(#1586): pin withPlanningLock liveness probe in perf-407 for determinism

### DIFF
--- a/tests/perf-407-planning-lock-buffer-alloc.test.cjs
+++ b/tests/perf-407-planning-lock-buffer-alloc.test.cjs
@@ -93,6 +93,9 @@ function spySAB() {
 describe('perf #407: withPlanningLock hoists sleep buffer — exactly one SAB per call', () => {
   let tmpDir;
   let lockPath;
+  // Keep a reference to the module so _setLockProbes/_resetLockProbes are
+  // accessible across beforeEach/afterEach boundaries.
+  let mod;
 
   beforeEach(() => {
     tmpDir = makeTempDir();
@@ -100,6 +103,12 @@ describe('perf #407: withPlanningLock hoists sleep buffer — exactly one SAB pe
   });
 
   afterEach(() => {
+    // Reset the liveness probe to the real implementation so other tests
+    // (or subsequent runs) are not affected by our deterministic override.
+    if (mod) {
+      mod._resetLockProbes();
+      mod = null;
+    }
     try { fs.unlinkSync(lockPath); } catch { /* already gone */ }
     removeTempDir(tmpDir);
     // Purge module cache so each test gets a fresh require (and fresh SAB spy window).
@@ -119,11 +128,23 @@ describe('perf #407: withPlanningLock hoists sleep buffer — exactly one SAB pe
         // Purge any previously cached versions so the spy catches module-level allocs.
         delete require.cache[PLANNING_WORKSPACE_CJS_PATH];
         delete require.cache[CLOCK_CJS_PATH];
-        withPlanningLock = require(PLANNING_WORKSPACE_CJS_PATH).withPlanningLock;
+        mod = require(PLANNING_WORKSPACE_CJS_PATH);
+        withPlanningLock = mod.withPlanningLock;
       } finally {
         spy.restore();
       }
       const sabCountAtLoad = spy.getCount();
+
+      // ── Inject deterministic liveness probe ───────────────────────────────
+      // PR #1532 replaced mtime-staleness with PID-liveness (process.kill(pid,0))
+      // to decide whether a contending lock holder should be waited on (live) or
+      // immediately stolen (dead). The test plants pid: process.pid + 1, which is
+      // environment-dependent: on some runners that pid is alive, on others it is
+      // not, making the retry/sleep path non-deterministic and causing CI flakiness
+      // (issue #1531). The _setLockProbes seam lets us pin the decision: treating
+      // the planted pid as LIVE deterministically forces the SUT into the retry path
+      // on every runner, which is exactly what the test intends to exercise.
+      mod._setLockProbes({ isPidAlive: (pid) => pid === process.pid + 1 });
 
       // ── Step 2: pre-create the lock file (simulates a contending process) ──
       // writing a valid lock JSON so withPlanningLock's stale-check doesn't


### PR DESCRIPTION
## Fix PR

## Linked Issue
Fixes #1586

## Root Cause
#1531/#1532 replaced `withPlanningLock`'s mtime-staleness with PID-liveness (`process.kill(pid,0)`). The pre-existing regression test `tests/perf-407-planning-lock-buffer-alloc.test.cjs` plants a lock with `pid: process.pid + 1` and relied on the old mtime model (mtime=now → not stale → retry/sleep). Under the new model that pid's liveness is environment-dependent — alive on some runners (retry path taken), dead on others (lock stolen immediately, `sleepCallCount: 0` precondition failure). It passed on #1532's CI by luck and went red on a later PR's macOS shard, flaking `next` and blocking the merge queue.

## Fix
Pin the planted holder live via the `_setLockProbes({ isPidAlive })` seam that #1532 added (scoped to the planted pid), and `_resetLockProbes()` in `afterEach`. The retry/sleep path is now exercised deterministically on every runner. **No assertion weakened** (`sleepCallCount >= 1` and `sabCountAtLoad === 1` unchanged); **no variable renamed**. `perf-316` (state lock) is unaffected — its worker writes the parent's own, always-live pid.

## Testing
- Proven mechanism: `_setLockProbes({isPidAlive:()=>false})` → fails with `sleepCallCount: 0`; `()=>true` → passes.
- perf-407 run 10× → all green; perf-316 run 10× → all green (unchanged).
- eslint clean; changeset lint → `ok_no_user_facing_changes` (test-only, no changeset required).

Test-only; no product change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1587"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784738080&installation_id=134682257&pr_number=1587&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1587&signature=511e908c0ecaaa89cd335897db8e87c5dcbc4e406289c674c88bf0ba98700ac0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->