### PR TITLE
ci: per-issue concurrency group for auto-label workflow

### DIFF
--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -5,7 +5,7 @@ on:
     types: [opened]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.issue.number }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## CI PR

## Linked context

Fixes the auto-label gap that left **#1911** and **#1912** unlabeled (exposed during triage). Not a single-issue fix — a workflow bug.

## What was broken

`Auto-label new issues` (`.github/workflows/auto-label-issues.yml`) uses a concurrency group of `${{ github.workflow }}-${{ github.ref }}`. For `issues:` events `github.ref` is the **default branch for every issue**, so the group is **global across all issues**. With `cancel-in-progress: true`, a burst of new issues (opened seconds apart) cascaded cancellations — only the **last** issue in the burst survived and got `needs-triage`; earlier ones were cancelled mid-flight and left unlabeled.

Confirmed in the run history (twice today):
- 08:12:01 #1911 ❌ cancelled · 08:12:02 #1912 ❌ cancelled · 08:12:03 #1913 ✅
- Same pattern in the #1900/#1904 epic bursts (04:00 UTC).

## Fix

Make the group per-issue so runs no longer collide across issues:

```diff
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.issue.number }}
   cancel-in-progress: true
```

`cancel-in-progress` is now scoped per-issue (only matters if the same issue re-triggers rapidly, e.g. reopen — harmless).

## Testing

- `gsd-test --base next` → **PASS 22172/22172** on the bench (suite unaffected by a workflow YAML change).
- Behavioral verification: the run history above is the before-state; after merge, a burst of issues will each get independent labeling runs.

## Platforms / Runtimes tested

- [x] N/A (GitHub Actions workflow change; no OS/runtime surface)

## Documentation

- [x] N/A — internal CI workflow; rationale is in the commit message. Applying `no-changelog` (not user-facing: no shipped product behavior change).

## Breaking changes

None. Internal workflow only.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1915"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785589000&installation_id=134682257&pr_number=1915&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1915&signature=a1118ee83402500de1d0ec3b36f06173f79a5900b787d174fe1fc3a286edcac2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->