### PR TITLE
fix(#1614): install Antigravity skills flat

### DIFF
--- a/.changeset/plucky-badgers-sprint.md
+++ b/.changeset/plucky-badgers-sprint.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**Antigravity installs all GSD slash-command skills where AGY can discover them** — concrete skills such as /gsd-progress and /gsd-verify-work now land directly under the Antigravity skills directory instead of router-nested folders. (#1614)

--- a/.changeset/plucky-badgers-sprint.md
+++ b/.changeset/plucky-badgers-sprint.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 1616
 ---
 **Antigravity installs all GSD slash-command skills where AGY can discover them** — concrete skills such as /gsd-progress and /gsd-verify-work now land directly under the Antigravity skills directory instead of router-nested folders. (#1614)

--- a/capabilities/antigravity/capability.json
+++ b/capabilities/antigravity/capability.json
@@ -3,7 +3,7 @@
   "role": "runtime",
   "version": "1.6.0-rc.2",
   "title": "Antigravity",
-  "description": "Google Antigravity IDE — nested under ~/.gemini/antigravity; probed across 1.x and 2.x layouts; Gemini hook event dialect; nested skill layout; tier-1 support.",
+  "description": "Google Antigravity IDE — nested under ~/.gemini/antigravity; probed across 1.x and 2.x layouts; Gemini hook event dialect; flat skill layout; tier-1 support.",
   "tier": "core",
   "requires": [],
   "engines": {
@@ -31,7 +31,7 @@
           "kind": "skills",
           "destSubpath": "skills",
           "prefix": "gsd-",
-          "nesting": "nested",
+          "nesting": "flat",
           "recursive": false,
           "converter": "convertClaudeCommandToAntigravitySkill"
         }
@@ -41,7 +41,7 @@
           "kind": "skills",
           "destSubpath": "skills",
           "prefix": "gsd-",
-          "nesting": "nested",
+          "nesting": "flat",
           "recursive": false,
           "converter": "convertClaudeCommandToAntigravitySkill"
         }

--- a/gsd-core/bin/lib/capability-registry.cjs
+++ b/gsd-core/bin/lib/capability-registry.cjs
@@ -65,7 +65,7 @@ const capabilities = {
     "role": "runtime",
     "version": "1.6.0-rc.2",
     "title": "Antigravity",
-    "description": "Google Antigravity IDE — nested under ~/.gemini/antigravity; probed across 1.x and 2.x layouts; Gemini hook event dialect; nested skill layout; tier-1 support.",
+    "description": "Google Antigravity IDE — nested under ~/.gemini/antigravity; probed across 1.x and 2.x layouts; Gemini hook event dialect; flat skill layout; tier-1 support.",
     "tier": "core",
     "requires": [],
     "engines": {
@@ -93,7 +93,7 @@ const capabilities = {
             "kind": "skills",
             "destSubpath": "skills",
             "prefix": "gsd-",
-            "nesting": "nested",
+            "nesting": "flat",
             "recursive": false,
             "converter": "convertClaudeCommandToAntigravitySkill"
           }
@@ -103,7 +103,7 @@ const capabilities = {
             "kind": "skills",
             "destSubpath": "skills",
             "prefix": "gsd-",
-            "nesting": "nested",
+            "nesting": "flat",
             "recursive": false,
             "converter": "convertClaudeCommandToAntigravitySkill"
           }
@@ -2723,7 +2723,7 @@ const runtimes = {
     "role": "runtime",
     "version": "1.6.0-rc.2",
     "title": "Antigravity",
-    "description": "Google Antigravity IDE — nested under ~/.gemini/antigravity; probed across 1.x and 2.x layouts; Gemini hook event dialect; nested skill layout; tier-1 support.",
+    "description": "Google Antigravity IDE — nested under ~/.gemini/antigravity; probed across 1.x and 2.x layouts; Gemini hook event dialect; flat skill layout; tier-1 support.",
     "tier": "core",
     "requires": [],
     "engines": {
@@ -2751,7 +2751,7 @@ const runtimes = {
             "kind": "skills",
             "destSubpath": "skills",
             "prefix": "gsd-",
-            "nesting": "nested",
+            "nesting": "flat",
             "recursive": false,
             "converter": "convertClaudeCommandToAntigravitySkill"
           }
@@ -2761,7 +2761,7 @@ const runtimes = {
             "kind": "skills",
             "destSubpath": "skills",
             "prefix": "gsd-",
-            "nesting": "nested",
+            "nesting": "flat",
             "recursive": false,
             "converter": "convertClaudeCommandToAntigravitySkill"
           }

--- a/src/runtime-artifact-layout.cts
+++ b/src/runtime-artifact-layout.cts
@@ -368,12 +368,15 @@ function convertedCommandsKind(
 //     augment    — https://docs.augmentcode.com/cli/skills (flat single-level)
 //     trae       — docs.trae.ai/ide/skills + Trae-AI/TRAE#2253 (flat; nesting errors)
 //                  Trae IDE (trae.ai), not trae-agent — see runtime-homes.cts header note
-//     antigravity— discuss.ai.google.dev/t/more-antigravity-issues/145875 ("will not recursive scan")
-//
 //   FLAT (recursive loader → nesting gives no saving):
 //     cursor     — https://cursor.com/docs/skills (walks skills root recursively)
 //     opencode   — sst/opencode skill/index.ts glob "skills/**/SKILL.md"
 //     kilo       — Kilo-Org/kilocode (opencode fork, same ** glob)
+//
+//   FLAT (one-level scan, but concrete skills must be directly discoverable):
+//     antigravity— https://antigravity.google/docs/skills + /docs/cli-plugins
+//                  (skills live at <skills-dir>/<skill-folder>/SKILL.md; AGY does not
+//                   register router-nested concrete skills as slash commands)
 //
 //   FLAT (reverted from nested — nested skills not discoverable by Skill tool, #924):
 //     claude     — https://code.claude.com/docs/en/skills + anthropics/claude-code#28266

--- a/tests/install-nested-layout.test.cjs
+++ b/tests/install-nested-layout.test.cjs
@@ -33,13 +33,12 @@ const { COMMANDS_GSD, ROUTER_STEMS, routerChildren } = require('./helpers/nested
 
 const NEST = [
   // Claude reverted to flat (#924: nested layout breaks Skill-tool discovery on Claude Code).
-  // Only the 6 runtimes below keep the nested layout.
+  // Only the 5 runtimes below keep the nested layout.
   { runtime: 'cline',       scope: 'global', skillsSub: 'skills',     prefix: 'gsd-' },
   { runtime: 'qwen',        scope: 'global', skillsSub: 'skills',     prefix: 'gsd-' },
   { runtime: 'hermes',      scope: 'global', skillsSub: 'skills/gsd', prefix: 'gsd-' }, // #947: restored canonical prefix
   { runtime: 'augment',     scope: 'global', skillsSub: 'skills',     prefix: 'gsd-' },
   { runtime: 'trae',        scope: 'global', skillsSub: 'skills',     prefix: 'gsd-' },
-  { runtime: 'antigravity', scope: 'global', skillsSub: 'skills',     prefix: 'gsd-' },
 ];
 
 const FLAT = [
@@ -53,6 +52,7 @@ const FLAT = [
   { runtime: 'codebuddy', scope: 'global', skillsSub: 'skills' },
   { runtime: 'opencode',  scope: 'global', skillsSub: 'skills' },
   { runtime: 'kilo',      scope: 'global', skillsSub: 'skills' },
+  { runtime: 'antigravity', scope: 'global', skillsSub: 'skills' },
 ];
 
 // ---------------------------------------------------------------------------

--- a/tests/install.test.cjs
+++ b/tests/install.test.cjs
@@ -1167,6 +1167,24 @@ describe('antigravity local install writes to .agents/ canonical dir (#791)', ()
     assert.ok(fs.existsSync(firstSkill), `SKILL.md must exist at ${firstSkill}`);
   });
 
+  test('install writes concrete skills at the immediate level AGY scans', () => {
+    install(false, 'antigravity');
+    const skillsDir = path.join(tmpDir, '.agents', 'skills');
+
+    assert.ok(
+      fs.existsSync(path.join(skillsDir, 'gsd-progress', 'SKILL.md')),
+      'AGY scans immediate skill folders, so /gsd-progress must be installed at .agents/skills/gsd-progress/SKILL.md',
+    );
+    assert.ok(
+      fs.existsSync(path.join(skillsDir, 'gsd-verify-work', 'SKILL.md')),
+      'AGY scans immediate skill folders, so /gsd-verify-work must be installed at .agents/skills/gsd-verify-work/SKILL.md',
+    );
+    assert.ok(
+      !fs.existsSync(path.join(skillsDir, 'gsd-ns-workflow', 'skills', 'progress', 'SKILL.md')),
+      'Antigravity must not rely on router-nested concrete skills that AGY does not discover',
+    );
+  });
+
   test('installed agent files reference .agents/ not ~/.claude/ or bare .agent/', () => {
     // NOTE: skill content is intentionally NOT asserted here. The installer calls
     // convertClaudeCommandToAntigravitySkill(content, skillName, runtime, cmdNames)


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

Fixes #1614

---

## What was broken

The Antigravity runtime installed concrete GSD skills under namespace-router subdirectories, such as `.agents/skills/gsd-ns-workflow/skills/progress/SKILL.md`. AGY discovers slash-command skills from immediate skill folders, so nested concrete skills like `/gsd-progress` and `/gsd-verify-work` were not registered.

## What this fix does

This changes Antigravity to use the flat skill layout so every concrete GSD skill is installed directly at `.agents/skills/<skill>/SKILL.md`. It also updates the generated capability registry and the runtime layout evidence comment.

## Root cause

The Antigravity capability manifest declared `nesting: "nested"` for both local and global skill artifacts. The installer honored that descriptor and nested concrete skills under namespace routers, which does not match the documented Antigravity/AGY skill discovery shape.

## Testing

### How I verified the fix

- `node --test tests/install.test.cjs --test-name-pattern "install writes concrete skills at the immediate level AGY scans"`
- `node --test tests/runtime-artifact-layout-descriptor-drive.test.cjs tests/runtime-artifact-layout-install-profiles.test.cjs`
- `npx eslint tests/install.test.cjs src/runtime-artifact-layout.cts`
- `npm run lint:regression-names`
- `npm run gen:capability-registry`
- `npm test` — 2675 passed, 0 failed
- `gsd-test-summary --reset` attempted; it completed in the Docker runner but reported 3 failures. Maintainer accepted the green local `npm test` run as sufficient for submission.

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [x] Other: Antigravity
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1616"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784816535&installation_id=134682257&pr_number=1616&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1616&signature=2e41269479789cdaa2d9a8b6969ab0cb9fbe69b7e7c51e710cddab40a8785cd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->