### PR TITLE
fix(#1657): recover malformed (non-object) ~/.gsd/defaults.json in finishInstall

### DIFF
--- a/.changeset/gentle-jaguars-munch.md
+++ b/.changeset/gentle-jaguars-munch.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 1661
 ---
 **`gsd install`/upgrade now recovers a malformed `~/.gsd/defaults.json` instead of leaving it broken** — a `defaults.json` containing a valid-JSON-but-non-object value (`null`, `[]`, a number, or a string) bypassed the parse `catch` and flowed through unrecovered: `null` threw a TypeError (swallowed by the outer guard, logging a confusing "Could not write" warning and leaving the file as `null`), while `[]`/`42`/`"str"` silently kept their broken shape on every install. The non-Claude finishInstall step now resets any non-object parse result to a fresh `{}` before reading/writing it, so the file is repaired and `resolve_model_ids` defaults normally.

--- a/.changeset/gentle-jaguars-munch.md
+++ b/.changeset/gentle-jaguars-munch.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`gsd install`/upgrade now recovers a malformed `~/.gsd/defaults.json` instead of leaving it broken** — a `defaults.json` containing a valid-JSON-but-non-object value (`null`, `[]`, a number, or a string) bypassed the parse `catch` and flowed through unrecovered: `null` threw a TypeError (swallowed by the outer guard, logging a confusing "Could not write" warning and leaving the file as `null`), while `[]`/`42`/`"str"` silently kept their broken shape on every install. The non-Claude finishInstall step now resets any non-object parse result to a fresh `{}` before reading/writing it, so the file is repaired and `resolve_model_ids` defaults normally.

--- a/bin/install.js
+++ b/bin/install.js
@@ -11322,6 +11322,14 @@ function finishInstall(settingsPath, settings, statuslineCommand, shouldInstallS
       fs.mkdirSync(gsdDir, { recursive: true });
       let defaults = {};
       try { defaults = JSON.parse(fs.readFileSync(defaultsPath, 'utf8')); } catch { /* new file */ }
+      // Recover a malformed (valid-JSON-but-non-object) defaults.json to a fresh object so
+      // the write below succeeds and the file is no longer broken. Without this, `null` /
+      // `[]` / a number / a string bypass the parse catch and either throw a TypeError on
+      // property access (swallowed by the outer try/catch, leaving the file broken) or get
+      // a property set that won't round-trip through JSON.stringify. (#1657)
+      if (defaults === null || typeof defaults !== 'object' || Array.isArray(defaults)) {
+        defaults = {};
+      }
       // Three-valued domain: false/absent → aliases; true → full IDs; "omit" → ''.
       // Honor ONLY an explicit canonical `true` opt-in (full model IDs) and an existing
       // "omit"; default everything else — absent, falsy, OR any non-canonical value — to

--- a/tests/bug-410-install-defaults-test-mode-guard.test.cjs
+++ b/tests/bug-410-install-defaults-test-mode-guard.test.cjs
@@ -254,3 +254,40 @@ describe('Bug #1569: non-Claude finishInstall preserves explicit resolve_model_i
     });
   });
 });
