### PR TITLE
docs(#1608): add probe-family predicates to CONTEXT.md

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -361,6 +361,31 @@ The prompt-level data/instruction isolation seam for untrusted web/document ingr
 
 ---
 
+## Probe family — spec-completeness probes (machine-oriented predicates)
+
+> Glossary prose for these modules lives above (Probe Core / Edge Probe / Prohibition Probe / Verification Tier / Verification substrate). These are the greppable one-line predicates ADR-550's Consequences promised alongside the glossary. Research-derived numbers (N17/N18 rates) are deliberately kept out of this machine-canon and live hedged in `docs/design/verifier-reach.md`. (That design note and `docs/adr/1606` are co-delivered sibling PRs of epic #1605; predicate refs to them below resolve once the batch lands.)
+
+`PROBE.principle=verifier-reach-equals-spec-reach (a goal-backward verifier only checks assertions that exist; probes make omitted assertions exist before code) — ADR-857 verification-substrate boundary; docs/design/verifier-reach.md`
+`PROBE.family=edge-probe(shape-axis)+prohibition-probe(must-NOT-axis), shared probe-core, run as spec-phase soft gates (ADR-550 D7)`
+`PROBE.protocol=recall(adversarial over-generate)->precision(drop routine-engineering); dismissals require a non-empty reason`
+`PROBE.core.seam=analyzeCoverage(items,resolutions?,validators) ingests ALREADY-proposed items; does NOT assume deterministic propose (ADR-550 D7b)`
+`PROBE.item.axes=status{resolved|dismissed|unresolved} x verification{<probe-defined>|null} — orthogonal; the lifecycle enum carries no verification fact (ADR-550 D7a)`
+`PROBE.edge.verification=explicit|backstop`
+`PROBE.prohib.verification=test|judgment`
+`PROBE.ci.surface=the contract (parse/validate, projection round-trip, fail-closed guards), NEVER the LLM judgment (ADR-550 D5)`
+`PROHIB.recall=LLM-prose; no compiled prohibition-probe recall engine (only the schema/projection layer is code, ADR-550 D7b)`
+`PROHIB.canon-referral=OWASP/GDPR/fairness-canon are REFERRED to /gsd:secure-phase+eslint, never minted as prohibitions (ADR-550 D6)`
+`PROHIB.enforce.green-rule=passed iff provenFailFirst===true && run.passed===true (runProhibitionEnforcement); every miss/fail/un-provable HARD-GATES both modes via dispositionForProhibition's fail-closed default`
+`PROHIB.enforce.kinds=node-test (non-vacuous red via isNonVacuousNodeTestRed; pass-side vacuity via isNonVacuousNodeTestPass) | lint-rule (eslint --format json filtered by ruleId)`
+`PROHIB.enforce.failfirst=MACHINE-PROVEN against an author-supplied violation fixture (#1279); caller failFirst attestation DEMOTED to a non-authoritative hint (FF-08)`
+`PROHIB.enforce.causation=opt-in clean-fixture control proves the red is content-caused not env-var-set (#1346); absent=documented residual`
+`PROHIB.descriptor.shape=5 FLAT scalars (check_kind,check_target,check_rule,check_violation_fixture,check_clean_fixture) — NEVER a nested check:{} (parseMustHavesBlock is a flat parser, src/frontmatter.cts)`
+`PROHIB.rail=core verify rail, non-toggleable (ADR-857 verification-substrate boundary / decision #6); the verifier<->predicate contract is NOT an off-by-default capability`
+`PROHIB.judgment-tier=never-silent / never-hard-halt soft gate; autonomous emits "unverified-prohibition — human review recommended" (exogenous grading, ADR-550 D4)`
+`PROHIB.enforce.adr=docs/adr/1606 (verify-time enforcement seam) + docs/adr/550 (spec-phase contract)`
+
+---
+
 ## Test rules and lint
 
 `RULESET.TESTS.no-source-grep=scripts/lint-no-source-grep.cjs rejects readFileSync source + .includes()/.match()/.startsWith() on the bound var; CI hard-fail`


### PR DESCRIPTION
## Docs PR — add probe-family predicates to CONTEXT.md

Closes #1608 (child of epic #1605).

### ⚠️ Rescoped from the original issue
The issue's premise was that the CONTEXT.md probe-family **glossary** "never landed." On re-verification that is **false** — the glossary entries (`Probe Family`, `Probe Core Module`, `Edge Probe Module`, `Prohibition Probe Module`, `Verification Tier`, `Verification substrate`) **already exist** in `CONTEXT.md`. The draft's premise came from a grep that returned `binary file matches` (a multibyte `§`/`↔` char trips grep's binary heuristic) and was misread as "returns nothing."

So this PR ships **only the net-new half**: the greppable `PROBE.*` / `PROHIB.*` **single-line predicates** ADR-550's Consequences promised *alongside* the glossary (the glossary half of that commitment was already met). This completes the epic's "glossary + predicates" CONTEXT.md goal.

### What this adds
A `## Probe family — spec-completeness probes (machine-oriented predicates)` section with 18 backtick-wrapped predicates in CONTEXT.md's house format, covering the probe protocol, the `status × verification` axes, the enforcement green-rule / kinds / fail-first / causation, the 5 flat-scalar descriptor shape, and the core-rail placement.

### Verification (trust-but-verify)
Glossary-already-present and predicates-absent both re-confirmed against the live `CONTEXT.md`; every predicate's facts cross-checked against `src/prohibition-enforcement.cts` / `src/probe-core.cts` (same source pass as #1606). Research-derived N17/N18 numbers are deliberately **kept out** of machine-canon — they live hedged in `docs/design/verifier-reach.md` (#1609).

### Notes
- Documentation only; no code change. No changeset (`*.md` scope) → `no-changelog`.

## Breaking changes
None — documentation only.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1717"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785006519&installation_id=134682257&pr_number=1717&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1717&signature=35b6632ab68ca3e0b904798853c61050412794bb17e23242dc4c847ae3e71785"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->