### PR TITLE
fix(#1639): parseDecisions handles the titled-colon bullet form

### DIFF
--- a/.changeset/noble-bears-munch.md
+++ b/.changeset/noble-bears-munch.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`check.decision-coverage-plan` no longer false-passes when CONTEXT.md decisions use the titled-colon bullet form** — `parseDecisions` recognized the colon-immediate (`- **D-NN:** text`) and em-dash (`- **D-NN — title** body`) forms but dropped the titled-colon form (`- **D-NN: Title.** body`, where a title sits between the colon and the closing `**`) via the parse-miss guard. When all decisions used the titled convention, the parser returned 0 decisions and the coverage gate passed vacuously. A third per-form regex (checked last, a strict superset of the colon form) now parses the titled-colon form; id and `[tags]` trackability are honored.

--- a/.changeset/noble-bears-munch.md
+++ b/.changeset/noble-bears-munch.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 1665
 ---
 **`check.decision-coverage-plan` no longer false-passes when CONTEXT.md decisions use the titled-colon bullet form** — `parseDecisions` recognized the colon-immediate (`- **D-NN:** text`) and em-dash (`- **D-NN — title** body`) forms but dropped the titled-colon form (`- **D-NN: Title.** body`, where a title sits between the colon and the closing `**`) via the parse-miss guard. When all decisions used the titled convention, the parser returned 0 decisions and the coverage gate passed vacuously. A third per-form regex (checked last, a strict superset of the colon form) now parses the titled-colon form; id and `[tags]` trackability are honored.

--- a/src/decisions.cts
+++ b/src/decisions.cts
@@ -76,9 +76,13 @@ const bulletEmDashRe = /^\s*-\s+\*\*D-([A-Za-z0-9][A-Za-z0-9_-]*)(?:\s*\[([^\]]+
  * A title sits between the colon and the closing `**` (so the `:**` anchor of
  * bulletColonRe fails, and there is no em-dash for bulletEmDashRe). This is a strict
  * superset of the colon-immediate form, so it MUST be checked AFTER bulletColonRe and
- * bulletEmDashRe — it only catches bullets those two miss. (#1639)
+ * bulletEmDashRe — it only catches bullets those two miss. The title run is `[^:*]*` (no
+ * colon, no `*`) so a genuinely-malformed bullet with a colon in the pre-separator run
+ * (e.g. `D-07 ratio 3:1:**`) still fails the anchor and falls through to the parse-miss
+ * guard — matching bulletColonRe's `[^:*]*` discipline that the separator colon is the
+ * only colon permitted before `**`. (#1639)
  */
-const bulletTitledColonRe = /^\s*-\s+\*\*D-([A-Za-z0-9][A-Za-z0-9_-]*)(?:\s*\[([^\]]+)\])?[^:*]*:[^*]*\*\*\s*(.*)$/;
+const bulletTitledColonRe = /^\s*-\s+\*\*D-([A-Za-z0-9][A-Za-z0-9_-]*)(?:\s*\[([^\]]+)\])?[^:*]*:[^:*]*\*\*\s*(.*)$/;
 
 interface ParseDecisionLinesResult {
   decisions: Decision[];

--- a/src/decisions.cts
+++ b/src/decisions.cts
@@ -71,6 +71,15 @@ const bulletColonRe = /^\s*-\s+\*\*D-([A-Za-z0-9][A-Za-z0-9_-]*)(?:\s*\[([^\]]+)
  */
 const bulletEmDashRe = /^\s*-\s+\*\*D-([A-Za-z0-9][A-Za-z0-9_-]*)(?:\s*\[([^\]]+)\])?[^*]*[—–][^*]*\*\*\s*(.*)$/;
 
+/**
+ * Titled-colon form: `- **D-NN[ [tags]]: Title.** body`
+ * A title sits between the colon and the closing `**` (so the `:**` anchor of
+ * bulletColonRe fails, and there is no em-dash for bulletEmDashRe). This is a strict
+ * superset of the colon-immediate form, so it MUST be checked AFTER bulletColonRe and
+ * bulletEmDashRe — it only catches bullets those two miss. (#1639)
+ */
+const bulletTitledColonRe = /^\s*-\s+\*\*D-([A-Za-z0-9][A-Za-z0-9_-]*)(?:\s*\[([^\]]+)\])?[^:*]*:[^*]*\*\*\s*(.*)$/;
+
 interface ParseDecisionLinesResult {
   decisions: Decision[];
   parseMisses: number;
@@ -147,6 +156,22 @@ function parseDecisionLines(block: string): ParseDecisionLinesResult {
       // title itself is embedded in the bold run but we report the body as text
       // (consistent with how the gate cares only about coverage, not title/body split).
       current = { id, text: emDashMatch[3] || '', category, tags, trackable };
+      continue;
+    }
+
+    // Titled-colon form: `- **D-NN[ [tags]]: Title.** body` (#1639). Checked LAST — it is
+    // a strict superset of bulletColonRe, so it only catches bullets the colon-immediate
+    // and em-dash forms missed (minimal blast radius). id + [tags] trackability honored;
+    // the body after the closing bold run is reported as text.
+    const titledColonMatch = line.match(bulletTitledColonRe);
+    if (titledColonMatch) {
+      flush();
+      const id = `D-${titledColonMatch[1]}`;
+      const tags = titledColonMatch[2]
+        ? titledColonMatch[2].split(',').map((t) => t.trim().toLowerCase()).filter(Boolean)
+        : [];
+      const trackable = !inDiscretion && !tags.some((t) => NON_TRACKABLE_TAGS.has(t));
+      current = { id, text: titledColonMatch[3] || '', category, tags, trackable };
       continue;
     }
 

--- a/tests/decisions.test.cjs
+++ b/tests/decisions.test.cjs
@@ -791,3 +791,40 @@ describe('FIX D: gap-checker surfaces decision could-not-parse even when require
     );
   });
 });
