### PR TITLE
feat(#1683): published Host-Integration SDK surface + smoke test — Slice 2

### DIFF
--- a/docs/INVENTORY-MANIFEST.json
+++ b/docs/INVENTORY-MANIFEST.json
@@ -341,6 +341,7 @@
       "handshake-serialized.cjs",
       "hook-bus.cjs",
       "host-integration.cjs",
+      "host-integration-sdk.cjs",
       "init-command-router.cjs",
       "init.cjs",
       "install-engine.cjs",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -59,6 +59,7 @@ export default tseslint.config(
       'gsd-core/bin/lib/semver-compare.cjs',
       'gsd-core/bin/lib/host-integration.cjs',
       'gsd-core/bin/lib/handshake-serialized.cjs',
+      'gsd-core/bin/lib/host-integration-sdk.cjs',
       'gsd-core/bin/lib/install-engine.cjs',
       'gsd-core/bin/lib/capability-loader.cjs',
       'gsd-core/bin/lib/capability-source.cjs',

--- a/src/host-integration-sdk.cts
+++ b/src/host-integration-sdk.cts
@@ -1,0 +1,58 @@
+/**
+ * Host-Integration SDK — the published public surface (ADR-1239 Phase E / #1683).
+ *
+ * External host-plugin authors import ONLY from this entry. It IS the contract:
+ * everything it re-exports is public + versioned (PROTOCOL_VERSION governs the
+ * set); everything else in gsd-core is internal. An SDK smoke test
+ * (tests/sdk-smoke.test.cjs) builds a new host-plugin against this surface only
+ * — proving an external author can wire a host without reading gsd-core internals.
+ *
+ * Surface: the negotiated schema + classification, the five adapters
+ * (declarative/imperative/model/hook/state), and the serialized handshake.
+ * Frozen so the public shape cannot be mutated by consumers.
+ */
+'use strict';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import hostIntegration = require('./host-integration.cjs');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import adapterDeclarative = require('./adapter-declarative.cjs');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import adapterImperative = require('./adapter-imperative.cjs');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import modelAdapter = require('./model-adapter.cjs');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import hookBus = require('./hook-bus.cjs');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import stateIo = require('./state-io.cjs');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import handshake = require('./handshake-serialized.cjs');
+
+const SDK = Object.freeze({
+  // ── Schema + protocol version ────────────────────────────────────────────
+  PROTOCOL_VERSION: hostIntegration.PROTOCOL_VERSION,
+  HOST_INTEGRATION_AXES: hostIntegration.HOST_INTEGRATION_AXES,
+  INTERFACE_POINTS: hostIntegration.INTERFACE_POINTS,
+  PROFILE_BASELINES: hostIntegration.PROFILE_BASELINES,
+
+  // ── Negotiation + classification ─────────────────────────────────────────
+  negotiateHostCapabilities: hostIntegration.negotiateHostCapabilities,
+  profileOf: hostIntegration.profileOf,
+  degradationFor: hostIntegration.degradationFor,
+  hookEventSurfaceFor: hostIntegration.hookEventSurfaceFor,
+  shouldFlattenDispatch: hostIntegration.shouldFlattenDispatch,
+
+  // ── Embedding + engine adapters ──────────────────────────────────────────
+  createDeclarativeAdapter: adapterDeclarative.createDeclarativeAdapter,
+  createImperativeAdapter: adapterImperative.createImperativeAdapter,
+  createModelAdapter: modelAdapter.createModelAdapter,
+  createHookBus: hookBus.createHookBus,
+  createStateIO: stateIo.createStateIO,
+
+  // ── Serialized handshake (out-of-process SDK hosts: pi / VS Code) ─────────
+  HANDSHAKE_METHOD: handshake.HANDSHAKE_METHOD,
+  buildHandshakeRequest: handshake.buildHandshakeRequest,
+  handleHandshakeRequest: handshake.handleHandshakeRequest,
+});
+
+export = SDK;

--- a/tests/sdk-smoke.test.cjs
+++ b/tests/sdk-smoke.test.cjs
@@ -1,0 +1,67 @@
+'use strict';
+
+/**
+ * SDK smoke test — ADR-1239 Phase E / #1683 Slice 2.
+ *
+ * Proves the Host-Integration Interface is PUBLISHED: an external developer can
+ * author + wire a new host-plugin against the SDK surface ONLY (no imports of
+ * gsd-core internal paths). This test imports exclusively from the SDK entry —
+ * if a host-plugin author needs a symbol that ISN'T here, the SDK is incomplete.
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+// EXTERNAL-AUTHOR CONTRACT: import ONLY from the published SDK entry.
+const SDK = require('../gsd-core/bin/lib/host-integration-sdk.cjs');
+
+test('SDK exports the full public surface a host-plugin author needs', () => {
+  assert.equal(typeof SDK.PROTOCOL_VERSION, 'number');
+  assert.ok(SDK.HOST_INTEGRATION_AXES, 'negotiated schema (axes)');
+  assert.ok(SDK.INTERFACE_POINTS, 'interface points');
+  assert.ok(SDK.PROFILE_BASELINES, 'profile baselines');
+
+  const fns = [
+    'negotiateHostCapabilities', 'profileOf', 'degradationFor',
+    'hookEventSurfaceFor', 'shouldFlattenDispatch',
+    'createDeclarativeAdapter', 'createImperativeAdapter',
+    'createModelAdapter', 'createHookBus', 'createStateIO',
+    'buildHandshakeRequest', 'handleHandshakeRequest',
+  ];
+  for (const fn of fns) {
+    assert.equal(typeof SDK[fn], 'function', `SDK must export function: ${fn}`);
+  }
+  assert.equal(typeof SDK.HANDSHAKE_METHOD, 'string');
+});
+
+test('the SDK surface is frozen (immutable public contract)', () => {
+  assert.equal(Object.isFrozen(SDK), true);
+});
+
+test('an external author can build a host-plugin against the SDK surface ONLY', () => {
+  // Compose a minimal host-plugin using EXCLUSIVELY the SDK entry — mirrors what
+  // an external author writes. No require() of any internal path succeeds here.
+  const model = SDK.createModelAdapter({ modelMode: 'passive' });
+  const bus = SDK.createHookBus({ bus: 'engine' });
+  const io = SDK.createStateIO({ io: 'filesystem' });
+  const adapter = SDK.createImperativeAdapter({ runtime: 'my-third-party-host' });
+
+  // Negotiate this host's capabilities via the SDK handshake.
+  const req = SDK.buildHandshakeRequest({ embeddingMode: 'imperative', runtime: 'node' });
+  const result = SDK.handleHandshakeRequest(req);
+  const profile = SDK.profileOf(result.effective);
+
+  assert.equal(model.mode, 'passive');
+  assert.equal(bus.bus, 'engine');
+  assert.equal(io.io, 'filesystem');
+  assert.equal(adapter.kind, 'imperative');
+  assert.equal(adapter.runtime, 'my-third-party-host');
+  assert.equal(profile, 'programmatic-cli');
+  assert.ok(result.effective && result.points, 'handshake yields a negotiated result');
+});
+
+test('the SDK handshake round-trips for a declarative host authored externally', () => {
+  const req = SDK.buildHandshakeRequest({ embeddingMode: 'declarative', commandSurface: 'slash-file' });
+  const result = SDK.handleHandshakeRequest(req);
+  assert.equal(SDK.profileOf(result.effective), 'declarative-cli');
+});


### PR DESCRIPTION
## Feature PR

> **Slice PR — Phase 6 (#1683) Slice 2** (published Host-Integration SDK surface). The single public entry host-plugin authors import + a smoke test building a third-party host against it only. Does NOT complete #1683 (docs + versioning policy + ADR Accepted remain). `Closes #1683` (gate requires closes/fixes/resolves; #1683 will be **reopened post-merge** — slice not complete; `next` is the default branch).

## Linked Issue

Closes #1683

> #1683 carries `approved-feature` (Phase 6 of epic #1678, ADR-1239 Phase E).

---

## Feature summary

Publishes the Host-Integration Interface as an SDK: `src/host-integration-sdk.cts` is the single frozen public surface (schema + classification + the five adapters + the serialized handshake). A smoke test imports ONLY from that entry and builds a third-party host-plugin end-to-end — proving an external author can wire a host without gsd-core internals.

## What changed

### New files

| File | Purpose |
|------|---------|
| `src/host-integration-sdk.cts` | The published SDK entry — frozen re-export of the public surface (axes/version, negotiation/classification, declarative/imperative/model/hook/state adapters, serialized handshake) |
| `tests/sdk-smoke.test.cjs` | Imports ONLY the SDK entry; asserts the full surface + builds a third-party host-plugin end-to-end (external-author contract) |

### Modified files

| File | What changed |
|------|-------------|
| `eslint.config.mjs` | ignore tsc-emitted `host-integration-sdk.cjs` (ADR-457) |
| `docs/INVENTORY-MANIFEST.json` | + host-integration-sdk.cjs |

## Implementation notes

- The SDK entry is the CONTRACT: everything it re-exports is public + versioned (PROTOCOL_VERSION governs the set); everything else stays internal. Frozen so consumers can't mutate the public shape.
- The smoke test is the "external author can build against the published surface only" AC proof — it requires no internal path.
- Reference host-plugins (OpenCode/Antigravity/pi/VS Code from Phase 5) are the canonical examples an SDK author mirrors.

## Spec compliance

Slice 2 — partial toward #1683 AC.

- [x] (this slice) Host-Integration Interface published as an SDK; an external developer can author + wire a new host-plugin without modifying gsd-core source (smoke test)
- Remaining #1683 AC: Diátaxis docs (how-to/tutorial/reference) + versioning/deprecation policy + ADR-1239 Status → Accepted

## Testing

### Test coverage
`tests/sdk-smoke.test.cjs`: full public surface present; SDK frozen; build a third-party host-plugin from the SDK entry only (compose adapters + handshake + classify).

### Platforms tested
- [ ] macOS / Windows (via CI)
- [x] Linux — `gsd-test` green (22277/22273+4, verdict `passed`) on `next`

---

## Scope confirmation
- [x] within approved scope (Slice 2 of #1683)
- [x] internal SDK entry; no user-facing behavior change (docs land in a later #1683 slice)

## Documentation
- [x] no user-facing docs impact yet (Diátaxis docs land in the next #1683 slice)

## Checklist
- [x] `Closes #1683` (#1683 will be reopened post-merge — slice not complete)
- [x] #1683 has `approved-feature`
- [x] `gsd-test` green (linux)
- [x] new SDK smoke test + eslint-ignore + inventory manifest in sync
- [x] no changeset (internal SDK surface; no user-facing change)
- [x] no new deps

## Breaking changes
None.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/1939"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785622651&installation_id=134682257&pr_number=1939&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F1939&signature=e60a649813b5072ac52f1c8d387c51d525ebdba70d2c5f166cc3553b848170dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->