### PR TITLE
test(#1682): Antigravity declarative-cli reference host dogfood — Slice 2

### DIFF
--- a/tests/declarative-reference-antigravity.test.cjs
+++ b/tests/declarative-reference-antigravity.test.cjs
@@ -1,0 +1,67 @@
+'use strict';
+
+/**
+ * Declarative reference host — Antigravity (#1682 Slice 2 / ADR-1239 Phase D).
+ *
+ * Locks in Antigravity as the Declarative-CLI reference host driven through the
+ * PUBLIC Host-Integration Interface (the declarative adapter), per #1682 AC:
+ *   "invoke a gsd command in the Declarative-CLI reference host (Antigravity)
+ *    driven by the embedded engine through the public interface, golden-parity
+ *    vs Claude."
+ *
+ * Byte-identity of adapter output vs today's install is gated globally by
+ * golden-install-parity (all 16 runtimes) + adapter-declarative-equivalence.
+ * THIS test is the reference-host dogfood: it (1) classifies Antigravity's
+ * profile via profileOf, (2) confirms the public adapter classifies it as
+ * declarative, and (3) round-trips a real install proving a gsd command surface
+ * is emitted through the same engine the adapter delegates to.
+ */
+
+const { test, before } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+const { profileOf } = require('../gsd-core/bin/lib/host-integration.cjs');
+const { createDeclarativeAdapter } = require('../gsd-core/bin/lib/adapter-declarative.cjs');
+const { cleanup } = require('./helpers.cjs');
+const { walk, runMinimalInstall, BUILD_SCRIPT } = require('./helpers/install-shared.cjs');
+
+const DESC = path.join(__dirname, '..', 'capabilities', 'antigravity', 'capability.json');
+
+// hooks/dist is gitignored and built (mirrors golden-install-parity harness).
+before(() => {
+  execFileSync(process.execPath, [BUILD_SCRIPT], { encoding: 'utf-8', stdio: 'pipe' });
+});
+
+test('Antigravity classifies as the declarative-cli reference profile (profileOf)', () => {
+  const desc = JSON.parse(fs.readFileSync(DESC, 'utf8'));
+  const axes = desc.runtime.hostIntegration;
+  assert.ok(axes && axes.embeddingMode, 'antigravity descriptor declares hostIntegration axes');
+  assert.equal(profileOf(axes), 'declarative-cli',
+    'Antigravity is the Declarative-CLI reference host');
+});
+
+test('the public declarative adapter classifies Antigravity as a declarative host', () => {
+  const adapter = createDeclarativeAdapter({ runtime: 'antigravity' });
+  assert.equal(adapter.kind, 'declarative');
+  assert.equal(adapter.runtime, 'antigravity');
+  assert.equal(typeof adapter.install, 'function');
+  assert.equal(typeof adapter.uninstall, 'function');
+});
+
+test('a real Antigravity install emits a gsd command/skill surface (invocable)', () => {
+  const { configDir, root } = runMinimalInstall({ runtime: 'antigravity', scope: 'global' });
+  try {
+    const files = walk(configDir);
+    assert.ok(files.length > 0, 'install must emit artifacts');
+    // Antigravity uses the nested gsd-ns-* router skill layout as its command
+    // surface (CONTEXT.md installer module). Assert a gsd skill/router is present.
+    const gsdSurface = files.filter((f) => /gsd/i.test(path.relative(configDir, f)));
+    assert.ok(gsdSurface.length > 0,
+      'install must emit a gsd command/skill surface (declarative reference)');
+  } finally {
+    cleanup(root);
+  }
+});


### PR DESCRIPTION
## Feature PR

> **Slice PR — Phase 5 (#1682) Slice 2** (Antigravity declarative-cli reference host dogfood). Test-only — locks in Antigravity as the Declarative-CLI reference through the public interface. The adapter/equivalence/golden-parity substrate already shipped in Phase 3 (#1680). Does NOT complete #1682 (pi remains). Merge to `next` (non-default) does not auto-close; **#1682 must stay open.**

## Linked Issue

Closes #1682

> #1682 carries `approved-feature` (Phase 5 of epic #1678, ADR-1239 Phase D).

---

## Feature summary

Proves Antigravity is the Declarative-CLI reference host driven through the public Host-Integration Interface (#1682 AC): `profileOf` classifies it `declarative-cli`, the public `createDeclarativeAdapter` classifies it `kind:"declarative"`, and a real install emits a gsd command/skill surface.

## What changed

### New files

| File | Purpose |
|------|---------|
| `tests/declarative-reference-antigravity.test.cjs` | Reference-host dogfood: profileOf classification + public-adapter classification + real install round-trip emitting a gsd surface |

### Modified files

(none — test-only; no user-facing behavior change, so no changeset)

## Implementation notes

- The declarative adapter (`createDeclarativeAdapter`) delegates in-process to the SAME `installEngine.installRuntimeArtifacts` bin/install.js uses → byte-identical by construction. Byte-identity across all 16 runtimes is gated by `golden-install-parity` + `adapter-declarative-equivalence` (Phase 3). This slice adds the reference-host dogfood assertion for Antigravity specifically.
- Antigravity already declares `embeddingMode:"declarative"` → `profileOf === 'declarative-cli'`; uses the nested `gsd-ns-*` router skill layout as its command surface.

## Spec compliance

Slice 2 — partial toward #1682.

- [x] (this slice) Antigravity Declarative-CLI reference host proven through the public interface (profileOf + adapter + install round-trip); golden parity vs today's install stays gated by the global harness
- Remaining #1682 AC: pi (Slice 3); VS Code deferred; per-host degradation parity

## Testing

### Test coverage
`tests/declarative-reference-antigravity.test.cjs`: profileOf=declarative-cli; adapter kind=declarative; real install emits a gsd surface.

### Platforms tested
- [ ] macOS / Windows (via CI)
- [x] Linux — `gsd-test` green (22258/22255+3, verdict `passed`) on `next`

### Runtimes tested
- [x] Antigravity

---

## Scope confirmation
- [x] within approved scope (Slice 2 of #1682)
- [x] test-only; no behavior change

## Documentation
- [x] no user-facing docs impact (test-only; no changeset)

## Checklist
- [x] `Closes #1682` (merge to `next` does not auto-close)
- [x] #1682 has `approved-feature`
- [ ] (partial) AC — Slice 2 only; #1682 stays open
- [x] `gsd-test` green (linux)
- [x] new reference-host test
- [x] no changeset (test-only, no user-facing change)
- [x] no new deps

## Breaking changes
None.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1931"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785615832&installation_id=134682257&pr_number=1931&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1931&signature=d51fce16f30407d07bdb52ec49113fc5264d33954ea70556bfedc641d3f00c4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->