### PR TITLE
feat(#1855): add .claude-plugin/marketplace.json + wire into version sync

### DIFF
--- a/.changeset/claude-plugin-marketplace.md
+++ b/.changeset/claude-plugin-marketplace.md
@@ -1,5 +1,5 @@
 ---
 type: Added
-pr: 0
+pr: 1860
 ---
 **Claude plugin marketplace support** — added .claude-plugin/marketplace.json so third-party Claude-plugin-compatible runtimes (ZCODE, etc.) can discover and install GSD Core from a custom marketplace source. (#1855)

--- a/.changeset/lively-cats-zip.md
+++ b/.changeset/lively-cats-zip.md
@@ -1,0 +1,5 @@
+---
+type: Added
+pr: 0
+---
+**Claude plugin marketplace support** — added .claude-plugin/marketplace.json so third-party Claude-plugin-compatible runtimes (ZCODE, etc.) can discover and install GSD Core from a custom marketplace source. (#1855)

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "gsd-core-dev",
+  "description": "Development marketplace for GSD Core — meta-prompting, context engineering, and spec-driven development system for AI coding agents",
+  "owner": {
+    "name": "open-gsd",
+    "url": "https://github.com/open-gsd"
+  },
+  "plugins": [
+    {
+      "name": "gsd-core",
+      "description": "GSD Core: meta-prompting, context engineering, and spec-driven development system for AI coding agents",
+      "version": "1.7.0-rc.1",
+      "source": "./",
+      "author": {
+        "name": "open-gsd",
+        "url": "https://github.com/open-gsd"
+      }
+    }
+  ]
+}

--- a/docs/how-to/install-on-your-runtime.md
+++ b/docs/how-to/install-on-your-runtime.md
@@ -102,6 +102,10 @@ The `gsd-tools` binary (installed as part of the `@opengsd/gsd-core` npm package
 
 Node.js (`node`) must also be available on your `PATH`. The plugin's always-on guard hooks (wired in `hooks/hooks.json`) are invoked as `node "${CLAUDE_PLUGIN_ROOT}/hooks/<script>"`. Some Claude Code distributions ship as a standalone binary and do not expose a `node` executable on `PATH`; in those environments the plugin's hooks will not run. Verify with `node --version` before relying on the plugin hooks.
 
+**Third-party marketplace discovery**
+
+The repo also ships a `.claude-plugin/marketplace.json` manifest, enabling third-party Claude-plugin-compatible runtimes (ZCODE, etc.) to discover and install GSD Core from a custom marketplace source. In ZCODE, for example, add `open-gsd/gsd-core` under Settings → Plugins → Marketplace → **+**, then install GSD Core from the catalog. The `version` field in `marketplace.json` is kept in sync with `package.json` by the same release-time stamping step that updates `plugin.json`.
+
 ---
 
 ### Gemini CLI

--- a/scripts/sync-manifest-versions.cjs
+++ b/scripts/sync-manifest-versions.cjs
@@ -21,11 +21,12 @@ const { execFileSync } = require('child_process');
 
 const ROOT = path.resolve(__dirname, '..');
 
-// Single source of truth: runtime-integration manifests whose top-level `version`
+// Single source of truth: runtime-integration manifests whose `version`
 // MUST track package.json. Add a new manifest here so `npm version` keeps it in
 // sync — the regression guard test (issue 844) fails if you forget.
 const VERSIONED_MANIFESTS = [
   '.claude-plugin/plugin.json',
+  '.claude-plugin/marketplace.json',
   'gemini-extension.json',
 ];
 
@@ -38,6 +39,28 @@ function getPackageVersion(root) {
   return readJson(path.join(r, 'package.json')).version;
 }
 
+// Read the version field from a manifest, handling both flat (top-level
+// `version`) and marketplace (`plugins[0].version`) layouts.
+function readManifestVersion(manifest) {
+  if (Array.isArray(manifest.plugins) && manifest.plugins[0]) {
+    return manifest.plugins[0].version;
+  }
+  return manifest.version;
+}
+
+// Write the version field into a manifest, handling both flat and marketplace
+// layouts. Returns true if the value changed.
+function writeManifestVersion(manifest, v) {
+  if (Array.isArray(manifest.plugins) && manifest.plugins[0]) {
+    if (manifest.plugins[0].version === v) return false;
+    manifest.plugins[0].version = v;
+    return true;
+  }
+  if (manifest.version === v) return false;
+  manifest.version = v;
+  return true;
+}
+
 // Stamp `version` into each registered manifest, preserving field order and
 // 2-space + trailing-newline formatting. Returns the list of changed rel paths.
 function syncManifestVersions(opts) {
@@ -47,8 +70,7 @@ function syncManifestVersions(opts) {
   for (const rel of VERSIONED_MANIFESTS) {
     const abs = path.join(root, rel);
     const manifest = readJson(abs);
-    if (manifest.version !== v) {
-      manifest.version = v;
+    if (writeManifestVersion(manifest, v)) {
       fs.writeFileSync(abs, JSON.stringify(manifest, null, 2) + '\n');
       changed.push(rel);
     }
@@ -62,7 +84,7 @@ function findDrift(opts) {
   const v = (opts && opts.version) != null ? opts.version : getPackageVersion(root);
   const drift = [];
   for (const rel of VERSIONED_MANIFESTS) {
-    const found = readJson(path.join(root, rel)).version;
+    const found = readManifestVersion(readJson(path.join(root, rel)));
     if (found !== v) drift.push({ manifest: rel, found, expected: v });
   }
   return drift;
@@ -158,6 +180,8 @@ module.exports = {
   findDrift,
   getPackageVersion,
   stageManifests,
+  readManifestVersion,
+  writeManifestVersion,
   // ADR-1244 D6: native capability version sweep
   listCapabilityManifests,
   syncCapabilityVersions,

--- a/tests/issue-844-manifest-version-sync.test.cjs
+++ b/tests/issue-844-manifest-version-sync.test.cjs
@@ -29,6 +29,8 @@ const {
   stageManifests,
   listCapabilityManifests,
   syncCapabilityVersions,
+  readManifestVersion,
+  writeManifestVersion,
 } = require(path.join(ROOT, 'scripts', 'sync-manifest-versions.cjs'));
 
 // ─── A: RED→GREEN repro via temp fixture ─────────────────────────────────────
@@ -54,7 +56,7 @@ describe('A: syncManifestVersions — temp fixture', () => {
     for (const rel of VERSIONED_MANIFESTS) {
       const realAbs = path.join(ROOT, rel);
       const manifest = JSON.parse(fs.readFileSync(realAbs, 'utf8'));
-      manifest.version = '0.0.0';
+      writeManifestVersion(manifest, '0.0.0');
 
       const destAbs = path.join(tmpRoot, rel);
       const destDir = path.dirname(destAbs);
@@ -93,7 +95,7 @@ describe('A: syncManifestVersions — temp fixture', () => {
       const abs = path.join(tmpRoot, rel);
       const m = JSON.parse(fs.readFileSync(abs, 'utf8'));
       assert.equal(
-        m.version,
+        readManifestVersion(m),
         '9.9.9-test.0',
         `${rel} version should be 9.9.9-test.0 after sync`
       );
@@ -111,7 +113,7 @@ describe('A: syncManifestVersions — temp fixture', () => {
       );
       for (const rel of VERSIONED_MANIFESTS) {
         const manifest = JSON.parse(fs.readFileSync(path.join(ROOT, rel), 'utf8'));
-        manifest.version = '0.0.0';
+        writeManifestVersion(manifest, '0.0.0');
         const destAbs = path.join(sub, rel);
         const destDir = path.dirname(destAbs);
         if (!fs.existsSync(destDir)) fs.mkdirSync(destDir, { recursive: true });
@@ -165,9 +167,9 @@ describe('B: real manifests match package.json version', () => {
       assert.ok(fs.existsSync(abs), `${rel} must exist at ${abs}`);
       const m = JSON.parse(fs.readFileSync(abs, 'utf8'));
       assert.equal(
-        m.version,
+        readManifestVersion(m),
         pkgVersion,
-        `${rel} version (${m.version}) must match package.json version (${pkgVersion}). ` +
+        `${rel} version (${readManifestVersion(m)}) must match package.json version (${pkgVersion}). ` +
         'Run `node scripts/sync-manifest-versions.cjs` to fix.'
       );
     });


### PR DESCRIPTION
## Feature PR

---

## Linked Issue

Closes #1855

---

## Feature summary

Adds `.claude-plugin/marketplace.json` — the Claude plugin marketplace manifest — so third-party Claude-plugin-compatible runtimes (ZCODE, etc.) can discover and install GSD Core from a custom marketplace source. The manifest's `plugins[0].version` is wired into the existing `sync-manifest-versions.cjs` release-time stamping step, keeping it in lockstep with `package.json` alongside `plugin.json` and `gemini-extension.json`.

## What changed

### New files

| File | Purpose |
|------|---------|
| `.claude-plugin/marketplace.json` | Claude plugin marketplace manifest (`name`, `description`, `owner`, `plugins[]` with `name`/`description`/`version`/`source`/`author`). Schema mirrors the superpowers reference. |
| `.changeset/lively-cats-zip.md` | `Added` changeset fragment |

### Modified files

| File | What changed |
|------|-------------|
| `scripts/sync-manifest-versions.cjs` | Registered `marketplace.json` in `VERSIONED_MANIFESTS`; added `readManifestVersion`/`writeManifestVersion` helpers to handle the nested `plugins[0].version` path (marketplace schema stores version per-plugin, not at top level) |
| `tests/issue-844-manifest-version-sync.test.cjs` | Updated fixture setup and assertions to use the version helpers so nested-path manifests are correctly seeded and verified |
| `docs/how-to/install-on-your-runtime.md` | Added "Third-party marketplace discovery" paragraph under the Claude Code section documenting ZCODE et al. support |

## Implementation notes

The marketplace.json schema stores `version` at `plugins[0].version` (per-plugin versioning, matching the superpowers reference), not at the top level like `plugin.json` or `gemini-extension.json`. The existing `syncManifestVersions` function read/wrote `manifest.version` directly, which would not touch the nested path. Rather than deviate from the reference schema by adding a redundant top-level `version`, I extracted `readManifestVersion`/`writeManifestVersion` helpers that auto-detect the layout (flat top-level vs. `plugins[0].version`) and dispatch accordingly. This keeps the schema correct while reusing the single sync entry point.

## Spec compliance

- [x] `.claude-plugin/marketplace.json` exists with valid schema (`name`, `description`, `owner`, `plugins[]` each with `name`/`description`/`version`/`source`/`author`)
- [x] `version` equals the current `package.json` version and is covered by the same release-sync that updates `plugin.json`'s version (registered in `VERSIONED_MANIFESTS`)
- [x] A validation check catches drift (`node scripts/sync-manifest-versions.cjs --check` exits 1 on drift; issue-844 test suite enforces it in CI)
- [x] `.claude-plugin/plugin.json` and Claude Code plugin discovery are unchanged (diff is additive — one new file + sync wiring)
- [x] `owner`/`author` use `open-gsd` / `https://github.com/open-gsd`, consistent with `plugin.json`

## Testing

### Test coverage

`tests/issue-844-manifest-version-sync.test.cjs` — all 49 tests pass:
- Describe A (temp fixture): fixture setup uses `writeManifestVersion` to seed stale versions; assertions use `readManifestVersion` to verify stamping, idempotency, field preservation, trailing newline
- Describe B (real manifests): `marketplace.json` version verified against `package.json`
- Describe C (regression guard): all version-bearing JSON files are registered or allowed
- Describe D: `--check` CLI exits 0

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux (CI)

### Runtimes tested

- [x] N/A — this is a static manifest file + sync-script change, not runtime-specific behavior

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue exactly
- [x] No additional features, commands, or behaviors were added beyond what was approved
- [x] If scope changed during implementation, I updated the issue spec and received re-approval

---

## Documentation

- [x] Updated `docs/how-to/install-on-your-runtime.md` — added "Third-party marketplace discovery" paragraph
- [x] All `docs/` content added in this PR is written in English

## Checklist

- [x] Issue linked above with `Closes #1855`
- [x] Linked issue has the `approved-feature` label
- [x] All acceptance criteria from the issue are met (listed above)
- [x] Implementation scope matches the approved spec exactly
- [x] All existing tests pass (`node --test tests/issue-844-manifest-version-sync.test.cjs` — 49/49)
- [x] New tests cover the nested version path (helpers tested via existing issue-844 fixture suite)
- [x] `.changeset/` fragment added (`Added` type)
- [x] No unnecessary external dependencies added
- [x] Works on Windows (no platform-specific code; forward-slash paths used in sync script per existing convention)

## Breaking changes

None — this adds a new file and extends the sync script. Existing `plugin.json` and Claude Code discovery are unchanged.

## Screenshots / recordings

N/A — no visual output.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1860"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785509009&installation_id=134682257&pr_number=1860&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1860&signature=fbecebfc50db9b0357a7257bd38efc2273ff36a37daf9b354aedd59eb0d8b100"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->