### PR TITLE
fix(#1660): fail-closed frontmatter set of object-list fields instead of silent no-op

### DIFF
--- a/.changeset/plucky-wolves-run.md
+++ b/.changeset/plucky-wolves-run.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`frontmatter set` on an object-list field now fails closed instead of silently doing nothing** — setting `must_haves` (or another object-list field) to a value whose lossy parse projection matched the original's was a silent no-op: the command reported `{updated:true}` but the change never applied (the writer's scalar-only parser had flattened both to the same shape). `frontmatter set` now detects a no-op write for dict-valued fields and surfaces a clear error directing the user to edit the file directly. Scalars and scalar arrays round-trip faithfully, so idempotent sets of those still report `{updated:true}` (no false positive).

--- a/.changeset/plucky-wolves-run.md
+++ b/.changeset/plucky-wolves-run.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 1664
 ---
 **`frontmatter set` on an object-list field now fails closed instead of silently doing nothing** — setting `must_haves` (or another object-list field) to a value whose lossy parse projection matched the original's was a silent no-op: the command reported `{updated:true}` but the change never applied (the writer's scalar-only parser had flattened both to the same shape). `frontmatter set` now detects a no-op write for dict-valued fields and surfaces a clear error directing the user to edit the file directly. Scalars and scalar arrays round-trip faithfully, so idempotent sets of those still report `{updated:true}` (no false positive).

--- a/src/frontmatter.cts
+++ b/src/frontmatter.cts
@@ -503,26 +503,33 @@ function cmdFrontmatterSet(cwd: string, filePath: string, field: string | undefi
   try { parsedValue = JSON.parse(value as string); } catch { parsedValue = value; }
   fm[field as string] = parsedValue as FrontmatterValue;
   const newContent = spliceFrontmatter(content, fm);
-  // #1660: a no-op set (newContent unchanged) with a dict-valued (object) field means the
-  // lossy frontmatter parser made the new value's projection equal the original's — the
-  // intended change did not apply. This bites object-list fields like must_haves, whose
-  // `{path, provides}` items flatten to scalar strings under extractFrontmatter. Refuse to
-  // silently report {updated:true}; surface an error directing the user to edit the file
-  // directly. Scalars and scalar arrays round-trip faithfully, so idempotent sets of those
-  // are NOT flagged (no false positive).
-  if (newContent === content && parsedValue !== null && typeof parsedValue === 'object' && !Array.isArray(parsedValue)) {
-    output(
-      {
-        error: `frontmatter set had no effect on "${field}" — the supplied value is equivalent to the existing field under the frontmatter parser, which cannot faithfully round-trip object-list fields like must_haves. Edit the file directly.`,
-        field,
-      },
-      raw,
-      undefined,
-    );
+  // #1660: a no-op set (newContent unchanged) with a dict-valued field means the lossy
+  // frontmatter parser made the new value's projection equal the original's — the change
+  // did not apply (bites object-list fields like must_haves). Detection lives in the pure
+  // exported helper noOpObjectListSetError so the mutation gate (property/unit set) covers
+  // it — the cmd path itself is not in that set.
+  const noOpErr = noOpObjectListSetError(content, newContent, parsedValue);
+  if (noOpErr) {
+    output({ error: noOpErr, field }, raw, undefined);
     return;
   }
   platformWriteSync(fullPath, newContent);
   output({ updated: true, field, value: parsedValue }, raw, 'true');
+}
+
+/**
+ * #1660: detect a frontmatter `set` that would be a silent no-op on a dict-valued field.
+ * Returns an error message when the splice produced no content change but the new value
+ * is a dict (object-list fields like must_haves, whose `{path, provides}` items flatten to
+ * scalar strings under extractFrontmatter so a replacement can deep-equal the original's
+ * projection), else null. Scalars and scalar arrays round-trip faithfully, so idempotent
+ * sets of those are intentionally NOT flagged. Pure and unit-tested directly (the cmd path
+ * is not in Stryker's property/unit set, so the detection must be testable in isolation).
+ */
+function noOpObjectListSetError(originalContent: string, newContent: string, parsedValue: unknown): string | null {
+  if (newContent !== originalContent) return null;
+  if (parsedValue === null || typeof parsedValue !== 'object' || Array.isArray(parsedValue)) return null;
+  return 'frontmatter set had no effect — the supplied value is equivalent to the existing field under the frontmatter parser, which cannot faithfully round-trip object-list fields like must_haves. Edit the file directly.';
 }
 
 function cmdFrontmatterMerge(cwd: string, filePath: string, data: string | undefined, raw: boolean): void {
@@ -561,6 +568,7 @@ export = {
   parseFrontmatter: extractFrontmatter,
   reconstructFrontmatter,
   spliceFrontmatter,
+  noOpObjectListSetError,
   parseMustHavesBlock,
   FRONTMATTER_SCHEMAS,
   cmdFrontmatterGet,

--- a/src/frontmatter.cts
+++ b/src/frontmatter.cts
@@ -503,6 +503,24 @@ function cmdFrontmatterSet(cwd: string, filePath: string, field: string | undefi
   try { parsedValue = JSON.parse(value as string); } catch { parsedValue = value; }
   fm[field as string] = parsedValue as FrontmatterValue;
   const newContent = spliceFrontmatter(content, fm);
+  // #1660: a no-op set (newContent unchanged) with a dict-valued (object) field means the
+  // lossy frontmatter parser made the new value's projection equal the original's — the
+  // intended change did not apply. This bites object-list fields like must_haves, whose
+  // `{path, provides}` items flatten to scalar strings under extractFrontmatter. Refuse to
+  // silently report {updated:true}; surface an error directing the user to edit the file
+  // directly. Scalars and scalar arrays round-trip faithfully, so idempotent sets of those
+  // are NOT flagged (no false positive).
+  if (newContent === content && parsedValue !== null && typeof parsedValue === 'object' && !Array.isArray(parsedValue)) {
+    output(
+      {
+        error: `frontmatter set had no effect on "${field}" — the supplied value is equivalent to the existing field under the frontmatter parser, which cannot faithfully round-trip object-list fields like must_haves. Edit the file directly.`,
+        field,
+      },
+      raw,
+      undefined,
+    );
+    return;
+  }
   platformWriteSync(fullPath, newContent);
   output({ updated: true, field, value: parsedValue }, raw, 'true');
 }

--- a/tests/frontmatter-cli.test.cjs
+++ b/tests/frontmatter-cli.test.cjs
@@ -400,6 +400,9 @@ describe('frontmatter set/merge preserves must_haves object-lists (#1572)', () =
       ],
       'the original must_haves.artifacts must be intact after the refused set',
     );
+  });
+});
+
 // Bug #1660 — frontmatter set of an object-list field (e.g. must_haves) is a silent no-op
 // when the new value's lossy parse projection equals the original's. Folded into the owning
 // frontmatter-cli test (no new top-level bug-NNNN file).

