### PR TITLE
refactor(#1679): ADR-1239 Phase B — collapse program + command chains [AC2 slice 4]

### DIFF
--- a/.changeset/agile-newts-roar.md
+++ b/.changeset/agile-newts-roar.md
@@ -1,0 +1,7 @@
+---
+type: Changed
+pr: 1813
+---
+**Internal: the installer's `program` (display-name) + `command` (slash-invocation) chains are now single-source lookups** — the 14-line `program` chain (an exact duplicate of `runtimeLabel`) → `getRuntimeLabel`, and the 14-line `command` chain (the per-runtime `/gsd-new-project` syntax: gemini `/gsd:`, codex `$`, cursor skill-mention, kimi `/skill:`, default `/gsd-new-project`) → new `getRuntimeNewProjectCommand(runtime)` helper (ADR-1239 Phase B / #1679 AC2 slice 4). `runtime ===` count in `bin/install.js`: 53 → 25 (cumulative this session: 129 → 25). Stdout strings preserved byte-for-byte; no install-output change (golden-parity 16/16). No user-facing change.
+
+<!-- docs-exempt: internal refactor; no user-facing doc surface -->

--- a/bin/install.js
+++ b/bin/install.js
@@ -37,7 +37,7 @@ const {
 // installer to the runtime-name-policy leaf (ADR-1508 / #1510 Phase 1) so the
 // conversion module's rewrite engine can consume it without importing
 // bin/install.js. Re-exported below for back-compat consumers/tests.
-const { getDirName, getRuntimeLabel, getGlobalConfigHomeFragment, runtimeFlags } = require('../gsd-core/bin/lib/runtime-name-policy.cjs');
+const { getDirName, getRuntimeLabel, getGlobalConfigHomeFragment, runtimeFlags, getRuntimeNewProjectCommand } = require('../gsd-core/bin/lib/runtime-name-policy.cjs');
 const {
   applyWorktreeBaseRef,
   readBaseRefFromSettings,
@@ -10519,37 +10519,11 @@ function finishInstall(settingsPath, settings, statuslineCommand, shouldInstallS
     }
   }
 
-  let program = 'Claude Code';
-  if (runtime === 'opencode') program = 'OpenCode';
-  if (runtime === 'gemini') program = 'Gemini';
-  if (runtime === 'kilo') program = 'Kilo';
-  if (runtime === 'codex') program = 'Codex';
-  if (runtime === 'copilot') program = 'Copilot';
-  if (runtime === 'antigravity') program = 'Antigravity';
-  if (runtime === 'cursor') program = 'Cursor';
-  if (runtime === 'windsurf') program = 'Windsurf';
-  if (runtime === 'augment') program = 'Augment';
-  if (runtime === 'trae') program = 'Trae';
-  if (runtime === 'cline') program = 'Cline';
-  if (runtime === 'qwen') program = 'Qwen Code';
-  if (runtime === 'hermes') program = 'Hermes Agent';
-  if (runtime === 'kimi') program = 'Kimi CLI';
-
-  let command = '/gsd-new-project';
-  if (runtime === 'opencode') command = '/gsd-new-project';
-  if (runtime === 'kilo') command = '/gsd-new-project';
-  if (runtime === 'gemini') command = '/gsd:new-project';
-  if (runtime === 'codex') command = '$gsd-new-project';
-  if (runtime === 'copilot') command = '/gsd-new-project';
-  if (runtime === 'antigravity') command = '/gsd-new-project';
-  if (runtime === 'cursor') command = 'gsd-new-project (mention the skill name)';
-  if (runtime === 'windsurf') command = '/gsd-new-project';
-  if (runtime === 'augment') command = '/gsd-new-project';
-  if (runtime === 'trae') command = '/gsd-new-project';
-  if (runtime === 'cline') command = '/gsd-new-project';
-  if (runtime === 'qwen') command = '/gsd-new-project';
-  if (runtime === 'hermes') command = '/gsd-new-project';
-  if (runtime === 'kimi') command = '/skill:gsd-new-project';
+  // program + command are now single-source lookups (ADR-1239 Phase B / #1679):
+  // program is the runtime display label; command is the per-host /gsd-new-project
+  // invocation syntax.
+  const program = getRuntimeLabel(runtime);
+  const command = getRuntimeNewProjectCommand(runtime);
 
   // Claude Code global installs use the skills/ format (CC 2.1.88+).
   // Restart is required for CC to pick up newly-installed skills, and the

--- a/src/runtime-name-policy.cts
+++ b/src/runtime-name-policy.cts
@@ -284,3 +284,24 @@ export function runtimeFlags(runtime: string): Readonly<Record<string, boolean>>
   }
   return Object.freeze(flags);
 }