+
+// ─── Regression #1639: titled-colon bullet form '- **D-NN: Title.** body' ─────
+// Both bulletColonRe (':**' anchor) and bulletEmDashRe (em-dash) miss the form where a
+// title sits between the colon and the closing **, so it was dropped by the parse-miss
+// guard and check.decision-coverage-plan passed vacuously when all decisions were titled.
+describe('parseDecisions — titled-colon bullet form (#1639)', () => {
+  test('titled-colon bullet is parsed, not dropped', () => {
+    const md = '## Locked decisions\n- **D-01: Default sandbox ON.** body\n- **D-02: Reject unsigned.** body two\n';
+    const out = parseDecisions(md);
+    assert.equal(out.length, 2, 'should extract both titled-colon decisions (not 0)');
+    assert.equal(out[0].id, 'D-01');
+    assert.equal(out[1].id, 'D-02');
+  });
+
+  test('titled-colon coexists with colon-immediate and em-dash forms', () => {
+    const md = '## Locked decisions\n- **D-01:** plain colon\n- **D-02 — emdash** body\n- **D-03: Titled.** body\n';
+    const out = parseDecisions(md);
+    assert.equal(out.length, 3);
+    assert.deepEqual(out.map((d) => d.id), ['D-01', 'D-02', 'D-03']);
+  });
+
+  test('titled-colon with [tags] still parses id and tags', () => {
+    const md = '## Locked decisions\n- **D-01 [informational]: Title.** body\n';
+    const out = parseDecisions(md);
+    assert.equal(out.length, 1);
+    assert.equal(out[0].id, 'D-01');
+    assert.ok(out[0].tags.includes('informational'), `tags should include informational, got ${JSON.stringify(out[0].tags)}`);
+  });
+
+  test('all-titled CONTEXT.md parses every decision (no vacuous 0)', () => {
+    // The reporter case: 13 decisions all titled → previously all dropped → gate passed vacuously.
+    let md = '## Locked decisions\n';
+    for (let i = 1; i <= 13; i++) md += `- **D-${String(i).padStart(2, '0')}: Decision ${i}.** body\n`;
+    const out = parseDecisions(md);
+    assert.equal(out.length, 13, 'all 13 titled-colon decisions must parse (not vacuously 0)');
+  });
+});


