### PR TITLE
fix(#1625): resolve security config in secure-phase.md before auditor handoff

### DIFF
--- a/.changeset/kind-deer-rest.md
+++ b/.changeset/kind-deer-rest.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 1633
+---
+**`/gsd:secure-phase` now honors the configured ASVS level and block threshold** — the security auditor previously received unsubstituted `{SECURITY_ASVS}` / `{SECURITY_BLOCK_ON}` placeholder text because secure-phase.md never assigned those variables. It now resolves `workflow.security_asvs_level` and `workflow.security_block_on` from config (`--raw`) before the auditor handoff. (#1625)

--- a/gsd-core/workflows/secure-phase.md
+++ b/gsd-core/workflows/secure-phase.md
@@ -27,6 +27,8 @@ Parse: `phase_dir`, `phase_number`, `phase_name`, `phase_slug`, `padded_phase`.
 ```bash
 AUDITOR_MODEL=$(gsd_run query resolve-model gsd-security-auditor --raw)
 VERIFY_POST_HOOKS_JSON=$(gsd_run loop render-hooks verify:post --raw)
+SECURITY_ASVS=$(gsd_run query config-get workflow.security_asvs_level --raw 2>/dev/null || echo "1")
+SECURITY_BLOCK_ON=$(gsd_run query config-get workflow.security_block_on --raw 2>/dev/null || echo "high")
 ```
 
 Resolve active step hooks from `VERIFY_POST_HOOKS_JSON` where `kind == "step"` and `ref.skill == "secure-phase"`.
@@ -94,6 +96,8 @@ Call AskUserQuestion with threat table and options:
 
 - `register_authored_at_plan_time: true` — **Verify mitigations exist** — do not scan for new threats. The register is complete; verify each threat's mitigation is present in the implementation.
 - `register_authored_at_plan_time: false` (retroactive-STRIDE mode) — **Retroactive-STRIDE: build a STRIDE register from implementation files first, then verify mitigations.** The phase was authored before formal threat modelling; the auditor must construct the register from scratch before verifying.
+
+Substitute `{SECURITY_ASVS}` with the value of `$SECURITY_ASVS` and `{SECURITY_BLOCK_ON}` with the value of `$SECURITY_BLOCK_ON` resolved in Step 0 via `config-get`.
 
 Print: `◆ Spawning security auditor... (runs in a subagent — no output until it returns, ~1–5 min; expected, not a freeze)`
 

--- a/tests/secure-phase.test.cjs
+++ b/tests/secure-phase.test.cjs
@@ -451,3 +451,80 @@ describe('SECURE: threat-model-anchored behaviour', () => {
     );
   });
 });
+
+// ─── 8. Regression: security config variables resolved before use (#1625) ────
+// allow-test-rule: runtime-contract-is-the-product — secure-phase.md prose is the executed contract (#1625)
+
+describe('SECURE: security config variables resolved before use (#1625)', () => {
+  const wfPath = path.join(WORKFLOWS_DIR, 'secure-phase.md');
+
+  test('SECURITY_ASVS is assigned (not only used as placeholder)', () => {
+    const content = fs.readFileSync(wfPath, 'utf-8');
+    assert.ok(
+      content.includes('SECURITY_ASVS='),
+      'SECURITY_ASVS must be assigned via config-get in the workflow, not only appear as {SECURITY_ASVS} placeholder'
+    );
+  });
+
+  test('SECURITY_BLOCK_ON is assigned (not only used as placeholder)', () => {
+    const content = fs.readFileSync(wfPath, 'utf-8');
+    assert.ok(
+      content.includes('SECURITY_BLOCK_ON='),
+      'SECURITY_BLOCK_ON must be assigned via config-get in the workflow, not only appear as {SECURITY_BLOCK_ON} placeholder'
+    );
+  });
+
+  test('SECURITY_ASVS assignment appears before the auditor <config> injection line', () => {
+    const content = fs.readFileSync(wfPath, 'utf-8');
+    const assignIdx = content.indexOf('SECURITY_ASVS=');
+    const configInjIdx = content.indexOf('block_on: {SECURITY_BLOCK_ON}');
+    assert.ok(assignIdx > -1, 'SECURITY_ASVS= must exist in the file');
+    assert.ok(configInjIdx > -1, 'block_on: {SECURITY_BLOCK_ON} injection line must exist');
+    assert.ok(
+      assignIdx < configInjIdx,
+      'SECURITY_ASVS must be assigned before the auditor <config> injection line that references {SECURITY_BLOCK_ON}'
+    );
+  });
+
+  test('SECURITY_BLOCK_ON assignment appears before the auditor <config> injection line', () => {
+    const content = fs.readFileSync(wfPath, 'utf-8');
+    const assignIdx = content.indexOf('SECURITY_BLOCK_ON=');
+    const configInjIdx = content.indexOf('block_on: {SECURITY_BLOCK_ON}');
+    assert.ok(assignIdx > -1, 'SECURITY_BLOCK_ON= must exist in the file');
+    assert.ok(configInjIdx > -1, 'block_on: {SECURITY_BLOCK_ON} injection line must exist');
+    assert.ok(
+      assignIdx < configInjIdx,
+      'SECURITY_BLOCK_ON must be assigned before the auditor <config> injection line that references it'
+    );
+  });
+
+  test('security config resolved via config-get with correct keys and defaults', () => {
+    const content = fs.readFileSync(wfPath, 'utf-8');
+    assert.ok(
+      content.includes('config-get workflow.security_asvs_level'),
+      'must resolve SECURITY_ASVS via config-get workflow.security_asvs_level'
+    );
+    assert.ok(
+      content.includes('config-get workflow.security_block_on'),
+      'must resolve SECURITY_BLOCK_ON via config-get workflow.security_block_on'
+    );
+    assert.ok(
+      content.includes('echo "1"') && content.includes('echo "high"'),
+      'config-get resolution must include the registry default fallbacks (1, high) so an unset/failed lookup still yields a valid value'
+    );
+  });
+
+  test('security config-get uses --raw so the injected string value is unquoted', () => {
+    const content = fs.readFileSync(wfPath, 'utf-8');
+    // Without --raw, config-get returns JSON ("high" with quotes), which would
+    // corrupt the auditor <config> block to `block_on: "high"`. --raw yields bare `high`.
+    assert.ok(
+      /config-get workflow\.security_block_on --raw/.test(content),
+      'SECURITY_BLOCK_ON must be resolved with --raw (config-get returns a quoted "high" without it)'
+    );
+    assert.ok(
+      /config-get workflow\.security_asvs_level --raw/.test(content),
+      'SECURITY_ASVS must be resolved with --raw for consistency'
+    );
+  });
+});

