### PR TITLE
fix(#1911): milestone complete --ws archives to the workstream

### DIFF
--- a/.changeset/rapid-pumas-click.md
+++ b/.changeset/rapid-pumas-click.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 1917
+---
+**`milestone complete --ws` now archives into the workstream instead of root** — the archive paths (MILESTONES.md, the milestones/ archive dir, and the per-version MILESTONE-AUDIT.md) were hardcoded to root `.planning/`, so a workstream milestone close scattered its artifacts into root and never produced a workstream-local archive. They now derive from the workstream-aware planning base (`planningPaths(cwd).planning`); flat-mode (no --ws) is unchanged. (#1911)

--- a/src/milestone.cts
+++ b/src/milestone.cts
@@ -130,8 +130,13 @@ function cmdMilestoneComplete(cwd: string, version: string, options: MilestoneCo
   const roadmapPath = planningPaths(cwd).roadmap;
   const reqPath = planningPaths(cwd).requirements;
   const statePath = planningPaths(cwd).state;
-  const milestonesPath = path.join(cwd, '.planning', 'MILESTONES.md');
-  const archiveDir = path.join(cwd, '.planning', 'milestones');
+  // #1911: derive the archive base from the workstream-aware planning root so
+  // `milestone complete --ws` archives into the workstream, not root. planningPaths(cwd).planning
+  // resolves to the workstream base when GSD_WORKSTREAM is set and to root .planning otherwise
+  // (flat mode is a no-op).
+  const planningBase = planningPaths(cwd).planning;
+  const milestonesPath = path.join(planningBase, 'MILESTONES.md');
+  const archiveDir = path.join(planningBase, 'milestones');
   const phasesDir = planningPaths(cwd).phases;
   const today = new Date().toISOString().split('T')[0];
   const milestoneName = options.name || version;
@@ -283,7 +288,7 @@ function cmdMilestoneComplete(cwd: string, version: string, options: MilestoneCo
   }
 
   // Archive audit file if exists
-  const auditFile = path.join(cwd, '.planning', `${version}-MILESTONE-AUDIT.md`);
+  const auditFile = path.join(planningBase, `${version}-MILESTONE-AUDIT.md`);
   if (fs.existsSync(auditFile)) {
     retryRenameSync(auditFile, path.join(archiveDir, `${version}-MILESTONE-AUDIT.md`));
   }

--- a/tests/milestone.test.cjs
+++ b/tests/milestone.test.cjs
@@ -716,3 +716,46 @@ describe('milestone complete explicit version scope (#3043)', () => {
     }
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #1911: milestone complete --ws must archive to the workstream, not root
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#1911 — milestone complete --ws archives to the workstream', () => {
+  let tmpDir;
+
+  beforeEach(() => { tmpDir = createTempProject(); });
+  afterEach(() => cleanup(tmpDir));
+
+  test('--ws archives roadmap/requirements into the workstream milestones dir, not root', () => {
+    const wsBase = path.join(tmpDir, '.planning', 'workstreams', 'ws1');
+    fs.mkdirSync(path.join(wsBase, 'phases', '01-foo'), { recursive: true });
+    fs.writeFileSync(path.join(wsBase, 'STATE.md'), 'milestone: v2.0\nstatus: executing\n');
+    fs.writeFileSync(
+      path.join(wsBase, 'ROADMAP.md'),
+      '# Roadmap\n## Milestones\n- v2.0 Test (Phases 1) — IN PROGRESS\n## Phases\n### Phase 1: Foo\n**Goal:** foo\n',
+    );
+    fs.writeFileSync(path.join(wsBase, 'REQUIREMENTS.md'), '# Requirements\n- [ ] REQ-01\n');
+    fs.writeFileSync(path.join(wsBase, 'phases', '01-foo', '01-SUMMARY.md'), '---\none-liner: foo done\n---\n# Summary\n');
+    // Root milestones dir pre-exists; it must NOT receive the workstream archive.
+    fs.mkdirSync(path.join(tmpDir, '.planning', 'milestones'), { recursive: true });
+
+    const result = runGsdTools('milestone complete v2.0 --ws ws1 --force', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    // Archive lands inside the workstream.
+    assert.ok(
+      fs.existsSync(path.join(wsBase, 'milestones', 'v2.0-ROADMAP.md')),
+      'v2.0-ROADMAP.md should be archived into the workstream milestones dir',
+    );
+    assert.ok(
+      fs.existsSync(path.join(wsBase, 'milestones', 'v2.0-REQUIREMENTS.md')),
+      'v2.0-REQUIREMENTS.md should be archived into the workstream milestones dir',
+    );
+    // And NOT in root.
+    assert.ok(
+      !fs.existsSync(path.join(tmpDir, '.planning', 'milestones', 'v2.0-ROADMAP.md')),
+      'must not archive to root .planning/milestones/ in workstream mode',
+    );
+  });
+});


### PR DESCRIPTION
## Fix PR

Closes #1911  (issue carries `confirmed-bug`)

## What was broken

`cmdMilestoneComplete` (`src/milestone.cts`) resolved `roadmap`/`requirements`/`state`/`phases` via the workstream-aware `planningPaths(cwd)` but **hardcoded root** for three archive paths: `milestonesPath` (MILESTONES.md), `archiveDir` (milestones/), and the per-version `auditFile`. So `milestone complete <v> --ws <name>` scattered its archive into root `.planning/` and never created `workstreams/<name>/milestones/`.

## Root cause

`path.join(cwd, .planning, …)` instead of the workstream-aware base for those three paths — a partial workstream-scoping of the function. The archive dir feeds every archive write (`${v}-ROADMAP.md`, `${v}-REQUIREMENTS.md`, `${v}-MILESTONE-AUDIT.md`, `${v}-phases/`), so all of them landed in root.

## The fix

Derive the archive base from `planningPaths(cwd).planning` (workstream-aware; resolves to root `.planning` for flat mode → no-op, and to the workstream base when `GSD_WORKSTREAM` is set). Applied to `milestonesPath`, `archiveDir`, and `auditFile`. Matches the reporter's locally-verified fix.

## Testing

Regression folded into `tests/milestone.test.cjs` (`#1911 — milestone complete --ws archives to the workstream`): a workstream fixture (own STATE/ROADMAP/REQUIREMENTS + phase SUMMARY) + `milestone complete v2.0 --ws ws1 --force`; asserts `v2.0-ROADMAP.md`/`v2.0-REQUIREMENTS.md` land under `workstreams/ws1/milestones/` and NOT under root. Fails before the fix (archives in root), passes after.

`gsd-test --base next` → **PASS, 0 failures** on the bench.

- [x] `Closes #1911` · issue has `confirmed-bug`
- [x] Regression test added (would have caught the bug) · `gsd-test` green before push
- [x] `.changeset/` (`Fixed`) · no dependencies added
- [x] N/A platform/runtime-specific

## Breaking changes

None. Flat-mode (`milestone complete` without `--ws`) is byte-identical (planningPaths(cwd).planning == root). Workstream mode now archives correctly.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1917"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785591680&installation_id=134682257&pr_number=1917&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1917&signature=b8fe52bf3978129726f27ecf70754915cb72b8efea390f9a09e9700191e174ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->