### PR TITLE
fix: exclude CHANGELOG.md from golden-install-parity hash manifest

### DIFF
--- a/tests/fixtures/golden-install-parity/antigravity.json
+++ b/tests/fixtures/golden-install-parity/antigravity.json
@@ -35,7 +35,6 @@
   "agents/gsd-ui-researcher.md": "8c7e91c85e7099f5",
   "agents/gsd-user-profiler.md": "25d65f6458454764",
   "agents/gsd-verifier.md": "5902e27c7091f4b1",
-  "gsd-core/CHANGELOG.md": "8bf626da3d88f8af",
   "gsd-core/VERSION": "ef0deccd81a6723c",
   "gsd-core/bin/check-latest-version.cjs": "e4a224058c8f4d74",
   "gsd-core/bin/gsd-tools.cjs": "5cf26d5f9e588cf8",

--- a/tests/fixtures/golden-install-parity/augment.json
+++ b/tests/fixtures/golden-install-parity/augment.json
@@ -104,7 +104,6 @@
   "commands/gsd-verify-work.md": "1cb62ea69b117acb",
   "commands/gsd-workspace.md": "dd1bc09d2b768e0b",
   "commands/gsd-workstreams.md": "52ab9c585d3a00f3",
-  "gsd-core/CHANGELOG.md": "8bf626da3d88f8af",
   "gsd-core/VERSION": "ef0deccd81a6723c",
   "gsd-core/bin/check-latest-version.cjs": "e4a224058c8f4d74",
   "gsd-core/bin/gsd-tools.cjs": "74594e8bf36e5580",

--- a/tests/fixtures/golden-install-parity/claude.json
+++ b/tests/fixtures/golden-install-parity/claude.json
@@ -34,7 +34,6 @@
   "agents/gsd-ui-researcher.md": "85d7d6cc36388435",
   "agents/gsd-user-profiler.md": "003276f85792cfda",
   "agents/gsd-verifier.md": "76bcf41aa9fd9b53",
-  "gsd-core/CHANGELOG.md": "8bf626da3d88f8af",
   "gsd-core/VERSION": "ef0deccd81a6723c",
   "gsd-core/bin/check-latest-version.cjs": "e4a224058c8f4d74",
   "gsd-core/bin/gsd-tools.cjs": "74594e8bf36e5580",

--- a/tests/fixtures/golden-install-parity/cline.json
+++ b/tests/fixtures/golden-install-parity/cline.json
@@ -38,7 +38,6 @@
   "agents/gsd-ui-researcher.md": "878c7d0e82fa861a",
   "agents/gsd-user-profiler.md": "622220df0654b6bf",
   "agents/gsd-verifier.md": "0a437cf3ed90693f",
-  "gsd-core/CHANGELOG.md": "8bf626da3d88f8af",
   "gsd-core/VERSION": "ef0deccd81a6723c",
   "gsd-core/bin/check-latest-version.cjs": "e4a224058c8f4d74",
   "gsd-core/bin/gsd-tools.cjs": "74594e8bf36e5580",

--- a/tests/fixtures/golden-install-parity/codebuddy.json
+++ b/tests/fixtures/golden-install-parity/codebuddy.json
@@ -104,7 +104,6 @@
   "commands/gsd-verify-work.md": "6edbbb82a1f2aea7",
   "commands/gsd-workspace.md": "d765ff60cde657a6",
   "commands/gsd-workstreams.md": "884b6c8d648422c7",
-  "gsd-core/CHANGELOG.md": "8bf626da3d88f8af",
   "gsd-core/VERSION": "ef0deccd81a6723c",
   "gsd-core/bin/check-latest-version.cjs": "e4a224058c8f4d74",
   "gsd-core/bin/gsd-tools.cjs": "74594e8bf36e5580",

--- a/tests/fixtures/golden-install-parity/codex.json
+++ b/tests/fixtures/golden-install-parity/codex.json
@@ -70,7 +70,6 @@
   "agents/gsd-verifier.md": "3471118de7e985c7",
   "agents/gsd-verifier.toml": "68f4dcc6c0311e00",
   "config.toml": "a34316b9ac61a620",
-  "gsd-core/CHANGELOG.md": "8bf626da3d88f8af",
   "gsd-core/VERSION": "ef0deccd81a6723c",
   "gsd-core/bin/check-latest-version.cjs": "e4a224058c8f4d74",
   "gsd-core/bin/gsd-tools.cjs": "74594e8bf36e5580",

--- a/tests/fixtures/golden-install-parity/copilot.json
+++ b/tests/fixtures/golden-install-parity/copilot.json
@@ -36,7 +36,6 @@
   "agents/gsd-user-profiler.agent.md": "ae16a248e18dd42b",
   "agents/gsd-verifier.agent.md": "6fe2c4f008ebfa22",
   "copilot-instructions.md": "1fb04111759f1645",
