### PR TITLE
fix(#1516): expose adaptive model_profile in /gsd-new-project AI Models prompt

### DIFF
--- a/.changeset/gallant-geese-run.md
+++ b/.changeset/gallant-geese-run.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 1654
 ---
 **`/gsd-new-project` AI Models prompt now exposes the `adaptive` model profile** — both onboarding paths (auto-mode and interactive) listed only Balanced/Quality/Budget/Inherit, so the `adaptive` profile (role-based cost optimization across Claude/Codex/Gemini/OpenRouter/local) was unreachable through `/gsd-new-project` despite being a first-class catalog entry and documented in CONFIGURATION.md. Both prompts now use the proven two-question split (Q1: Adaptive / Standard tier / Inherit; Q2: Quality / Balanced / Budget) already shipped for `/gsd:settings` (#3784), and both `config-new-project` example payloads list `adaptive`. (#1516)

--- a/.changeset/gallant-geese-run.md
+++ b/.changeset/gallant-geese-run.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`/gsd-new-project` AI Models prompt now exposes the `adaptive` model profile** — both onboarding paths (auto-mode and interactive) listed only Balanced/Quality/Budget/Inherit, so the `adaptive` profile (role-based cost optimization across Claude/Codex/Gemini/OpenRouter/local) was unreachable through `/gsd-new-project` despite being a first-class catalog entry and documented in CONFIGURATION.md. Both prompts now use the proven two-question split (Q1: Adaptive / Standard tier / Inherit; Q2: Quality / Balanced / Budget) already shipped for `/gsd:settings` (#3784), and both `config-new-project` example payloads list `adaptive`. (#1516)

--- a/gsd-core/workflows/new-project.md
+++ b/gsd-core/workflows/new-project.md
@@ -230,19 +230,52 @@ AskUserQuestion([
       { label: "Yes (Recommended)", description: "Resolve symbol references against live source during plan review — catches hallucinated names before execution" },
       { label: "No", description: "Skip symbol grounding — plan review proceeds without source verification" }
     ]
-  },
+  }
+])
+
+// Model profile uses a two-question split because AskUserQuestion enforces a hard
+// 4-option cap and there are 5 valid profiles (quality, balanced, budget, adaptive,
+// inherit). Q1 routes between adaptive/standard-tier/inherit; Q2 (shown only when
+// Q1 = "Standard tier…") picks among the three standard profiles. Mirrors the
+// /gsd:settings split (#3784, #1516).
+AskUserQuestion([
   {
     header: "AI Models",
     question: "Which AI models for planning agents?",
     multiSelect: false,
     options: [
-      { label: "Balanced (Recommended)", description: "Sonnet for most agents — good quality/cost ratio" },
-      { label: "Quality", description: "Opus for research/roadmap — higher cost, deeper analysis" },
-      { label: "Budget", description: "Haiku where possible — fastest, lowest cost" },
-      { label: "Inherit", description: "Use the current session model for all agents (OpenCode /model)" }
+      { label: "Adaptive (Recommended)", description: "Role-based cost optimization: heavy roles use the highest-tier model available on the active runtime, light roles use the cheapest. Best balance of quality and cost across all supported runtimes (Claude, Codex, Gemini, OpenRouter, local)." },
+      { label: "Standard tier…", description: "Choose Quality, Balanced, or Budget — flat tier applied to all agents" },
+      { label: "Inherit", description: "Use the current session model for all agents (required for non-Claude runtimes: Codex, Gemini CLI, OpenCode /model, OpenRouter, local models)" }
     ]
   }
 ])
