### PR TITLE
fix(#1729): support parenthetical phase header tags

### DIFF
--- a/.changeset/smart-bears-drum.md
+++ b/.changeset/smart-bears-drum.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 1729
+---
+**`roadmap get-phase` now resolves phase headings with pre-colon parenthetical tags** — headings like `### Phase 26 (Cluster B): Engine-adapter caveats` match the same as ordinary phase headings, including zero-padding tolerant lookups.

--- a/src/phase-id.cts
+++ b/src/phase-id.cts
@@ -22,6 +22,7 @@ const PROJECT_CODE_PREFIX_STRIP_RE = /^[A-Z][A-Z0-9_]*-(?=\d)/;
 const PROJECT_CODE_PREFIX_STRIP_RE_I = /^[A-Z][A-Z0-9_]*-(?=\d)/i;
 const PROJECT_CODE_PREFIX_CAPTURE_RE_I = /^([A-Z][A-Z0-9_]*)-(\d.*)/i;
 const OPTIONAL_PROJECT_CODE_PREFIX_SOURCE = '(?:[A-Z][A-Z0-9_]*-)?';
+const PHASE_HEADING_PARENTHETICAL_SOURCE = '(?:\\s*\\([^\\n)]*\\))?';
 
 function stripProjectCodePrefix(value: unknown, caseInsensitive = true): string {
   const input = String(value);
@@ -121,6 +122,10 @@ function phaseMarkdownRegexSourceExact(phaseNum: unknown): string | null {
   const raw = String(phaseNum);
   if (!hasProjectCodePrefix(raw)) return null;
   return escapeRegex(raw);
+}
+
+function phaseHeadingParentheticalRegexSource(): string {
+  return PHASE_HEADING_PARENTHETICAL_SOURCE;
 }
 
 function comparePhaseNum(a: unknown, b: unknown): number {
@@ -226,6 +231,7 @@ export = {
   getPhaseDirFromPhaseId,
   phaseMarkdownRegexSource,
   phaseMarkdownRegexSourceExact,
+  phaseHeadingParentheticalRegexSource,
   comparePhaseNum,
   extractPhaseToken,
   phaseTokenMatches,

--- a/src/phase.cts
+++ b/src/phase.cts
@@ -33,6 +33,7 @@ const {
   escapeRegex,
   normalizePhaseName,
   phaseMarkdownRegexSource,
+  phaseHeadingParentheticalRegexSource,
   comparePhaseNum,
   phaseTokenMatches,
   OPTIONAL_PROJECT_CODE_PREFIX_SOURCE,
@@ -216,7 +217,7 @@ function cmdPhaseNextDecimal(cwd: string, basePhase: string, raw: boolean): void
       try {
         const roadmapContent = fs.readFileSync(roadmapPath, 'utf-8');
         const phasePattern = new RegExp(
-          `#{2,4}\\s*Phase\\s+${phaseMarkdownRegexSource(normalized)}\\.(\\d+)\\s*:`,
+          `#{2,4}\\s*Phase\\s+${phaseMarkdownRegexSource(normalized)}\\.(\\d+)${phaseHeadingParentheticalRegexSource()}\\s*:`,
           'gi',
         );
         let pm: RegExpExecArray | null;
@@ -263,7 +264,7 @@ function getRoadmapModeForPhase(cwd: string, phaseNum: string): string | null {
   const milestoneContent = extractCurrentMilestone(rawContent, cwd);
   const fullContent = stripShippedMilestones(rawContent);
   const escapedPhase = phaseMarkdownRegexSource(phaseNum);
-  const phaseHeader = new RegExp(`#{2,4}\\s*Phase\\s+${escapedPhase}\\s*:`, 'i');
+  const phaseHeader = new RegExp(`#{2,4}\\s*Phase\\s+${escapedPhase}${phaseHeadingParentheticalRegexSource()}\\s*:`, 'i');
 
   for (const content of [milestoneContent, fullContent]) {
     const headerMatch = content.match(phaseHeader);
@@ -929,7 +930,7 @@ function cmdPhaseInsert(cwd: string, afterPhase: string, description: string, ra
     }
 
     const rmPhasePattern = new RegExp(
-      `#{2,4}\\s*Phase\\s+${phaseMarkdownRegexSource(normalizedBase)}\\.(\\d+)\\s*:`,
+      `#{2,4}\\s*Phase\\s+${phaseMarkdownRegexSource(normalizedBase)}\\.(\\d+)${phaseHeadingParentheticalRegexSource()}\\s*:`,
       'gi',
     );
     let rmMatch: RegExpExecArray | null;
@@ -1355,7 +1356,7 @@ function writePlanningFileSet(writes: WriteSpec[]): void {
 function phaseDisplayNameFromRoadmap(roadmapContent: string | null, phaseNum: string | null): string | null {
   if (!roadmapContent || !phaseNum) return null;
   const phaseEscaped = phaseMarkdownRegexSource(phaseNum);
-  const heading = roadmapContent.match(new RegExp(`^#{2,4}\\s*Phase\\s+${phaseEscaped}\\s*:\\s*([^\\n]+)`, 'im'));
+  const heading = roadmapContent.match(new RegExp(`^#{2,4}\\s*Phase\\s+${phaseEscaped}${phaseHeadingParentheticalRegexSource()}\\s*:\\s*([^\\n]+)`, 'im'));
   if (!heading) return null;
   const name = heading[1].replace(/\(INSERTED\)/i, '').trim();
   return name || null;
@@ -1444,7 +1445,7 @@ function cmdPhaseComplete(cwd: string, phaseNum: string, raw: boolean): void {
 
         const phaseEscaped = phaseMarkdownRegexSource(phaseNum);
         const checkboxPattern = new RegExp(
-          `(-\\s*\\[)[ ](\\]\\s*.*Phase\\s+${phaseEscaped}[:\\s][^\\n]*)`,
+          `(-\\s*\\[)[ ](\\]\\s*.*Phase\\s+${phaseEscaped}${phaseHeadingParentheticalRegexSource()}[:\\s][^\\n]*)`,
           'i',
         );
         roadmapContent = roadmapContent.replace(
@@ -1508,7 +1509,7 @@ function cmdPhaseComplete(cwd: string, phaseNum: string, raw: boolean): void {
           const currentMilestoneRoadmap = extractCurrentMilestone(roadmapContent, cwd);
           const phaseSectionMatch = currentMilestoneRoadmap.match(
             new RegExp(
-              `(#{2,4}\\s*Phase\\s+${phaseEsc}[:\\s][\\s\\S]*?)(?=#{2,4}\\s*Phase\\s+|$)`,
+              `(#{2,4}\\s*Phase\\s+${phaseEsc}${phaseHeadingParentheticalRegexSource()}[:\\s][\\s\\S]*?)(?=#{2,4}\\s*Phase\\s+|$)`,
               'i',
             ),
           );

--- a/src/roadmap-parser.cts
+++ b/src/roadmap-parser.cts
@@ -23,6 +23,7 @@ const {
   escapeRegex,
   phaseMarkdownRegexSource,
   phaseMarkdownRegexSourceExact,
+  phaseHeadingParentheticalRegexSource,
   stripProjectCodePrefix,
   OPTIONAL_PROJECT_CODE_PREFIX_SOURCE,
 } = phaseIdModule;
@@ -209,8 +210,9 @@ interface RoadmapPhaseResult {
 }
 
 function findRoadmapPhaseInContent(content: string, phaseNum: unknown, phaseSource?: string): RoadmapPhaseResult | null {
+  const phaseTag = phaseHeadingParentheticalRegexSource();
   const phasePattern = new RegExp(
-    `#{2,4}\\s*(?:\\[[^\\]]+\\]\\s*)?Phase\\s+${phaseSource ?? phaseMarkdownRegexSource(phaseNum)}:\\s*([^\\n]+)`,
+    `#{2,4}\\s*(?:\\[[^\\]]+\\]\\s*)?Phase\\s+${phaseSource ?? phaseMarkdownRegexSource(phaseNum)}${phaseTag}:\\s*([^\\n]+)`,
     'i'
   );
   const headerMatch = content.match(phasePattern);
@@ -434,7 +436,7 @@ function getMilestonePhaseFilter(cwd: string, versionOverride?: string | null, p
 
     // Use tokenizeHeadings (fence-aware) instead of stripFencedLines + regex.
     // T4 seam migration: phase headings inside fences are excluded automatically.
-    const phaseHeadingPattern = /^(?:\[[^\]]+\]\s*)?Phase\s+([\w][\w.-]*)\s*:/i;
+    const phaseHeadingPattern = /^(?:\[[^\]]+\]\s*)?Phase\s+([\w][\w.-]*)(?:\s*\([^\n)]*\))?\s*:/i;
     for (const h of tokenizeHeadings(roadmap)) {
       if (h.level < 2 || h.level > 4) continue;
       const pm = phaseHeadingPattern.exec(h.text);

--- a/src/roadmap.cts
+++ b/src/roadmap.cts
@@ -14,7 +14,7 @@ import ioMod = require('./io.cjs');
 const { output, error } = ioMod;
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import phaseIdMod = require('./phase-id.cjs');
-const { escapeRegex, normalizePhaseName, phaseMarkdownRegexSource, phaseMarkdownRegexSourceExact, phaseTokenMatches } = phaseIdMod;
+const { escapeRegex, normalizePhaseName, phaseMarkdownRegexSource, phaseMarkdownRegexSourceExact, phaseHeadingParentheticalRegexSource, phaseTokenMatches } = phaseIdMod;
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import phaseLocatorMod = require('./phase-locator.cjs');
 const { findPhaseInternal } = phaseLocatorMod;
@@ -115,8 +115,9 @@ function countPhasePlansAndSummaries(phaseDir: string): PhasePlansAndSummaries {
  */
 function searchPhaseInContent(content: string, escapedPhase: string, phaseNum: string): PhaseSearchResult | null {
   // Match "## Phase X:", "### Phase X:", or "#### Phase X:" with optional name
+  const phaseTag = phaseHeadingParentheticalRegexSource();
   const phasePattern = new RegExp(
-    `#{2,4}\\s*(?:\\[[^\\]]+\\]\\s*)?Phase\\s+${escapedPhase}:\\s*([^\\n]+)`,
+    `#{2,4}\\s*(?:\\[[^\\]]+\\]\\s*)?Phase\\s+${escapedPhase}${phaseTag}:\\s*([^\\n]+)`,
     'i'
   );
   const headerMatch = content.match(phasePattern);
@@ -124,7 +125,7 @@ function searchPhaseInContent(content: string, escapedPhase: string, phaseNum: s
   if (!headerMatch) {
     // Fallback: check if phase exists in summary list but missing detail section
     const checklistPattern = new RegExp(
-      `-\\s*\\[[ x]\\]\\s*\\*\\*Phase\\s+${escapedPhase}:\\s*([^*]+)\\*\\*`,
+      `-\\s*\\[[ x]\\]\\s*\\*\\*Phase\\s+${escapedPhase}${phaseTag}:\\s*([^*]+)\\*\\*`,
       'i'
     );
     const checklistMatch = content.match(checklistPattern);
@@ -760,7 +761,7 @@ function cmdRoadmapAnnotateDependencies(cwd: string, phaseNum: string | null | u
     // #3537: padding-tolerant fragment so the caller's resolved padded id
     // matches un-padded ROADMAP headings.
     const phaseEscaped = phaseMarkdownRegexSource(phaseNum);
-    const phaseHeaderPattern = new RegExp(`(#{2,4}\\s*Phase\\s+${phaseEscaped}:[^\\n]*)`, 'i');
+    const phaseHeaderPattern = new RegExp(`(#{2,4}\\s*Phase\\s+${phaseEscaped}${phaseHeadingParentheticalRegexSource()}:[^\\n]*)`, 'i');
     const phaseMatch = content.match(phaseHeaderPattern);
     if (!phaseMatch) return;
 

--- a/tests/bug-1729-parenthetical-phase-header.test.cjs
+++ b/tests/bug-1729-parenthetical-phase-header.test.cjs
@@ -1,0 +1,73 @@
+// allow-test-rule: source-text-is-the-product
+'use strict';
+
+const { describe, test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { runGsdTools, createTempProject, cleanup } = require('./helpers.cjs');
+
+function writeRoadmap(tmpDir, phaseHeading) {
+  fs.writeFileSync(
+    path.join(tmpDir, '.planning', 'STATE.md'),
+    '---\nmilestone: v1.0.0\n---\n',
+  );
+  fs.writeFileSync(
+    path.join(tmpDir, '.planning', 'ROADMAP.md'),
+    [
+      '# Roadmap',
+      '',
+      '## Current Milestone: v1.0.0 - Test',
+      '',
+      phaseHeading,
+      '**Goal:** Verify parenthetical phase headings',
+      '',
+      '### Phase 27: Next phase',
+      '**Goal:** Boundary marker',
+      '',
+    ].join('\n'),
+  );
+}
+
+function getPhase(tmpDir, phaseNum) {
+  const result = runGsdTools(`roadmap get-phase ${phaseNum} --json`, tmpDir);
+  assert.ok(result.success, `command failed: ${result.error || result.output}`);
+  return JSON.parse(result.output);
+}
+
+describe('bug #1729: parenthetical phase heading tags before colon', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempProject('bug-1729-');
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('roadmap get-phase finds unpadded phase with parenthetical before colon', () => {
+    writeRoadmap(tmpDir, '### Phase 26 (Cluster B): Engine-adapter caveats');
+
+    const payload = getPhase(tmpDir, '26');
+    assert.equal(payload.found, true);
+    assert.equal(payload.phase_name, 'Engine-adapter caveats');
+    assert.equal(payload.goal, 'Verify parenthetical phase headings');
+  });
+
+  test('roadmap get-phase preserves padding tolerance with parenthetical before colon', () => {
+    writeRoadmap(tmpDir, '### Phase 26 (Cluster B): Engine-adapter caveats');
+
+    const payload = getPhase(tmpDir, '026');
+    assert.equal(payload.found, true);
+    assert.equal(payload.phase_name, 'Engine-adapter caveats');
+  });
+
+  test('roadmap get-phase still supports parenthetical after colon', () => {
+    writeRoadmap(tmpDir, '### Phase 26: Engine-adapter caveats (Cluster B)');
+
+    const payload = getPhase(tmpDir, '026');
+    assert.equal(payload.found, true);
+    assert.equal(payload.phase_name, 'Engine-adapter caveats (Cluster B)');
+  });
+});


### PR DESCRIPTION
Summary:
- Adds a shared phase-heading parenthetical regex fragment.
- Allows roadmap phase lookups to resolve headings such as `### Phase 26 (Cluster B): Title`.
- Adds regression coverage for unpadded, padded, and post-colon parenthetical cases.

Testing:
- npm ci
- node --test tests/bug-1729-parenthetical-phase-header.test.cjs
- GITHUB_BASE_REF=next npm run lint:changeset
- git diff --check

Fixes #1729

AI assistance: This bug fix was prepared with AI assistance and reviewed before submission.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1741"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785035271&installation_id=134682257&pr_number=1741&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1741&signature=8f834f4ca8eafbafc27ad108f547a9af37a843ec20a597c6adb280d153fedc32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->