-  "gsd-core/CHANGELOG.md": "8bf626da3d88f8af",
   "gsd-core/VERSION": "ef0deccd81a6723c",
   "gsd-core/bin/check-latest-version.cjs": "e4a224058c8f4d74",
   "gsd-core/bin/gsd-tools.cjs": "5cf26d5f9e588cf8",

--- a/tests/fixtures/golden-install-parity/cursor.json
+++ b/tests/fixtures/golden-install-parity/cursor.json
@@ -104,7 +104,6 @@
   "commands/gsd-verify-work.md": "86a42f859bc26dd6",
   "commands/gsd-workspace.md": "5c40114e6af87e3d",
   "commands/gsd-workstreams.md": "112660ceb663c750",
-  "gsd-core/CHANGELOG.md": "8bf626da3d88f8af",
   "gsd-core/VERSION": "ef0deccd81a6723c",
   "gsd-core/bin/check-latest-version.cjs": "e4a224058c8f4d74",
   "gsd-core/bin/gsd-tools.cjs": "5cf26d5f9e588cf8",

--- a/tests/fixtures/golden-install-parity/gemini.json
+++ b/tests/fixtures/golden-install-parity/gemini.json
@@ -104,7 +104,6 @@
   "commands/gsd/verify-work.toml": "58ec25cb1f5d5434",
   "commands/gsd/workspace.toml": "7f1658bb61c9743d",
   "commands/gsd/workstreams.toml": "95f0c349b808a84c",
-  "gsd-core/CHANGELOG.md": "8bf626da3d88f8af",
   "gsd-core/VERSION": "ef0deccd81a6723c",
   "gsd-core/bin/check-latest-version.cjs": "e4a224058c8f4d74",
   "gsd-core/bin/gsd-tools.cjs": "74594e8bf36e5580",

--- a/tests/fixtures/golden-install-parity/hermes.json
+++ b/tests/fixtures/golden-install-parity/hermes.json
@@ -35,7 +35,6 @@
   "agents/gsd-ui-researcher.md": "87cf9eebc37c4a37",
   "agents/gsd-user-profiler.md": "ca3bf75581f211a0",
   "agents/gsd-verifier.md": "c1d1448bf31039ec",
-  "gsd-core/CHANGELOG.md": "8bf626da3d88f8af",
   "gsd-core/VERSION": "ef0deccd81a6723c",
   "gsd-core/bin/check-latest-version.cjs": "e4a224058c8f4d74",
   "gsd-core/bin/gsd-tools.cjs": "74594e8bf36e5580",

--- a/tests/fixtures/golden-install-parity/kilo.json
+++ b/tests/fixtures/golden-install-parity/kilo.json
@@ -104,7 +104,6 @@
   "command/gsd-verify-work.md": "d07409c940a6ff00",
   "command/gsd-workspace.md": "9048133312f47fdc",
   "command/gsd-workstreams.md": "5e57eed1881c3891",
-  "gsd-core/CHANGELOG.md": "8bf626da3d88f8af",
   "gsd-core/VERSION": "ef0deccd81a6723c",
   "gsd-core/bin/check-latest-version.cjs": "e4a224058c8f4d74",
   "gsd-core/bin/gsd-tools.cjs": "74594e8bf36e5580",

--- a/tests/fixtures/golden-install-parity/kimi.json
+++ b/tests/fixtures/golden-install-parity/kimi.json
@@ -71,7 +71,6 @@
   "agents/subagents/gsd-user-profiler.yaml": "645826a29d079159",
   "agents/subagents/gsd-verifier.md": "1536f3fa5a2d4419",
   "agents/subagents/gsd-verifier.yaml": "2d2bd6b37626f382",
-  "gsd-core/CHANGELOG.md": "8bf626da3d88f8af",
   "gsd-core/VERSION": "ef0deccd81a6723c",
   "gsd-core/bin/check-latest-version.cjs": "e4a224058c8f4d74",
   "gsd-core/bin/gsd-tools.cjs": "74594e8bf36e5580",

--- a/tests/fixtures/golden-install-parity/opencode.json
+++ b/tests/fixtures/golden-install-parity/opencode.json
@@ -104,7 +104,6 @@
   "command/gsd-verify-work.md": "f23fff8e6d71f704",
   "command/gsd-workspace.md": "1e581bdb33bc8f55",
   "command/gsd-workstreams.md": "5e57eed1881c3891",
-  "gsd-core/CHANGELOG.md": "8bf626da3d88f8af",
   "gsd-core/VERSION": "ef0deccd81a6723c",
   "gsd-core/bin/check-latest-version.cjs": "e4a224058c8f4d74",
   "gsd-core/bin/gsd-tools.cjs": "74594e8bf36e5580",

--- a/tests/fixtures/golden-install-parity/qwen.json
+++ b/tests/fixtures/golden-install-parity/qwen.json
@@ -35,7 +35,6 @@
   "agents/gsd-ui-researcher.md": "67596ca5ee2f4547",
   "agents/gsd-user-profiler.md": "ca3bf75581f211a0",
   "agents/gsd-verifier.md": "4bc6c8e197ee56e0",
