### PR TITLE
fix(#1580): exclude 0/999 sentinels from milestone-complete guard and roadmap analyze

### DIFF
--- a/.changeset/1580-999-sentinel-milestone-roadmap.md
+++ b/.changeset/1580-999-sentinel-milestone-roadmap.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 1691
+---
+`milestone complete` and `roadmap analyze` now exclude the Phase 0 / Phase 999 backlog sentinels. A milestone whose only directory-less ROADMAP heading is a backlog sentinel can be completed without `--force`, and `roadmap analyze` no longer counts the sentinel in `phase_count` or routes `next_phase` into it. Completes the `^999` exclusion #1445 added to the progress denominators.

--- a/src/milestone.cts
+++ b/src/milestone.cts
@@ -184,6 +184,13 @@ function cmdMilestoneComplete(cwd: string, version: string, options: MilestoneCo
         })();
         while ((pm = phasePattern.exec(scopedContent)) !== null) {
           const phaseNum = pm[1];
+          // Phase 0 (pre-milestone) and Phase 999 (backlog) are sentinels, not
+          // real phases — they legitimately have no directory and must not block
+          // milestone completion. Mirrors the engine-wide sentinel convention
+          // (phase-id getMilestoneFromPhaseId, roadmap-command-router SENTINELS,
+          // the #1445 /^999/ progress filters). (#1580)
+          const major = parseInt(phaseNum, 10);
+          if (major === 0 || major === 999) continue;
           const normalized = normalizePhaseName(phaseNum);
           // A phase has disk_status: 'no_directory' when no phase directory
           // with a matching token exists on disk. Use the same phaseTokenMatches

--- a/src/roadmap.cts
+++ b/src/roadmap.cts
@@ -318,6 +318,16 @@ function cmdRoadmapAnalyze(cwd: string, raw: boolean): void {
   }> = [];
   let match: RegExpExecArray | null;
 
+  // Phase 0 (pre-milestone) and Phase 999 (backlog) are sentinels, not real
+  // phases. They legitimately have no directory and must never be surfaced as
+  // current/next phase or counted in phase_count. Mirrors the engine-wide
+  // sentinel convention (phase-id getMilestoneFromPhaseId, roadmap-command-router
+  // SENTINELS, the #1445 /^999/ progress filters). (#1580)
+  const isSentinelPhase = (num: string): boolean => {
+    const major = parseInt(num, 10);
+    return major === 0 || major === 999;
+  };
+
   // Build phase directory lookup once (O(1) readdir instead of O(N) per phase)
   const _phaseDirNames = (() => {
     try {
@@ -329,6 +339,7 @@ function cmdRoadmapAnalyze(cwd: string, raw: boolean): void {
 
   while ((match = phasePattern.exec(content)) !== null) {
     const phaseNum = match[1];
+    if (isSentinelPhase(phaseNum)) continue;
     const phaseName = match[2].replace(/\(INSERTED\)/i, '').trim();
 
     // Extract goal from the section
@@ -437,7 +448,7 @@ function cmdRoadmapAnalyze(cwd: string, raw: boolean): void {
     checklistPhases.add(checklistMatch[1]);
   }
   const detailPhases = new Set(phases.map(p => p.number));
-  const missingDetails = [...checklistPhases].filter(p => !detailPhases.has(p));
+  const missingDetails = [...checklistPhases].filter(p => !detailPhases.has(p) && !isSentinelPhase(p));
 
   const result = {
     milestones,

--- a/tests/bug-978-milestone-complete-force.test.cjs
+++ b/tests/bug-978-milestone-complete-force.test.cjs
@@ -19,10 +19,13 @@ const { runGsdTools, createTempProject, cleanup } = require('./helpers.cjs');
  * Build a fixture where the guard will fire:
  *  - STATE.md has `milestone: <version>` so the guard's version-match check is
  *    satisfied.
- *  - ROADMAP.md lists a `### Phase 999.1: Backlog Work` heading for that
- *    milestone, but there is NO on-disk phase directory for it.
+ *  - ROADMAP.md lists a `### Phase 2: Real Work` heading for that milestone, but
+ *    there is NO on-disk phase directory for it.
  *
  * This guarantees "unstarted phase" detection without touching any real phases.
+ * NOTE: the unstarted phase must be a REAL phase number — Phase 0 and Phase 999
+ * are backlog/pre-milestone sentinels that are intentionally excluded from this
+ * guard (#1580), so they would not fire it.
  */
 function makeGuardFixture(tmpDir, version) {
   // STATE.md with frontmatter milestone field matching the version
@@ -32,10 +35,10 @@ function makeGuardFixture(tmpDir, version) {
   );
 
   // ROADMAP.md — the heading must include the version so getMilestonePhaseFilter
-  // does not return missingExplicitVersion.  Phase 999.1 has no on-disk dir.
+  // does not return missingExplicitVersion.  Phase 2 has no on-disk dir.
   fs.writeFileSync(
     path.join(tmpDir, '.planning', 'ROADMAP.md'),
-    `# Roadmap ${version}\n\n### Phase 999.1: Backlog Work\n**Goal:** Not started\n`,
+    `# Roadmap ${version}\n\n### Phase 2: Real Work\n**Goal:** Not started\n`,
   );
 }
 
@@ -80,7 +83,7 @@ describe('bug-978: milestone complete --force overrides unstarted-phase guard', 
 
     const output = JSON.parse(result.output);
     assert.strictEqual(output.version, 'v1.0');
-    // Milestone entry should have been created even though phase 999.1 has no dir
+    // Milestone entry should have been created even though phase 2 has no dir
     assert.ok(
       fs.existsSync(path.join(tmpDir, '.planning', 'MILESTONES.md')),
       'MILESTONES.md should have been created',

--- a/tests/fix-1445-999x-backlog-excluded-from-total-phases.test.cjs
+++ b/tests/fix-1445-999x-backlog-excluded-from-total-phases.test.cjs
@@ -16,6 +16,14 @@
  * Scenarios:
  *   A. deriveProgressFromRoadmap with a progress table containing a 999.x row.
  *   B. state json total_phases via extractCurrentMilestone / roadmapPhaseCount.
+ *
+ * Follow-up #1580: the same `^999` (and Phase 0) sentinel exclusion was missing
+ * in two more code paths — `milestone complete`'s unstarted-phase guard
+ * (src/milestone.cts) and `roadmap analyze`'s next_phase routing + phase_count
+ * (src/roadmap.cts). Scenarios C and D below cover those.
+ *
+ *   C. milestone complete is NOT blocked by a Phase 999 backlog heading.
+ *   D. roadmap analyze never routes next_phase to 999 / never counts it.
  */
 
 const { describe, test, beforeEach, afterEach } = require('node:test');
@@ -169,6 +177,119 @@ describe('bug #1445 — state json excludes 999.x phase headings from total_phas
       state.progress.total_phases,
       3,
       `total_phases must be 3 (not 5). 999.x backlog phases must be excluded. Got ${state.progress.total_phases}`,
+    );
+  });
+});
+
+// ─── Scenario C: milestone complete not blocked by a 999 backlog heading ─────
+
+describe('fix #1580 — milestone complete ignores the 999 backlog sentinel', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempProject('fix-1580-mc-');
+    const planning = path.join(tmpDir, '.planning');
+    // One real, on-disk phase + a directory-less Phase 999 backlog heading.
+    fs.writeFileSync(
+      path.join(planning, 'ROADMAP.md'),
+      [
+        '# Roadmap v1.0',
+        '## v1.0 Milestone',
+        '## Phases',
+        '- [x] **Phase 1: Foundation**',
+        '## Phase Details',
+        '### Phase 1: Foundation',
+        '**Goal:** build it',
+        '### Phase 999: Backlog / Someday',
+        '**Goal:** deferred, never executed',
+      ].join('\n'),
+      'utf-8',
+    );
+    fs.writeFileSync(
+      path.join(planning, 'STATE.md'),
+      `---\nmilestone: v1.0\n---\n# State\n\n**Status:** In progress\n**Last Activity:** 2025-01-01\n**Last Activity Description:** Working\n`,
+      'utf-8',
+    );
+    const dir = path.join(planning, 'phases', '01-foundation');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'PLAN.md'), '# Plan\n', 'utf-8');
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('completes WITHOUT --force despite a Phase 999 backlog heading', () => {
+    const result = runGsdTools(
+      ['milestone', 'complete', 'v1.0', '--name', 'Regression'],
+      tmpDir,
+    );
+    assert.ok(
+      result.success,
+      `milestone complete must not be blocked by the 999 sentinel; got error: ${result.error}`,
+    );
+    assert.ok(
+      !/Cannot mark milestone complete/.test(result.error || ''),
+      `the unstarted-phase guard must not fire on Phase 999. Got: ${result.error}`,
+    );
+  });
+});
+
+// ─── Scenario D: roadmap analyze never routes/ counts the 999 sentinel ────────
+
+describe('fix #1580 — roadmap analyze excludes the 999 backlog sentinel', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempProject('fix-1580-ra-');
+    const planning = path.join(tmpDir, '.planning');
+    fs.writeFileSync(
+      path.join(planning, 'ROADMAP.md'),
+      [
+        '# Roadmap v1.0',
+        '## v1.0 Milestone',
+        '## Phases',
+        '- [x] **Phase 1: Foundation**',
+        '## Phase Details',
+        '### Phase 1: Foundation',
+        '**Goal:** build it',
+        '### Phase 999: Backlog / Someday',
+        '**Goal:** deferred, never executed',
+      ].join('\n'),
+      'utf-8',
+    );
+    fs.writeFileSync(
+      path.join(planning, 'STATE.md'),
+      `---\nmilestone: v1.0\n---\n# State\n`,
+      'utf-8',
+    );
+    const dir = path.join(planning, 'phases', '01-foundation');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'PLAN.md'), '# Plan\n', 'utf-8');
+    fs.writeFileSync(path.join(dir, 'SUMMARY.md'), '# Summary\n', 'utf-8');
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('next_phase is never 999 and phase_count excludes the sentinel', () => {
+    const result = runGsdTools(['roadmap', 'analyze', '--raw'], tmpDir);
+    assert.ok(result.success, `roadmap analyze failed: ${result.error}`);
+    const analysis = JSON.parse(result.output);
+    assert.notEqual(
+      String(analysis.next_phase),
+      '999',
+      `next_phase must never route to the 999 backlog sentinel. Got ${analysis.next_phase}`,
+    );
+    assert.equal(
+      analysis.phase_count,
+      1,
+      `phase_count must exclude the 999 sentinel (expected 1). Got ${analysis.phase_count}`,
+    );
+    assert.ok(
+      !(analysis.phases || []).some(p => String(p.number) === '999'),
+      'the phases array must not include the 999 backlog sentinel',
     );
   });
 });


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #1580

