### PR TITLE
fix(decisions): parse non-colon bold terminators in decision bullets

### DIFF
--- a/get-shit-done/bin/lib/decisions.cjs
+++ b/get-shit-done/bin/lib/decisions.cjs
@@ -52,12 +52,26 @@ function parseDecisions(content) {
     const out = [];
     let category = '';
     let inDiscretion = false;
-    // Bullet line: `- **D-NN[ [tags]]:** text`
-    // Phase 6 (#3575): aligned to CJS regex — accepts alphanumeric IDs (D-01, D-INFRA-01, D-FOO_BAR)
-    // in addition to numeric-only IDs (D-42). The first character after `D-` must
-    // be alphanumeric, so malformed shapes like `D--foo` or `D-_bar` are rejected.
+    // Bullet line: `- **D-NN[ [tag]][ Title][:]** [`[tag]`][:] text`
+    // Accepts alphanumeric IDs (D-01, D-INFRA-01, D-FOO_BAR) in addition to
+    // numeric-only IDs (D-42). The first character after `D-` must be
+    // alphanumeric, so malformed shapes like `D--foo` or `D-_bar` are rejected.
+    //
+    // The bold lead-in may close with ANY punctuation, not only a colon: the
+    // terminator is `[^*]*\*\*` (consume the rest of the title up to the closing
+    // `**`), which makes period-terminated bullets like `- **D-PS-01 New field.**`
+    // parse instead of silently dropping. Before this, the terminator was
+    // `:\*\*`, which required a literal `...:**` and dropped every other shape —
+    // the post-planning gate then counted only what parsed and returned a
+    // vacuous pass over a fraction of the real decisions.
+    //
+    // Capture groups: 1=ID, 2=tag inside the bold (`[tag] Title:**`),
+    // 3=tag outside the bold (`** `[tag]`:` or `** [tag]:`), 4=body. The tag is
+    // resolved as (m[2] || m[3]); back-compat with `- **D-NN [deferred]:** text`
+    // is preserved (the colon and tag are absorbed by `[^*]*` / the optionals).
+    // Residual: a lone `*` inside a title still terminates the bold prematurely.
     // CJS callers consume {id, text} and ignore the optional extras.
-    const bulletRe = /^\s*-\s+\*\*D-([A-Za-z0-9][A-Za-z0-9_-]*)(?:\s*\[([^\]]+)\])?\s*:\*\*\s*(.*)$/;
+    const bulletRe = /^\s*-\s+\*\*D-([A-Za-z0-9][A-Za-z0-9_-]*)(?:\s*\[([^\]]+)\])?[^*]*\*\*\s*`?(?:\[([^\]]+)\])?`?\s*:?\s*(.*)$/;
     let current = null;
     const flush = () => {
         if (current) {
@@ -88,14 +102,17 @@ function parseDecisions(content) {
         if (bulletMatch) {
             flush();
             const id = `D-${bulletMatch[1]}`;
-            const tags = bulletMatch[2]
-                ? bulletMatch[2]
+            // Tag may appear inside the bold (`[tag] Title:**`, group 2) or
+            // outside it (`** [tag]:` / `` ** `[tag]`: ``, group 3); take whichever matched.
+            const rawTag = bulletMatch[2] || bulletMatch[3];
+            const tags = rawTag
+                ? rawTag
                     .split(',')
                     .map((t) => t.trim().toLowerCase())
                     .filter(Boolean)
                 : [];
             const trackable = !inDiscretion && !tags.some((t) => NON_TRACKABLE_TAGS.has(t));
-            current = { id, text: bulletMatch[3], category, tags, trackable };
+            current = { id, text: bulletMatch[4], category, tags, trackable };
             continue;
         }
         // Continuation line for current decision (indented with space OR tab,

--- a/tests/post-planning-gaps-2493.test.cjs
+++ b/tests/post-planning-gaps-2493.test.cjs
@@ -123,6 +123,67 @@ After the block. - **D-77:** Also not real.
     const ds = parseDecisions(md);
     assert.deepStrictEqual(ds.map(d => d.id), ['D-01']);
   });
+
+  // Regression: bulletRe required a colon to close the bold lead-in (`...:**`),
+  // so a bullet whose bold ends with any other punctuation — e.g.
+  // `- **D-NN Title.** body` (bold ends `.**`, not `:**`) — silently failed to
+  // parse and the decision was DROPPED. The post-planning gate counts only what
+  // parsed, so dropping bullets produced a vacuous pass (total:2 covered:2 when
+  // the real block had 8 decisions). These tests assert the backward-compatible
+  // superset terminator parses every shape with ZERO drops.
+
+  test('parses all decision bullet terminator shapes with zero drops', () => {
+    const md = `
+<decisions>
+## CONTEXT Decisions
+
+### Implementation
+- **D-00 [informational] Framing:** establishes the framing
+- **D-PS-01 New field.** adds the persisted column
+- **D-CARRY-2 Column trap:** carried over from the prior phase
+- **D-NN [deferred]:** revisit next milestone
+</decisions>
+`;
+    const ds = parseDecisions(md);
+    assert.strictEqual(ds.length, 4, 'all four bullets must parse — zero silent drops');
+    assert.deepStrictEqual(ds.map(d => d.id), ['D-00', 'D-PS-01', 'D-CARRY-2', 'D-NN']);
+    // informational + deferred are non-trackable; the two plain bullets are trackable.
+    assert.strictEqual(ds.filter(d => d.trackable).length, 2,
+      'only the non-tagged bullets are trackable; informational/deferred are excluded');
+  });
+
+  test('period-terminated bullet (`Title.**`) parses as trackable (the bug case)', () => {
+    const ds = parseDecisions('<decisions>\n- **D-PS-01 New field.** adds the persisted column\n</decisions>');
+    assert.strictEqual(ds.length, 1, 'period-terminated bullet must not be dropped');
+    assert.strictEqual(ds[0].id, 'D-PS-01');
+    assert.strictEqual(ds[0].text, 'adds the persisted column');
+    assert.strictEqual(ds[0].trackable, true);
+  });
+
+  test('colon-in-title bullet (`Title:**`) parses as trackable (back-compat)', () => {
+    const ds = parseDecisions('<decisions>\n- **D-CARRY-2 Column trap:** carried over from the prior phase\n</decisions>');
+    assert.strictEqual(ds.length, 1, 'colon-in-title bullet must parse');
+    assert.strictEqual(ds[0].id, 'D-CARRY-2');
+    assert.strictEqual(ds[0].text, 'carried over from the prior phase');
+    assert.strictEqual(ds[0].trackable, true);
+  });
+
+  test('inside-bold [informational] tag parses and marks the decision non-trackable', () => {
+    const ds = parseDecisions('<decisions>\n- **D-00 [informational] Framing:** establishes the framing\n</decisions>');
+    assert.strictEqual(ds.length, 1, 'informational bullet must parse');
+    assert.strictEqual(ds[0].id, 'D-00');
+    assert.deepStrictEqual(ds[0].tags, ['informational']);
+    assert.strictEqual(ds[0].trackable, false);
+  });
+
+  test('canonical `- **D-NN [deferred]:** text` bullet parses with deferred tag (back-compat)', () => {
+    const ds = parseDecisions('<decisions>\n- **D-NN [deferred]:** text\n</decisions>');
+    assert.strictEqual(ds.length, 1, 'canonical deferred bullet must parse');
+    assert.strictEqual(ds[0].id, 'D-NN');
+    assert.strictEqual(ds[0].text, 'text');
+    assert.deepStrictEqual(ds[0].tags, ['deferred']);
+    assert.strictEqual(ds[0].trackable, false);
+  });
 });
 
 // ─── Gap analysis CLI ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #1780