+
+**Conditional visibility — model_profile (Q2):**
+  Only ask this question when Q1's answer is "Standard tier…".
+  If Q1 = "Adaptive (Recommended)" → write model_profile=adaptive and SKIP Q2.
+  If Q1 = "Inherit"                → write model_profile=inherit and SKIP Q2.
+  If user cancels Q2 after picking "Standard tier…" → leave existing model_profile value unchanged.
+
+AskUserQuestion([
+  {
+    question: "Which standard profile? (Quality / Balanced / Budget)",
+    header: "Model Tier",
+    multiSelect: false,
+    options: [
+      { label: "Quality", description: "Opus everywhere except verification (highest cost) — Claude only" },
+      { label: "Balanced", description: "Opus for planning, Sonnet for research/execution/verification — Claude only" },
+      { label: "Budget", description: "Sonnet for writing, Haiku for research/verification (lowest cost) — Claude only" }
+    ]
+  }
+])
+
+// Map UI choices → config values:
+//   Q1 "Adaptive (Recommended)"         → model_profile = "adaptive"
+//   Q1 "Inherit"                        → model_profile = "inherit"
+//   Q1 "Standard tier…" + Q2 "Quality"  → model_profile = "quality"
+//   Q1 "Standard tier…" + Q2 "Balanced" → model_profile = "balanced"
+//   Q1 "Standard tier…" + Q2 "Budget"   → model_profile = "budget"
 ```
 
 **Round 3 — PR body onboarding:**
@@ -273,7 +306,7 @@ Create `.planning/config.json` with all settings (CLI fills in remaining default
 
 ```bash
 mkdir -p .planning
-gsd_run query config-new-project '{"mode":"yolo","granularity":"[selected]","parallelization":true|false,"commit_docs":true|false,"model_profile":"quality|balanced|budget|inherit","workflow":{"research":true|false,"plan_check":true|false,"verifier":true|false,"nyquist_validation":true|false,"auto_advance":true},"plan_review":{"source_grounding":true|false},"ship":{"pr_body_sections":[{"heading":"User Stories & Acceptance Criteria","enabled":true|false,"source":"REQUIREMENTS.md ## User Stories || REQUIREMENTS.md ## Acceptance Criteria","fallback":"- Acceptance criteria are covered by the linked requirements and verification evidence."},{"heading":"Risks & Dependencies","enabled":true|false,"source":"PLAN.md ## Risks || PLAN.md ## Dependencies","fallback":"- No known high-risk rollout dependencies."},{"heading":"Success Metrics & Release Criteria","enabled":true|false,"source":"REQUIREMENTS.md ## Definition of Done || VERIFICATION.md ## Release Criteria","fallback":"- Release when automated verification and required manual checks pass."},{"heading":"Stakeholder Review & Approval","enabled":true|false,"template":"- Product owner approval pending for {phase_name}."}]}}'
+gsd_run query config-new-project '{"mode":"yolo","granularity":"[selected]","parallelization":true|false,"commit_docs":true|false,"model_profile":"quality|balanced|budget|adaptive|inherit","workflow":{"research":true|false,"plan_check":true|false,"verifier":true|false,"nyquist_validation":true|false,"auto_advance":true},"plan_review":{"source_grounding":true|false},"ship":{"pr_body_sections":[{"heading":"User Stories & Acceptance Criteria","enabled":true|false,"source":"REQUIREMENTS.md ## User Stories || REQUIREMENTS.md ## Acceptance Criteria","fallback":"- Acceptance criteria are covered by the linked requirements and verification evidence."},{"heading":"Risks & Dependencies","enabled":true|false,"source":"PLAN.md ## Risks || PLAN.md ## Dependencies","fallback":"- No known high-risk rollout dependencies."},{"heading":"Success Metrics & Release Criteria","enabled":true|false,"source":"REQUIREMENTS.md ## Definition of Done || VERIFICATION.md ## Release Criteria","fallback":"- Release when automated verification and required manual checks pass."},{"heading":"Stakeholder Review & Approval","enabled":true|false,"template":"- Product owner approval pending for {phase_name}."}]}}'
 ```
 
 **If commit_docs = No:** Add `.planning/` to `.gitignore`.
@@ -745,19 +778,52 @@ questions: [
       { label: "Yes (Recommended)", description: "Confirm deliverables match phase goals" },
       { label: "No", description: "Trust execution, skip verification" }
     ]
-  },
+  }
+]
+
+// Model profile uses a two-question split because AskUserQuestion enforces a hard
+// 4-option cap and there are 5 valid profiles (quality, balanced, budget, adaptive,
+// inherit). Q1 routes between adaptive/standard-tier/inherit; Q2 (shown only when
+// Q1 = "Standard tier…") picks among the three standard profiles. Mirrors the
+// /gsd:settings split (#3784, #1516).
+questions: [
   {
     header: "AI Models",
     question: "Which AI models for planning agents?",
     multiSelect: false,
     options: [
-      { label: "Balanced (Recommended)", description: "Sonnet for most agents — good quality/cost ratio" },
-      { label: "Quality", description: "Opus for research/roadmap — higher cost, deeper analysis" },
-      { label: "Budget", description: "Haiku where possible — fastest, lowest cost" },
-      { label: "Inherit", description: "Use the current session model for all agents (OpenCode /model)" }
+      { label: "Adaptive (Recommended)", description: "Role-based cost optimization: heavy roles use the highest-tier model available on the active runtime, light roles use the cheapest. Best balance of quality and cost across all supported runtimes (Claude, Codex, Gemini, OpenRouter, local)." },
+      { label: "Standard tier…", description: "Choose Quality, Balanced, or Budget — flat tier applied to all agents" },
+      { label: "Inherit", description: "Use the current session model for all agents (required for non-Claude runtimes: Codex, Gemini CLI, OpenCode /model, OpenRouter, local models)" }
     ]
   }
 ]
+
+**Conditional visibility — model_profile (Q2):**
+  Only ask this question when Q1's answer is "Standard tier…".
+  If Q1 = "Adaptive (Recommended)" → write model_profile=adaptive and SKIP Q2.
+  If Q1 = "Inherit"                → write model_profile=inherit and SKIP Q2.
+  If user cancels Q2 after picking "Standard tier…" → leave existing model_profile value unchanged.
+
+questions: [
+  {
+    question: "Which standard profile? (Quality / Balanced / Budget)",
+    header: "Model Tier",
+    multiSelect: false,
+    options: [
+      { label: "Quality", description: "Opus everywhere except verification (highest cost) — Claude only" },
+      { label: "Balanced", description: "Opus for planning, Sonnet for research/execution/verification — Claude only" },
+      { label: "Budget", description: "Sonnet for writing, Haiku for research/verification (lowest cost) — Claude only" }
+    ]
+  }
+]
+
+// Map UI choices → config values:
+//   Q1 "Adaptive (Recommended)"         → model_profile = "adaptive"
+//   Q1 "Inherit"                        → model_profile = "inherit"
+//   Q1 "Standard tier…" + Q2 "Quality"  → model_profile = "quality"
+//   Q1 "Standard tier…" + Q2 "Balanced" → model_profile = "balanced"
+//   Q1 "Standard tier…" + Q2 "Budget"   → model_profile = "budget"
 ```
 
 **PR body onboarding:** Ask which optional PRD-style sections `/gsd:ship` should append to generated PR bodies. Use the same `ship.pr_body_sections` mapping as Step 2a: selected sections get `enabled: true`, seeded-but-unselected sections get `enabled: false`, and selecting none writes an empty list. Prefer lean/agile PRD sections that make user value, acceptance criteria, Definition of Done, and stakeholder traceability explicit.