---

## What was broken

Closed #1445 made `999.x` the canonical backlog sentinel and added the `^999` exclusion — but only to the progress denominators (`deriveProgressFromRoadmap` / `extractCurrentMilestone`). The same exclusion was missing in two other resolvers, so on a milestone whose only directory-less ROADMAP heading is `### Phase 999: Backlog`:

- **(A) `milestone complete` was blocked** — `src/milestone.cts`'s unstarted-phase guard flagged Phase 999 as an unstarted phase: `Cannot mark milestone complete: ROADMAP lists 1 unstarted phase(s) (e.g. Phase 999). Re-run with --force to override.` A fully-shipped milestone could not be closed without `--force`.
- **(B) `roadmap analyze` routed `next_phase` into the backlog** — `src/roadmap.cts :: cmdRoadmapAnalyze` counted the sentinel in `phase_count` and returned `next_phase: 999`, so the engine would route the user straight into the backlog sentinel.

## What this fix does

Both resolvers now skip Phase 0 (pre-milestone) and Phase 999 (backlog) sentinels:

- `src/milestone.cts`: the unstarted-phase guard skips sentinel headings, so a backlog heading no longer blocks completion.
- `src/roadmap.cts`: sentinel headings are excluded when building the `phases` array, so `phase_count`, `current_phase`, `next_phase`, and `completed_phases` all exclude them; the `missing_phase_details` check is also sentinel-aware so a checklisted sentinel can't become a phantom missing-detail.

