### PR TITLE
fix(#1582): derive phase-complete velocity from By-Phase table (idempotent)

### DIFF
--- a/.changeset/zesty-elks-click.md
+++ b/.changeset/zesty-elks-click.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`phase complete` no longer double-counts Total plans completed velocity on re-run** — re-running `phase complete` on an already-complete phase incremented the velocity total each time (2 -> 4 -> 6 ...), because the metric re-read the cumulative total and blind-added the phase's plan count on every invocation. The total is now derived from the By-Phase table's Plans column (the same source the table upserts against), so re-completing a phase upserts the same row and the sum stays stable — and a hand-edited inflated total self-heals to the true sum on the next completion. (#1582)

--- a/.changeset/zesty-elks-click.md
+++ b/.changeset/zesty-elks-click.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 1655
 ---
 **`phase complete` no longer double-counts Total plans completed velocity on re-run** — re-running `phase complete` on an already-complete phase incremented the velocity total each time (2 -> 4 -> 6 ...), because the metric re-read the cumulative total and blind-added the phase's plan count on every invocation. The total is now derived from the By-Phase table's Plans column (the same source the table upserts against), so re-completing a phase upserts the same row and the sum stays stable — and a hand-edited inflated total self-heals to the true sum on the next completion. (#1582)

--- a/src/state.cts
+++ b/src/state.cts
@@ -2450,10 +2450,12 @@ function updatePerformanceMetricsSection(content: string, cwd: string, phaseNum:
     if (tableForSum) {
       let sum = 0;
       for (const row of tableForSum[2].split(/\r?\n/)) {
-        // Data rows look like `| <phase> | <plans> | … |`. Header (`| Phase | Plans | …`)
-        // and separator (`| --- | --- | …`) rows have a non-numeric second cell and are
-        // skipped; non-numeric cells contribute 0 (never NaN).
-        const cellMatch = row.match(/^\|\s*[^|]+\s*\|\s*(\d+)\s*\|/);
+        // Data rows look like `| <phase> | <plans> | … |`, optionally indented (the
+        // byPhaseTablePattern data-row capture allows `[ \t]*` leading whitespace, so the
+        // sum must too or hand-edited/legacy indented rows are silently skipped — #1582
+        // codex review). Header (`| Phase | Plans | …`) and separator (`| --- | --- | …`)
+        // rows have a non-numeric second cell and are skipped; non-numeric cells → 0.
+        const cellMatch = row.match(/^\s*\|\s*[^|]+\s*\|\s*(\d+)\s*\|/);
         if (cellMatch) sum += parseInt(cellMatch[1], 10);
       }
       content = content.replace(

--- a/src/state.cts
+++ b/src/state.cts
@@ -2417,16 +2417,11 @@ function cmdSignalResume(cwd: string, raw: boolean): void {
  * Returns modified content string.
  */
 function updatePerformanceMetricsSection(content: string, cwd: string, phaseNum: string | number, planCount: number, summaryCount: number): string {
-  // Update Velocity: Total plans completed
-  const totalMatch = content.match(/Total plans completed:\s*(\d+|\[N\])/);
-  const prevTotal = totalMatch && totalMatch[1] !== '[N]' ? parseInt(totalMatch[1], 10) : 0;
-  const newTotal = prevTotal + summaryCount;
-  content = content.replace(
-    /Total plans completed:\s*(\d+|\[N\])/,
-    `Total plans completed: ${newTotal}`
-  );
-
-  // Update By Phase table — upsert row for this phase
+  // By Phase table — upsert the row for THIS phase FIRST. The velocity total is then
+  // DERIVED from the table's Plans column so it stays idempotent on re-run: completing
+  // the same phase again upserts the same row, so the column sum is stable. The previous
+  // blind-add (prevTotal + summaryCount) re-read the cumulative total each call and
+  // double-counted on every re-run. (#1582)
   const byPhaseMatch = content.match(byPhaseTablePattern);
   if (byPhaseMatch) {
     let tableBody = byPhaseMatch[2].trim();
@@ -2443,6 +2438,29 @@ function updatePerformanceMetricsSection(content: string, cwd: string, phaseNum:
     }
 
     content = content.replace(byPhaseTablePattern, (_match, tableHeader: string) => `${tableHeader}${tableBody}\n`);
+  }
+
+  // Velocity: Total plans completed — DERIVED as the sum of the By-Phase Plans column
+  // (the second cell) across all data rows. Idempotent by construction (re-running phase
+  // complete upserts the same row → same sum) and self-healing (a hand-edited inflated
+  // total is corrected to the true sum on the next completion). When the By-Phase table
+  // is absent, leave the velocity total unchanged rather than guess. (#1582)
+  if (/Total plans completed:\s*(\d+|\[N\])/.test(content)) {
+    const tableForSum = content.match(byPhaseTablePattern);
+    if (tableForSum) {
+      let sum = 0;
+      for (const row of tableForSum[2].split(/\r?\n/)) {
+        // Data rows look like `| <phase> | <plans> | … |`. Header (`| Phase | Plans | …`)
+        // and separator (`| --- | --- | …`) rows have a non-numeric second cell and are
+        // skipped; non-numeric cells contribute 0 (never NaN).
+        const cellMatch = row.match(/^\|\s*[^|]+\s*\|\s*(\d+)\s*\|/);
+        if (cellMatch) sum += parseInt(cellMatch[1], 10);
+      }
+      content = content.replace(
+        /Total plans completed:\s*(\d+|\[N\])/,
+        `Total plans completed: ${sum}`,
+      );
+    }
   }
 
   return content;

--- a/tests/state.test.cjs
+++ b/tests/state.test.cjs
@@ -2046,15 +2046,72 @@ describe('updatePerformanceMetricsSection', () => {
     runGsdTools('phase complete 5', tmpDir);
     const afterSecond = fs.readFileSync(statePath, 'utf-8');
 
-    // Both should have same total plans count (idempotent update for same phase)
+    // #1582: the velocity total must be IDEMPOTENT across re-runs of the same phase.
+    // The old blind-add (prevTotal + summaryCount) double-counted on every re-run
+    // (1 -> 2 here); the fix derives the total from the By-Phase Plans column, so
+    // re-running the same phase upserts the same row and the sum stays stable.
     const firstCount = afterFirst.match(/Total plans completed:\s*(\d+)/);
     const secondCount = afterSecond.match(/Total plans completed:\s*(\d+)/);
     assert.ok(firstCount, 'First run should have total plans');
     assert.ok(secondCount, 'Second run should have total plans');
-    // Second run adds another completion for phase 5, so count increments
-    // The key is the By Phase row for phase 5 should be updated, not duplicated
+    assert.equal(
+      firstCount[1],
+      secondCount[1],
+      `velocity total must be idempotent across re-runs of phase 5 (#1582): first=${firstCount[1]} second=${secondCount[1]}`,
+    );
+    assert.equal(firstCount[1], '1', 'phase 5 has 1 plan, so the velocity total must be 1');
+    // The By Phase row for phase 5 should be updated, not duplicated.
     const phase5Rows = (afterSecond.match(/\|\s*5\s*\|/g) || []).length;
     assert.ok(phase5Rows <= 1, 'Phase 5 should appear at most once in By Phase table (no duplicates)');
+  });
+
+  test('#1582 — velocity self-heals a hand-inflated total down to the true By-Phase sum', () => {
+    // A hand-edited STATE.md whose velocity line says 99 but whose By-Phase table
+    // records the true completed plans. Completing a fresh phase must RECOMPUTE the
+    // total from the table (derive, not accumulate), correcting the inflated value
+    // downward rather than adding to it.
+    const content = `# Project State
+
+**Current Phase:** 02
+**Status:** Executing Phase 2
+
+## Performance Metrics
+
+**Velocity:**
+- Total plans completed: 99
+- Average duration: 5 min
+- Total execution time: 0.1 hours
+
+**By Phase:**
+
+| Phase | Plans | Total | Avg/Plan |
+|-------|-------|-------|----------|
+| 1 | 2 | 10 min | 5 min |
+
+## Accumulated Context
+`;
+    const statePath = path.join(tmpDir, '.planning', 'STATE.md');
+    fs.writeFileSync(statePath, content);
+
+    const phaseDir = path.join(tmpDir, '.planning', 'phases', '02-next');
+    fs.mkdirSync(phaseDir, { recursive: true });
+    fs.writeFileSync(path.join(phaseDir, '02-01-PLAN.md'), '# Plan\n');
+    fs.writeFileSync(path.join(phaseDir, '02-01-SUMMARY.md'), '# Summary\n');
+
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      `# Roadmap\n\n## Phase 2: Next\n\n- [ ] Phase 2: Next\n`
+    );
+
+    const result = runGsdTools('phase complete 2', tmpDir);
+    assert.ok(result.success, `phase complete failed: ${result.error}`);
+
+    const stateAfter = fs.readFileSync(statePath, 'utf-8');
+    // True sum = phase 1 (2) + phase 2 (1) = 3. Old blind-add would yield 99 + 1 = 100.
+    assert.ok(
+      stateAfter.match(/Total plans completed:\s*3\b/),
+      'velocity total must self-heal to the true By-Phase sum (3), not accumulate from the inflated 99 (#1582)',
+    );
   });
 
   test('byPhaseTablePattern behavior-lock (#320): By Phase table header preserved and phase row upserted after hoist to module scope', () => {
@@ -2108,8 +2165,11 @@ describe('updatePerformanceMetricsSection', () => {
     const phase6Rows = (stateAfter.match(/\|\s*6\s*\|/g) || []).length;
     assert.strictEqual(phase6Rows, 1, 'Phase 6 row must appear exactly once in By Phase table (upsert, not append)');
 
-    // Total plans count updated correctly (1 pre-existing + 2 new summaries)
-    assert.ok(stateAfter.match(/Total plans completed:\s*3/), 'Total plans completed should be 3 after upsert');
+    // Total plans count = sum of the By-Phase Plans column after the upsert. Phase 6's
+    // row is upserted to its current summaryCount (2), and it is the only row, so the
+    // derived total is 2. (#1582: derived from the table, not blind-added onto the prior
+    // velocity — which previously produced 1+2=3 by double-counting phase 6.)
+    assert.ok(stateAfter.match(/Total plans completed:\s*2\b/), 'Total plans completed should equal the By-Phase Plans sum (2) after upsert (#1582)');
   });
 
   test('#1658 — By-Phase table row upserts on a CRLF STATE.md (byPhaseTablePattern must be CRLF-tolerant)', () => {

--- a/tests/state.test.cjs
+++ b/tests/state.test.cjs
@@ -2114,6 +2114,55 @@ describe('updatePerformanceMetricsSection', () => {
     );
   });
 
+  test('#1582 — velocity sums indented By-Phase data rows too (codex review: byPhaseTablePattern allows [ \\t]* leading whitespace, so the sum must match it)', () => {
+    // byPhaseTablePattern's data-row capture is `(?:[ \\t]*\\|...)*` — it ALLOWS leading
+    // whitespace. The derive sum must tolerate the same, or a hand-edited/legacy indented
+    // row is captured by the table but silently skipped by the sum (undercount).
+    const content = `# Project State
+
+**Current Phase:** 02
+**Status:** Executing Phase 2
+
+## Performance Metrics
+
+**Velocity:**
+- Total plans completed: 0
+- Average duration: N/A
+- Total execution time: 0 hours
+
+**By Phase:**
+
+| Phase | Plans | Total | Avg/Plan |
+|-------|-------|-------|----------|
+  | 1 | 2 | - | - |
+
+## Accumulated Context
+`;
+    const statePath = path.join(tmpDir, '.planning', 'STATE.md');
+    fs.writeFileSync(statePath, content);
+
+    const phaseDir = path.join(tmpDir, '.planning', 'phases', '02-next');
+    fs.mkdirSync(phaseDir, { recursive: true });
+    fs.writeFileSync(path.join(phaseDir, '02-01-PLAN.md'), '# Plan\n');
+    fs.writeFileSync(path.join(phaseDir, '02-01-SUMMARY.md'), '# Summary\n');
+
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      `# Roadmap\n\n## Phase 2: Next\n\n- [ ] Phase 2: Next\n`
+    );
+
+    const result = runGsdTools('phase complete 2', tmpDir);
+    assert.ok(result.success, `phase complete failed: ${result.error}`);
+
+    const stateAfter = fs.readFileSync(statePath, 'utf-8');
+    // Indented phase-1 row (2) + new column-0 phase-2 row (1) = 3. A sum regex anchored
+    // at ^\\| would skip the indented row and report 1.
+    assert.ok(
+      stateAfter.match(/Total plans completed:\s*3\b/),
+      'velocity must sum indented By-Phase rows too (codex review, #1582): expected 3 (2 + 1)',
+    );
+  });
+
   test('byPhaseTablePattern behavior-lock (#320): By Phase table header preserved and phase row upserted after hoist to module scope', () => {
     // Exercises the byPhaseTablePattern match path directly: header must be preserved,
     // an existing phase row must be replaced (not duplicated), and a new phase row inserted.

--- a/tests/state.test.cjs
+++ b/tests/state.test.cjs
@@ -2097,6 +2097,7 @@ describe('updatePerformanceMetricsSection', () => {
     fs.mkdirSync(phaseDir, { recursive: true });
     fs.writeFileSync(path.join(phaseDir, '02-01-PLAN.md'), '# Plan\n');
     fs.writeFileSync(path.join(phaseDir, '02-01-SUMMARY.md'), '# Summary\n');
+    writePassedVerification(tmpDir, '02-next', '02');
 
     fs.writeFileSync(
       path.join(tmpDir, '.planning', 'ROADMAP.md'),
@@ -2145,6 +2146,7 @@ describe('updatePerformanceMetricsSection', () => {
     fs.mkdirSync(phaseDir, { recursive: true });
     fs.writeFileSync(path.join(phaseDir, '02-01-PLAN.md'), '# Plan\n');
     fs.writeFileSync(path.join(phaseDir, '02-01-SUMMARY.md'), '# Summary\n');
+    writePassedVerification(tmpDir, '02-next', '02');
 
     fs.writeFileSync(
       path.join(tmpDir, '.planning', 'ROADMAP.md'),


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #1582

> The linked issue carries the `confirmed-bug` label.

---

## What was broken

`phase complete` non-idempotently incremented the **Total plans completed** velocity metric on every re-run of an already-complete phase — re-completing the same phase progressed the total `2 → 4 → 6 …`. Root cause: `updatePerformanceMetricsSection` re-read the cumulative total each call and blind-added the phase's `summaryCount` (`newTotal = prevTotal + summaryCount`), with no ratchet. This is the velocity-field sibling of #4, which fixed the *Completed Phases* counter the same way (derive from source, don't accumulate) but missed the velocity field — which an existing "idempotent" test explicitly declined to assert (its comment: *"Second run adds another completion for phase 5, so count increments"*), the latent gap that let the bug persist.

## What this fix does

The velocity total is now **derived as the sum of the By-Phase table's Plans column, after the row upsert** — the same authoritative source the table upserts against. Completing a phase upserts that phase's row, so:

- **Idempotent:** re-completing the same phase upserts the same row → same column sum → stable total.
- **Self-healing:** a hand-edited/inflated total is corrected *downward* to the true sum on the next completion.
- **Self-consistent:** the velocity line can never disagree with the By-Phase table it summarizes.

When the By-Phase table is absent, the total is left unchanged (no crash). The By-Phase upsert itself is unchanged (it was already idempotent) — only the velocity-field derivation changed.

## Root cause

`src/state.cts` `updatePerformanceMetricsSection` (single caller: `runPhaseCompleteTransaction` in `src/phase.cts`). Blind read-modify-write on cumulative state with no phase-keyed dedup, exactly the class fixed for `Completed Phases` in #4 via ROADMAP derivation. Blast radius LOW (one caller, no downstream replication).

## Testing

### How I verified the fix

Reproduced the original failure deterministically via the CLI harness, then applied TDD:

- **Strengthened the misnamed `idempotent — running twice produces same result` test** (`tests/state.test.cjs`) — its body previously only asserted By-Phase row dedup and explicitly *declined* to assert velocity idempotency. It now asserts the velocity total is byte-identical across two `phase complete` runs of the same phase. Fails-first on the unpatched code (`1 → 2`); passes after.
- **Added a self-heal regression** — a hand-edited STATE.md with velocity `99` but a By-Phase table recording the true plans; completing a fresh phase recomputes the total to the true sum (`3`), not `99 + 1 = 100`.
- **Corrected the `#320` behavior-lock velocity assertion** — it had encoded the blind-add (`3 = 1 + 2`, double-counting phase 6); the derived value is `2` (the upserted By-Phase sum), which is the correct, self-consistent value. This is a Behavior-Change test correction per CONTRIBUTING.

- `node --test tests/state.test.cjs` → 174/174 pass
- `node --test tests/phase.test.cjs` → 170 pass / 0 fail / 1 platform-gated skip (`#3785` case-collision test, Linux-only — runs and passes in the Linux CI mirror)
- `npx eslint src/state.cts tests/state.test.cjs` → clean
- `gsd-test-summary -base next -head HEAD` (Docker ubuntu-CI mirror, Linux) → **20878/20878 pass, exit 0**

### Regression test added?

- [x] Yes — strengthened an existing test that would have caught this bug (its name claimed idempotency but its body didn't assert it), plus a new self-heal regression.

### Platforms tested

- [x] macOS (local node --test)
- [x] Linux (Docker CI mirror via `gsd-test-summary`)

### Runtimes tested

- [x] N/A (not runtime-specific — STATE.md mutation)

---

## Checklist

- [x] Issue linked above with `Fixes #1582`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — one function's velocity derivation; no unrelated changes
- [x] Regression test added (strengthened + new)
- [x] All existing tests pass (20878/20878 in the Docker mirror)
- [x] `.changeset/` fragment added (`Fixed` type) — `Fixed` is docs-exempt; no docs change needed
- [x] No unnecessary dependencies added

## Breaking changes

Behavior change (intended): the velocity total is now derived from the By-Phase table rather than accumulated. For a *correct* first-time completion the value is unchanged; the only observable difference is that re-running `phase complete` no longer inflates the total, and a previously-inflated total self-corrects on the next completion. Any test or consumer that relied on the blind-add accumulation (none found beyond the one corrected `#320` assertion) would need updating — flagged here for reviewers.

---

> *The diagnosis and fix were produced via an automated bug-remediation workflow. The linked issue's content was treated as untrusted data and every claim verified against the source (`src/state.cts` `updatePerformanceMetricsSection` + caller `runPhaseCompleteTransaction`) before editing.*

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1655"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784900307&installation_id=134682257&pr_number=1655&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1655&signature=73387b3a389de9b65be48a271325488d38353c4dad09c5f1c5a892aa4ba5dfc5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->