### PR TITLE
fix(#1905): normalize hand-authored backstop marker so it can't degrade to green

### DIFF
--- a/.changeset/tidy-pumas-munch.md
+++ b/.changeset/tidy-pumas-munch.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 1909
+---
+Fixed: a hand-authored non-inferable backstop truth with a stray trailing space or surrounding quotes no longer silently grades green — it correctly abstains (insufficient_spec), restoring the #1154 honest-verifier guarantee.

--- a/src/frontmatter.cts
+++ b/src/frontmatter.cts
@@ -441,7 +441,11 @@ function parseMustHavesBlock(content: string, blockName: string): unknown[] {
       } else {
         const kvMatch = trimmed.match(/^(\w+):\s*"?([^"]*)"?\s*$/);
         if (kvMatch) {
-          const val = kvMatch[2];
+          // Trim: a quoted value like `"backstop "` captures the inner trailing space in group 2.
+          // Left untrimmed, a hand-authored `must_haves` marker degrades (a `backstop` truth silently
+          // grades green instead of abstaining — #1905, the #1154 false-pass; also the sibling
+          // check_target/violationFixture path). Whitespace is never semantic in a scalar KV value.
+          const val = kvMatch[2].trim();
           // Try to parse as number
           (current)[kvMatch[1]] = /^\d+$/.test(val) ? parseInt(val, 10) : val;
         }

--- a/src/probe-core.cts
+++ b/src/probe-core.cts
@@ -527,12 +527,21 @@ export function truthStatement(truth: unknown): string {
 /**
  * Extract a truth's verification tier, or `null` when it carries none (a plain string, or an object
  * with no/garbled marker). Failing toward `null` is the Postel-safe direction: an unrecognized marker
- * grades NORMALLY (never a spurious abstention — the over-abstention guard, AC#3), and the marker is
- * machine-emitted from validated edge data so garbling is not a live input path.
+ * grades NORMALLY (never a spurious abstention — the over-abstention guard, AC#3).
+ *
+ * The marker is NOT only machine-emitted: `must_haves` markers can be authored BY HAND (#1820's
+ * spec-optional predicate rail), and the frontmatter continuation-KV parser preserves stray
+ * surrounding whitespace/quotes on a hand-authored value. So we normalize before comparison
+ * (Postel: be liberal in what you accept) — `'backstop '`, `' backstop'`, `'"backstop"'` all
+ * recognize as the tier. Without this, a hand-authored non-inferable `backstop` truth with a stray
+ * trailing space silently grades green instead of abstaining — the exact #1154 false-pass (#1905).
+ * An unrecoverably-corrupted marker (e.g. an embedded quote) stays unrecognized → null → graded
+ * normally (AC#3): we cannot know its intent, and abstaining on it would be a spurious abstention.
  */
 export function truthVerification(truth: unknown): TruthVerification | null {
   if (truth == null || typeof truth !== 'object') return null;
-  const v = (truth as { verification?: unknown }).verification;
+  const raw = (truth as { verification?: unknown }).verification;
+  const v = typeof raw === 'string' ? raw.trim().replace(/^["']|["']$/g, '').trim() : raw;
   return v === 'explicit' || v === 'backstop' ? v : null;
 }
 

--- a/tests/frontmatter.test.cjs
+++ b/tests/frontmatter.test.cjs
@@ -366,6 +366,22 @@ Body content.`;
     assert.strictEqual(result[1], 'Coverage exceeds 80%');
   });
 
+  test('trims a continuation-KV value so a quoted trailing space does not survive (#1905, root cause of the #1154 false-pass)', () => {
+    // A quoted value like `"backstop "` captures the inner trailing space in group 2; left untrimmed,
+    // a hand-authored non-inferable `backstop` marker (#1820 spec-optional rail) degrades to `'backstop '`,
+    // which `truthVerification` no longer recognizes → the truth silently grades green instead of abstaining.
+    // Whitespace is never semantic in a scalar KV value, so the parser must trim it.
+    const content = `---
+must_haves:
+  truths:
+    - statement: user data is never logged
+      verification: "backstop "
+---
+Body.`;
+    const result = parseMustHavesBlock(content, 'truths');
+    assert.strictEqual(result[0].verification, 'backstop', 'the captured value is trimmed, not left as "backstop "');
+  });
+
   test('extracts artifacts as object array', () => {
     const content = `---
 phase: 01

--- a/tests/probe-core.test.cjs
+++ b/tests/probe-core.test.cjs
@@ -554,6 +554,19 @@ describe('probe-core: truthStatement / truthVerification normalizers (#1154, Hyr
     assert.equal(pc.truthVerification('Overlapping intervals are merged'), null);
     assert.equal(pc.truthVerification({ statement: 'x', verification: 'explicit' }), 'explicit');
   });
+
+  test('normalizes a hand-authored marker with stray whitespace/surrounding quotes (#1905, the #1154 false-pass)', () => {
+    // A `must_haves` marker can be authored BY HAND (#1820 spec-optional predicate rail), and the
+    // frontmatter continuation-KV parser preserves stray surrounding whitespace/quotes. Failing to
+    // normalize means `'backstop '` → null → the non-inferable truth silently grades green (Postel:
+    // be liberal in what you accept).
+    assert.equal(pc.truthVerification({ statement: 'x', verification: 'backstop ' }), 'backstop', 'trailing space');
+    assert.equal(pc.truthVerification({ statement: 'x', verification: ' backstop' }), 'backstop', 'leading space');
+    assert.equal(pc.truthVerification({ statement: 'x', verification: '"backstop"' }), 'backstop', 'surrounding quotes');
+    assert.equal(pc.truthVerification({ statement: 'x', verification: 'explicit ' }), 'explicit', 'trailing space, explicit tier');
+    // An unrecoverably-corrupted marker stays unrecognized → null → graded normally (AC#3 over-abstention guard).
+    assert.equal(pc.truthVerification({ statement: 'x', verification: 'back"stop' }), null, 'an embedded quote is unrecoverable — no spurious tier');
+  });
 });
 
 describe('probe-core: dispositionForUnverifiableTruth (#1154, ADR-550 D4 truth-axis mirror)', () => {
@@ -586,6 +599,35 @@ describe('probe-core: dispositionForUnverifiableTruth (#1154, ADR-550 D4 truth-a
     const d = pc.dispositionForUnverifiableTruth('Overlapping intervals are merged', { evidence: [] });
     assert.equal(d.status, 'green', 'a plain inferable truth is graded normally, never abstained');
     assert.equal(d.flagged, false);
+  });
+
+  test('a whitespace-mangled backstop truth still ABSTAINS, never silently greens (#1905 — the #1154 false-pass)', () => {
+    const d = pc.dispositionForUnverifiableTruth(
+      { statement: 'user data is never logged', verification: 'backstop ' }, // stray trailing space
+      { evidence: [] },
+    );
+    assert.equal(d.status, 'unverified', 'a mangled backstop marker must not degrade to a silent green');
+    assert.equal(d.flagged, true);
+    assert.equal(d.tier, 'backstop');
+    assert.equal(d.reason, 'insufficient_spec');
+  });
+
+  test('END-TO-END (#1905, #1820 hand-authoring path): a HAND-AUTHORED must_haves.truths trailing-space backstop marker parses to the tier and abstains, never greens', () => {
+    // A human authors the marker directly (the #1820 spec-optional predicate rail), NOT projectTruths.
+    // The frontmatter continuation-KV parser used to preserve the stray trailing space inside the quotes,
+    // so truthVerification saw 'backstop ' → null → the non-inferable truth graded green. It must parse
+    // clean and abstain — the exact honesty regression #1154 exists to eliminate (ADR-550 D4 truth axis).
+    const doc = [
+      '---', 'must_haves:', '  truths:',
+      '    - statement: user data is never logged',
+      '      verification: "backstop "',
+      '---', 'body',
+    ].join('\n');
+    const parsed = fm.parseMustHavesBlock(doc, 'truths');
+    assert.equal(pc.truthVerification(parsed[0]), 'backstop', 'the mangled marker normalizes to the tier');
+    const d = pc.dispositionForUnverifiableTruth(parsed[0], { evidence: [] });
+    assert.equal(d.status, 'unverified', 'never a silent green (ADR-550 D4 truth-axis, #1154)');
+    assert.equal(d.reason, 'insufficient_spec');
   });
 
   test('over-abstention guard (AC#3): an explicit-tier truth NEVER abstains even with no evidence (only backstop triggers it)', () => {


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #1905

## What was broken

A hand-authored non-inferable `backstop` truth with a stray trailing space (or surrounding quotes) in its `verification` marker silently graded `{status: green, flagged: false}` instead of abstaining to `insufficient_spec` — the exact #1154 false-pass, now on the truth axis (ADR-550 D4). A human can author these markers directly via the #1820 spec-optional predicate rail, so this is a live honesty regression, not a theoretical one.

## What this fix does

Normalizes the marker before comparison and at the parser, so a mangled-but-recoverable `backstop` marker is recognized as the tier and still abstains:

- `src/probe-core.cts` — `truthVerification` trims and strips surrounding quotes on a string marker before comparison (Postel: be liberal in what you accept). `'backstop '`, `' backstop'`, `'"backstop"'` now recognize as `backstop`.
- `src/frontmatter.cts` — the `parseMustHavesBlock` continuation-KV parser trims the captured value (the durable root cause — a quoted `"backstop "` captured the inner trailing space). This also cleans up the sibling `check_target`/`violationFixture` trailing-space path.

An unrecoverably-corrupted marker (e.g. an embedded quote `back"stop`) stays unrecognized → `null` → graded normally, preserving the AC#3 over-abstention guard (we cannot know its intent; abstaining would be a spurious abstention).

## Root cause

`truthVerification` returned `null` for any value other than exactly `'explicit'`/`'backstop'`, and `dispositionForUnverifiableTruth` treats a `null` tier as non-backstop → always green. The function's docstring assumed the marker was "machine-emitted from validated edge data so garbling is not a live input path" — but #1820's spec-optional rail made hand-authoring a real path, and the frontmatter continuation-KV regex `/^(\w+):\s*"?([^"]*)"?\s*$/` captures whitespace that sits *inside* the quotes without trimming it.

## Testing

### How I verified the fix

- Reproduced live on `next @ 3c13903d`: `dispositionForUnverifiableTruth({verification:'backstop '}, {})` returned `{status:'green', flagged:false, tier:null}` before the fix; returns `{status:'unverified', reason:'insufficient_spec'}` after.
- Added 5 regression tests (RED before the fix, GREEN after): `truthVerification` normalizer matrix, the disposition abstention on a mangled marker, an end-to-end hand-authored `must_haves.truths` block, and the parser-trim unit test.
- Ran the full `parseMustHavesBlock` blast radius (11 suites, 477 tests) — 0 failures — since the parser trim affects every continuation-KV consumer (Hyrum's-Law check).
- `npm run lint:ci` exits 0.

### Regression test added?

- [x] Yes — added a test that would have caught this bug

### Platforms tested

- [x] Linux
- [ ] macOS
- [ ] Windows (including backslash path handling)
- [x] N/A (not platform-specific — pure string/parse logic, no path handling)

### Runtimes tested

- [x] N/A (not runtime-specific — engine-internal)

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix
- [x] No unnecessary dependencies added

## Breaking changes

Yes — disclosed per the artificer Hyrum's-Law pass:

- A `backstop` truth whose marker had a stray trailing/leading space or surrounding quotes previously (wrongly) graded **green**; it now **abstains** (`unverified`/`insufficient_spec`). This is the intended correctness fix — it restores the #1154 never-silent-pass guarantee.
- The `parseMustHavesBlock` continuation-KV parser now trims all scalar KV values. Whitespace is never semantic in these values; verified against all 477 tests in the parser's blast radius with no regressions. A numeric value with surrounding whitespace (e.g. `min_lines: "50 "`) now parses to the number `50` rather than the string `"50 "` — the intuitive/correct result.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1909"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785569158&installation_id=134682257&pr_number=1909&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1909&signature=8981d975c8bc0bbd565dc21e1207022635d6e7ee530937dc449ea388a9a337ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->