+
+/**
+ * The `/gsd-new-project` invocation syntax per runtime — the post-install
+ * "next step" command string. Most runtimes use the default `/gsd-new-project`;
+ * a few hosts need a different surface syntax. Collapses the 14-line
+ * `if (runtime === 'x') command = ...` chain in bin/install.js's next-step
+ * message (ADR-1239 Phase B / #1679 AC2). Pure: no I/O.
+ */
+const DEFAULT_NEW_PROJECT_COMMAND = '/gsd-new-project';
+const RUNTIME_NEW_PROJECT_COMMANDS: Readonly<Record<string, string>> = {
+  gemini: '/gsd:new-project',
+  codex: '$gsd-new-project',
+  cursor: 'gsd-new-project (mention the skill name)',
+  kimi: '/skill:gsd-new-project',
+};
+
+export function getRuntimeNewProjectCommand(runtime: string): string {
+  if (!runtime) return DEFAULT_NEW_PROJECT_COMMAND;
+  const c = RUNTIME_NEW_PROJECT_COMMANDS[runtime];
+  return typeof c === 'string' && c.length > 0 ? c : DEFAULT_NEW_PROJECT_COMMAND;
+}

--- a/tests/runtime-label-policy.test.cjs
+++ b/tests/runtime-label-policy.test.cjs
@@ -33,7 +33,7 @@ const assert = require('node:assert/strict');
 const runtimeNamePolicy = require('../gsd-core/bin/lib/runtime-name-policy.cjs');
 const registry = require('../gsd-core/bin/lib/capability-registry.cjs');
 
-const { getRuntimeLabel } = runtimeNamePolicy;
+const { getRuntimeLabel, getRuntimeNewProjectCommand } = runtimeNamePolicy;
 
 // Golden oracle: hardcoded expected map of all 16 runtime ids to their short
 // install/uninstall display label. A pinned expected value in a TEST is correct
@@ -100,4 +100,31 @@ test('getRuntimeLabel fallback: alias is NOT auto-expanded (raw id match only)',
   // explicit and prevents a future alias from changing console output by accident.
   assert.strictEqual(getRuntimeLabel('claude-code'), 'Claude Code',
     'getRuntimeLabel("claude-code") must return the default "Claude Code" (raw-id match only; aliases are not expanded)');
+});
+
+// ---------------------------------------------------------------------------
+// getRuntimeNewProjectCommand (ADR-1239 Phase B / #1679 AC2) — the per-runtime
+// /gsd-new-project invocation syntax for the post-install next-step message.
+// ---------------------------------------------------------------------------
+
+const GOLDEN_COMMAND_MAP = {
+  // 4 real overrides (the rest use the default):
+  gemini: '/gsd:new-project',
+  codex: '$gsd-new-project',
+  cursor: 'gsd-new-project (mention the skill name)',
+  kimi: '/skill:gsd-new-project',
+};
+const DEFAULT_CMD = '/gsd-new-project';
+
+test('getRuntimeNewProjectCommand: the 4 overrides + the default for the other 12 runtimes', () => {
+  for (const [id, expected] of Object.entries(GOLDEN_COMMAND_MAP)) {
+    assert.strictEqual(getRuntimeLabel ? getRuntimeNewProjectCommand(id) : null, expected, `override ${id}`);
+  }
+  // sanity: getRuntimeNewProjectCommand is imported alongside getRuntimeLabel above
+});
+
+test('getRuntimeNewProjectCommand: claude/unknown/empty + the 12 non-override runtimes → default', () => {
+  for (const id of ['claude', 'opencode', 'kilo', 'copilot', 'antigravity', 'windsurf', 'augment', 'trae', 'cline', 'qwen', 'hermes', 'codebuddy', 'unknown', '']) {
+    assert.strictEqual(getRuntimeNewProjectCommand(id), DEFAULT_CMD, `runtime '${id}' must return the default command`);
+  }
 });


### PR DESCRIPTION
## Feature PR

> **Using the wrong template?**
> — Bug fix: use [fix.md](?template=fix.md)
> — Enhancement to existing behavior: use [enhancement.md](?template=enhancement.md)

---

## Linked Issue

Closes #1679

