### PR TITLE
fix(#1716): route resume_from_file to complete_session when no pending tests remain

### DIFF
--- a/.changeset/curious-koalas-gather.md
+++ b/.changeset/curious-koalas-gather.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 1722
+---
+**`/gsd:verify-work` no longer silently terminates when all remaining UAT tests are blocked** — sessions with `blocked_count > 0` and `pending_count == 0` now route to `complete_session` as expected, enabling the zero-issues auto-transition path.

--- a/gsd-core/workflows/verify-work.md
+++ b/gsd-core/workflows/verify-work.md
@@ -417,6 +417,7 @@ If no more tests → Go to `complete_session`
 Read the full UAT file.
 
 Find first test with `result: [pending]`.
+If no `[pending]` test found → go to `complete_session`.
 
 Announce:
 ```

--- a/tests/bug-3381-verify-work-workstream.test.cjs
+++ b/tests/bug-3381-verify-work-workstream.test.cjs
@@ -7,6 +7,36 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
 
+describe('bug #1716: resume_from_file routes to complete_session when no [pending] tests remain', () => {
+  test('resume_from_file step contains guard clause for zero-pending (all-blocked) case', () => {
+    const workflow = fs.readFileSync(
+      path.join(__dirname, '..', 'gsd-core', 'workflows', 'verify-work.md'),
+      'utf8',
+    );
+
+    const stepStart = workflow.indexOf('<step name="resume_from_file">');
+    assert.ok(stepStart !== -1, 'resume_from_file step must exist');
+
+    const stepEnd = workflow.indexOf('</step>', stepStart);
+    const stepBody = workflow.slice(stepStart, stepEnd);
+
+    // Guard must appear immediately after the find-pending instruction.
+    // Without it, all-blocked sessions (pending_count==0, blocked_count>0)
+    // silently terminate and never reach complete_session (#1716).
+    const findIdx = stepBody.indexOf("Find first test with `result: [pending]`.");
+    const guardIdx = stepBody.indexOf("If no `[pending]` test found → go to `complete_session`.");
+
+    assert.ok(findIdx !== -1, 'find-pending instruction must be present');
+    assert.ok(guardIdx !== -1, 'guard clause for zero-pending case must be present');
+    assert.ok(guardIdx > findIdx, 'guard must appear after find-pending instruction');
+
+    const between = stepBody
+      .slice(findIdx + "Find first test with `result: [pending]`.".length, guardIdx)
+      .trim();
+    assert.strictEqual(between, '', 'guard must be the next non-whitespace line after find-pending');
+  });
+});
+
 describe('bug #3381: verify-work forwards workstream context', () => {
   test('workflow forwards ${GSD_WS} to workstream-sensitive SDK queries', () => {
     const workflow = fs.readFileSync(

--- a/tests/fixtures/golden-install-parity/antigravity.json
+++ b/tests/fixtures/golden-install-parity/antigravity.json
@@ -299,7 +299,7 @@
   "gsd-core/workflows/update.md": "dc93f366e2156e37",
   "gsd-core/workflows/validate-phase.md": "5bac28c71d21c740",
   "gsd-core/workflows/verify-phase.md": "e7059c04c816e62d",
-  "gsd-core/workflows/verify-work.md": "7f3c7d0d0932cec6",
+  "gsd-core/workflows/verify-work.md": "d1f5cfc8e22b7ce7",
   "hooks/gsd-check-update-worker.js": "fa301e6366270d5f",
   "hooks/gsd-check-update.js": "4617a98bf529e4c3",
   "hooks/gsd-config-reload.js": "96546e0e8bb47904",

--- a/tests/fixtures/golden-install-parity/augment.json
+++ b/tests/fixtures/golden-install-parity/augment.json
@@ -368,7 +368,7 @@
   "gsd-core/workflows/update.md": "231e7c305b40c417",
   "gsd-core/workflows/validate-phase.md": "50f37b705b6e44fb",
   "gsd-core/workflows/verify-phase.md": "7579af6cd757f644",
-  "gsd-core/workflows/verify-work.md": "e106af0b705382b5",
+  "gsd-core/workflows/verify-work.md": "d77ace0fc4f33ff7",
   "hooks/gsd-check-update-worker.js": "cc1ef5f840f9dfc9",
   "hooks/gsd-check-update.js": "7b3a7983d5f1f5d3",
   "hooks/gsd-config-reload.js": "96546e0e8bb47904",

--- a/tests/fixtures/golden-install-parity/claude.json
+++ b/tests/fixtures/golden-install-parity/claude.json
@@ -298,7 +298,7 @@
   "gsd-core/workflows/update.md": "0b389258dcc09332",
   "gsd-core/workflows/validate-phase.md": "2aa540f2c2479501",
   "gsd-core/workflows/verify-phase.md": "15a999f82868ad29",
-  "gsd-core/workflows/verify-work.md": "81c4591e25f9315c",
+  "gsd-core/workflows/verify-work.md": "ea61f9e88a44b68b",
   "hooks/gsd-check-update-worker.js": "a530efdb5fdc0da3",
   "hooks/gsd-check-update.js": "25cde66a12d6b886",
   "hooks/gsd-config-reload.js": "96546e0e8bb47904",

--- a/tests/fixtures/golden-install-parity/cline.json
+++ b/tests/fixtures/golden-install-parity/cline.json
@@ -302,7 +302,7 @@
   "gsd-core/workflows/update.md": "9cad8a8f4baff922",
   "gsd-core/workflows/validate-phase.md": "54687a0f2a562fc4",
   "gsd-core/workflows/verify-phase.md": "5caca0023bc88a9a",
-  "gsd-core/workflows/verify-work.md": "553197cb36695180",
+  "gsd-core/workflows/verify-work.md": "a327274299317cb1",
   "scripts/changeset/README.md": "86ff89331dfd94b2",
   "scripts/changeset/cli.cjs": "68f92a344b199271",
   "scripts/changeset/github-release-notes.cjs": "795677f0c009b132",

--- a/tests/fixtures/golden-install-parity/codebuddy.json
+++ b/tests/fixtures/golden-install-parity/codebuddy.json
@@ -368,7 +368,7 @@
   "gsd-core/workflows/update.md": "6a593863d1b0a287",
   "gsd-core/workflows/validate-phase.md": "50f37b705b6e44fb",
   "gsd-core/workflows/verify-phase.md": "7579af6cd757f644",
-  "gsd-core/workflows/verify-work.md": "e106af0b705382b5",
+  "gsd-core/workflows/verify-work.md": "d77ace0fc4f33ff7",
   "hooks/gsd-check-update-worker.js": "bdc9324a2f080ddd",
   "hooks/gsd-check-update.js": "b7669f605631e506",
   "hooks/gsd-config-reload.js": "96546e0e8bb47904",

--- a/tests/fixtures/golden-install-parity/codex.json
+++ b/tests/fixtures/golden-install-parity/codex.json
@@ -334,7 +334,7 @@
   "gsd-core/workflows/update.md": "4166fd3e3ca72a7b",
   "gsd-core/workflows/validate-phase.md": "4e94708c9ca15d70",
   "gsd-core/workflows/verify-phase.md": "59bb0b12ebb47f5e",
-  "gsd-core/workflows/verify-work.md": "1482cd4f8af40387",
+  "gsd-core/workflows/verify-work.md": "c5cf0c2fc422fa4e",
   "hooks/gsd-check-update.js": "ef48957eb6ac6a10",
   "hooks/gsd-context-monitor.js": "76fecaaa2babd6c1",
   "scripts/changeset/README.md": "86ff89331dfd94b2",

--- a/tests/fixtures/golden-install-parity/copilot.json
+++ b/tests/fixtures/golden-install-parity/copilot.json
@@ -300,7 +300,7 @@
   "gsd-core/workflows/update.md": "712ab18a9b7c14f5",
   "gsd-core/workflows/validate-phase.md": "f923eac9442b6053",
   "gsd-core/workflows/verify-phase.md": "eea9b642393b6b90",
-  "gsd-core/workflows/verify-work.md": "700b44e881a29ece",
+  "gsd-core/workflows/verify-work.md": "a5bcec82bfc2da53",
   "hooks/gsd-session.json": "0a462834f2a28fee",
   "scripts/changeset/README.md": "86ff89331dfd94b2",
   "scripts/changeset/cli.cjs": "68f92a344b199271",

--- a/tests/fixtures/golden-install-parity/cursor.json
+++ b/tests/fixtures/golden-install-parity/cursor.json
@@ -368,7 +368,7 @@
   "gsd-core/workflows/update.md": "a27dcfd2814bf2b1",
   "gsd-core/workflows/validate-phase.md": "f513c28c01a44cb7",
   "gsd-core/workflows/verify-phase.md": "15a999f82868ad29",
-  "gsd-core/workflows/verify-work.md": "f55fb54bcd7650bb",
+  "gsd-core/workflows/verify-work.md": "531a00b7f46d08db",
   "hooks/gsd-cursor-post-tool.js": "019d503aee8b4a3f",
   "hooks/gsd-cursor-session-start.js": "c6e04ed597ea7020",
   "scripts/changeset/README.md": "86ff89331dfd94b2",

--- a/tests/fixtures/golden-install-parity/gemini.json
+++ b/tests/fixtures/golden-install-parity/gemini.json
@@ -368,7 +368,7 @@
   "gsd-core/workflows/update.md": "51c3af33474bdc24",
   "gsd-core/workflows/validate-phase.md": "2d998cb78c918d08",
   "gsd-core/workflows/verify-phase.md": "7579af6cd757f644",
-  "gsd-core/workflows/verify-work.md": "4df959def1892391",
+  "gsd-core/workflows/verify-work.md": "ba76036f0eff5c5e",
   "hooks/gsd-check-update-worker.js": "5f5f2b73e6c14a7f",
   "hooks/gsd-check-update.js": "0e955593b7884d99",
   "hooks/gsd-config-reload.js": "96546e0e8bb47904",

--- a/tests/fixtures/golden-install-parity/hermes.json
+++ b/tests/fixtures/golden-install-parity/hermes.json
@@ -299,7 +299,7 @@
   "gsd-core/workflows/update.md": "472d4905fc8c5ce5",
   "gsd-core/workflows/validate-phase.md": "067acd7aeed52c5b",
   "gsd-core/workflows/verify-phase.md": "4e1d99795e8e9413",
-  "gsd-core/workflows/verify-work.md": "ca5990c760e73c10",
+  "gsd-core/workflows/verify-work.md": "e93eb5a56b769694",
   "hooks/gsd-check-update-worker.js": "7989cc2bedd1138d",
   "hooks/gsd-check-update.js": "25f5ad726f76fc11",
   "hooks/gsd-config-reload.js": "880b696458e85e9b",

--- a/tests/fixtures/golden-install-parity/kilo.json
+++ b/tests/fixtures/golden-install-parity/kilo.json
@@ -368,7 +368,7 @@
   "gsd-core/workflows/update.md": "5d0a2356dadf2017",
   "gsd-core/workflows/validate-phase.md": "7915e3a261f7c9c9",
   "gsd-core/workflows/verify-phase.md": "15a999f82868ad29",
-  "gsd-core/workflows/verify-work.md": "5ee188f029ecc97e",
+  "gsd-core/workflows/verify-work.md": "6194c487f858d85e",
   "hooks/gsd-check-update-worker.js": "c992bbad91d0e994",
   "hooks/gsd-check-update.js": "fdd77abe7ef26a2d",
   "hooks/gsd-config-reload.js": "96546e0e8bb47904",

--- a/tests/fixtures/golden-install-parity/kimi.json
+++ b/tests/fixtures/golden-install-parity/kimi.json
@@ -335,7 +335,7 @@
   "gsd-core/workflows/update.md": "6369691790864147",
   "gsd-core/workflows/validate-phase.md": "50f37b705b6e44fb",
   "gsd-core/workflows/verify-phase.md": "7579af6cd757f644",
-  "gsd-core/workflows/verify-work.md": "e106af0b705382b5",
+  "gsd-core/workflows/verify-work.md": "d77ace0fc4f33ff7",
   "scripts/changeset/README.md": "86ff89331dfd94b2",
   "scripts/changeset/cli.cjs": "68f92a344b199271",
   "scripts/changeset/github-release-notes.cjs": "795677f0c009b132",

--- a/tests/fixtures/golden-install-parity/opencode.json
+++ b/tests/fixtures/golden-install-parity/opencode.json
@@ -368,7 +368,7 @@
   "gsd-core/workflows/update.md": "af51041a3172c523",
   "gsd-core/workflows/validate-phase.md": "0fc5991f6d7c6c39",
   "gsd-core/workflows/verify-phase.md": "13a1a43395b5e47b",
-  "gsd-core/workflows/verify-work.md": "401453f01c19eb14",
+  "gsd-core/workflows/verify-work.md": "c218bc9c5972dcdb",
   "hooks/gsd-check-update-worker.js": "385fb7c67810baf6",
   "hooks/gsd-check-update.js": "4549451414ffa7d7",
   "hooks/gsd-config-reload.js": "96546e0e8bb47904",

--- a/tests/fixtures/golden-install-parity/qwen.json
+++ b/tests/fixtures/golden-install-parity/qwen.json
@@ -299,7 +299,7 @@
   "gsd-core/workflows/update.md": "baae1a977fbeba49",
   "gsd-core/workflows/validate-phase.md": "0e153ccb3bdb9dda",
   "gsd-core/workflows/verify-phase.md": "0ef74d5b7f7646f6",
-  "gsd-core/workflows/verify-work.md": "ca95afc02dda87cb",
+  "gsd-core/workflows/verify-work.md": "69d9d98563b9ec81",
   "hooks/gsd-check-update-worker.js": "4bb354044e0dff91",
   "hooks/gsd-check-update.js": "d2065cb3e725a42a",
   "hooks/gsd-config-reload.js": "4f52b8a0120bb1b8",

--- a/tests/fixtures/golden-install-parity/trae.json
+++ b/tests/fixtures/golden-install-parity/trae.json
@@ -299,7 +299,7 @@
   "gsd-core/workflows/update.md": "e259898f86ae7133",
   "gsd-core/workflows/validate-phase.md": "70d102b4d5113dd4",
   "gsd-core/workflows/verify-phase.md": "67eefbd1f6417281",
-  "gsd-core/workflows/verify-work.md": "24df47d0b0e6a453",
+  "gsd-core/workflows/verify-work.md": "b48ff071a4c733c9",
   "scripts/changeset/README.md": "86ff89331dfd94b2",
   "scripts/changeset/cli.cjs": "68f92a344b199271",
   "scripts/changeset/github-release-notes.cjs": "795677f0c009b132",

--- a/tests/fixtures/golden-install-parity/windsurf.json
+++ b/tests/fixtures/golden-install-parity/windsurf.json
@@ -299,7 +299,7 @@
   "gsd-core/workflows/update.md": "cbf978622ad0f577",
   "gsd-core/workflows/validate-phase.md": "a36cf2c688c261ac",
   "gsd-core/workflows/verify-phase.md": "8a89a915dad5960b",
-  "gsd-core/workflows/verify-work.md": "7eff85ce5879f5bf",
+  "gsd-core/workflows/verify-work.md": "f4429f002440a5ae",
   "scripts/changeset/README.md": "86ff89331dfd94b2",
   "scripts/changeset/cli.cjs": "68f92a344b199271",
   "scripts/changeset/github-release-notes.cjs": "795677f0c009b132",

--- a/tests/workflow-size-baseline.json
+++ b/tests/workflow-size-baseline.json
@@ -87,5 +87,5 @@
   "update.md": 21053,
   "validate-phase.md": 10745,
   "verify-phase.md": 40728,
-  "verify-work.md": 35112
+  "verify-work.md": 35171
 }


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

Fixes #1716

> The linked issue has the `confirmed-bug` label.

---

## What was broken

When a UAT session had `status: partial` with all remaining tests `result: blocked` (`blocked_count > 0`, `pending_count == 0`), `resume_from_file` searched for the first `result: [pending]` test, found none, and terminated silently — never routing to `complete_session`. The `issues == 0` auto-transition path was unreachable even with zero code defects.

## What this fix does

Adds a guard clause immediately after the find-pending step in `resume_from_file`: if no `[pending]` test is found, route to `complete_session`. This mirrors the guard `process_response` already uses. `complete_session` then correctly computes `status: partial` (because `blocked_count > 0`) without presenting further tests.

## Root cause

`resume_from_file` assumed at least one `[pending]` test would always exist when entered. No branch existed for the all-blocked edge case — the step fell through silently. The sibling step `process_response` has the equivalent guard (`If no more tests → Go to complete_session`); `resume_from_file` was missing it.

## Testing

### How I verified the fix

Regression test added to `tests/bug-3381-verify-work-workstream.test.cjs` (owning module test for `verify-work.md` — standalone `bug-NNNN-*.test.cjs` files are rejected by CI lint). The test locates the `resume_from_file` step, asserts the guard clause is present, and asserts it is the immediate next non-whitespace line after the find-pending instruction. The test fails on the unfixed workflow and passes after the fix.

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [x] N/A (not platform-specific — workflow text change only; CI green on ubuntu + windows)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific — guard clause is runtime-agnostic workflow instruction text)

---

## Checklist

- [x] Issue linked above with `Fixes #1716` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added (`curious-koalas-gather.md`, type `Fixed`, pr: 1722)
- [x] No unnecessary dependencies added

## Breaking changes

None