### PR TITLE
feat(#1680): ADR-1239 Phase C-1 — imperative embedding adapter (composes loadRegistry) [AC2]

### DIFF
--- a/.changeset/happy-jays-travel.md
+++ b/.changeset/happy-jays-travel.md
@@ -1,0 +1,7 @@
+---
+type: Changed
+pr: 1803
+---
+**Internal: the imperative embedding adapter now composes the capability registry behind the same `HostIntegrationInterface`** — `createImperativeAdapter({runtime})` (new `src/adapter-imperative.cts`) calls `loadRegistry({includeInstalled:true})` (first-party-wins + consent + fail-closed — identical trust semantics to the CLI) and binds the engine surface behind the same contract the declarative adapter (AC1) satisfies, plus a `registry` accessor for an in-process host to bind its primitives to (ADR-1239 Phase C-1 / #1680 AC2). Concrete host binding is deferred to Phase 5. No user-facing change — the adapter is not yet wired to any runtime path.
+
+<!-- docs-exempt: internal adapter infrastructure; no user-facing command/flag/config/schema/doc surface -->

--- a/docs/INVENTORY-MANIFEST.json
+++ b/docs/INVENTORY-MANIFEST.json
@@ -280,6 +280,7 @@
     "cli_modules": [
       "active-workstream-store.cjs",
       "adapter-declarative.cjs",
+      "adapter-imperative.cjs",
       "adr-parser.cjs",
       "agent-command-router.cjs",
       "agent-install-check.cjs",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -203,6 +203,7 @@ export default tseslint.config(
       // ADR-1239 Phase C-1 (#1680): tsc-generated — lint src/embedding-adapter.cts + src/adapter-declarative.cts.
       'gsd-core/bin/lib/embedding-adapter.cjs',
       'gsd-core/bin/lib/adapter-declarative.cjs',
+      'gsd-core/bin/lib/adapter-imperative.cjs',
     ],
   },
 

--- a/src/adapter-imperative.cts
+++ b/src/adapter-imperative.cts
@@ -1,0 +1,77 @@
+/**
+ * Imperative embedding adapter (ADR-1239 Phase C-1, AC2 / #1680).
+ *
+ * The engine-as-library path: an in-process host plugin calls
+ * `createImperativeAdapter({runtime})`, which composes the capability registry
+ * via `loadRegistry({includeInstalled:true})` (first-party-wins + consent +
+ * fail-closed gates) and binds the engine surface behind the SAME
+ * `HostIntegrationInterface` the declarative adapter satisfies. The adapter
+ * stays thin — it does NOT reimplement the loop resolver; it delegates to the
+ * engine + exposes the composed registry so a host (Phase 5) can bind its
+ * primitives (command/dispatch/model/hooks/state/artifact) to the registry's
+ * declared capability set.
+ *
+ * Concrete host binding (OpenCode/VS Code/pi) is deferred to Phase 5 (#1682,
+ * D15/D18). This slice ships the adapter + the composed-registry seam.
+ *
+ * Minimal interface (per ADR-1239 open wire-shape question): satisfies the same
+ * `{kind, runtime, install, uninstall}` contract as the declarative adapter,
+ * plus an imperative-specific `registry` accessor (the composed loadRegistry
+ * result). The full 6-point binding surface grows when a real host consumer
+ * fixes the shape.
+ */
+'use strict';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import installEngine = require('./install-engine.cjs');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import capabilityLoader = require('./capability-loader.cjs');
+import type { HostIntegrationInterface, AdapterInstallIntent, AdapterUninstallIntent } from './embedding-adapter.cjs';
+
+/**
+ * The imperative adapter: the shared contract PLUS the composed capability
+ * registry an in-process host binds its primitives to.
+ */
+export interface ImperativeAdapter extends HostIntegrationInterface {
+  readonly kind: 'imperative';
+  /** The composed capability registry (loadRegistry({includeInstalled:true})). */
+  readonly registry: ReturnType<typeof capabilityLoader.loadRegistry>;
+}
+
+export interface CreateImperativeAdapterOptions {
+  /** Optional overrides forwarded to loadRegistry (cwd, gsdHome, hostVersion). */
+  loadOptions?: Record<string, unknown>;
+}
+
+export function createImperativeAdapter(
+  { runtime }: { runtime: string },
+  options: CreateImperativeAdapterOptions = {},
+): ImperativeAdapter {
+  if (!runtime || typeof runtime !== 'string') {
+    throw new TypeError('createImperativeAdapter: runtime is required (non-empty string)');
+  }
+  // Compose first-party ∪ installed capability overlays with the SAME
+  // precedence, consent, and fail-closed-gate guarantees the CLI enforces —
+  // an in-process host gets identical trust semantics, not a parallel path.
+  const registry = capabilityLoader.loadRegistry({
+    includeInstalled: true,
+    ...(options.loadOptions ?? {}),
+  });
+  return Object.freeze({
+    kind: 'imperative' as const,
+    runtime,
+    registry,
+    install(intent: AdapterInstallIntent): void {
+      installEngine.installRuntimeArtifacts(
+        runtime,
+        intent.configDir,
+        intent.scope,
+        intent.resolvedProfile,
+        intent.resolveAttribution,
+      );
+    },
+    uninstall(intent: AdapterUninstallIntent): void {
+      installEngine.uninstallRuntimeArtifacts(runtime, intent.configDir, intent.scope);
+    },
+  });
+}

--- a/src/adapter-imperative.cts
+++ b/src/adapter-imperative.cts
@@ -14,8 +14,8 @@
  * Concrete host binding (OpenCode/VS Code/pi) is deferred to Phase 5 (#1682,
  * D15/D18). This slice ships the adapter + the composed-registry seam.
  *
- * Minimal interface (per ADR-1239 open wire-shape question): satisfies the same
- * `{kind, runtime, install, uninstall}` contract as the declarative adapter,
+ * Minimal interface (per ADR-1239 open wire-shape question): satisfies the
+ * same `{kind, runtime, install, uninstall}` shape as the declarative adapter,
  * plus an imperative-specific `registry` accessor (the composed loadRegistry
  * result). The full 6-point binding surface grows when a real host consumer
  * fixes the shape.

--- a/tests/adapter-imperative.test.cjs
+++ b/tests/adapter-imperative.test.cjs
@@ -1,0 +1,98 @@
+'use strict';
+/**
+ * Tests for the imperative embedding adapter (ADR-1239 Phase C-1, AC2 / #1680).
+ *
+ * Pins:
+ *   1. KIND — `kind: 'imperative'`, satisfies the same HostIntegrationInterface
+ *      as the declarative adapter (both bind one engine).
+ *   2. REGISTRY COMPOSITION — the adapter composes loadRegistry({includeInstalled:
+ *      true}) and exposes the result as `.registry` (first-party ∪ installed, so
+ *      an in-process host gets identical trust semantics to the CLI).
+ *   3. DELEGATION — install/uninstall delegate in-process to install-engine
+ *      (byte-identity link, same as the declarative adapter).
+ *   4. FAIL-CLOSED CONSTRUCTION — missing/invalid runtime throws.
+ *
+ * Behavioral tests only; delegation + loadRegistry verified via module-ref
+ * monkeypatch (Node module cache shares the one module object).
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { createImperativeAdapter } = require('../gsd-core/bin/lib/adapter-imperative.cjs');
+const installEngine = require('../gsd-core/bin/lib/install-engine.cjs');
+const capabilityLoader = require('../gsd-core/bin/lib/capability-loader.cjs');
+const registry = require('../gsd-core/bin/lib/capability-registry.cjs');
+
+const RUNTIMES = Object.keys(registry.runtimes);
+
+test('imperative adapter: kind === "imperative" + runtime echoed + registry present, for all 16 runtimes', () => {
+  for (const r of RUNTIMES) {
+    const adapter = createImperativeAdapter({ runtime: r });
+    assert.strictEqual(adapter.kind, 'imperative', `${r}: kind must be 'imperative'`);
+    assert.strictEqual(adapter.runtime, r, `${r}: adapter must echo the runtime id`);
+    assert.ok(adapter.registry && typeof adapter.registry === 'object', `${r}: registry must be present (composed loadRegistry result)`);
+    assert.strictEqual(typeof adapter.install, 'function', `${r}: install must be a function`);
+    assert.strictEqual(typeof adapter.uninstall, 'function', `${r}: uninstall must be a function`);
+  }
+});
+
+test('imperative adapter: loadRegistry composed with includeInstalled:true (host gets CLI-equivalent trust semantics)', () => {
+  // Restore-able spy on capabilityLoader.loadRegistry (module-ref, shared via Node cache).
+  const original = capabilityLoader.loadRegistry;
+  const calls = [];
+  capabilityLoader.loadRegistry = function (opts) {
+    calls.push(opts);
+    // Return a minimal stand-in registry so the factory does not crash.
+    return { _spy: true, runtimes: registry.runtimes };
+  };
+  try {
+    const adapter = createImperativeAdapter({ runtime: 'opencode' });
+    assert.ok(calls.length >= 1, 'loadRegistry must be invoked once during construction');
+    assert.strictEqual(calls[0].includeInstalled, true, 'loadRegistry must be called with includeInstalled:true (compose first-party ∪ installed)');
+    assert.strictEqual(adapter.registry._spy, true, 'adapter.registry must expose the composed loadRegistry result');
+  } finally {
+    capabilityLoader.loadRegistry = original;
+  }
+});
+
+test('imperative adapter: loadOptions forwarded to loadRegistry (cwd/gsdHome/hostVersion pass-through)', () => {
+  const original = capabilityLoader.loadRegistry;
+  let captured = null;
+  capabilityLoader.loadRegistry = function (opts) { captured = opts; return { runtimes: registry.runtimes }; };
+  try {
+    createImperativeAdapter({ runtime: 'codex' }, { loadOptions: { cwd: '/tmp/proj', hostVersion: '1.7.0' } });
+    assert.strictEqual(captured.includeInstalled, true, 'includeInstalled default preserved');
+    assert.strictEqual(captured.cwd, '/tmp/proj', 'loadOptions.cwd forwarded');
+    assert.strictEqual(captured.hostVersion, '1.7.0', 'loadOptions.hostVersion forwarded');
+  } finally {
+    capabilityLoader.loadRegistry = original;
+  }
+});
+
+test('imperative adapter.install/uninstall delegate in-process to install-engine with exact args', () => {
+  const origInstall = installEngine.installRuntimeArtifacts;
+  const origUninstall = installEngine.uninstallRuntimeArtifacts;
+  try {
+    for (const r of RUNTIMES) {
+      const adapter = createImperativeAdapter({ runtime: r });
+      let installArgs = null;
+      let uninstallArgs = null;
+      installEngine.installRuntimeArtifacts = function (...a) { installArgs = a; return undefined; };
+      installEngine.uninstallRuntimeArtifacts = function (...a) { uninstallArgs = a; return undefined; };
+      adapter.install({ configDir: '/tmp/imp/' + r, scope: 'global', resolvedProfile: { p: 1 } });
+      adapter.uninstall({ configDir: '/tmp/imp/' + r, scope: 'local' });
+      assert.deepStrictEqual(installArgs, [r, '/tmp/imp/' + r, 'global', { p: 1 }, undefined], `${r}: install delegation args`);
+      assert.deepStrictEqual(uninstallArgs, [r, '/tmp/imp/' + r, 'local'], `${r}: uninstall delegation args`);
+    }
+  } finally {
+    installEngine.installRuntimeArtifacts = origInstall;
+    installEngine.uninstallRuntimeArtifacts = origUninstall;
+  }
+});
+
+test('createImperativeAdapter: throws on missing/invalid runtime (fail-closed construction)', () => {
+  for (const bad of ['', undefined, null]) {
+    assert.throws(() => createImperativeAdapter({ runtime: bad }), TypeError, `runtime=${JSON.stringify(bad)} must throw`);
+  }
+  assert.throws(() => createImperativeAdapter({}), TypeError, 'missing runtime must throw');
+});

--- a/tests/bug-1760-state-prune-noop-template-field.test.cjs
+++ b/tests/bug-1760-state-prune-noop-template-field.test.cjs
@@ -16,9 +16,6 @@ const { runGsdTools, createTempProject, cleanup } = require('./helpers.cjs');
 function writeStateMd(tmpDir, content) {
   fs.writeFileSync(path.join(tmpDir, '.planning', 'STATE.md'), content);
 }
-function readStateMd(tmpDir) {
-  return fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
-}
 
 describe('#1760: state prune engages on template-conformant STATE.md (Phase: X of Y)', () => {
   let tmpDir;


### PR DESCRIPTION
## Feature PR

> **Using the wrong template?**
> — Bug fix: use [fix.md](?template=fix.md)
> — Enhancement to existing behavior: use [enhancement.md](?template=enhancement.md)

---

## Linked Issue

Closes #1680

> #1680 carries `approved-feature` (Phase 3 of epic #1678, ADR-1239 Phase C-1).
>
> ⚠️ **This PR is AC2** (the imperative adapter). AC1 (declarative adapter + minimal interface, #1802) is merged. AC3 (model seams) + AC4 (hook/state seams) remain. Merging into `next` does not auto-close the issue; **#1680 must remain open.**

---

## Feature summary

Phase 3 slice 2 (AC2): the **imperative embedding adapter** — `createImperativeAdapter({runtime})`. The engine-as-library path: an in-process host plugin gets an adapter that composes the capability registry via `loadRegistry({includeInstalled:true})` (first-party-wins + consent + fail-closed gates — identical trust semantics to the CLI) and binds the engine surface behind the **same** `HostIntegrationInterface` the declarative adapter satisfies. The adapter stays thin: it delegates to the engine + exposes the composed registry so a host (Phase 5) can bind its primitives to the declared capability set.

---

## What changed

### New files

| File | Purpose |
|------|---------|
| `src/adapter-imperative.cts` | `createImperativeAdapter({runtime}, options?)` factory — composes `loadRegistry({includeInstalled:true})`, exposes `.registry`, binds install/uninstall to install-engine behind `HostIntegrationInterface`. Adds `ImperativeAdapter` (shared interface + `registry` accessor). |
| `tests/adapter-imperative.test.cjs` | kind classification (16 runtimes), registry composition (loadRegistry called with `includeInstalled:true`), loadOptions pass-through, install/uninstall delegation, fail-closed construction. |

### Modified files

| File | What changed |
|------|-------------|
| `eslint.config.mjs` | Add `gsd-core/bin/lib/adapter-imperative.cjs` to ADR-457 ignores (lint the `.cts` source, not the emitted `.cjs`). |
| `docs/INVENTORY-MANIFEST.json` | Add `adapter-imperative.cjs` to the `cli_modules` array (drift gate). |

---

## Implementation notes

- **Same interface, extra accessor:** `ImperativeAdapter extends HostIntegrationInterface` with `kind: 'imperative'` + a `registry` accessor (the composed `loadRegistry` result). The shared 6-point binding surface stays deferred (ADR-1239 open wire-shape question); this slice adds only what AC2 needs.
- **CLI-equivalent trust:** `loadRegistry({includeInstalled:true})` applies first-party-wins precedence, the consent gate, and the fail-closed incompatible-gate list — an in-process host gets the SAME guarantees as the CLI, not a parallel path.
- **Thin by design:** the adapter does NOT reimplement the loop resolver; it delegates install/uninstall to install-engine (byte-identity link, gated by `golden-install-parity`).
- **Proactive CI gates:** the ADR-457 eslint ignores entry + the INVENTORY-MANIFEST cli_modules entry are included in THIS slice (the two drift gates that bit AC1).

---

## Spec compliance

This PR is **AC2**. Per-AC status of #1680:

- [x] **AC1** declarative adapter + minimal interface — ✅ shipped (#1802)
- [x] **AC2** imperative adapter composes `loadRegistry({includeInstalled:true})` + binds the registry behind the same interface — **this PR.**
- [ ] **AC3** model layer `passive` + `active` seam — follow-up slice.
- [ ] **AC4** hook-bus + `stateIO` seams — follow-up slice.
- **Deferred (per issue):** binding the imperative adapter to a concrete host + the OpenCode worked binding → Phase 5 (#1682, D15/D18).

---

## Testing

### Test coverage

- **New:** `tests/adapter-imperative.test.cjs` — 5 tests, TDD red→green. Kind/registry/delegation/loadOptions/fail-closed.
- **Unaffected:** `golden-install-parity` (additive; no install.js/install-engine changes).
- **Drift gates:** `inventory-manifest-sync` ✅; `lint:ci` ✅ (0 errors).

### Platforms tested

- [x] macOS (local)
- [ ] Windows / Linux — CI matrix.

### Runtimes tested

- [x] Claude Code, Gemini CLI, OpenCode, Codex, Copilot + **all 16** (kind/delegation asserted per registry runtime).

---

## Scope confirmation

- [ ] matches approved scope exactly — **No: AC2 slice of #1680; within scope.**
- [x] no additional features/behaviors beyond approved
- [x] scope changes → re-approval — N/A

---

## Documentation

- [ ] updated docs/ — **No user-facing doc surface** (internal adapter infrastructure).
- [x] English — N/A
- [x] docs-exempt marker inside the triggering changeset fragment.

---

## Checklist

- [x] Issue linked with `Closes #1680`
- [x] Linked issue has `approved-feature`
- [ ] all AC met — **No: AC2 of 4; #1680 must stay open.**
- [x] scope within #1680; no creep
- [x] existing tests pass — imperative test green; golden parity unaffected
- [x] new tests cover happy path + edge cases
- [x] `.changeset/` fragment added (`type: Changed`, docs-exempt)
- [x] no new external deps
- [x] Windows — no platform-specific code; CI matrix asserts

---

## Breaking changes

None. Purely additive. The imperative adapter is not yet bound to any concrete host (Phase 5). No install behavior, file output, config schema, or API change.

---

Closes #1680 *(AC2 slice; issue should remain open)*.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1803"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785249602&installation_id=134682257&pr_number=1803&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1803&signature=b2ef82790085fddf801e8e3717bec066dd56bf85cb2c8e93bb5624e882542a8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->