### PR TITLE
fix(#1993): milestone --ws requirements archive header points at workstream path

### DIFF
--- a/.changeset/1993-milestone-ws-requirements-header.md
+++ b/.changeset/1993-milestone-ws-requirements-header.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`milestone complete --ws` requirements archive header now points at the workstream REQUIREMENTS.md** — the archive header string hardcoded the root path (`` `…see .planning/REQUIREMENTS.md` ``), so a workstream archive directed readers at the wrong file even though #1917 had already fixed the archive *locations* to land inside the workstream. The display path is now derived from the same workstream-aware `reqPath` the writer uses (`path.relative(cwd, reqPath)`), so root behavior is byte-identical and the workstream case correctly reads `.planning/workstreams/<ws>/REQUIREMENTS.md`. (#1993)

--- a/.changeset/1993-milestone-ws-requirements-header.md
+++ b/.changeset/1993-milestone-ws-requirements-header.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 2015
 ---
 **`milestone complete --ws` requirements archive header now points at the workstream REQUIREMENTS.md** — the archive header string hardcoded the root path (`` `…see .planning/REQUIREMENTS.md` ``), so a workstream archive directed readers at the wrong file even though #1917 had already fixed the archive *locations* to land inside the workstream. The display path is now derived from the same workstream-aware `reqPath` the writer uses (`path.relative(cwd, reqPath)`), so root behavior is byte-identical and the workstream case correctly reads `.planning/workstreams/<ws>/REQUIREMENTS.md`. (#1993)

--- a/src/milestone.cts
+++ b/src/milestone.cts
@@ -287,7 +287,9 @@ function cmdMilestoneComplete(cwd: string, version: string, options: MilestoneCo
     // Derive the display path from the same source the writer uses (reqPath), so a
     // workstream archive header points at `.planning/workstreams/<ws>/REQUIREMENTS.md`
     // instead of the hardcoded root path (#1993). Root case is byte-identical.
-    const reqDisplay = path.relative(cwd, reqPath);
+    // Normalize to POSIX separators so the header is cross-platform (Windows
+    // path.relative yields backslashes; the original literal was forward-slash).
+    const reqDisplay = path.relative(cwd, reqPath).split(path.sep).join('/');
     const archiveHeader = `# Requirements Archive: ${version} ${milestoneName}\n\n**Archived:** ${today}\n**Status:** SHIPPED\n\nFor current requirements, see \`${reqDisplay}\`.\n\n---\n\n`;
     platformWriteSync(path.join(archiveDir, `${version}-REQUIREMENTS.md`), archiveHeader + reqContent);
   }

--- a/src/milestone.cts
+++ b/src/milestone.cts
@@ -284,7 +284,11 @@ function cmdMilestoneComplete(cwd: string, version: string, options: MilestoneCo
   // Archive REQUIREMENTS.md
   if (fs.existsSync(reqPath)) {
     const reqContent = fs.readFileSync(reqPath, 'utf-8');
-    const archiveHeader = `# Requirements Archive: ${version} ${milestoneName}\n\n**Archived:** ${today}\n**Status:** SHIPPED\n\nFor current requirements, see \`.planning/REQUIREMENTS.md\`.\n\n---\n\n`;
+    // Derive the display path from the same source the writer uses (reqPath), so a
+    // workstream archive header points at `.planning/workstreams/<ws>/REQUIREMENTS.md`
+    // instead of the hardcoded root path (#1993). Root case is byte-identical.
+    const reqDisplay = path.relative(cwd, reqPath);
+    const archiveHeader = `# Requirements Archive: ${version} ${milestoneName}\n\n**Archived:** ${today}\n**Status:** SHIPPED\n\nFor current requirements, see \`${reqDisplay}\`.\n\n---\n\n`;
     platformWriteSync(path.join(archiveDir, `${version}-REQUIREMENTS.md`), archiveHeader + reqContent);
   }
 

--- a/tests/milestone.test.cjs
+++ b/tests/milestone.test.cjs
@@ -758,6 +758,36 @@ describe('#1911 — milestone complete --ws archives to the workstream', () => {
       'must not archive to root .planning/milestones/ in workstream mode',
     );
   });
+
+  test('#1993 — --ws requirements archive header points at the workstream REQUIREMENTS.md, not root', () => {
+    const wsBase = path.join(tmpDir, '.planning', 'workstreams', 'ws1');
+    fs.mkdirSync(path.join(wsBase, 'phases', '01-foo'), { recursive: true });
+    fs.writeFileSync(path.join(wsBase, 'STATE.md'), 'milestone: v2.0\nstatus: executing\n');
+    fs.writeFileSync(
+      path.join(wsBase, 'ROADMAP.md'),
+      '# Roadmap\n## Milestones\n- v2.0 Test (Phases 1) — IN PROGRESS\n## Phases\n### Phase 1: Foo\n**Goal:** foo\n',
+    );
+    fs.writeFileSync(path.join(wsBase, 'REQUIREMENTS.md'), '# Requirements\n- [ ] REQ-01\n');
+    fs.writeFileSync(path.join(wsBase, 'phases', '01-foo', '01-SUMMARY.md'), '---\none-liner: foo done\n---\n# Summary\n');
+    fs.mkdirSync(path.join(tmpDir, '.planning', 'milestones'), { recursive: true });
+
+    const result = runGsdTools('milestone complete v2.0 --ws ws1 --force', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const archivedReq = fs.readFileSync(
+      path.join(wsBase, 'milestones', 'v2.0-REQUIREMENTS.md'), 'utf-8',
+    );
+    // Header must point readers at the WORKSTREAM requirements file...
+    assert.ok(
+      archivedReq.includes('see `.planning/workstreams/ws1/REQUIREMENTS.md`'),
+      `workstream archive header must reference the workstream path; got:\n${archivedReq.split('\n').slice(0, 6).join('\n')}`,
+    );
+    // ...and must NOT point at the root path (the #1993 bug).
+    assert.ok(
+      !/\bsee\s+`\.planning\/REQUIREMENTS\.md`\b/.test(archivedReq),
+      'workstream archive header must not hardcode the root REQUIREMENTS.md path',
+    );
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/tests/milestone.test.cjs
+++ b/tests/milestone.test.cjs
@@ -780,7 +780,7 @@ describe('#1911 — milestone complete --ws archives to the workstream', () => {
     // Header must point readers at the WORKSTREAM requirements file...
     assert.ok(
       archivedReq.includes('see `.planning/workstreams/ws1/REQUIREMENTS.md`'),
-      `workstream archive header must reference the workstream path; got:\n${archivedReq.split('\n').slice(0, 6).join('\n')}`,
+      `workstream archive header must reference the workstream path; got:\n${archivedReq.split(/\r?\n/).slice(0, 6).join('\n')}`,
     );
     // ...and must NOT point at the root path (the #1993 bug).
     assert.ok(


### PR DESCRIPTION
## Fix PR

> Fixes #1993 (follow-up to #1917). `confirmed-bug`.

## What was wrong

`milestone complete --ws` archives the requirements file into the workstream correctly (fixed by #1917), but the **archive header string** still hardcoded the root path: `` For current requirements, see `.planning/REQUIREMENTS.md`. `` — so a workstream archive directed readers at the wrong (root) file.

## Root cause

`src/milestone.cts` — the archive header used a literal `.planning/REQUIREMENTS.md` instead of the same workstream-aware `reqPath` the writer already uses (`planningPaths(cwd).requirements`, which resolves to `.planning/workstreams/<ws>/REQUIREMENTS.md` under `--ws`).

## The fix

Derive the display path from the writer's source of truth: `const reqDisplay = path.relative(cwd, reqPath);` and interpolate `reqDisplay` into the header.
- Root case → `path.relative(cwd, '<cwd>/.planning/REQUIREMENTS.md')` = `.planning/REQUIREMENTS.md` (**byte-identical**).
- `--ws <ws>` → `.planning/workstreams/<ws>/REQUIREMENTS.md`.

## Regression test

Added inside the existing `#1911 — milestone complete --ws` block in `tests/milestone.test.cjs`: runs `milestone complete v2.0 --ws ws1 --force` and asserts the archived `v2.0-REQUIREMENTS.md` header references `.planning/workstreams/ws1/REQUIREMENTS.md` and does NOT match the root literal. The pre-existing root header test still passes (byte-identical).

## Testing
- `tests/milestone.test.cjs` — 59/59 pass (incl. new regression + unchanged root test).
- **`gsd-test -base next` → `outcome:"passed"`, 23561/23561 on linux-node22 + linux-node24, 0 failures.**

## Checklist
- [x] Closes #1993 · [x] root cause addressed (literal vs derived path) · [x] regression test · [x] gsd-test green · [x] `.changeset` (Fixed)

## Breaking changes
None — root behavior is byte-identical; only the previously-wrong `--ws` display path is corrected.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2015"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785815319&installation_id=134682257&pr_number=2015&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2015&signature=ff815610c7da840e28198f5d85553c9e9c7c4d6661dd9c1f31a8df791d08cc54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->