--- a/tests/frontmatter-cli.test.cjs
+++ b/tests/frontmatter-cli.test.cjs
@@ -400,5 +400,41 @@ describe('frontmatter set/merge preserves must_haves object-lists (#1572)', () =
       ],
       'the original must_haves.artifacts must be intact after the refused set',
     );
+// Bug #1660 — frontmatter set of an object-list field (e.g. must_haves) is a silent no-op
+// when the new value's lossy parse projection equals the original's. Folded into the owning
+// frontmatter-cli test (no new top-level bug-NNNN file).
+describe('Bug #1660: frontmatter set of an object-list field fails closed instead of a silent no-op', () => {
+  const PLAN_WITH_MUST_HAVES = [
+    '---', 'phase: 1', 'wave: 1',
+    'must_haves:', '  artifacts:', '    - path: src/foo.ts', '      provides: the foo',
+    '---', '# body', '',
+  ].join('\n');
+
+  test('setting must_haves to a value that flattens to the original projection fails closed (no silent no-op)', () => {
+    const file = writeTempFile(PLAN_WITH_MUST_HAVES);
+    const before = fs.readFileSync(file, 'utf-8');
+    // New value {artifacts:["path: src/foo.ts"]} — its extractFrontmatter projection equals
+    // the original's flattened projection, so the set would otherwise be a silent no-op.
+    const result = runGsdTools(['frontmatter', 'set', file, '--field', 'must_haves', '--value', JSON.stringify({ artifacts: ['path: src/foo.ts'] })]);
+    const parsed = JSON.parse(result.output);
+    assert.ok(parsed.error, 'a no-op set of an object-list field must surface an error, not silent {updated:true}');
+    const after = fs.readFileSync(file, 'utf-8');
+    assert.equal(after, before, 'the file must be unchanged when the set is refused (no silent partial write)');
+  });
+
+  test('an idempotent set of a scalar (wave, same value) still reports updated (no false positive)', () => {
+    const file = writeTempFile('---\nphase: 1\nwave: 1\n---\n# body\n');
+    const result = runGsdTools(['frontmatter', 'set', file, '--field', 'wave', '--value', '1']);
+    const parsed = JSON.parse(result.output);
+    assert.equal(parsed.updated, true, 'an idempotent SCALAR set must still report {updated:true} (not fail-closed)');
+    assert.ok(!parsed.error, 'an idempotent scalar set must not produce an error');
+  });
+
+  test('an idempotent set of a scalar array (tags, same value) still reports updated (no false positive)', () => {
+    const file = writeTempFile('---\nphase: 1\ntags: ["a","b"]\n---\n# body\n');
+    const result = runGsdTools(['frontmatter', 'set', file, '--field', 'tags', '--value', '["a","b"]']);
+    const parsed = JSON.parse(result.output);
+    assert.equal(parsed.updated, true, 'an idempotent scalar-ARRAY set must still report {updated:true} (arrays round-trip; not fail-closed)');
+    assert.ok(!parsed.error, 'an idempotent scalar-array set must not produce an error');
   });
 });