+
+// Bug #1657 — finishInstall reads ~/.gsd/defaults.json with JSON.parse but did not
+// validate the result is a plain object. A valid-JSON-but-non-object value (null, [],
+// 42, "str") bypassed the catch and flowed through, leaving the malformed file on disk
+// unrecovered (and, for null, throwing a TypeError swallowed by the outer try/catch).
+// Folded into the owning install-defaults test (no new top-level bug-NNNN file).
+describe('Bug #1657: finishInstall recovers a malformed (non-object) defaults.json', () => {
+  function seedDefaultsRaw(raw) {
+    fs.mkdirSync(GSD_DIR, { recursive: true });
+    fs.writeFileSync(DEFAULTS_PATH, raw, 'utf8');
+  }
+  function runAndRead(runtime) {
+    const saved = process.env.GSD_TEST_MODE;
+    delete process.env.GSD_TEST_MODE;
+    const log = console.log; console.log = () => {};
+    let threw = null;
+    try {
+      installModule.finishInstall(SETTINGS_PATH, {}, null, false, runtime, true, null);
+    } catch (e) { threw = e.message; } finally { console.log = log; process.env.GSD_TEST_MODE = saved; }
+    let after = null;
+    try { after = JSON.parse(fs.readFileSync(DEFAULTS_PATH, 'utf8')); } catch (e) { after = 'UNPARSEABLE: ' + e.message; }
+    return { threw, after };
+  }
+
+  for (const [label, raw] of [['null', 'null'], ['array', '[]'], ['number', '42'], ['string', '"oops"']]) {
+    test(`seed ${label} (${raw}) recovers to a valid object with resolve_model_ids:omit`, () => {
+      seedDefaultsRaw(raw);
+      const { threw, after } = runAndRead('codex');
+      assert.equal(threw, null, `must not throw for seed ${label} (got: ${threw})`);
+      assert.equal(
+        after !== null && typeof after === 'object' && !Array.isArray(after) && after.resolve_model_ids === 'omit',
+        true,
+        `seed ${label} must recover to { resolve_model_ids: 'omit' }, got: ${JSON.stringify(after)}`,
+      );
+    });
+  }
+});


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #1657

> The linked issue carries the `confirmed-bug` label.

---

## What was broken

`finishInstall` (the post-copy step run for every non-Claude install/upgrade) read `~/.gsd/defaults.json` with `JSON.parse` but did not validate the result was a plain object. A file containing a valid-JSON-but-non-object value bypassed the `catch`:

- `null` → accessing `defaults.resolve_model_ids` threw `TypeError`; the outer `try/catch` swallowed it and logged a confusing "Could not write ~/.gsd/defaults.json" warning, leaving the file as `null` on disk (never recovered).
- `[]` / `42` / `"oops"` → `resolve_model_ids` was read/set on a non-object and `JSON.stringify` round-tripped the broken shape, so the malformed file persisted across every install.

## What this fix does

After `JSON.parse`, reset any non-object result (`null`, non-object, or array) to a fresh `{}` before any property access or write. The file is repaired and `resolve_model_ids` defaults normally on the next install. No throw, no scary warning, no broken-shape round-trip.

## Root cause

`bin/install.js` `finishInstall` non-Claude block: `let defaults = {}; try { defaults = JSON.parse(...) } catch { /* new file */ }` — no `typeof === 'object' && !Array.isArray && !== null` guard after the parse, so a valid-JSON-but-non-object value slipped through the `catch`.

## Testing

### How I verified the fix

Reproduced deterministically before the fix (seeding `null`/`[]`/`42`/`"oops"` left each verbatim on disk, none recovered to an object). Regression folded into the owning `tests/bug-410-install-defaults-test-mode-guard.test.cjs` (new `describe('Bug #1657: …')`), parameterized over the four malformed shapes — each must recover to `{ resolve_model_ids: 'omit' }` with no throw. Fails-first on the unpatched code; passes after.

- `node --test tests/bug-410-install-defaults-test-mode-guard.test.cjs` → 7/7 pass
- `npx eslint bin/install.js …` → clean
- `gsd-test-summary -base next -head HEAD` (Docker ubuntu-CI mirror) → **pass, exit 0**

### Regression test added?

- [x] Yes — parameterized over null/[]/42/"str"

### Platforms tested

- [x] macOS (local) · [x] Linux (Docker mirror)

### Runtimes tested

- [x] N/A (core installer library, all runtimes)

---

## Checklist

- [x] `Fixes #1657` · [x] `confirmed-bug` · [x] scoped to the reported bug (one guard) · [x] regression test added · [x] all tests pass (Docker) · [x] `.changeset/Fixed` · [x] no new deps

## Breaking changes

None. A malformed `defaults.json` that was previously left broken (or caused a swallowed throw) is now repaired to `{}` on the next install — strictly an improvement; valid object configs are unaffected.

---

> *Surfaced during the codex review of #1653 and filed separately per one-concern-per-PR. Issue content treated as untrusted data and verified against the source before editing.*

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1661"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784907058&installation_id=134682257&pr_number=1661&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1661&signature=d25e2c567ca83dde20baa615ecc6cbc1972ff7560521b6cb4623322b978cceb1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->