> Note: I'm an external contributor (no write access). A maintainer needs to add the `confirmed-bug` label to #1780 to satisfy the pre-approved-issue policy, then reopen this PR.

## What was broken

`parseDecisions` (`get-shit-done/bin/lib/decisions.cjs`) silently dropped any `<decisions>` bullet whose bold lead-in closed with punctuation other than a colon (e.g. `- **D-PS-01 New field.**`). Because the post-planning decision-coverage gate counts only the bullets that parsed, dropped bullets produced a **vacuous pass** (observed: 6 of 8 CONTEXT decisions dropped, gate reported `total:2 covered:2 passed:true`).

## What this fix does

Replaces the colon-mandatory bold terminator with a backward-compatible **superset**: consume the rest of the title up to the closing `**`, then optionally absorb a backticked/plain external `[tag]` and a trailing colon. Period-terminated, colon-in-title, inside-bold-`[tag]`, and the canonical `[deferred]:` bullets all parse now — zero drops.

## Root cause

```js
// before — required a literal `...:**`
/^\s*-\s+\*\*D-([A-Za-z0-9][A-Za-z0-9_-]*)(?:\s*\[([^\]]+)\])?\s*:\*\*\s*(.*)$/
```

The `\s*:\*\*` terminator demanded a colon to close the bold. Any bullet with title text before the close (`Title.**`, `Title:**`) failed to match and was dropped. The gate measures coverage only over parsed decisions, so the missing decisions were invisible.

```js
// after — any punctuation may close the bold; tag may sit inside or outside it
/^\s*-\s+\*\*D-([A-Za-z0-9][A-Za-z0-9_-]*)(?:\s*\[([^\]]+)\])?[^*]*\*\*\s*`?(?:\[([^\]]+)\])?`?\s*:?\s*(.*)$/
```

Capture groups are now `1=ID, 2=inside-bold tag, 3=external tag, 4=body`; the tag is resolved as `(m[2] || m[3])` and the body reads from `m[4]`. Known residual (unchanged from before): a lone `*` inside a title still terminates the bold prematurely.

## Testing

### How I verified the fix

Added four regression assertions to `tests/post-planning-gaps-2493.test.cjs` (the existing `decisions.cjs parser` describe block). Pre-fix, the period / colon-in-title / inside-bold-`[informational]` cases failed (silent drops) and the combined-block test failed `length 1 !== 4`; post-fix all pass.

- `- **D-00 [informational] Framing:** ...` → parsed, tag `informational`, non-trackable
- `- **D-PS-01 New field.** ...` → parsed, trackable (period-terminated — the bug case)
- `- **D-CARRY-2 Column trap:** ...` → parsed, trackable (colon back-compat)
- `- **D-NN [deferred]:** text` → parsed, tag `deferred` (canonical back-compat)

`npm test`: **1983 pass, 0 fail**, 2 skipped (pre-existing Windows-incompatible POSIX shell tests). `npm run lint`: exit 0.

### Regression test added?

- [x] Yes — added tests that would have caught this bug
- [ ] No

### Platforms tested

- [ ] macOS
- [x] Windows (including backslash path handling)
- [ ] Linux
- [x] N/A (parser logic is platform-independent)

### Runtimes tested

- [x] N/A (not runtime-specific)

## Checklist

- [x] Issue linked above with `Fixes #1780`
- [ ] Linked issue has the `confirmed-bug` label — needs a maintainer (external contributor)
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added
- [x] No unnecessary dependencies added

## Breaking changes

None. The new pattern is a strict superset of the old one; bullets that parsed before parse identically (`id`/`text` unchanged), and previously-dropped bullets now parse.