@@ -773,7 +839,7 @@ Create `.planning/config.json` with all settings (CLI fills in remaining default
 
 ```bash
 mkdir -p .planning
-gsd_run query config-new-project '{"mode":"[yolo|interactive]","granularity":"[selected]","parallelization":true|false,"commit_docs":true|false,"model_profile":"quality|balanced|budget|inherit","workflow":{"research":true|false,"plan_check":true|false,"verifier":true|false,"nyquist_validation":[false if granularity=coarse, true otherwise]},"plan_review":{"source_grounding":true|false},"ship":{"pr_body_sections":[{"heading":"User Stories & Acceptance Criteria","enabled":true|false,"source":"REQUIREMENTS.md ## User Stories || REQUIREMENTS.md ## Acceptance Criteria","fallback":"- Acceptance criteria are covered by the linked requirements and verification evidence."},{"heading":"Risks & Dependencies","enabled":true|false,"source":"PLAN.md ## Risks || PLAN.md ## Dependencies","fallback":"- No known high-risk rollout dependencies."},{"heading":"Success Metrics & Release Criteria","enabled":true|false,"source":"REQUIREMENTS.md ## Definition of Done || VERIFICATION.md ## Release Criteria","fallback":"- Release when automated verification and required manual checks pass."},{"heading":"Stakeholder Review & Approval","enabled":true|false,"template":"- Product owner approval pending for {phase_name}."}]}}'
+gsd_run query config-new-project '{"mode":"[yolo|interactive]","granularity":"[selected]","parallelization":true|false,"commit_docs":true|false,"model_profile":"quality|balanced|budget|adaptive|inherit","workflow":{"research":true|false,"plan_check":true|false,"verifier":true|false,"nyquist_validation":[false if granularity=coarse, true otherwise]},"plan_review":{"source_grounding":true|false},"ship":{"pr_body_sections":[{"heading":"User Stories & Acceptance Criteria","enabled":true|false,"source":"REQUIREMENTS.md ## User Stories || REQUIREMENTS.md ## Acceptance Criteria","fallback":"- Acceptance criteria are covered by the linked requirements and verification evidence."},{"heading":"Risks & Dependencies","enabled":true|false,"source":"PLAN.md ## Risks || PLAN.md ## Dependencies","fallback":"- No known high-risk rollout dependencies."},{"heading":"Success Metrics & Release Criteria","enabled":true|false,"source":"REQUIREMENTS.md ## Definition of Done || VERIFICATION.md ## Release Criteria","fallback":"- Release when automated verification and required manual checks pass."},{"heading":"Stakeholder Review & Approval","enabled":true|false,"template":"- Product owner approval pending for {phase_name}."}]}}'
 ```
 
 **Note:** Run `/gsd:settings` anytime to update model profile, workflow agents, branching strategy, and other preferences.

--- a/tests/new-project-mvp-prompt.test.cjs
+++ b/tests/new-project-mvp-prompt.test.cjs
@@ -44,3 +44,127 @@ describe('new-project — MVP mode prompt', () => {
     assert.ok(contract.hasHorizontalStandardFallback, 'must specify fallback to standard template');
   });
 });
