### PR TITLE
feat(#1681): ADR-1239 Phase C-2 — external-descriptor trust gate (configHome confinement) [slice 1]

### DIFF
--- a/.changeset/wise-elks-caper.md
+++ b/.changeset/wise-elks-caper.md
@@ -1,0 +1,7 @@
+---
+type: Changed
+pr: 1806
+---
+**Internal: external-descriptor trust gate — load-time `configHome` confinement** — `assertDescriptorConfined(descriptor, configHome)` (new `src/external-descriptor-trust.cts`) fail-closed rejects any installed third-party host-plugin descriptor whose declared `destSubpath` resolves outside the user-approved `configHome`, before its install plan runs (ADR-1239 Phase C-2 / #1681 slice 1). Defense-in-depth load-time twin of Phase 2's install-time `assertDestWithinConfigHome`. Not yet wired into the loader (slice 2). No user-facing change.
+
+<!-- docs-exempt: internal security module; no user-facing doc surface until the loader wiring in slice 2 -->

--- a/docs/INVENTORY-MANIFEST.json
+++ b/docs/INVENTORY-MANIFEST.json
@@ -327,6 +327,7 @@
       "eval-command-router.cjs",
       "eval.cjs",
       "embedding-adapter.cjs",
+      "external-descriptor-trust.cjs",
       "fallow-runner.cjs",
       "federated-config.cjs",
       "frontmatter.cjs",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -207,6 +207,7 @@ export default tseslint.config(
       'gsd-core/bin/lib/model-adapter.cjs',
       'gsd-core/bin/lib/hook-bus.cjs',
       'gsd-core/bin/lib/state-io.cjs',
+      'gsd-core/bin/lib/external-descriptor-trust.cjs',
     ],
   },
 

--- a/src/external-descriptor-trust.cts
+++ b/src/external-descriptor-trust.cts
@@ -1,0 +1,82 @@
+/**
+ * External-descriptor trust gate (ADR-1239 Phase C-2, #1681).
+ *
+ * Load-time `configHome` write-confinement for installed third-party host-plugin
+ * descriptors. The opt-in loader (`loadRegistry({includeInstalled:true})`) already
+ * applies schema validation + consent + first-party-wins + fail-closed gates;
+ * this adds defense-in-depth: **before** a third-party descriptor's install plan
+ * is ever executed, assert every destSubpath it declares resolves within the
+ * user-approved `configHome`. A path-escaping or malformed descriptor is
+ * rejected fail-closed.
+ *
+ * This is the load-time twin of Phase 2's install-time gate
+ * (`assertDestWithinConfigHome` in runtime-artifact-install-plan.cts, #1679 AC3).
+ * The two are defense-in-depth: load-time rejects malformed descriptors early
+ * (before consent even matters); install-time bounds the actual writes.
+ *
+ * Do NOT conflate with ADR-1577's prompt-injection circuit-breaker — separate
+ * concern sharing the word "trust".
+ */
+'use strict';
+
+import path from 'node:path';
+
+/**
+ * Pure path-containment check (cross-platform). `target` is confined to `root`
+ * iff resolving it relative to `root` yields a path equal to or under `root`.
+ * Absolute paths outside `root` and `..`-escapes return false.
+ */
+export function isPathConfined(target: string, root: string): boolean {
+  if (typeof target !== 'string' || typeof root !== 'string' || target.length === 0 || root.length === 0) {
+    return false;
+  }
+  const rootResolved = path.resolve(root);
+  const targetResolved = path.resolve(root, target);
+  const prefix = rootResolved + path.sep;
+  return targetResolved === rootResolved || targetResolved.startsWith(prefix);
+}
+
+export interface DescriptorArtifactKind {
+  destSubpath?: unknown;
+}
+export interface DescriptorArtifactLayout {
+  global?: DescriptorArtifactKind[];
+  local?: DescriptorArtifactKind[];
+}
+export interface DescriptorRuntimeBlock {
+  artifactLayout?: DescriptorArtifactLayout;
+}
+export interface DescriptorLike {
+  id?: string;
+  runtime?: DescriptorRuntimeBlock;
+}
+
+/**
+ * Assert every destSubpath the descriptor declares (global + local artifact
+ * layout) resolves within `configHome`. Throws fail-closed naming the offending
+ * descriptor + path on the first escape. A descriptor with no artifact layout
+ * passes (nothing to confine).
+ */
+export function assertDescriptorConfined(descriptor: DescriptorLike, configHome: string): void {
+  if (!descriptor || typeof descriptor !== 'object') return;
+  const id = typeof descriptor.id === 'string' ? descriptor.id : '<unknown>';
+  const layout = descriptor.runtime?.artifactLayout;
+  if (!layout || typeof layout !== 'object') return;
+
+  const check = (scope: 'global' | 'local', kinds: DescriptorArtifactKind[] | undefined) => {
+    if (!Array.isArray(kinds)) return;
+    for (const kind of kinds) {
+      const dest = kind?.destSubpath;
+      if (typeof dest !== 'string' || dest.length === 0) continue;
+      if (!isPathConfined(dest, configHome)) {
+        throw new Error(
+          `external-descriptor-trust: descriptor '${id}' declares an unconfined ${scope} destSubpath ` +
+          `${JSON.stringify(dest)} (resolves outside configHome ${JSON.stringify(configHome)}) — rejected fail-closed.`,
+        );
+      }
+    }
+  };
+
+  check('global', layout.global);
+  check('local', layout.local);
+}

--- a/tests/external-descriptor-confinement.test.cjs
+++ b/tests/external-descriptor-confinement.test.cjs
@@ -1,0 +1,84 @@
+'use strict';
+/**
+ * Tests for the external-descriptor trust gate (ADR-1239 Phase C-2, #1681).
+ * Pins: confined passes; escapes (.. / absolute) rejected fail-closed; missing
+ * layout passes; the configHome-equals-root edge; non-string destSubpath skipped.
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const {
+  isPathConfined,
+  assertDescriptorConfined,
+} = require('../gsd-core/bin/lib/external-descriptor-trust.cjs');
+
+test('isPathConfined: confined paths are true, escapes are false', () => {
+  const root = path.join('/home', 'me', '.gsd');
+  assert.ok(isPathConfined('skills', root), 'simple subdir is confined');
+  assert.ok(isPathConfined('skills/gsd-plan.md', root), 'nested subdir is confined');
+  assert.ok(isPathConfined('.', root), 'root itself is confined');
+  assert.ok(!isPathConfined('../etc/passwd', root), 'parent escape is NOT confined');
+  assert.ok(!isPathConfined('../../etc', root), 'multi-level escape is NOT confined');
+  assert.ok(!isPathConfined('/etc/passwd', root), 'absolute path outside root is NOT confined');
+  assert.ok(!isPathConfined('', root), 'empty target is NOT confined');
+  assert.ok(!isPathConfined('skills', ''), 'empty root is NOT confined');
+});
+
+test('assertDescriptorConfined: a benign descriptor (all destSubpaths under configHome) passes', () => {
+  const desc = {
+    id: 'community-host',
+    runtime: { artifactLayout: {
+      global: [{ destSubpath: 'skills' }, { destSubpath: 'agents' }],
+      local: [{ destSubpath: 'commands' }],
+    } },
+  };
+  assert.doesNotThrow(() => assertDescriptorConfined(desc, '/home/me/.community'));
+});
+
+test('assertDescriptorConfined: a global destSubpath escape is rejected fail-closed', () => {
+  const desc = {
+    id: 'malicious-host',
+    runtime: { artifactLayout: { global: [{ destSubpath: '../../../etc/passwd' }] } },
+  };
+  assert.throws(
+    () => assertDescriptorConfined(desc, '/home/me/.gsd'),
+    /malicious-host.*unconfined global destSubpath.*fail-closed/,
+    'an escaping global destSubpath must be rejected with a fail-closed error naming the descriptor',
+  );
+});
+
+test('assertDescriptorConfined: a local destSubpath escape is rejected fail-closed', () => {
+  const desc = {
+    id: 'sneaky-host',
+    runtime: { artifactLayout: { local: [{ destSubpath: '../../.ssh/authorized_keys' }] } },
+  };
+  assert.throws(
+    () => assertDescriptorConfined(desc, '/home/me/.gsd'),
+    /sneaky-host.*unconfined local destSubpath/,
+    'an escaping local destSubpath must be rejected',
+  );
+});
+
+test('assertDescriptorConfined: an absolute destSubpath outside configHome is rejected', () => {
+  const desc = {
+    id: 'abs-host',
+    runtime: { artifactLayout: { global: [{ destSubpath: '/etc/cron.d/evil' }] } },
+  };
+  assert.throws(() => assertDescriptorConfined(desc, '/home/me/.gsd'), /unconfined global destSubpath/);
+});
+
+test('assertDescriptorConfined: a descriptor with no artifact layout passes (nothing to confine)', () => {
+  assert.doesNotThrow(() => assertDescriptorConfined({ id: 'bare', runtime: {} }, '/home/me/.gsd'));
+  assert.doesNotThrow(() => assertDescriptorConfined({ id: 'noruntime' }, '/home/me/.gsd'));
+  assert.doesNotThrow(() => assertDescriptorConfined({}, '/home/me/.gsd'));
+  assert.doesNotThrow(() => assertDescriptorConfined(null, '/home/me/.gsd'));
+});
+
+test('assertDescriptorConfined: non-string / empty destSubpath entries are skipped (not flagged)', () => {
+  const desc = {
+    id: 'mixed',
+    runtime: { artifactLayout: { global: [{ destSubpath: 'skills' }, { destSubpath: '' }, { destSubpath: null }, {}, { destSubpath: 'agents' }] } },
+  };
+  assert.doesNotThrow(() => assertDescriptorConfined(desc, '/home/me/.x'), 'valid entries pass; invalid entries skipped');
+});


### PR DESCRIPTION
## Feature PR

> **Using the wrong template?**
> — Bug fix: use [fix.md](?template=fix.md)
> — Enhancement to existing behavior: use [enhancement.md](?template=enhancement.md)

---

## Linked Issue

Closes #1681

> #1681 carries `approved-feature` (Phase 4 of epic #1678, ADR-1239 Phase C-2).
>
> ⚠️ **This PR is slice 1 of Phase 4** — the **trust-gate module** (load-time `configHome` confinement validator). The loadRegistry wiring (slice 2) + the companion MCP server (slice 3) remain. **#1681 must stay open.**

---

## Feature summary

Phase 4 slice 1: the **external-descriptor trust gate** — `src/external-descriptor-trust.cts`. A load-time, fail-closed validator that asserts every `destSubpath` an installed third-party host-plugin descriptor declares resolves within the user-approved `configHome`, BEFORE its install plan is ever executed. Defense-in-depth on top of the existing opt-in/schema/consent/first-party-wins/fail-closed loader gates + Phase 2's install-time `assertDestWithinConfigHome` (#1679 AC3): load-time rejects malformed/escaping descriptors early; install-time bounds the actual writes.

---

## What changed

### New files

| File | Purpose |
|------|---------|
| `src/external-descriptor-trust.cts` | `isPathConfined(target, root)` pure containment primitive + `assertDescriptorConfined(descriptor, configHome)` fail-closed validator (walks `runtime.artifactLayout` global/local destSubpaths). |
| `tests/external-descriptor-confinement.test.cjs` | 7 tests: containment primitive, benign passes, global/local/absolute escapes rejected, missing-layout passes, invalid entries skipped. |

### Modified files

| File | What changed |
|------|-------------|
| `eslint.config.mjs` | ADR-457 ignores entry for `external-descriptor-trust.cjs`. |
| `docs/INVENTORY-MANIFEST.json` | `external-descriptor-trust.cjs` in `cli_modules`. |

---

## Implementation notes

- **Load-time twin of Phase 2's install-time gate:** `assertDestWithinConfigHome` (runtime-artifact-install-plan.cjs) bounds writes at install; this gate bounds declared writes at load — before consent even matters. Defense-in-depth, not redundant.
- **Self-contained primitive:** `isPathConfined` uses `path.resolve` + `path.sep` (cross-platform); rejects absolute-outside-root + `..` escapes. No cross-module dependency (cleaner for a security gate the loader calls cheaply).
- **Fail-closed by construction:** the first escaping destSubpath throws, naming the descriptor + path.
- **Not wired into `loadRegistry` yet** (slice 2) — this ships the reusable gate + tests; the integration (4 callers, medium blast radius) is the next slice.
- Do NOT conflate with ADR-1577's prompt-injection circuit-breaker (separate concern, shared word "trust").

---

## Spec compliance

This PR is **Phase 4 slice 1**. Per-AC status of #1681:

- [~] **AC1** opt-in load external descriptor + schema/consent/**configHome confinement**/fail-closed — **confinement module shipped this PR; loadRegistry wiring is slice 2.** Schema/consent already exist (loader).
- [ ] **AC2** companion MCP server exposes points 1 + 5 — slice 3.
- [ ] **AC3** MCP server reachable by any MCP host; transport disclosed at consent — slice 3.
- [ ] **AC4** server lifecycle documented + tested — slice 3.
- [ ] **AC5** security review of the trust gate — the gate ships with a fail-closed test suite here; full review pending.

---

## Testing

- **New:** `tests/external-descriptor-confinement.test.cjs` (7 tests, TDD red→green). Containment primitive + benign + 3 escape vectors + missing-layout + invalid-entry skip.
- **Gates:** security injection scan ✅, inventory drift ✅, eslint 0 problems, golden parity unaffected (additive).
- macOS local; Windows/Linux via CI matrix (path semantics cross-platform via `path.resolve`).

---

## Documentation

- [x] docs-exempt marker inside the changeset fragment (internal security module; no user-facing doc surface until the loader wiring in slice 2).

---

## Checklist

- [x] `Closes #1681` · [x] `approved-feature` · [ ] all AC met (slice 1 of 3; #1681 open) · [x] scope within · [x] tests + gates green · [x] `.changeset/` (Changed, docs-exempt) · [x] no new deps · [x] Windows via CI

---

## Breaking changes

None. Additive module; not wired into the loader yet (slice 2). No behavior change for any user.

---

Closes #1681 *(Phase 4 slice 1; issue should remain open)*.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1806"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785253757&installation_id=134682257&pr_number=1806&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1806&signature=c42d42e73e8b55552cd43170726a8d3030991c88315832191719a55fabb3bdb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->