### PR TITLE
fix(#1528): drop next-phase guidance from security-blocked verify-work presentation

### DIFF
--- a/.changeset/1528-verify-work-security-blocked-next-phase.md
+++ b/.changeset/1528-verify-work-security-blocked-next-phase.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 1687
+---
+The `verify-work` security-blocked presentation no longer offers next-phase planning. When security enforcement blocks phase advancement (no `SECURITY.md` produced), the workflow now routes only to the current-phase fix instead of competing `/gsd:plan-phase {next}` and `/gsd:execute-phase {next}` options.

--- a/gsd-core/workflows/verify-work.md
+++ b/gsd-core/workflows/verify-work.md
@@ -514,8 +514,6 @@ Resolve the security review failure before advancing to the next phase.
 All tests passed, but phase advancement is blocked until security review produces SECURITY.md.
 
 - `/gsd:secure-phase {phase}` — security review (required before advancing)
-- `/gsd:plan-phase {next}` — Plan next phase
-- `/gsd:execute-phase {next}` — Execute next phase
 - `/gsd:ui-review {phase}` — visual quality audit (if frontend files were modified)
 ```
 

--- a/tests/fixtures/golden-install-parity/antigravity.json
+++ b/tests/fixtures/golden-install-parity/antigravity.json
@@ -298,7 +298,7 @@
   "gsd-core/workflows/update.md": "dc93f366e2156e37",
   "gsd-core/workflows/validate-phase.md": "5bac28c71d21c740",
   "gsd-core/workflows/verify-phase.md": "e7059c04c816e62d",
-  "gsd-core/workflows/verify-work.md": "dd7f78f947b86976",
+  "gsd-core/workflows/verify-work.md": "7f3c7d0d0932cec6",
   "hooks/gsd-check-update-worker.js": "fa301e6366270d5f",
   "hooks/gsd-check-update.js": "4617a98bf529e4c3",
   "hooks/gsd-config-reload.js": "96546e0e8bb47904",

--- a/tests/fixtures/golden-install-parity/augment.json
+++ b/tests/fixtures/golden-install-parity/augment.json
@@ -367,7 +367,7 @@
   "gsd-core/workflows/update.md": "231e7c305b40c417",
   "gsd-core/workflows/validate-phase.md": "50f37b705b6e44fb",
   "gsd-core/workflows/verify-phase.md": "7579af6cd757f644",
-  "gsd-core/workflows/verify-work.md": "6f9c666386cb6d7e",
+  "gsd-core/workflows/verify-work.md": "e106af0b705382b5",
   "hooks/gsd-check-update-worker.js": "cc1ef5f840f9dfc9",
   "hooks/gsd-check-update.js": "7b3a7983d5f1f5d3",
   "hooks/gsd-config-reload.js": "96546e0e8bb47904",

--- a/tests/fixtures/golden-install-parity/claude.json
+++ b/tests/fixtures/golden-install-parity/claude.json
@@ -297,7 +297,7 @@
   "gsd-core/workflows/update.md": "0b389258dcc09332",
   "gsd-core/workflows/validate-phase.md": "2aa540f2c2479501",
   "gsd-core/workflows/verify-phase.md": "15a999f82868ad29",
-  "gsd-core/workflows/verify-work.md": "d2e8f5d5f2b8f050",
+  "gsd-core/workflows/verify-work.md": "81c4591e25f9315c",
   "hooks/gsd-check-update-worker.js": "a530efdb5fdc0da3",
   "hooks/gsd-check-update.js": "25cde66a12d6b886",
   "hooks/gsd-config-reload.js": "96546e0e8bb47904",

--- a/tests/fixtures/golden-install-parity/cline.json
+++ b/tests/fixtures/golden-install-parity/cline.json
@@ -301,7 +301,7 @@
   "gsd-core/workflows/update.md": "9cad8a8f4baff922",
   "gsd-core/workflows/validate-phase.md": "54687a0f2a562fc4",
   "gsd-core/workflows/verify-phase.md": "5caca0023bc88a9a",
-  "gsd-core/workflows/verify-work.md": "6f482d32e0c8d49a",
+  "gsd-core/workflows/verify-work.md": "553197cb36695180",
   "scripts/changeset/README.md": "86ff89331dfd94b2",
   "scripts/changeset/cli.cjs": "68f92a344b199271",
   "scripts/changeset/github-release-notes.cjs": "795677f0c009b132",

--- a/tests/fixtures/golden-install-parity/codebuddy.json
+++ b/tests/fixtures/golden-install-parity/codebuddy.json
@@ -367,7 +367,7 @@
   "gsd-core/workflows/update.md": "6a593863d1b0a287",
   "gsd-core/workflows/validate-phase.md": "50f37b705b6e44fb",
   "gsd-core/workflows/verify-phase.md": "7579af6cd757f644",
-  "gsd-core/workflows/verify-work.md": "6f9c666386cb6d7e",
+  "gsd-core/workflows/verify-work.md": "e106af0b705382b5",
   "hooks/gsd-check-update-worker.js": "bdc9324a2f080ddd",
   "hooks/gsd-check-update.js": "b7669f605631e506",
   "hooks/gsd-config-reload.js": "96546e0e8bb47904",

--- a/tests/fixtures/golden-install-parity/codex.json
+++ b/tests/fixtures/golden-install-parity/codex.json
@@ -333,7 +333,7 @@
   "gsd-core/workflows/update.md": "4166fd3e3ca72a7b",
   "gsd-core/workflows/validate-phase.md": "4e94708c9ca15d70",
   "gsd-core/workflows/verify-phase.md": "59bb0b12ebb47f5e",
-  "gsd-core/workflows/verify-work.md": "92fb4e876d75ded5",
+  "gsd-core/workflows/verify-work.md": "1482cd4f8af40387",
   "hooks/gsd-check-update.js": "ef48957eb6ac6a10",
   "hooks/gsd-context-monitor.js": "76fecaaa2babd6c1",
   "scripts/changeset/README.md": "86ff89331dfd94b2",

--- a/tests/fixtures/golden-install-parity/copilot.json
+++ b/tests/fixtures/golden-install-parity/copilot.json
@@ -299,7 +299,7 @@
   "gsd-core/workflows/update.md": "712ab18a9b7c14f5",
   "gsd-core/workflows/validate-phase.md": "f923eac9442b6053",
   "gsd-core/workflows/verify-phase.md": "eea9b642393b6b90",
-  "gsd-core/workflows/verify-work.md": "e253fb8e33c68fa4",
+  "gsd-core/workflows/verify-work.md": "700b44e881a29ece",
   "hooks/gsd-session.json": "0a462834f2a28fee",
   "scripts/changeset/README.md": "86ff89331dfd94b2",
   "scripts/changeset/cli.cjs": "68f92a344b199271",

--- a/tests/fixtures/golden-install-parity/cursor.json
+++ b/tests/fixtures/golden-install-parity/cursor.json
@@ -367,7 +367,7 @@
   "gsd-core/workflows/update.md": "a27dcfd2814bf2b1",
   "gsd-core/workflows/validate-phase.md": "f513c28c01a44cb7",
   "gsd-core/workflows/verify-phase.md": "15a999f82868ad29",
-  "gsd-core/workflows/verify-work.md": "24d323b667d15d01",
+  "gsd-core/workflows/verify-work.md": "f55fb54bcd7650bb",
   "hooks/gsd-cursor-post-tool.js": "019d503aee8b4a3f",
   "hooks/gsd-cursor-session-start.js": "c6e04ed597ea7020",
   "scripts/changeset/README.md": "86ff89331dfd94b2",

--- a/tests/fixtures/golden-install-parity/gemini.json
+++ b/tests/fixtures/golden-install-parity/gemini.json
@@ -367,7 +367,7 @@
   "gsd-core/workflows/update.md": "51c3af33474bdc24",
   "gsd-core/workflows/validate-phase.md": "2d998cb78c918d08",
   "gsd-core/workflows/verify-phase.md": "7579af6cd757f644",
-  "gsd-core/workflows/verify-work.md": "1265e07f2c74a218",
+  "gsd-core/workflows/verify-work.md": "4df959def1892391",
   "hooks/gsd-check-update-worker.js": "5f5f2b73e6c14a7f",
   "hooks/gsd-check-update.js": "0e955593b7884d99",
   "hooks/gsd-config-reload.js": "96546e0e8bb47904",

--- a/tests/fixtures/golden-install-parity/hermes.json
+++ b/tests/fixtures/golden-install-parity/hermes.json
@@ -298,7 +298,7 @@
   "gsd-core/workflows/update.md": "472d4905fc8c5ce5",
   "gsd-core/workflows/validate-phase.md": "067acd7aeed52c5b",
   "gsd-core/workflows/verify-phase.md": "4e1d99795e8e9413",
-  "gsd-core/workflows/verify-work.md": "aa0b4d000b15dbf1",
+  "gsd-core/workflows/verify-work.md": "ca5990c760e73c10",
   "hooks/gsd-check-update-worker.js": "7989cc2bedd1138d",
   "hooks/gsd-check-update.js": "25f5ad726f76fc11",
   "hooks/gsd-config-reload.js": "880b696458e85e9b",

--- a/tests/fixtures/golden-install-parity/kilo.json
+++ b/tests/fixtures/golden-install-parity/kilo.json
@@ -367,7 +367,7 @@
   "gsd-core/workflows/update.md": "5d0a2356dadf2017",
   "gsd-core/workflows/validate-phase.md": "7915e3a261f7c9c9",
   "gsd-core/workflows/verify-phase.md": "15a999f82868ad29",
-  "gsd-core/workflows/verify-work.md": "7cb5144cc74986e7",
+  "gsd-core/workflows/verify-work.md": "5ee188f029ecc97e",
   "hooks/gsd-check-update-worker.js": "c992bbad91d0e994",
   "hooks/gsd-check-update.js": "fdd77abe7ef26a2d",
   "hooks/gsd-config-reload.js": "96546e0e8bb47904",

--- a/tests/fixtures/golden-install-parity/kimi.json
+++ b/tests/fixtures/golden-install-parity/kimi.json
@@ -334,7 +334,7 @@
   "gsd-core/workflows/update.md": "6369691790864147",
   "gsd-core/workflows/validate-phase.md": "50f37b705b6e44fb",
   "gsd-core/workflows/verify-phase.md": "7579af6cd757f644",
-  "gsd-core/workflows/verify-work.md": "6f9c666386cb6d7e",
+  "gsd-core/workflows/verify-work.md": "e106af0b705382b5",
   "scripts/changeset/README.md": "86ff89331dfd94b2",
   "scripts/changeset/cli.cjs": "68f92a344b199271",
   "scripts/changeset/github-release-notes.cjs": "795677f0c009b132",

--- a/tests/fixtures/golden-install-parity/opencode.json
+++ b/tests/fixtures/golden-install-parity/opencode.json
@@ -367,7 +367,7 @@
   "gsd-core/workflows/update.md": "af51041a3172c523",
   "gsd-core/workflows/validate-phase.md": "0fc5991f6d7c6c39",
   "gsd-core/workflows/verify-phase.md": "13a1a43395b5e47b",
-  "gsd-core/workflows/verify-work.md": "52f6011634cff599",
+  "gsd-core/workflows/verify-work.md": "401453f01c19eb14",
   "hooks/gsd-check-update-worker.js": "385fb7c67810baf6",
   "hooks/gsd-check-update.js": "4549451414ffa7d7",
   "hooks/gsd-config-reload.js": "96546e0e8bb47904",

--- a/tests/fixtures/golden-install-parity/qwen.json
+++ b/tests/fixtures/golden-install-parity/qwen.json
@@ -298,7 +298,7 @@
   "gsd-core/workflows/update.md": "baae1a977fbeba49",
   "gsd-core/workflows/validate-phase.md": "0e153ccb3bdb9dda",
   "gsd-core/workflows/verify-phase.md": "0ef74d5b7f7646f6",
-  "gsd-core/workflows/verify-work.md": "8a4157d179fce9c4",
+  "gsd-core/workflows/verify-work.md": "ca95afc02dda87cb",
   "hooks/gsd-check-update-worker.js": "4bb354044e0dff91",
   "hooks/gsd-check-update.js": "d2065cb3e725a42a",
   "hooks/gsd-config-reload.js": "4f52b8a0120bb1b8",

--- a/tests/fixtures/golden-install-parity/trae.json
+++ b/tests/fixtures/golden-install-parity/trae.json
@@ -298,7 +298,7 @@
   "gsd-core/workflows/update.md": "e259898f86ae7133",
   "gsd-core/workflows/validate-phase.md": "70d102b4d5113dd4",
   "gsd-core/workflows/verify-phase.md": "67eefbd1f6417281",
-  "gsd-core/workflows/verify-work.md": "1e2a10168f8fdc2b",
+  "gsd-core/workflows/verify-work.md": "24df47d0b0e6a453",
   "scripts/changeset/README.md": "86ff89331dfd94b2",
   "scripts/changeset/cli.cjs": "68f92a344b199271",
   "scripts/changeset/github-release-notes.cjs": "795677f0c009b132",

--- a/tests/fixtures/golden-install-parity/windsurf.json
+++ b/tests/fixtures/golden-install-parity/windsurf.json
@@ -298,7 +298,7 @@
   "gsd-core/workflows/update.md": "cbf978622ad0f577",
   "gsd-core/workflows/validate-phase.md": "a36cf2c688c261ac",
   "gsd-core/workflows/verify-phase.md": "8a89a915dad5960b",
-  "gsd-core/workflows/verify-work.md": "7586bdeeeb9ecba6",
+  "gsd-core/workflows/verify-work.md": "7eff85ce5879f5bf",
   "scripts/changeset/README.md": "86ff89331dfd94b2",
   "scripts/changeset/cli.cjs": "68f92a344b199271",
   "scripts/changeset/github-release-notes.cjs": "795677f0c009b132",

--- a/tests/ui-review-next-guidance.test.cjs
+++ b/tests/ui-review-next-guidance.test.cjs
@@ -8,6 +8,7 @@ const path = require('node:path');
 
 const UI_REVIEW = path.join(__dirname, '..', 'gsd-core', 'workflows', 'ui-review.md');
 const MANAGER = path.join(__dirname, '..', 'gsd-core', 'workflows', 'manager.md');
+const VERIFY_WORK = path.join(__dirname, '..', 'gsd-core', 'workflows', 'verify-work.md');
 
 describe('ui-review next guidance', () => {
   test('prioritizes current-phase verification over next-phase planning (#1528)', () => {
@@ -27,6 +28,53 @@ describe('ui-review next guidance', () => {
       (nextBlock.match(/verify-work \{N\}/g) || []).length,
       1,
       'ui-review next block must not duplicate verify-work guidance',
+    );
+  });
+});
+
+describe('verify-work blocked-state next guidance', () => {
+  test('security-blocked presentation does not offer next-phase planning (#1528)', () => {
+    const content = fs.readFileSync(VERIFY_WORK, 'utf-8');
+    // The security-blocked presentation explicitly states advancement is blocked
+    // until SECURITY.md exists; it must route to the current-phase fix only.
+    const blockedStart = content.indexOf(
+      'If `SECURITY_FILE` is still empty, stop before phase advancement',
+    );
+    const blockedBlock = content.slice(
+      blockedStart,
+      content.indexOf('If an active secure-phase step hook exists', blockedStart),
+    );
+
+    assert.match(
+      blockedBlock,
+      /secure-phase \{phase\}/,
+      'security-blocked presentation must route to the current-phase secure-phase fix',
+    );
+    assert.doesNotMatch(
+      blockedBlock,
+      /plan-phase \{next\}/,
+      'security-blocked presentation must not offer next-phase planning while advancement is blocked',
+    );
+    assert.doesNotMatch(
+      blockedBlock,
+      /execute-phase \{next\}/,
+      'security-blocked presentation must not offer next-phase execution while advancement is blocked',
+    );
+  });
+
+  test('next-phase planning is still offered after the phase is marked complete (#1528)', () => {
+    const content = fs.readFileSync(VERIFY_WORK, 'utf-8');
+    // The post-transition "next-step options" block is the legitimate place for
+    // next-phase guidance — it only renders after the completion contract passes.
+    const completeBlock = content.slice(
+      content.indexOf('Phase {phase} marked complete.'),
+      content.indexOf('<step name="scan_phase_artifacts">'),
+    );
+
+    assert.match(
+      completeBlock,
+      /plan-phase \{next\}/,
+      'post-completion presentation must still offer next-phase planning',
     );
   });
 });

--- a/tests/workflow-size-baseline.json
+++ b/tests/workflow-size-baseline.json
@@ -87,5 +87,5 @@
   "update.md": 21053,
   "validate-phase.md": 10745,
   "verify-phase.md": 40728,
-  "verify-work.md": 35212
+  "verify-work.md": 35112
 }


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #1528

---

## What was broken

When security enforcement blocks phase advancement (the `secure-phase` step ran but produced no `SECURITY.md`), the `verify-work` presentation told the user *"phase advancement is blocked until security review produces SECURITY.md"* — and then listed `/gsd:plan-phase {next}` and `/gsd:execute-phase {next}` as next steps, competing with the required current-phase fix.

## What this fix does

Removes those two next-phase lines from the security-blocked presentation so the blocked state routes only to current-phase actions (`/gsd:secure-phase {phase}`, `/gsd:ui-review {phase}`). The post-transition presentation — reached only after the completion contract passes — still offers next-phase planning, which is the correct place for it.

## Root cause

This is the residual gap left after #1548 (`Fixes #1522`) landed the bulk of the verification-gate epic. #1548 cleaned up the `ui-review` advisory output and the stale / predicate-fail / `threats_open` blocked branches, but the security-missing-`SECURITY.md` branch still carried the legacy next-phase options that contradict its own "advancement is blocked" message.

## Testing

### How I verified the fix

- `node --test tests/ui-review-next-guidance.test.cjs tests/workflow-size-budget.test.cjs tests/verify-work-auto-transition.test.cjs tests/transition-verification-gate.test.cjs` → 136/136 pass
- `npm run lint` (eslint), `npm run lint:docs`, `node scripts/lint-allow-test-rule-refs.cjs`, `node scripts/lint-regression-test-names.cjs`, `node scripts/lint-test-file-count.cjs` → all clean
- `git diff --check` → clean
- Regenerated `tests/workflow-size-baseline.json` (verify-work.md shrank 35212 → 35112 bytes)

I also audited the sibling advisory flows for the same class of bug and found none in scope: the `threats_open`, stale, and predicate-fail branches of `verify-work.md` already route to current-phase commands only; `eval-review.md` gates next-phase planning behind `PRODUCTION READY`; `execute-phase.md` offers next-phase commands only after verification passes.

### Regression test added?

- [x] Yes — added a test that would have caught this bug

Two cases added to `tests/ui-review-next-guidance.test.cjs`: the security-blocked block must not offer `plan-phase {next}`/`execute-phase {next}` (but must keep `secure-phase {phase}`), and the post-completion block must still offer `plan-phase {next}` (proving the legitimate path is preserved).

### Platforms tested

- [x] N/A (not platform-specific)

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass
- [x] `.changeset/` fragment added if this is a user-facing fix — added after PR number is known
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1687"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784945070&installation_id=134682257&pr_number=1687&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1687&signature=dac7359274cdca47b6e050361c31a800225e7ff0ec37e68e735fe9a6b66ea3ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->