### PR TITLE
docs(#1642): amend ADR-0174 §5 — reconcile Result type + add exitReason?

### DIFF
--- a/docs/adr/0174-retire-gsd-sdk-package-boundary.md
+++ b/docs/adr/0174-retire-gsd-sdk-package-boundary.md
@@ -1,6 +1,6 @@
 # ADR-0174: Retire @opengsd/gsd-sdk package boundary — single-runtime collapse
 
-- **Status:** Accepted (2026-05-23)
+- **Status:** Accepted (2026-05-23); amended #1642 (2026-06-23) — §5 reconciled to as-built Result type + `exitReason?` field added on `InvalidArgs`
 - **Date:** 2026-05-23
 - **Tracking issue:** [#174](https://github.com/open-gsd/get-shit-done-redux/issues/174) — sub-issues #175–#197
 
@@ -71,19 +71,33 @@ Dispatch is synchronous: `dispatch<T>(req: DispatchRequest): Result<T>`.
 
 Rationale: continuous stack traces, no async-boundary races in the logger, no orphaned side effects, SIGINT shows what is actually running. `synckit` dependency is removed.
 
-The `Result<T>` type is a discriminated union per `errorKind` variant, not a flat string field:
+The `Result<T>` type is a discriminated union per `errorKind` variant, not a flat string field. The as-built type (in `src/command-routing-hub.cts`) is:
 
 ```ts
 type Result<T> =
   | { ok: true; data: T }
-  | { ok: false; kind: 'Unknown'; command: string }
-  | { ok: false; kind: 'BadArgs'; arg: string; reason: string }
-  | { ok: false; kind: 'ValidationFailed'; field: string; expected: string; actual: unknown }
-  | { ok: false; kind: 'HandlerFailed'; message: string; cause?: Error }
-  | { ok: false; kind: 'NotImplemented'; command: string };
+  | { ok: false; kind: 'UnknownCommand'; command: string }
+  | { ok: false; kind: 'InvalidArgs'; arg: string; reason: string; exitReason?: string }
+  | { ok: false; kind: 'HandlerRefusal'; reason: string }
+  | { ok: false; kind: 'HandlerFailure'; message: string; cause?: Error };
 ```
 
-Adding a new variant requires amending this ADR (preserving the drift-prevention property from ADR-0012).
+> **Drift note (amendment #1642, 2026-06-23):** the original §5 text specified a different planned shape — `'Unknown'` / `'BadArgs'` / `'ValidationFailed'` / `'NotImplemented'` / `'HandlerFailed'`. The SDK retirement migration kept the ADR-0012 names (`UnknownCommand` / `InvalidArgs` / `HandlerFailure`) and never added the planned `ValidationFailed` or `NotImplemented` variants; `HandlerRefusal` was added during implementation but never back-filled into this ADR. This amendment reconciles the ADR to the as-built code so the contract documented here matches what consumers actually depend on. The drift was caught during architecture review (parent #1641).
+
+**Factories** (`src/command-routing-hub.cts`):
+
+```ts
+makeUnknownCommand(command: string) → Readonly<UnknownCommandResult>
+makeInvalidArgs(arg: string, reason: string, exitReason?: string) → Readonly<InvalidArgsResult>
+makeHandlerRefusal(reason: string) → Readonly<HandlerRefusalResult>
+makeHandlerFailure(message: string, cause?: unknown) → HandlerFailureResult
+```
+
+**The `exitReason?` field on `InvalidArgs`** (added by this amendment) carries an `ERROR_REASON` enum value (e.g. `ERROR_REASON.USAGE`) separately from the existing `reason` explanation text. This lets routers that today call `error(msg, ERROR_REASON.USAGE)` directly — bypassing the Hub — preserve `ERROR_REASON` granularity when they migrate to returning `makeInvalidArgs(...)` Results through the Hub. The field is optional and additive; existing callers are unaffected.
+
+**Dispatcher translation contract:** when an adapter translates an `InvalidArgs` Result whose `exitReason` is present, it passes `exitReason` as the second argument to `error(message, exitReason)` so the JSON-error envelope (`GSD_JSON_ERRORS=1`) preserves the typed reason for downstream consumers (CLI tests, integration harnesses).
+
+Adding a new variant **or adding a field to an existing variant** requires amending this ADR (preserving the drift-prevention property from ADR-0012).
 
 ### 6. Observability seam — silent on success, structured JSON on error, opt-in audit
 


### PR DESCRIPTION
<!-- pr-template-exempt: docs-only ADR amendment; per .github/pull_request_template.md HTML comment (lines 38-40), doc-only PRs are auto-detected from changed file paths and no fix/enhancement/feature template applies -->

Closes #1642
Part of #1641 (Phase 0 of 4).

## What

Amends ADR-0174 §5 to (a) reconcile the documented Result type to the as-built code, and (b) record the new optional `exitReason?: string` field on the `InvalidArgs` variant.

## Why

The original §5 text drifted from the implementation. It planned `'Unknown' / 'BadArgs' / 'ValidationFailed' / 'NotImplemented' / 'HandlerFailed'`; the SDK retirement migration kept the ADR-0012 names (`UnknownCommand` / `InvalidArgs` / `HandlerFailure`) and never added the planned `ValidationFailed` or `NotImplemented` variants. `HandlerRefusal` was added during implementation but never back-filled into this ADR. The ADR currently lies about the contract; this PR fixes the lie.

The `exitReason?` field addition is pre-recorded here (rather than in Phase 1's code PR) so Phase 1 can reference an ADR-level contract rather than introducing the field ad-hoc. Per `META.RULE.canonical-source-precedence=CONTRIBUTING.md > docs/adr/* > CONTEXT.md > agent memory`, ADRs are the canonical source — the amendment lands before code that depends on it.

## How

Two surgical edits to `docs/adr/0174-retire-gsd-sdk-package-boundary.md` (1 file, +22/-8):

1. **Status line** amended to record the change: `Accepted (2026-05-23); amended #1642 (2026-06-23) — §5 reconciled to as-built Result type + exitReason? field added on InvalidArgs`
2. **§5 body** replaced with:
   - The as-built Result type (4 variants, matching `src/command-routing-hub.cts:60-95`)
   - A drift note citing the original planned shape and why the migration kept the ADR-0012 names
   - Factories block documenting the four `make*` factories
   - Semantic explanation of `exitReason?` (carries `ERROR_REASON` enum value separately from `reason` explanation text)
   - Dispatcher translation contract (when `exitReason` is present, adapters pass it as the second arg to `error(message, exitReason)`)
   - Tightened amendment requirement: "Adding a new variant **or adding a field to an existing variant** requires amending this ADR"

## Verification

- [x] ADR header rule satisfied — Status + Date immediately after title per `RULESET.ADR-HEADER`
- [x] markdownlint: no new violations introduced (pre-existing violations in the migration plan table at lines 127–161 are out of scope per CONTRIBUTING L188 "no drive-by formatting")
- [x] Result variant names verified against the as-built code via Memtrace (`find_symbol command-routing-hub.cts`: `UnknownCommand`, `InvalidArgs`, `HandlerRefusal`, `HandlerFailure` — all match)
- [x] Factory signatures verified via Memtrace (`get_source_window command-routing-hub.cts:120-159`: `makeUnknownCommand`, `makeInvalidArgs`, `makeHandlerRefusal`, `makeHandlerFailure` — all match)

## Workflow directive alignment

Per the engineering workflow directive for this Phase 0:

| Step | Status |
|---|---|
| 1. Research & classification | ✅ Read CONTRIBUTING, CONTEXT.md, ADR-0012/0174/959; classified as chore/docs (not bug); ADR-0012 is superseded by ADR-0174, target corrected |
| 2. Rubber-duck + Artificer laws | ✅ Hyrum's Law: typed Result is the documented contract; amendment restores accuracy. Postel's Law: optional additive field is liberal acceptance |
| 3. QA + TDD | ✅ No code → no tests; "test" is markdownlint + ADR header rule compliance |
| 4. Adversarial review | ✅ Self-reviewed every Result variant name + factory signature against the as-built code via Memtrace |
| 5. Diátaxis docs | ✅ ADRs are Explanation docs; amendment enriches explanation accuracy |
| 6. Rebase + PR | ✅ Branched from `next` (the integration branch per ADR-230); pushed; this PR targets `next` |

## Scope

- **In scope:** ADR-0174 §5 amendment (text only, no code)
- **Out of scope:** Phase 1 (Hub + adapter code changes), Phase 2 (router conversions), Phase 3 (verification) — tracked in parent #1641

## CI labels

- `no-changelog` applied — pure docs PR, no user-facing impact per CONTRIBUTING L208. No `.changeset/` fragment required.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1643"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784857207&installation_id=134682257&pr_number=1643&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1643&signature=cba5fce38d359766491c2ca062be2c9245cc414ea47698416f8eaae9977f4119"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->