### PR TITLE
fix(#1871): phases clear archives dirs instead of destroying them

### DIFF
--- a/.changeset/humble-zebras-zip.md
+++ b/.changeset/humble-zebras-zip.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 1919
+---
+**`phases clear` archives phase directories instead of destroying them** — at a milestone switch, committed phase directories were hard-deleted (`rmSync`) with no archive, silently losing browsable phase history (the #1447 dirty-tree guard was a no-op for the common committed case). Phase directories are now moved to `milestones/<version>-phases/` (collision-safe; timestamp fallback when no version resolves), so history survives the switch. The #1447 uncommitted-changes guard is retained as a secondary backstop. (#1871)

--- a/src/milestone.cts
+++ b/src/milestone.cts
@@ -26,7 +26,7 @@ import phaseIdMod = require('./phase-id.cjs');
 const { escapeRegex, normalizePhaseName, phaseTokenMatches } = phaseIdMod;
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import roadmapParserMod = require('./roadmap-parser.cjs');
-const { getMilestonePhaseFilter, extractCurrentMilestone } = roadmapParserMod;
+const { getMilestonePhaseFilter, extractCurrentMilestone, getMilestoneInfo } = roadmapParserMod;
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import coreUtilsMod = require('./core-utils.cjs');
 const { extractOneLinerFromBody } = coreUtilsMod;
@@ -435,8 +435,30 @@ function cmdPhasesClear(cwd: string, raw: boolean, args: string[]): void {
     }
 
     try {
+      // #1871: archive phase directories instead of destroying them. Move each
+      // non-999 dir to milestones/<version>-phases/ so browsable phase history
+      // survives the milestone switch (previously rmSync hard-deleted committed
+      // dirs, leaving orphaned uncommitted deletions and no archive).
+      let archiveVersion: string | null = null;
+      try {
+        archiveVersion = getMilestoneInfo(cwd).version ?? null;
+      } catch {
+        /* ROADMAP/STATE unreadable — fall back to a dated label */
+      }
+      if (!archiveVersion) {
+        archiveVersion = `archived-${new Date().toISOString().replace(/[-:T]/g, '').slice(0, 8)}`;
+      }
+      const archivePhasesDir = path.join(planningPaths(cwd).planning, 'milestones', `${archiveVersion}-phases`);
+      platformEnsureDir(archivePhasesDir);
       for (const entry of dirs) {
-        fs.rmSync(path.join(phasesDir, entry.name), { recursive: true, force: true });
+        const src = path.join(phasesDir, entry.name);
+        // Collision-safe: if a same-named archive entry exists (re-run), suffix it.
+        let dest = path.join(archivePhasesDir, entry.name);
+        let n = 1;
+        while (fs.existsSync(dest)) {
+          dest = path.join(archivePhasesDir, `${entry.name}.${n++}`);
+        }
+        retryRenameSync(src, dest);
         cleared++;
       }
     } catch (e) {

--- a/tests/new-milestone-clear-phases.test.cjs
+++ b/tests/new-milestone-clear-phases.test.cjs
@@ -101,7 +101,7 @@ describe('phases clear command', () => {
     );
   });
 
-  test('clears nested phase content (recursive delete)', () => {
+  test('archives nested phase content (moved, not deleted) (#1871)', () => {
     const phasesDir = path.join(tmpDir, '.planning', 'phases');
     const phase1 = path.join(phasesDir, '01-foundation');
     const nested = path.join(phase1, 'subdir');
@@ -111,9 +111,32 @@ describe('phases clear command', () => {
     const result = runGsdTools('phases clear --confirm', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
-    assert.ok(!fs.existsSync(phase1), 'phase directory including nested content should be removed');
+    // Source is cleared (moved away)...
+    assert.ok(!fs.existsSync(phase1), 'phase directory should be moved out of .planning/phases/');
+    // ...but the nested content SURVIVES in the archive (not destroyed).
+    const archive = findPhasesArchive(tmpDir);
+    assert.ok(archive, 'an archive dir milestones/*-phases/ should exist');
+    assert.ok(
+      fs.existsSync(path.join(archive, '01-foundation', 'subdir', 'deep-file.md')),
+      'nested phase content must be preserved in the archive, not deleted',
+    );
   });
 });
+
+// Locate the `milestones/<version>-phases/` archive directory created by phases clear.
+function findPhasesArchive(tmpDir) {
+  const milestonesDir = path.join(tmpDir, '.planning', 'milestones');
+  try {
+    for (const entry of fs.readdirSync(milestonesDir, { withFileTypes: true })) {
+      if (entry.isDirectory() && /-phases$/.test(entry.name)) {
+        return path.join(milestonesDir, entry.name);
+      }
+    }
+  } catch {
+    /* no milestones dir */
+  }
+  return null;
+}
 
 // ─── #1447: uncommitted-changes guard ───────────────────────────────────────
 
@@ -190,7 +213,14 @@ describe('phases clear: uncommitted-changes guard (#1447)', () => {
     assert.ok(result.success, `should succeed when phase files are committed: ${result.error}`);
     const output = JSON.parse(result.output);
     assert.strictEqual(output.cleared, 1, 'should clear 1 phase directory');
-    assert.ok(!fs.existsSync(phase1), 'committed phase directory should be removed');
+    // #1871: a committed phase dir is ARCHIVED (moved to milestones/*-phases/), not destroyed.
+    assert.ok(!fs.existsSync(phase1), 'committed phase directory should be moved out of .planning/phases/');
+    const archive = findPhasesArchive(tmpDir);
+    assert.ok(archive, 'a milestones/*-phases/ archive should be created for committed phase dirs');
+    assert.ok(
+      fs.existsSync(path.join(archive, '01-foundation', 'PLAN.md')),
+      'committed phase content must be preserved in the archive, not hard-deleted',
+    );
   });
 
   test('guard skips gracefully when not in a git repo (no guard, proceeds normally)', () => {


### PR DESCRIPTION
## Fix PR

Closes #1871  (issue carries `confirmed-bug`)

## What was broken

`cmdPhasesClear` (`src/milestone.cts`) hard-deleted committed phase directories (`rmSync`) with no archive. At a milestone switch, `new-milestone` §6 runs `phases clear --confirm`; the #1447 dirty-tree guard is a **no-op for the committed case** (a clean tree passes the guard, then `rmSync` destroyed the dirs), leaving orphaned uncommitted deletions and no archive. Browsable phase history was silently lost.

## Root cause

`phases clear` destroyed instead of archiving. Notably, `cmdMilestoneComplete` *already* archives phases correctly (`src/milestone.cts:338-356`, the `archivePhases` option moves milestone-scoped dirs to `milestones/<version>-phases/` via `retryRenameSync`) — the standalone `phases clear` command never used that pattern.

## The fix

Archive-then-remove in `cmdPhasesClear`: move each non-999 phase dir to `milestones/<version>-phases/` (version from `getMilestoneInfo(cwd)`; timestamp fallback when no version resolves; collision-safe for re-runs) using `retryRenameSync` (Windows-safe) — mirroring the existing `archivePhases` path. The #1447 uncommitted-changes guard is retained as a secondary backstop.

## Testing

Updated `tests/new-milestone-clear-phases.test.cjs`: the tests that previously asserted phase dirs are **destroyed** now assert they are **archived** — content survives under `milestones/*-phases/`, including the committed-dirs case (the one that codified the no-op). Added a `findPhasesArchive` helper.

`gsd-test --base next` → **PASS 22172/22172** (the updated assertions pass with the fix; the first eslint pass caught an unnecessary cast + an unguarded `fs.renameSync` → fixed to use the Windows-safe `retryRenameSync`).

- [x] `Closes #1871` · `confirmed-bug`
- [x] Regression test updated (would have caught the bug) · `gsd-test` green before push
- [x] `.changeset/` (`Fixed`) · no dependencies
- [x] N/A platform (uses Windows-safe retryRenameSync)

## Scope note (deferred items)

This PR closes the **data-loss hole** (archive instead of destroy) — the reporter's "minimal, closes the actual hole" item 1. The remaining recommendations are deferred as separate concerns to keep this PR focused:
- route `phases.archive` to a dedicated `cmdPhasesArchive` + drop the router exclusion (`phases-command-router.cjs:22`);
- `complete-milestone` archive by default;
- `new-milestone` §6 stage the archive move + source removal in the same commit (atomicity).

## Breaking changes

Behavior change (the fix): `phases clear` now archives instead of deleting. Callers that relied on deletion will see the dirs preserved under `milestones/*-phases/` rather than destroyed — which is the intended fix. The `--force` flag and the #1447 guard are unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1919"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785593863&installation_id=134682257&pr_number=1919&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1919&signature=c094531aa9756dc71cbcf816f5c7194c99726cc6e87e4cb11e596da700143d9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->