### PR TITLE
fix(#1760): resolve current phase from prose Phase field in state prune

### DIFF
--- a/.changeset/state-prune-prose-phase-1760.md
+++ b/.changeset/state-prune-prose-phase-1760.md
@@ -1,0 +1,6 @@
+---
+type: Fixed
+pr: 1773
+---
+
+`state prune` (and `workflow.auto_prune_state`) now resolves the current phase from the canonical template's prose `Phase: [X] of [Y]` field, not only an explicit `Current Phase:` field. Previously, prune was a silent no-op on any STATE.md generated from the template — it always reported `"Only 0 phases — nothing to prune"` because the template never emits `Current Phase:`. Mirrors the prose fallback `buildStateFrontmatter` and `state sync` already use.

--- a/src/state.cts
+++ b/src/state.cts
@@ -2864,7 +2864,15 @@ function cmdStatePrune(cwd: string, options: StatePruneOptions, raw: boolean): v
 
   const keepRecent = parseInt(String(options.keepRecent), 10) || 3;
   const dryRun = !!options.dryRun;
-  const currentPhaseRaw = stateExtractField(fs.readFileSync(statePath, 'utf-8'), 'Current Phase');
+  // STATE.md from the canonical template emits the position as a prose
+  // `Phase: [X] of [Y]` field and never `Current Phase:` (#1760). Without the
+  // prose fallback, `Current Phase` is absent → currentPhase = 0 → prune always
+  // bails with "Only 0 phases". Mirror the fallback buildStateFrontmatter and
+  // cmdStateSync already use so prune resolves the phase on a template file.
+  const pruneContent = fs.readFileSync(statePath, 'utf-8');
+  const currentPhaseRaw =
+    stateExtractField(pruneContent, 'Current Phase') ??
+    parseProsePhaseField(stateExtractField(pruneContent, 'Phase')).phase;
   const currentPhase = parseInt(currentPhaseRaw as string, 10) || 0;
   const cutoff = currentPhase - keepRecent;
 

--- a/tests/state-prune.test.cjs
+++ b/tests/state-prune.test.cjs
@@ -274,4 +274,74 @@ describe('state prune (#1970)', () => {
       assert.match(newState, /\| 5 \|/);
     });
   });
+
+  // #1760: STATE.md generated from the canonical template (templates/state.md)
+  // emits the position as a prose `Phase: [X] of [Y] ([name])` field and never
+  // `Current Phase:`. Before the fix, cmdStatePrune read only `Current Phase`,
+  // so on a template-conformant file currentPhase resolved to 0 and prune always
+  // bailed with "Only 0 phases" — making `state prune` / `auto_prune_state`
+  // a silent no-op for every project built from the template. These tests pin
+  // the prose fallback so prune engages, and guard the precedence ordering.
+  describe('resolves current phase from prose "Phase: X of Y" field (#1760)', () => {
+    test('prunes using the template prose field when "Current Phase:" is absent', () => {
+      writeStateMd(tmpDir, [
+        '# Project State',
+        '',
+        // canonical template format — note: no "Current Phase:" line at all
+        'Phase: 10 of 12 (Build the thing)',
+        'Status: In progress',
+        '',
+        '## Decisions',
+        '',
+        '- [Phase 1]: Old decision',
+        '- [Phase 3]: Old decision 3',
+        '- [Phase 8]: Recent decision',
+        '- [Phase 10]: Current decision',
+        '',
+      ].join('\n'));
+
+      const result = runGsdTools('state prune --keep-recent 3', tmpDir);
+      assert.ok(result.success, `Command failed: ${result.error}`);
+
+      const output = JSON.parse(result.output);
+      // Would be pruned:false / "Only 0 phases" without the prose fallback.
+      assert.strictEqual(output.pruned, true);
+      assert.strictEqual(output.cutoff_phase, 7);
+
+      const newState = readStateMd(tmpDir);
+      assert.match(newState, /\[Phase 8\]: Recent decision/);
+      assert.match(newState, /\[Phase 10\]: Current decision/);
+      assert.doesNotMatch(newState, /\[Phase 1\]: Old decision/);
+      assert.doesNotMatch(newState, /\[Phase 3\]: Old decision 3/);
+
+      assert.ok(archiveExists(tmpDir), 'STATE-ARCHIVE.md should exist');
+      const archive = readArchive(tmpDir);
+      assert.match(archive, /\[Phase 1\]: Old decision/);
+      assert.match(archive, /\[Phase 3\]: Old decision 3/);
+    });
+
+    test('"Current Phase:" still takes precedence over the prose "Phase:" field', () => {
+      // A stale prose `Phase: 2` must not override an explicit `Current Phase: 10`
+      // — the fallback only applies when `Current Phase` is absent.
+      writeStateMd(tmpDir, [
+        '# Project State',
+        '',
+        'Phase: 2 of 12 (stale prose value)',
+        '**Current Phase:** 10',
+        '',
+        '## Decisions',
+        '',
+        '- [Phase 1]: Old decision',
+        '- [Phase 8]: Recent decision',
+        '',
+      ].join('\n'));
+
+      const result = runGsdTools('state prune --keep-recent 3', tmpDir);
+      assert.ok(result.success, `Command failed: ${result.error}`);
+
+      const output = JSON.parse(result.output);
+      // cutoff derives from Current Phase (10), not the stale prose value (2).
+      assert.strictEqual(output.cutoff_phase, 7);
+    });
+  });
 });


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #1760