> #1679 carries `approved-feature` (Phase 2 of epic #1678, ADR-1239 Phase B).
>
> ⚠️ **This PR is AC2 slice 4** — collapses the `program` (display-name) + `command` (slash-invocation) chains in the post-install next-step message. Builds on the flag-block collapse (#1811). AC1/3/4 shipped; AC2 data-collapse now essentially complete. **#1679 must stay open** for the ADR-1235 agent-loop tail + the genuinely per-runtime semantic branches.

---

## Feature summary

Phase 2 AC2 slice 4: collapse two more duplicated runtime→string chains in `bin/install.js`'s post-install next-step message:

- **`program`** (14 branches) — an **exact duplicate** of `runtimeLabel` → `getRuntimeLabel(runtime)`.
- **`command`** (14 branches) — the per-runtime `/gsd-new-project` invocation syntax (gemini `/gsd:`, codex `$`, cursor skill-mention, kimi `/skill:`, default `/gsd-new-project`) → new `getRuntimeNewProjectCommand(runtime)` helper, sibling to `runtimeFlags`/`getRuntimeLabel`.

`runtime ===` count in `bin/install.js`: **53 → 25** (−28). Cumulative Phase 2 this session: **129 → 25** (−104).

---

## What changed

### Modified files

| File | What changed |
|------|-------------|
| `src/runtime-name-policy.cts` | Add `RUNTIME_NEW_PROJECT_COMMANDS` table + `getRuntimeNewProjectCommand(runtime)` (default + 4 overrides). |
| `bin/install.js` | Import `getRuntimeNewProjectCommand`; replace the `program` chain (→ `getRuntimeLabel`) + the `command` chain (→ `getRuntimeNewProjectCommand`) with single lookups. |
| `tests/runtime-label-policy.test.cjs` | 2 new tests for `getRuntimeNewProjectCommand` (4 overrides + default for the other 12 runtimes). |

---

## Implementation notes

- **`program` is a pure dedup:** all 14 values are byte-identical to `RUNTIME_LABELS`, so `getRuntimeLabel` is a drop-in.
- **`command` has 4 real overrides** (gemini/codex/cursor/kimi) + 10 no-op lines that set the default; the helper preserves the 4 overrides verbatim + defaults the rest.
- Both are **stdout message strings** (not install file output), so golden parity doesn't cover them — byte-identity is guaranteed by exact value preservation (`program` matches `RUNTIME_LABELS`; `command` values pinned in the table + 2 unit tests).

---

## Spec compliance

#1679 AC2 after this PR:

- [x] data-collapse: runtimeLabel (#1800), config-home fragment (#1801), `is<Runtime>` flags (#1811), **program + command (this PR)** — `runtime ===` 129 → 25.
- [x] `copyWithPathReplacement` converter selection data-driven; `installOpencodeFamilySkills` moved; `getDirName`/`NON_CLAUDE_RUNTIMES` registry-derived (prior).
- [ ] **ADR-1235 inline agent loop — fully deleted.** Partially done (5 runtimes migrated; cline excluded by design — documented local/global complication).
- [~] ~25 remaining `runtime ===` branches are genuinely per-runtime *behavior* (attribution reading, frontmatter generation, per-runtime install blocks) — the semantic tail, not collapsible data.

AC1/AC3/AC4 shipped. This slice completes the data-collapse intent; #1679 stays open for the ADR-1235 tail + semantic residue.

---

## Testing

- **New:** 2 `getRuntimeNewProjectCommand` tests (added to `runtime-label-policy.test.cjs`).
- **Gate:** golden-install-parity 16/16 (no install-output regression).
- eslint 0 problems, security scan clean.

---

## Documentation

- [x] docs-exempt marker inside the changeset fragment (internal refactor; no user-facing doc surface).

---

## Checklist

- [x] `Closes #1679` · [x] `approved-feature` · [ ] all AC met (data-collapse done; ADR-1235 tail + semantic residue remain; #1679 open) · [x] scope within · [x] tests + gates green · [x] `.changeset/` · [x] no new deps · [x] Windows via CI

---

## Breaking changes

None. Internal refactor; stdout message strings preserved byte-for-byte.

---

Closes #1679 *(AC2 data-collapse complete; ADR-1235 tail + semantic residue remain — issue stays open)*.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1813"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785265591&installation_id=134682257&pr_number=1813&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1813&signature=bd666b9dd5e8958387241c4b165fda93fd47d7ad77f542faa2ce91a4330d21a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->