### PR TITLE
feat(#1680): ADR-1239 Phase C-1 — model adapter seam (passive + active) [AC3]

### DIFF
--- a/.changeset/humble-geese-roam.md
+++ b/.changeset/humble-geese-roam.md
@@ -1,0 +1,7 @@
+---
+type: Changed
+pr: 1804
+---
+**Internal: the model adapter seam exposes `passive` + `active` adapters selected by `modelMode`** — `createModelAdapter({modelMode})` (new `src/model-adapter.cts`): `passive` formalizes today's tier routing (delegates to `model-resolver.resolveModelForTier`), `active` is a host-supplied `sendRequest` seam (VS Code `vscode.lm` / pi providers), fail-closed until Phase 5 binds a concrete provider (ADR-1239 Phase C-1 / #1680 AC3). No user-facing change — the seam is not yet wired to any runtime path.
+
+<!-- docs-exempt: internal adapter seam; no user-facing command/flag/config/schema/doc surface -->

--- a/docs/INVENTORY-MANIFEST.json
+++ b/docs/INVENTORY-MANIFEST.json
@@ -352,6 +352,7 @@
       "loop-resolver.cjs",
       "markdown-sectionizer.cjs",
       "milestone.cjs",
+      "model-adapter.cjs",
       "model-catalog.cjs",
       "model-profiles.cjs",
       "model-resolver.cjs",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -204,6 +204,7 @@ export default tseslint.config(
       'gsd-core/bin/lib/embedding-adapter.cjs',
       'gsd-core/bin/lib/adapter-declarative.cjs',
       'gsd-core/bin/lib/adapter-imperative.cjs',
+      'gsd-core/bin/lib/model-adapter.cjs',
     ],
   },
 

--- a/src/model-adapter.cts
+++ b/src/model-adapter.cts
@@ -1,0 +1,78 @@
+/**
+ * Model adapter seam (ADR-1239 Phase C-1, AC3 / #1680).
+ *
+ * Two model-layer adapters selected by the negotiated `modelMode` axis
+ * (host-integration.cts):
+ *
+ *   - `passive` — GSD can only inject prompts / a per-agent `model` field (the
+ *     CLI runtimes: claude/gemini/codex/opencode/cursor/…). Formalizes today's
+ *     tier routing from src/model-resolver.cts: `resolveModel` delegates
+ *     straight to `resolveModelForTier`, so passive reproduces current behavior
+ *     byte-for-behavior.
+ *   - `active` — the host exposes a provider `sendRequest` (VS Code `vscode.lm`,
+ *     pi providers). GSD calls the model through the host. Ships here as a SEAM:
+ *     a host-supplied `sendRequest` slot, fail-closed until a real consumer
+ *     binds it (Phase 5 / #1682).
+ *
+ * Minimal (per ADR-1239 open wire-shape question): one factory, two shapes
+ * discriminated by `mode`. Concrete provider protocol (request/response shape)
+ * is fixed when a real active host lands in Phase 5.
+ */
+'use strict';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import modelResolver = require('./model-resolver.cjs');
+
+export type ModelMode = 'passive' | 'active';
+
+export interface ModelAdapter {
+  readonly mode: ModelMode;
+}
+
+export interface PassiveModelAdapter extends ModelAdapter {
+  readonly mode: 'passive';
+  /** Resolve a model id for a tier. Delegates to model-resolver's tier routing. */
+  resolveModel(args: { cwd: string; agentType: string; attempt?: number }): string;
+}
+
+export interface ActiveModelAdapter extends ModelAdapter {
+  readonly mode: 'active';
+  /** Host-supplied model-call primitive. Throws (fail-closed) if not bound. */
+  sendRequest(req: unknown): unknown;
+}
+
+export interface CreateModelAdapterOptions {
+  /** Required for `active`: the host's model-call primitive. Ignored for `passive`. */
+  sendRequest?: (req: unknown) => unknown;
+}
+
+export function createModelAdapter(
+  { modelMode }: { modelMode: ModelMode },
+  options: CreateModelAdapterOptions = {},
+): ModelAdapter {
+  if (modelMode !== 'passive' && modelMode !== 'active') {
+    throw new TypeError(`createModelAdapter: modelMode must be 'passive' | 'active' (got ${JSON.stringify(modelMode)})`);
+  }
+  if (modelMode === 'passive') {
+    return Object.freeze({
+      mode: 'passive' as const,
+      resolveModel({ cwd, agentType, attempt }: { cwd: string; agentType: string; attempt?: number }): string {
+        return modelResolver.resolveModelForTier(cwd, agentType, attempt);
+      },
+    });
+  }
+  // active: bind the host's sendRequest, fail-closed if absent.
+  const sendRequest = options.sendRequest;
+  return Object.freeze({
+    mode: 'active' as const,
+    sendRequest(req: unknown): unknown {
+      if (typeof sendRequest !== 'function') {
+        throw new Error(
+          'ActiveModelAdapter.sendRequest: no host provider bound — the active model seam ' +
+          'requires a sendRequest primitive from the host (Phase 5 wires a concrete provider).',
+        );
+      }
+      return sendRequest(req);
+    },
+  });
+}

