### PR TITLE
fix(#1571): resolve schema-drift phases by token

### DIFF
--- a/.changeset/silly-foxes-caper.md
+++ b/.changeset/silly-foxes-caper.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 1651
+---
+Fix schema-drift phase resolution to use exact phase tokens instead of substring matching.

--- a/src/verify.cts
+++ b/src/verify.cts
@@ -2056,17 +2056,18 @@ function cmdVerifySchemaDrift(
   }
 
   let phaseDir: string | null = null;
-  const entries = fs.readdirSync(phasesDir, { withFileTypes: true });
-  for (const entry of entries) {
-    if (entry.isDirectory() && entry.name.includes(phaseArg)) {
-      phaseDir = path.join(phasesDir, entry.name);
-      break;
-    }
-  }
+  const exact = path.join(phasesDir, phaseArg);
+  if (fs.existsSync(exact)) phaseDir = exact;
 
   if (!phaseDir) {
-    const exact = path.join(phasesDir, phaseArg);
-    if (fs.existsSync(exact)) phaseDir = exact;
+    const normalizedPhase = normalizePhaseName(phaseArg);
+    const entries = fs.readdirSync(phasesDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.isDirectory() && phaseTokenMatches(entry.name, normalizedPhase)) {
+        phaseDir = path.join(phasesDir, entry.name);
+        break;
+      }
+    }
   }
 
   if (!phaseDir) {

--- a/tests/schema-drift.test.cjs
+++ b/tests/schema-drift.test.cjs
@@ -338,6 +338,25 @@ describe('verify schema-drift CLI command', () => {
     assert.strictEqual(output.blocking, false);
   });
 
+  test('does not resolve phase by substring match', () => {
+    const phaseDir = path.join(tmpDir, '.planning', 'phases', '11-expansion');
+    fs.mkdirSync(phaseDir, { recursive: true });
+    fs.writeFileSync(path.join(phaseDir, '11-01-PLAN.md'), [
+      '---',
+      'files_modified: [supabase/migrations/0001_init.sql]',
+      '---',
+      '',
+      'Plan content',
+    ].join('\n'));
+
+    const result = runGsdTools(['verify', 'schema-drift', '1'], tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.drift_detected, false);
+    assert.strictEqual(output.blocking, false);
+    assert.strictEqual(output.message, 'Phase directory not found: 1');
+  });
+
   test('respects skip flag', () => {
     const phaseDir = path.join(tmpDir, '.planning', 'phases', '01-setup');
     fs.mkdirSync(phaseDir, { recursive: true });


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #1571

## What was broken

`verify schema-drift <phase>` resolved phase directories with substring matching, so a phase argument like `1` could inspect `11-expansion` instead of reporting that phase `1` was not found.

## What this fix does

The command now checks for an exact phase directory first, then uses the existing phase-token matcher to resolve phase directories by token instead of substring.

## Root cause

`cmdVerifySchemaDrift` used `entry.name.includes(phaseArg)` rather than the canonical `normalizePhaseName` / `phaseTokenMatches` path used for phase-id matching elsewhere.

## Testing

### How I verified the fix

- RED: `node --test tests/schema-drift.test.cjs` failed before the implementation on the new substring regression.
- `npm run build:lib`
- `node --test tests/schema-drift.test.cjs`
- `npx eslint src/verify.cts tests/schema-drift.test.cjs`
- `npm run test:affected`

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [x] Other: gsd-tools CJS CLI
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [ ] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None

## Standards followed

Follows `CONTEXT.md` Phase Id Module / Phase Locator Module vocabulary and the confirmed-bug scope in #1571. No ADR change required; this is a bugfix within the existing phase-token resolution policy.
