### PR TITLE
feat(#1680): ADR-1239 Phase C-1 — declarative embedding adapter + minimal HostIntegrationInterface [AC1]

### DIFF
--- a/.changeset/daring-deer-leap.md
+++ b/.changeset/daring-deer-leap.md
@@ -1,0 +1,7 @@
+---
+type: Changed
+pr: 1802
+---
+**Internal: the declarative embedding adapter is now named + bound behind a minimal `HostIntegrationInterface`** — `createDeclarativeAdapter({runtime})` (new `src/adapter-declarative.cts`) delegates in-process to `install-engine`'s `installRuntimeArtifacts`/`uninstallRuntimeArtifacts`, formalizing today's projection path as one of the two embedding adapters behind a common contract (ADR-1239 Phase C-1 / #1680 AC1). Output is byte-identical to today's install (gated by `golden-install-parity`). The full 6-point interface binding surface is deferred until the imperative adapter (AC2) fixes the shape (ADR-1239 open wire-shape question). No user-facing change — the adapter is not yet wired to any runtime path.
+
+<!-- docs-exempt: internal adapter infrastructure; no user-facing command/flag/config/schema/doc surface -->

--- a/docs/INVENTORY-MANIFEST.json
+++ b/docs/INVENTORY-MANIFEST.json
@@ -279,6 +279,7 @@
     ],
     "cli_modules": [
       "active-workstream-store.cjs",
+      "adapter-declarative.cjs",
       "adr-parser.cjs",
       "agent-command-router.cjs",
       "agent-install-check.cjs",
@@ -324,6 +325,7 @@
       "edge-probe.cjs",
       "eval-command-router.cjs",
       "eval.cjs",
+      "embedding-adapter.cjs",
       "fallow-runner.cjs",
       "federated-config.cjs",
       "frontmatter.cjs",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -200,6 +200,9 @@ export default tseslint.config(
       'gsd-core/bin/lib/teams-status.cjs',
       // ADR-1372: tsc-generated runtime artifact — lint the src/markdown-sectionizer.cts source.
       'gsd-core/bin/lib/markdown-sectionizer.cjs',
+      // ADR-1239 Phase C-1 (#1680): tsc-generated — lint src/embedding-adapter.cts + src/adapter-declarative.cts.
+      'gsd-core/bin/lib/embedding-adapter.cjs',
+      'gsd-core/bin/lib/adapter-declarative.cjs',
     ],
   },
 

--- a/src/adapter-declarative.cts
+++ b/src/adapter-declarative.cts
@@ -1,0 +1,42 @@
+/**
+ * Declarative embedding adapter (ADR-1239 Phase C-1, AC1 / #1680).
+ *
+ * NAMES + BOUNDS today's projection path (file emission via install-engine)
+ * behind `HostIntegrationInterface`. The declarative adapter is lossy by
+ * design: it projects skills/agents/commands and does NOT drive the loop
+ * orchestration (that is the imperative adapter's job, AC2 / a later slice).
+ *
+ * `install`/`uninstall` delegate IN-PROCESS to install-engine's
+ * `installRuntimeArtifacts` / `uninstallRuntimeArtifacts` — the SAME engine
+ * functions `bin/install.js` uses — so the adapter's output is byte-identical to
+ * today's install (the link is gated by `tests/golden-install-parity.test.cjs`).
+ * The module-ref call style (`installEngine.fn`) keeps it monkeypatch-friendly
+ * for tests, mirroring the install-engine.cts:31-38 pattern.
+ */
+'use strict';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import installEngine = require('./install-engine.cjs');
+import type { HostIntegrationInterface, AdapterInstallIntent, AdapterUninstallIntent } from './embedding-adapter.cjs';
+
+export function createDeclarativeAdapter({ runtime }: { runtime: string }): HostIntegrationInterface {
+  if (!runtime || typeof runtime !== 'string') {
+    throw new TypeError('createDeclarativeAdapter: runtime is required (non-empty string)');
+  }
+  return Object.freeze({
+    kind: 'declarative' as const,
+    runtime,
+    install(intent: AdapterInstallIntent): void {
+      installEngine.installRuntimeArtifacts(
+        runtime,
+        intent.configDir,
+        intent.scope,
+        intent.resolvedProfile,
+        intent.resolveAttribution,
+      );
+    },
+    uninstall(intent: AdapterUninstallIntent): void {
+      installEngine.uninstallRuntimeArtifacts(runtime, intent.configDir, intent.scope);
+    },
+  });
+}

--- a/src/embedding-adapter.cts
+++ b/src/embedding-adapter.cts
@@ -1,0 +1,74 @@
+/**
+ * Embedding adapter contract — the common `HostIntegrationInterface` both
+ * embedding adapters satisfy (ADR-1239 Phase C-1, #1680).
+ *
+ * INTENTIONALLY MINIMAL (Phase 3 slice 1). The full six-interface-point binding
+ * surface (command / dispatch / model / hooks / state / artifact) is DEFERRED
+ * until the imperative adapter (AC2) provides a real consumer that fixes the
+ * shape — ADR-1239 lists the wire-shape as an open question:
+ *   "Exact wire-shape of the initialize handshake … Where precisely to cut the
+ *    engine↔host boundary"
+ * (docs/adr/1239-gsd-embeddable-orchestration-engine.md#open-questions-narrowed-by-the-research).
+ * Freezing a 6-point contract before the imperative adapter exists would risk
+ * rework across Phases 3-6. This slice ships only what the declarative adapter
+ * (AC1) needs: the kind discriminator + runtime + install/uninstall entry.
+ *
+ * Both adapters bind the SAME engine (install-engine.cjs / the loop resolver);
+ * they differ in HOW — declarative projects files (lossy: drops loop
+ * orchestration), imperative drives host primitives in-process. See ADR-1239
+ * "How a capability reaches a host (two adapters, one engine)".
+ */
+'use strict';
+
+// ---------------------------------------------------------------------------
+// Kinds
+// ---------------------------------------------------------------------------
+
+export const ADAPTER_KINDS = Object.freeze(['declarative', 'imperative'] as const);
+export type AdapterKind = (typeof ADAPTER_KINDS)[number];
+export type Scope = 'global' | 'local';
+// ---------------------------------------------------------------------------
+// Intent shapes (minimal — grow when the imperative adapter fixes the shape)
+// ---------------------------------------------------------------------------
+
+/**
+ * Install intent accepted by a `HostIntegrationInterface.install`.
+ *
+ * `resolvedProfile` + `resolveAttribution` mirror `installRuntimeArtifacts`
+ * (install-engine.cjs) — the declarative adapter passes them straight through to
+ * the engine. The imperative adapter (future) will source them from the host.
+ */
+export interface AdapterInstallIntent {
+  configDir: string;
+  scope: Scope;
+  resolvedProfile: unknown;
+  resolveAttribution?: (runtime: string) => unknown;
+}
+
+export interface AdapterUninstallIntent {
+  configDir: string;
+  scope: Scope;
+}
+
+// ---------------------------------------------------------------------------
+// The contract
+// ---------------------------------------------------------------------------
+
+/**
+ * The minimal contract both embedding adapters satisfy. `kind` discriminates
+ * declarative (projection) from imperative (in-process engine drive). Both
+ * `install`/`uninstall` delegate to the shared engine surface; neither
+ * reimplements the loop. The byte-identity of the declarative adapter's output
+ * to today's install is gated by `tests/golden-install-parity.test.cjs`
+ * (both route through the same `installRuntimeArtifacts` engine function).
+ */
+export interface HostIntegrationInterface {
+  readonly kind: AdapterKind;
+  readonly runtime: string;
+  install(intent: AdapterInstallIntent): void;
+  uninstall(intent: AdapterUninstallIntent): void;
+}
+
+// NOTE: `ADAPTER_KINDS` is exported above as a runtime const so this module
+// compiles to a non-empty .cjs (the interfaces above are erased by tsc) and so
+// adapter implementors can reference the frozen kind set at runtime.

--- a/tests/adapter-declarative-equivalence.test.cjs
+++ b/tests/adapter-declarative-equivalence.test.cjs
@@ -1,0 +1,102 @@
+'use strict';
+/**
+ * Equivalence test for the declarative embedding adapter (ADR-1239 Phase C-1,
+ * AC1 / #1680).
+ *
+ * The declarative adapter NAMES + BOUNDS today's projection path behind
+ * `HostIntegrationInterface`. This test pins the three load-bearing properties:
+ *
+ *   1. KIND — every runtime's adapter classifies as `kind: 'declarative'` and
+ *      echoes its runtime id.
+ *   2. DELEGATION (the byte-identity link) — `install`/`uninstall` delegate
+ *      IN-PROCESS to install-engine's `installRuntimeArtifacts` /
+ *      `uninstallRuntimeArtifacts` with the EXACT args passed through. Because
+ *      the adapter calls the SAME engine functions `bin/install.js` uses, its
+ *      output is byte-identical to today's install — the 16-runtime byte
+ *      identity is gated by `tests/golden-install-parity.test.cjs` (which
+ *      exercises these engine functions end-to-end). Asserting the delegation
+ *      link here proves the adapter never diverges from the reference path.
+ *   3. FAIL-CLOSED CONSTRUCTION — missing/invalid runtime throws (no silent
+ *      default adapter).
+ *
+ * Behavioral tests only; delegation verified via module-ref monkeypatch (the
+ * install-engine.cts:31-38 stub-compatible pattern — Node module cache shares
+ * the one module object, so patching it here is seen by the adapter).
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { createDeclarativeAdapter } = require('../gsd-core/bin/lib/adapter-declarative.cjs');
+const installEngine = require('../gsd-core/bin/lib/install-engine.cjs');
+const registry = require('../gsd-core/bin/lib/capability-registry.cjs');
+
+const RUNTIMES = Object.keys(registry.runtimes);
+
+test('declarative adapter: kind === "declarative" + runtime echoed, for all 16 runtimes', () => {
+  assert.ok(RUNTIMES.length >= 16, `expected ≥16 runtimes in registry, got ${RUNTIMES.length}`);
+  for (const r of RUNTIMES) {
+    const adapter = createDeclarativeAdapter({ runtime: r });
+    assert.strictEqual(adapter.kind, 'declarative', `${r}: kind must be 'declarative'`);
+    assert.strictEqual(adapter.runtime, r, `${r}: adapter must echo the runtime id`);
+    assert.strictEqual(typeof adapter.install, 'function', `${r}: install must be a function`);
+    assert.strictEqual(typeof adapter.uninstall, 'function', `${r}: uninstall must be a function`);
+  }
+});
+
+test('declarative adapter.install delegates in-process to installRuntimeArtifacts with exact args (byte-identity link)', () => {
+  const original = installEngine.installRuntimeArtifacts;
+  try {
+    for (const r of RUNTIMES) {
+      const adapter = createDeclarativeAdapter({ runtime: r });
+      let captured = null;
+      installEngine.installRuntimeArtifacts = function (...args) { captured = args; return undefined; };
+      const resolveAttribution = () => 'attr-' + r;
+      const intent = {
+        configDir: '/tmp/adapter-eq/' + r,
+        scope: 'global',
+        resolvedProfile: { profile: r },
+        resolveAttribution,
+      };
+      assert.doesNotThrow(() => adapter.install(intent), `${r}: install threw`);
+      assert.ok(captured, `${r}: install did not delegate to installRuntimeArtifacts`);
+      assert.deepStrictEqual(
+        captured,
+        [r, '/tmp/adapter-eq/' + r, 'global', { profile: r }, resolveAttribution],
+        `${r}: install delegation args diverged from the engine signature`,
+      );
+    }
+  } finally {
+    installEngine.installRuntimeArtifacts = original;
+  }
+});
+
+test('declarative adapter.uninstall delegates in-process to uninstallRuntimeArtifacts with exact args', () => {
+  const original = installEngine.uninstallRuntimeArtifacts;
+  try {
+    for (const r of RUNTIMES) {
+      const adapter = createDeclarativeAdapter({ runtime: r });
+      let captured = null;
+      installEngine.uninstallRuntimeArtifacts = function (...args) { captured = args; return undefined; };
+      assert.doesNotThrow(() => adapter.uninstall({ configDir: '/tmp/adapter-eq/' + r, scope: 'local' }), `${r}: uninstall threw`);
+      assert.ok(captured, `${r}: uninstall did not delegate to uninstallRuntimeArtifacts`);
+      assert.deepStrictEqual(
+        captured,
+        [r, '/tmp/adapter-eq/' + r, 'local'],
+        `${r}: uninstall delegation args diverged from the engine signature`,
+      );
+    }
+  } finally {
+    installEngine.uninstallRuntimeArtifacts = original;
+  }
+});
+
+test('createDeclarativeAdapter: throws on missing/invalid runtime (fail-closed construction)', () => {
+  for (const bad of ['', undefined, null]) {
+    assert.throws(
+      () => createDeclarativeAdapter({ runtime: bad }),
+      TypeError,
+      `runtime=${JSON.stringify(bad)} must throw TypeError`,
+    );
+  }
+  assert.throws(() => createDeclarativeAdapter({}), TypeError, 'missing runtime must throw TypeError');
+});


### PR DESCRIPTION
## Feature PR

> **Using the wrong template?**
> — Bug fix: use [fix.md](?template=fix.md)
> — Enhancement to existing behavior: use [enhancement.md](?template=enhancement.md)

---

## Linked Issue

Closes #1680

> #1680 carries `approved-feature` (Phase 3 of epic #1678, ADR-1239 Phase C-1).
>
> ⚠️ **This PR is AC1 only** (the declarative adapter + minimal interface). It does **not** complete #1680 — the imperative adapter (AC2) and the model/hook/state seams (AC3/AC4) are follow-up slices. Merging into `next` (non-default) does not auto-close the issue; **#1680 must remain open.** Phase 2 (#1679) AC1 (engine boundary) — the dependency — is shipped.

---

## Feature summary

Phase 3 slice 1 (AC1): the **declarative embedding adapter** + a minimal `HostIntegrationInterface`. Names + bounds today's projection path (file emission via `install-engine`) behind the common adapter contract that both declarative + imperative adapters will satisfy. The declarative adapter is lossy by design — it projects skills/agents/commands and does not drive the loop orchestration (the imperative adapter's job, AC2).

The full 6-point interface binding surface (command/dispatch/model/hooks/state/artifact) is **deliberately deferred** — ADR-1239 lists the wire-shape as an open question, so freezing it before the imperative adapter (AC2) exists would risk rework across Phases 3-6. This slice ships only what AC1 needs: kind discriminator + runtime + install/uninstall entry.

---

## What changed

### New files

| File | Purpose |
|------|---------|
| `src/embedding-adapter.cts` | The common `HostIntegrationInterface` contract (minimal: `kind`, `runtime`, `install`/`uninstall`) + `ADAPTER_KINDS`. Both adapters satisfy it. Documents the 6-point-shape deferral. |
| `src/adapter-declarative.cts` | `createDeclarativeAdapter({runtime})` factory — names/bounds today's projection; delegates in-process to `install-engine.installRuntimeArtifacts` / `uninstallRuntimeArtifacts`. |
| `tests/adapter-declarative-equivalence.test.cjs` | Equivalence test: kind classification (16 runtimes), delegation-with-exact-args (the byte-identity link), fail-closed construction. |

### Modified files

None. The adapter is purely additive — no install.js / install-engine changes (install output byte-identity is therefore unchanged + gated by `golden-install-parity`).

---

## Implementation notes

- **Minimal interface, deferred 6-point shape:** per ADR-1239's open wire-shape question, `HostIntegrationInterface` ships as `{ kind, runtime, install, uninstall }` only. The full command/dispatch/model/hooks/state/artifact binding surface grows when the imperative adapter (AC2) provides a real consumer that fixes the shape.
- **Byte-identity link:** the declarative adapter delegates in-process to the SAME `installRuntimeArtifacts` / `uninstallRuntimeArtifacts` engine functions `bin/install.js` uses (module-ref call style, monkeypatch-friendly per install-engine.cts:31-38). Therefore its output is byte-identical to today's install — gated by `golden-install-parity.test.cjs`. The equivalence test here asserts the delegation link (so the adapter can never silently diverge from the reference path).
- **Lossy by design:** declarative projects files; it does NOT drive the loop (steps/contributions/gates). That orchestration is the imperative adapter (AC2). See ADR-1239 "How a capability reaches a host (two adapters, one engine)".

---

## Spec compliance

This PR is **AC1 only**. Per-AC status of #1680:

- [x] **AC1** declarative adapter named + bound behind `HostIntegrationInterface`; equivalence test — **this PR.**
- [ ] **AC2** imperative adapter composes `loadRegistry({includeInstalled:true})` + binds host primitives — follow-up slice.
- [ ] **AC3** model layer `passive` + `active` seam, `modelMode` — follow-up slice.
- [ ] **AC4** hook-bus + `stateIO` seams — follow-up slice.

---

## Testing

### Test coverage

- **New:** `tests/adapter-declarative-equivalence.test.cjs` — kind classification (all 16 runtimes), install delegation with exact args, uninstall delegation with exact args, fail-closed construction (missing/invalid runtime throws). TDD red→green.
- **Unaffected:** `golden-install-parity.test.cjs` — adapter is additive (no install changes); install output byte-identity unchanged.

### Platforms tested

- [x] macOS (local)
- [ ] Windows — not local; CI matrix covers it.
- [ ] Linux — not local; CI matrix covers it.

### Runtimes tested

- [x] Claude Code
- [x] Gemini CLI
- [x] OpenCode
- [x] Codex
- [x] Copilot
- [x] Other: **all 16** — kind classification + delegation asserted for every registry runtime.

---

## Scope confirmation

- [ ] matches approved scope exactly — **No: AC1 slice only of #1680; strictly within scope.**
- [x] no additional features/commands/behaviors beyond approved
- [x] scope changes → re-approval — N/A

---

## Documentation

- [ ] updated docs/ — **No user-facing doc surface** (internal adapter infrastructure; no new command/flag/config/schema/workflow).
- [x] English — N/A
- [x] docs-exempt marker inside the triggering changeset fragment.

---

## Checklist

- [x] Issue linked with `Closes #1680`
- [x] Linked issue has `approved-feature`
- [ ] all AC met — **No: AC1 only; #1680 must stay open.**
- [x] scope within #1680; no creep
- [x] existing tests pass — adapter test green; install output unchanged
- [x] new tests cover happy path + edge cases (16-runtimes kind/delegation + fail-closed)
- [x] `.changeset/` fragment added (`type: Changed`, docs-exempt)
- [x] no new external deps
- [x] Windows — no platform-specific code; CI matrix asserts

---

## Breaking changes

None. Purely additive (two new modules + a test). No install behavior, file output, config schema, or API change. The interface is intentionally minimal and not yet consumed by any runtime path.

---

Closes #1680 *(AC1 slice only; issue should remain open)*.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1802"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785214587&installation_id=134682257&pr_number=1802&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1802&signature=0a5c8512f40a05ac7ca3cf41b249435d28f1126300b514d34b8cc8c0ecf74fd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->