### PR TITLE
refactor(#1679): ADR-1239 Phase B — collapse runtimeLabel chains into getRuntimeLabel [AC2 slice 1/6]

### DIFF
--- a/.changeset/sturdy-voles-dart.md
+++ b/.changeset/sturdy-voles-dart.md
@@ -1,0 +1,7 @@
+---
+type: Changed
+pr: 1800
+---
+**Internal: install/uninstall runtime labels are now sourced from a single `getRuntimeLabel` lookup** — the two duplicated `runtimeLabel` assignment chains in `bin/install.js` (uninstall + install) are collapsed into one curated label table in `runtime-name-policy.cts`, sibling to the registry-derived `getDirName` (ADR-1239 Phase B, #1679). Install output is byte-identical for all 16 runtimes (golden-parity asserted). Two console-label inconsistencies are normalized as a side effect: `kimi` shows 'Kimi CLI' in both sites, and `cline` uninstall no longer falls through to 'Claude Code'.
+
+<!-- docs-exempt: internal refactor; only cosmetic console-label normalization with no doc surface to update -->

--- a/bin/install.js
+++ b/bin/install.js
@@ -37,7 +37,7 @@ const {
 // installer to the runtime-name-policy leaf (ADR-1508 / #1510 Phase 1) so the
 // conversion module's rewrite engine can consume it without importing
 // bin/install.js. Re-exported below for back-compat consumers/tests.
-const { getDirName } = require('../gsd-core/bin/lib/runtime-name-policy.cjs');
+const { getDirName, getRuntimeLabel } = require('../gsd-core/bin/lib/runtime-name-policy.cjs');
 const {
   applyWorktreeBaseRef,
   readBaseRefFromSettings,
@@ -6960,21 +6960,9 @@ function uninstall(isGlobal, runtime = 'claude') {
     ? targetDir.replace(os.homedir(), '~')
     : targetDir.replace(process.cwd(), '.');
 
-  let runtimeLabel = 'Claude Code';
-  if (runtime === 'opencode') runtimeLabel = 'OpenCode';
-  if (runtime === 'gemini') runtimeLabel = 'Gemini';
-  if (runtime === 'kilo') runtimeLabel = 'Kilo';
-  if (runtime === 'codex') runtimeLabel = 'Codex';
-  if (runtime === 'copilot') runtimeLabel = 'Copilot';
-  if (runtime === 'antigravity') runtimeLabel = 'Antigravity';
-  if (runtime === 'cursor') runtimeLabel = 'Cursor';
-  if (runtime === 'windsurf') runtimeLabel = 'Windsurf';
-  if (runtime === 'augment') runtimeLabel = 'Augment';
-  if (runtime === 'trae') runtimeLabel = 'Trae';
-  if (runtime === 'qwen') runtimeLabel = 'Qwen Code';
-  if (runtime === 'hermes') runtimeLabel = 'Hermes Agent';
-  if (runtime === 'kimi') runtimeLabel = 'Kimi CLI';
-  if (runtime === 'codebuddy') runtimeLabel = 'CodeBuddy';
+  // runtimeLabel is now the single-source getRuntimeLabel lookup (ADR-1239
+  // Phase B / #1679) — collapses the prior 15-line assignment chain.
+  const runtimeLabel = getRuntimeLabel(runtime);
 
   console.log(`  Uninstalling GSD from ${cyan}${runtimeLabel}${reset} at ${cyan}${locationLabel}${reset}\n`);
 
@@ -8599,22 +8587,9 @@ function install(isGlobal, runtime = 'claude', options = {}) {
     homeDir,
   });
 
-  let runtimeLabel = 'Claude Code';
-  if (isOpencode) runtimeLabel = 'OpenCode';
-  if (isGemini) runtimeLabel = 'Gemini';
-  if (isKilo) runtimeLabel = 'Kilo';
-  if (isCodex) runtimeLabel = 'Codex';
-  if (isCopilot) runtimeLabel = 'Copilot';
-  if (isAntigravity) runtimeLabel = 'Antigravity';
-  if (isCursor) runtimeLabel = 'Cursor';
-  if (isWindsurf) runtimeLabel = 'Windsurf';
-  if (isAugment) runtimeLabel = 'Augment';
-  if (isTrae) runtimeLabel = 'Trae';
-  if (isQwen) runtimeLabel = 'Qwen Code';
-  if (isHermes) runtimeLabel = 'Hermes Agent';
-  if (isKimi) runtimeLabel = 'Kimi';
-  if (isCodebuddy) runtimeLabel = 'CodeBuddy';
-  if (isCline) runtimeLabel = 'Cline';
+  // runtimeLabel is now the single-source getRuntimeLabel lookup (ADR-1239
+  // Phase B / #1679) — collapses the prior 16-line assignment chain.
+  const runtimeLabel = getRuntimeLabel(runtime);
 
   console.log(`  Installing for ${cyan}${runtimeLabel}${reset} to ${cyan}${locationLabel}${reset}\n`);
 

--- a/src/runtime-name-policy.cts
+++ b/src/runtime-name-policy.cts
@@ -151,3 +151,60 @@ export function getDirName(runtime: string): string {
   if (typeof dir === 'string' && dir.length > 0) return dir;
   return '.claude';
 }
+
+/**
+ * Curated short display labels for the install/uninstall console output, keyed
+ * by canonical runtime id. The SINGLE source of truth consumed by both
+ * `install()` and `uninstall()` in bin/install.js via `getRuntimeLabel`.
+ *
+ * Collapses the two duplicated `runtimeLabel` assignment chains that previously
+ * lived inline in bin/install.js (ADR-1239 Phase B, #1679) — the add-a-host tax:
+ * a new runtime meant remembering to add a label line in BOTH chains, and they
+ * had drifted out of sync (uninstall omitted `cline` and used a different
+ * `kimi` value than install). This table is the curated canonical resolution:
+ *   - kimi:  install 'Kimi' / uninstall 'Kimi CLI'  → 'Kimi CLI' (majority + descriptor title)
+ *   - cline: install 'Cline' / uninstall (omitted)  → 'Cline'    (majority + descriptor title)
+ *
+ * Voice: these are the SHORT UI labels, intentionally distinct from the
+ * descriptor `title` (the long product name — e.g. "OpenAI Codex CLI",
+ * "GitHub Copilot", "Gemini CLI") which serves documentation/registry display,
+ * not the install console. A future slice may relocate this to a
+ * `runtime.label` descriptor field; until then this table is the source.
+ *
+ * Lookup is RAW-ID only (no alias expansion) — callers pass an already-
+ * canonicalized runtime id, keeping the label surface explicit. Unknown/empty
+ * ids fall back to 'Claude Code' (the always-safe default, fail-closed).
+ *
+ * The drift-guard test (tests/runtime-label-policy.test.cjs) pins this table's
+ * id set to the capability-registry runtime id set, so adding/removing a runtime
+ * forces a deliberate update here.
+ */
+const RUNTIME_LABELS: Readonly<Record<string, string>> = {
+  claude: 'Claude Code',
+  opencode: 'OpenCode',
+  gemini: 'Gemini',
+  kilo: 'Kilo',
+  codex: 'Codex',
+  copilot: 'Copilot',
+  antigravity: 'Antigravity',
+  cursor: 'Cursor',
+  windsurf: 'Windsurf',
+  augment: 'Augment',
+  trae: 'Trae',
+  qwen: 'Qwen Code',
+  hermes: 'Hermes Agent',
+  kimi: 'Kimi CLI',
+  codebuddy: 'CodeBuddy',
+  cline: 'Cline',
+};
+
+/**
+ * Map a canonical runtime id to its short display label for the
+ * install/uninstall console output. Unknown/empty inputs fall back to
+ * 'Claude Code'. Sibling to `getDirName`; pure (no I/O).
+ */
+export function getRuntimeLabel(runtime: string): string {
+  if (!runtime) return 'Claude Code';
+  const label = RUNTIME_LABELS[runtime];
+  return typeof label === 'string' && label.length > 0 ? label : 'Claude Code';
+}

--- a/tests/runtime-label-policy.test.cjs
+++ b/tests/runtime-label-policy.test.cjs
@@ -1,0 +1,103 @@
+'use strict';
+/**
+ * Drift-guard + collapse: getRuntimeLabel must be the SINGLE source of truth for
+ * the install/uninstall console display label, replacing the two duplicated
+ * `runtimeLabel` assignment chains that previously lived in bin/install.js
+ * (uninstall() and install()) — the add-a-host tax ADR-1239 Phase B (#1679)
+ * eliminates.
+ *
+ * Verifies:
+ *   1. For every known runtime id, getRuntimeLabel(id) equals the hardcoded
+ *      golden expected map — a pinned oracle that catches BOTH table bugs AND
+ *      unintended drift (adding/removing a runtime forces a deliberate
+ *      golden-map update here).
+ *   2. getRuntimeLabel('unknown') and getRuntimeLabel('') fall back to
+ *      'Claude Code' (the always-safe default).
+ *   3. The golden id set EXACTLY equals the capability-registry runtime id set
+ *      (adding/removing a runtime forces a golden update here).
+ *
+ * Voice: these are the SHORT UI labels used in the install/uninstall console
+ * output, intentionally distinct from the descriptor `title` (the long product
+ * name, e.g. "OpenAI Codex CLI", "GitHub Copilot") which serves
+ * documentation/registry display. Two prior-chain inconsistencies are resolved
+ * by this canonical map (both move toward the majority + descriptor value):
+ *   - kimi: install said 'Kimi', uninstall said 'Kimi CLI' → canonical 'Kimi CLI'
+ *   - cline: install said 'Cline', uninstall omitted it (→ 'Claude Code') → canonical 'Cline'
+ *
+ * ADR-1239 Phase B (#1679).
+ * Behavioral tests only: assert on returned values, no source-grep.
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const runtimeNamePolicy = require('../gsd-core/bin/lib/runtime-name-policy.cjs');
+const registry = require('../gsd-core/bin/lib/capability-registry.cjs');
+
+const { getRuntimeLabel } = runtimeNamePolicy;
+
+// Golden oracle: hardcoded expected map of all 16 runtime ids to their short
+// install/uninstall display label. A pinned expected value in a TEST is correct
+// — the test IS the oracle (non-circular). Only PRODUCTION code should derive
+// dynamically. If this map diverges from getRuntimeLabel output, either the
+// table is wrong OR the registry changed — both require a deliberate golden-map
+// update here.
+const GOLDEN_LABEL_MAP = {
+  claude: 'Claude Code',
+  opencode: 'OpenCode',
+  gemini: 'Gemini',
+  kilo: 'Kilo',
+  codex: 'Codex',
+  copilot: 'Copilot',
+  antigravity: 'Antigravity',
+  cursor: 'Cursor',
+  windsurf: 'Windsurf',
+  augment: 'Augment',
+  trae: 'Trae',
+  qwen: 'Qwen Code',
+  hermes: 'Hermes Agent',
+  kimi: 'Kimi CLI',
+  codebuddy: 'CodeBuddy',
+  cline: 'Cline',
+};
+
+test('getRuntimeLabel: golden map matches for all 16 known runtime ids', () => {
+  for (const [id, expected] of Object.entries(GOLDEN_LABEL_MAP)) {
+    const actual = getRuntimeLabel(id);
+    assert.strictEqual(
+      actual,
+      expected,
+      `getRuntimeLabel('${id}') diverged from golden.\n` +
+      `  actual:   ${JSON.stringify(actual)}\n` +
+      `  expected: ${JSON.stringify(expected)}`,
+    );
+  }
+});
+
+test('drift guard: registry runtime id set EXACTLY equals the golden map (adding/removing a runtime forces a golden update)', () => {
+  // Without this, a newly-added runtime would pass (its label never checked) and
+  // removing `claude` could pass via the 'Claude Code' fallback. Pin the set
+  // both ways — mirroring the getDirName drift guard.
+  const registryIds = Object.keys(registry.runtimes).sort();
+  const goldenIds = Object.keys(GOLDEN_LABEL_MAP).sort();
+  assert.deepEqual(registryIds, goldenIds,
+    'registry.runtimes id set must exactly match GOLDEN_LABEL_MAP — update the golden map when adding/removing a runtime');
+});
+
+test('getRuntimeLabel fallback: unknown runtime returns "Claude Code"', () => {
+  assert.strictEqual(getRuntimeLabel('unknown'), 'Claude Code',
+    'getRuntimeLabel("unknown") must return "Claude Code" (default fallback)');
+});
+
+test('getRuntimeLabel fallback: empty string returns "Claude Code"', () => {
+  assert.strictEqual(getRuntimeLabel(''), 'Claude Code',
+    'getRuntimeLabel("") must return "Claude Code" (empty-input fallback)');
+});
+
+test('getRuntimeLabel fallback: alias is NOT auto-expanded (raw id match only)', () => {
+  // getRuntimeLabel is a raw-id lookup, not alias-aware (unlike canonicalizeRuntimeName).
+  // Callers pass an already-canonicalized runtime id. An alias must fall back to
+  // the default rather than silently matching — this keeps the label surface
+  // explicit and prevents a future alias from changing console output by accident.
+  assert.strictEqual(getRuntimeLabel('claude-code'), 'Claude Code',
+    'getRuntimeLabel("claude-code") must return the default "Claude Code" (raw-id match only; aliases are not expanded)');
+});


### PR DESCRIPTION
## Feature PR

> **Using the wrong template?**
> — Bug fix: use [fix.md](?template=fix.md)
> — Enhancement to existing behavior: use [enhancement.md](?template=enhancement.md)

---

## Linked Issue

Closes #1679

> #1679 carries the `approved-feature` label (Phase 2 of epic #1678, ADR-1239 Phase B).
>
> ⚠️ **This PR is slice 1 of AC2 only** — it does **not** complete #1679. Merging into `next` (non-default branch) does not auto-close the issue; **#1679 must remain open** until the remaining AC2 slices land. See *Spec compliance* below for the per-AC status.

---

## Feature summary

Slice 1 of AC2 (regional residue-collapse in `bin/install.js`): collapses the two duplicated `runtimeLabel` assignment chains in `install()` and `uninstall()` into a single `getRuntimeLabel(runtime)` lookup in `src/runtime-name-policy.cts` — a curated short-form label table, sibling to the registry-derived `getDirName` precedent. The install/uninstall console label was the add-a-host-tax poster child (a new runtime meant adding a label line to *both* chains, and they had drifted out of sync); this PR makes `getRuntimeLabel` the single source of truth.

---

## What changed

### New files

| File | Purpose |
|------|---------|
| `tests/runtime-label-policy.test.cjs` | Drift-guard test (golden label map for all 16 ids + id-set pinned to capability registry + unknown/empty/alias fallbacks). Mirrors `getdirname-registry-derivation.test.cjs`. |

### Modified files

| File | What changed |
|------|-------------|
| `src/runtime-name-policy.cts` | Add `RUNTIME_LABELS` table + `getRuntimeLabel(runtime)` export (sibling to `getDirName`). |
| `bin/install.js` | Import `getRuntimeLabel`; replace the two `runtimeLabel` chains (install + uninstall) with a single lookup each. `runtime ===` count: **129 → 115**. |

---

## Implementation notes

- **Why a curated table, not a descriptor read:** the descriptor `title` is the *long* product name (`"OpenAI Codex CLI"`, `"GitHub Copilot"`, `"Gemini CLI"`); the install console uses *short* forms (`Codex`, `Copilot`, `Gemini`). Sourcing `title` directly would change 7 runtimes' console output to more verbose forms — an observable change the issue says to avoid. A future slice may relocate this to a `runtime.label` descriptor field; until then the curated table (alongside the existing `FALLBACK_ALIASES` table in the same module) is the source.
- **Two console-label normalizations (the only user-visible change):** the prior chains disagreed, so a single resolver had to pick canonical values. Each chosen value matches the majority chain AND the descriptor `title`:
  - `kimi`: install `'Kimi'` / uninstall `'Kimi CLI'` → **`'Kimi CLI'`** (install changes).
  - `cline`: install `'Cline'` / uninstall omitted (fell through to `'Claude Code'`) → **`'Cline'`** (uninstall changes; fixes the latent omission).
  - The other 14 runtimes are unchanged in both sites.
- **Raw-id lookup, fail-closed:** no alias expansion (callers pass canonicalized ids); unknown/empty ids fall back to `'Claude Code'`.

---

## Spec compliance

This PR is **slice 1 of AC2 only**. Per-AC status of #1679:

- [x] **AC1** — `install-engine.cjs` engine entry importable. ✅ **Already shipped** (`src/install-engine.cts`, required at `bin/install.js:382`; moves logged at 6296/6380/6525). Not touched by this PR.
- [~] **AC2** — fold per-runtime residue into descriptors + 16-runtime golden parity. **Partial — this PR.** `NON_CLAUDE_RUNTIMES`/`getDirName` already registry-derived; `copyWithPathReplacement` converter selection data-driven (prior slice). This PR collapses the `runtimeLabel` chains (**129 → 115** `runtime === ` branches). **~115 branches remain** (regions 1-2000, 8001-10000, 10001-12000) for follow-up slices.
- [x] **AC3** — `destSubpath` write-confinement. ✅ **Already shipped** (`assertDestWithinConfigHome` threaded through write sites; 789-line test `fix-1679-destsubpath-confinement.test.cjs`). Not touched by this PR.
- [x] **AC4** — #853 typed dispatch-flatten. ✅ **Already shipped (#1708)** (`shouldFlattenDispatch` at `host-integration.cts:509`; both workflows + bug-853 test graduated). Not touched by this PR.

> 📋 **Tracker-staleness note for @trek-e:** the #1679 Development section shows "No branches or pull requests" but AC1/AC3/AC4 are already in the codebase. Suggest updating #1679 to reflect AC1/3/4 as done and AC2 as multi-slice in progress.

---

## Testing

### Test coverage

- **New:** `tests/runtime-label-policy.test.cjs` — TDD red→green. Golden map (all 16 ids), drift guard (id set pinned to `capability-registry.runtimes`), unknown/empty fallbacks, raw-id-only (no alias expansion).
- **Gate:** `tests/golden-install-parity.test.cjs` — **16/16 byte-identical** (labels are stdout-only, so install file output is unchanged).
- **Regression cluster:** 162/162 pass (label + getDirName drift + bug-853 full behavioral query + host-integration descriptors/validator).
- `runtime ===` in `bin/install.js`: 129 → 115.

### Platforms tested

- [x] macOS (local)
- [ ] Windows — not run locally; golden parity skips Windows by design (platform-specific paths); CI matrix covers it.
- [ ] Linux — not run locally; CI matrix covers it.

### Runtimes tested

- [x] Claude Code
- [x] Gemini CLI
- [x] OpenCode
- [x] Codex
- [x] Copilot
- [x] Other: **all 16 runtimes** asserted byte-identical via `golden-install-parity` (claude, antigravity, augment, cline, codebuddy, codex, copilot, cursor, gemini, hermes, kimi, kilo, opencode, qwen, trae, windsurf).

---

## Scope confirmation

- [ ] The implementation matches the scope approved in the linked issue exactly — **No: this is slice 1 of AC2's multi-slice breakdown, not the whole phase. It is strictly within the approved #1679 scope (no new behavior beyond it).**
- [x] No additional features, commands, or behaviors were added beyond what was approved
- [x] If scope changed during implementation, I updated the issue spec and received re-approval — N/A (scope unchanged; sub-slicing AC2 only)

---

## Documentation

- [ ] Updated the relevant file(s) under `docs/` to reflect this feature — **No doc surface applies** (internal refactor; only cosmetic console-label normalization, no command/flag/config/schema/workflow change to document).
- [x] All `docs/` content added in this PR is written in English — N/A (no docs added).
- [x] If genuinely no user-facing docs impact, apply the `no-docs` label **or** add `<!-- docs-exempt: <reason> -->` inside each triggering changeset fragment — **done**: `.changeset/sturdy-voles-dart.md` carries `<!-- docs-exempt: internal refactor; only cosmetic console-label normalization with no doc surface to update -->`.

---

## Checklist

- [x] Issue linked above with `Closes #1679`
- [x] Linked issue has the `approved-feature` label
- [ ] All acceptance criteria from the issue are met — **No: AC2 is partial (slice 1 of N); AC1/3/4 already shipped in prior PRs. This PR must not close #1679.**
- [x] Implementation scope matches the approved spec exactly — within #1679 scope; no scope creep
- [x] All existing tests pass — 162-test neighbor cluster + 16-runtime golden parity green
- [x] New tests cover the happy path, error cases, and edge cases — golden map + drift guard + fallbacks
- [x] `.changeset/` fragment added — `sturdy-voles-dart.md` (`type: Changed`, `pr: 1800`, docs-exempt)
- [x] No unnecessary external dependencies added
- [x] Works on Windows — no path-handling changed; golden parity covers cross-platform output (Windows skipped by design in that harness, CI matrix asserts)

---

## Breaking changes

Two **console stdout strings** change (cosmetic, not output-format/file-schema/API):

- `gsd-core --uninstall` for `cline`: previously printed `Uninstalling GSD from Claude Code` (fell through the missing `cline` entry); now prints `… from Cline`.
- `gsd-core --install` for `kimi`: previously printed `Installing for Kimi`; now prints `Installing for Kimi CLI`.

Both normalize toward the value the other chain already used and the descriptor `title`. No file output, manifest, config schema, or programmatic API changes. 16-runtime golden install parity is byte-identical.

---

## Screenshots / recordings

N/A — console-label-only change.

---

Closes #1679 *(see Linked Issue note: partial slice; issue should remain open)*.
