### PR TITLE
feat(#1754): CLI version-skew detection — warn when a global install shadows project-local GSD

### DIFF
--- a/.changeset/happy-birds-chatter.md
+++ b/.changeset/happy-birds-chatter.md
@@ -1,0 +1,5 @@
+---
+type: Added
+pr: 0
+---
+**GSD now warns when a stale global CLI (e.g. a retired @gsd-build/sdk canary) shadows your project-local install** — the gsd-tools CLI startup detects when the running binary is outside the project root while a project-local install exists, and prints a remediation warning to stderr (non-blocking). (#1754)

--- a/.changeset/happy-birds-chatter.md
+++ b/.changeset/happy-birds-chatter.md
@@ -1,5 +1,5 @@
 ---
 type: Added
-pr: 0
+pr: 1755
 ---
 **GSD now warns when a stale global CLI (e.g. a retired @gsd-build/sdk canary) shadows your project-local install** — the gsd-tools CLI startup detects when the running binary is outside the project root while a project-local install exists, and prints a remediation warning to stderr (non-blocking). (#1754)

--- a/docs/INVENTORY-MANIFEST.json
+++ b/docs/INVENTORY-MANIFEST.json
@@ -299,6 +299,7 @@
       "check-command-router.cjs",
       "cjs-command-router-adapter.cjs",
       "cli-exit.cjs",
+      "cli-skew-check.cjs",
       "clock.cjs",
       "clusters.cjs",
       "code-review-flags.cjs",

--- a/docs/how-to/update-gsd.md
+++ b/docs/how-to/update-gsd.md
@@ -138,3 +138,13 @@ Each GSD release may include installer migrations that rename, move, or retire m
 - [Manual update](../manual-update.md)
 - [Installer migrations](../installer-migrations.md)
 - [Docs index](../README.md)
+
+## CLI version-skew warning
+
+GSD warns (to stderr, non-blocking) when the resolved `gsd-tools.cjs` is **outside your project root** while a project-local install exists — a sign that a global install (often a retired `@gsd-build/sdk` canary) is shadowing your project-local GSD. The warning names the resolved path and, for the `@gsd-build/sdk` case, gives the removal command:
+
+```bash
+npm uninstall -g @gsd-build/sdk
+```
+
+If you see this warning, remove the stale global package so `gsd_run` resolves the project-local install.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -192,6 +192,8 @@ export default tseslint.config(
       'gsd-core/bin/lib/git-base-branch.cjs',
       // ADR-1213: tsc-generated runtime artifact — lint the src/capability-writer.cts source.
       'gsd-core/bin/lib/capability-writer.cjs',
+      // issue #1754: tsc-generated runtime artifact — lint the src/cli-skew-check.cts source.
+      'gsd-core/bin/lib/cli-skew-check.cjs',
       // issue #1355: tsc-generated runtime artifact — lint the src/teams-status.cts source.
       'gsd-core/bin/lib/teams-status.cjs',
       // ADR-1372: tsc-generated runtime artifact — lint the src/markdown-sectionizer.cts source.

--- a/gsd-core/bin/gsd-tools.cjs
+++ b/gsd-core/bin/gsd-tools.cjs
@@ -204,6 +204,24 @@ const projectRoot = require('./lib/project-root.cjs');
 // against any require/load-ordering edge where the export isn't bound yet
 // when this entrypoint is first required (#604).
 const findProjectRoot = (...args) => projectRoot.findProjectRoot(...args);
+
+// #1754: CLI skew detection — warn (stderr, non-blocking) if this gsd-tools.cjs
+// is NOT the project-local install while a project-local install exists. Catches
+// the shadowing scenario from #1748 (stale global canary shadowing project-local).
+try {
+  const _skew = require('./lib/cli-skew-check.cjs');
+  const _skewRoot = findProjectRoot(process.cwd());
+  if (_skewRoot) {
+    const _skewLocal = path.join(_skewRoot, '.claude', 'gsd-core', 'bin', 'gsd-tools.cjs');
+    const _skewWarn = _skew.checkCliSkew({
+      resolvedPath: path.resolve(__filename),
+      projectRoot: _skewRoot,
+      projectLocalExists: fs.existsSync(_skewLocal),
+    });
+    if (_skewWarn) process.stderr.write(_skewWarn + '\n');
+  }
+} catch { /* advisory — never block */ }
+
 const { getActiveWorkstream } = require('./lib/planning-workspace.cjs');
 const { resolveActiveWorkstream, applyResolvedWorkstreamEnv } = require('./lib/active-workstream-store.cjs');
 const state = require('./lib/state.cjs');

--- a/src/cli-skew-check.cts
+++ b/src/cli-skew-check.cts
@@ -1,0 +1,47 @@
+'use strict';
+
+/**
+ * cli-skew-check.cts — CLI version-skew detection (#1754).
+ *
+ * Pure function: compares the resolved gsd-tools.cjs path to the project root.
+ * If the resolved CLI is OUTSIDE the project root while a project-local install
+ * EXISTS, returns a warning string (the caller writes it to stderr). Non-blocking.
+ *
+ * Catches the shadowing scenario from #1748: a stale global canary CLI (e.g.
+ * from the retired @gsd-build/sdk) shadowing the project-local GSD install.
+ *
+ * The function is PURE (no I/O) — the caller provides the resolved path, the
+ * project root, and whether a project-local install exists. This makes it
+ * trivially testable without filesystem setup.
+ */
+
+import path from 'node:path';
+
+/**
+ * Check for CLI version skew.
+ *
+ * @param opts.resolvedPath - The absolute path of the running gsd-tools.cjs (__filename).
+ * @param opts.projectRoot - The project root (from findProjectRoot), or null if no project.
+ * @param opts.projectLocalExists - Whether a project-local gsd-tools.cjs exists.
+ * @returns A warning string if skew is detected, or null if no skew.
+ */
+export function checkCliSkew(opts: {
+  resolvedPath: string;
+  projectRoot: string | null;
+  projectLocalExists: boolean;
+}): string | null {
+  const { resolvedPath, projectRoot, projectLocalExists } = opts;
+
+  // No project context or no project-local install → no skew possible.
+  if (!projectRoot || !projectLocalExists) return null;
+
+  // If the resolved CLI is under the project root, it IS a project-local install.
+  const rel = path.relative(projectRoot, resolvedPath);
+  if (!rel.startsWith('..')) return null;
+
+  // Resolved CLI is outside project root while a project-local install exists → SKEW.
+  const hint = resolvedPath.includes('@gsd-build')
+    ? ' If @gsd-build/sdk: npm uninstall -g @gsd-build/sdk'
+    : '';
+  return `⚠ GSD: ${resolvedPath} may shadow project-local GSD.${hint}`;
+}

--- a/tests/feat-1754-cli-skew-detection.test.cjs
+++ b/tests/feat-1754-cli-skew-detection.test.cjs
@@ -1,0 +1,85 @@
+'use strict';
+
+/**
+ * feat-1754-cli-skew-detection.test.cjs
+ *
+ * Tests for the CLI version-skew detection module (src/cli-skew-check.cts).
+ *
+ * The check warns (returns a string) when the running gsd-tools.cjs is NOT the
+ * project-local install while a project-local install EXISTS — the shadowing
+ * scenario from #1748 (a stale global canary from @gsd-build/sdk shadowing
+ * project-local 1.6.0).
+ *
+ * DEFECT class: environment / version skew (enhancement #1754)
+ *
+ * The function is PURE (no I/O — the caller provides paths + existence flags),
+ * making it trivially testable without filesystem setup.
+ */
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const { checkCliSkew } = require('../gsd-core/bin/lib/cli-skew-check.cjs');
+
+describe('#1754: checkCliSkew — pure path-comparison skew detection', () => {
+  test('SKEW: resolved CLI outside project root + project-local exists → returns warning', () => {
+    const warning = checkCliSkew({
+      resolvedPath: '/opt/homebrew/bin/gsd-tools',
+      projectRoot: '/home/user/my-project',
+      projectLocalExists: true,
+    });
+    assert.ok(warning, 'Expected a warning string when resolved CLI is outside project root and project-local exists');
+    assert.ok(warning.includes('shadow') || warning.includes('outside') || warning.includes('may'),
+      `Warning should mention the shadowing/outside nature, got: "${warning}"`);
+  });
+
+  test('NO-SKEW: resolved CLI is the project-local install → returns null', () => {
+    const warning = checkCliSkew({
+      resolvedPath: '/home/user/my-project/.claude/gsd-core/bin/gsd-tools.cjs',
+      projectRoot: '/home/user/my-project',
+      projectLocalExists: true,
+    });
+    assert.strictEqual(warning, null, 'No warning expected when resolved CLI IS the project-local install');
+  });
+
+  test('NO-SKEW: resolved CLI outside project root but NO project-local install → returns null', () => {
+    const warning = checkCliSkew({
+      resolvedPath: '/usr/local/bin/gsd-tools',
+      projectRoot: '/home/user/my-project',
+      projectLocalExists: false,
+    });
+    assert.strictEqual(warning, null, 'No warning expected when no project-local install exists (legitimate global-only)');
+  });
+
+  test('NO-SKEW: projectRoot is null (no project context) → returns null', () => {
+    const warning = checkCliSkew({
+      resolvedPath: '/usr/local/bin/gsd-tools',
+      projectRoot: null,
+      projectLocalExists: false,
+    });
+    assert.strictEqual(warning, null, 'No warning expected when there is no project root');
+  });
+
+  test('LEGACY-SDK: resolved path contains @gsd-build → warning includes removal instructions', () => {
+    const warning = checkCliSkew({
+      resolvedPath: '/opt/homebrew/lib/node_modules/@gsd-build/sdk/bin/gsd-tools',
+      projectRoot: '/home/user/my-project',
+      projectLocalExists: true,
+    });
+    assert.ok(warning, 'Expected a warning for @gsd-build/sdk paths');
+    assert.ok(warning.includes('@gsd-build/sdk') || warning.includes('npm uninstall'),
+      `Warning should include @gsd-build/sdk removal instructions, got: "${warning}"`);
+  });
+
+  test('PATH-NORMALIZATION: resolved under project root via realpath → no false positive', () => {
+    // Even if the resolved path differs in symlink resolution, if it's under the
+    // project root, it's not a skew. The caller normalizes paths before calling.
+    const warning = checkCliSkew({
+      resolvedPath: path.resolve('/home/user/my-project/.claude/gsd-core/bin/gsd-tools.cjs'),
+      projectRoot: path.resolve('/home/user/my-project'),
+      projectLocalExists: true,
+    });
+    assert.strictEqual(warning, null, 'No warning when resolved path is under project root (even with realpath normalization)');
+  });
+});

--- a/tests/fixtures/golden-install-parity/antigravity.json
+++ b/tests/fixtures/golden-install-parity/antigravity.json
@@ -38,7 +38,7 @@
   "gsd-core/CHANGELOG.md": "e141e3fb369ff712",
   "gsd-core/VERSION": "562368b20a64be95",
   "gsd-core/bin/check-latest-version.cjs": "e4a224058c8f4d74",
-  "gsd-core/bin/gsd-tools.cjs": "08cbf1f404d64b93",
+  "gsd-core/bin/gsd-tools.cjs": "46deb2174be356dd",
   "gsd-core/bin/gsd_run": "62d9b647ede212e6",
   "gsd-core/bin/shared/config-defaults.manifest.json": "517e6a7c1e9f4f16",
   "gsd-core/bin/shared/config-schema.manifest.json": "67e4addbfd248a7c",

--- a/tests/fixtures/golden-install-parity/augment.json
+++ b/tests/fixtures/golden-install-parity/augment.json
@@ -107,7 +107,7 @@
   "gsd-core/CHANGELOG.md": "e141e3fb369ff712",
   "gsd-core/VERSION": "562368b20a64be95",
   "gsd-core/bin/check-latest-version.cjs": "e4a224058c8f4d74",
-  "gsd-core/bin/gsd-tools.cjs": "1f2ff4e80aa45439",
+  "gsd-core/bin/gsd-tools.cjs": "b7968e3e3af00249",
   "gsd-core/bin/gsd_run": "62d9b647ede212e6",
   "gsd-core/bin/shared/config-defaults.manifest.json": "517e6a7c1e9f4f16",
   "gsd-core/bin/shared/config-schema.manifest.json": "67e4addbfd248a7c",

--- a/tests/fixtures/golden-install-parity/claude.json
+++ b/tests/fixtures/golden-install-parity/claude.json
@@ -37,7 +37,7 @@
   "gsd-core/CHANGELOG.md": "e141e3fb369ff712",
   "gsd-core/VERSION": "562368b20a64be95",
   "gsd-core/bin/check-latest-version.cjs": "e4a224058c8f4d74",
-  "gsd-core/bin/gsd-tools.cjs": "1f2ff4e80aa45439",
+  "gsd-core/bin/gsd-tools.cjs": "b7968e3e3af00249",
   "gsd-core/bin/gsd_run": "62d9b647ede212e6",
   "gsd-core/bin/shared/config-defaults.manifest.json": "517e6a7c1e9f4f16",
   "gsd-core/bin/shared/config-schema.manifest.json": "67e4addbfd248a7c",

--- a/tests/fixtures/golden-install-parity/cline.json
+++ b/tests/fixtures/golden-install-parity/cline.json
@@ -41,7 +41,7 @@
   "gsd-core/CHANGELOG.md": "e141e3fb369ff712",
   "gsd-core/VERSION": "562368b20a64be95",
   "gsd-core/bin/check-latest-version.cjs": "e4a224058c8f4d74",
-  "gsd-core/bin/gsd-tools.cjs": "1f2ff4e80aa45439",
+  "gsd-core/bin/gsd-tools.cjs": "b7968e3e3af00249",
   "gsd-core/bin/gsd_run": "62d9b647ede212e6",
   "gsd-core/bin/shared/config-defaults.manifest.json": "517e6a7c1e9f4f16",
   "gsd-core/bin/shared/config-schema.manifest.json": "67e4addbfd248a7c",

--- a/tests/fixtures/golden-install-parity/codebuddy.json
+++ b/tests/fixtures/golden-install-parity/codebuddy.json
@@ -107,7 +107,7 @@
   "gsd-core/CHANGELOG.md": "e141e3fb369ff712",
   "gsd-core/VERSION": "562368b20a64be95",
   "gsd-core/bin/check-latest-version.cjs": "e4a224058c8f4d74",
-  "gsd-core/bin/gsd-tools.cjs": "1f2ff4e80aa45439",
+  "gsd-core/bin/gsd-tools.cjs": "b7968e3e3af00249",
   "gsd-core/bin/gsd_run": "62d9b647ede212e6",
   "gsd-core/bin/shared/config-defaults.manifest.json": "517e6a7c1e9f4f16",
   "gsd-core/bin/shared/config-schema.manifest.json": "67e4addbfd248a7c",

--- a/tests/fixtures/golden-install-parity/codex.json
+++ b/tests/fixtures/golden-install-parity/codex.json
@@ -73,7 +73,7 @@
   "gsd-core/CHANGELOG.md": "e141e3fb369ff712",
   "gsd-core/VERSION": "562368b20a64be95",
   "gsd-core/bin/check-latest-version.cjs": "e4a224058c8f4d74",
-  "gsd-core/bin/gsd-tools.cjs": "1f2ff4e80aa45439",
+  "gsd-core/bin/gsd-tools.cjs": "b7968e3e3af00249",
   "gsd-core/bin/gsd_run": "62d9b647ede212e6",
   "gsd-core/bin/shared/config-defaults.manifest.json": "517e6a7c1e9f4f16",
   "gsd-core/bin/shared/config-schema.manifest.json": "67e4addbfd248a7c",

--- a/tests/fixtures/golden-install-parity/copilot.json
+++ b/tests/fixtures/golden-install-parity/copilot.json
@@ -39,7 +39,7 @@
   "gsd-core/CHANGELOG.md": "e141e3fb369ff712",
   "gsd-core/VERSION": "562368b20a64be95",
   "gsd-core/bin/check-latest-version.cjs": "e4a224058c8f4d74",
-  "gsd-core/bin/gsd-tools.cjs": "08cbf1f404d64b93",
+  "gsd-core/bin/gsd-tools.cjs": "46deb2174be356dd",
   "gsd-core/bin/gsd_run": "62d9b647ede212e6",
   "gsd-core/bin/shared/config-defaults.manifest.json": "517e6a7c1e9f4f16",
   "gsd-core/bin/shared/config-schema.manifest.json": "67e4addbfd248a7c",

--- a/tests/fixtures/golden-install-parity/cursor.json
+++ b/tests/fixtures/golden-install-parity/cursor.json
@@ -107,7 +107,7 @@
   "gsd-core/CHANGELOG.md": "e141e3fb369ff712",
   "gsd-core/VERSION": "562368b20a64be95",
   "gsd-core/bin/check-latest-version.cjs": "e4a224058c8f4d74",
-  "gsd-core/bin/gsd-tools.cjs": "08cbf1f404d64b93",
+  "gsd-core/bin/gsd-tools.cjs": "46deb2174be356dd",
   "gsd-core/bin/gsd_run": "62d9b647ede212e6",
   "gsd-core/bin/shared/config-defaults.manifest.json": "517e6a7c1e9f4f16",
   "gsd-core/bin/shared/config-schema.manifest.json": "67e4addbfd248a7c",

--- a/tests/fixtures/golden-install-parity/gemini.json
+++ b/tests/fixtures/golden-install-parity/gemini.json
@@ -107,7 +107,7 @@
   "gsd-core/CHANGELOG.md": "e141e3fb369ff712",
   "gsd-core/VERSION": "562368b20a64be95",
   "gsd-core/bin/check-latest-version.cjs": "e4a224058c8f4d74",
-  "gsd-core/bin/gsd-tools.cjs": "1f2ff4e80aa45439",
+  "gsd-core/bin/gsd-tools.cjs": "b7968e3e3af00249",
   "gsd-core/bin/gsd_run": "62d9b647ede212e6",
   "gsd-core/bin/shared/config-defaults.manifest.json": "517e6a7c1e9f4f16",
   "gsd-core/bin/shared/config-schema.manifest.json": "67e4addbfd248a7c",

--- a/tests/fixtures/golden-install-parity/hermes.json
+++ b/tests/fixtures/golden-install-parity/hermes.json
@@ -38,7 +38,7 @@
   "gsd-core/CHANGELOG.md": "e141e3fb369ff712",
   "gsd-core/VERSION": "562368b20a64be95",
   "gsd-core/bin/check-latest-version.cjs": "e4a224058c8f4d74",
-  "gsd-core/bin/gsd-tools.cjs": "1f2ff4e80aa45439",
+  "gsd-core/bin/gsd-tools.cjs": "b7968e3e3af00249",
   "gsd-core/bin/gsd_run": "62d9b647ede212e6",
   "gsd-core/bin/shared/config-defaults.manifest.json": "517e6a7c1e9f4f16",
   "gsd-core/bin/shared/config-schema.manifest.json": "67e4addbfd248a7c",

--- a/tests/fixtures/golden-install-parity/kilo.json
+++ b/tests/fixtures/golden-install-parity/kilo.json
@@ -107,7 +107,7 @@
   "gsd-core/CHANGELOG.md": "e141e3fb369ff712",
   "gsd-core/VERSION": "562368b20a64be95",
   "gsd-core/bin/check-latest-version.cjs": "e4a224058c8f4d74",
-  "gsd-core/bin/gsd-tools.cjs": "1f2ff4e80aa45439",
+  "gsd-core/bin/gsd-tools.cjs": "b7968e3e3af00249",
   "gsd-core/bin/gsd_run": "62d9b647ede212e6",
   "gsd-core/bin/shared/config-defaults.manifest.json": "517e6a7c1e9f4f16",
   "gsd-core/bin/shared/config-schema.manifest.json": "67e4addbfd248a7c",

--- a/tests/fixtures/golden-install-parity/kimi.json
+++ b/tests/fixtures/golden-install-parity/kimi.json
@@ -74,7 +74,7 @@
   "gsd-core/CHANGELOG.md": "e141e3fb369ff712",
   "gsd-core/VERSION": "562368b20a64be95",
   "gsd-core/bin/check-latest-version.cjs": "e4a224058c8f4d74",
-  "gsd-core/bin/gsd-tools.cjs": "1f2ff4e80aa45439",
+  "gsd-core/bin/gsd-tools.cjs": "b7968e3e3af00249",
   "gsd-core/bin/gsd_run": "62d9b647ede212e6",
   "gsd-core/bin/shared/config-defaults.manifest.json": "517e6a7c1e9f4f16",
   "gsd-core/bin/shared/config-schema.manifest.json": "67e4addbfd248a7c",

--- a/tests/fixtures/golden-install-parity/opencode.json
+++ b/tests/fixtures/golden-install-parity/opencode.json
@@ -107,7 +107,7 @@
   "gsd-core/CHANGELOG.md": "e141e3fb369ff712",
   "gsd-core/VERSION": "562368b20a64be95",
   "gsd-core/bin/check-latest-version.cjs": "e4a224058c8f4d74",
-  "gsd-core/bin/gsd-tools.cjs": "1f2ff4e80aa45439",
+  "gsd-core/bin/gsd-tools.cjs": "b7968e3e3af00249",
   "gsd-core/bin/gsd_run": "62d9b647ede212e6",
   "gsd-core/bin/shared/config-defaults.manifest.json": "517e6a7c1e9f4f16",
   "gsd-core/bin/shared/config-schema.manifest.json": "67e4addbfd248a7c",

--- a/tests/fixtures/golden-install-parity/qwen.json
+++ b/tests/fixtures/golden-install-parity/qwen.json
@@ -38,7 +38,7 @@
   "gsd-core/CHANGELOG.md": "e141e3fb369ff712",
   "gsd-core/VERSION": "562368b20a64be95",
   "gsd-core/bin/check-latest-version.cjs": "e4a224058c8f4d74",
-  "gsd-core/bin/gsd-tools.cjs": "1f2ff4e80aa45439",
+  "gsd-core/bin/gsd-tools.cjs": "b7968e3e3af00249",
   "gsd-core/bin/gsd_run": "62d9b647ede212e6",
   "gsd-core/bin/shared/config-defaults.manifest.json": "517e6a7c1e9f4f16",
   "gsd-core/bin/shared/config-schema.manifest.json": "67e4addbfd248a7c",

--- a/tests/fixtures/golden-install-parity/trae.json
+++ b/tests/fixtures/golden-install-parity/trae.json
@@ -38,7 +38,7 @@
   "gsd-core/CHANGELOG.md": "e141e3fb369ff712",
   "gsd-core/VERSION": "562368b20a64be95",
   "gsd-core/bin/check-latest-version.cjs": "e4a224058c8f4d74",
-  "gsd-core/bin/gsd-tools.cjs": "08cbf1f404d64b93",
+  "gsd-core/bin/gsd-tools.cjs": "46deb2174be356dd",
   "gsd-core/bin/gsd_run": "62d9b647ede212e6",
   "gsd-core/bin/shared/config-defaults.manifest.json": "517e6a7c1e9f4f16",
   "gsd-core/bin/shared/config-schema.manifest.json": "67e4addbfd248a7c",

--- a/tests/fixtures/golden-install-parity/windsurf.json
+++ b/tests/fixtures/golden-install-parity/windsurf.json
@@ -38,7 +38,7 @@
   "gsd-core/CHANGELOG.md": "e141e3fb369ff712",
   "gsd-core/VERSION": "562368b20a64be95",
   "gsd-core/bin/check-latest-version.cjs": "e4a224058c8f4d74",
-  "gsd-core/bin/gsd-tools.cjs": "08cbf1f404d64b93",
+  "gsd-core/bin/gsd-tools.cjs": "46deb2174be356dd",
   "gsd-core/bin/gsd_run": "62d9b647ede212e6",
   "gsd-core/bin/shared/config-defaults.manifest.json": "517e6a7c1e9f4f16",
   "gsd-core/bin/shared/config-schema.manifest.json": "67e4addbfd248a7c",


### PR DESCRIPTION
## Enhancement PR

Implements #1754 — proactive CLI version-skew detection. When the running `gsd-tools.cjs` is outside the project root while a project-local install exists, GSD warns (stderr, non-blocking) with a remediation hint. Catches the shadowing scenario from #1748 (stale global `@gsd-build/sdk` canary overriding project-local GSD).

---

## Linked Issue

Closes #1754

---

## What this enhancement improves

When a user has a stale global CLI (e.g. the retired `@gsd-build/sdk` canary) that shadows their project-local GSD install, the orchestrator and the worktree-spawning CLI disagree on behavior — producing confusing fail-closed mismatches (as in #1748). This enhancement detects the skew at CLI startup and warns with the one-line fix.

## Before / After

**Before:** A global canary CLI silently shadows the project-local install; the user discovers the skew only when a feature the canary doesn't support causes a confusing failure.

**After:** GSD warns at startup: `⚠ GSD: /opt/homebrew/bin/gsd-tools may shadow project-local GSD. If @gsd-build/sdk: npm uninstall -g @gsd-build/sdk`.

## How it was implemented

- **`src/cli-skew-check.cts`** — pure function `checkCliSkew({ resolvedPath, projectRoot, projectLocalExists })` → `string | null`. Compares the running CLI path to the project root via `path.relative`; returns a warning when the CLI is outside the project root AND a project-local install exists. `@gsd-build/sdk`-specific removal hint. No I/O (pure), no `gsd-sdk` literal.
- **`gsd-core/bin/gsd-tools.cjs`** — wired at startup via the existing `findProjectRoot` resolver. Non-blocking (try/catch; advisory stderr warning, never gates).
- **Design note:** the check lives in the Node CLI entry point (not the shell snippet) to avoid bloating 93 workflow files past their size caps (the snippet-level approach was tried and rejected during development).

## Testing

### How I verified

- 6 `node:test` cases (skew / no-skew / no-project-local / no-project-root / legacy-@gsd-build / path-normalization) — all green.
- **FULL `npm test`: 3354 pass, 0 regressions** (1 pre-existing local failure: `AGENTS.md` exists on disk for opencode but is untracked — fails on clean `next` too).
- `lint:ci` green.
- Golden fixtures regenerated (`UPDATE_GOLDEN=1`) for the new compiled artifact.

### Platforms tested
- [x] macOS — [ ] Windows — [x] Linux — [x] N/A (CLI startup, cross-platform)

### Runtimes tested
- [x] N/A (not runtime-specific — runs in the gsd-tools CLI entry, all runtimes)

---

## Scope confirmation
- [x] Matches the approved scope (#1754)

## Documentation
- [x] Updated `docs/how-to/update-gsd.md` (Diátaxis reference: CLI version-skew warning)
- [x] All content in English

## Checklist
- [x] `Closes #1754` — [x] `approved-enhancement` — [x] scoped — [x] full `npm test` green (3354/0 regressions) — [x] `lint:ci` green — [x] changeset added — [x] no new dependencies

## Breaking changes
None — additive stderr warning, non-blocking.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1755"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785077733&installation_id=134682257&pr_number=1755&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1755&signature=f26e231a5d0a245d4a3cd3a7092386ebbb1f08d6c21a6303d62060d773598858"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->