### PR TITLE
fix(#1659): dedup By-Phase rows across padded/unpadded phase numbers

### DIFF
--- a/.changeset/rapid-jays-wave.md
+++ b/.changeset/rapid-jays-wave.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`phase complete` no longer duplicates a By-Phase row when the phase number's padding differs** — completing a phase by its unpadded number (e.g. `phase complete 5`) against an existing zero-padded By-Phase row (`| 05 |`) appended a second `| 5 |` row instead of updating it, double-counting the phase in any column sum. The row matcher now canonicalizes a numeric phase to its integer form (matching `5`, `05`, `005` in either direction), so the existing row is upserted regardless of padding.

--- a/.changeset/rapid-jays-wave.md
+++ b/.changeset/rapid-jays-wave.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 1663
 ---
 **`phase complete` no longer duplicates a By-Phase row when the phase number's padding differs** — completing a phase by its unpadded number (e.g. `phase complete 5`) against an existing zero-padded By-Phase row (`| 05 |`) appended a second `| 5 |` row instead of updating it, double-counting the phase in any column sum. The row matcher now canonicalizes a numeric phase to its integer form (matching `5`, `05`, `005` in either direction), so the existing row is upserted regardless of padding.

--- a/src/state.cts
+++ b/src/state.cts
@@ -2425,7 +2425,12 @@ function updatePerformanceMetricsSection(content: string, cwd: string, phaseNum:
   const byPhaseMatch = content.match(byPhaseTablePattern);
   if (byPhaseMatch) {
     let tableBody = byPhaseMatch[2].trim();
-    const phaseRowPattern = new RegExp(`^\\|\\s*${escapeRegex(String(phaseNum))}\\s*\\|.*$`, 'm');
+    // Match the existing row for this phase, tolerating leading-zero padding in either
+    // direction (#1659): canonicalize a numeric phase to its integer form so a seeded
+    // "| 05 |" row is upserted (not duplicated) by `phase complete 5`, and vice-versa.
+    const phaseNumStr = String(phaseNum);
+    const canonCell = /^\d+$/.test(phaseNumStr) ? `0*${Number(phaseNumStr)}` : escapeRegex(phaseNumStr);
+    const phaseRowPattern = new RegExp(`^\\|\\s*${canonCell}\\s*\\|.*$`, 'm');
     const newRow = `| ${phaseNum} | ${summaryCount} | - | - |`;
 
     if (phaseRowPattern.test(tableBody)) {

--- a/tests/state.test.cjs
+++ b/tests/state.test.cjs
@@ -2267,6 +2267,39 @@ describe('updatePerformanceMetricsSection', () => {
       'velocity total must update from the CRLF STATE.md body (proves CRLF content is processed)',
     );
   });
+
+  test('#1659 — completing an unpadded phase number upserts an existing zero-padded By-Phase row (no duplicate)', () => {
+    const content = [
+      '# Project State', '',
+      '**Current Phase:** 05', '**Status:** Executing Phase 5', '',
+      '## Performance Metrics', '',
+      '**Velocity:**', '- Total plans completed: 1', '- Average duration: N/A', '- Total execution time: 0 hours', '',
+      '**By Phase:**', '',
+      '| Phase | Plans | Total | Avg/Plan |',
+      '|-------|-------|-------|----------|',
+      '| 05 | 1 | - | - |',   // seeded ZERO-PADDED row
+      '',
+      '## Accumulated Context', '',
+    ].join('\n');
+    const statePath = path.join(tmpDir, '.planning', 'STATE.md');
+    fs.writeFileSync(statePath, content, 'utf8');
+
+    const phaseDir = path.join(tmpDir, '.planning', 'phases', '05-final');
+    fs.mkdirSync(phaseDir, { recursive: true });
+    fs.writeFileSync(path.join(phaseDir, '05-01-PLAN.md'), '# Plan\n');
+    fs.writeFileSync(path.join(phaseDir, '05-01-SUMMARY.md'), '# Summary\n');
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), '# Roadmap\n\n## Phase 5: Final\n\n- [ ] Phase 5\n');
+
+    // phase complete with the UNPADDED number "5" — must upsert the seeded "| 05 |" row,
+    // not append a duplicate "| 5 |".
+    const result = runGsdTools('phase complete 5', tmpDir);
+    assert.ok(result.success, `phase complete failed: ${result.error}`);
+
+    const after = fs.readFileSync(statePath, 'utf8');
+    const rows05 = (after.match(/^\|\s*05\s*\|/gm) || []).length;
+    const rows5 = (after.match(/^\|\s*5\s*\|/gm) || []).length;
+    assert.equal(rows05 + rows5, 1, `phase 5 must appear exactly once in By Phase (got |05|=${rows05} |5|=${rows5}) — padded/unpadded must dedup (#1659)`);
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/tests/state.test.cjs
+++ b/tests/state.test.cjs
@@ -2288,6 +2288,7 @@ describe('updatePerformanceMetricsSection', () => {
     fs.mkdirSync(phaseDir, { recursive: true });
     fs.writeFileSync(path.join(phaseDir, '05-01-PLAN.md'), '# Plan\n');
     fs.writeFileSync(path.join(phaseDir, '05-01-SUMMARY.md'), '# Summary\n');
+    writePassedVerification(tmpDir, '05-final', '05');
     fs.writeFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), '# Roadmap\n\n## Phase 5: Final\n\n- [ ] Phase 5\n');
 
     // phase complete with the UNPADDED number "5" — must upsert the seeded "| 05 |" row,


### PR DESCRIPTION
## Fix PR

Fixes #1659  ·  `confirmed-bug`

## What was broken

`updatePerformanceMetricsSection`'s By-Phase row upsert matched the existing phase row with a literal `escapeRegex(String(phaseNum))`. Completing a phase by its unpadded number (`phase complete 5`) built the pattern `^\|\s*5\s*\|`, which did **not** match an existing zero-padded row (`| 05 | … |`) — so a **duplicate** `| 5 | … |` row was appended, double-counting the phase in any column sum (including the velocity-from-table derivation from #1582/#1655).

## What this fix does

Canonicalize a numeric phase to its integer form (`Number("05") === Number("5") === 5`) and match the cell with a `0*` prefix, so `5` / `05` / `005` collapse to the same row **in either direction** (existing padded + complete unpadded, and vice-versa). Non-numeric phase IDs retain the literal `escapeRegex` match.

## Root cause

`src/state.cts` `updatePerformanceMetricsSection` (~line 2433): `new RegExp(\`^\\|\\s*${escapeRegex(String(phaseNum))}\\s*\\|.*$\`, 'm')` — no numeric/zero-pad normalization.

## Testing

Reproduced deterministically (seeded `| 05 | 1 |`, `phase complete 5` → both `| 05 |` and `| 5 |` present). Regression folded into `tests/state.test.cjs`: seeded zero-padded row + unpadded complete yields exactly one phase-5 row. Fails-first; passes after.

- `node --test tests/state.test.cjs` → 174/174 · `npm run build:lib` → clean · `npx eslint src/state.cts` → clean
- `gsd-test-summary -base next -head HEAD` (Docker ubuntu-CI mirror) → **pass, exit 0**

- [x] Regression test · [x] macOS + Linux · [x] `Fixes #1659` · `confirmed-bug` · scoped · `.changeset/Fixed` · no new deps

## Breaking changes

None. Phase rows are now deduped across padding variants; existing unpadded→unpadded and padded→padded flows are unchanged.

> *Surfaced during the codex review of #1655; pre-existing. Filed per one-concern-per-PR.*

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1663"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784907985&installation_id=134682257&pr_number=1663&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1663&signature=49aa2478fca253272ffbbd86d2f52b30d94319483d1ef32793f742b9fd29c65e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->