### PR TITLE
feat(#1681): ADR-1239 Phase C-2 — wire trust gate into loadRegistry (configHome confinement) [slice 2]

### DIFF
--- a/.changeset/bold-ravens-wake.md
+++ b/.changeset/bold-ravens-wake.md
@@ -1,0 +1,7 @@
+---
+type: Changed
+pr: 1808
+---
+**Internal: third-party descriptor loader enforces `configHome` write-confinement at load time** — `loadRegistry({includeInstalled:true, configHome})` now rejects (skip + warn, fail-closed) any installed third-party host-plugin descriptor whose declared `destSubpath` resolves outside the supplied `configHome`, before it is composed into the registry (ADR-1239 Phase C-2 / #1681 slice 2). The `configHome` option is optional and backward-compatible (omitted → no load-time check; install-time gate still bounds writes). No user-facing change for existing flows.
+
+<!-- docs-exempt: internal loader hardening; no user-facing doc surface until slice 3's MCP server -->

--- a/src/capability-loader.cts
+++ b/src/capability-loader.cts
@@ -101,6 +101,14 @@ export interface LoadRegistryOptions {
   gsdHome?: string;
   /** Override the running GSD version used for engines.gsd satisfaction. */
   hostVersion?: string;
+  /**
+   * Optional configHome root for load-time write-confinement of installed
+   * third-party descriptors (ADR-1239 Phase C-2 / #1681). When set, each
+   * installed overlay's declared destSubpaths must resolve within this root or
+   * the descriptor is rejected fail-closed (skip + warn). Omit to rely on the
+   * install-time gate only (backward-compatible).
+   */
+  configHome?: string;
 }
 
 export interface OverlaySkip {
@@ -473,6 +481,10 @@ export function loadRegistry(options: LoadRegistryOptions = {}): Registry {
   const ledgerMod: LedgerModule = require('./capability-ledger.cjs');
   // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-unsafe-assignment
   const consentMod: ConsentModule = require('./capability-consent.cjs');
+  // ADR-1239 Phase C-2 (#1681): load-time configHome confinement for installed
+  // third-party descriptors. Accessed via module ref for stub compatibility.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-unsafe-assignment
+  const externalDescriptorTrust: { assertDescriptorConfined(descriptor: unknown, configHome: string): void; isPathConfined(target: string, root: string): boolean } = require('./external-descriptor-trust.cjs');
 
   const cwd = options.cwd || process.cwd();
   const hostVersion = options.hostVersion || readHostVersion();
@@ -746,6 +758,20 @@ export function loadRegistry(options: LoadRegistryOptions = {}): Registry {
         acceptedMap.delete(id);
         skip('cross-capability validation failed: ' + crossErrs.slice(0, 3).join('; '));
         continue;
+      }
+
+      // ADR-1239 Phase C-2 (#1681): load-time configHome confinement — reject
+      // (skip + warn) any installed third-party descriptor whose declared
+      // destSubpath escapes the user-approved configHome, BEFORE it is composed.
+      // Defense-in-depth on top of the install-time gate (#1679 AC3).
+      if (typeof options.configHome === 'string' && options.configHome.length > 0) {
+        try {
+          externalDescriptorTrust.assertDescriptorConfined(cap, options.configHome);
+        } catch (confineErr) {
+          acceptedMap.delete(id);
+          skip('configHome confinement rejected: ' + errMessage(confineErr));
+          continue;
+        }
       }
 
       // Accepted.

--- a/tests/external-descriptor-loader-wiring.test.cjs
+++ b/tests/external-descriptor-loader-wiring.test.cjs
@@ -1,0 +1,75 @@
+'use strict';
+/**
+ * Integration test: loadRegistry wires the external-descriptor trust gate
+ * (ADR-1239 Phase C-2 / #1681 slice 2). When `configHome` is supplied, an
+ * installed overlay whose declared destSubpath escapes it is rejected
+ * (skip + confinement reason) and NOT composed; a confined overlay composes.
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { cleanup } = require('./helpers.cjs');
+const { loadRegistry } = require('../gsd-core/bin/lib/capability-loader.cjs');
+
+const HOST = '1.6.0';
+
+function featureCap(id, extra) {
+  return {
+    id, role: 'feature', version: '1.0.0', title: id, description: 'overlay cap',
+    tier: 'standard', requires: [], engines: { gsd: '>=1.0.0' },
+    runtimeCompat: { supported: ['*'], unsupported: [] },
+    skills: [], agents: [], hooks: [], config: {}, steps: [], contributions: [], gates: [],
+    ...extra,
+  };
+}
+
+// Build a temp GSD home with .gsd/capabilities/<id>/capability.json per cap.
+function makeOverlayHome(caps) {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'cap-trust-'));
+  for (const cap of caps) {
+    const dir = path.join(home, '.gsd', 'capabilities', cap.id);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'capability.json'), JSON.stringify(cap), 'utf8');
+  }
+  return home;
+}
+
+test('loadRegistry configHome confinement: escaping overlay is skipped with a confinement reason', () => {
+  const home = makeOverlayHome([
+    featureCap('confined-host', { runtime: { artifactLayout: { global: [{ destSubpath: 'skills' }] } } }),
+    featureCap('escape-host', { runtime: { artifactLayout: { global: [{ destSubpath: '../../../etc/passwd' }] } } }),
+  ]);
+  try {
+    const reg = loadRegistry({
+      includeInstalled: true, gsdHome: home, cwd: home, hostVersion: HOST,
+      configHome: path.join(home, '.target'),
+    });
+    const overlayIds = Object.keys(reg.capabilities || {}).filter((id) => id === 'confined-host' || id === 'escape-host');
+    assert.ok(overlayIds.includes('confined-host'), 'confined overlay must be composed');
+    assert.ok(!overlayIds.includes('escape-host'), 'escaping overlay must NOT be composed');
+    const skips = (reg._overlay && reg._overlay.warnings) || [];
+    const confinementSkip = skips.find((s) => /confinement/.test(s.reason || ''));
+    assert.ok(confinementSkip, `an overlay must be skipped with a confinement reason; warnings=${JSON.stringify(skips)}`);
+    assert.match(confinementSkip.reason, /escape-host/, 'the confinement skip must name the escaping descriptor');
+  } finally {
+    cleanup(home);
+  }
+});
+
+test('loadRegistry configHome confinement: omitted configHome = no load-time check (backward-compatible; relies on install-time gate)', () => {
+  // Same escaping overlay, but no configHome passed → it is NOT rejected by the load-time gate.
+  const home = makeOverlayHome([
+    featureCap('escape-host', { runtime: { artifactLayout: { global: [{ destSubpath: '../../../etc' }] } } }),
+  ]);
+  try {
+    const reg = loadRegistry({ includeInstalled: true, gsdHome: home, cwd: home, hostVersion: HOST });
+    const warnings = (reg._overlay && reg._overlay.warnings) || [];
+    const confinementSkip = warnings.find((s) => /confinement/.test(s.reason || ''));
+    assert.ok(!confinementSkip, 'no configHome → no load-time confinement check (backward-compatible)');
+  } finally {
+    cleanup(home);
+  }
+});


### PR DESCRIPTION
## Feature PR

> **Using the wrong template?**
> — Bug fix: use [fix.md](?template=fix.md)
> — Enhancement to existing behavior: use [enhancement.md](?template=enhancement.md)

---

## Linked Issue

Closes #1681

> #1681 carries `approved-feature` (Phase 4 of epic #1678, ADR-1239 Phase C-2).
>
> ⚠️ **This PR is slice 2 of Phase 4** — wiring the trust gate (#1806) into `loadRegistry`. The companion MCP server (slice 3) remains. **#1681 must stay open.**

---

## Feature summary

Phase 4 slice 2: wire the external-descriptor trust gate (#1806) into the loader. `loadRegistry({includeInstalled:true, configHome})` now rejects (skip + warn, fail-closed) any installed third-party descriptor whose declared `destSubpath` resolves outside the supplied `configHome` — before it is composed. The `configHome` option is **optional** (backward-compatible: omitted → no load-time check, relies on the install-time gate #1679 AC3).

---

## What changed

### New files

| File | Purpose |
|------|---------|
| `tests/external-descriptor-loader-wiring.test.cjs` | Integration: escaping overlay skipped with a confinement reason when `configHome` set; confined overlay composes; omitted `configHome` = no load-time check (backward-compatible). |

### Modified files

| File | What changed |
|------|-------------|
| `src/capability-loader.cts` | `LoadRegistryOptions.configHome?: string`; require `external-descriptor-trust.cjs`; before `overlayCaps.push(cap)`, if `configHome` set, `assertDescriptorConfined` — on throw, `skip('configHome confinement rejected: …')` + `continue`. |

---

## Implementation notes

- **Fail-closed via the loader's existing skip semantics:** an escaping descriptor is dropped from composition + recorded in `_overlay.warnings` with a confinement reason — the registry's first-party base is never compromised. (The loader already fail-closes per-candidate via its try/catch; this adds a precise confinement skip reason.)
- **Backward-compatible:** `configHome` is optional. The 4 existing callers pass no `configHome` → identical behavior (load-time check off; install-time gate still bounds writes).
- **Defense-in-depth with Phase 2:** load-time (#1681, this slice) rejects malformed descriptors early; install-time `assertDestWithinConfigHome` (#1679 AC3) bounds the actual writes.

---

## Spec compliance

- [x] **AC1** opt-in load external descriptor + schema/consent/**configHome confinement**/fail-closed — **confinement now wired** (this slice + #1806). Schema/consent already existed.
- [ ] **AC2–AC4** companion MCP server — slice 3.
- [ ] **AC5** security review — gate + wiring ship with fail-closed tests.

---

## Testing

- **New:** `tests/external-descriptor-loader-wiring.test.cjs` (2 integration tests).
- **Regression:** `capability-loader.test.cjs` 54/54 (additive option, no behavior change for existing callers).
- **Gates:** security scan ✅, eslint 0 problems, golden parity unaffected.
- macOS local; Windows/Linux via CI.

---

## Documentation

- [x] docs-exempt marker inside the changeset fragment (internal loader hardening; no user-facing doc surface until slice 3's MCP server).

---

## Checklist

- [x] `Closes #1681` · [x] `approved-feature` · [ ] all AC met (slice 2 of 3; #1681 open) · [x] scope within · [x] tests + gates green · [x] `.changeset/` · [x] no new deps · [x] Windows via CI

---

## Breaking changes

None. `configHome` is optional; existing callers unchanged.

---

Closes #1681 *(Phase 4 slice 2; issue should remain open)*.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1808"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785255207&installation_id=134682257&pr_number=1808&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1808&signature=c53602caa62450d5acc49ca6ec40e6307285e19a4c7746d0a5aea0547cdea3b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->