### PR TITLE
fix(#1693): don't double-quote $CLAUDE_PROJECT_DIR-anchored hook paths on Windows

### DIFF
--- a/.changeset/lucky-quails-greet.md
+++ b/.changeset/lucky-quails-greet.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 1746
+---
+Windows: stop double-quoting $CLAUDE_PROJECT_DIR-anchored managed node hook paths during the #2979 legacy rewrite, which produced "\"$CLAUDE_PROJECT_DIR\"/..." and broke every node managed hook with MODULE_NOT_FOUND (PreToolUse-guard deadlock).

--- a/src/shell-command-projection.cts
+++ b/src/shell-command-projection.cts
@@ -254,6 +254,15 @@ export function isManagedHookCommand(commandText: unknown, opts: { surface?: str
 }
 
 /**
+ * Detect a `"$VAR"/rest` anchored hook-script token — a path whose leading
+ * shell variable is already double-quoted with the remainder left bare (the
+ * shape `projectLocalHookPrefix` emits for local installs, e.g.
+ * `"$CLAUDE_PROJECT_DIR"/.claude/hooks/gsd-x.js`). Such a token is ALREADY a
+ * valid, correctly-quoted shell argument and must never be re-quoted.
+ */
+const ANCHORED_HOOK_SCRIPT_TOKEN = /^"\$[A-Za-z_][A-Za-z0-9_]*"\//;
+
+/**
  * Projection helper for legacy settings.json hook rewrites.
  *
  * Non-Windows keeps the original script token shape when provided (single
@@ -275,8 +284,20 @@ export function projectLegacySettingsHookCommand({
 }): string | null {
   if (!absoluteRunner || !scriptPath) return null;
   const normalizedScriptPath = platform === 'win32' ? scriptPath.replace(/\\/g, '/') : scriptPath;
+  // #1693: a script path already carrying a `"$CLAUDE_PROJECT_DIR"`-anchored
+  // quoted prefix (local installs) is already a valid shell token — only the
+  // variable is quoted, the rest is bare. JSON.stringify-ing it on Windows
+  // yields `"\"$CLAUDE_PROJECT_DIR\"/..."` (escaped quotes inside an outer
+  // quote); node then receives an argument that *starts* with a `"`, treats it
+  // as relative, and dies with MODULE_NOT_FOUND. Emit anchored tokens verbatim;
+  // only bare absolute paths (which may contain spaces, e.g. "Program Files")
+  // need the JSON.stringify quoting. Scoped to win32: the non-Windows branch
+  // already preserves the caller's `scriptToken` (which is the bare anchored
+  // token for these inputs), so it never had the double-quote bug.
   const commandScriptToken = platform === 'win32'
-    ? JSON.stringify(normalizedScriptPath)
+    ? (ANCHORED_HOOK_SCRIPT_TOKEN.test(normalizedScriptPath)
+        ? normalizedScriptPath
+        : JSON.stringify(normalizedScriptPath))
     : (scriptToken || JSON.stringify(normalizedScriptPath));
   return projectShellCommandText({
     runnerToken: absoluteRunner,

--- a/tests/bug-3413-shell-command-projection.test.cjs
+++ b/tests/bug-3413-shell-command-projection.test.cjs
@@ -187,3 +187,92 @@ describe('bug #3439: shell projection module owns managed-hook policy and legacy
     );
   });
 });
+
+describe('#1693 regression: Windows legacy-node rewrite must not double-quote a "$CLAUDE_PROJECT_DIR"-anchored local hook path', () => {
+  const winRunner = '"C:/Program Files/nodejs/node.exe"';
+
+  // WHY: a local-install hook path already carries a `"$CLAUDE_PROJECT_DIR"`
+  // anchored prefix (only the variable quoted, rest bare). On Windows the legacy
+  // rewrite previously JSON.stringify'd the whole token, yielding
+  // `"\"$CLAUDE_PROJECT_DIR\"/..."`. node then received an argument starting with
+  // a literal `"`, treated it as relative, and died with MODULE_NOT_FOUND —
+  // breaking every node managed hook at once (self-locking deadlock).
+  test('projectLegacySettingsHookCommand emits the anchored path verbatim, not re-quoted', () => {
+    const anchored = '"$CLAUDE_PROJECT_DIR"/.claude/hooks/gsd-context-monitor.js';
+    const command = projectLegacySettingsHookCommand({
+      absoluteRunner: winRunner,
+      scriptPath: anchored,
+      scriptToken: anchored,
+      platform: 'win32',
+      runtime: 'claude',
+    });
+    assert.equal(
+      command,
+      '"C:/Program Files/nodejs/node.exe" "$CLAUDE_PROJECT_DIR"/.claude/hooks/gsd-context-monitor.js',
+    );
+    assert.ok(!command.includes('\\"'), 'must not contain escaped double-quotes');
+  });
+
+  // WHY: the fix must be surgical — a BARE absolute Windows path (no anchored
+  // prefix) can contain spaces ("Program Files") and still REQUIRES quoting.
+  test('projectLegacySettingsHookCommand still quotes a bare absolute Windows path', () => {
+    const abs = 'C:/Program Files App/.claude/hooks/gsd-context-monitor.js';
+    const command = projectLegacySettingsHookCommand({
+      absoluteRunner: winRunner,
+      scriptPath: abs,
+      scriptToken: JSON.stringify(abs),
+      platform: 'win32',
+      runtime: 'claude',
+    });
+    assert.equal(
+      command,
+      '"C:/Program Files/nodejs/node.exe" "C:/Program Files App/.claude/hooks/gsd-context-monitor.js"',
+    );
+  });
+
+  // WHY: the anchored short-circuit is scoped to win32. On POSIX the rewrite
+  // already preserved the caller's original `scriptToken` and never had the
+  // double-quote bug, so that behavior must be left byte-identical. scriptPath
+  // is anchored but scriptToken is a DISTINCT single-quoted value: if the
+  // win32 gate were removed, the anchored short-circuit would emit scriptPath
+  // and this assertion would fail — that is what pins the gate.
+  test('projectLegacySettingsHookCommand preserves the original scriptToken for anchored paths on POSIX', () => {
+    const command = projectLegacySettingsHookCommand({
+      absoluteRunner: '"/usr/local/bin/node"',
+      scriptPath: '"$CLAUDE_PROJECT_DIR"/.claude/hooks/gsd-statusline.js',
+      scriptToken: "'/x/hooks/gsd-statusline.js'",
+      platform: 'linux',
+      runtime: 'claude',
+    });
+    assert.equal(command, `"/usr/local/bin/node" '/x/hooks/gsd-statusline.js'`);
+  });
+
+  // WHY: end-to-end through the installer rewrite — the actual #2979 path that
+  // ran during the user's 1.5.0 -> 1.6.0 local update. Managed node hooks get
+  // the absolute runner + clean anchored path; a non-node-prefixed managed .sh
+  // hook (already correct) is left untouched.
+  test('rewriteLegacyManagedNodeHookCommands produces clean anchored node commands on Windows', () => {
+    const settings = {
+      hooks: {
+        PostToolUse: [
+          {
+            hooks: [
+              { command: 'node "$CLAUDE_PROJECT_DIR"/.claude/hooks/gsd-context-monitor.js' },
+            ],
+          },
+        ],
+      },
+    };
+    const changed = rewriteLegacyManagedNodeHookCommands(settings, winRunner, {
+      platform: 'win32',
+      runtime: 'claude',
+    });
+    assert.equal(changed, true);
+    const rewritten = settings.hooks.PostToolUse[0].hooks[0].command;
+    assert.equal(
+      rewritten,
+      '"C:/Program Files/nodejs/node.exe" "$CLAUDE_PROJECT_DIR"/.claude/hooks/gsd-context-monitor.js',
+    );
+    assert.ok(!rewritten.includes('\\"'), 'rewritten command must not contain escaped double-quotes');
+  });
+});


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #1693

The linked issue has the `confirmed-bug` label.

---

## What was broken

On Windows, the installer's #2979 "Rewrote legacy bare-node managed-hook commands to absolute path" step wrote node hook commands with `$CLAUDE_PROJECT_DIR` wrapped in literal escaped quotes inside an already-quoted argument — `"…/node.exe" "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/gsd-context-monitor.js"`. Node received a path starting with a literal `"`, treated it as relative, and failed with `MODULE_NOT_FOUND`, breaking every node managed hook at once (a self-locking `PreToolUse`-guard deadlock).

## What this fix does

`projectLegacySettingsHookCommand` now emits an already-`"$CLAUDE_PROJECT_DIR"`-anchored script token verbatim instead of re-quoting it, while bare absolute paths (which may contain spaces like `Program Files`) still get `JSON.stringify` quoting. The result matches the correct form already used by `.sh` hooks and the fresh-registration path: `"$CLAUDE_PROJECT_DIR"/.claude/hooks/x.js`.

## Root cause

The legacy-rewrite regex in `rewriteLegacyManagedNodeHookCommands` extracts the script token *including* its embedded `"$CLAUDE_PROJECT_DIR"` quotes (the bare-token `(\S+)` alternative matches the whole thing). `projectLegacySettingsHookCommand` then unconditionally `JSON.stringify`'d that token on `win32`, double-quoting the already-quoted prefix. The fresh-registration path (`install.js` `localCmd`) was unaffected because it passes the anchored path bare through `projectShellCommandText`.

## Testing

### How I verified the fix

- Reproduced the exact broken string (`"\"$CLAUDE_PROJECT_DIR\"/..."`) against the pre-fix build, then confirmed the fixed build emits the clean anchored form.
- Added a `#1693 regression` block to `tests/bug-3413-shell-command-projection.test.cjs` (4 tests): win32 anchored → verbatim; win32 bare-absolute-with-spaces → still quoted (no regression); POSIX anchored with a distinct `scriptToken` → `scriptToken` preserved (pins the win32 gate); end-to-end `rewriteLegacyManagedNodeHookCommands` → clean output with no escaped quotes.
- Test-the-test: with the source reverted, the win32 anchored tests fail (2/3); with the win32 gate removed, the POSIX test fails — so each test catches the regression it claims to.
- Ran all test files that touch these functions (`bug-3413`, `shell-command-projection-dispatch`, `bug-3181`, `bug-3017`, `bug-2979`, `install-regressions`, `bug-3426`) plus the full suite — green. `eslint` clean on both changed files.

### Regression test added?

- [x] Yes — added a test that would have caught this bug

### Platforms tested

- [x] macOS
- [x] Windows (including backslash path handling)
- [x] Linux

### Runtimes tested

- [x] Claude Code
- [x] N/A (not runtime-specific) — fix is in the shared projection seam; non-win32 token shape is unchanged

---

## Checklist

- [x] Issue linked above with `Fixes #1693`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix
- [x] No unnecessary dependencies added

## Breaking changes

None — non-Windows token-shape behavior is byte-identical; only the broken Windows double-quoting is corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1746"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785040165&installation_id=134682257&pr_number=1746&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1746&signature=02f252f4ccb4d2c94b3f960b2ccf4282ce2ee61076364d9c99b4c36d2e30af69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->