### PR TITLE
refactor(#1679): ADR-1239 Phase B — collapse getConfigDirFromHome chain into getGlobalConfigHomeFragment [AC2 slice 2/6]

### DIFF
--- a/.changeset/witty-seals-snooze.md
+++ b/.changeset/witty-seals-snooze.md
@@ -1,0 +1,7 @@
+---
+type: Changed
+pr: 1801
+---
+**Internal: the installer's runtime → global-config-home hook-pathogen fragment is now a single `getGlobalConfigHomeFragment` lookup** — the 14-branch `if (runtime === 'x') return "'...'"` chain in `getConfigDirFromHome` (`bin/install.js`, the hook `path.join()` codegen mapping) is collapsed into one table in `runtime-name-policy.cts`, sibling to `getRuntimeLabel` (ADR-1239 Phase B, #1679 AC2 slice 2). Generated hook output is byte-identical for all 16 runtimes (golden-parity asserted); antigravity's dynamic env-overridable resolution is preserved in the caller. No user-facing change.
+
+<!-- docs-exempt: internal refactor; hook codegen path-fragment table, no user-facing doc surface -->

--- a/bin/install.js
+++ b/bin/install.js
@@ -37,7 +37,7 @@ const {
 // installer to the runtime-name-policy leaf (ADR-1508 / #1510 Phase 1) so the
 // conversion module's rewrite engine can consume it without importing
 // bin/install.js. Re-exported below for back-compat consumers/tests.
-const { getDirName, getRuntimeLabel } = require('../gsd-core/bin/lib/runtime-name-policy.cjs');
+const { getDirName, getRuntimeLabel, getGlobalConfigHomeFragment } = require('../gsd-core/bin/lib/runtime-name-policy.cjs');
 const {
   applyWorktreeBaseRef,
   readBaseRefFromSettings,
@@ -510,18 +510,11 @@ function getConfigDirFromHome(runtime, isGlobal) {
     // Local installs use the same dir name pattern
     return `'${getDirName(runtime)}'`;
   }
-  // Global installs - OpenCode uses XDG path structure
-  if (runtime === 'copilot') return "'.copilot'";
-  if (runtime === 'opencode') {
-    // OpenCode: ~/.config/opencode -> '.config', 'opencode'
-    // Return as comma-separated for path.join() replacement
-    return "'.config', 'opencode'";
-  }
-  if (runtime === 'gemini') return "'.gemini'";
-  if (runtime === 'kilo') return "'.config', 'kilo'";
-  if (runtime === 'codex') return "'.codex'";
+  // Global installs. antigravity's home is resolved dynamically (env-overridable,
+  // multi-segment via resolveAntigravityGlobalDir + path.relative) — not a table
+  // entry. (The prior inner `if (!isGlobal) return "'.agents'"` was unreachable:
+  // !isGlobal returns at the top of this function.)
   if (runtime === 'antigravity') {
-    if (!isGlobal) return "'.agents'";
     const antigravityDir = resolveAntigravityGlobalDir();
     const rel = path.relative(os.homedir(), antigravityDir);
     const segments = rel.split(path.sep).filter(Boolean);
@@ -532,16 +525,9 @@ function getConfigDirFromHome(runtime, isGlobal) {
     // stable legacy template so generated path.join() calls remain valid.
     return "'.gemini', 'antigravity'";
   }
-  if (runtime === 'cursor') return "'.cursor'";
-  if (runtime === 'windsurf') return "'.windsurf'";
-  if (runtime === 'augment') return "'.augment'";
-  if (runtime === 'trae') return "'.trae'";
-  if (runtime === 'qwen') return "'.qwen'";
-  if (runtime === 'hermes') return "'.hermes'";
-  if (runtime === 'codebuddy') return "'.codebuddy'";
-  if (runtime === 'cline') return "'.cline'";
-  if (runtime === 'kimi') return "'.config', 'agents'";
-  return "'.claude'";
+  // All other runtimes: single source-of-truth fragment table (ADR-1239 Phase B,
+  // #1679). claude/unknown fall through to the table's default '.claude'.
+  return getGlobalConfigHomeFragment(runtime);
 }
 
 /**

--- a/src/runtime-name-policy.cts
+++ b/src/runtime-name-policy.cts
@@ -208,3 +208,52 @@ export function getRuntimeLabel(runtime: string): string {
   const label = RUNTIME_LABELS[runtime];
   return typeof label === 'string' && label.length > 0 ? label : 'Claude Code';
 }
+
+/**
+ * Source-string fragments for the runtime → global config-home path, used by
+ * `getConfigDirFromHome` in bin/install.js to template `path.join()` calls in
+ * generated hook scripts. Each value is a JS-source snippet (embedded quotes /
+ * commas are intentional — it is spliced into generated code as path.join args).
+ *
+ * Collapses the prior 14-branch `if (runtime === 'x') return "'...'"` chain in
+ * bin/install.js (ADR-1239 Phase B / #1679, AC2 slice 2) — the add-a-host tax:
+ * a new runtime meant remembering to add a branch here. Values are preserved
+ * BYTE-FOR-BYTE from the prior chain; golden install parity asserts generated
+ * hook output is unchanged across all 16 runtimes.
+ *
+ * Two runtimes are intentionally absent (handled by the caller, NOT this table):
+ *   - `claude`     → the default; falls through to `DEFAULT_FRAGMENT`.
+ *   - `antigravity`→ resolved dynamically via resolveAntigravityGlobalDir +
+ *                    path.relative (multi-segment, env-overridable).
+ *
+ * Unknown/empty ids fall back to the default (`.claude`).
+ */
+const DEFAULT_CONFIG_HOME_FRAGMENT = "'.claude'";
+const GLOBAL_CONFIG_HOME_FRAGMENTS: Readonly<Record<string, string>> = {
+  copilot:   "'.copilot'",
+  opencode:  "'.config', 'opencode'",
+  gemini:    "'.gemini'",
+  kilo:      "'.config', 'kilo'",
+  codex:     "'.codex'",
+  cursor:    "'.cursor'",
+  windsurf:  "'.windsurf'",
+  augment:   "'.augment'",
+  trae:      "'.trae'",
+  qwen:      "'.qwen'",
+  hermes:    "'.hermes'",
+  codebuddy: "'.codebuddy'",
+  cline:     "'.cline'",
+  kimi:      "'.config', 'agents'",
+};
+
+/**
+ * Return the global config-home path-fragment source snippet for a runtime
+ * (for hook path.join() codegen). `claude`/unknown/empty → the default
+ * `'.claude'` fragment. `antigravity` is NOT handled here (caller resolves it
+ * dynamically). Pure: no I/O. Sibling to `getDirName` / `getRuntimeLabel`.
+ */
+export function getGlobalConfigHomeFragment(runtime: string): string {
+  if (!runtime) return DEFAULT_CONFIG_HOME_FRAGMENT;
+  const frag = GLOBAL_CONFIG_HOME_FRAGMENTS[runtime];
+  return typeof frag === 'string' && frag.length > 0 ? frag : DEFAULT_CONFIG_HOME_FRAGMENT;
+}

--- a/tests/global-config-home-fragment.test.cjs
+++ b/tests/global-config-home-fragment.test.cjs
@@ -1,0 +1,95 @@
+'use strict';
+/**
+ * Drift-guard + collapse: getGlobalConfigHomeFragment must be the SINGLE source
+ * of truth for the runtime → global config-home path-fragment mapping used by
+ * `getConfigDirFromHome` in bin/install.js for hook path.join() codegen.
+ *
+ * Collapses the prior 14-branch `if (runtime === 'x') return "'...'"` chain
+ * (install.js ~514-543) into one table — ADR-1239 Phase B / #1679, AC2 slice 2.
+ *
+ * Invariants pinned here:
+ *   1. Each of the 14 table runtimes returns its exact verbatim source fragment
+ *      (byte-identical to the prior chain — golden install parity asserts the
+ *      generated hook output is unchanged).
+ *   2. claude + unknown + empty fall back to the default "'.claude'" fragment.
+ *   3. antigravity is intentionally NOT in the table (handled dynamically by the
+ *      caller via resolveAntigravityGlobalDir).
+ *   4. Drift guard: every registry runtime EXCEPT {claude, antigravity} has a
+ *      table entry — so adding a runtime forces a deliberate fragment decision
+ *      here (the add-a-host tax this collapse removes).
+ *
+ * ADR-1239 Phase B (#1679). Behavioral tests only.
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const runtimeNamePolicy = require('../gsd-core/bin/lib/runtime-name-policy.cjs');
+const registry = require('../gsd-core/bin/lib/capability-registry.cjs');
+
+const { getGlobalConfigHomeFragment } = runtimeNamePolicy;
+
+// Golden oracle: the exact source-string fragments the prior install.js chain
+// emitted, preserved verbatim. These are path.join() arg-source snippets (the
+// embedded quotes/commas are intentional — they get spliced into generated hook
+// scripts). Pinned here as the test oracle.
+const GOLDEN_FRAGMENT_MAP = {
+  copilot:   "'.copilot'",
+  opencode:  "'.config', 'opencode'",
+  gemini:    "'.gemini'",
+  kilo:      "'.config', 'kilo'",
+  codex:     "'.codex'",
+  cursor:    "'.cursor'",
+  windsurf:  "'.windsurf'",
+  augment:   "'.augment'",
+  trae:      "'.trae'",
+  qwen:      "'.qwen'",
+  hermes:    "'.hermes'",
+  codebuddy: "'.codebuddy'",
+  cline:     "'.cline'",
+  kimi:      "'.config', 'agents'",
+};
+
+// Runtimes intentionally NOT in the table: claude is the default; antigravity is
+// resolved dynamically by the caller (resolveAntigravityGlobalDir + path.relative).
+const SPECIAL_CASED = new Set(['claude', 'antigravity']);
+
+test('getGlobalConfigHomeFragment: golden map matches for all 14 table runtimes', () => {
+  for (const [id, expected] of Object.entries(GOLDEN_FRAGMENT_MAP)) {
+    const actual = getGlobalConfigHomeFragment(id);
+    assert.strictEqual(
+      actual,
+      expected,
+      `getGlobalConfigHomeFragment('${id}') diverged from golden.\n` +
+      `  actual:   ${JSON.stringify(actual)}\n` +
+      `  expected: ${JSON.stringify(expected)}`,
+    );
+  }
+});
+
+test('getGlobalConfigHomeFragment fallback: claude/unknown/empty return the default fragment', () => {
+  assert.strictEqual(getGlobalConfigHomeFragment('claude'), "'.claude'",
+    'claude must return the default fragment (it is special-cased as the default)');
+  assert.strictEqual(getGlobalConfigHomeFragment('unknown'), "'.claude'",
+    'unknown runtime must return the default fragment');
+  assert.strictEqual(getGlobalConfigHomeFragment(''), "'.claude'",
+    'empty input must return the default fragment');
+});
+
+test('drift guard: every registry runtime except {claude, antigravity} has a table entry (add-a-host tax removed)', () => {
+  // A newly-added registry runtime that is NOT claude/antigravity MUST get a
+  // deliberate fragment entry here — otherwise it silently falls through to the
+  // '.claude' default. claude (default) and antigravity (caller-dynamic) are the
+  // only legitimate absences.
+  const tableIds = new Set(Object.keys(GOLDEN_FRAGMENT_MAP));
+  const missing = Object.keys(registry.runtimes)
+    .filter((id) => !SPECIAL_CASED.has(id) && !tableIds.has(id));
+  assert.deepEqual(missing, [],
+    `registry runtimes missing a fragment table entry (add one to GOLDEN_FRAGMENT_MAP + the module table, or add to SPECIAL_CASED if caller-dynamic): ${missing.join(', ')}`);
+});
+
+test('drift guard: table keys are a subset of the registry (no stale entries)', () => {
+  const registryIds = new Set(Object.keys(registry.runtimes));
+  const stale = Object.keys(GOLDEN_FRAGMENT_MAP).filter((id) => !registryIds.has(id));
+  assert.deepEqual(stale, [],
+    `fragment table references runtimes not in the registry (stale entries): ${stale.join(', ')}`);
+});


### PR DESCRIPTION
## Feature PR

> **Using the wrong template?**
> — Bug fix: use [fix.md](?template=fix.md)
> — Enhancement to existing behavior: use [enhancement.md](?template=enhancement.md)

---

## Linked Issue

Closes #1679

> #1679 carries `approved-feature` (Phase 2 of epic #1678, ADR-1239 Phase B).
>
> ⚠️ **This PR is AC2 slice 2** — it does **not** complete #1679. Merging into `next` (non-default) does not auto-close the issue; **#1679 must remain open** until the remaining AC2 slices land. Slice 1 (#1800, runtimeLabel) is already merged.

---

## Feature summary

AC2 slice 2: collapses the 14-branch runtime → global-config-home source-fragment chain in `getConfigDirFromHome` (`bin/install.js`) into a single `getGlobalConfigHomeFragment(runtime)` lookup in `src/runtime-name-policy.cts`, sibling to `getDirName` / `getRuntimeLabel`. This function templates `path.join()` calls inside generated hook scripts — the mapping was a hand-kept duplicate of per-runtime path data (the add-a-host tax); it is now one table.

---

## What changed

### New files

| File | Purpose |
|------|---------|
| `tests/global-config-home-fragment.test.cjs` | Drift-guard test: golden fragment map (14 runtimes, verbatim) + two drift guards (every registry runtime except {claude, antigravity} has an entry; no stale entries) + fallbacks. |

### Modified files

| File | What changed |
|------|-------------|
| `src/runtime-name-policy.cts` | Add `GLOBAL_CONFIG_HOME_FRAGMENTS` table + `getGlobalConfigHomeFragment(runtime)` export (sibling to `getRuntimeLabel`). |
| `bin/install.js` | Import `getGlobalConfigHomeFragment`; replace the 14-branch chain in `getConfigDirFromHome` with a lookup. antigravity stays dynamic; dropped an unreachable dead `if (!isGlobal)` inside it. `runtime ===` count: **115 → 101**. |

---

## Implementation notes

- **Fragments are JS-source snippets, not resolved paths:** each value (e.g. `"'.config', 'opencode'"`) is spliced into generated hook scripts as `path.join()` args. Preserved BYTE-FOR-BYTE from the prior chain — golden parity proves generated hook output is unchanged.
- **antigravity is intentionally NOT a table entry:** its global home is env-overridable + multi-segment, resolved dynamically via `resolveAntigravityGlobalDir` + `path.relative`. Kept in the caller.
- **Dead code dropped:** the prior antigravity block had an inner `if (!isGlobal) return "'.agents'"` that was unreachable (`!isGlobal` returns at the top of the function). Removed; golden parity confirms no behavior change.
- **claude/unknown/empty → default `'.claude'` fragment** (fail-closed).

---

## Spec compliance

This PR is **AC2 slice 2 only**. Per-AC status of #1679 (unchanged from slice 1's report):

- [x] **AC1** `install-engine.cjs` entry — ✅ shipped (prior PRs)
- [~] **AC2** fold residue → descriptors + 16-runtime golden parity — **in progress.** Slices 1+2 collapse **28 of ~129** `runtime ===` branches (129 → 101). ~101 remain (boolean flags + per-runtime special cases).
- [x] **AC3** `destSubpath` write-confinement — ✅ shipped (prior PRs)
- [x] **AC4** #853 typed dispatch-flatten — ✅ shipped (#1708)

---

## Testing

### Test coverage

- **New:** `tests/global-config-home-fragment.test.cjs` — TDD red→green. Golden map (14 fragments, verbatim), two drift guards, fallbacks.
- **Gate:** `tests/golden-install-parity.test.cjs` — **16/16 byte-identical** (this slice touches hook codegen, so parity is the load-bearing gate; it passes).
- `runtime ===` in `bin/install.js`: 115 → 101.

### Platforms tested

- [x] macOS (local)
- [ ] Windows — not local; golden parity skips Windows by design (platform paths); CI matrix covers it.
- [ ] Linux — not local; CI matrix covers it.

### Runtimes tested

- [x] Claude Code
- [x] Gemini CLI
- [x] OpenCode
- [x] Codex
- [x] Copilot
- [x] Other: **all 16** asserted byte-identical via `golden-install-parity`.

---

## Scope confirmation

- [ ] matches the approved scope exactly — **No: AC2 slice 2 of N; strictly within #1679 scope.**
- [x] no additional features/commands/behaviors beyond approved
- [x] scope changes → re-approval — N/A

---

## Documentation

- [ ] updated docs/ — **No doc surface** (internal refactor; hook path-fragment codegen, no user-facing command/flag/config/schema change).
- [x] English — N/A
- [x] docs-exempt marker inside the triggering changeset fragment — `.changeset/<fragment>.md` carries `<!-- docs-exempt: internal refactor; hook codegen path-fragment table, no user-facing doc surface -->`.

---

## Checklist

- [x] Issue linked with `Closes #1679`
- [x] Linked issue has `approved-feature`
- [ ] all AC met — **No: AC2 partial (slice 2 of N); #1679 must stay open.**
- [x] scope within #1679; no creep
- [x] existing tests pass — 16-runtime golden parity + neighbor cluster green
- [x] new tests cover happy path + edge cases (golden map + drift guards + fallbacks)
- [x] `.changeset/` fragment added (`type: Changed`, docs-exempt)
- [x] no new external deps
- [x] Windows — no path-handling behavior change; CI matrix asserts

---

## Breaking changes

None. Hook path-fragment output is byte-identical (16-runtime golden parity). No file output, manifest, config schema, or API change.

---

Closes #1679 *(partial slice; issue should remain open)*.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1801"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785211994&installation_id=134682257&pr_number=1801&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1801&signature=8666b0e278b5c66a7164b389c97bdfa67d3940811edb23533eddfef6f65b6bb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->