### PR TITLE
fix(#1761): don't write conflated progress when milestone scope is unresolvable

### DIFF
--- a/.changeset/state-sync-unbounded-milestone-1761.md
+++ b/.changeset/state-sync-unbounded-milestone-1761.md
@@ -1,0 +1,6 @@
+---
+type: Fixed
+pr: 1777
+---
+
+`state sync` and `state json` no longer write or report incorrect progress when the current milestone cannot be resolved to a bounded ROADMAP section (free-form/unversioned milestone headings). Previously the phase count was derived from a scope that conflated every milestone, silently rewriting `total_phases`/`percent` in both the STATE.md body and frontmatter. GSD now detects the ambiguous scope, leaves the existing progress untouched, and surfaces a warning. Bounded, versioned, and single-milestone projects are unaffected.

--- a/src/roadmap-parser.cts
+++ b/src/roadmap-parser.cts
@@ -347,6 +347,96 @@ function getMilestoneInfo(cwd: string): MilestoneInfo {
   }
 }
 
+/**
+ * Derives a stable identity for a milestone-boundary heading, or null when the
+ * heading is not a milestone boundary. Identity is the version token if present
+ * (`v3.0`, `v3.0-B`), else a numeric `Milestone N` label, else — for an
+ * emoji-marked heading carrying neither — its normalized text. The `(Phase
+ * Details)` suffix is stripped so a milestone's split continuation heading shares
+ * its boundary heading's identity (#730 split layouts). A non-numeric prose
+ * heading like `## Milestone Notes` yields null (not a boundary).
+ */
+function milestoneHeadingIdentity(headingText: string): string | null {
+  const ver = headingText.match(/v\d+(?:\.\d+)+(?:[-.][A-Za-z0-9]+)*/i);
+  if (ver) return 'v:' + ver[0].toLowerCase();
+  const mnum = headingText.match(/\bMilestone\s+(\d+)/i);
+  if (mnum) return 'm:' + mnum[1];
+  if (/✅|📋|🚧|🔄/u.test(headingText)) {
+    return 't:' + headingText.replace(/\(Phase\s+Details\)/i, '').replace(/[✅📋🚧🔄]/gu, '').trim().toLowerCase();
+  }
+  return null;
+}
+
+/**
+ * Counts the number of DISTINCT milestones a block of ROADMAP text spans, used
+ * to decide whether a resolved milestone scope conflates siblings (#1761).
+ *
+ * Only milestone-boundary headings at the SHALLOWEST matched level are counted —
+ * deeper marker-bearing subheadings (e.g. `### v3.0 Notes`, `### Milestone 4
+ * Risks`) inside a section are not milestone boundaries. Boundaries are then
+ * deduplicated by milestone identity, so a milestone heading and its same-version
+ * `(Phase Details)` continuation count once (#730 split layouts), while genuinely
+ * distinct siblings count separately.
+ */
+function countMilestoneHeadings(text: string): number {
+  const matched: Array<{ level: number; id: string }> = [];
+  for (const h of tokenizeHeadings(text)) {
+    if (h.level < 1 || h.level > 3) continue;
+    if (/^Phase\s+\S/i.test(h.text)) continue;
+    const id = milestoneHeadingIdentity(h.text);
+    if (id) matched.push({ level: h.level, id });
+  }
+  if (matched.length === 0) return 0;
+  const base = Math.min(...matched.map(m => m.level));
+  return new Set(matched.filter(m => m.level === base).map(m => m.id)).size;
+}
+
+/**
+ * Detects when the current milestone cannot be bounded to a single ROADMAP
+ * section, so any phase count derived from the resolved scope would conflate
+ * phases from sibling milestones (#1761).
+ *
+ * Works on the SCOPE that `extractCurrentMilestone` actually returns, counting
+ * the milestone-boundary headings inside it. A correctly bounded milestone yields
+ * exactly one; >= 2 means the scope conflates siblings — whether because the
+ * version anchor matched no heading (whole-document fallback) or because the
+ * section bled past an unversioned sibling milestone (extractCurrentMilestone's
+ * computeSectionEnd only stops on versioned/marked headings).
+ *
+ * Returns true only when BOTH hold:
+ *   1. A milestone version anchor is resolvable — STATE.md's `milestone:` field,
+ *      else a `🚧/🔄 **vX.Y` in-progress marker in the ROADMAP. Without an anchor
+ *      the project has not declared a current milestone and whole-document scope
+ *      is the intended reading, so we never fire.
+ *   2. The resolved scope contains >= 2 milestone-boundary headings.
+ *
+ * A single-milestone ROADMAP (one heading in scope) or a version that resolves
+ * cleanly to one section both return false, so callers proceed exactly as before.
+ */
+function currentMilestoneScopeIsAmbiguous(roadmapContent: string, cwd?: string): boolean {
+  // (1) Resolve the version anchor exactly as extractCurrentMilestone does.
+  let version: string | null = null;
+  if (cwd) {
+    try {
+      const stateRaw = platformReadSync(path.join(planningDir(cwd), 'STATE.md'));
+      if (stateRaw !== null) {
+        const m = stateRaw.match(/^milestone:\s*(.+)/m);
+        if (m) version = m[1].trim();
+      }
+    } catch { /* ignore */ }
+  }
+  if (!version) {
+    const inProgress = roadmapContent.match(/(?:🚧|🔄)\s*\*\*v(\d+\.\d+)\s/);
+    if (inProgress) version = 'v' + inProgress[1];
+  }
+  if (!version) return false; // No anchor → legacy whole-document scope is intended.
+
+  // (2) Count milestone-boundary headings within the RESOLVED scope. >= 2 means
+  // the scope conflates more than one milestone.
+  const scope = extractCurrentMilestone(roadmapContent, cwd);
+  return countMilestoneHeadings(scope) >= 2;
+}
+
 // ─── Milestone phase filter ───────────────────────────────────────────────────
 
 type MilestonePhaseFilter = ((dirName: string) => boolean) & {
@@ -487,4 +577,5 @@ export = {
   getRoadmapPhaseInternal,
   getMilestoneInfo,
   getMilestonePhaseFilter,
+  currentMilestoneScopeIsAmbiguous,
 };

--- a/src/state.cts
+++ b/src/state.cts
@@ -19,7 +19,7 @@ import phaseIdMod = require('./phase-id.cjs');
 const { escapeRegex, normalizePhaseName, extractPhaseToken } = phaseIdMod;
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import roadmapParserMod = require('./roadmap-parser.cjs');
-const { getMilestoneInfo, getMilestonePhaseFilter, extractCurrentMilestone } = roadmapParserMod;
+const { getMilestoneInfo, getMilestonePhaseFilter, extractCurrentMilestone, currentMilestoneScopeIsAmbiguous } = roadmapParserMod;
 import { platformWriteSync, platformReadSync, platformEnsureDir, retryRenameSync } from './shell-command-projection.cjs';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import planningWorkspace = require('./planning-workspace.cjs');
@@ -1664,6 +1664,31 @@ function stripFrontmatter(content: string): string {
   return result;
 }
 
+/**
+ * #1761 progress guard, shared by the write path (syncStateFrontmatter) and the
+ * read path (cmdStateJson `state json`). When the current milestone cannot be
+ * bounded to a ROADMAP section, buildStateFrontmatter derived `progress`
+ * (total_phases, percent, …) from a scope that conflates sibling milestones.
+ * Prefer the existing frontmatter progress over that conflated derivation; when
+ * none exists, drop the block rather than report/persist a wrong denominator.
+ * Mutates `fm` in place. No-op for the common (bounded) case.
+ */
+function applyAmbiguousMilestoneProgressGuard(
+  fm: Record<string, unknown>,
+  existingFm: Record<string, unknown> | null | undefined,
+  cwd: string | undefined,
+): void {
+  if (!cwd || !fm['progress']) return;
+  let roadmapRaw: string | null = null;
+  try { roadmapRaw = platformReadSync(path.join(planningDir(cwd), 'ROADMAP.md')); } catch { /* ignore */ }
+  if (roadmapRaw === null || !currentMilestoneScopeIsAmbiguous(roadmapRaw, cwd)) return;
+  if (existingFm && existingFm['progress']) {
+    fm['progress'] = normalizeProgressNumbers(existingFm['progress']);
+  } else {
+    delete fm['progress'];
+  }
+}
+
 function syncStateFrontmatter(content: string, cwd: string | undefined): string {
   // Read existing frontmatter BEFORE stripping — it may contain values
   // that the body no longer has (e.g., Status field removed by an agent).
@@ -1737,6 +1762,9 @@ function syncStateFrontmatter(content: string, cwd: string | undefined): string 
   if (!derivedFm['progress'] && existingFm['progress']) {
     derivedFm['progress'] = normalizeProgressNumbers(existingFm['progress']);
   }
+  // #1761: prefer existing progress (or drop it) when the milestone scope is
+  // ambiguous so frontmatter is not silently rewritten off a conflated count.
+  applyAmbiguousMilestoneProgressGuard(derivedFm, existingFm, cwd);
 
   const yamlStr = reconstructFrontmatter(derivedFm as unknown as Frontmatter);
   return `---\n${yamlStr}\n---\n\n${body}`;
@@ -2162,6 +2190,11 @@ function cmdStateJson(cwd: string, raw: boolean): void {
   if (existingFm && shouldPreserveExistingProgress(existingFm['progress'], built['progress'])) {
     built['progress'] = normalizeProgressNumbers(existingFm['progress']);
   }
+  // #1761: `state json` rebuilds progress directly via buildStateFrontmatter and
+  // bypasses syncStateFrontmatter, so apply the same ambiguous-scope guard here —
+  // otherwise the machine-readable read path reports the conflated progress the
+  // write path now refuses to persist.
+  applyAmbiguousMilestoneProgressGuard(built, existingFm, cwd);
 
   output(built, raw, JSON.stringify(built, null, 2));
 }
@@ -2714,11 +2747,18 @@ function cmdStateSync(cwd: string, options: StateSyncOptions | undefined, raw: b
   // would keep re-deriving the inflated denominator and report "no drift".
   let syncRoadmapScope: string | null = null;
   let syncRetiredPhaseNums = new Set<string>();
+  // #1761: when the current milestone cannot be bounded to a ROADMAP section,
+  // extractCurrentMilestone falls back to the whole document and the derived
+  // phase count conflates sibling milestones. Detect that case so we skip the
+  // progress write (off a wrong denominator) and warn instead of silently
+  // persisting incorrect numbers.
+  let milestoneScopeAmbiguous = false;
   try {
     const roadmapRaw = platformReadSync(path.join(planningDir(cwd), 'ROADMAP.md'));
     if (roadmapRaw !== null) {
       syncRoadmapScope = extractCurrentMilestone(roadmapRaw, cwd);
       syncRetiredPhaseNums = extractRetiredPhaseNumbers(syncRoadmapScope);
+      milestoneScopeAmbiguous = currentMilestoneScopeIsAmbiguous(roadmapRaw, cwd);
     }
   } catch { /* fall through: no roadmap scope → no retired exclusion */ }
 
@@ -2811,8 +2851,12 @@ function cmdStateSync(cwd: string, options: StateSyncOptions | undefined, raw: b
     const p = computeProgressPercent(totalDiskSummaries, totalDiskPlans, diskCompletedPhases, syncTotalPhases);
     return p !== null ? p : 0;
   })();
+  // #1761: skip the progress write when the milestone scope is ambiguous —
+  // `percent` would be computed off a denominator that conflates sibling
+  // milestones. Leave the existing Progress line untouched and warn instead of
+  // silently persisting a wrong value.
   const currentProgress = stateExtractField(modified, 'Progress');
-  if (currentProgress) {
+  if (currentProgress && !milestoneScopeAmbiguous) {
     const currentPercent = parseInt(currentProgress.replace(/[^\d]/g, ''), 10);
     if (currentPercent !== percent) {
       const barWidth = 10;
@@ -2835,8 +2879,15 @@ function cmdStateSync(cwd: string, options: StateSyncOptions | undefined, raw: b
     modified = result;
   }
 
+  // #1761: surface the ambiguous-scope skip so the progress mismatch is visible
+  // rather than silent. Emitted on stderr (human) and in the JSON result.
+  const warning = milestoneScopeAmbiguous
+    ? 'Current milestone could not be bounded to a ROADMAP section (no versioned milestone heading matched the STATE.md milestone anchor). Progress left untouched to avoid writing a count that conflates sibling milestones. Add a versioned milestone heading (e.g. "## vX.Y — Name") or correct the STATE.md `milestone:` anchor.'
+    : null;
+  if (warning) console.warn(`[gsd] ${warning}`);
+
   if (verify) {
-    output({ synced: false, changes, dry_run: true }, raw, undefined);
+    output({ synced: false, changes, dry_run: true, ...(warning ? { warning } : {}) }, raw, undefined);
     return;
   }
 
@@ -2844,7 +2895,7 @@ function cmdStateSync(cwd: string, options: StateSyncOptions | undefined, raw: b
     writeStateMd(statePath, modified, cwd);
   }
 
-  output({ synced: true, changes, dry_run: false }, raw, undefined);
+  output({ synced: true, changes, dry_run: false, ...(warning ? { warning } : {}) }, raw, undefined);
 }
 
 /**

--- a/tests/roadmap-parser.test.cjs
+++ b/tests/roadmap-parser.test.cjs
@@ -32,6 +32,7 @@ const {
   getRoadmapPhaseInternal,
   getMilestoneInfo,
   getMilestonePhaseFilter,
+  currentMilestoneScopeIsAmbiguous,
 } = roadmapParser;
 
 // ─── helpers ─────────────────────────────────────────────────────────────────
@@ -606,5 +607,182 @@ describe('roadmap-parser: getMilestonePhaseFilter', () => {
     const filter = getMilestonePhaseFilter(tmpDir);
     assert.strictEqual(filter('02-01-setup'), true, 'bracket-prefixed phase 2-01 matched');
     assert.strictEqual(filter('02-02-build'), true, 'bracket-prefixed phase 2-02 matched');
+  });
+});
+
+// ─── currentMilestoneScopeIsAmbiguous (#1761) ─────────────────────────────────
+//
+// The detector exists so `state sync` can refuse to write a progress number
+// derived from extractCurrentMilestone's whole-document fallback when that
+// fallback would conflate sibling milestones. It must fire ONLY when the
+// fallback is demonstrably wrong, never on legacy single-milestone projects.
+describe('roadmap-parser: currentMilestoneScopeIsAmbiguous (#1761)', () => {
+  let tmpDir;
+
+  beforeEach(() => { tmpDir = createTempProject(); });
+  afterEach(() => { cleanup(tmpDir); });
+
+  test('true: multi-milestone, unversioned headings, anchor matches no heading', () => {
+    writeRoadmap(tmpDir, [
+      '# Roadmap',
+      '## Milestone 2: Foundation',
+      '### Phase 1: Setup',
+      '### Phase 2: Scaffold',
+      '## Milestone 3: Build',
+      '### Phase 4: API',
+      '### Phase 5: UI',
+    ].join('\n'));
+    writeState(tmpDir, { milestone: 'v3.0' });
+    const roadmap = fs.readFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), 'utf-8');
+    assert.strictEqual(currentMilestoneScopeIsAmbiguous(roadmap, tmpDir), true);
+  });
+
+  test('false: single-milestone unversioned heading (whole-doc scope is correct)', () => {
+    writeRoadmap(tmpDir, [
+      '# Roadmap',
+      '## Milestone 1: Everything',
+      '### Phase 1: Setup',
+      '### Phase 2: Build',
+    ].join('\n'));
+    writeState(tmpDir, { milestone: 'v1.0' });
+    const roadmap = fs.readFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), 'utf-8');
+    assert.strictEqual(currentMilestoneScopeIsAmbiguous(roadmap, tmpDir), false);
+  });
+
+  test('false: anchor resolves to a versioned milestone heading', () => {
+    writeRoadmap(tmpDir, [
+      '# Roadmap',
+      '## v2.0 — Foundation ✅',
+      '### Phase 1: Setup',
+      '## v3.0 — Build 🚧',
+      '### Phase 4: API',
+      '### Phase 5: UI',
+    ].join('\n'));
+    writeState(tmpDir, { milestone: 'v3.0' });
+    const roadmap = fs.readFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), 'utf-8');
+    assert.strictEqual(currentMilestoneScopeIsAmbiguous(roadmap, tmpDir), false);
+  });
+
+  test('false: no milestone anchor at all (legacy whole-doc scope intended)', () => {
+    writeRoadmap(tmpDir, [
+      '# Roadmap',
+      '## Milestone 2: Foundation',
+      '### Phase 1: Setup',
+      '## Milestone 3: Build',
+      '### Phase 4: API',
+    ].join('\n'));
+    writeState(tmpDir, { phase: 'some-phase' }); // no `milestone:` field
+    const roadmap = fs.readFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), 'utf-8');
+    assert.strictEqual(currentMilestoneScopeIsAmbiguous(roadmap, tmpDir), false);
+  });
+
+  test('false: anchor resolves via a <summary> in a shipped <details> block', () => {
+    writeRoadmap(tmpDir, [
+      '# Roadmap',
+      '<details><summary>v2.0 — Foundation</summary>',
+      '### Phase 1: Setup',
+      '</details>',
+      '## Milestone 3: Build',
+      '### Phase 4: API',
+    ].join('\n'));
+    writeState(tmpDir, { milestone: 'v2.0' });
+    const roadmap = fs.readFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), 'utf-8');
+    assert.strictEqual(currentMilestoneScopeIsAmbiguous(roadmap, tmpDir), false);
+  });
+
+  test('true: mixed roadmap — current versioned but section bleeds into an unversioned sibling', () => {
+    // extractCurrentMilestone's section end only stops on versioned/marked
+    // headings, so `## v3.0` scope bleeds past the unversioned `## Milestone 4`,
+    // conflating its phases. The scope-based count catches this even though the
+    // anchor itself resolves to a heading.
+    writeRoadmap(tmpDir, [
+      '# Roadmap',
+      '## v3.0 — Build 🚧',
+      '### Phase 4: API',
+      '### Phase 5: UI',
+      '## Milestone 4: Later',
+      '### Phase 6: Polish',
+    ].join('\n'));
+    writeState(tmpDir, { milestone: 'v3.0' });
+    const roadmap = fs.readFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), 'utf-8');
+    assert.strictEqual(currentMilestoneScopeIsAmbiguous(roadmap, tmpDir), true);
+  });
+
+  test('false: a non-milestone "## Milestone Notes" prose heading does not count as a milestone', () => {
+    // The numeric `Milestone \d` requirement keeps prose headings from being
+    // mistaken for milestone-section boundaries (would otherwise false-positive).
+    writeRoadmap(tmpDir, [
+      '# Roadmap',
+      '## v3.0 — Build 🚧',
+      '### Phase 4: API',
+      '## Milestone Notes',
+      'Some running notes.',
+    ].join('\n'));
+    writeState(tmpDir, { milestone: 'v3.0' });
+    const roadmap = fs.readFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), 'utf-8');
+    assert.strictEqual(currentMilestoneScopeIsAmbiguous(roadmap, tmpDir), false);
+  });
+
+  test('false: deeper marker-bearing subheadings inside a bounded milestone do not count', () => {
+    // extractCurrentMilestone bounds `## v3.0` correctly; the scope legitimately
+    // contains deeper `### v3.0 Notes` / `### Milestone 4 Risks` subheadings.
+    // Only the shallowest milestone level counts, so this stays bounded (false).
+    writeRoadmap(tmpDir, [
+      '# Roadmap',
+      '## v3.0 — Build 🚧',
+      '### Phase 4: API',
+      '### v3.0 Notes',
+      '### Milestone 4 Risks',
+      '### Phase 5: UI',
+    ].join('\n'));
+    writeState(tmpDir, { milestone: 'v3.0' });
+    const roadmap = fs.readFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), 'utf-8');
+    assert.strictEqual(currentMilestoneScopeIsAmbiguous(roadmap, tmpDir), false);
+  });
+
+  test('false: #730 split layout — a milestone + its (Phase Details) continuation count once', () => {
+    // extractCurrentMilestone appends the current milestone's `(Phase Details)`
+    // section to its scope. Boundary heading and continuation share the same
+    // version identity, so the scope spans ONE distinct milestone — not ambiguous.
+    writeRoadmap(tmpDir, [
+      '# Roadmap: Example',
+      '',
+      '## Phases',
+      '',
+      '- [x] **Phase 1: Setup**',
+      '',
+      '### Milestone v1.1 — Second milestone (added 2026-01-01)',
+      '',
+      '- [ ] **Phase 2: Feature**',
+      '',
+      '## Phase Details',
+      '',
+      '### Phase 1: Setup',
+      '**Goal:** scaffold.',
+      '',
+      '## Milestone v1.1 — Second milestone (Phase Details)',
+      '',
+      '### Phase 2: Feature',
+      '**Goal:** build.',
+    ].join('\n'));
+    writeState(tmpDir, { milestone: 'v1.1' });
+    const roadmap = fs.readFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), 'utf-8');
+    assert.strictEqual(currentMilestoneScopeIsAmbiguous(roadmap, tmpDir), false);
+  });
+
+  test('false (documented limitation): free-form Sprint/Release headings are not detected', () => {
+    // `## Sprint N` / `## Release N` carry no milestone marker and no `Milestone`
+    // label, so the detector stays conservative and preserves existing behavior
+    // rather than guessing. Pinned so a future change to this boundary is deliberate.
+    writeRoadmap(tmpDir, [
+      '# Roadmap',
+      '## Sprint 2',
+      '### Phase 1: Setup',
+      '## Sprint 3',
+      '### Phase 4: API',
+    ].join('\n'));
+    writeState(tmpDir, { milestone: 'v3.0' });
+    const roadmap = fs.readFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), 'utf-8');
+    assert.strictEqual(currentMilestoneScopeIsAmbiguous(roadmap, tmpDir), false);
   });
 });

--- a/tests/state.test.cjs
+++ b/tests/state.test.cjs
@@ -2704,6 +2704,163 @@ describe('state sync command', () => {
     const after = fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
     assert.strictEqual(before, after, 'File should not be modified in verify mode');
   });
+
+  // #1761: When the current milestone cannot be bounded to a ROADMAP section,
+  // extractCurrentMilestone falls back to the whole document and the derived
+  // phase count conflates sibling milestones. state sync must NOT write a
+  // progress value off that conflated denominator — it must leave Progress
+  // untouched and surface a warning instead of silently persisting wrong data.
+  describe('ambiguous milestone scope (#1761)', () => {
+    // Two-milestone ROADMAP with UNVERSIONED headings; STATE anchors to v3.0,
+    // which matches no heading. The current milestone (v3.0) has 2 phases (4,5),
+    // both complete → correct progress is 100%. The whole-document fallback sees
+    // 5 phases across both milestones → would compute a wrong 40%.
+    function setupAmbiguousProject(tmpDir) {
+      fs.writeFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), [
+        '# Roadmap',
+        '## Milestone 2: Foundation',
+        '### Phase 1: Setup',
+        '### Phase 2: Scaffold',
+        '### Phase 3: Models',
+        '## Milestone 3: Build',
+        '### Phase 4: API',
+        '### Phase 5: UI',
+      ].join('\n'));
+      fs.writeFileSync(path.join(tmpDir, '.planning', 'STATE.md'), [
+        '---', 'milestone: v3.0', '---', '',
+        '# Project State', '',
+        'Progress: [██████████] 100%',
+        'Last Activity: 2026-06-01',
+      ].join('\n'));
+      for (const p of ['04-api', '05-ui']) {
+        const dir = path.join(tmpDir, '.planning', 'phases', p);
+        fs.mkdirSync(dir, { recursive: true });
+        fs.writeFileSync(path.join(dir, 'PLAN.md'), '# Plan\n');
+        fs.writeFileSync(path.join(dir, 'SUMMARY.md'), '# Summary\n');
+      }
+    }
+
+    test('--verify does not propose a Progress change and reports a warning', () => {
+      setupAmbiguousProject(tmpDir);
+      const result = runGsdTools('state sync --verify', tmpDir);
+      assert.ok(result.success, `Command failed: ${result.error}`);
+      const output = JSON.parse(result.output);
+
+      const progressChange = (output.changes || []).find(c => /^Progress:/.test(c));
+      assert.strictEqual(progressChange, undefined,
+        'must not propose a Progress change off a conflated denominator');
+      assert.ok(output.warning && /milestone/i.test(output.warning),
+        'should surface a milestone-scope warning');
+    });
+
+    test('write mode leaves both body AND frontmatter progress untouched', () => {
+      // Seed correct progress in BOTH the body line and the YAML frontmatter so
+      // we can prove neither is silently rewritten off the conflated (5-phase)
+      // denominator. Without the frontmatter guard, writeStateMd -> buildState-
+      // Frontmatter would rewrite `percent: 100` to the conflated `percent: 40`.
+      fs.writeFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), [
+        '# Roadmap',
+        '## Milestone 2: Foundation',
+        '### Phase 1: Setup',
+        '### Phase 2: Scaffold',
+        '### Phase 3: Models',
+        '## Milestone 3: Build',
+        '### Phase 4: API',
+        '### Phase 5: UI',
+      ].join('\n'));
+      fs.writeFileSync(path.join(tmpDir, '.planning', 'STATE.md'), [
+        '---', 'milestone: v3.0', 'status: in-progress',
+        'progress:', '  total_phases: 2', '  completed_phases: 2',
+        '  total_plans: 2', '  completed_plans: 2', '  percent: 100', '---', '',
+        '# Project State', '',
+        'Progress: [██████████] 100%',
+        'Last Activity: 2026-06-01',
+      ].join('\n'));
+      for (const p of ['04-api', '05-ui']) {
+        const dir = path.join(tmpDir, '.planning', 'phases', p);
+        fs.mkdirSync(dir, { recursive: true });
+        fs.writeFileSync(path.join(dir, 'PLAN.md'), '# Plan\n');
+        fs.writeFileSync(path.join(dir, 'SUMMARY.md'), '# Summary\n');
+      }
+
+      const result = runGsdTools('state sync', tmpDir);
+      assert.ok(result.success, `Command failed: ${result.error}`);
+
+      const stateAfter = fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
+      // Body Progress line preserved; the conflated 40% never written anywhere.
+      assert.match(stateAfter, /Progress: \[██████████\] 100%/);
+      assert.doesNotMatch(stateAfter, /40%/);
+      // Frontmatter progress preserved (CRITICAL: not rewritten off 5 phases).
+      assert.match(stateAfter, /percent:\s*100/);
+      assert.match(stateAfter, /total_phases:\s*2/);
+    });
+
+    test('bounded milestone (versioned heading) still syncs progress normally', () => {
+      // Same phases, but headings carry the version → scope bounds correctly,
+      // so the gate must NOT fire and sync proceeds as before.
+      fs.writeFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), [
+        '# Roadmap',
+        '## v2.0 — Foundation ✅',
+        '### Phase 1: Setup',
+        '## v3.0 — Build 🚧',
+        '### Phase 4: API',
+        '### Phase 5: UI',
+      ].join('\n'));
+      fs.writeFileSync(path.join(tmpDir, '.planning', 'STATE.md'), [
+        '---', 'milestone: v3.0', '---', '',
+        '# Project State', '',
+        'Progress: [░░░░░░░░░░] 0%',
+        'Last Activity: 2026-06-01',
+      ].join('\n'));
+      for (const p of ['04-api', '05-ui']) {
+        const dir = path.join(tmpDir, '.planning', 'phases', p);
+        fs.mkdirSync(dir, { recursive: true });
+        fs.writeFileSync(path.join(dir, 'PLAN.md'), '# Plan\n');
+        fs.writeFileSync(path.join(dir, 'SUMMARY.md'), '# Summary\n');
+      }
+
+      const result = runGsdTools('state sync --verify', tmpDir);
+      assert.ok(result.success, `Command failed: ${result.error}`);
+      const output = JSON.parse(result.output);
+      assert.strictEqual(output.warning, undefined, 'bounded scope must not warn');
+    });
+
+    test('state json does not report conflated progress for an ambiguous scope', () => {
+      // `state json` rebuilds progress via buildStateFrontmatter and bypasses the
+      // write-path guard, so it must apply the same ambiguous-scope guard — else
+      // the machine-readable read path reports the conflated value the write path
+      // refuses to persist.
+      fs.writeFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), [
+        '# Roadmap',
+        '## Milestone 2: Foundation',
+        '### Phase 1: Setup',
+        '### Phase 2: Scaffold',
+        '### Phase 3: Models',
+        '## Milestone 3: Build',
+        '### Phase 4: API',
+        '### Phase 5: UI',
+      ].join('\n'));
+      fs.writeFileSync(path.join(tmpDir, '.planning', 'STATE.md'), [
+        '---', 'milestone: v3.0',
+        'progress:', '  total_phases: 2', '  completed_phases: 2', '  percent: 100', '---', '',
+        '# Project State', '',
+        'Progress: [██████████] 100%',
+      ].join('\n'));
+      for (const p of ['04-api', '05-ui']) {
+        const dir = path.join(tmpDir, '.planning', 'phases', p);
+        fs.mkdirSync(dir, { recursive: true });
+        fs.writeFileSync(path.join(dir, 'PLAN.md'), '# Plan\n');
+        fs.writeFileSync(path.join(dir, 'SUMMARY.md'), '# Summary\n');
+      }
+
+      const result = runGsdTools('state json', tmpDir);
+      assert.ok(result.success, `Command failed: ${result.error}`);
+      const output = JSON.parse(result.output);
+      // Existing (correct) progress preserved; conflated 5-phase/40% not reported.
+      assert.strictEqual(output.progress.total_phases, 2);
+      assert.strictEqual(output.progress.percent, 100);
+    });
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #1761

## What was broken

On a ROADMAP that uses free-form (unversioned) milestone headings (e.g. `## Milestone 3: Name`), `gsd-tools state sync` silently wrote **incorrect** progress numbers into STATE.md — both the body `Progress:` line and the YAML frontmatter `progress` block — reporting `synced: true` with no warning. `state json` reported the same conflated value.

## What this fix does

Detects when the current milestone cannot be bounded to a single ROADMAP section and, in that case, leaves progress untouched (preferring the existing values) and surfaces a warning, instead of persisting/reporting a count derived from a scope that conflates sibling milestones.

## Root cause

`extractCurrentMilestone` resolves the current-milestone scope from STATE.md's `milestone:` anchor. When that version matches no versioned milestone heading and no `<summary>`, it falls back to `stripShippedMilestones(content)` — effectively the **whole** document. The progress math (`cmdStateSync` for the body line, `buildStateFrontmatter` for the frontmatter, both reached on every `writeStateMd`, plus `cmdStateJson` directly) then counts phase headings across **all** milestones → inflated `total_phases` → wrong `percent`. Empirically: a 2-milestone unversioned ROADMAP with the current milestone (2 phases, both complete = 100%) was written as `40%` (2 complete / 5 conflated phases).

## How it fixes it

- New scope-based detector `currentMilestoneScopeIsAmbiguous` (`src/roadmap-parser.cts`): resolves the version anchor, then counts **distinct milestone identities at the shallowest heading level within the resolved scope**. A correctly bounded milestone yields one; the whole-document fallback **and** a section that bleeds past an unversioned sibling both yield ≥ 2. Identity dedupe (version token / numeric `Milestone N` / emoji-marked text, with the `(Phase Details)` suffix stripped) prevents a milestone's split [#730] continuation from double-counting; the shallowest-level filter ignores deeper marker-bearing subheadings (`### v3.0 Notes`).
- `cmdStateSync`: skips the body `Progress` write and emits a `warning` (stderr + JSON) when ambiguous.
- `syncStateFrontmatter` **and** `cmdStateJson`: a shared `applyAmbiguousMilestoneProgressGuard` prefers the existing frontmatter `progress` (or drops it) over the conflated derivation, so neither the on-disk frontmatter nor `state json` output is rewritten off a wrong denominator.

Single-milestone, versioned-and-resolved, and no-anchor ROADMAPs are unaffected (detector returns `false`), so existing projects sync exactly as before.

## Testing

### How I verified the fix

Reproduced and verified end-to-end against the **built** `gsd-tools.cjs` artifact: a 2-milestone unversioned ROADMAP went from a silent `Progress: 100% → 40%` (body) and `percent: 40` (frontmatter) write to leaving both at 100% with a warning; `state json` reports the preserved `total_phases: 2, percent: 100` instead of the conflated `5 / 40`. Verified the detector against the full matrix: whole-doc fallback, mixed versioned/unversioned bleed, deep subheadings, `## Milestone Notes`, bounded versioned multi, single-milestone free-form, and #730 split `(Phase Details)` layouts.

Test-the-test: confirmed the new behavioral tests fail on the unfixed artifact and pass on the fix. Full sweep across roadmap/milestone/phase/state/init suites: 836 pass / 0 fail / 1 pre-existing skip. ESLint, regression-test-name, allow-test-rule, and golden-install-parity (16/16) all clean. Reviewed by Codex over three rounds (APPROVED).

### Regression test added?

- [x] Yes — 10 detector unit tests (`tests/roadmap-parser.test.cjs`) + 4 `state sync`/`state json` integration tests (`tests/state.test.cjs`)
- [ ] No — explain why:

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [x] N/A (not platform-specific)

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix — added after PR creation (the `pr:` field needs the real PR number)
- [x] No unnecessary dependencies added

## Known limitation

Free-form milestone headings that use neither a version token, a numeric `Milestone N` label, nor a status emoji (e.g. `## Sprint 3`, `## Release 2`) are intentionally **not** detected — the detector stays conservative and preserves current behavior rather than guessing. This is pinned by a test so any future change to that boundary is deliberate.

## Breaking changes

None — behavior changes only for STATE.md/ROADMAP combinations where progress was already being computed off an unresolvable (conflated) milestone scope. Bounded and single-milestone projects are byte-for-byte unaffected.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1777"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785169297&installation_id=134682257&pr_number=1777&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1777&signature=07cd7eb287333394ad9be89a5a0d4b32ac05f7a997c1a52da9b99b503b635524"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->