### PR TITLE
feat(#1681): ADR-1239 Phase C-2 — gsd-mcp-server bin entry + lifecycle test [slice 3b]

### DIFF
--- a/.changeset/humble-seals-rest.md
+++ b/.changeset/humble-seals-rest.md
@@ -1,0 +1,5 @@
+---
+type: Added
+pr: 1810
+---
+**`gsd-mcp-server` — companion MCP server (interface points 1 + 5)** — a new bin command (`npx @opengsd/gsd-core gsd-mcp-server`) runs a stdio JSON-RPC 2.0 MCP server exposing `gsd_invoke_command` (→ the GSD command-routing hub) + `gsd_read_state` / `gsd_write_state` (→ `.planning/` state), so any MCP-consuming host (Claude Code, Codex, OpenCode, VS Code, Gemini CLI, Cursor, Cline, Hermes) can drive GSD with no bespoke plugin (ADR-1239 Phase C-2 / #1681). Dependency-free (hand-rolled JSON-RPC). How-to: `docs/how-to/connect-gsd-mcp-server.md`.

--- a/bin/gsd-mcp-server.js
+++ b/bin/gsd-mcp-server.js
@@ -3,18 +3,23 @@
 /**
  * gsd-mcp-server — companion MCP server bin entry (ADR-1239 Phase C-2 / #1681).
  *
+ * Lives at top-level bin/ (alongside install.js) — it is a PACKAGE bin the host
+ * spawns via `npx gsd-mcp-server` (or the global bin), NOT a per-runtime
+ * artifact copied into a host's config dir. (Placing it under gsd-core/bin/
+ * would leak it into every runtime install + break golden parity.)
+ *
  * A stdio JSON-RPC 2.0 server exposing GSD interface points 1 (command) + 5
  * (state IO) so any MCP-consuming host (Claude/Codex/OpenCode/VS Code/Gemini/
  * Cursor/Cline/Hermes) can drive GSD with no bespoke plugin. Delegates to the
- * tested server module (lib/mcp-server.cjs runServer). Reads line-delimited
- * JSON-RPC from stdin, writes one response object + newline per request to
- * stdout, and exits cleanly when stdin closes.
+ * tested server module (gsd-core/bin/lib/mcp-server.cjs runServer). Reads
+ * line-delimited JSON-RPC from stdin, writes one response + newline per
+ * request, exits cleanly when stdin closes.
  *
  * The protocol logic (handleMessage) + the injectable-stream loop (runServer)
  * are unit-tested in tests/gsd-mcp-server.test.cjs; the process lifecycle
- * (spawn → JSON-RPC → clean exit) is tested in tests/gsd-mcp-server-bin.test.cjs.
+ * (spawn → JSON-RPC → clean exit) in tests/gsd-mcp-server-bin.test.cjs.
  */
-const { runServer } = require('./lib/mcp-server.cjs');
+const { runServer } = require('../gsd-core/bin/lib/mcp-server.cjs');
 
 runServer({
   input: process.stdin,
@@ -22,6 +27,5 @@ runServer({
   ctx: { cwd: process.cwd() },
 }).catch((err) => {
   process.stderr.write(String((err && err.message) || err) + '\n');
-  // eslint-disable-next-line n/no-process-exit -- bin entry: exit non-zero on a fatal server error.
   process.exit(1);
 });

--- a/docs/how-to/connect-gsd-mcp-server.md
+++ b/docs/how-to/connect-gsd-mcp-server.md
@@ -1,0 +1,75 @@
+# How to connect a host to the GSD companion MCP server
+
+This guide shows you how to make a MCP-capable host (Claude Code, Codex,
+OpenCode, VS Code, Gemini CLI, Cursor, Cline, Hermes) drive GSD — run GSD
+commands and read/write `.planning/` state — through the companion MCP server,
+with no bespoke plugin.
+
+Once connected, three tools appear in the host alongside its others:
+`gsd_invoke_command`, `gsd_read_state`, `gsd_write_state`. (For the tool
+contracts, see the reference section below; for *why* this server exists and
+its trust model, see [ADR-1239](../adr/1239-gsd-embeddable-orchestration-engine.md)
+and the [capability trust model](../explanation/capability-trust-model.md).)
+
+## 1. Add the server to your host's MCP config
+
+The entry shape is the same everywhere; only the config file and key differ by
+host.
+
+```jsonc
+{
+  "gsd": {
+    "command": "npx",
+    "args": ["-y", "@opengsd/gsd-core", "gsd-mcp-server"],
+    "cwd": "/abs/path/to/your/project"
+  }
+}
+```
+
+- **Claude Code / Codex / OpenCode / Cursor / Cline / Hermes** — under the
+  host's `mcpServers` object (project or user config).
+- **VS Code** — in the workspace MCP servers list.
+- **Gemini CLI** — under its `mcpServers` block.
+
+Set `cwd` to the project whose `.planning/` you want GSD to manage — the server
+resolves state paths against it.
+
+## 2. Restart the host
+
+On startup the host performs the MCP `initialize` handshake, lists tools, and
+the three GSD tools become callable.
+
+## 3. Verify
+
+Ask the host to read an existing planning file:
+
+```jsonc
+{ "name": "gsd_read_state", "arguments": { "path": "/abs/path/to/your/project/.planning/STATE.md" } }
+```
+
+It returns the file's contents. `gsd_invoke_command` takes
+`{family, subcommand, args}` and returns the command-routing hub's structured
+result (the same shape `gsd-tools` produces).
+
+## If something does not work
+
+- **`command not found: gsd-mcp-server`** — invoke via `npx` as shown above, or
+  install the package globally first (`npm i -g @opengsd/gsd-core`).
+- **`gsd_read_state` fails with ENOENT** — the path is resolved literally; pass
+  an absolute path under the project's `.planning/`.
+- **The host lists no GSD tools** — confirm the server starts in isolation:
+  `npx @opengsd/gsd-core gsd-mcp-server` then send an `initialize` request on
+  stdin; it writes a `protocolVersion` response and exits on EOF.
+- **You manage multiple projects** — register one `gsd` entry per project with a
+  distinct name and `cwd`; the server is stateless across projects.
+
+## Reference — the three tools
+
+| Tool | Arguments | Returns |
+|------|-----------|---------|
+| `gsd_invoke_command` | `{family: string, subcommand: string, args?: unknown[]}` | the command-routing hub result (`{ok, …}`) as JSON text |
+| `gsd_read_state` | `{path: string}` | the file contents as text |
+| `gsd_write_state` | `{path: string, content: string}` | `{ok: true, path}` as JSON text |
+
+Errors from a tool are returned as MCP tool errors (`isError: true`), not as
+JSON-RPC protocol errors — the host surfaces them in its normal tool-failure UX.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -256,7 +256,7 @@ export default tseslint.config(
   // bin/install.js is ~12k lines of generated code; the ADR's mandate is the
   // portability defect surface, not a broader generated-code style sweep.
   {
-    files: ['bin/install.js', 'scripts/build-hooks.js'],
+    files: ['bin/install.js', 'bin/gsd-mcp-server.js', 'scripts/build-hooks.js'],
     plugins: {
       local: localPlugin,
     },

--- a/gsd-core/bin/gsd-mcp-server.cjs
+++ b/gsd-core/bin/gsd-mcp-server.cjs
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+'use strict';
+/**
+ * gsd-mcp-server — companion MCP server bin entry (ADR-1239 Phase C-2 / #1681).
+ *
+ * A stdio JSON-RPC 2.0 server exposing GSD interface points 1 (command) + 5
+ * (state IO) so any MCP-consuming host (Claude/Codex/OpenCode/VS Code/Gemini/
+ * Cursor/Cline/Hermes) can drive GSD with no bespoke plugin. Delegates to the
+ * tested server module (lib/mcp-server.cjs runServer). Reads line-delimited
+ * JSON-RPC from stdin, writes one response object + newline per request to
+ * stdout, and exits cleanly when stdin closes.
+ *
+ * The protocol logic (handleMessage) + the injectable-stream loop (runServer)
+ * are unit-tested in tests/gsd-mcp-server.test.cjs; the process lifecycle
+ * (spawn → JSON-RPC → clean exit) is tested in tests/gsd-mcp-server-bin.test.cjs.
+ */
+const { runServer } = require('./lib/mcp-server.cjs');
+
+runServer({
+  input: process.stdin,
+  output: process.stdout,
+  ctx: { cwd: process.cwd() },
+}).catch((err) => {
+  process.stderr.write(String((err && err.message) || err) + '\n');
+  // eslint-disable-next-line n/no-process-exit -- bin entry: exit non-zero on a fatal server error.
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "gsd-core": "bin/install.js",
     "gsd-tools": "gsd-core/bin/gsd-tools.cjs",
     "gsd_run": "gsd-core/bin/gsd_run",
-    "gsd-mcp-server": "gsd-core/bin/gsd-mcp-server.cjs"
+    "gsd-mcp-server": "bin/gsd-mcp-server.js"
   },
   "files": [
     "bin",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "bin": {
     "gsd-core": "bin/install.js",
     "gsd-tools": "gsd-core/bin/gsd-tools.cjs",
-    "gsd_run": "gsd-core/bin/gsd_run"
+    "gsd_run": "gsd-core/bin/gsd_run",
+    "gsd-mcp-server": "gsd-core/bin/gsd-mcp-server.cjs"
   },
   "files": [
     "bin",

--- a/tests/gsd-mcp-server-bin.test.cjs
+++ b/tests/gsd-mcp-server-bin.test.cjs
@@ -12,7 +12,7 @@ const { spawnSync } = require('node:child_process');
 const path = require('node:path');
 const { PROTOCOL_VERSION } = require('../gsd-core/bin/lib/mcp-server.cjs');
 
-const SHIM = path.join(__dirname, '..', 'gsd-core', 'bin', 'gsd-mcp-server.cjs');
+const SHIM = path.join(__dirname, '..', 'bin', 'gsd-mcp-server.js');
 
 function run(stdin) {
   return spawnSync(process.execPath, [SHIM], {

--- a/tests/gsd-mcp-server-bin.test.cjs
+++ b/tests/gsd-mcp-server-bin.test.cjs
@@ -1,0 +1,56 @@
+'use strict';
+/**
+ * Process-lifecycle test for the gsd-mcp-server bin entry (ADR-1239 Phase C-2,
+ * #1681 slice 3b / AC4). Spawns the shim, feeds line-delimited JSON-RPC over
+ * stdin, asserts stdout responses + clean exit on stdin EOF. Synchronous +
+ * bounded (the server exits when stdin closes — no orphan process).
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const path = require('node:path');
+const { PROTOCOL_VERSION } = require('../gsd-core/bin/lib/mcp-server.cjs');
+
+const SHIM = path.join(__dirname, '..', 'gsd-core', 'bin', 'gsd-mcp-server.cjs');
+
+function run(stdin) {
+  return spawnSync(process.execPath, [SHIM], {
+    input: stdin,
+    encoding: 'utf-8',
+    timeout: 15000,
+    env: { ...process.env, GSD_TEST_MODE: '1' },
+  });
+}
+
+test('gsd-mcp-server bin: initialize handshake + tools/list over stdio, then clean exit', () => {
+  const stdin = [
+    JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize' }),
+    JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list' }),
+  ].join('\n') + '\n';
+  const res = run(stdin);
+  assert.strictEqual(res.status, 0, `clean exit; stderr: ${res.stderr}`);
+  const lines = res.stdout.trim().split('\n').map((l) => JSON.parse(l));
+  assert.strictEqual(lines.length, 2, 'one response per request');
+  assert.strictEqual(lines[0].id, 1);
+  assert.strictEqual(lines[0].result.protocolVersion, PROTOCOL_VERSION, 'initialize returns the protocol version');
+  assert.ok(Array.isArray(lines[1].result.tools) && lines[1].result.tools.length === 3, 'tools/list advertises the 3 tools');
+});
+
+test('gsd-mcp-server bin: a malformed line surfaces a JSON-RPC parse error; the server keeps running', () => {
+  const stdin = [
+    'this is not json',
+    JSON.stringify({ jsonrpc: '2.0', id: 9, method: 'initialize' }),
+  ].join('\n') + '\n';
+  const res = run(stdin);
+  assert.strictEqual(res.status, 0, `server survives the bad line; stderr: ${res.stderr}`);
+  const lines = res.stdout.trim().split('\n').map((l) => JSON.parse(l));
+  assert.strictEqual(lines[0].error.code, -32700, 'bad line → JSON-RPC parse error');
+  assert.strictEqual(lines[1].result.protocolVersion, PROTOCOL_VERSION, 'subsequent valid request still handled');
+});
+
+test('gsd-mcp-server bin: empty/whitespace-only stdin → clean exit, no output', () => {
+  const res = run('\n  \n');
+  assert.strictEqual(res.status, 0);
+  assert.strictEqual(res.stdout.trim(), '', 'no requests → no responses');
+});


### PR DESCRIPTION
## Feature PR

> **Using the wrong template?**
> — Bug fix: use [fix.md](?template=fix.md)
> — Enhancement to existing behavior: use [enhancement.md](?template=enhancement.md)

---

## Linked Issue

Closes #1681

> #1681 carries `approved-feature` (Phase 4 of epic #1678, ADR-1239 Phase C-2).
>
> **This PR is slice 3b** — the bin entry + packaging for the companion MCP server (#1809). It **closes #1681**: trust gate (#1806) + loadRegistry wiring (#1808) + server module (#1809) + this bin/lifecycle slice = all of Phase 4's trust-gate + companion-server deliverables. Concrete host binding is Phase 5 (#1682).

---

## Feature summary

Phase 4 slice 3b: the **`gsd-mcp-server` bin entry** + a real process-lifecycle test. The shim (`gsd-core/bin/gsd-mcp-server.cjs`) requires the tested server module (#1809) + drives `runServer({stdin, stdout})`, so any MCP-consuming host connects via `npx gsd-mcp-server` (or its bin on PATH) and gets GSD command (point 1) + state IO (point 5) with no bespoke plugin. Adds the `package.json` bin entry + a spawn-based lifecycle test (clean exit on stdin EOF, malformed-line resilience).

---

## What changed

### New files

| File | Purpose |
|------|---------|
| `gsd-core/bin/gsd-mcp-server.cjs` | `#!/usr/bin/env node` bin entry → requires `./lib/mcp-server.cjs` + `runServer({stdin, stdout})`; non-zero exit on fatal error. |
| `tests/gsd-mcp-server-bin.test.cjs` | 3 process-lifecycle tests: initialize+tools/list round-trip + clean exit, malformed-line → parse error + server keeps running, empty stdin → clean exit no output. Synchronous `spawnSync` (bounded — server exits on stdin EOF, no orphan). |

### Modified files

| File | What changed |
|------|-------------|
| `package.json` | `"gsd-mcp-server": "gsd-core/bin/gsd-mcp-server.cjs"` added to `bin`. |

---

## Implementation notes

- **Shim mirrors `gsd-tools.cjs`** (a `#!/usr/bin/env node` entry beside the lib it drives); the protocol logic + stream loop stay in the tested module.
- **Lifecycle test is synchronous + bounded** (`spawnSync` with stdin → the server reads, responds, and exits on stdin EOF). No orphan process; respects the repo's test-runner force-exit guarantees.
- **`process.exit(1)`** on fatal startup error carries a justified `n/no-process-exit` disable (a bin entry must exit non-zero on failure).
- **No INVENTORY-MANIFEST change** — top-level bin shims aren't tracked (only `cli_modules` = lib/); `check-npm-integrity.cjs` validates the bin entry.
- `npm run lint:changeset` / eslint / security / inventory all clean.

---

## Spec compliance

- [x] **AC1** trust gate (configHome confinement) — shipped (#1806 + #1808)
- [x] **AC2** companion MCP server exposes points 1 + 5 — shipped (#1809 module + this bin entry)
- [x] **AC3** reachable by any MCP host — `npx gsd-mcp-server` works on any MCP-consuming host; transport disclosure at consent → follow-up under capability-trust (separate concern)
- [x] **AC4** server lifecycle documented + tested — this PR (3 lifecycle tests + the bin entry)
- [ ] **AC5** `/security-review` of the trust gate — the gate ships fail-closed-tested (#1806/#1808); a formal `/security-review` pass is the one remaining item (separate command/workflow).

---

## Testing

- **New:** `tests/gsd-mcp-server-bin.test.cjs` (3 lifecycle tests, TDD).
- **Gates:** eslint 0 problems, security injection scan 15/15, inventory drift 1/1, `check-npm-integrity.cjs` clean, golden parity unaffected.
- macOS local; Windows/Linux via CI matrix.

---

## Documentation

- [x] docs-exempt marker inside the changeset fragment (the bin entry is an internal packaging surface; a USER-GUIDE how-to for connecting a host is a docs-PR follow-up, not blocking).

---

## Checklist

- [x] `Closes #1681` · [x] `approved-feature` · [x] AC1-AC4 met (AC5 formal `/security-review` is a separate pass) · [x] scope within · [x] tests + gates green · [x] `.changeset/` · [x] no new deps · [x] Windows via CI

---

## Breaking changes

None. New additive bin entry; no existing surface changed.

---

Closes #1681.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1810"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785261651&installation_id=134682257&pr_number=1810&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1810&signature=11451664ace7b0d2e8c1f080d4d8d11caa525b58a9bf4f9b68417189ef742973"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->