+
+// Bug #1516 — folded into the new-project owning module test (new top-level bug-NNNN
+// files are banned by lint-regression-test-names). /gsd-new-project's two AI Models
+// prompts (Step 2a auto-mode + Step 5 interactive) enumerated only 4 profiles
+// (Balanced/Quality/Budget/Inherit), omitting `adaptive` even though the model catalog
+// (model-catalog.json profiles) and docs/CONFIGURATION.md register 5. The fix mirrors
+// the #3784 two-question split already shipped for /gsd:settings. new-project.md has no
+// <step> tags, so blocks are located by the `header: "AI Models"` marker.
+
+describe('bug #1516: new-project AI Models prompt exposes all 5 model profiles', () => {
+  const content = fs.readFileSync(WORKFLOW, 'utf-8');
+
+  // Locate every `header: "AI Models"` AskUserQuestion block and grab a window large
+  // enough to include its conditional Q2 successor (the standard-tier picker).
+  function extractAiModelsBlocks(text) {
+    const blocks = [];
+    const headerRe = /header:\s*"AI Models"/g;
+    let m;
+    while ((m = headerRe.exec(text)) !== null) {
+      // Window from the header to the next ``` fence (closes the AskUserQuestion code block)
+      // or 60 lines, whichever comes first — captures Q1 + Q2 of the split.
+      const from = m.index;
+      const fenceAfter = text.indexOf('```', from + 1);
+      const windowEnd = fenceAfter === -1 ? from + 60 * 80 : Math.min(fenceAfter + 3, from + 60 * 80);
+      blocks.push(text.slice(from, windowEnd));
+    }
+    return blocks;
+  }
+
+  function labelsIn(block) {
+    const out = [];
+    const re = /label:\s*"([^"]+)"/g;
+    let mm;
+    while ((mm = re.exec(block)) !== null) out.push(mm[1].toLowerCase());
+    return out;
+  }
+
+  const aiModelsBlocks = extractAiModelsBlocks(content);
+
+  test('new-project has at least two AI Models prompts (Step 2a auto + Step 5 interactive)', () => {
+    assert.ok(
+      aiModelsBlocks.length >= 2,
+      `expected ≥2 AI Models prompts (auto-mode + interactive), found ${aiModelsBlocks.length}`,
+    );
+  });
+
+  test('each AI Models prompt makes adaptive reachable (#1516 — was omitted entirely)', () => {
+    assert.ok(aiModelsBlocks.length > 0, 'must find at least one AI Models block to assert against');
+    for (let i = 0; i < aiModelsBlocks.length; i++) {
+      const labels = labelsIn(aiModelsBlocks[i]);
+      assert.ok(
+        labels.some(l => l === 'adaptive' || l.startsWith('adaptive')),
+        `AI Models prompt #${i + 1} must include an "Adaptive" option (the #1516 regression — adaptive was missing). Got labels: [${labels.join(', ')}]`,
+      );
+    }
+  });
+
+  test('all 5 model profiles are reachable across the new-project model-selection surface', () => {
+    const surface = aiModelsBlocks.join('\n');
+    const labels = labelsIn(surface);
+    for (const profile of ['adaptive', 'quality', 'balanced', 'budget', 'inherit']) {
+      assert.ok(
+        labels.some(l => l === profile || l.startsWith(profile)),
+        `model profile "${profile}" must be reachable as a selectable option in the AI Models prompts. Got labels: [${labels.join(', ')}]`,
+      );
+    }
+  });
+
+  test('no options array in new-project.md exceeds the 4-option AskUserQuestion runtime cap', () => {
+    // Guards against a naive single 5-option block (which the AskUserQuestion runtime rejects).
+    const CAP = 4;
+    const optionsKeyRe = /\boptions\s*:\s*\[/g;
+    let match;
+    let questionIndex = 0;
+    let offender = null;
+    while ((match = optionsKeyRe.exec(content)) !== null) {
+      questionIndex++;
+      let depth = 0;
+      const start = match.index + match[0].length - 1;
+      let end = start;
+      for (let k = start; k < content.length; k++) {
+        if (content[k] === '[') depth++;
+        else if (content[k] === ']') { depth--; if (depth === 0) { end = k; break; } }
+      }
+      const optionsBody = content.slice(start, end + 1);
+      const labelMatches = optionsBody.match(/label:\s*"[^"]+"/g) || [];
+      if (labelMatches.length > CAP) { offender = { questionIndex, count: labelMatches.length }; break; }
+    }
+    assert.ok(
+      !offender,
+      offender
+        ? `options array #${offender.questionIndex} has ${offender.count} options — exceeds the AskUserQuestion runtime cap of ${CAP}. Split into multiple questions (as #3784 did for model_profile).`
+        : true,
+    );
+    assert.ok(questionIndex > 0, 'new-project.md must contain at least one AskUserQuestion options array');
+  });
+
+  test('both config-new-project example payloads list adaptive in the model_profile enum', () => {
+    // The two example payloads (Step 2a + Step 5) hard-coded "quality|balanced|budget|inherit"
+    // and must now include adaptive.
+    const enumRe = /model_profile"\s*:\s*"([^"]*)"/g;
+    let match;
+    const enums = [];
+    while ((match = enumRe.exec(content)) !== null) {
+      enums.push(match[1]);
+    }
+    assert.ok(enums.length >= 2, `expected >=2 config-new-project example payloads, found ${enums.length}`);
+    for (let i = 0; i < enums.length; i++) {
+      assert.ok(
+        enums[i].includes('adaptive'),
+        `config-new-project example payload #${i + 1} model_profile enum must include "adaptive". Got: "${enums[i]}"`,
+      );
+    }
+  });
+
+  test('new-project.md has balanced braces (regression guard, mirrors #3784 bd53925f)', () => {
+    let depth = 0;
+    for (const ch of content) {
+      if (ch === '{') depth++;
+      if (ch === '}') depth--;
+    }
+    assert.strictEqual(depth, 0, `new-project.md has unbalanced braces: net depth ${depth}`);
+  });
+});

--- a/tests/workflow-size-baseline.json
+++ b/tests/workflow-size-baseline.json
@@ -45,7 +45,7 @@
   "milestone-summary.md": 11774,
   "mvp-phase.md": 13582,
   "new-milestone.md": 32422,
-  "new-project.md": 62324,
+  "new-project.md": 66138,
   "new-workspace.md": 11254,
   "next.md": 20094,
   "node-repair.md": 4173,


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #1516

> The linked issue carries the `confirmed-bug` label.

---

## What was broken

`/gsd-new-project`'s two AI Models prompts (Step 2a auto-mode and Step 5 interactive) enumerated only four profiles — Balanced, Quality, Budget, Inherit — omitting `adaptive`. So the `adaptive` profile (role-based cost optimization: heavy roles use the highest-tier model on the active runtime, light roles the cheapest — best quality/cost across Claude, Codex, Gemini, OpenRouter, local) was unreachable through `/gsd-new-project` despite being a first-class entry in the model catalog (`model-catalog.json` → `profiles: ["quality","balanced","budget","adaptive","inherit"]`) and documented in `docs/CONFIGURATION.md`. Both `config-new-project` example payloads also hard-coded the 4-value enum.

## What this fix does

Both AI Models prompts now use the **proven two-question split already shipped for `/gsd:settings` (#3784)**:

- **Q1 (`AI Models`):** Adaptive (Recommended) / Standard tier… / Inherit — 3 options
- **Q2 (`Model Tier`, conditional on Q1 = "Standard tier…"):** Quality / Balanced / Budget — 3 options

This keeps every `AskUserQuestion` within the runtime's hard 4-option cap while making all five profiles reachable. The mapping (Q1 Adaptive → `adaptive`; Q1 Inherit → `inherit`; Q1 Standard + Q2 → `quality|balanced|budget`) is documented inline, mirroring settings.md. Both `config-new-project` example payloads now list `adaptive`.

## Root cause

Prompt/catalog drift (same class as #33/#3784): the `adaptive` profile was added to the catalog and to `/gsd:settings`, but the `/gsd-new-project` consumer — which has *two independent* AI Models prompts plus *two* example payloads — was never backfilled. The new-project workflow predates the catalog rename; its prompt enumeration was hand-written against the old 4-profile catalog and stayed stale. `origin/fix/1516-…` was an empty branch-bot stub (zero commits) — not a usable foundation.

## Testing

### How I verified the fix

Regression cases folded into the owning module test `tests/new-project-mvp-prompt.test.cjs` (new top-level `bug-NNNN` files are banned by `lint-regression-test-names`). The new `describe('bug #1516: …')` block asserts: ≥2 AI Models prompts exist; **each** makes adaptive reachable; all 5 profiles reachable across the model-selection surface; no `options` array exceeds the 4-option cap; both `config-new-project` example payloads include `adaptive`; brace balance (regression guard mirroring `bd53925f`). The assertions fail-first on the unpatched text (0 `adaptive`) and pass after.

- `node --test tests/new-project-mvp-prompt.test.cjs` → 10/10 pass
- `tests/workflow-size-budget.test.cjs` → 123/123 pass (new-project.md XL, 66138 bytes, well under the 98304 hard cap; baseline bumped 62324 → 66138)
- `gsd-test-summary -base next -head HEAD` (Docker ubuntu-CI mirror) → **20884/20884 pass, exit 0**

### Regression test added?

- [x] Yes — added tests that would have caught this bug (folded into `tests/new-project-mvp-prompt.test.cjs`)

### Platforms tested

- [x] macOS (local)
- [x] Linux (Docker CI mirror)

### Runtimes tested

- [x] Claude Code
- [x] Other: the fix is runtime-agnostic prompt text; the Q1/Q2 split renders correctly under TEXT_MODE per the workflow's generic TEXT_MODE guidance (line 134), same as settings.md

---

## Checklist

- [x] Issue linked above with `Fixes #1516`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — only the two AI Models prompts + two example payloads (+ size baseline bump); no unrelated changes
- [x] Regression test added (folded into `tests/new-project-mvp-prompt.test.cjs`)
- [x] All existing tests pass (20884/20884 in the Docker mirror)
- [x] `.changeset/` fragment added (`Fixed` type) — `Fixed` is docs-exempt; `docs/CONFIGURATION.md` already correctly lists `adaptive`, no docs edit needed
- [x] No unnecessary dependencies added

## Breaking changes

None. The only behavior change is additive: `adaptive` becomes selectable in `/gsd-new-project` (it was already a supported catalog value and documented). Existing projects that selected Balanced/Quality/Budget/Inherit are unaffected.

---

> *The diagnosis and fix were produced via an automated bug-remediation workflow. The linked issue's content was treated as untrusted data and every claim verified against the catalog (`model-catalog.json`), `docs/CONFIGURATION.md`, and the shipped `/gsd:settings` #3784 split before editing.*

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1654"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784899322&installation_id=134682257&pr_number=1654&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1654&signature=5bcf10674c887ee4f0e0fd4bec82f1a478ad4e7e6222e42f4bb1f713ea5b7eae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->