### PR TITLE
refactor(#1679): ADR-1239 Phase B — collapse program + command chains [AC2 slice 4]

### DIFF
--- a/.changeset/bold-orcas-wander.md
+++ b/.changeset/bold-orcas-wander.md
@@ -1,0 +1,7 @@
+---
+type: Changed
+pr: 1811
+---
+**Internal: the installer's per-function `is<Runtime>` flag-declaration blocks are now a single `runtimeFlags` lookup** — the four duplicated `const isX = runtime === 'x'` blocks in `bin/install.js` (uninstall / writeManager / install / a fourth helper — 48 branches) are collapsed into one `runtimeFlags(runtime)` helper in `runtime-name-policy.cts` (ADR-1239 Phase B / #1679 AC2 slice 3). The add-a-host tax for flags is removed (one `RUNTIME_FLAG_IDS` entry, not four declaration blocks). Install output is byte-identical for all 16 runtimes (golden-parity asserted); `runtime ===` count in `bin/install.js`: 101 → 53. No user-facing change.
+
+<!-- docs-exempt: internal refactor; no user-facing doc surface -->

--- a/bin/install.js
+++ b/bin/install.js
@@ -37,7 +37,7 @@ const {
 // installer to the runtime-name-policy leaf (ADR-1508 / #1510 Phase 1) so the
 // conversion module's rewrite engine can consume it without importing
 // bin/install.js. Re-exported below for back-compat consumers/tests.
-const { getDirName, getRuntimeLabel, getGlobalConfigHomeFragment } = require('../gsd-core/bin/lib/runtime-name-policy.cjs');
+const { getDirName, getRuntimeLabel, getGlobalConfigHomeFragment, runtimeFlags } = require('../gsd-core/bin/lib/runtime-name-policy.cjs');
 const {
   applyWorktreeBaseRef,
   readBaseRefFromSettings,
@@ -6918,19 +6918,7 @@ const GSD_UNINSTALL_HOOKS = [
  * @param {string} runtime - Target runtime ('claude', 'opencode', 'gemini', 'codex', 'copilot')
  */
 function uninstall(isGlobal, runtime = 'claude') {
-  const isOpencode = runtime === 'opencode';
-  const isKilo = runtime === 'kilo';
-  const isGemini = runtime === 'gemini';
-  const isCodex = runtime === 'codex';
-  const isCopilot = runtime === 'copilot';
-  const isAntigravity = runtime === 'antigravity';
-  const isCursor = runtime === 'cursor';
-  const isWindsurf = runtime === 'windsurf';
-  const isAugment = runtime === 'augment';
-  const isTrae = runtime === 'trae';
-  const isQwen = runtime === 'qwen';
-  const isHermes = runtime === 'hermes';
-  const isCodebuddy = runtime === 'codebuddy';
+  const { isOpencode, isKilo, isGemini, isCodex, isCopilot, isAntigravity, isCursor, isWindsurf, isAugment, isTrae, isQwen, isHermes, isCodebuddy, isCline, isKimi } = runtimeFlags(runtime);
   const dirName = getDirName(runtime);
 
   // Get the target directory based on runtime and install type. Cline local
@@ -7915,18 +7903,7 @@ function resolveInstallRelativePath(baseDir, relPath) {
  * Write file manifest after installation for future modification detection
  */
 function writeManifest(configDir, runtime = 'claude', options = {}) {
-  const isOpencode = runtime === 'opencode';
-  const isKilo = runtime === 'kilo';
-  const isGemini = runtime === 'gemini';
-  const isCodex = runtime === 'codex';
-  const isCopilot = runtime === 'copilot';
-  const isAntigravity = runtime === 'antigravity';
-  const isCursor = runtime === 'cursor';
-  const isWindsurf = runtime === 'windsurf';
-  const isTrae = runtime === 'trae';
-  const isCline = runtime === 'cline';
-  const isKimi = runtime === 'kimi';
-  const isHermes = runtime === 'hermes';
+  const { isOpencode, isKilo, isGemini, isCodex, isCopilot, isAntigravity, isCursor, isWindsurf, isAugment, isTrae, isQwen, isHermes, isCodebuddy, isCline, isKimi } = runtimeFlags(runtime);
   const gsdDir = path.join(configDir, 'gsd-core');
   // #1367: Claude local now writes flat gsd-*.md files at commands/ (not commands/gsd/).
   // commandsDir points to the old location for Gemini (which still uses commands/gsd/).
@@ -8413,21 +8390,7 @@ function reportInstallerMigrationResult(result) {
 }
 
 function install(isGlobal, runtime = 'claude', options = {}) {
-  const isOpencode = runtime === 'opencode';
-  const isGemini = runtime === 'gemini';
-  const isKilo = runtime === 'kilo';
-  const isKimi = runtime === 'kimi';
-  const isCodex = runtime === 'codex';
-  const isCopilot = runtime === 'copilot';
-  const isAntigravity = runtime === 'antigravity';
-  const isCursor = runtime === 'cursor';
-  const isWindsurf = runtime === 'windsurf';
-  const isAugment = runtime === 'augment';
-  const isTrae = runtime === 'trae';
-  const isQwen = runtime === 'qwen';
-  const isHermes = runtime === 'hermes';
-  const isCodebuddy = runtime === 'codebuddy';
-  const isCline = runtime === 'cline';
+  const { isOpencode, isKilo, isGemini, isCodex, isCopilot, isAntigravity, isCursor, isWindsurf, isAugment, isTrae, isQwen, isHermes, isCodebuddy, isCline, isKimi } = runtimeFlags(runtime);
   const plan = resolveInstallPlan(runtime);
   const dirName = getDirName(runtime);
   const src = path.join(__dirname, '..');
@@ -10433,14 +10396,7 @@ function install(isGlobal, runtime = 'claude', options = {}) {
  * Apply statusline config, then print completion message
  */
 function finishInstall(settingsPath, settings, statuslineCommand, shouldInstallStatusline, runtime = 'claude', isGlobal = true, configDir = null, bannerOpts = {}) {
-  const isOpencode = runtime === 'opencode';
-  const isKilo = runtime === 'kilo';
-  const isCodex = runtime === 'codex';
-  const isCopilot = runtime === 'copilot';
-  const isCursor = runtime === 'cursor';
-  const isWindsurf = runtime === 'windsurf';
-  const isTrae = runtime === 'trae';
-  const isCline = runtime === 'cline';
+  const { isOpencode, isKilo, isGemini, isCodex, isCopilot, isAntigravity, isCursor, isWindsurf, isAugment, isTrae, isQwen, isHermes, isCodebuddy, isCline, isKimi } = runtimeFlags(runtime);
   const plan = resolveInstallPlan(runtime);
 
   if (shouldInstallStatusline && plan.writesSharedSettings && !isOpencode) {

--- a/src/runtime-name-policy.cts
+++ b/src/runtime-name-policy.cts
@@ -257,3 +257,30 @@ export function getGlobalConfigHomeFragment(runtime: string): string {
   const frag = GLOBAL_CONFIG_HOME_FRAGMENTS[runtime];
   return typeof frag === 'string' && frag.length > 0 ? frag : DEFAULT_CONFIG_HOME_FRAGMENT;
 }
+
+/**
+ * The runtime ids for which `bin/install.js` needs an `is<Runtime>` boolean
+ * predicate (every installed host that takes a non-claude install branch).
+ * Single source of truth — adding a runtime is one entry here, not a per-
+ * function declaration block (the add-a-host tax ADR-1239 Phase B / #1679 AC2
+ * removes).
+ */
+const RUNTIME_FLAG_IDS = Object.freeze([
+  'opencode', 'kilo', 'gemini', 'codex', 'copilot', 'antigravity', 'cursor',
+  'windsurf', 'augment', 'trae', 'qwen', 'hermes', 'codebuddy', 'cline', 'kimi',
+] as const);
+
+/**
+ * Return a frozen map of `is<Runtime>` boolean predicates for the given runtime
+ * id (e.g. `flags.isOpencode`). Collapses the four duplicated `const isX =
+ * runtime === 'x'` declaration blocks that lived in `bin/install.js`'s
+ * `uninstall`/`writeManifest`/`install`/etc. into one helper (sibling to
+ * `getDirName`/`getRuntimeLabel`). Pure: no I/O.
+ */
+export function runtimeFlags(runtime: string): Readonly<Record<string, boolean>> {
+  const flags: Record<string, boolean> = {};
+  for (const id of RUNTIME_FLAG_IDS) {
+    flags['is' + id.charAt(0).toUpperCase() + id.slice(1)] = runtime === id;
+  }
+  return Object.freeze(flags);
+}

--- a/tests/runtime-flags.test.cjs
+++ b/tests/runtime-flags.test.cjs
@@ -1,0 +1,54 @@
+'use strict';
+/**
+ * Tests for runtimeFlags (ADR-1239 Phase B / #1679 AC2). Collapses the four
+ * duplicated `const isX = runtime === 'x'` declaration blocks in bin/install.js
+ * into one helper. Pins: all flags present, exactly one true per known runtime,
+ * claude/unknown/empty → all false, frozen.
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { runtimeFlags } = require('../gsd-core/bin/lib/runtime-name-policy.cjs');
+const registry = require('../gsd-core/bin/lib/capability-registry.cjs');
+
+const EXPECTED_FLAGS = [
+  'isOpencode', 'isKilo', 'isGemini', 'isCodex', 'isCopilot', 'isAntigravity',
+  'isCursor', 'isWindsurf', 'isAugment', 'isTrae', 'isQwen', 'isHermes',
+  'isCodebuddy', 'isCline', 'isKimi',
+];
+
+test('runtimeFlags: every known non-claude runtime sets exactly its own flag true', () => {
+  const ids = EXPECTED_FLAGS.map((f) => f.slice(2).toLowerCase());
+  for (const id of ids) {
+    const flags = runtimeFlags(id);
+    const trues = EXPECTED_FLAGS.filter((f) => flags[f] === true);
+    assert.deepStrictEqual(trues, ['is' + id.charAt(0).toUpperCase() + id.slice(1)], `runtime '${id}' must set exactly its own flag`);
+  }
+});
+
+test('runtimeFlags: claude / unknown / empty → all flags false (fail-closed)', () => {
+  for (const id of ['claude', 'unknown', '', 'claude-code']) {
+    const flags = runtimeFlags(id);
+    for (const f of EXPECTED_FLAGS) {
+      assert.strictEqual(flags[f], false, `runtime '${id}': ${f} must be false`);
+    }
+  }
+});
+
+test('runtimeFlags: all 15 flags present + boolean + the object is frozen', () => {
+  const flags = runtimeFlags('opencode');
+  for (const f of EXPECTED_FLAGS) {
+    assert.strictEqual(typeof flags[f], 'boolean', `${f} must be boolean`);
+  }
+  assert.deepStrictEqual(Object.keys(flags).sort(), [...EXPECTED_FLAGS].sort(), 'exactly the 15 flags');
+  assert.ok(Object.isFrozen(flags), 'flags object must be frozen');
+});
+
+test('runtimeFlags drift guard: covers every registry runtime except claude', () => {
+  // Adding a registry runtime that is not claude must get a flag or be added to
+  // RUNTIME_FLAG_IDS — pin the set so a new runtime forces a deliberate update.
+  const registryNonClaude = Object.keys(registry.runtimes).filter((r) => r !== 'claude').sort();
+  const flagIds = EXPECTED_FLAGS.map((f) => f.slice(2).toLowerCase()).sort();
+  const missing = registryNonClaude.filter((r) => !flagIds.includes(r));
+  assert.deepEqual(missing, [], `registry runtimes missing a runtimeFlags entry: ${missing.join(', ')} — add to RUNTIME_FLAG_IDS`);
+});


### PR DESCRIPTION
## Feature PR

> **Using the wrong template?**
> — Bug fix: use [fix.md](?template=fix.md)
> — Enhancement to existing behavior: use [enhancement.md](?template=enhancement.md)

---

## Linked Issue

Closes #1679

> #1679 carries `approved-feature` (Phase 2 of epic #1678, ADR-1239 Phase B).
>
> ⚠️ **This PR is AC2 slice 3** — collapses the four duplicated `is<Runtime>` boolean-flag declaration blocks, the single biggest remaining AC2 cluster. AC1/3/4 already shipped; AC2's data-collapse (labels #1800, config-home fragments #1801) + this flag collapse = the bulk of the residue fold. **#1679 must stay open** for the ADR-1235 agent-loop tail + the genuinely per-runtime semantic branches (documented below).

---

## Feature summary

Phase 2 AC2 slice 3: collapse the four `const isX = runtime === 'x'` declaration blocks (one each in `uninstall`, `writeManifest`, `install`, and a fourth helper — 48 of the 101 remaining `runtime ===` branches) into a single `runtimeFlags(runtime)` helper in `src/runtime-name-policy.cts`, sibling to `getDirName`/`getRuntimeLabel`/`getGlobalConfigHomeFragment`. This is the purest "add-a-host tax": a new runtime meant remembering to add ~12 flag lines to each of four functions. Now it is one entry in `RUNTIME_FLAG_IDS`.

`runtime ===` count in `bin/install.js`: **101 → 53** (−48). 16-runtime golden install parity byte-identical.

---

## What changed

### New files

| File | Purpose |
|------|---------|
| `tests/runtime-flags.test.cjs` | 4 tests: each runtime sets exactly its flag, claude/unknown/empty → all false, all 15 flags present + frozen, drift guard (every non-claude registry runtime has a flag). |

### Modified files

| File | What changed |
|------|-------------|
| `src/runtime-name-policy.cts` | Add `RUNTIME_FLAG_IDS` + `runtimeFlags(runtime)` (frozen map of `is<Runtime>` booleans; single `runtime ===` source). |
| `bin/install.js` | Import `runtimeFlags`; replace the 4 declaration blocks (uninstall / writeManifest / install / helper) with one destructure each. Usages unchanged (flag names preserved). |

---

## Implementation notes

- **Zero usage-site churn:** `runtimeFlags` keys are `is<Runtime>` (the existing flag names), so each block becomes one `const { isOpencode, … } = runtimeFlags(runtime);` line and every `if (isCopilot)` usage stays untouched. `bin/install.js`'s eslint block has no `no-unused-vars` rule, so destructuring all 15 flags per function (each uses a subset) is clean.
- **Single source of truth:** adding a runtime is now one `RUNTIME_FLAG_IDS` entry, not four declaration blocks.
- **Golden parity is the gate:** 16/16 byte-identical proves the collapse is behavior-identical for every runtime's install.

---

## Spec compliance

#1679 AC2 status after this PR:

- [x] `copyWithPathReplacement` converter selection data-driven (prior slice)
- [x] `installOpencodeFamilySkills` moved to `install-engine.cts` (prior)
- [x] `getDirName` / `NON_CLAUDE_RUNTIMES` registry-derived (prior)
- [x] **`is<Runtime>` flag-declaration blocks → `runtimeFlags` (this PR, −48 branches)**
- [x] `runtimeLabel` / config-home fragment data-collapses (#1800 / #1801)
- [ ] **ADR-1235 inline agent loop — fully deleted.** Partially done: 5 runtimes (cursor/windsurf/augment/trae/codebuddy) migrated to the descriptor-driven agent path; cline + the long tail remain inline (separate, parity-riskier change).
- [~] ~53 remaining `runtime ===` branches are genuinely per-runtime *behavior* (attribution-reading, frontmatter generation, per-runtime install blocks), not collapsible data — tracked as the semantic tail.

AC1/AC3/AC4 remain shipped (prior PRs). This slice does not close #1679 (the ADR-1235 tail + semantic residue remain) but completes the data-collapse intent.

---

## Testing

- **New:** `tests/runtime-flags.test.cjs` (4 tests, TDD).
- **Gate:** `golden-install-parity.test.cjs` — **16/16 byte-identical** (behavior-identical collapse).
- eslint 0 problems, security scan clean, `lint:test-file-count` clean.
- macOS local; Windows/Linux via CI.

---

## Documentation

- [x] docs-exempt marker inside the changeset fragment (internal refactor; no user-facing doc surface).

---

## Checklist

- [x] `Closes #1679` · [x] `approved-feature` · [ ] all AC met (AC2 data-collapse done; ADR-1235 tail + semantic residue remain; #1679 open) · [x] scope within · [x] tests + gates green · [x] `.changeset/` · [x] no new deps · [x] Windows via CI

---

## Breaking changes

None. Golden parity byte-identical across all 16 runtimes; internal refactor only.

---

Closes #1679 *(AC2 data-collapse substantially complete; ADR-1235 tail + semantic residue remain — issue should stay open)*.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1812"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785265461&installation_id=134682257&pr_number=1812&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1812&signature=46a8e055a73d8307202ded059aa39b7b0d5e273ace755be591a93f8489864221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->