## What was broken

`gsd-tools state prune` (and `workflow.auto_prune_state`) was a silent no-op against any STATE.md generated from the canonical template — it always returned `{"pruned": false, "reason": "Only 0 phases — nothing to prune"}` regardless of how many phases the project had.

## What this fix does

`cmdStatePrune` now resolves the current phase using the same precedence the rest of `state.cts` already uses: prefer an explicit `Current Phase:` field, and fall back to the prose `Phase: [X] of [Y]` field (via `parseProsePhaseField`) when `Current Phase:` is absent. Prune then computes a real cutoff and archives as expected.

## Root cause

`cmdStatePrune` derived the current phase via `stateExtractField(content, 'Current Phase')`, but the canonical template (`gsd-core/templates/state.md`) emits the position only as a prose `Phase: [X] of [Y] ([name])` field and **never** `Current Phase:`. So `Current Phase` was `null` → `currentPhase = parseInt(null) || 0 = 0` → the guard `cutoff = currentPhase - keepRecent <= 0` always tripped and prune bailed. `buildStateFrontmatter` (`src/state.cts:1310-1311`) and `cmdStateSync` (`src/state.cts:1470-1471`) already carry the prose fallback — `cmdStatePrune` was the one path missing it.

## Testing

### How I verified the fix

Reproduced and verified end-to-end against the **built** `gsd-core/bin/gsd-tools.cjs` artifact with a template-conformant STATE.md (`Phase: 6 of 10`, no `Current Phase:`):

- **Before:** `state prune --keep-recent 3 --dry-run` → `{"pruned": false, "reason": "Only 0 phases — nothing to prune"}`.
- **After:** same input → `cutoff_phase: 3`, `total_would_archive: 4` (Decisions + Recently Completed items for phases ≤ cutoff).

Two regression tests added to `tests/state-prune.test.cjs`; confirmed the prose-only test **fails on the unfixed artifact and passes on the fixed one** (test-the-test). Full state suite: 222/222 pass. ESLint clean; `lint-regression-test-names` and `lint-allow-test-rule-refs` clean.

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [x] N/A (not platform-specific)

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix — added after PR creation (the `pr:` field needs the real PR number)
- [x] No unnecessary dependencies added

## Out-of-scope follow-up

`stateExtractField` also matches a pipe-table `| Phase | N |` row, so the new fallback can now resolve a phase from a table-format STATE.md as well. That table path predates this change and is not a regression introduced here; a stronger future hardening would scope the prose-fallback extraction to the `## Current Position` section. Tracked as a separate follow-up: #1776.

## Breaking changes

None — behavior changes only for STATE.md files where prune was already non-functional (no `Current Phase:` field). Files with an explicit `Current Phase:` are unaffected (it still wins).
