### PR TITLE
fix(#1836): count prefixed milestone phase dirs

### DIFF
--- a/.changeset/eager-ibex-bark.md
+++ b/.changeset/eager-ibex-bark.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 1844
+---
+**`init milestone-op` now counts project_code-prefixed phase directories correctly** — fully shipped milestones using the standard prefixed directory layout no longer report `completed_phases: 0` or stay falsely incomplete. (#1844)

--- a/src/init.cts
+++ b/src/init.cts
@@ -64,7 +64,7 @@ const {
   extractCurrentMilestone,
 } = roadmapParser;
 const { pathExistsInternal, generateSlugInternal, toPosixPath } = coreUtils;
-const { normalizePhaseName, phaseTokenMatches } = phaseId;
+const { normalizePhaseName, phaseTokenMatches, stripProjectCodePrefix } = phaseId;
 const { pruneOrphanedWorktrees } = worktreeSafety;
 
 const {
@@ -1204,7 +1204,7 @@ function cmdInitMilestoneOp(cwd: string, raw: boolean): void {
     const entries = fs.readdirSync(phasesDir, { withFileTypes: true });
     for (const e of entries) {
       if (!e.isDirectory()) continue;
-      const m = e.name.match(/^(\d+[A-Z]?(?:\.\d+)*)/);
+      const m = stripProjectCodePrefix(e.name).match(/^(\d+[A-Z]?(?:\.\d+)*)/);
       if (!m) continue;
       diskPhaseDirs.set(canonicalizePhase(m[1]), e.name);
     }

--- a/tests/init.test.cjs
+++ b/tests/init.test.cjs
@@ -906,6 +906,47 @@ describe('cmdInitMilestoneOp', () => {
     assert.strictEqual(output.all_phases_complete, true);
   });
 
+  test('project_code-prefixed phase directories count as completed milestone phases (#1836)', () => {
+    seedPhase(tmpDir, 'PROJ-01-setup', {
+      'PROJ-01-01-PLAN.md': '# Plan',
+      'PROJ-01-01-SUMMARY.md': '# Summary',
+    });
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({ project_code: 'PROJ' }, null, 2)
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'STATE.md'),
+      [
+        '---',
+        'gsd_state_version: 1.0',
+        'milestone: v1.0.0',
+        'milestone_name: Test Milestone',
+        'status: executing',
+        '---',
+        '',
+      ].join('\n')
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      [
+        '# Roadmap',
+        '',
+        '## 🚧 v1.0.0 Test Milestone',
+        '### Phase 1: Setup',
+        '',
+      ].join('\n')
+    );
+
+    const result = runGsdTools('init milestone-op', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.phase_count, 1);
+    assert.strictEqual(output.completed_phases, 1);
+    assert.strictEqual(output.all_phases_complete, true);
+  });
+
   test('archive directory scanning', () => {
     fs.mkdirSync(path.join(tmpDir, '.planning', 'archive', 'v1.0'), { recursive: true });
     fs.mkdirSync(path.join(tmpDir, '.planning', 'archive', 'v0.9'), { recursive: true });


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #1836

---

## What was broken

`init milestone-op` scanned roadmap phases correctly but failed to match standard `project_code`-prefixed phase directories on disk, so `completed_phases` stayed at `0` and `all_phases_complete` stayed false for fully shipped milestones.

## What this fix does

This strips the optional `project_code` prefix before the disk-dir phase matcher runs, so milestone completion counts line up with the canonical prefixed directory layout.

## Root cause

`cmdInitMilestoneOp` hand-rolled its own disk directory matcher and required a leading digit, while the repo already had a canonical `stripProjectCodePrefix` helper for this exact normalization step.

## Testing

### How I verified the fix

- Added a regression test in `tests/init.test.cjs` covering a `PROJ-01-*` milestone phase directory.
- Ran `node --test tests/init.test.cjs`.
- Ran `npx eslint src/init.cts tests/init.test.cjs`.
- Ran `npm test` successfully in the branch worktree.

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [ ] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1844"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785443254&installation_id=134682257&pr_number=1844&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1844&signature=c5acdca1fa6060d60e9ee077fde71a6e36ad97e4520287174e98463de429f2ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->