### PR TITLE
fix(#1668): restore CRLF By-Phase row-upsert regression (resolved via #1655)

### DIFF
--- a/tests/state.test.cjs
+++ b/tests/state.test.cjs
@@ -2256,15 +2256,22 @@ describe('updatePerformanceMetricsSection', () => {
     assert.ok(result.success, `phase complete failed: ${result.error}`);
 
     const after = fs.readFileSync(statePath, 'utf8');
-    // #1658 fixed byPhaseTablePattern to be CRLF-tolerant. This integration test proves the
-    // CRLF STATE.md is processed end-to-end (phase complete succeeds under #1522's
-    // verification gate and the velocity total updates from the CRLF body). The By-Phase
-    // *row* upsert on CRLF has a separate downstream bug in phase complete's table-write
-    // path (the pattern matches CRLF — verified directly — but the row isn't persisted on
-    // CRLF while it is on LF); that is tracked separately and intentionally not asserted here.
+    // #1658: byPhaseTablePattern is CRLF-tolerant. #1668 (By-Phase row not persisted on a
+    // CRLF STATE.md even though the pattern matches CRLF) was resolved by #1655's
+    // restructure of updatePerformanceMetricsSection (table upsert now runs before the
+    // velocity manipulation). Assert the full contract: row present, placeholder removed,
+    // velocity derived — all on a CRLF STATE.md.
+    assert.ok(
+      /\|\s*7\s*\|\s*1\s*\|/.test(after),
+      'By-Phase row for phase 7 must be upserted even on a CRLF STATE.md (#1658/#1668)',
+    );
+    assert.ok(
+      !/\|\s*-\s*\|\s*-\s*\|\s*-\s*\|\s*-\s*\|/.test(after),
+      'placeholder row must be removed on CRLF STATE.md once a real row is upserted',
+    );
     assert.ok(
       /Total plans completed:\s*1\b/.test(after),
-      'velocity total must update from the CRLF STATE.md body (proves CRLF content is processed)',
+      'velocity total must derive from the CRLF By-Phase table (1 plan)',
     );
   });
 


### PR DESCRIPTION
## Fix PR

Fixes #1668

## What was broken

`phase complete <N>` on a CRLF (`\r\n`) STATE.md updated the velocity total and Status but did **not** upsert the completed phase's row into the By-Phase table — the placeholder stayed — while an otherwise-identical LF STATE.md upserted correctly.

## What this fix does

**#1668 no longer reproduces on `next`** — it was resolved as a side effect of **#1655**, which restructured `updatePerformanceMetricsSection` to upsert the By-Phase table **before** the velocity manipulation (the pre-#1655 ordering lost the table update on CRLF). This PR is the **verification + regression lock**: it restores the full row-upsert + placeholder-removed + velocity-derived assertions on the #1658 CRLF test (which #1667 had relaxed when this bug appeared), proving the CRLF STATE.md is now handled end-to-end. Verified clean on `next`: CRLF STATE.md → `phase complete 7` → row `| 7 | 1 |` upserted, placeholder removed, velocity `1` derived.

No production code changed (test-only); codex adversarial review was not applicable (no security/correctness surface — this is verification of an already-merged fix).

## Testing

- `node --test --test-name-pattern="1658" tests/state.test.cjs` → pass (row + placeholder + velocity all asserted on CRLF)
- `gsd-test-summary -base next -head HEAD` (Docker ubuntu-CI mirror) → **20968/20968 pass, exit 0**

- [x] Regression test restored · [x] macOS + Linux (Docker) · [x] `Fixes #1668` · `.changeset` not required (test-only, no user-facing change)

## Breaking changes

None (test-only).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1669"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784926251&installation_id=134682257&pr_number=1669&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1669&signature=be859aee9bcaaea4e332c008622dba743d86eda6dd2c654416c4642d970eeb5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->