### PR TITLE
fix(#1658): make byPhaseTablePattern CRLF-tolerant on STATE.md tables

### DIFF
--- a/.changeset/sturdy-tigers-caper.md
+++ b/.changeset/sturdy-tigers-caper.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`phase complete` now updates the By-Phase table on CRLF (Windows) STATE.md files** — the By-Phase table matcher required bare `\n` line endings, so a STATE.md written or hand-edited with CRLF (`\r\n`) was treated as having no table: the completed phase's row was never upserted (and, with the velocity-from-table derivation, the total went stale). The matcher is now CRLF-tolerant (`\r?\n`) on the header/separator/lookahead, so CRLF STATE.md files are handled identically to LF.

--- a/.changeset/sturdy-tigers-caper.md
+++ b/.changeset/sturdy-tigers-caper.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 1662
 ---
 **`phase complete` now updates the By-Phase table on CRLF (Windows) STATE.md files** — the By-Phase table matcher required bare `\n` line endings, so a STATE.md written or hand-edited with CRLF (`\r\n`) was treated as having no table: the completed phase's row was never upserted (and, with the velocity-from-table derivation, the total went stale). The matcher is now CRLF-tolerant (`\r?\n`) on the header/separator/lookahead, so CRLF STATE.md files are handled identically to LF.

--- a/src/state.cts
+++ b/src/state.cts
@@ -263,7 +263,7 @@ function _stateLockBodyPid(lockPath: string): number | null {
 let _stateStealSeq = 0;
 
 // Hoisted to module scope — compiled once, not per call (#320). Stateless (/i, used with .match).
-const byPhaseTablePattern = /(\|\s*Phase\s*\|\s*Plans\s*\|\s*Total\s*\|\s*Avg\/Plan\s*\|[ \t]*\n\|(?:[- :\t]+\|)+[ \t]*\n)((?:[ \t]*\|[^\n]*\n)*)(?=\n|$)/i;
+const byPhaseTablePattern = /(\|\s*Phase\s*\|\s*Plans\s*\|\s*Total\s*\|\s*Avg\/Plan\s*\|[ \t]*\r?\n\|(?:[- :\t]+\|)+[ \t]*\r?\n)((?:[ \t]*\|[^\n]*\n)*)(?=\r?\n|$)/i;
 
 // ─── ADR-1372 T6: seam-based section splice helper ───────────────────────────
 

--- a/tests/state.test.cjs
+++ b/tests/state.test.cjs
@@ -2111,6 +2111,45 @@ describe('updatePerformanceMetricsSection', () => {
     // Total plans count updated correctly (1 pre-existing + 2 new summaries)
     assert.ok(stateAfter.match(/Total plans completed:\s*3/), 'Total plans completed should be 3 after upsert');
   });
+
+  test('#1658 — By-Phase table row upserts on a CRLF STATE.md (byPhaseTablePattern must be CRLF-tolerant)', () => {
+    const content = [
+      '# Project State', '',
+      '**Current Phase:** 07', '**Status:** Executing Phase 7', '',
+      '## Performance Metrics', '',
+      '**Velocity:**',
+      '- Total plans completed: [N]',
+      '- Average duration: N/A',
+      '- Total execution time: 0 hours', '',
+      '**By Phase:**', '',
+      '| Phase | Plans | Total | Avg/Plan |',
+      '|-------|-------|-------|----------|',
+      '| - | - | - | - |', '',
+      '## Accumulated Context', '',
+    ].join('\n');
+    const statePath = path.join(tmpDir, '.planning', 'STATE.md');
+    // Force CRLF line endings across the whole STATE.md (Windows / hand-edited).
+    fs.writeFileSync(statePath, content.replace(/\n/g, '\r\n'), 'utf8');
+
+    const phaseDir = path.join(tmpDir, '.planning', 'phases', '07-crlf');
+    fs.mkdirSync(phaseDir, { recursive: true });
+    fs.writeFileSync(path.join(phaseDir, '07-01-PLAN.md'), '# Plan\n');
+    fs.writeFileSync(path.join(phaseDir, '07-01-SUMMARY.md'), '# Summary\n');
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), '# Roadmap\n\n## Phase 7: CRLF\n\n- [ ] Phase 7\n');
+
+    const result = runGsdTools('phase complete 7', tmpDir);
+    assert.ok(result.success, `phase complete failed: ${result.error}`);
+
+    const after = fs.readFileSync(statePath, 'utf8');
+    assert.ok(
+      /\|\s*7\s*\|\s*1\s*\|/.test(after),
+      'By-Phase row for phase 7 must be upserted even on a CRLF STATE.md (#1658)',
+    );
+    assert.ok(
+      !/\|\s*-\s*\|\s*-\s*\|\s*-\s*\|\s*-\s*\|/.test(after),
+      'placeholder row must be removed on CRLF STATE.md once a real row is upserted',
+    );
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #1658  ·  `confirmed-bug`

## What was broken

`byPhaseTablePattern` (the regex that locates the `**By Phase:**` markdown table in STATE.md) required a bare `\n` after the header and separator rows. A STATE.md with CRLF (`\r\n`) line endings — Windows editors, some git configs, or hand-edits — failed to match at the header, so the table was treated as **absent**. `phase complete` then never upserted the completed phase's row, and the velocity-from-table derivation (from #1582/#1655) went stale. CONTRIBUTING's QA matrix lists "Mixed CRLF/LF newlines" as a required parser case.

## What this fix does

Make the header/separator terminators and the closing lookahead CRLF-tolerant: `[ \t]*\n` → `[ \t]*\r?\n` (×2) and `(?=\n|$)` → `(?=\r?\n|$)`. Backward-compatible with LF (the `\r?` matches zero chars on LF input). The data-row capture already tolerated `\r` via `[^\n]*`, so only the header anchor was the bottleneck. The pattern is shared by the upsert and the derive path, so both are fixed.

## Root cause

`src/state.cts` `byPhaseTablePattern` (line 266): header/separator terminators `[ \t]*\n` cannot match `\r\n` (the `\r` isn't consumed by `[ \t]*`, so the `\n` anchor fails).

## Testing

Reproduced deterministically (CRLF table → no match; LF → match; full-flow: phase complete on CRLF STATE.md left the By-Phase row un-upserted). Regression folded into `tests/state.test.cjs` (`updatePerformanceMetricsSection` describe): phase complete on a CRLF STATE.md upserts the phase row and removes the placeholder. Fails-first on the unpatched pattern; passes after.

- `node --test tests/state.test.cjs` → 174/174 pass (no LF regression)
- `npm run build:lib` → clean · `npx eslint src/state.cts` → clean
- `gsd-test-summary -base next -head HEAD` (Docker ubuntu-CI mirror) → **pass, exit 0**

- [x] Regression test added · [x] macOS + Linux (Docker) · [x] N/A runtime-specific
- [x] `Fixes #1658` · `confirmed-bug` · scoped to one pattern · all tests pass · `.changeset/Fixed` · no new deps

## Breaking changes

None. LF behavior is unchanged (`\r?` matches zero on LF); CRLF STATE.md files now work.

> *Surfaced during the codex review of #1655; pre-existing. Filed per one-concern-per-PR.*

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1662"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784907569&installation_id=134682257&pr_number=1662&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1662&signature=c805fa279b0453dd1d257f784f659813b877a531fcff697e0ceeb08e274bdf8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->