### PR TITLE
fix(#1772): read full multi-line command in graphify-update hook Gate 2

### DIFF
--- a/.changeset/1772-graphify-update-multi-line-command.md
+++ b/.changeset/1772-graphify-update-multi-line-command.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 1815
+---
+**`gsd-graphify-update.sh` now reads the full multi-line command in Gate 2 (#1772)** — the PostToolUse auto-update hook joined `tool_name` + `\n` + `tool_input.command` and extracted the command with `sed -n '2p'` (line 2 only). Agent runtimes (Claude Code's Bash tool among them) routinely emit HEAD-advancing commits as multi-line scripts (`cd /path`, then `git add`, then `git commit …`), so line 2 was the `cd`, Gate 2's `*"git commit"*` match failed, and the rebuild silently no-op'd on real commits even with `graphify.auto_update: true`. The failure was invisible in manual probes because a single-line `git commit -m x` passes line 2 verbatim. The hook now captures line 2 through EOF (`sed -n '2,$p'`) so the `case` glob sees the full command string; single-line behavior is unchanged and multi-line commands without a HEAD-advancing op still no-op cleanly.

--- a/hooks/gsd-graphify-update.sh
+++ b/hooks/gsd-graphify-update.sh
@@ -45,7 +45,13 @@ process.stdin.on("end", () => {
 });
 ' 2>/dev/null || printf '\n')
 TOOL_NAME=$(printf '%s\n' "$TOOL_INFO" | sed -n '1p')
-COMMAND=$(printf '%s\n' "$TOOL_INFO" | sed -n '2p')
+# Capture the FULL command (line 2 through EOF). Agent runtimes routinely emit
+# HEAD-advancing commits as multi-line scripts (`cd /path` then `git add` then
+# `git commit …`); reading only line 2 (`sed -n '2p'`) missed a `git commit`
+# that was not on the first command line and silently no-op'd the rebuild
+# (#1772). Line 2..EOF preserves embedded newlines; the `case` glob below
+# matches the substring anywhere in the multi-line string.
+COMMAND=$(printf '%s\n' "$TOOL_INFO" | sed -n '2,$p')
 
 [ "$TOOL_NAME" = "Bash" ] || exit 0
 

--- a/tests/fixtures/golden-install-parity/antigravity.json
+++ b/tests/fixtures/golden-install-parity/antigravity.json
@@ -306,7 +306,7 @@
   "hooks/gsd-cursor-post-tool.js": "d61ee04f6ee7858c",
   "hooks/gsd-cursor-session-start.js": "148b8ec4e2c97f00",
   "hooks/gsd-ensure-canonical-path.js": "83e02e841e123037",
-  "hooks/gsd-graphify-update.sh": "396ebda3c6705dc9",
+  "hooks/gsd-graphify-update.sh": "845aeecb0d82dd6e",
   "hooks/gsd-phase-boundary.sh": "6aa3ba9af3d465d9",
   "hooks/gsd-prompt-guard.js": "4b08c2dce0233e2d",
   "hooks/gsd-read-guard.js": "b602f88f046a7551",

--- a/tests/fixtures/golden-install-parity/augment.json
+++ b/tests/fixtures/golden-install-parity/augment.json
@@ -375,7 +375,7 @@
   "hooks/gsd-cursor-post-tool.js": "d61ee04f6ee7858c",
   "hooks/gsd-cursor-session-start.js": "148b8ec4e2c97f00",
   "hooks/gsd-ensure-canonical-path.js": "3499b6e6b453dc59",
-  "hooks/gsd-graphify-update.sh": "396ebda3c6705dc9",
+  "hooks/gsd-graphify-update.sh": "845aeecb0d82dd6e",
   "hooks/gsd-phase-boundary.sh": "6aa3ba9af3d465d9",
   "hooks/gsd-prompt-guard.js": "4b08c2dce0233e2d",
   "hooks/gsd-read-guard.js": "b602f88f046a7551",

--- a/tests/fixtures/golden-install-parity/claude.json
+++ b/tests/fixtures/golden-install-parity/claude.json
@@ -305,7 +305,7 @@
   "hooks/gsd-cursor-post-tool.js": "dd1b12f795de8d72",
   "hooks/gsd-cursor-session-start.js": "a93095ac609a3ea6",
   "hooks/gsd-ensure-canonical-path.js": "34f4522a23cc5f41",
-  "hooks/gsd-graphify-update.sh": "396ebda3c6705dc9",
+  "hooks/gsd-graphify-update.sh": "845aeecb0d82dd6e",
   "hooks/gsd-phase-boundary.sh": "6aa3ba9af3d465d9",
   "hooks/gsd-prompt-guard.js": "4b08c2dce0233e2d",
   "hooks/gsd-read-guard.js": "b602f88f046a7551",

--- a/tests/fixtures/golden-install-parity/codebuddy.json
+++ b/tests/fixtures/golden-install-parity/codebuddy.json
@@ -375,7 +375,7 @@
   "hooks/gsd-cursor-post-tool.js": "d61ee04f6ee7858c",
   "hooks/gsd-cursor-session-start.js": "148b8ec4e2c97f00",
   "hooks/gsd-ensure-canonical-path.js": "6900c226c1c28a44",
-  "hooks/gsd-graphify-update.sh": "396ebda3c6705dc9",
+  "hooks/gsd-graphify-update.sh": "845aeecb0d82dd6e",
   "hooks/gsd-phase-boundary.sh": "6aa3ba9af3d465d9",
   "hooks/gsd-prompt-guard.js": "4b08c2dce0233e2d",
   "hooks/gsd-read-guard.js": "b602f88f046a7551",

--- a/tests/fixtures/golden-install-parity/gemini.json
+++ b/tests/fixtures/golden-install-parity/gemini.json
@@ -375,7 +375,7 @@
   "hooks/gsd-cursor-post-tool.js": "d61ee04f6ee7858c",
   "hooks/gsd-cursor-session-start.js": "148b8ec4e2c97f00",
   "hooks/gsd-ensure-canonical-path.js": "a19947cac42002d4",
-  "hooks/gsd-graphify-update.sh": "396ebda3c6705dc9",
+  "hooks/gsd-graphify-update.sh": "845aeecb0d82dd6e",
   "hooks/gsd-phase-boundary.sh": "6aa3ba9af3d465d9",
   "hooks/gsd-prompt-guard.js": "4b08c2dce0233e2d",
   "hooks/gsd-read-guard.js": "b602f88f046a7551",

--- a/tests/fixtures/golden-install-parity/hermes.json
+++ b/tests/fixtures/golden-install-parity/hermes.json
@@ -306,7 +306,7 @@
   "hooks/gsd-cursor-post-tool.js": "dd1b12f795de8d72",
   "hooks/gsd-cursor-session-start.js": "a93095ac609a3ea6",
   "hooks/gsd-ensure-canonical-path.js": "c49fb011c3b97f4a",
-  "hooks/gsd-graphify-update.sh": "396ebda3c6705dc9",
+  "hooks/gsd-graphify-update.sh": "845aeecb0d82dd6e",
   "hooks/gsd-phase-boundary.sh": "6aa3ba9af3d465d9",
   "hooks/gsd-prompt-guard.js": "4b08c2dce0233e2d",
   "hooks/gsd-read-guard.js": "474bc1800d34456f",

--- a/tests/fixtures/golden-install-parity/kilo.json
+++ b/tests/fixtures/golden-install-parity/kilo.json
@@ -375,7 +375,7 @@
   "hooks/gsd-cursor-post-tool.js": "d61ee04f6ee7858c",
   "hooks/gsd-cursor-session-start.js": "148b8ec4e2c97f00",
   "hooks/gsd-ensure-canonical-path.js": "a5c67a1a7abc90c0",
-  "hooks/gsd-graphify-update.sh": "396ebda3c6705dc9",
+  "hooks/gsd-graphify-update.sh": "845aeecb0d82dd6e",
   "hooks/gsd-phase-boundary.sh": "6aa3ba9af3d465d9",
   "hooks/gsd-prompt-guard.js": "4b08c2dce0233e2d",
   "hooks/gsd-read-guard.js": "b602f88f046a7551",

--- a/tests/fixtures/golden-install-parity/opencode.json
+++ b/tests/fixtures/golden-install-parity/opencode.json
@@ -375,7 +375,7 @@
   "hooks/gsd-cursor-post-tool.js": "d61ee04f6ee7858c",
   "hooks/gsd-cursor-session-start.js": "148b8ec4e2c97f00",
   "hooks/gsd-ensure-canonical-path.js": "5f8be5b0a01a88ea",
-  "hooks/gsd-graphify-update.sh": "396ebda3c6705dc9",
+  "hooks/gsd-graphify-update.sh": "845aeecb0d82dd6e",
   "hooks/gsd-phase-boundary.sh": "6aa3ba9af3d465d9",
   "hooks/gsd-prompt-guard.js": "4b08c2dce0233e2d",
   "hooks/gsd-read-guard.js": "b602f88f046a7551",

--- a/tests/fixtures/golden-install-parity/qwen.json
+++ b/tests/fixtures/golden-install-parity/qwen.json
@@ -306,7 +306,7 @@
   "hooks/gsd-cursor-post-tool.js": "dd1b12f795de8d72",
   "hooks/gsd-cursor-session-start.js": "a93095ac609a3ea6",
   "hooks/gsd-ensure-canonical-path.js": "4c1626ed20ab7a75",
-  "hooks/gsd-graphify-update.sh": "396ebda3c6705dc9",
+  "hooks/gsd-graphify-update.sh": "845aeecb0d82dd6e",
   "hooks/gsd-phase-boundary.sh": "6aa3ba9af3d465d9",
   "hooks/gsd-prompt-guard.js": "4b08c2dce0233e2d",
   "hooks/gsd-read-guard.js": "9d1b227b6fcb6dba",

--- a/tests/graphify-auto-update.slow.test.cjs
+++ b/tests/graphify-auto-update.slow.test.cjs
@@ -613,6 +613,62 @@ describe('auto-update', () => {
       );
     });
 
+    // #1772 — agent runtimes (Claude Code's Bash tool among them) routinely
+    // emit HEAD-advancing commits as multi-line scripts (`cd /path` then
+    // `git add` then `git commit …`). The hook joins tool_name + "\n" +
+    // tool_input.command and must match the command across ALL its lines
+    // (line 2 through EOF), not just line 2 — otherwise a `git commit` that
+    // is not on the first command line silently no-ops the rebuild.
+    for (const cmd of [
+      "cd /tmp/repo\ngit add .\ngit commit -m 'multi-line commit'",
+      "cd /tmp/repo\ngit merge feature-branch",
+      "git fetch origin\ngit pull --ff-only",
+    ]) {
+      test(`dispatches on multi-line command (#1772): ${cmd.split('\n').slice(0, 2).join(' ⏎ ')}…`, async (t) => {
+        const tmpDir = createTempGitRepo({
+          config: { graphify: { enabled: true, auto_update: true } },
+        });
+        t.after(() => cleanupHookRepo(tmpDir));
+        const mockBin = makeMockGraphifyBin(tmpDir, { sleepMs: 100 });
+        runHook(
+          tmpDir,
+          { tool_name: 'Bash', tool_input: { command: cmd } },
+          { pathPrepend: mockBin },
+        );
+        const statusPath = path.join(tmpDir, '.planning/graphs/.last-build-status.json');
+        await waitForBuildStatus(statusPath, new Set(['ok', 'failed']));
+        assert.ok(
+          fs.existsSync(statusPath),
+          `must dispatch for multi-line command where the HEAD-advancing op is not on line 1 (#1772): ${cmd}`,
+        );
+      });
+    }
+
+    test('multi-line command with NO HEAD-advancing op still no-ops (#1772 no-regression)', (t) => {
+      const tmpDir = createTempGitRepo({
+        config: { graphify: { enabled: true, auto_update: true } },
+      });
+      t.after(() => cleanupHookRepo(tmpDir));
+      const mockBin = makeMockGraphifyBin(tmpDir, { sleepMs: 100 });
+      const r = runHook(
+        tmpDir,
+        {
+          tool_name: 'Bash',
+          tool_input: {
+            // Multi-line, but only non-HEAD-advancing ops. Widening line
+            // extraction to 2..EOF must not cause a spurious dispatch.
+            command: 'cd /tmp/repo\nls -la\necho done',
+          },
+        },
+        { pathPrepend: mockBin },
+      );
+      assert.strictEqual(r.status, 0);
+      assert.ok(
+        !fs.existsSync(path.join(tmpDir, '.planning/graphs/.last-build-status.json')),
+        'multi-line command without a HEAD-advancing git op must still no-op (#1772)',
+      );
+    });
+
     // #3653 — only the SDK `commit` verb invokes git internally. Other
     // `gsd-tools query` verbs (phase.complete, roadmap.update-plan-progress,
     // state.begin-phase) mutate .md files but do NOT advance HEAD; matching


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #1772

> `confirmed-bug` label present on #1772.

## What was broken

With `graphify.auto_update: true`, the bundled `hooks/gsd-graphify-update.sh` PostToolUse hook silently no-opd on real-world commits. Agent runtimes (Claude Codes Bash tool among them) routinely emit HEAD-advancing commits as multi-line scripts (`cd /path`, then `git add`, then `git commit …`). The hook joined `tool_name` + `\n` + `tool_input.command` and extracted the command with `sed -n '2p'` — **line 2 only** — so for a multi-line command line 2 was the `cd`, Gate 2s `*"git commit"*` match failed, and the rebuild was never dispatched. The failure was silent and was masked in manual probes because a single-line `git commit -m x` passes line 2 verbatim.

## What this fix does

Capture the command from line 2 through EOF (`sed -n '2,$p'`) so the `case` glob sees the full multi-line string. Single-line behavior is unchanged (the match only widens), and multi-line commands with no HEAD-advancing git op still no-op cleanly.

## Root cause

A line-extraction off-by-one in the hooks Gate 1→2 handoff (`sed -n '2p'` reads exactly one line where the full command was intended). Verified against the reported symptom: `sed -n '2p'` on `Bash\ncd /path\ngit commit…` captures `cd /path` and misses `git commit`; `sed -n '2,$p'` captures the full command and matches.

## Testing

### How I verified the fix

`node --test tests/graphify-auto-update.slow.test.cjs` — new #1772 tests went RED (3 multi-line dispatch cases timed out at the 30s `waitForBuildStatus` deadline because no status file was written) before the hook edit, GREEN after.

Full file (40 tests, including the existing #3653 SDK-commit matchers and all single-line dispatchers): **40 pass, 0 fail** — no regressions. The `changeset-lint` script confirms `hooks/` is user-facing, so a changeset fragment is added in a follow-up commit on this PR.

### Regression test added?

- [x] Yes — added to `tests/graphify-auto-update.slow.test.cjs` ("hook — HEAD-advancing command matchers"):
  - 3 multi-line dispatch cases (`cd … ⏎ git commit`, `cd … ⏎ git merge`, `git fetch ⏎ git pull`) assert the rebuild is dispatched (status file appears).
  - 1 multi-line no-op case asserts a multi-line command with no HEAD-advancing op still does not dispatch (guards against over-widening).

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling) — hook is POSIX-only (`bash` + `sed`); Windows is explicitly out of scope per the issue and the existing tests skip on `win32`.
- [ ] Linux
- [ ] N/A

### Runtimes tested

- [x] Claude Code (the runtime whose multi-line Bash emissions triggered the report)
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___

## Checklist

- [x] Linked issue carries `confirmed-bug`
- [x] Regression test added
- [x] No unrelated working-tree files included in the commit (only `hooks/gsd-graphify-update.sh` + `tests/graphify-auto-update.slow.test.cjs`; changeset added in a follow-up commit)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1815"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785283149&installation_id=134682257&pr_number=1815&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1815&signature=2b1981c7ccc83a7e6704a970732bb88673bb7f13db66a8a9601155ec34b6c57d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->