--- a/tests/frontmatter.unit.test.cjs
+++ b/tests/frontmatter.unit.test.cjs
@@ -20,6 +20,7 @@ const {
   extractFrontmatter,
   reconstructFrontmatter,
   spliceFrontmatter,
+  noOpObjectListSetError,
   parseMustHavesBlock,
   FRONTMATTER_SCHEMAS,
 } = require('../gsd-core/bin/lib/frontmatter.cjs');
@@ -1200,5 +1201,31 @@ describe('reconstructFrontmatter: nested subval plain string', () => {
   test('nested subval with hash quoted', () => {
     const result = reconstructFrontmatter({ meta: { tag: 'issue#42' } });
     assert.equal(result, 'meta:\n  tag: "issue#42"');
+  });
+});
+
+// noOpObjectListSetError (#1660) — pure detection helper, unit-tested directly because the
+// cmdFrontmatterSet path is not in Stryker's property/unit set.
+describe('noOpObjectListSetError (#1660)', () => {
+  const ORIG = '---\nphase: 1\n---\n';
+  test('changed content (real update) → null', () => {
+    assert.equal(noOpObjectListSetError(ORIG, ORIG + 'x', { must_haves: 1 }), null);
+  });
+  test('scalar value no-op → null (idempotent scalar sets are fine)', () => {
+    for (const v of [1, 'str', true, 0, '']) assert.equal(noOpObjectListSetError(ORIG, ORIG, v), null, `scalar ${JSON.stringify(v)}`);
+  });
+  test('scalar-array value no-op → null (scalar arrays round-trip faithfully)', () => {
+    assert.equal(noOpObjectListSetError(ORIG, ORIG, ['a', 'b']), null);
+    assert.equal(noOpObjectListSetError(ORIG, ORIG, []), null);
+  });
+  test('null value no-op → null', () => {
+    assert.equal(noOpObjectListSetError(ORIG, ORIG, null), null);
+  });
+  test('dict value no-op → error message naming the object-list round-trip limit', () => {
+    const msg = noOpObjectListSetError(ORIG, ORIG, { artifacts: [{ path: 'p' }] });
+    assert.equal(typeof msg, 'string');
+    assert.ok(msg.includes('had no effect'), msg);
+    assert.ok(msg.includes('object-list'), msg);
+    assert.ok(msg.includes('Edit the file directly'), msg);
   });
 });


### PR DESCRIPTION
## Fix PR

Fixes #1660  ·  `confirmed-bug`

## What was broken

`frontmatter set --field must_haves --value '<json>'` was a **silent no-op** when the new value's `extractFrontmatter` projection (the lossy, scalar-only parse) equaled the original's. Because `extractFrontmatter` flattens object-list items (`{path, provides}` → the bare string `"path: …"`, dropping `provides`), a replacement value can deep-equal the original's flattened form even though the user intends to REPLACE the block. `spliceFrontmatter` then returned the content unchanged and `cmdFrontmatterSet` reported `{updated:true}` — the change never applied, with no error.

## What this fix does

`cmdFrontmatterSet` now detects a no-op write (`newContent === content`) for a **dict-valued** field and surfaces a clear error directing the user to edit the file directly, instead of silently accepting a no-op set. Scalars and scalar arrays round-trip faithfully under the parser, so idempotent sets of those still report `{updated:true}` — **not** flagged (two precision regression tests lock this, preventing false positives on legitimate idempotent `tags`/`wave` sets).

## Root cause

`src/frontmatter.cts` `cmdFrontmatterSet`: reported `{updated:true}` unconditionally after `spliceFrontmatter`, even when `spliceFrontmatter` returned the content unchanged (the whole-document no-op guard fires when the lossy projections match).

## Testing

Reproduced deterministically (set must_haves to a flattened-equal value → `{updated:true}`, file unchanged, no error). Regression folded into `tests/frontmatter-cli.test.cjs`:
- the object-list no-op now surfaces an error and leaves the file unchanged;
- an idempotent **scalar** set (wave) still reports `{updated:true}` (no false positive);
- an idempotent **scalar-array** set (tags) still reports `{updated:true}` (no false positive).

Fails-first on the unpatched code (the must_haves case reported `{updated:true}`); passes after.

- `node --test tests/frontmatter-cli.test.cjs` → 23/23 · `npm run build:lib` → clean · `npx eslint` → clean
- `gsd-test-summary -base next -head HEAD` (Docker ubuntu-CI mirror) → **pass, exit 0**

- [x] Regression test (+ 2 precision tests) · [x] macOS + Linux · [x] `Fixes #1660` · `confirmed-bug` · scoped · `.changeset/Fixed` · no new deps

## Breaking changes

None for valid sets. The only behavior change is that a previously-silent no-op on a dict-valued (object-list) field now returns an error JSON instead of `{updated:true}` — which is the fix. Idempotent scalar/scalar-array sets are unchanged.

> *Surfaced as codex finding #2 during the review of #1656; pre-existing (the whole-document no-op guard produced the same silent behavior before #1572). Filed per one-concern-per-PR.*

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1664"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784908632&installation_id=134682257&pr_number=1664&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1664&signature=013430e2938da06ee2f259dd83b2436e9e82837150cfa95b203d0906b23bf4f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->