### PR TITLE
fix(#1847): add Claude Sonnet 5 and curated 1.6.1 hotfix fixes

### DIFF
--- a/.changeset/1580-999-sentinel-milestone-roadmap.md
+++ b/.changeset/1580-999-sentinel-milestone-roadmap.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 1691
+---
+`milestone complete` and `roadmap analyze` now exclude the Phase 0 / Phase 999 backlog sentinels. A milestone whose only directory-less ROADMAP heading is a backlog sentinel can be completed without `--force`, and `roadmap analyze` no longer counts the sentinel in `phase_count` or routes `next_phase` into it. Completes the `^999` exclusion #1445 added to the progress denominators.

--- a/.changeset/1591-phase-complete-details-wrapped-checklist.md
+++ b/.changeset/1591-phase-complete-details-wrapped-checklist.md
@@ -1,0 +1,6 @@
+---
+type: Fixed
+pr: 1819
+---
+**`phase.complete` no longer reports a false `is_last_phase` on a `<details>`-wrapped checkbox checklist (#1591, #1752)** — when the active milestone's phase checklist was written as `- [ ] Phase N:` checkbox items inside a `<details>` block and the next phase had no directory on disk yet (still in planning), `phase.complete`'s `isLastPhase` roadmap-enumeration fallback used a heading-only pattern (`/#{2,4}\s*Phase…/`) that never matched checkbox items. It returned `is_last_phase: true, next_phase: null` on a mid-milestone phase and — via the milestone-complete cascade — wrongly flipped STATE.md to `Milestone complete` and decremented `progress.total_phases` (e.g. 8 → 7). The pattern now matches both heading-style (`### Phase N:`) and checkbox-list phases (`- [ ] Phase N:` / `- [x] Phase N:`); `extractCurrentMilestone` already surfaces the `<details>`-wrapped checklist correctly, so no parser change was needed. Only the reproduced `phase.complete` fallback is changed; the heading-only sibling patterns elsewhere in `phase.cts` are untouched.
+

--- a/.changeset/1847-claude-sonnet-5-standard-tier.md
+++ b/.changeset/1847-claude-sonnet-5-standard-tier.md
@@ -1,0 +1,5 @@
+---
+type: Added
+pr: 1847
+---
+**Claude Sonnet 5 is now the `standard` (sonnet) tier model.** The model catalog and provider presets resolve the sonnet/standard tier to `claude-sonnet-5` (GA 2026-06-30) across the Anthropic-backed runtimes (`claude`, `copilot`, and the `anthropic`/`anthropic-fable` presets), plus the OpenRouter-style `anthropic/claude-sonnet-5` for `opencode`/`hermes`, replacing the superseded `claude-sonnet-4-6`. Opus and Haiku tiers are unchanged. (#1847)

--- a/.changeset/1847-claude-sonnet-5-standard-tier.md
+++ b/.changeset/1847-claude-sonnet-5-standard-tier.md
@@ -1,5 +1,5 @@
 ---
 type: Added
-pr: 1847
+pr: 1848
 ---
 **Claude Sonnet 5 is now the `standard` (sonnet) tier model.** The model catalog and provider presets resolve the sonnet/standard tier to `claude-sonnet-5` (GA 2026-06-30) across the Anthropic-backed runtimes (`claude`, `copilot`, and the `anthropic`/`anthropic-fable` presets), plus the OpenRouter-style `anthropic/claude-sonnet-5` for `opencode`/`hermes`, replacing the superseded `claude-sonnet-4-6`. Opus and Haiku tiers are unchanged. (#1847)

--- a/.changeset/lucky-quails-greet.md
+++ b/.changeset/lucky-quails-greet.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 1746
+---
+Windows: stop double-quoting $CLAUDE_PROJECT_DIR-anchored managed node hook paths during the #2979 legacy rewrite, which produced "\"$CLAUDE_PROJECT_DIR\"/..." and broke every node managed hook with MODULE_NOT_FOUND (PreToolUse-guard deadlock).

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1355,13 +1355,13 @@ When `runtime` is set, profile tiers (`opus`/`sonnet`/`haiku`) resolve to runtim
 
 | Runtime | `opus` | `sonnet` | `haiku` | reasoning_effort |
 |---------|--------|----------|---------|------------------|
-| `claude` | `claude-opus-4-8` | `claude-sonnet-4-6` | `claude-haiku-4-5` | (not used) |
+| `claude` | `claude-opus-4-8` | `claude-sonnet-5` | `claude-haiku-4-5` | (not used) |
 | `codex` | `gpt-5.5` | `gpt-5.4` | `gpt-5.4-mini` | `xhigh` / `medium` / `medium` |
 | `gemini` | `gemini-3.1-pro-preview` | `gemini-3-flash` | `gemini-2.5-flash-lite` | (not used) |
 | `qwen` | `qwen3-max-2026-01-23` | `qwen3-coder-plus` | `qwen3-coder-next` | (not used) |
-| `opencode` | `anthropic/claude-opus-4-8` | `anthropic/claude-sonnet-4-6` | `anthropic/claude-haiku-4-5` | (not used) |
-| `copilot` | `claude-opus-4-8` | `claude-sonnet-4-6` | `claude-haiku-4-5` | (not used) |
-| `hermes` | `anthropic/claude-opus-4-8` | `anthropic/claude-sonnet-4-6` | `anthropic/claude-haiku-4-5` | (not used) |
+| `opencode` | `anthropic/claude-opus-4-8` | `anthropic/claude-sonnet-5` | `anthropic/claude-haiku-4-5` | (not used) |
+| `copilot` | `claude-opus-4-8` | `claude-sonnet-5` | `claude-haiku-4-5` | (not used) |
+| `hermes` | `anthropic/claude-opus-4-8` | `anthropic/claude-sonnet-5` | `anthropic/claude-haiku-4-5` | (not used) |
 | Group B (`kilo`, `cline`, `cursor`, `windsurf` (alias: `devin-desktop`), `augment`, `trae`, `codebuddy`, `antigravity`) | (no built-in default — your runtime handles model selection) | | | |
 
 > **How these model IDs are sourced.** The catalog (`bin/shared/model-catalog.json`) pins each runtime's tier defaults to that provider's current frontier IDs, and may intentionally carry forward-dated IDs ahead of a provider's public docs. To verify an ID is live before changing it, check the provider's own source/API — e.g. Gemini: gemini-cli `packages/core/src/config/models.ts` or `gemini --model <id> --prompt ping`; Codex: `codex debug models` or the OpenAI Codex models page; Qwen: Alibaba Model Studio model list. Only change an ID that the provider actually rejects — absence from documentation alone is not proof of invalidity.

--- a/docs/pt-BR/CONFIGURATION.md
+++ b/docs/pt-BR/CONFIGURATION.md
@@ -1139,13 +1139,13 @@ A saída JSON de `resolve-model` inclui `reasoning_effort` quando o nível de ru
 
 | Runtime | `opus` | `sonnet` | `haiku` | reasoning_effort |
 |---------|--------|----------|---------|------------------|
-| `claude` | `claude-opus-4-8` | `claude-sonnet-4-6` | `claude-haiku-4-5` | (não usado) |
+| `claude` | `claude-opus-4-8` | `claude-sonnet-5` | `claude-haiku-4-5` | (não usado) |
 | `codex` | `gpt-5.5` | `gpt-5.3-codex` | `gpt-5.4-mini` | `xhigh` / `medium` / `medium` |
 | `gemini` | `gemini-3-pro` | `gemini-3-flash` | `gemini-2.5-flash-lite` | (não usado) |
 | `qwen` | `qwen3-max-2026-01-23` | `qwen3-coder-plus` | `qwen3-coder-next` | (não usado) |
-| `opencode` | `anthropic/claude-opus-4-8` | `anthropic/claude-sonnet-4-6` | `anthropic/claude-haiku-4-5` | (não usado) |
-| `copilot` | `claude-opus-4-8` | `claude-sonnet-4-6` | `claude-haiku-4-5` | (não usado) |
-| `hermes` | `anthropic/claude-opus-4-8` | `anthropic/claude-sonnet-4-6` | `anthropic/claude-haiku-4-5` | (não usado) |
+| `opencode` | `anthropic/claude-opus-4-8` | `anthropic/claude-sonnet-5` | `anthropic/claude-haiku-4-5` | (não usado) |
+| `copilot` | `claude-opus-4-8` | `claude-sonnet-5` | `claude-haiku-4-5` | (não usado) |
+| `hermes` | `anthropic/claude-opus-4-8` | `anthropic/claude-sonnet-5` | `anthropic/claude-haiku-4-5` | (não usado) |
 | Grupo B (`kilo`, `cline`, `cursor`, `windsurf`, `augment`, `trae`, `codebuddy`, `antigravity`) | (sem padrão integrado — seu runtime trata da seleção de modelo) | | | |
 
 **Exemplo Codex** — uma configuração, modelos em nível, sem bloco grande de `model_overrides`:

--- a/docs/zh-CN/CONFIGURATION.md
+++ b/docs/zh-CN/CONFIGURATION.md
@@ -1108,13 +1108,13 @@ minimal < low < medium < high < xhigh < max
 
 | 运行时 | `opus` | `sonnet` | `haiku` | reasoning_effort |
 |---------|--------|----------|---------|------------------|
-| `claude` | `claude-opus-4-8` | `claude-sonnet-4-6` | `claude-haiku-4-5` | （不使用） |
+| `claude` | `claude-opus-4-8` | `claude-sonnet-5` | `claude-haiku-4-5` | （不使用） |
 | `codex` | `gpt-5.5` | `gpt-5.3-codex` | `gpt-5.4-mini` | `xhigh` / `medium` / `medium` |
 | `gemini` | `gemini-3-pro` | `gemini-3-flash` | `gemini-2.5-flash-lite` | （不使用） |
 | `qwen` | `qwen3-max-2026-01-23` | `qwen3-coder-plus` | `qwen3-coder-next` | （不使用） |
-| `opencode` | `anthropic/claude-opus-4-8` | `anthropic/claude-sonnet-4-6` | `anthropic/claude-haiku-4-5` | （不使用） |
-| `copilot` | `claude-opus-4-8` | `claude-sonnet-4-6` | `claude-haiku-4-5` | （不使用） |
-| `hermes` | `anthropic/claude-opus-4-8` | `anthropic/claude-sonnet-4-6` | `anthropic/claude-haiku-4-5` | （不使用） |
+| `opencode` | `anthropic/claude-opus-4-8` | `anthropic/claude-sonnet-5` | `anthropic/claude-haiku-4-5` | （不使用） |
+| `copilot` | `claude-opus-4-8` | `claude-sonnet-5` | `claude-haiku-4-5` | （不使用） |
+| `hermes` | `anthropic/claude-opus-4-8` | `anthropic/claude-sonnet-5` | `anthropic/claude-haiku-4-5` | （不使用） |
 | B 组（`kilo`、`cline`、`cursor`、`windsurf`、`augment`、`trae`、`codebuddy`、`antigravity`） | （无内置默认——您的运行时处理模型选择） | | | |
 
 **Codex 示例** — 单个配置，分层模型，无大型 `model_overrides` 块：

--- a/gsd-core/bin/shared/model-catalog.json
+++ b/gsd-core/bin/shared/model-catalog.json
@@ -9,7 +9,7 @@
   "runtimeTierDefaults": {
     "claude": {
       "opus": { "model": "claude-opus-4-8" },
-      "sonnet": { "model": "claude-sonnet-4-6" },
+      "sonnet": { "model": "claude-sonnet-5" },
       "haiku": { "model": "claude-haiku-4-5" }
     },
     "codex": {
@@ -29,17 +29,17 @@
     },
     "opencode": {
       "opus": { "model": "anthropic/claude-opus-4-8" },
-      "sonnet": { "model": "anthropic/claude-sonnet-4-6" },
+      "sonnet": { "model": "anthropic/claude-sonnet-5" },
       "haiku": { "model": "anthropic/claude-haiku-4-5" }
     },
     "copilot": {
       "opus": { "model": "claude-opus-4-8" },
-      "sonnet": { "model": "claude-sonnet-4-6" },
+      "sonnet": { "model": "claude-sonnet-5" },
       "haiku": { "model": "claude-haiku-4-5" }
     },
     "hermes": {
       "opus": { "model": "anthropic/claude-opus-4-8" },
-      "sonnet": { "model": "anthropic/claude-sonnet-4-6" },
+      "sonnet": { "model": "anthropic/claude-sonnet-5" },
       "haiku": { "model": "anthropic/claude-haiku-4-5" }
     },
     "kilo": {
@@ -91,13 +91,13 @@
   "providerPresets": {
     "anthropic": {
       "opus":   { "low": { "model": "claude-opus-4-5" }, "medium": { "model": "claude-opus-4-8" }, "high": { "model": "claude-opus-4-8" } },
-      "sonnet": { "low": { "model": "claude-haiku-4-5" }, "medium": { "model": "claude-sonnet-4-6" }, "high": { "model": "claude-opus-4-8" } },
-      "haiku":  { "low": { "model": "claude-haiku-4-5" }, "medium": { "model": "claude-haiku-4-5" }, "high": { "model": "claude-sonnet-4-6" } }
+      "sonnet": { "low": { "model": "claude-haiku-4-5" }, "medium": { "model": "claude-sonnet-5" }, "high": { "model": "claude-opus-4-8" } },
+      "haiku":  { "low": { "model": "claude-haiku-4-5" }, "medium": { "model": "claude-haiku-4-5" }, "high": { "model": "claude-sonnet-5" } }
     },
     "anthropic-fable": {
       "opus":   { "low": { "model": "claude-opus-4-5" }, "medium": { "model": "claude-opus-4-8" }, "high": { "model": "claude-fable-5" } },
-      "sonnet": { "low": { "model": "claude-haiku-4-5" }, "medium": { "model": "claude-sonnet-4-6" }, "high": { "model": "claude-fable-5" } },
-      "haiku":  { "low": { "model": "claude-haiku-4-5" }, "medium": { "model": "claude-haiku-4-5" }, "high": { "model": "claude-sonnet-4-6" } }
+      "sonnet": { "low": { "model": "claude-haiku-4-5" }, "medium": { "model": "claude-sonnet-5" }, "high": { "model": "claude-fable-5" } },
+      "haiku":  { "low": { "model": "claude-haiku-4-5" }, "medium": { "model": "claude-haiku-4-5" }, "high": { "model": "claude-sonnet-5" } }
     },
     "openai": {
       "opus":   { "low": { "model": "gpt-5.4", "reasoning_effort": "medium" }, "medium": { "model": "gpt-5.5", "reasoning_effort": "high" }, "high": { "model": "gpt-5.5", "reasoning_effort": "xhigh" } },

--- a/gsd-core/workflows/settings-advanced.md
+++ b/gsd-core/workflows/settings-advanced.md
@@ -353,13 +353,13 @@ Built-in tier defaults by runtime:
 
 | Runtime    | `opus`                        | `sonnet`                        | `haiku`                       |
 |------------|-------------------------------|---------------------------------|-------------------------------|
-| `claude`   | `claude-opus-4-8`             | `claude-sonnet-4-6`             | `claude-haiku-4-5`            |
+| `claude`   | `claude-opus-4-8`             | `claude-sonnet-5`             | `claude-haiku-4-5`            |
 | `codex`    | `gpt-5.5`                     | `gpt-5.4`                       | `gpt-5.4-mini`                |
 | `gemini`   | `gemini-3.1-pro-preview`      | `gemini-3-flash`                | `gemini-2.5-flash-lite`       |
 | `qwen`     | `qwen3-max-2026-01-23`        | `qwen3-coder-plus`              | `qwen3-coder-next`            |
-| `opencode` | `anthropic/claude-opus-4-8`   | `anthropic/claude-sonnet-4-6`   | `anthropic/claude-haiku-4-5`  |
-| `copilot`  | `claude-opus-4-8`             | `claude-sonnet-4-6`             | `claude-haiku-4-5`            |
-| `hermes`   | `anthropic/claude-opus-4-8`   | `anthropic/claude-sonnet-4-6`   | `anthropic/claude-haiku-4-5`  |
+| `opencode` | `anthropic/claude-opus-4-8`   | `anthropic/claude-sonnet-5`   | `anthropic/claude-haiku-4-5`  |
+| `copilot`  | `claude-opus-4-8`             | `claude-sonnet-5`             | `claude-haiku-4-5`            |
+| `hermes`   | `anthropic/claude-opus-4-8`   | `anthropic/claude-sonnet-5`   | `anthropic/claude-haiku-4-5`  |
 | Group B (`kilo`, `cline`, `cursor`, `windsurf`, `augment`, `trae`, `codebuddy`, `antigravity`) | (no built-in default — your runtime handles model selection) | | |
 
 Display a table to the user showing the effective configuration:
@@ -623,8 +623,8 @@ AskUserQuestion([
     header: "Provider",
     multiSelect: false,
     options: [
-      { label: "anthropic", description: "claude-opus-4-8 / claude-sonnet-4-6 / claude-haiku-4-5 (Anthropic / Claude)" },
-      { label: "anthropic-fable", description: "claude-fable-5 / claude-sonnet-4-6 / claude-haiku-4-5 (Anthropic / Claude Fable opt-in)" },
+      { label: "anthropic", description: "claude-opus-4-8 / claude-sonnet-5 / claude-haiku-4-5 (Anthropic / Claude)" },
+      { label: "anthropic-fable", description: "claude-fable-5 / claude-sonnet-5 / claude-haiku-4-5 (Anthropic / Claude Fable opt-in)" },
       { label: "openai", description: "gpt-5.5 / gpt-5.4 / gpt-5.4-mini (OpenAI / Codex)" },
       { label: "Other known provider", description: "Type google or qwen; both still use the canonical tier mapping." }
     ]
@@ -654,11 +654,11 @@ Canonical tier mappings by provider and budget:
 
 | Provider  | Budget | high                       | medium                     | low                        |
 |-----------|--------|----------------------------|----------------------------|----------------------------|
-| anthropic | high   | claude-opus-4-8            | claude-opus-4-8            | claude-sonnet-4-6          |
-| anthropic | medium | claude-opus-4-8            | claude-sonnet-4-6          | claude-haiku-4-5           |
+| anthropic | high   | claude-opus-4-8            | claude-opus-4-8            | claude-sonnet-5          |
+| anthropic | medium | claude-opus-4-8            | claude-sonnet-5          | claude-haiku-4-5           |
 | anthropic | low    | claude-haiku-4-5           | claude-haiku-4-5           | claude-haiku-4-5           |
-| anthropic-fable | high   | claude-fable-5             | claude-fable-5             | claude-sonnet-4-6          |
-| anthropic-fable | medium | claude-opus-4-8            | claude-sonnet-4-6          | claude-haiku-4-5           |
+| anthropic-fable | high   | claude-fable-5             | claude-fable-5             | claude-sonnet-5          |
+| anthropic-fable | medium | claude-opus-4-8            | claude-sonnet-5          | claude-haiku-4-5           |
 | anthropic-fable | low    | claude-haiku-4-5           | claude-haiku-4-5           | claude-haiku-4-5           |
 | openai    | high   | gpt-5.5                    | gpt-5.5                    | gpt-5.5                    |
 | openai    | medium | gpt-5.5                    | gpt-5.4                    | gpt-5.4-mini               |

--- a/src/milestone.cts
+++ b/src/milestone.cts
@@ -184,6 +184,13 @@ function cmdMilestoneComplete(cwd: string, version: string, options: MilestoneCo
         })();
         while ((pm = phasePattern.exec(scopedContent)) !== null) {
           const phaseNum = pm[1];
+          // Phase 0 (pre-milestone) and Phase 999 (backlog) are sentinels, not
+          // real phases — they legitimately have no directory and must not block
+          // milestone completion. Mirrors the engine-wide sentinel convention
+          // (phase-id getMilestoneFromPhaseId, roadmap-command-router SENTINELS,
+          // the #1445 /^999/ progress filters). (#1580)
+          const major = parseInt(phaseNum, 10);
+          if (major === 0 || major === 999) continue;
           const normalized = normalizePhaseName(phaseNum);
           // A phase has disk_status: 'no_directory' when no phase directory
           // with a matching token exists on disk. Use the same phaseTokenMatches

--- a/src/phase.cts
+++ b/src/phase.cts
@@ -1650,15 +1650,18 @@ function cmdPhaseComplete(cwd: string, phaseNum: string, raw: boolean): void {
         try {
           const roadmapForPhases = extractCurrentMilestone(roadmapContent, cwd);
           // #1591: match BOTH heading-style phases (`### Phase N:`) AND
-          // checkbox-list items (`- [ ] Phase N:` / `- [x] Phase N:`). When
-          // the active milestone's checklist is `- [ ]` items inside a
-          // <details> block (and the next phase has no directory yet, so the
-          // disk-based resolver finds nothing), this roadmap-enumeration
-          // fallback is the only path that can find the next phase. The prior
-          // heading-only pattern missed checkbox items → is_last_phase=true on
-          // a mid-milestone phase. The marker alternation is the only change;
-          // the number/name captures are unchanged.
-          const phasePattern = /(?:#{2,4}|-\s*\[[ xX]\])\s*Phase\s+(\d+[A-Z]?(?:\.\d+)*)\s*:\s*([^\n]+)/gi;
+          // checkbox-list items, INCLUDING the canonical bold form the roadmap
+          // template emits (`- [ ] **Phase N: Name**`). When the active
+          // milestone's checklist is `- [ ]` items inside a <details> block
+          // (and the next phase has no directory yet, so the disk-based
+          // resolver finds nothing), this roadmap-enumeration fallback is the
+          // only path that can find the next phase. The prior heading-only
+          // pattern missed checkbox items, and a checkbox-only broadening still
+          // missed the bold template rows → is_last_phase=true on a mid-milestone
+          // phase. Allow optional `**`/`__` emphasis after the marker and stop
+          // the name capture at emphasis so bold names slug cleanly; the number
+          // capture is unchanged.
+          const phasePattern = /(?:#{2,4}|-\s*\[[ xX]\])\s*(?:\*\*|__)?\s*Phase\s+(\d+[A-Z]?(?:\.\d+)*)\s*:\s*([^\n*]+)/gi;
           let pm: RegExpExecArray | null;
           while ((pm = phasePattern.exec(roadmapForPhases)) !== null) {
             if (comparePhaseNum(pm[1], phaseNum) > 0) {

--- a/src/phase.cts
+++ b/src/phase.cts
@@ -1649,7 +1649,16 @@ function cmdPhaseComplete(cwd: string, phaseNum: string, raw: boolean): void {
       if (isLastPhase && roadmapContent !== null) {
         try {
           const roadmapForPhases = extractCurrentMilestone(roadmapContent, cwd);
-          const phasePattern = /#{2,4}\s*Phase\s+(\d+[A-Z]?(?:\.\d+)*)\s*:\s*([^\n]+)/gi;
+          // #1591: match BOTH heading-style phases (`### Phase N:`) AND
+          // checkbox-list items (`- [ ] Phase N:` / `- [x] Phase N:`). When
+          // the active milestone's checklist is `- [ ]` items inside a
+          // <details> block (and the next phase has no directory yet, so the
+          // disk-based resolver finds nothing), this roadmap-enumeration
+          // fallback is the only path that can find the next phase. The prior
+          // heading-only pattern missed checkbox items → is_last_phase=true on
+          // a mid-milestone phase. The marker alternation is the only change;
+          // the number/name captures are unchanged.
+          const phasePattern = /(?:#{2,4}|-\s*\[[ xX]\])\s*Phase\s+(\d+[A-Z]?(?:\.\d+)*)\s*:\s*([^\n]+)/gi;
           let pm: RegExpExecArray | null;
           while ((pm = phasePattern.exec(roadmapForPhases)) !== null) {
             if (comparePhaseNum(pm[1], phaseNum) > 0) {

--- a/src/roadmap.cts
+++ b/src/roadmap.cts
@@ -318,6 +318,16 @@ function cmdRoadmapAnalyze(cwd: string, raw: boolean): void {
   }> = [];
   let match: RegExpExecArray | null;
 
+  // Phase 0 (pre-milestone) and Phase 999 (backlog) are sentinels, not real
+  // phases. They legitimately have no directory and must never be surfaced as
+  // current/next phase or counted in phase_count. Mirrors the engine-wide
+  // sentinel convention (phase-id getMilestoneFromPhaseId, roadmap-command-router
+  // SENTINELS, the #1445 /^999/ progress filters). (#1580)
+  const isSentinelPhase = (num: string): boolean => {
+    const major = parseInt(num, 10);
+    return major === 0 || major === 999;
+  };
+
   // Build phase directory lookup once (O(1) readdir instead of O(N) per phase)
   const _phaseDirNames = (() => {
     try {
@@ -329,6 +339,7 @@ function cmdRoadmapAnalyze(cwd: string, raw: boolean): void {
 
   while ((match = phasePattern.exec(content)) !== null) {
     const phaseNum = match[1];
+    if (isSentinelPhase(phaseNum)) continue;
     const phaseName = match[2].replace(/\(INSERTED\)/i, '').trim();
 
     // Extract goal from the section
@@ -437,7 +448,7 @@ function cmdRoadmapAnalyze(cwd: string, raw: boolean): void {
     checklistPhases.add(checklistMatch[1]);
   }
   const detailPhases = new Set(phases.map(p => p.number));
-  const missingDetails = [...checklistPhases].filter(p => !detailPhases.has(p));
+  const missingDetails = [...checklistPhases].filter(p => !detailPhases.has(p) && !isSentinelPhase(p));
 
   const result = {
     milestones,

--- a/src/shell-command-projection.cts
+++ b/src/shell-command-projection.cts
@@ -254,6 +254,15 @@ export function isManagedHookCommand(commandText: unknown, opts: { surface?: str
 }
 
 /**
+ * Detect a `"$VAR"/rest` anchored hook-script token — a path whose leading
+ * shell variable is already double-quoted with the remainder left bare (the
+ * shape `projectLocalHookPrefix` emits for local installs, e.g.
+ * `"$CLAUDE_PROJECT_DIR"/.claude/hooks/gsd-x.js`). Such a token is ALREADY a
+ * valid, correctly-quoted shell argument and must never be re-quoted.
+ */
+const ANCHORED_HOOK_SCRIPT_TOKEN = /^"\$[A-Za-z_][A-Za-z0-9_]*"\//;
+
+/**
  * Projection helper for legacy settings.json hook rewrites.
  *
  * Non-Windows keeps the original script token shape when provided (single
@@ -275,8 +284,20 @@ export function projectLegacySettingsHookCommand({
 }): string | null {
   if (!absoluteRunner || !scriptPath) return null;
   const normalizedScriptPath = platform === 'win32' ? scriptPath.replace(/\\/g, '/') : scriptPath;
+  // #1693: a script path already carrying a `"$CLAUDE_PROJECT_DIR"`-anchored
+  // quoted prefix (local installs) is already a valid shell token — only the
+  // variable is quoted, the rest is bare. JSON.stringify-ing it on Windows
+  // yields `"\"$CLAUDE_PROJECT_DIR\"/..."` (escaped quotes inside an outer
+  // quote); node then receives an argument that *starts* with a `"`, treats it
+  // as relative, and dies with MODULE_NOT_FOUND. Emit anchored tokens verbatim;
+  // only bare absolute paths (which may contain spaces, e.g. "Program Files")
+  // need the JSON.stringify quoting. Scoped to win32: the non-Windows branch
+  // already preserves the caller's `scriptToken` (which is the bare anchored
+  // token for these inputs), so it never had the double-quote bug.
   const commandScriptToken = platform === 'win32'
-    ? JSON.stringify(normalizedScriptPath)
+    ? (ANCHORED_HOOK_SCRIPT_TOKEN.test(normalizedScriptPath)
+        ? normalizedScriptPath
+        : JSON.stringify(normalizedScriptPath))
     : (scriptToken || JSON.stringify(normalizedScriptPath));
   return projectShellCommandText({
     runnerToken: absoluteRunner,

--- a/tests/bug-3413-shell-command-projection.test.cjs
+++ b/tests/bug-3413-shell-command-projection.test.cjs
@@ -187,3 +187,92 @@ describe('bug #3439: shell projection module owns managed-hook policy and legacy
     );
   });
 });
+
+describe('#1693 regression: Windows legacy-node rewrite must not double-quote a "$CLAUDE_PROJECT_DIR"-anchored local hook path', () => {
+  const winRunner = '"C:/Program Files/nodejs/node.exe"';
+
+  // WHY: a local-install hook path already carries a `"$CLAUDE_PROJECT_DIR"`
+  // anchored prefix (only the variable quoted, rest bare). On Windows the legacy
+  // rewrite previously JSON.stringify'd the whole token, yielding
+  // `"\"$CLAUDE_PROJECT_DIR\"/..."`. node then received an argument starting with
+  // a literal `"`, treated it as relative, and died with MODULE_NOT_FOUND —
+  // breaking every node managed hook at once (self-locking deadlock).
+  test('projectLegacySettingsHookCommand emits the anchored path verbatim, not re-quoted', () => {
+    const anchored = '"$CLAUDE_PROJECT_DIR"/.claude/hooks/gsd-context-monitor.js';
+    const command = projectLegacySettingsHookCommand({
+      absoluteRunner: winRunner,
+      scriptPath: anchored,
+      scriptToken: anchored,
+      platform: 'win32',
+      runtime: 'claude',
+    });
+    assert.equal(
+      command,
+      '"C:/Program Files/nodejs/node.exe" "$CLAUDE_PROJECT_DIR"/.claude/hooks/gsd-context-monitor.js',
+    );
+    assert.ok(!command.includes('\\"'), 'must not contain escaped double-quotes');
+  });
+
+  // WHY: the fix must be surgical — a BARE absolute Windows path (no anchored
+  // prefix) can contain spaces ("Program Files") and still REQUIRES quoting.
+  test('projectLegacySettingsHookCommand still quotes a bare absolute Windows path', () => {
+    const abs = 'C:/Program Files App/.claude/hooks/gsd-context-monitor.js';
+    const command = projectLegacySettingsHookCommand({
+      absoluteRunner: winRunner,
+      scriptPath: abs,
+      scriptToken: JSON.stringify(abs),
+      platform: 'win32',
+      runtime: 'claude',
+    });
+    assert.equal(
+      command,
+      '"C:/Program Files/nodejs/node.exe" "C:/Program Files App/.claude/hooks/gsd-context-monitor.js"',
+    );
+  });
+
+  // WHY: the anchored short-circuit is scoped to win32. On POSIX the rewrite
+  // already preserved the caller's original `scriptToken` and never had the
+  // double-quote bug, so that behavior must be left byte-identical. scriptPath
+  // is anchored but scriptToken is a DISTINCT single-quoted value: if the
+  // win32 gate were removed, the anchored short-circuit would emit scriptPath
+  // and this assertion would fail — that is what pins the gate.
+  test('projectLegacySettingsHookCommand preserves the original scriptToken for anchored paths on POSIX', () => {
+    const command = projectLegacySettingsHookCommand({
+      absoluteRunner: '"/usr/local/bin/node"',
+      scriptPath: '"$CLAUDE_PROJECT_DIR"/.claude/hooks/gsd-statusline.js',
+      scriptToken: "'/x/hooks/gsd-statusline.js'",
+      platform: 'linux',
+      runtime: 'claude',
+    });
+    assert.equal(command, `"/usr/local/bin/node" '/x/hooks/gsd-statusline.js'`);
+  });
+
+  // WHY: end-to-end through the installer rewrite — the actual #2979 path that
+  // ran during the user's 1.5.0 -> 1.6.0 local update. Managed node hooks get
+  // the absolute runner + clean anchored path; a non-node-prefixed managed .sh
+  // hook (already correct) is left untouched.
+  test('rewriteLegacyManagedNodeHookCommands produces clean anchored node commands on Windows', () => {
+    const settings = {
+      hooks: {
+        PostToolUse: [
+          {
+            hooks: [
+              { command: 'node "$CLAUDE_PROJECT_DIR"/.claude/hooks/gsd-context-monitor.js' },
+            ],
+          },
+        ],
+      },
+    };
+    const changed = rewriteLegacyManagedNodeHookCommands(settings, winRunner, {
+      platform: 'win32',
+      runtime: 'claude',
+    });
+    assert.equal(changed, true);
+    const rewritten = settings.hooks.PostToolUse[0].hooks[0].command;
+    assert.equal(
+      rewritten,
+      '"C:/Program Files/nodejs/node.exe" "$CLAUDE_PROJECT_DIR"/.claude/hooks/gsd-context-monitor.js',
+    );
+    assert.ok(!rewritten.includes('\\"'), 'rewritten command must not contain escaped double-quotes');
+  });
+});

--- a/tests/bug-978-milestone-complete-force.test.cjs
+++ b/tests/bug-978-milestone-complete-force.test.cjs
@@ -19,10 +19,13 @@ const { runGsdTools, createTempProject, cleanup } = require('./helpers.cjs');
  * Build a fixture where the guard will fire:
  *  - STATE.md has `milestone: <version>` so the guard's version-match check is
  *    satisfied.
- *  - ROADMAP.md lists a `### Phase 999.1: Backlog Work` heading for that
- *    milestone, but there is NO on-disk phase directory for it.
+ *  - ROADMAP.md lists a `### Phase 2: Real Work` heading for that milestone, but
+ *    there is NO on-disk phase directory for it.
  *
  * This guarantees "unstarted phase" detection without touching any real phases.
+ * NOTE: the unstarted phase must be a REAL phase number — Phase 0 and Phase 999
+ * are backlog/pre-milestone sentinels that are intentionally excluded from this
+ * guard (#1580), so they would not fire it.
  */
 function makeGuardFixture(tmpDir, version) {
   // STATE.md with frontmatter milestone field matching the version
@@ -32,10 +35,10 @@ function makeGuardFixture(tmpDir, version) {
   );
 
   // ROADMAP.md — the heading must include the version so getMilestonePhaseFilter
-  // does not return missingExplicitVersion.  Phase 999.1 has no on-disk dir.
+  // does not return missingExplicitVersion.  Phase 2 has no on-disk dir.
   fs.writeFileSync(
     path.join(tmpDir, '.planning', 'ROADMAP.md'),
-    `# Roadmap ${version}\n\n### Phase 999.1: Backlog Work\n**Goal:** Not started\n`,
+    `# Roadmap ${version}\n\n### Phase 2: Real Work\n**Goal:** Not started\n`,
   );
 }
 
@@ -80,7 +83,7 @@ describe('bug-978: milestone complete --force overrides unstarted-phase guard', 
 
     const output = JSON.parse(result.output);
     assert.strictEqual(output.version, 'v1.0');
-    // Milestone entry should have been created even though phase 999.1 has no dir
+    // Milestone entry should have been created even though phase 2 has no dir
     assert.ok(
       fs.existsSync(path.join(tmpDir, '.planning', 'MILESTONES.md')),
       'MILESTONES.md should have been created',

--- a/tests/feat-49-model-policy-presets.test.cjs
+++ b/tests/feat-49-model-policy-presets.test.cjs
@@ -142,8 +142,8 @@ describe('#49 resolveModelPolicy Sub-path B: provider presets', () => {
   test('known provider "anthropic-fable" + tier "haiku" + budget "high" keeps low tier on Sonnet', () => {
     const policy = { provider: 'anthropic-fable', budget: 'high' };
     const result = resolveModelPolicy(policy, 'haiku');
-    assert.strictEqual(result, 'claude-sonnet-4-6',
-      `expected anthropic-fable haiku/high to resolve to claude-sonnet-4-6, got: ${result}`);
+    assert.strictEqual(result, 'claude-sonnet-5',
+      `expected anthropic-fable haiku/high to resolve to claude-sonnet-5, got: ${result}`);
   });
 
   test('known provider "openai" + tier "sonnet" + budget "low" returns model with reasoning_effort from preset', () => {

--- a/tests/fix-1445-999x-backlog-excluded-from-total-phases.test.cjs
+++ b/tests/fix-1445-999x-backlog-excluded-from-total-phases.test.cjs
@@ -16,6 +16,14 @@
  * Scenarios:
  *   A. deriveProgressFromRoadmap with a progress table containing a 999.x row.
  *   B. state json total_phases via extractCurrentMilestone / roadmapPhaseCount.
+ *
+ * Follow-up #1580: the same `^999` (and Phase 0) sentinel exclusion was missing
+ * in two more code paths — `milestone complete`'s unstarted-phase guard
+ * (src/milestone.cts) and `roadmap analyze`'s next_phase routing + phase_count
+ * (src/roadmap.cts). Scenarios C and D below cover those.
+ *
+ *   C. milestone complete is NOT blocked by a Phase 999 backlog heading.
+ *   D. roadmap analyze never routes next_phase to 999 / never counts it.
  */
 
 const { describe, test, beforeEach, afterEach } = require('node:test');
@@ -169,6 +177,119 @@ describe('bug #1445 — state json excludes 999.x phase headings from total_phas
       state.progress.total_phases,
       3,
       `total_phases must be 3 (not 5). 999.x backlog phases must be excluded. Got ${state.progress.total_phases}`,
+    );
+  });
+});
+
+// ─── Scenario C: milestone complete not blocked by a 999 backlog heading ─────
+
+describe('fix #1580 — milestone complete ignores the 999 backlog sentinel', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempProject('fix-1580-mc-');
+    const planning = path.join(tmpDir, '.planning');
+    // One real, on-disk phase + a directory-less Phase 999 backlog heading.
+    fs.writeFileSync(
+      path.join(planning, 'ROADMAP.md'),
+      [
+        '# Roadmap v1.0',
+        '## v1.0 Milestone',
+        '## Phases',
+        '- [x] **Phase 1: Foundation**',
+        '## Phase Details',
+        '### Phase 1: Foundation',
+        '**Goal:** build it',
+        '### Phase 999: Backlog / Someday',
+        '**Goal:** deferred, never executed',
+      ].join('\n'),
+      'utf-8',
+    );
+    fs.writeFileSync(
+      path.join(planning, 'STATE.md'),
+      `---\nmilestone: v1.0\n---\n# State\n\n**Status:** In progress\n**Last Activity:** 2025-01-01\n**Last Activity Description:** Working\n`,
+      'utf-8',
+    );
+    const dir = path.join(planning, 'phases', '01-foundation');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'PLAN.md'), '# Plan\n', 'utf-8');
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('completes WITHOUT --force despite a Phase 999 backlog heading', () => {
+    const result = runGsdTools(
+      ['milestone', 'complete', 'v1.0', '--name', 'Regression'],
+      tmpDir,
+    );
+    assert.ok(
+      result.success,
+      `milestone complete must not be blocked by the 999 sentinel; got error: ${result.error}`,
+    );
+    assert.ok(
+      !/Cannot mark milestone complete/.test(result.error || ''),
+      `the unstarted-phase guard must not fire on Phase 999. Got: ${result.error}`,
+    );
+  });
+});
+
+// ─── Scenario D: roadmap analyze never routes/ counts the 999 sentinel ────────
+
+describe('fix #1580 — roadmap analyze excludes the 999 backlog sentinel', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempProject('fix-1580-ra-');
+    const planning = path.join(tmpDir, '.planning');
+    fs.writeFileSync(
+      path.join(planning, 'ROADMAP.md'),
+      [
+        '# Roadmap v1.0',
+        '## v1.0 Milestone',
+        '## Phases',
+        '- [x] **Phase 1: Foundation**',
+        '## Phase Details',
+        '### Phase 1: Foundation',
+        '**Goal:** build it',
+        '### Phase 999: Backlog / Someday',
+        '**Goal:** deferred, never executed',
+      ].join('\n'),
+      'utf-8',
+    );
+    fs.writeFileSync(
+      path.join(planning, 'STATE.md'),
+      `---\nmilestone: v1.0\n---\n# State\n`,
+      'utf-8',
+    );
+    const dir = path.join(planning, 'phases', '01-foundation');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'PLAN.md'), '# Plan\n', 'utf-8');
+    fs.writeFileSync(path.join(dir, 'SUMMARY.md'), '# Summary\n', 'utf-8');
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('next_phase is never 999 and phase_count excludes the sentinel', () => {
+    const result = runGsdTools(['roadmap', 'analyze', '--raw'], tmpDir);
+    assert.ok(result.success, `roadmap analyze failed: ${result.error}`);
+    const analysis = JSON.parse(result.output);
+    assert.notEqual(
+      String(analysis.next_phase),
+      '999',
+      `next_phase must never route to the 999 backlog sentinel. Got ${analysis.next_phase}`,
+    );
+    assert.equal(
+      analysis.phase_count,
+      1,
+      `phase_count must exclude the 999 sentinel (expected 1). Got ${analysis.phase_count}`,
+    );
+    assert.ok(
+      !(analysis.phases || []).some(p => String(p.number) === '999'),
+      'the phases array must not include the 999 backlog sentinel',
     );
   });
 });

--- a/tests/issue-2517-runtime-aware-profiles.test.cjs
+++ b/tests/issue-2517-runtime-aware-profiles.test.cjs
@@ -705,9 +705,9 @@ describe('issue #2612: runtime "opencode" — OpenCode tier resolution', () => {
     assert.strictEqual(resolveModelInternal(tmpDir, 'gsd-planner'), 'anthropic/claude-opus-4-8');
   });
 
-  test('sonnet tier -> anthropic/claude-sonnet-4-6', () => {
+  test('sonnet tier -> anthropic/claude-sonnet-5', () => {
     writeConfig(tmpDir, { runtime: 'opencode', model_profile: 'balanced' });
-    assert.strictEqual(resolveModelInternal(tmpDir, 'gsd-roadmapper'), 'anthropic/claude-sonnet-4-6');
+    assert.strictEqual(resolveModelInternal(tmpDir, 'gsd-roadmapper'), 'anthropic/claude-sonnet-5');
   });
 
   test('haiku tier -> anthropic/claude-haiku-4-5', () => {
@@ -733,9 +733,9 @@ describe('issue #2612: runtime "copilot" — Copilot tier resolution', () => {
     assert.strictEqual(resolveModelInternal(tmpDir, 'gsd-planner'), 'claude-opus-4-8');
   });
 
-  test('sonnet tier -> claude-sonnet-4-6', () => {
+  test('sonnet tier -> claude-sonnet-5', () => {
     writeConfig(tmpDir, { runtime: 'copilot', model_profile: 'balanced' });
-    assert.strictEqual(resolveModelInternal(tmpDir, 'gsd-roadmapper'), 'claude-sonnet-4-6');
+    assert.strictEqual(resolveModelInternal(tmpDir, 'gsd-roadmapper'), 'claude-sonnet-5');
   });
 
   test('haiku tier -> claude-haiku-4-5', () => {
@@ -862,6 +862,6 @@ describe('issue #2612: partial override merge for new Group A runtimes', () => {
     // gsd-codebase-mapper budget -> haiku -> overridden
     assert.strictEqual(resolveModelInternal(tmpDir, 'gsd-codebase-mapper'), 'claude-haiku-4-6');
     // gsd-planner budget -> sonnet -> built-in default
-    assert.strictEqual(resolveModelInternal(tmpDir, 'gsd-planner'), 'claude-sonnet-4-6');
+    assert.strictEqual(resolveModelInternal(tmpDir, 'gsd-planner'), 'claude-sonnet-5');
   });
 });

--- a/tests/model-alias-map.test.cjs
+++ b/tests/model-alias-map.test.cjs
@@ -17,8 +17,8 @@ describe('MODEL_ALIAS_MAP (#1690 regression)', () => {
     assert.equal(MODEL_ALIAS_MAP.opus, 'claude-opus-4-8');
   });
 
-  test('sonnet maps to claude-sonnet-4-6', () => {
-    assert.equal(MODEL_ALIAS_MAP.sonnet, 'claude-sonnet-4-6');
+  test('sonnet maps to claude-sonnet-5', () => {
+    assert.equal(MODEL_ALIAS_MAP.sonnet, 'claude-sonnet-5');
   });
 
   test('haiku maps to claude-haiku-4-5', () => {

--- a/tests/phase.test.cjs
+++ b/tests/phase.test.cjs
@@ -2362,6 +2362,187 @@ describe('phase complete command', () => {
     assert.ok(state.includes('Milestone complete'), 'status should be milestone complete');
   });
 
+  // #1591: when the active milestone's phase checklist is wrapped in a
+  // <details> block AND phases are written as `- [ ] Phase N:` checkbox list
+  // items (not `### Phase N:` headings), phase.complete's next-phase enumerator
+  // saw no further phases → is_last_phase=true, next_phase=null on a mid-
+  // milestone phase, and STATE.md was wrongly marked "Milestone complete" with
+  // total_phases decremented. extractCurrentMilestone correctly surfaces the
+  // <details>-wrapped checklist; the defect was the heading-only phasePattern
+  // at the isLastPhase enumerator not recognizing checkbox-list phase items.
+  test('#1591: <details>-wrapped checkbox checklist — mid-milestone phase is NOT last', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      [
+        '# ROADMAP',
+        '',
+        '## Phases',
+        '',
+        '<details>',
+        '<summary>✅ v1.0 First (Phases 1–3) — SHIPPED</summary>',
+        '',
+        '- [x] Phase 1: a',
+        '- [x] Phase 2: b',
+        '- [x] Phase 3: c',
+        '',
+        '</details>',
+        '',
+        '<details>',
+        '<summary>🚀 v2.0 Second (Phases 36–38) — IN PLANNING</summary>',
+        '',
+        '- [x] Phase 36: first (completed)',
+        '- [ ] Phase 37: second',
+        '- [ ] Phase 38: third',
+        '',
+        '</details>',
+        '',
+        '## Backlog',
+        '',
+        '### Phase 999.1: future (BACKLOG)',
+        '',
+      ].join('\n')
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'STATE.md'),
+      [
+        '---',
+        'gsd_state_version: 1.0',
+        'milestone: v2.0',
+        'milestone_name: Second',
+        'current_phase: "36"',
+        'status: executing',
+        '---',
+        '',
+        '# GSD State',
+        '',
+        '**Current Phase:** 36',
+        '**Status:** Executing Phase 36',
+        '',
+      ].join('\n')
+    );
+    // Only the COMPLETING phase (36) has a directory. Phases 37/38 exist only
+    // as `- [ ]` checklist items in the ROADMAP — they are not yet started, so
+    // they have no phase dirs. This is the @Azd325 scenario: the disk-based
+    // next-phase resolver finds nothing, and the roadmap-enumeration fallback
+    // (the heading-only phasePattern) is the only path that can find Phase 37.
+    const d36 = path.join(tmpDir, '.planning', 'phases', '36-first');
+    fs.mkdirSync(d36, { recursive: true });
+    fs.writeFileSync(path.join(d36, '36-PLAN.md'), '# Plan\n');
+    fs.writeFileSync(path.join(d36, '36-SUMMARY.md'), '# Summary\n');
+
+    const result = runVerifiedPhaseComplete('phase complete 36', tmpDir);
+    assert.ok(result.success, `phase complete failed: ${result.error}`);
+    const output = JSON.parse(result.output);
+
+    assert.strictEqual(
+      output.is_last_phase,
+      false,
+      'Phase 36 of 36–38 must NOT be last — Phases 37/38 are still open `- [ ]` (#1591)',
+    );
+    assert.strictEqual(
+      output.next_phase,
+      '37',
+      'next_phase must resolve to 37 from the <details>-wrapped checkbox checklist (#1591)',
+    );
+
+    // Cascade check: a wrong is_last_phase=true previously wrote "Milestone
+    // complete" + decremented total_phases. With the fix, the milestone is
+    // still in progress.
+    const state = fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
+    assert.ok(
+      !/Milestone complete/i.test(state),
+      'a mid-milestone phase must not flip STATE.md to "Milestone complete" (#1591)',
+    );
+  });
+
+  // #1752: the #1591 follow-up — when phase.complete wrongly returned
+  // is_last_phase=true on a <details>-wrapped mid-milestone checklist, the
+  // milestone-complete cascade also DECREMENTED progress.total_phases (e.g.
+  // 8 -> 7) and flipped status. Same root cause, distinct symptom. With the
+  // #1591 fix (is_last_phase=false), the decrement must not occur: with all 8
+  // phase dirs on disk, total_phases stays 8 and status does not flip.
+  test('#1752: <details>-wrapped checklist — total_phases is NOT decremented on a mid-milestone phase', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      [
+        '# ROADMAP',
+        '',
+        '## Phases',
+        '',
+        '<details>',
+        '<summary>✅ v1.0 First (Phases 1–3) — SHIPPED</summary>',
+        '',
+        '- [x] Phase 1: a',
+        '- [x] Phase 2: b',
+        '- [x] Phase 3: c',
+        '',
+        '</details>',
+        '',
+        '<details>',
+        '<summary>🚀 v2.0 Second (Phases 36–43) — IN PLANNING</summary>',
+        '',
+        '- [x] Phase 36: first (completed)',
+        '- [ ] Phase 37: second',
+        '- [ ] Phase 38: third',
+        '- [ ] Phase 39: fourth',
+        '',
+        '</details>',
+        '',
+      ].join('\n')
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'STATE.md'),
+      [
+        '---',
+        'gsd_state_version: 1.0',
+        'milestone: v2.0',
+        'milestone_name: Second',
+        'current_phase: "36"',
+        'status: executing',
+        'progress:',
+        '  total_phases: 8',
+        '  completed_phases: 5',
+        '  percent: 62',
+        '---',
+        '',
+        '# GSD State',
+        '',
+        '**Current Phase:** 36',
+        '**Status:** Executing Phase 36',
+        '',
+      ].join('\n')
+    );
+    // All 8 phase dirs on disk (Phases 36–43) so the disk count is 8 — the
+    // reporter's real state. Before the #1591 fix, phase.complete 36 returned
+    // is_last_phase=true (no Phase 37+ heading match) and the milestone-complete
+    // path DECREMENTED total_phases 8 -> 7.
+    const names = ['first', 'second', 'third', 'fourth', 'fifth', 'sixth', 'seventh', 'eighth'];
+    for (let i = 0; i < 8; i++) {
+      const num = String(36 + i);
+      const d = path.join(tmpDir, '.planning', 'phases', `${num}-${names[i]}`);
+      fs.mkdirSync(d, { recursive: true });
+      fs.writeFileSync(path.join(d, `${num}-PLAN.md`), '# Plan\n');
+    }
+
+    const result = runVerifiedPhaseComplete('phase complete 36', tmpDir);
+    assert.ok(result.success, `phase complete failed: ${result.error}`);
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.is_last_phase, false, 'is_last_phase must be false (#1752 cascade root)');
+
+    const state = fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
+    assert.ok(
+      !/Milestone complete/i.test(state),
+      'a mid-milestone phase must not flip STATE.md to "Milestone complete" (#1752)',
+    );
+    const tpMatch = state.match(/total_phases:\s*(\d+)/);
+    assert.ok(tpMatch, 'STATE.md must carry a total_phases value after phase.complete');
+    assert.notStrictEqual(
+      parseInt(tpMatch[1], 10),
+      7,
+      'total_phases must NOT be decremented to 7 — the #1752 cascade of the false is_last_phase',
+    );
+  });
+
   test('updates REQUIREMENTS.md traceability when phase completes', () => {
     fs.writeFileSync(
       path.join(tmpDir, '.planning', 'ROADMAP.md'),

--- a/tests/phase.test.cjs
+++ b/tests/phase.test.cjs
@@ -2455,6 +2455,76 @@ describe('phase complete command', () => {
     );
   });
 
+  // #1591 (bold-checklist follow-up): the roadmap TEMPLATE emits checklist rows
+  // in the canonical BOLD form `- [ ] **Phase N: Name**`. The initial checkbox
+  // broadening only matched the un-bolded `- [ ] Phase N:` shape, so the exact
+  // <details>-wrapped bold template still fell through to is_last_phase=true.
+  // Guard the canonical bold form explicitly.
+  test('#1591: <details>-wrapped BOLD checkbox checklist — mid-milestone phase is NOT last', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      [
+        '# ROADMAP',
+        '',
+        '## Phases',
+        '',
+        '<details>',
+        '<summary>🚀 v2.0 Second (Phases 36–38) — IN PLANNING</summary>',
+        '',
+        '- [x] **Phase 36: first (completed)** - done',
+        '- [ ] **Phase 37: second** - one-line description',
+        '- [ ] **Phase 38: third** - one-line description',
+        '',
+        '</details>',
+        '',
+      ].join('\n')
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'STATE.md'),
+      [
+        '---',
+        'gsd_state_version: 1.0',
+        'milestone: v2.0',
+        'milestone_name: Second',
+        'current_phase: "36"',
+        'status: executing',
+        '---',
+        '',
+        '# GSD State',
+        '',
+        '**Current Phase:** 36',
+        '**Status:** Executing Phase 36',
+        '',
+      ].join('\n')
+    );
+    // Only Phase 36 has a directory; 37/38 are bold `- [ ]` checklist rows only.
+    const d36 = path.join(tmpDir, '.planning', 'phases', '36-first');
+    fs.mkdirSync(d36, { recursive: true });
+    fs.writeFileSync(path.join(d36, '36-PLAN.md'), '# Plan\n');
+    fs.writeFileSync(path.join(d36, '36-SUMMARY.md'), '# Summary\n');
+
+    const result = runVerifiedPhaseComplete('phase complete 36', tmpDir);
+    assert.ok(result.success, `phase complete failed: ${result.error}`);
+    const output = JSON.parse(result.output);
+
+    assert.strictEqual(
+      output.is_last_phase,
+      false,
+      'Phase 36 of 36–38 must NOT be last with the canonical BOLD checklist (#1591)',
+    );
+    assert.strictEqual(
+      output.next_phase,
+      '37',
+      'next_phase must resolve to 37 from the BOLD `- [ ] **Phase N: ...**` checklist (#1591)',
+    );
+
+    const state = fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
+    assert.ok(
+      !/Milestone complete/i.test(state),
+      'a mid-milestone phase must not flip STATE.md to "Milestone complete" — bold checklist (#1591)',
+    );
+  });
+
   // #1752: the #1591 follow-up — when phase.complete wrongly returned
   // is_last_phase=true on a <details>-wrapped mid-milestone checklist, the
   // milestone-complete cascade also DECREMENTED progress.total_phases (e.g.

--- a/tests/workflow-size-baseline.json
+++ b/tests/workflow-size-baseline.json
@@ -67,7 +67,7 @@
   "scan.md": 7688,
   "secure-phase.md": 13476,
   "session-report.md": 4044,
-  "settings-advanced.md": 39666,
+  "settings-advanced.md": 39646,
   "settings-integrations.md": 15848,
   "settings.md": 33413,
   "ship.md": 24647,


### PR DESCRIPTION
## Fix PR

**1.6.1 hotfix** — cut from the `v1.6.0` tag onto `hotfix/1.6.1`. Bundles the Claude Sonnet 5 catalog update with the curated set of already-merged `fix:` commits from `next` that apply cleanly and coherently on the 1.6.0 base. Scope was curated deliberately: `refactor:`/`feat:` work and fixes depending on 1.7.0-line features (state-rebuild #1829/#1830, portability epic #1702) were intentionally excluded — see "Curation" below.

## Linked Issue

Fixes #1847

Also delivers (already-resolved on `next`, cherry-picked `-x` for the patch): #1580, #1693, #1591.

## What was broken

- **#1847** — the `sonnet`/`standard` tier resolved to the superseded `claude-sonnet-4-6`; Claude Sonnet 5 (`claude-sonnet-5`, GA 2026-06-30) shipped but the catalog still pointed at the prior generation.
- **#1580** — the milestone-complete guard and roadmap analyze counted the `0`/`999` sentinel phases.
- **#1693** — `$CLAUDE_PROJECT_DIR`-anchored hook paths were double-quoted, breaking on Windows.
- **#1591** — `phase.complete` didn't recognize checkbox-list phases in the `isLastPhase` fallback.

## What this fix does

- Points the sonnet/standard tier (and the `anthropic`/`anthropic-fable` provider presets) at `claude-sonnet-5` across the Anthropic-backed runtimes; opus/haiku untouched. Mirrors the parity-gated docs (`CONFIGURATION.md`, `settings-advanced.md`, pt-BR/zh-CN) and regenerates the workflow size baseline.
- Cherry-picks the three independent bug fixes above, each with its own changeset fragment.
- **Follow-up to #1591 (from adversarial review):** the cherry-picked #1591 fix matched `- [ ] Phase N:` but not the canonical **bold** checklist the roadmap template emits (`- [ ] **Phase N: Name**`), so the exact `<details>`-wrapped bold repro still fell through to `is_last_phase=true`. Broadened the marker to allow optional `**`/`__` emphasis and added a bold-checklist regression test.

## Root cause

Per-item; documented in each linked issue. The Sonnet item is a catalog-currency refresh (the pinned ID lagged a GA model release), verified against the official Anthropic models reference.

## Curation

The "normal 1.6.1" candidate set was the 21 `fix:`/`chore:` commits on `next` since `v1.6.0`. Excluded, with reason:
- **Version bookkeeping** — `chore: sync next package version to 1.6.0` / `to 1.7.0-rc.1` (not a 1.6.1 concern).
- **Depends on 1.7.0-line work absent at 1.6.0** — #1749 (portability epic #1702; touches files that don't exist at v1.6.0), #1776 / #1761 / #1831-eslint (state-rebuild `state-transition.cts`).
- **Blocked by reworked golden-install-parity fixtures / generated snapshots** — #1747, #1778, #1772, #1528, #1698, #1837, #1840 (fixture system was reworked on the 1.7.0 line; would require regeneration and are not clean patches on 1.6.0).
- **CI-workflow-only chores** — auto-backmerge / rc-timeout tweaks (not part of the shipped package).

Only fixes that apply cleanly AND stand coherently on the 1.6.0 base were included (e.g. `chore(#1698): add changeset` was dropped because its code fix is excluded — no orphan changelog entry).

## Testing

### How I verified the fix

- Full local unit suite green on the combined set (`npm run test:unit` → exit 0), including the `#3229` catalog↔docs parity gate, `model-alias-map`, `feat-49` presets, `issue-2517` runtime profiles, and the workflow size-baseline gate.
- `lint:docs` and `lint:changeset` pass.
- Sonnet IDs verified against the official Anthropic models reference (`claude-sonnet-5`, dateless pinned snapshot).

### Regression test added?

- [x] Yes — the Sonnet change is covered by the existing `#3229` parity gate + updated `model-alias-map`/`feat-49`/`issue-2517` assertions; each cherry-picked fix carried its own regression test.

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [x] N/A (not platform-specific) — except #1693 which is Windows path handling (covered by its test)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [x] N/A (catalog change spans all Anthropic-backed runtimes)

---

## Checklist

- [x] Curated set applies cleanly on the `v1.6.0` base
- [x] Full unit suite green locally
- [x] Changeset fragments present (3 cherry-picked + Sonnet added in this PR)
- [x] Targets `hotfix/1.6.1` (not `next`)

## Pre-PR gates (all green on final head)

- `eslint` + `lint:ci` — clean
- `npm run test:unit` — exit 0
- docker `gsd-test` (`-base hotfix/1.6.1 -head fix/1847-sonnet-5`) — linux 21061/21061, exit 0
- security review — no findings
- code review — approve
- adversarial (codex) review — surfaced the #1591 bold-checklist gap, now fixed + regression-tested

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1848"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785460616&installation_id=134682257&pr_number=1848&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1848&signature=a5c6ddb91231938e380f7a76f3be5a285dfea24da571b3976c90a35d1901dd04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->