### PR TITLE
docs(#1600): Phase C+D — per-platform plugin skill model assessment (all N/A)

### DIFF
--- a/docs/reference/skill-mapping-matrix.md
+++ b/docs/reference/skill-mapping-matrix.md
@@ -24,9 +24,9 @@ For the transform each converter applies, see [ADR-1593 §3 — converter transf
 
 | Runtime | Skill dest (global) | Prefix | Nesting | Loader | Converter | Notes |
 |---------|---------------------|--------|---------|--------|-----------|-------|
-| **claude** | `skills/` | `gsd-` | flat | one-level (reverted from nested, #924) | `convertClaudeCommandToClaudeSkill` | Local scope ships commands+agents only (no `skills` kind). Plugin manifest (`ADR-766`) ships commands+hooks today; `skills` field is Phase B-provide. |
+| **claude** | `skills/` | `gsd-` | flat | one-level (reverted from nested, #924) | `convertClaudeCommandToClaudeSkill` | Local scope ships commands+agents only (no `skills` kind). Plugin manifest (ADR-766) ships skills via build-generated `skills/` dir (Phase B-provide, PR #1597, merged). |
 | **codex** | `skills/` | `gsd-` | flat | unconfirmed → conservative | `convertClaudeCommandToCodexSkill` | TOML config (`configFormat: toml`). Description truncated to 180 chars (`metadata.short-description`). `sandboxTier: codex-agent-sandbox`. |
-| **gemini** | — *(no skills kind)* | — | — | — | — | Commands-only (TOML `.toml` in `commands/gsd`). No skill surface today — Phase C1 assesses Gemini's extension/skill model. |
+| **gemini** | — *(no skills kind)* | — | — | — | — | Commands-only (TOML `.toml` in `commands/gsd`). No skill surface; extension model has no `skills` field (C1: N/A). |
 | **opencode** | `skills/` | `gsd-` | flat | recursive (`**` glob) | `convertClaudeCommandToOpencodeSkill` | XDG config home. Shares the opencode-family converter entry point (`convertClaudeCommandToOpencodeFamilySkill`). Also ships `command` (singular) commands. |
 | **kilo** | `skills/` | `gsd-` | flat | recursive (`**` glob) | `convertClaudeCommandToKiloSkill` | OpenCode fork; same `**` glob loader. `permissionWriter: kilo`. Also ships `command` commands. |
 | **cursor** | `skills/` | `gsd-` | flat | recursive | `convertClaudeCommandToCursorSkill` | Also ships flat `commands/` via `convertClaudeCommandToCursorCommand`. `configFormat: none`. |
@@ -63,15 +63,17 @@ The nesting flag is set per the verified loader behavior of each runtime. Source
 
 Per [ADR-1593 §5](../adr/1593-skill-mapping-converter-methodology.md#5-plugin--external-skill-provision--consumption-methodology), each platform's first-party packaging should provide and consume skills through the platform's *documented, native* mechanism.
 
-| Runtime | Provision model | Consumption model | Phase |
-|---------|-----------------|-------------------|-------|
-| **claude** | `.claude-plugin/plugin.json` `skills` field / `skills/` dir (ADR-766; today commands+hooks only) | Sub-agent `skills:` preload + runtime `Skill` tool (PR #1261 — merged) | B-provide / D |
-| **gemini** | `gemini-extension.json` (today commands-only, #775) | TBD — assess Gemini's extension/skill model | C1 |
-| **codex** | Codex extension model | TBD | C2 |
-| **opencode / kilo** | Recursive-loader plugin model | TBD | C3 |
-| **cursor, copilot, windsurf, codebuddy** | Flat-skill platform models | TBD | C4 |
-| **cline, qwen, hermes, augment, trae, antigravity** | Nested `gsd-ns-*` router models | TBD | C5 |
-| **kimi** | `kimi-agents` CLI module model | TBD | C6 |
+| Runtime | Provision model | Consumption model | Outcome |
+|---------|-----------------|-------------------|---------|
+| **claude** | `.claude-plugin/plugin.json` `"skills": "./skills/"` — build-generated dir (PR #1597, merged) | Sub-agent `skills:` preload + runtime `Skill` tool (PR #1261, merged) | **Implemented (Phase B)** |
+| **gemini** | **N/A** — `gemini-extension.json` supports `mcpServers` + `contextFileName` only; no `skills` field. Gemini CLI SDK lists skills as a future extension primitive (*"currently not implemented"*). | **N/A** — same rationale. | **C1: N/A** |
+| **codex** | **N/A** — no plugin/extension manifest model. Uses `AGENTS.md` + TOML via file-copy install. | **N/A** — same rationale. | **C2: N/A** |
+| **opencode / kilo** | **N/A** — no first-party plugin manifest. Recursive `skills/**/SKILL.md` glob loader scans the local config dir that `bin/install.js` writes to. | **N/A** — same rationale. | **C3: N/A** |
+| **cursor, copilot, windsurf, codebuddy** | **N/A** — IDE-based tools with no plugin skill-provision model. File-copy install only. | **N/A** — same rationale. | **C4: N/A** |
+| **cline, qwen, hermes, augment, trae, antigravity** | **N/A** — CLI tools with no plugin marketplace model. File-copy install only. | **N/A** — same rationale. | **C5: N/A** |
+| **kimi** | **N/A** — special `kimi-agents` kind but no plugin/extension manifest. File-copy install only. | **N/A** — same rationale. | **C6: N/A** |
+
+**Phase D (first-party packaging parity):** Complete. Claude Code's `.claude-plugin/plugin.json` is the only first-party manifest with a `skills` field (Phase B-provide, PR #1597). Gemini's `gemini-extension.json` is context-only (no skills field — C1 N/A). No other first-party packaging exists.
 
 > **Rejected for all platforms:** reading another plugin's ephemeral/undocumented cache (e.g. Claude Code's `${CLAUDE_PLUGIN_ROOT}` / `~/.claude/plugins/cache`). The platform's native mechanism is the contract; cache-reading is a workaround, not a fix.
 


### PR DESCRIPTION
## Enhancement PR

## Linked Issue

Closes #1600

> Issue #1600 carries the `approved-enhancement` label (Phase C+D of epic #1258).

---

## What this enhancement improves

The per-runtime plugin skill provision/consumption table in the skill-mapping reference matrix — resolves all TBD entries with concrete per-platform assessments.

## Before / After

**Before:** The matrix had "TBD" entries for every non-Claude platform's provision/consumption model. The claude row still said "Phase B-provide" (future). The gemini row said "Phase C1 assesses."

**After:** Every cell resolved. All 15 non-Claude platforms documented as **N/A** with rationale (no documented plugin skill-provision model; file-copy install path handles skill provision). Claude row updated to reflect Phase B-provide merged (PR #1597). Phase D marked complete (Claude is the only first-party manifest with `skills`).

## How it was implemented

Doc-only. One file (`docs/reference/skill-mapping-matrix.md`): replaced the provision/consumption table with per-platform N/A rationale + updated the claude and gemini rows in the main matrix to reflect completed/outcome status.

## Testing

Doc-only change. `gsd-test-summary` run (full suite, 0 failures).

### Platforms tested

- [x] Linux (gsd-test-summary Bench)
- [x] N/A (doc-only)

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue — no additions or removals

## Documentation

- [x] This PR **is** the documentation update.
- [x] No changeset (doc-only, `docs/reference/` outside the Changeset-Required gate).

## Checklist

- [x] Issue linked with `Closes #1600`
- [x] Linked issue has `approved-enhancement`
- [x] All tests pass
- [x] No changeset needed (doc-only)

## Breaking changes

None. Doc-only.

---

This closes epic **#1258** — all phases complete:
- Phase A: ADR-1593 + reference matrix (#1593, merged)
- Phase B-consume: agent_skills plugin skill consumption (PR #1261, merged)
- Phase B-provide: plugin manifest ships skills (PR #1597, merged)
- Phase C (C1–C6): all N/A — documented (#1600, this PR)
- Phase D: complete — Claude is the only first-party manifest with skills

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1601"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784762603&installation_id=134682257&pr_number=1601&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1601&signature=9b7fe9dff5a0d51266a2ff8190da5cdbed93ece341589143a6711b4a54036746"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->