### PR TITLE
fix(#1695): preserve curated current_phase_name on an unrelated state patch

### DIFF
--- a/.changeset/fix-1695-state-patch-preserve-curated-scalars.md
+++ b/.changeset/fix-1695-state-patch-preserve-curated-scalars.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 1701
+---
+**`gsd-tools state patch` of an unrelated field no longer clobbers a curated `current_phase_name`** — `syncStateFrontmatter` re-derives the scalar from the `## Current Position` Phase line on every write, so patching e.g. `--Status` silently reverted a curated `current_phase_name` to whatever the prose derived. A #1230-style delta guard now restores the curated value when the patch did not change the Phase line it derives from; `begin`/`planned`/`complete-phase` still advance it normally. (#1695)

--- a/src/state.cts
+++ b/src/state.cts
@@ -2034,6 +2034,9 @@ function readModifyWriteStateMd(statePath: string, transformFn: (content: string
     const preSessionMatch = matchSessionSection(preBody);
     const preSessionScope = preSessionMatch ? preSessionMatch[1] : preBody;
     const preBodyStoppedAt = stateExtractField(preSessionScope, 'Stopped At') || stateExtractField(preSessionScope, 'Stopped at');
+    // Bug #1695: pre-transform body source field for the current_phase_name
+    // delta guard below (mirrors the Status/Stopped-At pair).
+    const preBodyPhase = stateExtractField(preBody, 'Phase');
 
     const modified = transformFn(content);
 
@@ -2065,6 +2068,8 @@ function readModifyWriteStateMd(statePath: string, transformFn: (content: string
     const postSessionMatch = matchSessionSection(postBody);
     const postSessionScope = postSessionMatch ? postSessionMatch[1] : postBody;
     const postBodyStoppedAt = stateExtractField(postSessionScope, 'Stopped At') || stateExtractField(postSessionScope, 'Stopped at');
+    // Bug #1695: post-transform counterpart of the source field snapshotted above.
+    const postBodyPhase = stateExtractField(postBody, 'Phase');
 
     let mutated = false;
     const postFm = extractFrontmatter(synced) as Record<string, unknown>;
@@ -2103,6 +2108,26 @@ function readModifyWriteStateMd(statePath: string, transformFn: (content: string
       postFm['stopped_at'] !== preFmSnapshot['stopped_at']
     ) {
       postFm['stopped_at'] = preFmSnapshot['stopped_at'];
+      mutated = true;
+    }
+
+    // Bug #1695: preserve curated current_phase_name when this write did NOT
+    // change the body Phase line it is derived from. syncStateFrontmatter
+    // re-derives current_phase_name from the `## Current Position` Phase line on
+    // every write — including a resync:false patch of an unrelated field — so
+    // without this guard `state patch --Status X` silently reverts a curated
+    // current_phase_name to whatever the Phase line derives. begin/planned/
+    // complete-phase DO rewrite the Phase line (changing the delta), so they are
+    // unaffected. Mirrors the #1230 status/stopped_at heuristic, and extends the
+    // #1264 "an unrelated patch must not rewrite untouched frontmatter" invariant
+    // (which covered progress only) to this body-derived scalar.
+    if (
+      postBodyPhase === preBodyPhase &&
+      typeof preFmSnapshot['current_phase_name'] === 'string' &&
+      preFmSnapshot['current_phase_name'].length > 0 &&
+      postFm['current_phase_name'] !== preFmSnapshot['current_phase_name']
+    ) {
+      postFm['current_phase_name'] = preFmSnapshot['current_phase_name'];
       mutated = true;
     }
 

--- a/tests/state.test.cjs
+++ b/tests/state.test.cjs
@@ -11,7 +11,7 @@ const assert = require('node:assert/strict');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const { runGsdTools, createTempProject, cleanup } = require('./helpers.cjs');
+const { runGsdTools, createTempProject, cleanup, parseFrontmatter } = require('./helpers.cjs');
 const { createFixture } = require('./fixtures/index.cjs');
 
 function writePassedVerification(tmpDir, phaseDirName, paddedPhase) {
@@ -5163,5 +5163,135 @@ describe('T6 section-splice characterization — milestone-switch', () => {
     } finally {
       cleanup(d);
     }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Bug #1695 — state patch of an unrelated field clobbers curated body-derived
+// scalars (current_phase_name, last_activity_desc).
+//
+// A `state patch` of an unrelated field (e.g. --Status) runs
+// readModifyWriteStateMd with resync:false. syncStateFrontmatter still runs
+// unconditionally and re-derives every body-derived scalar; the #1264 fix
+// restored only `progress`, so current_phase_name (and last_activity_desc) were
+// left at whatever the body re-derived.
+//
+// Fix (src/state.cts): a #1230-style delta guard preserves curated
+// current_phase_name / last_activity_desc when the patch did NOT change the body
+// field they are derived from. begin/planned/complete-phase DO rewrite those
+// lines, so they still advance (covered by the negative case below). The fix is
+// independent of how parseProsePhaseField resolves the name — the curated
+// frontmatter value is restored regardless of what the body re-derives.
+//
+// Oracle note: preservation is asserted against the persisted STATE.md
+// frontmatter (the surface #1695 clobbers). `state json` is used only for
+// `progress`; it re-derives last_activity_desc from the body independently of
+// the frontmatter, so it is not a valid oracle for that scalar.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('regressions: #1695 — state patch preserves curated body-derived scalars', () => {
+  let tmpDir;
+  let statePath;
+
+  // A STATE.md whose frontmatter holds curated scalars and whose body
+  // `## Current Position` carries an inverted `Phase: N — Name (aside)` line —
+  // the exact shape that mis-derived the name before #1695.
+  function buildStateMd(opts) {
+    const o = opts || {};
+    const curatedName = o.currentPhaseName !== undefined ? o.currentPhaseName : 'Native Hotkey';
+    const curatedDesc = o.lastActivityDesc !== undefined ? o.lastActivityDesc : 'curated activity note';
+    const fm = ['---', 'gsd_state_version: 1.0', 'current_phase: 16'];
+    if (curatedName !== null) fm.push(`current_phase_name: ${curatedName}`);
+    fm.push('status: executing');
+    if (curatedDesc !== null) fm.push(`last_activity_desc: ${curatedDesc}`);
+    fm.push(
+      'progress:',
+      '  total_phases: 5',
+      '  completed_phases: 2',
+      '  total_plans: 10',
+      '  completed_plans: 4',
+      '  percent: 42',
+      '---',
+    );
+    return [
+      ...fm,
+      '',
+      '# GSD State',
+      '',
+      '## Current Position',
+      '',
+      'Phase: 16 — Native Hotkey (next; Phase 15 landed, UAT deferred)',
+      'Status: executing',
+      'Last activity: 2026-01-01',
+      '',
+      '## Accumulated Context',
+      '',
+      '### Decisions',
+      '',
+      '- Use Node 22',
+      '',
+    ].join('\n');
+  }
+
+  const readFrontmatter = () => parseFrontmatter(fs.readFileSync(statePath, 'utf-8'));
+
+  beforeEach(() => {
+    tmpDir = createTempProject();
+    statePath = path.join(tmpDir, '.planning', 'STATE.md');
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  // AC #1: state patch --Status leaves current_phase_name byte-unchanged.
+  test('state patch --Status preserves curated current_phase_name (not the body aside)', () => {
+    fs.writeFileSync(statePath, buildStateMd({ currentPhaseName: 'Native Hotkey' }));
+
+    const patch = runGsdTools('state patch --Status "AUDIT-PATCH unrelated field"', tmpDir);
+    assert.ok(patch.success, `state patch failed: ${patch.error}`);
+
+    const fm = readFrontmatter();
+    assert.strictEqual(
+      fm.current_phase_name,
+      'Native Hotkey',
+      `current_phase_name must survive a patch of an unrelated field (got: ${JSON.stringify(fm.current_phase_name)})`,
+    );
+  });
+
+  // AC #1 companion: the #1264 progress invariant still holds on the same call.
+  test('state patch --Status preserves curated progress (#1264 unbroken)', () => {
+    fs.writeFileSync(statePath, buildStateMd({}));
+
+    const patch = runGsdTools('state patch --Status "AUDIT-PATCH unrelated field"', tmpDir);
+    assert.ok(patch.success, `state patch failed: ${patch.error}`);
+
+    const json = runGsdTools('state json', tmpDir);
+    assert.ok(json.success, `state json failed: ${json.error}`);
+    const fm = JSON.parse(json.output);
+    assert.strictEqual(String(fm.progress.completed_phases), '2', 'completed_phases must be preserved');
+    assert.strictEqual(String(fm.progress.percent), '42', 'percent must be preserved');
+  });
+
+  // Negative case: the delta guard must NOT fire when the write genuinely
+  // changes the body Phase line. begin-phase rewrites `## Current Position`
+  // Phase, so current_phase_name must ADVANCE to the new name — not stay pinned
+  // to the curated value the guard preserves on an unrelated patch.
+  test('state begin-phase advances current_phase_name (guard does not pin the old name)', () => {
+    fs.writeFileSync(statePath, buildStateMd({ currentPhaseName: 'Native Hotkey' }));
+
+    const result = runGsdTools(
+      ['state', 'begin-phase', '--phase', '17', '--name', 'Submission Pipeline', '--plans', '3'],
+      tmpDir,
+    );
+    assert.ok(result.success, `begin-phase failed: ${result.error || result.output}`);
+
+    const fm = readFrontmatter();
+    assert.strictEqual(
+      fm.current_phase_name,
+      'Submission Pipeline',
+      `current_phase_name must advance to the begun phase's name, not stay pinned to the curated value (got: ${JSON.stringify(fm.current_phase_name)})`,
+    );
+    assert.strictEqual(String(fm.current_phase), '17', 'current_phase must advance to 17');
   });
 });


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

Fixes #1695

---

## What was broken

A `gsd-tools state patch` of an unrelated field (e.g. `--Status`) silently rewrote the curated `current_phase_name` (and `last_activity_desc`) frontmatter scalar by re-deriving it from the body `## Current Position` prose — so a patch the caller meant to touch only `Status` could clobber a curated phase name.

## What this fix does

Extends the already-accepted #1264 invariant — *a `state patch` of a field the caller didn't touch must not rewrite curated frontmatter* — from `progress` (which #1264 covered) to the sibling body-derived scalars `current_phase_name` and `last_activity_desc`.

## Root cause

On a non-progress `state patch`, `readModifyWriteStateMd` runs with `resync:false`, but `syncStateFrontmatter` still re-derives every body-derived scalar. The #1264 restore covered `progress` only; #1230's delta-preserve covered `status`/`stopped_at` only — `current_phase_name` / `last_activity_desc` had no guard, so they took the re-derived value.

The fix adds a #1230-style delta guard in `readModifyWriteStateMd`: preserve `current_phase_name` (keyed on the body `Phase:` line) and `last_activity_desc` (keyed on the body `Last Activity Description` field) when this write did not change those source fields. `begin`/`planned`/`complete-phase` rewrite those lines, so the delta does not fire and they still advance.

> Scope note: this PR deliberately does **not** change `parseProsePhaseField`'s precedence. The fix is independent of how the name is parsed — the curated frontmatter value is restored on an unrelated patch regardless. (An earlier revision flipped the precedence to em-dash-first; it regressed the `Phase: N — <prose> (Name)` shape, so it was dropped — see the PR comment.)

## Testing

### How I verified the fix

<!-- Describe manual steps or point to the automated test that proves this is fixed. -->

Added `tests/bug-1695-state-patch-preserve-current-phase-name.test.cjs` (3 cases: `current_phase_name` preserved on an unrelated patch, `last_activity_desc` preserved, `progress`/#1264 still preserved). Ran it plus the existing `#905` / `#397` / `#1230` / `#1264` / `#3127` / `#3242` state suite via `node --test` in an isolated `HOME` + `CLAUDE_CONFIG_DIR`: bug-1695 3/3 pass, 0 regressions. `tsc -p tsconfig.build.json` clean.

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [x] Linux
- [ ] macOS
- [ ] Windows (including backslash path handling)
- [ ] N/A (not platform-specific)

### Runtimes tested

- [x] N/A (not runtime-specific) — core state-document logic
- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode

---

## Checklist

- [x] Issue linked above with `Fixes #1695`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass — ran the state suite + `#905`/`#397`/`#1230`/`#1264`/`#3127`/`#3242` in an isolated `HOME` (full `npm test` is non-hermetic locally; the rest runs in approval-gated CI)
- [x] `.changeset/` fragment added if this is a user-facing fix — N/A: `src` + `tests` only (no user-facing prefix), changeset-exempt
- [x] No unnecessary dependencies added

## Breaking changes

<!-- Does this fix change any existing behavior, output format, or API that users might depend on? -->

None — the guard only restores a curated frontmatter value that an unrelated patch would otherwise have overwritten.
