### PR TITLE
fix(#1838): exclude backlog 999.x milestone phases

### DIFF
--- a/.changeset/patient-mice-greet.md
+++ b/.changeset/patient-mice-greet.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 1843
+---
+**`init milestone-op` now ignores backlog `999.x` headings when counting milestone phases** — parked backlog items no longer inflate `phase_count` or pin `all_phases_complete` false for an otherwise finished milestone. (#1843)

--- a/src/init.cts
+++ b/src/init.cts
@@ -1189,6 +1189,7 @@ function cmdInitMilestoneOp(cwd: string, raw: boolean): void {
     const phasePattern = /#{2,4}\s*Phase\s+(\d+[A-Z]?(?:\.\d+)*)\s*:/gi;
     let m: RegExpExecArray | null;
     while ((m = phasePattern.exec(currentSection)) !== null) {
+      if (/^999(?:\.|$)/.test(m[1])) continue;
       roadmapPhaseNumbers.push(m[1]);
     }
   } catch {

--- a/tests/init.test.cjs
+++ b/tests/init.test.cjs
@@ -976,6 +976,7 @@ describe('cmdInitMilestoneOp', () => {
       path.join(tmpDir, '.planning', 'config.json'),
       JSON.stringify({ project_code: 'PROJ' }, null, 2)
     );
+
     fs.writeFileSync(
       path.join(tmpDir, '.planning', 'STATE.md'),
       [
@@ -995,6 +996,47 @@ describe('cmdInitMilestoneOp', () => {
         '',
         '## 🚧 v1.0.0 Test Milestone',
         '### Phase 1: Setup',
+        '',
+      ].join('\n')
+    );
+
+    const result = runGsdTools('init milestone-op', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.phase_count, 1);
+    assert.strictEqual(output.completed_phases, 1);
+    assert.strictEqual(output.all_phases_complete, true);
+  });
+
+  test('backlog 999.x headings do not inflate milestone phase counts (#1838)', () => {
+    const phase1 = path.join(tmpDir, '.planning', 'phases', '01-setup');
+    fs.mkdirSync(phase1, { recursive: true });
+    fs.writeFileSync(path.join(phase1, '01-01-PLAN.md'), '# Plan');
+    fs.writeFileSync(path.join(phase1, '01-01-SUMMARY.md'), '# Summary');
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'STATE.md'),
+      [
+        '---',
+        'gsd_state_version: 1.0',
+        'milestone: v1.0.0',
+        'milestone_name: Test Milestone',
+        'status: completed',
+        '---',
+        '',
+      ].join('\n')
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      [
+        '# Roadmap',
+        '',
+        '## 🚧 v1.0.0 Test Milestone',
+        '### Phase 1: Setup',
+        '',
+        '## Backlog',
+        '### Phase 999.1: Deferred Idea',
+        '### Phase 999.2: Another Deferred Idea',
         '',
       ].join('\n')
     );


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #1838

---

## What was broken

`init milestone-op` counted `### Phase 999.x:` backlog headings as real milestone phases when the backlog lived inside the extracted current-milestone slice, inflating `phase_count` and pinning `all_phases_complete` false.

## What this fix does

This skips the canonical `999.x` backlog lane while collecting roadmap phase numbers for milestone-op, so only real milestone phases contribute to completion counts.

## Root cause

`cmdInitMilestoneOp` had a local roadmap-phase loop with no `^999` exclusion, even though sibling milestone-counting paths already treat `999.x` as the backlog sentinel.

## Testing

### How I verified the fix

- Added a regression test in `tests/init.test.cjs` covering an active milestone followed by `## Backlog` with `999.x` headings.
- Ran `node --test tests/init.test.cjs`.
- Ran `npx eslint src/init.cts tests/init.test.cjs`.
- Ran `npm test` successfully in the branch worktree.

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [ ] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1843"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785443254&installation_id=134682257&pr_number=1843&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1843&signature=19c8c5ddd050963d41e2e7052d70149fd11f7058598d960e4b2d96d44bef64eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->