The predicate (`parseInt(num,10) === 0 || === 999`) mirrors the engine-wide sentinel convention (`phase-id` `getMilestoneFromPhaseId` major-check, `roadmap-command-router` `SENTINELS = {0, 999}`, the `#1445` `^999` progress filters) and naturally covers `999.x` sub-phases and zero-padded forms.

## Root cause

#1445 fixed the sentinel exclusion in the progress-denominator paths only. The milestone-complete guard and `roadmap analyze` were two more resolvers that independently scan ROADMAP phase headings and simply never received the same exclusion. (PR #1612 previously attempted a broader version of this and was closed as superseded; the maintainer invited a focused follow-up for any specific gap not covered by `next` — these two are exactly that gap, empirically still reproducing on `next`.)

## Scope

- **Symptom (C)** from the issue (`state.cts` `total_phases` counting 999) is **already fixed** inline by #1445/#1514 — verified still correct (`total_phases: 1, percent: 100`). Out of scope here.
- **`init progress` / `init manager` (`src/init.cts`)** intentionally list the backlog phase as a row in their `phases` array (the manager dashboard shows the backlog), while their routing (`next_phase`) and completion math (`all_complete` / `completed_count`) already exclude sentinels via the existing `init.cts` `^999` filters. Verified sentinel-safe (`next_phase: null`, `all_complete: false`). This is deliberate display behavior, not the #1580 defect, so it is left unchanged. Happy to file a focused follow-up if a maintainer considers the listing itself a bug.