### PR DESCRIPTION
## Fix PR

Fixes #1639  ·  `confirmed-bug`

## What was broken

`parseDecisions` recognized the colon-immediate (`- **D-NN:** text`), tags-before-colon, freeform-before-colon, and em-dash (`- **D-NN — title** body`) bullet forms, but **dropped** the titled-colon form `- **D-NN: Title.** body` (a title sits between the colon and the closing `**`). `bulletColonRe`'s `:**` anchor fails (colon isn't immediately before `**`), `bulletEmDashRe` needs an em-dash — so the bullet hit the parse-miss guard and was silently dropped. When every decision used the titled convention, `parseDecisions` returned 0 decisions and `check.decision-coverage-plan` passed **vacuously** — the same false-coverage failure mode as #1343/#1364/#1365.

## What this fix does

Add a third per-form regex `bulletTitledColonRe`, checked **last** (it is a strict superset of `bulletColonRe`, so it only catches bullets the colon and em-dash forms missed — minimal blast radius). The title run is `[^:*]*` (no colon, no `*`), matching `bulletColonRe`'s `[^:*]*` discipline that the separator colon is the **only** colon permitted before `**` — so a genuinely-malformed bullet with a colon in the pre-separator run (e.g. `D-07 ratio 3:1:**`) still fails the anchor and falls through to the parse-miss guard. `id` and `[tags]` trackability are honored.

## Root cause

`src/decisions.cts` `bulletColonRe` (line 62) anchors on `:**`; the titled form has `Title.**` after the colon, so the anchor fails.

## Testing

Reproduced deterministically (the reporter's exact repro: `parseDecisions('## Locked decisions\n- **D-01: Default sandbox ON.** body\n').length` → 0). Regression folded into `tests/decisions.test.cjs`: titled-colon parses; coexists with colon-immediate + em-dash; `[tags]` parsed; all-titled 13-bullet CONTEXT.md parses all 13 (not vacuously 0). Fails-first; passes after.

A first cut used `[^*]*` for the title and was too permissive (it matched the malformed `D-07 ratio 3:1:**` fixture, regressing the `tests/post-planning-gaps-2493.test.cjs` #1343 parse-miss guard). Tightened to `[^:*]*`; that suite (106 tests incl. the parse-miss fixtures) is green.

- `node --test tests/decisions.test.cjs tests/post-planning-gaps-2493.test.cjs` → 106/106
- `npm run build:lib` → clean · `npx eslint src/decisions.cts` → clean
- `gsd-test-summary -base next -head HEAD` (Docker ubuntu-CI mirror) → **20882/20882 pass, exit 0**

- [x] Regression test (+ parse-miss guard preserved) · [x] macOS + Linux · [x] `Fixes #1639` · `confirmed-bug` · scoped · `.changeset/Fixed` · no new deps

## Breaking changes

None. The only behavior change is additive: valid titled-colon bullets now parse. Bullets that were correctly rejected by the parse-miss guard (colon in the pre-separator run) are still rejected.

> *Reporter @0xdhx had a prepared PR; this implements the fix on `next` per the fix-all directive. The reporter's proposed `[^*]*` title was tightened to `[^:*]*` after the docker gate caught the parse-miss-guard regression — issue content treated as untrusted data and verified against the source.*

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1665"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784910448&installation_id=134682257&pr_number=1665&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1665&signature=3becbdb64a508234b3f90e1d0dfc5d5937be07151061669e424830333278cce4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->