### PR TITLE
fix(#1912): init.progress fails safe in workstream mode with no active workstream

### DIFF
--- a/.changeset/lively-lynx-snooze.md
+++ b/.changeset/lively-lynx-snooze.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 1918
+---
+**`/gsd-progress` no longer reports a stale root milestone in workstream mode** — in a multi-workstream project with no active workstream set, `gsd-tools query init.progress` silently fell back to root `.planning/STATE.md` (often stale) and reported it confidently. It now fails safe with an actionable error naming the available workstreams and the `--ws`/`workstream set` fix, so a stale root value is never reported. Flat mode and `--ws <name>` are unchanged. (#1912)

--- a/src/init.cts
+++ b/src/init.cts
@@ -71,6 +71,7 @@ const {
   planningPaths,
   planningDir,
   planningRoot,
+  getActiveWorkstream,
   findContextMdIn,
 } = planningWorkspace;
 
@@ -1682,6 +1683,31 @@ function cmdInitProgress(cwd: string, raw: boolean): void {
   const config = loadConfig(cwd);
   const milestone = getMilestoneInfo(cwd) as unknown as Record<string, unknown>;
   const _slashRuntime = resolveRuntime(cwd);
+
+  // #1912: fail safe in workstream mode with no active workstream. With no active
+  // workstream and no --ws, planningDir(cwd) resolves to root .planning — silently
+  // reporting a stale root milestone. Require an explicit workstream instead.
+  // Mirror planningDir's resolution (GSD_WORKSTREAM env > stored active pointer) so
+  // an explicit --ws (which sets GSD_WORKSTREAM) satisfies the check.
+  const _wsRoot = path.join(planningRoot(cwd), 'workstreams');
+  let _availableWorkstreams: string[] = [];
+  try {
+    _availableWorkstreams = fs
+      .readdirSync(_wsRoot, { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name)
+      .sort();
+  } catch {
+    /* no workstreams dir → flat mode */
+  }
+  const _resolvedWorkstream = process.env['GSD_WORKSTREAM'] || getActiveWorkstream(cwd);
+  if (_availableWorkstreams.length > 0 && !_resolvedWorkstream) {
+    error(
+      `init.progress requires a workstream in workstream mode — no active workstream is set, so root STATE.md (likely stale) would be reported. ` +
+        `Pass --ws <name> or run ${formatGsdSlash('workstream set', _slashRuntime) as string} first. ` +
+        `Available workstreams: ${_availableWorkstreams.join(', ')}`,
+    );
+  }
 
   const phasesDir = path.join(planningDir(cwd), 'phases');
   const phases: Record<string, unknown>[] = [];

--- a/tests/init.test.cjs
+++ b/tests/init.test.cjs
@@ -2221,5 +2221,53 @@ describe('init handlers honor GSD_WORKSTREAM (ADR-0006 planningPaths consumption
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
+// #1912: init.progress fails safe in workstream mode with no active workstream
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#1912 — init.progress fails safe in workstream mode with no active workstream', () => {
+  let tmpDir;
+
+  beforeEach(() => { tmpDir = createTempProject(); });
+  afterEach(() => { cleanup(tmpDir); });
+
+  function seedWs(name, milestoneVersion) {
+    const wsDir = path.join(tmpDir, '.planning', 'workstreams', name);
+    fs.mkdirSync(path.join(wsDir, 'phases'), { recursive: true });
+    fs.writeFileSync(
+      path.join(wsDir, 'STATE.md'),
+      `# State\n\n**Status:** executing\n**Milestone:** ${milestoneVersion}\n`,
+    );
+    fs.writeFileSync(
+      path.join(wsDir, 'ROADMAP.md'),
+      `# Roadmap\n\n## Milestones\n- ${milestoneVersion} Test (Phase 1)\n\n## Phases\n### Phase 1: X\n**Goal:** do x\n`,
+    );
+    return wsDir;
+  }
+
+  test('errors (does NOT report stale root) when workstreams exist but none active', () => {
+    seedWs('alpha', 'v9.0');
+    seedWs('beta', 'v9.0');
+    // Stale root STATE — the misleading value that must never be silently reported.
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'milestone: v7.1\nstatus: executing\n');
+    // No active-workstream pointer, no --ws.
+    const result = runGsdTools('init progress', tmpDir);
+    assert.equal(result.success, false, 'should fail safe rather than report the stale root milestone');
+    assert.match(result.error || '', /workstream|--ws/i, 'error should name the workstream requirement');
+  });
+
+  test('succeeds with --ws (reads the named workstream, not root)', () => {
+    seedWs('alpha', 'v9.0');
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'milestone: v7.1\nstatus: executing\n');
+    const result = runGsdTools('init progress --ws alpha', tmpDir);
+    assert.ok(result.success, `should succeed with --ws: ${result.error}`);
+  });
+
+  test('flat mode (no workstreams dir) is unchanged', () => {
+    const result = runGsdTools('init progress', tmpDir);
+    assert.ok(result.success, `flat mode should still work: ${result.error}`);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
 // roadmap analyze command
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Fix PR

Closes #1912  (issue carries `confirmed-bug`)

## What was broken

`cmdInitProgress` (`src/init.cts`) reads milestone/phase state via `planningDir(cwd)`, which resolves to **root** `.planning/` when there is no active workstream and no `--ws`/`GSD_WORKSTREAM` — regardless of `mode: workstream`. So `/gsd-progress` (driven by `init.progress`) confidently reported a stale root milestone with no signal it was stale.

## Root cause

No workstream-mode guard: with `mode: workstream` + `active: null` + no `--ws`, the command silently fell back to root instead of failing safe.

## The fix

Fail safe: when `.planning/workstreams/` has workstreams AND no workstream is resolved, error with an actionable hint (names the available workstreams + the `--ws`/`workstream set` fix). The "resolved" check mirrors `planningDir`'s resolution (`process.env.GSD_WORKSTREAM || getActiveWorkstream(cwd)`) so an explicit `--ws <name>` (which sets `GSD_WORKSTREAM`) satisfies it. Flat mode (no workstreams dir) and `--ws <name>` are unchanged.

## Testing

Regression folded into `tests/init.test.cjs`: errors when workstreams exist but none active (does NOT report stale root); succeeds with `--ws alpha` (reads the workstream); flat mode unchanged.

`gsd-test --base next` → **PASS 22176/22176** (the first run caught that my initial check used `getActiveWorkstream` alone, which misses the `--ws`/env override — fixed to env-first resolution; green on re-run).

- [x] `Closes #1912` · `confirmed-bug`
- [x] Regression test (would have caught the bug) · `gsd-test` green before push
- [x] `.changeset/` (`Fixed`) · no dependencies
- [x] N/A platform/runtime

## Breaking changes

None for flat mode or `--ws`. The only behavior change: `init.progress` with no resolvable workstream in workstream mode now errors (fail-safe) instead of returning a stale root-derived report — which is the fix.

Same root-vs-workstream scoping family as #1911 and #1913.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1918"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785592942&installation_id=134682257&pr_number=1918&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1918&signature=6f703be09d208cd031c472a16efd21bf33514db1e9573909bfd6c894d195df14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->