## Testing

### How I verified the fix

Empirically reproduced all three symptoms against `next` before the fix, and confirmed after:

| | before | after |
|---|---|---|
| (A) `milestone complete v1.0` | `Cannot mark milestone complete … Phase 999` (exit 1) | succeeds (exit 0) |
| (B) `roadmap analyze` | `phase_count: 2, next_phase: 999` | `phase_count: 1, next_phase: null` |
| (C) `state json` | `total_phases: 1` (already fixed) | `total_phases: 1` |

- Full suite `npm test` → **2902/2902 pass, 0 fail**
- `npm run lint` (eslint), `npm run lint:docs`, `lint-regression-test-names`, `lint-test-file-count`, `lint-allow-test-rule-refs` → all clean
- `git diff --check` clean

### Regression test added?

- [x] Yes — added a test that would have caught this bug

Scenarios C (milestone complete not blocked by Phase 999) and D (roadmap analyze excludes the sentinel from `next_phase`/`phase_count`/`phases`) folded into `tests/fix-1445-999x-backlog-excluded-from-total-phases.test.cjs` (the canonical 999-sentinel test home). Also updated `tests/bug-978-milestone-complete-force.test.cjs`: its guard fixture used a `Phase 999.1` heading as the stand-in "unstarted phase" — now correctly excluded by this fix — so it was changed to a real `Phase 2`, preserving the test's intent (proving `--force` overrides the unstarted-phase guard).

### Platforms tested

- [x] N/A (not platform-specific)

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix — added after PR number is known
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1691"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784947841&installation_id=134682257&pr_number=1691&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1691&signature=5cbe923c551b4518d47ef89aa8c3884059a7fd57cf46a99ed05c701159a0a5b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->