### PR TITLE
chore: bump rc job timeout from 10 to 30 minutes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -319,7 +319,7 @@ jobs:
     needs: [validate-version, install-smoke-rc]
     if: inputs.action == 'rc'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 30
     permissions:
       contents: write
       id-token: write


### PR DESCRIPTION
## Summary

- Bumps `rc` job `timeout-minutes` from 10 → 30 in `.github/workflows/release.yml`
- The unit test suite (`npm run test:coverage:unit`) across 861 files with coverage instrumentation runs ~12–15 minutes — the 10-minute ceiling consistently kills the RC dry-run before tests complete
- The `create` and `finalize` jobs (which don't run the full test suite) keep their existing 10-minute timeout

## Test plan

- [ ] Re-trigger `release.yml` with `action=rc, version=1.7.0, dry_run=true` — confirm `rc` job completes without timeout

Fixes: run [#28411568942](https://github.com/open-gsd/gsd-core/actions/runs/28411568942) (cancelled at 10m boundary mid-test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1834"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785372115&installation_id=134682257&pr_number=1834&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1834&signature=4fcd37d475f52ca4ec28e02919d10e676156ffb1f1512d2bc41b07b631f2cf82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->