### PR TITLE
fix(#1926): bug-1367 builds hooks/dist precondition in before()

### DIFF
--- a/.changeset/graceful-wasps-caper.md
+++ b/.changeset/graceful-wasps-caper.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 1927
+---
+**bug-1367 install test no longer fails on Windows CI when hooks/dist isn't pre-built** — the test ran install.js without building its hooks/dist precondition (a gitignored build artifact the unit lane doesn't build), so on a lane without pre-built hooks the installer hit "Failed to install hooks: directory is empty" and the before-hook threw. The test now builds hooks in its own before() (mirroring golden-install-parity). (#1926)

--- a/tests/bug-1367-claude-local-flat-command-layout.test.cjs
+++ b/tests/bug-1367-claude-local-flat-command-layout.test.cjs
@@ -33,6 +33,11 @@ const { cleanup } = require('./helpers.cjs');
 
 const REPO_ROOT = path.resolve(__dirname, '..');
 const INSTALL_PATH = path.join(REPO_ROOT, 'bin', 'install.js');
+// hooks/dist/ is a gitignored build artifact; the test must ensure it exists before
+// invoking the installer (mirrors golden-install-parity's BUILD_SCRIPT pattern). Without
+// this, the unit lane — whose ensureBuiltArtifacts() builds only bin/lib, not hooks —
+// leaves hooks/dist empty and install.js hard-fails "directory is empty" (#1926).
+const BUILD_HOOKS = path.join(REPO_ROOT, 'scripts', 'build-hooks.js');
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -61,6 +66,13 @@ describe('bug #1367 — Claude local install uses flat gsd-<cmd>.md command layo
   let tmpDir;
 
   before(() => {
+    // #1926: build hooks/dist/ so the installer's verifyInstalled(hooks) doesn't hit an
+    // empty directory. Self-contained — no dependency on the lane having pre-built hooks.
+    execFileSync(process.execPath, [BUILD_HOOKS], {
+      cwd: REPO_ROOT,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-1367-'));
     runClaudeLocalInstall(tmpDir);
   });


### PR DESCRIPTION
## Fix PR

Closes #1926

## Root cause (deterministic — not a flake)

`bug-1367`'s `before()` runs `install.js --claude --local` directly. `hooks/dist/` is a **gitignored build artifact** (`scripts/build-hooks.js`). The unit lane's `ensureBuiltArtifacts()` (`scripts/run-tests.cjs:55`) builds only `bin/lib` (tsc), **not hooks**. So the test had an undeclared precondition: `hooks/dist/` had to be pre-built.

On the Windows CI lane (no pre-built `hooks/dist/`), `install.js`'s `verifyInstalled(hooksDir)` (`bin/install.js:7800`) found the directory empty → hard-fail "Failed to install hooks: directory is empty" → the `before()` hook threw → `hookFailed` → L0–L5 subtests `cancelledByParent`. This is what put `next` red after the #1765 merge (independent of #1765 — none of today's merges touch hooks; it's a latent test-infrastructure fragility).

## Fix

Make the test self-contained: build hooks in `before()` via `scripts/build-hooks.js`, mirroring `golden-install-parity`'s `BUILD_SCRIPT` pattern (`tests/helpers/install-shared.cjs:18`). No more lane-ordering dependency.

- [x] `Closes #1926`
- [x] `gsd-test` green (linux) — but the real gate is **all CI lanes**; I will only merge once Windows + macOS + Ubuntu shards are all green.
- [x] `.changeset/` (`Fixed`) · test-only change, no product code

## Testing

I will not merge until every CI lane (Windows/macOS/Ubuntu + Stryker + golden-parity) reports green — `gsd-test` (linux-only) is not the CI gate and I will not treat it as one again.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1927"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785601830&installation_id=134682257&pr_number=1927&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1927&signature=6d38db330ec89551d41d3da1aaeb7d58bbd26e21ad7615aacc429239db9b23e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->