### PR TITLE
fix(#1581): validate config-set typed values

### DIFF
--- a/.changeset/rapid-koalas-caper.md
+++ b/.changeset/rapid-koalas-caper.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 1652
+---
+Validate config-set typed values so context_window rejects non-canonical numbers and project_code preserves string values.

--- a/src/config.cts
+++ b/src/config.cts
@@ -549,6 +549,17 @@ function assertEnumValue(parsedValue: unknown, rawVal: string, allowed: readonly
   }
 }
 
+function parsePositiveIntegerConfigValue(rawVal: string, keyPath: string): number {
+  if (!/^[1-9]\d*$/.test(rawVal)) {
+    error(`Invalid ${keyPath} '${rawVal}'. Must be a positive integer.`);
+  }
+  const parsed = Number(rawVal);
+  if (!Number.isSafeInteger(parsed)) {
+    error(`Invalid ${keyPath} '${rawVal}'. Must be a positive integer.`);
+  }
+  return parsed;
+}
+
 /**
  * Command to set a value in the config file, allowing nested values via dot notation (e.g.,
  * "workflow.research").
@@ -584,10 +595,12 @@ function cmdConfigSet(cwd: string, keyPath: string | undefined, value: string | 
 
   // Parse value (handle booleans, numbers, and JSON arrays/objects)
   let parsedValue: unknown = val;
-  if (val === 'true') parsedValue = true;
+  if (kp === 'project_code') parsedValue = val;
+  else if (kp === 'context_window') parsedValue = parsePositiveIntegerConfigValue(val, kp);
+  else if (val === 'true') parsedValue = true;
   else if (val === 'false') parsedValue = false;
   else if (!isNaN(Number(val)) && val !== '') parsedValue = Number(val);
-  else if (typeof val === 'string' && (val.startsWith('[') || val.startsWith('{'))) {
+  else if (val.startsWith('[') || val.startsWith('{')) {
     try { parsedValue = JSON.parse(val); } catch { /* keep as string */ }
   }
 

--- a/tests/config.test.cjs
+++ b/tests/config.test.cjs
@@ -1093,6 +1093,59 @@ describe('config-set/config-get context', () => {
   });
 });
 
+// ─── config-set value coercion (#1581) ───────────────────────────────────────
+
+describe('config-set value coercion (#1581)', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempProject();
+    runGsdTools('config-ensure-section', tmpDir, { HOME: tmpDir, USERPROFILE: tmpDir });
+    const config = readConfig(tmpDir);
+    config.context_window = 200000;
+    writeConfig(tmpDir, config);
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('rejects non-finite context_window instead of writing null', () => {
+    const result = runGsdTools(['config-set', 'context_window', 'Infinity', '--raw'], tmpDir);
+    assert.strictEqual(result.success, false);
+    assert.ok(
+      result.error.includes('Invalid context_window'),
+      `Expected context_window validation error: ${result.error}`,
+    );
+
+    const config = readConfig(tmpDir);
+    assert.strictEqual(config.context_window, 200000);
+  });
+
+  test('rejects non-canonical numeric context_window values', () => {
+    for (const value of ['  ', '0x10', '1e6', '0']) {
+      const result = runGsdTools(['config-set', 'context_window', value, '--raw'], tmpDir);
+      assert.strictEqual(result.success, false, `${value} should be rejected`);
+      assert.ok(
+        result.error.includes('Invalid context_window'),
+        `Expected context_window validation error for ${JSON.stringify(value)}: ${result.error}`,
+      );
+    }
+
+    const config = readConfig(tmpDir);
+    assert.strictEqual(config.context_window, 200000);
+  });
+
+  test('preserves numeric-looking project_code values as strings', () => {
+    const result = runGsdTools(['config-set', 'project_code', '007', '--raw'], tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+    assert.strictEqual(result.output.trim(), 'project_code=007');
+
+    const config = readConfig(tmpDir);
+    assert.strictEqual(config.project_code, '007');
+  });
+});
+
 // ─── config-path (#2282) ────────────────────────────────────────────────────
 
 describe('config-path command (#2282)', () => {


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #1581

---

## What was broken

`config-set` used generic numeric coercion before key-specific validation. That allowed `context_window Infinity` to print `Infinity` while JSON persisted `null`, and converted numeric-looking `project_code` values such as `007` into numbers.

## What this fix does

`context_window` now accepts only canonical positive integer literals before writing config. `project_code` is preserved as a string so codes with leading zeroes are not rewritten.

## Root cause

The shared CLI value parser treated any `Number(value)`-coercible string as numeric, including non-finite and non-canonical numeric forms, before considering config key semantics.

## Testing

### How I verified the fix

- RED check: `node --test tests/config.test.cjs` failed before implementation on the new #1581 regression tests
- `npm run build:lib`
- `node --test tests/config.test.cjs`
- `npx eslint src/config.cts tests/config.test.cjs`
- `node --test tests/feat-3593-cli-negative-config.test.cjs tests/bug-2943-config-get-context-window-default.test.cjs tests/bug-2798-context-window-config-key.test.cjs`
- `npm run test:affected`

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [x] Other: gsd-tools CJS CLI
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [ ] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

Invalid `context_window` inputs that previously wrote surprising values are now rejected. This is the intended validation fix for #1581.
