### PR TITLE
refactor(#1646): route capability routers through Command Routing Hub per ADR-959

### DIFF
--- a/.changeset/capability-routers-via-hub.md
+++ b/.changeset/capability-routers-via-hub.md
@@ -1,0 +1,5 @@
+---
+type: Changed
+pr: 0
+---
+**Capability commands now emit dispatch audit records** — `graphify`, `intel`, `audit-uat`, and `audit-open` now route through the Command Routing Hub per ADR-959 §III(B), so `GSD_AUDIT=1` traces, the structured stderr JSON error envelope, and the typed Result contract cover them uniformly with all other command families. JSON-error `reason` values (`usage`, `sdk_unknown_command`) are preserved byte-identical. (#1646)

--- a/.changeset/capability-routers-via-hub.md
+++ b/.changeset/capability-routers-via-hub.md
@@ -1,5 +1,5 @@
 ---
 type: Changed
-pr: 0
+pr: 1647
 ---
 **Capability commands now emit dispatch audit records** — `graphify`, `intel`, `audit-uat`, and `audit-open` now route through the Command Routing Hub per ADR-959 §III(B), so `GSD_AUDIT=1` traces, the structured stderr JSON error envelope, and the typed Result contract cover them uniformly with all other command families. JSON-error `reason` values (`usage`, `sdk_unknown_command`) are preserved byte-identical. (#1646)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1517,7 +1517,7 @@ When `/gsd-new-project` creates a new `config.json`, it reads global defaults an
 
 ## Observability
 
-The Command Routing Hub emits a structured `DispatchEvent` after every dispatch. Default behaviour is **silent on success** and **one structured JSON line to stderr on error**.
+The Command Routing Hub emits a structured `DispatchEvent` after every dispatch — including capability commands (`graphify`, `intel`, `audit-uat`, `audit-open`) since #1646. Default behaviour is **silent on success** and **one structured JSON line to stderr on error**.
 
 ### Stderr error format
 

--- a/src/audit-command-router.cts
+++ b/src/audit-command-router.cts
@@ -26,6 +26,11 @@
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import io = require('./io.cjs');
+// Phase 2 (#1646): route through the Hub per ADR-959 §III(B) line 75.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import cjsCommandRouterAdapter = require('./cjs-command-router-adapter.cjs');
+
+const { routeHubCommandFamily } = cjsCommandRouterAdapter;
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -71,28 +76,67 @@ function routeAuditUat({ args, cwd, raw, error, _uat }: RouteAuditUatOptions): v
   void error;
   // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-unsafe-assignment
   const u: UatModule = _uat ?? require('./uat.cjs');
-  u.cmdAuditUat(cwd, raw);
+
+  // Phase 2 (#1646): routes through the Hub for uniform observability and
+  // HandlerFailure taxonomy. audit-uat has no subcommands — a synthetic 'run'
+  // defaultSubcommand gives the Hub a single-handler manifest. The dispatch is
+  // trivial but the observability seam (DispatchEvent, GSD_AUDIT=1 trace) is
+  // now consistent with graphify/intel/host routers.
+  routeHubCommandFamily({
+    family: 'audit-uat',
+    args,
+    subcommands: ['run'],
+    defaultSubcommand: 'run',
+    handlers: {
+      run: () => u.cmdAuditUat(cwd, raw),
+    },
+    unknownMessage: (subcommand: string) =>
+      `Unknown audit-uat subcommand: "${subcommand}". audit-uat takes no subcommands.`,
+    error,
+    cwd,
+    raw,
+  });
 }
 
 // ─── routeAuditOpen ──────────────────────────────────────────────────────────
 
 function routeAuditOpen({ args, cwd, raw, error, _audit, _core }: RouteAuditOpenOptions): void {
-  // Suppress unused-variable warning for error — audit-open has no subcommand
-  // dispatch that would call error(); only flag parsing occurs here.
-  void error;
   // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-unsafe-assignment
   const a: AuditModule = _audit ?? require('./audit.cjs');
   const c: CoreModule = _core ?? io;
+
+  // Phase 2 (#1646): routes through the Hub for uniform observability.
+  // `--json` is a flag, not a subcommand — capture it in the closure and strip
+  // it from args before Hub dispatch so it isn't mistaken for a subcommand by
+  // the manifest check. The handler then branches on wantJson for the two
+  // output shapes (JSON object vs human-readable formatted report).
   const wantJson = args.includes('--json');
-  const result = a.auditOpenArtifacts(cwd);
-  if (wantJson) {
-    // io.output JSON-stringifies its first arg; pass the object directly.
-    c.output(result, raw);
-  } else {
-    // Human-readable report must bypass JSON encoding — use the rawValue
-    // form (third arg) which io.output emits verbatim.
-    c.output(null, true, a.formatAuditReport(result));
-  }
+  const hubArgs = wantJson ? args.filter((arg) => arg !== '--json') : args;
+
+  routeHubCommandFamily({
+    family: 'audit-open',
+    args: hubArgs,
+    subcommands: ['run'],
+    defaultSubcommand: 'run',
+    handlers: {
+      run: () => {
+        const result = a.auditOpenArtifacts(cwd);
+        if (wantJson) {
+          // io.output JSON-stringifies its first arg; pass the object directly.
+          c.output(result, raw);
+        } else {
+          // Human-readable report must bypass JSON encoding — use the rawValue
+          // form (third arg) which io.output emits verbatim.
+          c.output(null, true, a.formatAuditReport(result));
+        }
+      },
+    },
+    unknownMessage: (subcommand: string) =>
+      `Unknown audit-open subcommand: "${subcommand}". audit-open takes no subcommands (use --json for JSON output).`,
+    error,
+    cwd,
+    raw,
+  });
 }
 
 export = {

--- a/src/cjs-command-router-adapter.cts
+++ b/src/cjs-command-router-adapter.cts
@@ -13,6 +13,12 @@
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import commandRoutingHub = require('./command-routing-hub.cjs');
 const { createHub, ERROR_KINDS } = commandRoutingHub;
+// Phase 2 (#1646): import ERROR_REASON so the UnknownCommand translation can
+// pass `sdk_unknown_command` as the second arg to error(), preserving the
+// JSON-error envelope contract that capability routers' tests assert on.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import io = require('./io.cjs');
+const { ERROR_REASON } = io;
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -140,7 +146,12 @@ function routeHubCommandFamily({
 
   if (result.ok) return;
   if (result.kind === ERROR_KINDS.UnknownCommand) {
-    error(unknownMessage(subcommand ?? '', available));
+    // Phase 2 (#1646): pass SDK_UNKNOWN_COMMAND as the second arg so the
+    // JSON-error envelope (GSD_JSON_ERRORS=1) preserves the typed reason
+    // for downstream consumers. Additive for host routers (their existing
+    // one-arg `error` callbacks ignore the second arg); required for
+    // capability routers whose tests assert on `reason === 'sdk_unknown_command'`.
+    error(unknownMessage(subcommand ?? '', available), ERROR_REASON.SDK_UNKNOWN_COMMAND);
     return;
   }
   if (result.kind === ERROR_KINDS.InvalidArgs) {

--- a/src/graphify-command-router.cts
+++ b/src/graphify-command-router.cts
@@ -27,8 +27,15 @@
 import graphify = require('./graphify.cjs');
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import io = require('./io.cjs');
+// Phase 2 (#1646): route through the Hub per ADR-959 §III(B) line 75.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import commandRoutingHub = require('./command-routing-hub.cjs');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import cjsCommandRouterAdapter = require('./cjs-command-router-adapter.cjs');
 
 const { output, ERROR_REASON } = io;
+const { makeInvalidArgs } = commandRoutingHub;
+const { routeHubCommandFamily } = cjsCommandRouterAdapter;
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -52,42 +59,58 @@ interface RouteGraphifyCommandOptions {
 // ─── Implementation ───────────────────────────────────────────────────────────
 
 function routeGraphifyCommand({ args, cwd, raw, error, _graphify }: RouteGraphifyCommandOptions): void {
-  const subcommand = args[1];
   const g: GraphifyModule = _graphify ?? graphify;
 
-  if (subcommand === 'query') {
-    const term = args[2];
-    if (!term) {
-      error('Usage: gsd-tools graphify query <term>', ERROR_REASON.USAGE);
-      return;
-    }
-    const budgetIdx = args.indexOf('--budget');
-    let budget: number | null = null;
-    if (budgetIdx !== -1) {
-      const rawBudget = args[budgetIdx + 1];
-      if (rawBudget === undefined || Number.isNaN(parseInt(rawBudget, 10))) {
-        error('Usage: gsd-tools graphify query <term> [--budget <N>]', ERROR_REASON.USAGE);
-        return;
-      }
-      budget = parseInt(rawBudget, 10);
-    }
-    output(g.graphifyQuery(cwd, term, { budget }), raw);
-  } else if (subcommand === 'status') {
-    output(g.graphifyStatus(cwd), raw);
-  } else if (subcommand === 'diff') {
-    output(g.graphifyDiff(cwd), raw);
-  } else if (subcommand === 'build') {
-    if (args[2] === 'snapshot') {
-      output(g.writeSnapshot(cwd), raw);
-    } else {
-      output(g.graphifyBuild(cwd), raw);
-    }
-  } else {
-    error(
-      'Unknown graphify subcommand. Available: build, query, status, diff',
-      ERROR_REASON.SDK_UNKNOWN_COMMAND,
-    );
-  }
+  // Phase 2 (#1646): routes through the Command Routing Hub per ADR-959 §III(B)
+  // line 75. Validation handlers return `makeInvalidArgs(...)` Results (Q2=C,
+  // Q4=ii); the Hub → adapter translation preserves ERROR_REASON granularity
+  // via the exitReason field (Phase 1, #1644). Success handlers keep direct
+  // `output()` calls (audit's formatAuditReport quirk sets this precedent).
+  // The unknown-subcommand path is owned by the Hub's manifest check; the
+  // adapter passes SDK_UNKNOWN_COMMAND for UnknownCommand Results.
+  routeHubCommandFamily({
+    family: 'graphify',
+    args,
+    // Alphabetical order produces a stable, byte-identical `Available:` list
+    // in the unknown-subcommand message (matches the pre-conversion text).
+    subcommands: ['build', 'diff', 'query', 'status'],
+    handlers: {
+      query: () => {
+        const term = args[2];
+        if (!term) {
+          return makeInvalidArgs('term', 'Usage: gsd-tools graphify query <term>', ERROR_REASON.USAGE);
+        }
+        const budgetIdx = args.indexOf('--budget');
+        let budget: number | null = null;
+        if (budgetIdx !== -1) {
+          const rawBudget = args[budgetIdx + 1];
+          if (rawBudget === undefined || Number.isNaN(parseInt(rawBudget, 10))) {
+            return makeInvalidArgs(
+              '--budget',
+              'Usage: gsd-tools graphify query <term> [--budget <N>]',
+              ERROR_REASON.USAGE,
+            );
+          }
+          budget = parseInt(rawBudget, 10);
+        }
+        output(g.graphifyQuery(cwd, term, { budget }), raw);
+      },
+      status: () => output(g.graphifyStatus(cwd), raw),
+      diff: () => output(g.graphifyDiff(cwd), raw),
+      build: () => {
+        if (args[2] === 'snapshot') {
+          output(g.writeSnapshot(cwd), raw);
+        } else {
+          output(g.graphifyBuild(cwd), raw);
+        }
+      },
+    },
+    unknownMessage: (subcommand: string, available: string[]) =>
+      `Unknown graphify subcommand. Available: ${available.join(', ')}`,
+    error,
+    cwd,
+    raw,
+  });
 }
 
 export = {

--- a/src/intel-command-router.cts
+++ b/src/intel-command-router.cts
@@ -44,8 +44,15 @@ import io = require('./io.cjs');
 import coreUtils = require('./core-utils.cjs');
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import path = require('path');
+// Phase 2 (#1646): route through the Hub per ADR-959 §III(B) line 75.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import commandRoutingHub = require('./command-routing-hub.cjs');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import cjsCommandRouterAdapter = require('./cjs-command-router-adapter.cjs');
 
 const { ERROR_REASON } = io;
+const { makeInvalidArgs } = commandRoutingHub;
+const { routeHubCommandFamily } = cjsCommandRouterAdapter;
 // Default CoreModule implementation assembled from leaf modules.
 // _core seam overrides this entirely for test injection.
 const _defaultCore = { output: io.output, timeAgo: coreUtils.timeAgo };
@@ -87,62 +94,81 @@ function routeIntelCommand({ args, cwd, raw, error, _intel, _core }: RouteIntelC
   // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-unsafe-assignment
   const intel: IntelModule = _intel ?? require('./intel.cjs');
   const c: CoreModule = _core ?? _defaultCore;
-  const subcommand = args[1];
 
-  if (subcommand === 'query') {
-    const term = args[2];
-    if (!term) {
-      error('Usage: gsd-tools intel query <term>', ERROR_REASON.USAGE);
-      return;
-    }
-    const planningDir = path.join(cwd, '.planning');
-    c.output(intel.intelQuery(term, planningDir), raw);
-  } else if (subcommand === 'status') {
-    const planningDir = path.join(cwd, '.planning');
-    const status = intel.intelStatus(planningDir);
-    if (!raw && status.files) {
-      for (const file of Object.values(status.files)) {
-        if (file.updated_at) {
-          file.updated_at = c.timeAgo(new Date(file.updated_at));
+  // Phase 2 (#1646): routes through the Command Routing Hub per ADR-959 §III(B)
+  // line 75. Validation handlers return `makeInvalidArgs(...)` Results; the
+  // Hub → adapter translation preserves ERROR_REASON granularity via the
+  // exitReason field (Phase 1, #1644). Success handlers keep direct `c.output()`
+  // calls. The timeAgo mutation in non-raw `status` is preserved. Lazy require
+  // of intel.cjs inside the function is preserved (loads only when dispatched).
+  routeHubCommandFamily({
+    family: 'intel',
+    args,
+    // Alphabetical for stable unknownMessage text; the integration test asserts
+    // inclusion of all 9 subcommands, not order.
+    subcommands: ['api-surface', 'diff', 'extract-exports', 'patch-meta', 'query', 'snapshot', 'status', 'update', 'validate'],
+    handlers: {
+      query: () => {
+        const term = args[2];
+        if (!term) {
+          return makeInvalidArgs('term', 'Usage: gsd-tools intel query <term>', ERROR_REASON.USAGE);
         }
-      }
-    }
-    c.output(status, raw);
-  } else if (subcommand === 'diff') {
-    const planningDir = path.join(cwd, '.planning');
-    c.output(intel.intelDiff(planningDir), raw);
-  } else if (subcommand === 'snapshot') {
-    const planningDir = path.join(cwd, '.planning');
-    c.output(intel.intelSnapshot(planningDir), raw);
-  } else if (subcommand === 'patch-meta') {
-    const filePath = args[2];
-    if (!filePath) {
-      error('Usage: gsd-tools intel patch-meta <file-path>', ERROR_REASON.USAGE);
-      return;
-    }
-    c.output(intel.intelPatchMeta(path.resolve(cwd, filePath)), raw);
-  } else if (subcommand === 'validate') {
-    const planningDir = path.join(cwd, '.planning');
-    c.output(intel.intelValidate(planningDir), raw);
-  } else if (subcommand === 'extract-exports') {
-    const filePath = args[2];
-    if (!filePath) {
-      error('Usage: gsd-tools intel extract-exports <file-path>', ERROR_REASON.USAGE);
-      return;
-    }
-    c.output(intel.intelExtractExports(path.resolve(cwd, filePath)), raw);
-  } else if (subcommand === 'update') {
-    const planningDir = path.join(cwd, '.planning');
-    c.output(intel.intelUpdate(planningDir), raw);
-  } else if (subcommand === 'api-surface') {
-    const planningDir = path.join(cwd, '.planning');
-    c.output(intel.intelApiSurface(planningDir), raw);
-  } else {
-    error(
-      'Unknown intel subcommand. Available: query, status, update, diff, snapshot, patch-meta, validate, extract-exports, api-surface',
-      ERROR_REASON.SDK_UNKNOWN_COMMAND,
-    );
-  }
+        const planningDir = path.join(cwd, '.planning');
+        c.output(intel.intelQuery(term, planningDir), raw);
+      },
+      status: () => {
+        const planningDir = path.join(cwd, '.planning');
+        const status = intel.intelStatus(planningDir);
+        if (!raw && status.files) {
+          for (const file of Object.values(status.files)) {
+            if (file.updated_at) {
+              file.updated_at = c.timeAgo(new Date(file.updated_at));
+            }
+          }
+        }
+        c.output(status, raw);
+      },
+      diff: () => {
+        const planningDir = path.join(cwd, '.planning');
+        c.output(intel.intelDiff(planningDir), raw);
+      },
+      snapshot: () => {
+        const planningDir = path.join(cwd, '.planning');
+        c.output(intel.intelSnapshot(planningDir), raw);
+      },
+      'patch-meta': () => {
+        const filePath = args[2];
+        if (!filePath) {
+          return makeInvalidArgs('file-path', 'Usage: gsd-tools intel patch-meta <file-path>', ERROR_REASON.USAGE);
+        }
+        c.output(intel.intelPatchMeta(path.resolve(cwd, filePath)), raw);
+      },
+      validate: () => {
+        const planningDir = path.join(cwd, '.planning');
+        c.output(intel.intelValidate(planningDir), raw);
+      },
+      'extract-exports': () => {
+        const filePath = args[2];
+        if (!filePath) {
+          return makeInvalidArgs('file-path', 'Usage: gsd-tools intel extract-exports <file-path>', ERROR_REASON.USAGE);
+        }
+        c.output(intel.intelExtractExports(path.resolve(cwd, filePath)), raw);
+      },
+      update: () => {
+        const planningDir = path.join(cwd, '.planning');
+        c.output(intel.intelUpdate(planningDir), raw);
+      },
+      'api-surface': () => {
+        const planningDir = path.join(cwd, '.planning');
+        c.output(intel.intelApiSurface(planningDir), raw);
+      },
+    },
+    unknownMessage: (subcommand: string, available: string[]) =>
+      `Unknown intel subcommand. Available: ${available.join(', ')}`,
+    error,
+    cwd,
+    raw,
+  });
 }
 
 export = {


### PR DESCRIPTION
<!-- pr-template-exempt: internal refactor converting 3 capability routers to routeHubCommandFamily per ADR-959; the fix/enhancement/feature templates don't fit chore-class refactors with dormant additive observability; chore-equivalent of issue #1646 -->

Closes #1646
Part of #1641 (Phase 2 of 4). Builds on merged Phase 0 (#1642 / #1643) and Phase 1 (#1644 / #1645).

## What

Converts the three capability command routers (graphify, intel, audit) from hand-rolled `if`/`else` dispatch to `routeHubCommandFamily`, implementing the ADR-959 §III(B) line 75 mandate: *"the capability author writes a router using the same `routeCjsCommandFamily` helper."* All three routers now share the uniform dispatch shape with the 14 host routers.

Plus one adapter prerequisite: the UnknownCommand translation now passes `ERROR_REASON.SDK_UNKNOWN_COMMAND` as the second arg to `error()` so the JSON-error envelope preserves the typed reason (capability router tests assert on this).

## Why

ADR-959 §III(B) explicitly mandated that capability routers use the same dispatch helper as host routers. The three routers extracted under ADR-959 drifted from that mandate — they hand-rolled if/else chains and called `output()`/`error()` directly, bypassing the Hub's typed Result contract, manifest validation, and observability seam. Phase 2 closes that gap.

The user-visible change: `GSD_AUDIT=1` traces and the structured stderr JSON error envelope now cover capability commands (`graphify`, `intel`, `audit-uat`, `audit-open`) uniformly with all other command families. JSON-error `reason` values (`usage`, `sdk_unknown_command`) and message texts are preserved byte-identical.

## How (per-router)

### Adapter prerequisite (`src/cjs-command-router-adapter.cts`)

- Imported `ERROR_REASON` from `io.cjs`
- `UnknownCommand` Result translation now calls `error(unknownMessage(...), ERROR_REASON.SDK_UNKNOWN_COMMAND)` — additive for host routers (their existing one-arg `error` callbacks ignore the second arg); required for capability routers whose tests assert `reason === 'sdk_unknown_command'`

### graphify (`src/graphify-command-router.cts`)

- 4-branch if/else → `routeHubCommandFamily({family:'graphify', subcommands:['build','diff','query','status'], handlers:{...}})`
- Validation handlers (missing term, missing/invalid `--budget`) return `makeInvalidArgs(arg, reason, ERROR_REASON.USAGE)` Results
- Success handlers keep direct `output()` calls
- Subcommands array alphabetical for byte-identical `Available:` text

### intel (`src/intel-command-router.cts`)

- 9-branch if/else → `routeHubCommandFamily({family:'intel', subcommands:[9 alphabetical], handlers:{...}})`
- Validation handlers (missing term, missing filePath for `patch-meta`/`extract-exports`) return `makeInvalidArgs` Results
- Preserved the `timeAgo` mutation in non-raw `status` handler
- Preserved lazy `require('./intel.cjs')` inside the route function

### audit (`src/audit-command-router.cts`)

- `routeAuditUat`: routes through the Hub with a synthetic `'run'` `defaultSubcommand` (audit-uat has no real subcommands); gives uniform observability
- `routeAuditOpen`: captures `--json` in a closure, strips it from args before Hub dispatch (so it isn't mistaken for a subcommand by the manifest check), branches on `wantJson` inside the handler to preserve the `formatAuditReport` success-path quirk

## Design decisions (locked in candidate 2 grilling)

| Q | Decision |
|---|---|
| Q1 Scope | All 3 routers in one PR |
| Q2 Validation | C — handlers return `makeInvalidArgs(...)` Results, no direct `error()` from closures |
| Q3 Host-router scope | a — capability routers only; Hub extended once |
| Q4 Signal mechanism | ii — return Result from handler (no typed-throw class) |
| Q5 Router external contract | T1 — keep ADR-959 `{args, cwd, raw, error} → void` signature |
| Q6 Factory access | F1 — direct import `makeInvalidArgs` from `./command-routing-hub.cjs` |

## Verification

| Check | Result |
|---|---|
| `tests/graphify-command-cutover.test.cjs` | ✅ 119/119 pass (unit, dispatch, behavior, error paths, JSON-errors, registry) |
| `tests/intel-command-cutover.test.cjs` | ✅ 39/39 pass |
| `tests/audit-command-cutover.test.cjs` | ✅ 24/24 pass |
| `tests/bug-974-graphify-budget-missing-value.test.cjs` | ✅ regression guard passes |
| `tests/cjs-command-router-adapter.test.cjs` + `tests/command-routing-hub.test.cjs` (Phase 1) | ✅ still green (adapter UnknownCommand change is additive) |
| Full unit suite (`npm run test:unit`) | ✅ 2384 tests, 0 fail |
| `gsd-test-summary` on docker (RULESET.PR-FLOW.docker-before-push) | ✅ `outcome: passed`, `unique_failures: 0`, `total_failures: 0` |
| JSON-error envelope parity | ✅ `reason` values (`usage`, `sdk_unknown_command`) and message texts preserved byte-identical |

## CI / changeset

- `.changeset/capability-routers-via-hub.md` — type `Changed`, `pr: 0` placeholder (will be backfilled after this PR's number is known, per `DEFECT.CHANGESET-PR-FIELD-DRIFT`)
- `docs/CONFIGURATION.md` updated (required for `Changed` changeset per `RULESET.PR-FLOW.docs-by-changeset-type`)
- No `no-changelog` label — this PR has a real user-visible change (audit-trail expansion)

## Adversarial self-review (directive Step 4)

- ✅ No new I/O, network, eval, or shell interpolation surfaces
- ✅ `--json` arg stripping in audit-open is invariant-safe (only strips exact `'--json'` matches; other args preserved)
- ✅ Hub's `_validateErrResult` runtime-validator still rejects foreign keys on Result variants (only `exitReason` is newly allowed, per Phase 1)
- ✅ Lazy `require('./intel.cjs')` preserved — intel module loads only when an intel command is dispatched (no startup cost)
- ✅ All `_`-prefixed test seams (`_graphify`, `_intel`, `_core`, `_uat`, `_audit`) preserved — tests inject mocks the same way

## Workflow directive alignment

| Step | Status |
|---|---|
| 1. Research & classification | ✅ Read ADR-959 §III(B), ADR-0174 §5 (as amended), CONTRIBUTING; classified as chore/internal refactor |
| 2. Rubber-duck + Artificer laws | ✅ Hyrum's Law: the JSON-error envelope contract is now uniformly produced via the Hub Result → `error(msg, exitReason)` translation; ADR-959's mandate is honored |
| 3. QA + TDD | ✅ Existing tests ARE the spec — 182 cutover tests + bug-974 regression all pass byte-identical. The conversion is a refactor under green. |
| 4. Adversarial review | ✅ self-reviewed (above) |
| 5. Diátaxis docs | ✅ CONFIGURATION.md updated for the observability expansion |
| 6. Rebase + PR | ✅ Branched from `next` (Phase 1 merged), pushed, this PR targets `next` per ADR-230 |

## Scope

- **In scope:** 3 router conversions + adapter UnknownCommand prerequisite + CONFIGURATION.md note + changeset (6 files, +212/−103)
- **Out of scope:** Phase 3 (final verification, parent #1641 closeout) — the parent tracks the overall candidate

## Post-merge follow-up

After this PR merges and the number is known, the changeset's `pr: 0` will be backfilled to the real PR number per `DEFECT.CHANGESET-PR-FIELD-DRIFT`. I'll do this as a follow-up commit on `next` or via `gh api` edit.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1647"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784862642&installation_id=134682257&pr_number=1647&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1647&signature=149fae04bcc64c8bbbd3f68ab969463fbe2007337958c29f51a27fcd98293ebb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->