### PR TITLE
docs(#1507): mark ADR-1508 implementation-complete and close the conversion-module epic

### DIFF
--- a/docs/adr/1508-runtime-artifact-conversion-module.md
+++ b/docs/adr/1508-runtime-artifact-conversion-module.md
@@ -77,3 +77,17 @@ This is the **last upward dependency from the `.cts` source tree into the hand-a
 - **ADR-457 (generated-CJS single source):** the moved engine is authored in `src/*.cts` and consumed as generated `bin/lib/*.cjs`, consistent with the single-source rule.
 - **ADR-1235 (descriptor-driven agent conversion):** complementary — both narrow `bin/install.js`'s ownership of conversion concerns.
 - **Epic #1507** tracks the phases. **Distinct from epic #1258** (cross-runtime skill mapping + plugin skill provision/consumption): #1258 Phase A documents the converter *transform-contract catalog*; this ADR decides *module ownership + dependency direction + engine relocation*. Continues **#1099** (closed first slice that created the module) and is a sibling of **#1173** (agent-converter wiring).
+
+## Amendment — 2026-06-24: Implementation complete (epic #1507 closed)
+
+The decision recorded above is **implemented** on `next`. The ADR `Status` stays **Accepted** — per this directory's append-only convention there is no "Implemented" status; this dated amendment records that the decision is realized.
+
+Landed:
+- **Phase 1 (#1512):** `getDirName` → `src/runtime-name-policy.cts`; `processAttribution` → `src/runtime-artifact-conversion.cts`. (`getCommitAttribution` stays in `bin/install.js` — a documented scope refinement: it is impure install-time config I/O, not a content-transformation helper, so it cannot move into the pure conversion module. Phase 2 injects the resolved attribution value instead.)
+- **Phase 2 (#1513):** the content-rewrite engine (`_applyRuntimeRewrites`), both staged-content walkers, and `computePathPrefix` (private; `_computePathPrefix` for tests) live in `src/runtime-artifact-conversion.cts` behind the deep seam `rewriteStagedSkillBodies` / `rewriteStagedCommandBodies({runtime, configDir, scope, homedir?, platform?, resolveAttribution?})`. The `getInstallExports` / `loadInstallExports` / `InstallExports` relay and the `GSD_TEST_MODE` install.js `require` are **deleted** from `src/runtime-artifact-layout.cts` — the last upward `.cts → bin/install.js` dependency is gone. `CONTEXT.md` marks the module **SHIPPED**. (The install-side cutover lands one indirection deeper than the literal issue text — `install.js` delegates to `createRuntimeArtifactInstallPlan`, which performs the deep calls in `src/runtime-artifact-install-plan.cts` — satisfying the same dependency-direction intent with a cleaner owner.)
+
+Two deferred follow-ups were spun out as **sub-issues of #1507** and have since been **delivered** (neither was a blocker; the architectural goal — single ownership, downward dependency direction, relay deletion — was already met by the merged slices above):
+- **#1675** (PR #1685) — deduped the byte-identical `convertClaudeToAugmentMarkdown` / `convertSlashCommandsToAugmentSkillMentions` between `bin/install.js` and the conversion module (the Phase 1 → Phase 2 deferred cleanup; install.js now binds them from the conversion module, single-sourced).
+- **#1676** (PR #1686) — added the `fast-check` property test (`$HOME`-collapse invariant + path-rewrite idempotency) promised in #1511's test scope.
+
+Delivery verified by a Codex (`gpt-5.4`, high-effort, read-only) review against the epic's stated deliverables, cross-checked against the indexed code graph and live source.


### PR DESCRIPTION
## Summary

Closes epic **#1507** (close the installer content-rewrite relay — Runtime Artifact Conversion Module owns rewriting) and marks **ADR-1508** as implemented, per a Codex delivery review.

## Codex delivery review verdict

Review run with Codex (`gpt-5.4`, high effort, read-only) against every stated deliverable of #1507 / ADR-1508, cross-checked against the indexed code graph and live source.

**Epic core — DELIVERED:**
- **Phase 0 (ADR #1509):** `docs/adr/1508-runtime-artifact-conversion-module.md` + README index row. Status **Accepted**.
- **Phase 1 (#1512):** `getDirName` → `src/runtime-name-policy.cts`; `processAttribution` → `src/runtime-artifact-conversion.cts`. (`getCommitAttribution` correctly stays in `bin/install.js` — documented scope refinement: impure install-time config I/O.)
- **Phase 2 (#1513):** engine (`_applyRuntimeRewrites`) + both walkers + `computePathPrefix` (private; `_computePathPrefix` for tests) live in the conversion module behind the deep seam `rewriteStagedSkillBodies`/`rewriteStagedCommandBodies`. The `getInstallExports`/`loadInstallExports`/`InstallExports` relay + the `GSD_TEST_MODE` install.js `require` are **deleted** from `src/runtime-artifact-layout.cts` (0 graph matches). `CONTEXT.md` glossary flipped to **SHIPPED**. `_computePathPrefix` unit tests + `path-replacement.test.cjs` reimplementation removal (now a thin adapter) + `DEFECT.GENERATIVE-FIX` parity guard all present.

**Two deferred deliverables did NOT land** → tracked as new **sub-issues of #1507** (neither is a blocker; the architectural goal is met):
- **#1675** — dedup the byte-identical `convertClaudeToAugmentMarkdown`/`convertSlashCommandsToAugmentSkillMentions` between `bin/install.js:2583-2610` and `conversion.cts:1040-1067` (the Phase 1 → Phase 2 deferred cleanup).
- **#1676** — add the `fast-check` property test (`$HOME`-collapse invariant + path-rewrite idempotency) promised in #1511's test scope.

## Changes

- `docs/adr/1508-runtime-artifact-conversion-module.md` — append-only dated **Amendment (2026-06-24)** recording implementation-complete, the install-side cutover note (delegates via `createRuntimeArtifactInstallPlan`), and the two follow-up sub-issues. ADR `Status` stays **Accepted** (no "Implemented" status per `docs/adr/README.md`).

Doc-only. No code, no behavior change.

## Governance

Closes #1507
Relates to #1508 (ADR), #1512 (Phase 1), #1513 (Phase 2)
Follow-ups: #1675, #1676 (sub-issues of #1507)

- No changeset: `docs/adr/` is outside the `Changeset Required` gate's watched paths (`bin/`, `gsd-core/`, `agents/`, `commands/`, `hooks/`, `sdk/src/`).
- Base branch: `next` (per branching model).

<!-- pr-template-exempt: doc-only ADR amendment (docs/adr/ only) — no typed template required per pull_request_template.md doc-only auto-detection -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1677"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784938202&installation_id=134682257&pr_number=1677&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1677&signature=acc517fbf4c86147b611b91adaf9216d699f24c19e2bfea85c620451c4dadabc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->