--- a/tests/model-adapter.test.cjs
+++ b/tests/model-adapter.test.cjs
@@ -1,0 +1,73 @@
+'use strict';
+/**
+ * Tests for the model adapter seam (ADR-1239 Phase C-1, AC3 / #1680).
+ *
+ * Pins:
+ *   1. PASSIVE — `resolveModel` delegates to model-resolver's tier routing
+ *      (reproduces today's behavior).
+ *   2. ACTIVE — `sendRequest` calls the host-supplied primitive; FAIL-CLOSED
+ *      (throws) when no provider is bound.
+ *   3. FACTORY GATING — invalid modelMode throws.
+ *
+ * Behavioral tests only; delegation verified via module-ref monkeypatch.
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { createModelAdapter } = require('../gsd-core/bin/lib/model-adapter.cjs');
+const modelResolver = require('../gsd-core/bin/lib/model-resolver.cjs');
+
+test('passive model adapter: resolveModel delegates to model-resolver tier routing (reproduces today behavior)', () => {
+  const adapter = createModelAdapter({ modelMode: 'passive' });
+  assert.strictEqual(adapter.mode, 'passive');
+  const original = modelResolver.resolveModelForTier;
+  let captured = null;
+  modelResolver.resolveModelForTier = function (...a) { captured = a; return 'sonnet'; };
+  try {
+    const out = adapter.resolveModel({ cwd: '/tmp/proj', agentType: 'planner', attempt: 2 });
+    assert.strictEqual(out, 'sonnet', 'resolveModel must return the resolver result');
+    assert.deepStrictEqual(captured, ['/tmp/proj', 'planner', 2], 'must delegate (cwd, agentType, attempt) verbatim');
+  } finally {
+    modelResolver.resolveModelForTier = original;
+  }
+});
+
+test('passive model adapter: attempt is optional (delegates undefined when omitted)', () => {
+  const adapter = createModelAdapter({ modelMode: 'passive' });
+  const original = modelResolver.resolveModelForTier;
+  let captured = null;
+  modelResolver.resolveModelForTier = function (...a) { captured = a; return 'haiku'; };
+  try {
+    adapter.resolveModel({ cwd: '/tmp/proj', agentType: 'executor' });
+    assert.deepStrictEqual(captured, ['/tmp/proj', 'executor', undefined], 'attempt defaults to undefined');
+  } finally {
+    modelResolver.resolveModelForTier = original;
+  }
+});
+
+test('active model adapter: sendRequest invokes the bound host provider', () => {
+  const calls = [];
+  const adapter = createModelAdapter(
+    { modelMode: 'active' },
+    { sendRequest: (req) => { calls.push(req); return { ok: true, echo: req }; } },
+  );
+  assert.strictEqual(adapter.mode, 'active');
+  const out = adapter.sendRequest({ prompt: 'hi' });
+  assert.deepStrictEqual(calls, [{ prompt: 'hi' }], 'host provider invoked with the request');
+  assert.deepStrictEqual(out, { ok: true, echo: { prompt: 'hi' } }, 'host provider return value passed through');
+});
+
+test('active model adapter: FAIL-CLOSED when no host provider is bound (sendRequest throws)', () => {
+  const adapter = createModelAdapter({ modelMode: 'active' });
+  assert.throws(
+    () => adapter.sendRequest({ prompt: 'hi' }),
+    /no host provider bound/,
+    'sendRequest must throw when no provider is bound (fail-closed, never silently no-op)',
+  );
+});
+
+test('createModelAdapter: invalid modelMode throws (fail-closed construction)', () => {
+  for (const bad of ['host', 'dynamic', '', null, undefined, 3]) {
+    assert.throws(() => createModelAdapter({ modelMode: bad }), TypeError, `modelMode=${JSON.stringify(bad)} must throw TypeError`);
+  }
+});


### PR DESCRIPTION
## Feature PR

> **Using the wrong template?**
> — Bug fix: use [fix.md](?template=fix.md)
> — Enhancement to existing behavior: use [enhancement.md](?template=enhancement.md)

---

## Linked Issue

Closes #1680

> #1680 carries `approved-feature` (Phase 3 of epic #1678, ADR-1239 Phase C-1).
>
> ⚠️ **This PR is AC3** (model seams). AC1 (#1802) + AC2 (#1803) merged. AC4 (hook/state seams) remains. **#1680 must stay open.**

---

## Feature summary

Phase 3 slice 3 (AC3): the **model adapter seam** — `createModelAdapter({modelMode})`. Two model-layer adapters selected by the negotiated `modelMode` axis: `passive` (formalizes today's tier routing from `model-resolver.cts` — GSD injects prompts / per-agent `model` field) and `active` (a host-supplied `sendRequest` seam — VS Code `vscode.lm` / pi providers — fail-closed until Phase 5 binds a concrete provider).

---

## What changed

### New files

| File | Purpose |
|------|---------|
| `src/model-adapter.cts` | `createModelAdapter({modelMode}, {sendRequest?})` factory → `PassiveModelAdapter` (resolveModel delegates to model-resolver) or `ActiveModelAdapter` (sendRequest seam, fail-closed). |
| `tests/model-adapter.test.cjs` | passive delegation + attempt-optional, active sendRequest binding + fail-closed-unbound, invalid-mode throws. |

### Modified files

| File | What changed |
|------|-------------|
| `eslint.config.mjs` | ADR-457 ignores entry for `model-adapter.cjs`. |
| `docs/INVENTORY-MANIFEST.json` | `model-adapter.cjs` in `cli_modules`. |

---

## Implementation notes

- **passive reproduces today's behavior:** `resolveModel` delegates straight to `modelResolver.resolveModelForTier(cwd, agentType, attempt)` — byte-for-behavior identical.
- **active is a seam only:** `sendRequest` is a host-supplied slot; throws fail-closed if unbound. Concrete request/response protocol is fixed when Phase 5 wires a real provider.
- Proactive gates: ADR-457 ignores + INVENTORY-MANIFEST + comment-wording audited for the injection-scan `act as` substring trap.

---

## Spec compliance

- [x] **AC1** declarative adapter — shipped (#1802)
- [x] **AC2** imperative adapter — shipped (#1803)
- [x] **AC3** model `passive` + `active` seam — **this PR**
- [ ] **AC4** hook-bus + `stateIO` seams — follow-up

---

## Testing

- **New:** `tests/model-adapter.test.cjs` (5 tests, TDD red→green).
- **Gates:** security injection scan 15/15, inventory drift 1/1, eslint 0 problems, golden parity unaffected (additive).
- macOS local; Windows/Linux via CI matrix.

---

## Documentation

- [x] docs-exempt marker inside the changeset fragment (internal seam; no user-facing doc surface).

---

## Checklist

- [x] `Closes #1680` · [x] `approved-feature` · [ ] all AC met (AC3 of 4; #1680 open) · [x] scope within · [x] tests + gates green · [x] `.changeset/` (Changed, docs-exempt) · [x] no new deps · [x] Windows via CI

---

## Breaking changes

None. Additive seam; not wired to any runtime path. Phase 5 binds the active provider.

---

Closes #1680 *(AC3 slice; issue should remain open)*.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785251773&installation_id=134682257&pr_number=1804&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1804&signature=fd14914d51e2ffbb33f65d56326402bb0dfdd3abcd2052e0d61aa8cc6f074edc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->