### PR TITLE
fix(#1907): validate per-item shape in isValidReport so adapter garbage fails closed

### DIFF
--- a/.changeset/clever-rams-march.md
+++ b/.changeset/clever-rams-march.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 1910
+---
+Fixed: probe-core's runProbeCli now fails closed on per-item adapter garbage inside a well-shaped report envelope, matching its documented 'fails closed on adapter garbage' contract.

--- a/src/probe-core.cts
+++ b/src/probe-core.cts
@@ -97,15 +97,41 @@ function errMessage(e: unknown): string {
 }
 
 /**
+ * Structural guard for ONE item of the report `items[]` — enforces the `Item` contract (#1907).
+ * `analyzeCoverage` always emits fully-populated, category/status-validated Items, so this never
+ * rejects legitimate output; it catches an adapter that bypasses the merge and hands back per-item
+ * garbage (e.g. `items:[{}]`) inside a well-shaped envelope — which the container-only guard let
+ * sail through as green output despite the fail-closed docstring below.
+ */
+function isValidItem(item: unknown): item is Item {
+  if (item == null || typeof item !== 'object') return false;
+  const i = item as {
+    requirement_id?: unknown; category?: unknown; status?: unknown;
+    verification?: unknown; resolution?: unknown; reason?: unknown; probe?: unknown;
+  };
+  if (typeof i.requirement_id !== 'string' || !i.requirement_id.trim()) return false;
+  if (typeof i.category !== 'string' || !i.category.trim()) return false;
+  if (!VALID_STATUS.includes(i.status as Status)) return false;
+  if (typeof i.probe !== 'string') return false;
+  // The three nullable fields must be a string or null — never some other type.
+  if (i.verification !== null && typeof i.verification !== 'string') return false;
+  if (i.resolution !== null && typeof i.resolution !== 'string') return false;
+  if (i.reason !== null && typeof i.reason !== 'string') return false;
+  return true;
+}
+
+/**
  * Structural guard for the report an adapter's `analyze` returns. The scaffold types `analyze`
  * loosely (it runs over JSON-parsed input the adapter `as`-casts), so a future adapter (#644)
  * that forgets to validate inside its closure could hand back a malformed object. Rather than
- * stringify garbage as green output, `runProbeCli` checks the report shape and fails closed.
+ * stringify garbage as green output, `runProbeCli` checks the report shape — container AND every
+ * item — and fails closed.
  */
 function isValidReport(report: unknown): report is CoverageReport {
   if (report == null || typeof report !== 'object') return false;
   const r = report as { items?: unknown; coverage?: unknown };
   if (!Array.isArray(r.items)) return false;
+  if (!r.items.every(isValidItem)) return false;
   const c = r.coverage as
     | { applicable?: unknown; resolved?: unknown; unresolved?: unknown; byVerification?: unknown }
     | undefined;

--- a/tests/probe-core.test.cjs
+++ b/tests/probe-core.test.cjs
@@ -332,6 +332,31 @@ describe('probe-core: runProbeCli (generic I/O scaffold, injected io)', () => {
     });
     assert.deepEqual(JSON.parse(out), report);
   });
+  test('per-item garbage inside a well-shaped envelope (items:[{}]) → exits 2, writes nothing (#1907 — matches the "fails closed on adapter garbage" docstring)', () => {
+    // The container is well-shaped (items is an array, coverage has the right scalars) but an item
+    // is an empty object. Before #1907 this sailed through and stringified as green output, despite
+    // the docstring promising it fails closed. A future adapter (#644-class) returning per-item
+    // garbage inside a good envelope must fail closed, not emit garbage as valid coverage.
+    let code; let out = '';
+    pc.runProbeCli(() => ({ items: [{}], coverage: { applicable: 0, resolved: 0, unresolved: 0, byVerification: {} } }), {
+      usage: 'demo', argv: ['node', 'demo', '/req.json'],
+      readFile: () => '[]', write: (s) => { out += s; }, writeErr: () => {}, exit: (c) => { code = c; },
+    });
+    assert.equal(code, 2);
+    assert.equal(out, '');
+  });
+  test('a report with a fully-formed item still writes (per-item validation does not over-reject legitimate coverage)', () => {
+    let out = '';
+    const good = {
+      items: [{ requirement_id: 'R1', category: 'empty', status: 'unresolved', verification: null, resolution: null, reason: null, probe: 'edge' }],
+      coverage: { applicable: 1, resolved: 0, unresolved: 1, byVerification: {} },
+    };
+    pc.runProbeCli(() => good, {
+      usage: 'demo', argv: ['node', 'demo', '/req.json'],
+      readFile: () => '[]', write: (s) => { out += s; }, exit: () => {},
+    });
+    assert.deepEqual(JSON.parse(out), good);
+  });
 });
 
 // ─── CHK-07 (#1278): descriptor-less backward-compat byte-stability ──────────────────────────────


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #1907

## What was broken

`isValidReport` (`src/probe-core.cts`) validated only the report *container* — that `items` is an array and `coverage` has the right scalar types. A report like `{ items: [{}], coverage: {...} }` (per-item garbage inside a well-shaped envelope) sailed through `runProbeCli` and was stringified as green output — despite the docstring promising it "checks the report shape and fails closed" on adapter garbage.

## What this fix does

Adds a per-item structural guard (`isValidItem`) enforcing the `Item` contract — `requirement_id`/`category` non-empty strings, `status` in `VALID_STATUS`, `probe` a string, and the nullable `verification`/`resolution`/`reason` each a string or null — and applies it to every element of `items[]` inside `isValidReport`. Per-item garbage now fails closed (exit 2, nothing written), matching the docstring.

## Root cause

The guard was written to catch a malformed *envelope* but never inspected the items inside it. `analyzeCoverage` validates each item (category + status/fields) during the merge, so well-behaved adapters were fine — but the docstring's stated purpose is to catch a *future* adapter (a #644-class addition) that bypasses the merge and hands back garbage from its own closure, and that path was unguarded.

## Testing

### How I verified the fix

- Reproduced live on `next @ 3c13903d`: `runProbeCli(() => ({items:[{}], coverage:{...}}))` exited success and echoed `items: [{}]` as green output; now exits 2 and writes nothing.
- Added a RED-before-GREEN regression test for `items:[{}]` failing closed, plus a positive test asserting a fully-formed item still writes (guards against over-rejection).
- Ran the full probe-core + `adr857-predicate-boundary` (the other `isValidReport`/`runProbeCli` consumer) + both shipped adapters' suites (edge-probe, prohibition-probe) — 0 failures, confirming no legitimate coverage is rejected.
- `npm run lint:ci` exits 0.

### Regression test added?

- [x] Yes — added a test that would have caught this bug

### Platforms tested

- [x] Linux
- [x] N/A (not platform-specific — pure structural validation)

### Runtimes tested

- [x] N/A (not runtime-specific — engine-internal)

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix
- [x] No unnecessary dependencies added

## Breaking changes

Disclosed per the artificer Hyrum's-Law pass: an adapter that previously returned a report with per-item garbage inside a well-shaped envelope would have emitted it as valid green output; it now fails closed (exit 2). No shipped adapter (edge, prohibition) produces such output — `analyzeCoverage` always emits validated Items — so the blast radius is future/misbehaving adapters only, which is the intended fail-closed behavior. Otherwise: None.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1910"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785569432&installation_id=134682257&pr_number=1910&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1910&signature=75f1c715a7c62afe7508b4dd62dc12ad7f81c48cb9fc7f78e0957cc758c3c984"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->