-  "gsd-core/CHANGELOG.md": "8bf626da3d88f8af",
   "gsd-core/VERSION": "ef0deccd81a6723c",
   "gsd-core/bin/check-latest-version.cjs": "e4a224058c8f4d74",
   "gsd-core/bin/gsd-tools.cjs": "74594e8bf36e5580",

--- a/tests/fixtures/golden-install-parity/trae.json
+++ b/tests/fixtures/golden-install-parity/trae.json
@@ -35,7 +35,6 @@
   "agents/gsd-ui-researcher.md": "e09f0f7034eaa366",
   "agents/gsd-user-profiler.md": "622220df0654b6bf",
   "agents/gsd-verifier.md": "3065cc4cf897078d",
-  "gsd-core/CHANGELOG.md": "8bf626da3d88f8af",
   "gsd-core/VERSION": "ef0deccd81a6723c",
   "gsd-core/bin/check-latest-version.cjs": "e4a224058c8f4d74",
   "gsd-core/bin/gsd-tools.cjs": "5cf26d5f9e588cf8",

--- a/tests/fixtures/golden-install-parity/windsurf.json
+++ b/tests/fixtures/golden-install-parity/windsurf.json
@@ -35,7 +35,6 @@
   "agents/gsd-ui-researcher.md": "f04d24e6459bd23d",
   "agents/gsd-user-profiler.md": "622220df0654b6bf",
   "agents/gsd-verifier.md": "e6353ed8a4baaa32",
-  "gsd-core/CHANGELOG.md": "8bf626da3d88f8af",
   "gsd-core/VERSION": "ef0deccd81a6723c",
   "gsd-core/bin/check-latest-version.cjs": "e4a224058c8f4d74",
   "gsd-core/bin/gsd-tools.cjs": "5cf26d5f9e588cf8",

--- a/tests/golden-install-parity.test.cjs
+++ b/tests/golden-install-parity.test.cjs
@@ -48,7 +48,11 @@ const UPDATE = process.env.UPDATE_GOLDEN === '1';
 const FIXTURE_DIR = path.join(__dirname, 'fixtures', 'golden-install-parity');
 
 // Volatile metadata files always excluded from the parity manifest.
-const VOLATILE_FILES = new Set(['gsd-file-manifest.json', 'gsd-install-state.json']);
+// gsd-core/CHANGELOG.md is excluded because it contains historical version strings
+// that cause hash drift between local (PKG_VERSION=1.x.x) and CI (PKG_VERSION=1.x.x-rc.N):
+// the PKG_VERSION normalization below replaces only the *current* version, but
+// CHANGELOG.md references prior-release versions, so the normalized hash diverges.
+const VOLATILE_FILES = new Set(['gsd-file-manifest.json', 'gsd-install-state.json', 'gsd-core/CHANGELOG.md']);
 
 // The installed package version, normalized to '<VERSION>' in hash computation so
 // the golden is stable across version bumps (the rc step runs `npm version X.Y.Z-rc.N`


### PR DESCRIPTION
## Summary

- Excludes `gsd-core/CHANGELOG.md` from the golden-install-parity hash manifest by adding it to `VOLATILE_FILES`
- Regenerates all 16 golden fixtures to remove the stale `CHANGELOG.md` entry

## Root cause

PR #1837 added `PKG_VERSION` normalization to make golden hashes stable across `npm version` bumps. This worked for hook files and `gsd-core/VERSION` — but introduced a new mismatch for `CHANGELOG.md`:

- CHANGELOG.md contains **historical** version strings (`1.6.0`, `1.5.x`, etc.) from prior release entries
- Locally (`PKG_VERSION = '1.6.0'`): normalization mutates the CHANGELOG content (replaces `1.6.0` with `<VERSION>`) → produces hash A  
- In CI (`PKG_VERSION = '1.7.0-rc.1'`): `1.7.0-rc.1` doesn't appear in CHANGELOG → no mutation → produces hash B  
- A ≠ B, 16 tests fail

The fix: exclude `gsd-core/CHANGELOG.md` from the manifest entirely. It's release documentation, not a functional install artifact, and it changes every release anyway.

## Test plan

- [ ] `node --test tests/golden-install-parity.test.cjs` passes locally (16/16) ✅
- [ ] RC dry run completes without golden parity failures

Closes issue underlying rc dry-run failures (run [#28412330064](https://github.com/open-gsd/gsd-core/actions/runs/28412330064) and [#28419735341](https://github.com/open-gsd/gsd-core/actions/runs/28419735341))

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1840"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785387273&installation_id=134682257&pr_number=1840&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1840&signature=442ab51092f1da6ec1afa1517cc8abf5144997ca55ee0caeb81d836e2acde8ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->