--- a/tests/workflow-size-baseline.json
+++ b/tests/workflow-size-baseline.json
@@ -65,7 +65,7 @@
   "resume-project.md": 17226,
   "review.md": 39404,
   "scan.md": 7688,
-  "secure-phase.md": 12282,
+  "secure-phase.md": 12656,
   "session-report.md": 4044,
   "settings-advanced.md": 39666,
   "settings-integrations.md": 15848,


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #1625

## What was broken

`/gsd:secure-phase` spawned the security auditor with `"<config>asvs_level: {SECURITY_ASVS}, block_on: {SECURITY_BLOCK_ON}</config>"` (`gsd-core/workflows/secure-phase.md:104`), but neither `SECURITY_ASVS` nor `SECURITY_BLOCK_ON` was ever assigned anywhere in the file — the canonical retroactive-audit path delivered the literal placeholder text to the auditor.

## What this fix does

Resolves both values in Step 0 via `config-get --raw` (`workflow.security_asvs_level`, default `1`; `workflow.security_block_on`, default `high`) and adds a prose note instructing the orchestrator to substitute them into the auditor `<config>` block.

## Root cause

The sibling plan-phase path reads these from the planner *contribution* hook's `configValues`, but the secure-phase *step* hook in the capability registry carries no `configValues`. So secure-phase.md had nothing to substitute and the variables were never resolved. `--raw` is required because `config-get` returns a JSON-quoted `"high"` otherwise, which would corrupt the `<config>` block.

## Testing

### How I verified the fix

- Regression tests in `tests/secure-phase.test.cjs` (#1625 block): both variables are assigned via `config-get` before the auditor `<config>` injection line, `--raw` is used, and the registry default fallbacks (1, high) are present. 48/48 pass.
- Confirmed live: `config-get workflow.security_block_on --raw` → `high` (vs `"high"` without `--raw`); defaults resolve to `1` / `high` when unset.
- Codex adversarial review: no blocking findings.
- Docker full-suite gate (linux): green.

### Regression test added?

- [x] Yes — `tests/secure-phase.test.cjs` (#1625 regression block)

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [x] N/A (not platform-specific — workflow prose + config resolution)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

## Checklist

- [x] Issue linked above with `Fixes #1625`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added
- [x] No unnecessary dependencies added

## Breaking changes

None. The auditor now receives the configured values instead of placeholder text — pure correctness fix. (Consumer-side gaps in how those values gate the phase are tracked separately in #1626 / #1627.)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1633"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784838892&installation_id=134682257&pr_number=1633&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1633&signature=a5ae83def6e772665506002b06371efa87a45cbb37586d5ddae1cb8955f6eed9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->