### PR TITLE
fix(#2019): planning-config.md global-learnings path ~/.gsd/learnings → ~/.gsd/knowledge

### DIFF
--- a/.changeset/2019-planning-config-learnings-path.md
+++ b/.changeset/2019-planning-config-learnings-path.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`planning-config.md` global-learnings path corrected to `~/.gsd/knowledge/`** — the `features.global_learnings` row directed users to `~/.gsd/learnings/`, but the implementation (`src/learnings.cts`, `execute-phase.md`) stores and reads global learnings from `~/.gsd/knowledge/`. Anyone following the docs to inspect, back up, or seed their global learnings looked in a directory the code never touches. (#2019)

--- a/.changeset/2019-planning-config-learnings-path.md
+++ b/.changeset/2019-planning-config-learnings-path.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 2026
 ---
 **`planning-config.md` global-learnings path corrected to `~/.gsd/knowledge/`** — the `features.global_learnings` row directed users to `~/.gsd/learnings/`, but the implementation (`src/learnings.cts`, `execute-phase.md`) stores and reads global learnings from `~/.gsd/knowledge/`. Anyone following the docs to inspect, back up, or seed their global learnings looked in a directory the code never touches. (#2019)

--- a/gsd-core/references/planning-config.md
+++ b/gsd-core/references/planning-config.md
@@ -317,7 +317,7 @@ Set via `features.*` namespace (e.g., `"features": { "thinking_partner": true }`
 | Key | Type | Default | Allowed Values | Description |
 |-----|------|---------|----------------|-------------|
 | `features.thinking_partner` | boolean | `false` | `true`, `false` | Enable conditional extended thinking at workflow decision points (used by discuss-phase and plan-phase for architectural tradeoff analysis) |
-| `features.global_learnings` | boolean | `false` | `true`, `false` | Enable injection of global learnings from `~/.gsd/learnings/` into agent prompts |
+| `features.global_learnings` | boolean | `false` | `true`, `false` | Enable injection of global learnings from `~/.gsd/knowledge/` into agent prompts |
 
 ### Hook Fields
 

--- a/tests/fixtures/golden-install-parity/antigravity.json
+++ b/tests/fixtures/golden-install-parity/antigravity.json
@@ -106,7 +106,7 @@
   "gsd-core/references/planner-reviews.md": "da39eace09a10743",
   "gsd-core/references/planner-revision.md": "86ba8a511f081f05",
   "gsd-core/references/planner-source-audit.md": "7de5bdb07232ce0b",
-  "gsd-core/references/planning-config.md": "8ce19741d18507f7",
+  "gsd-core/references/planning-config.md": "49fbbfdac6b8ced4",
   "gsd-core/references/prohibition-probe-fixtures/01-streak-reminder/expected.json": "f10df472f2846cc6",
   "gsd-core/references/prohibition-probe-fixtures/02-clean-utility/expected.json": "31e8a781eeffe020",
   "gsd-core/references/prohibition-probe-fixtures/03-multi-prohibition/expected.json": "70a532a7cc1b6ae8",

--- a/tests/fixtures/golden-install-parity/augment.json
+++ b/tests/fixtures/golden-install-parity/augment.json
@@ -176,7 +176,7 @@
   "gsd-core/references/planner-reviews.md": "dda0193a0fbd4947",
   "gsd-core/references/planner-revision.md": "86ba8a511f081f05",
   "gsd-core/references/planner-source-audit.md": "7de5bdb07232ce0b",
-  "gsd-core/references/planning-config.md": "1c3a3aae2ae89e83",
+  "gsd-core/references/planning-config.md": "7fe958e09e74b6c8",
   "gsd-core/references/prohibition-probe-fixtures/01-streak-reminder/expected.json": "f10df472f2846cc6",
   "gsd-core/references/prohibition-probe-fixtures/02-clean-utility/expected.json": "31e8a781eeffe020",
   "gsd-core/references/prohibition-probe-fixtures/03-multi-prohibition/expected.json": "70a532a7cc1b6ae8",

--- a/tests/fixtures/golden-install-parity/claude.json
+++ b/tests/fixtures/golden-install-parity/claude.json
@@ -105,7 +105,7 @@
   "gsd-core/references/planner-reviews.md": "da39eace09a10743",
   "gsd-core/references/planner-revision.md": "86ba8a511f081f05",
   "gsd-core/references/planner-source-audit.md": "7de5bdb07232ce0b",
-  "gsd-core/references/planning-config.md": "4435dfdc3381233f",
+  "gsd-core/references/planning-config.md": "35aa39fef2641311",
   "gsd-core/references/prohibition-probe-fixtures/01-streak-reminder/expected.json": "f10df472f2846cc6",
   "gsd-core/references/prohibition-probe-fixtures/02-clean-utility/expected.json": "31e8a781eeffe020",
   "gsd-core/references/prohibition-probe-fixtures/03-multi-prohibition/expected.json": "70a532a7cc1b6ae8",

--- a/tests/fixtures/golden-install-parity/cline.json
+++ b/tests/fixtures/golden-install-parity/cline.json
@@ -109,7 +109,7 @@
   "gsd-core/references/planner-reviews.md": "dda0193a0fbd4947",
   "gsd-core/references/planner-revision.md": "86ba8a511f081f05",
   "gsd-core/references/planner-source-audit.md": "7de5bdb07232ce0b",
-  "gsd-core/references/planning-config.md": "c386ac9e804f862e",
+  "gsd-core/references/planning-config.md": "15a5fc63268379d4",
   "gsd-core/references/prohibition-probe-fixtures/01-streak-reminder/expected.json": "f10df472f2846cc6",
   "gsd-core/references/prohibition-probe-fixtures/02-clean-utility/expected.json": "31e8a781eeffe020",
   "gsd-core/references/prohibition-probe-fixtures/03-multi-prohibition/expected.json": "70a532a7cc1b6ae8",

--- a/tests/fixtures/golden-install-parity/codebuddy.json
+++ b/tests/fixtures/golden-install-parity/codebuddy.json
@@ -176,7 +176,7 @@
   "gsd-core/references/planner-reviews.md": "dda0193a0fbd4947",
   "gsd-core/references/planner-revision.md": "86ba8a511f081f05",
   "gsd-core/references/planner-source-audit.md": "7de5bdb07232ce0b",
-  "gsd-core/references/planning-config.md": "1c3a3aae2ae89e83",
+  "gsd-core/references/planning-config.md": "7fe958e09e74b6c8",
   "gsd-core/references/prohibition-probe-fixtures/01-streak-reminder/expected.json": "f10df472f2846cc6",
   "gsd-core/references/prohibition-probe-fixtures/02-clean-utility/expected.json": "31e8a781eeffe020",
   "gsd-core/references/prohibition-probe-fixtures/03-multi-prohibition/expected.json": "70a532a7cc1b6ae8",

--- a/tests/fixtures/golden-install-parity/codex.json
+++ b/tests/fixtures/golden-install-parity/codex.json
@@ -141,7 +141,7 @@
   "gsd-core/references/planner-reviews.md": "7889bfa28e82156b",
   "gsd-core/references/planner-revision.md": "2ebf1a714d1ec4bf",
   "gsd-core/references/planner-source-audit.md": "7de5bdb07232ce0b",
-  "gsd-core/references/planning-config.md": "0767f44905c9a65e",
+  "gsd-core/references/planning-config.md": "8593e6610784a339",
   "gsd-core/references/prohibition-probe-fixtures/01-streak-reminder/expected.json": "f10df472f2846cc6",
   "gsd-core/references/prohibition-probe-fixtures/02-clean-utility/expected.json": "31e8a781eeffe020",
   "gsd-core/references/prohibition-probe-fixtures/03-multi-prohibition/expected.json": "70a532a7cc1b6ae8",

--- a/tests/fixtures/golden-install-parity/copilot.json
+++ b/tests/fixtures/golden-install-parity/copilot.json
@@ -107,7 +107,7 @@
   "gsd-core/references/planner-reviews.md": "da39eace09a10743",
   "gsd-core/references/planner-revision.md": "86ba8a511f081f05",
   "gsd-core/references/planner-source-audit.md": "7de5bdb07232ce0b",
-  "gsd-core/references/planning-config.md": "ea950944302fba67",
+  "gsd-core/references/planning-config.md": "091d7541826f8cb0",
   "gsd-core/references/prohibition-probe-fixtures/01-streak-reminder/expected.json": "f10df472f2846cc6",
   "gsd-core/references/prohibition-probe-fixtures/02-clean-utility/expected.json": "31e8a781eeffe020",
   "gsd-core/references/prohibition-probe-fixtures/03-multi-prohibition/expected.json": "70a532a7cc1b6ae8",

--- a/tests/fixtures/golden-install-parity/cursor.json
+++ b/tests/fixtures/golden-install-parity/cursor.json
@@ -176,7 +176,7 @@
   "gsd-core/references/planner-reviews.md": "da39eace09a10743",
   "gsd-core/references/planner-revision.md": "86ba8a511f081f05",
   "gsd-core/references/planner-source-audit.md": "7de5bdb07232ce0b",
-  "gsd-core/references/planning-config.md": "e2330447f33f6609",
+  "gsd-core/references/planning-config.md": "a7b41174b754b215",
   "gsd-core/references/prohibition-probe-fixtures/01-streak-reminder/expected.json": "f10df472f2846cc6",
   "gsd-core/references/prohibition-probe-fixtures/02-clean-utility/expected.json": "31e8a781eeffe020",
   "gsd-core/references/prohibition-probe-fixtures/03-multi-prohibition/expected.json": "70a532a7cc1b6ae8",

--- a/tests/fixtures/golden-install-parity/hermes.json
+++ b/tests/fixtures/golden-install-parity/hermes.json
@@ -106,7 +106,7 @@
   "gsd-core/references/planner-reviews.md": "da39eace09a10743",
   "gsd-core/references/planner-revision.md": "86ba8a511f081f05",
   "gsd-core/references/planner-source-audit.md": "7de5bdb07232ce0b",
-  "gsd-core/references/planning-config.md": "9b5f8ed49024cdbf",
+  "gsd-core/references/planning-config.md": "b5a719401e701e12",
   "gsd-core/references/prohibition-probe-fixtures/01-streak-reminder/expected.json": "f10df472f2846cc6",
   "gsd-core/references/prohibition-probe-fixtures/02-clean-utility/expected.json": "31e8a781eeffe020",
   "gsd-core/references/prohibition-probe-fixtures/03-multi-prohibition/expected.json": "70a532a7cc1b6ae8",

--- a/tests/fixtures/golden-install-parity/kilo.json
+++ b/tests/fixtures/golden-install-parity/kilo.json
@@ -176,7 +176,7 @@
   "gsd-core/references/planner-reviews.md": "da39eace09a10743",
   "gsd-core/references/planner-revision.md": "86ba8a511f081f05",
   "gsd-core/references/planner-source-audit.md": "7de5bdb07232ce0b",
-  "gsd-core/references/planning-config.md": "4acefb3c71169c84",
+  "gsd-core/references/planning-config.md": "af0a9694b3c39557",
   "gsd-core/references/prohibition-probe-fixtures/01-streak-reminder/expected.json": "f10df472f2846cc6",
   "gsd-core/references/prohibition-probe-fixtures/02-clean-utility/expected.json": "31e8a781eeffe020",
   "gsd-core/references/prohibition-probe-fixtures/03-multi-prohibition/expected.json": "70a532a7cc1b6ae8",

--- a/tests/fixtures/golden-install-parity/kimi.json
+++ b/tests/fixtures/golden-install-parity/kimi.json
@@ -142,7 +142,7 @@
   "gsd-core/references/planner-reviews.md": "dda0193a0fbd4947",
   "gsd-core/references/planner-revision.md": "86ba8a511f081f05",
   "gsd-core/references/planner-source-audit.md": "7de5bdb07232ce0b",
-  "gsd-core/references/planning-config.md": "1c3a3aae2ae89e83",
+  "gsd-core/references/planning-config.md": "7fe958e09e74b6c8",
   "gsd-core/references/prohibition-probe-fixtures/01-streak-reminder/expected.json": "f10df472f2846cc6",
   "gsd-core/references/prohibition-probe-fixtures/02-clean-utility/expected.json": "31e8a781eeffe020",
   "gsd-core/references/prohibition-probe-fixtures/03-multi-prohibition/expected.json": "70a532a7cc1b6ae8",

--- a/tests/fixtures/golden-install-parity/opencode.json
+++ b/tests/fixtures/golden-install-parity/opencode.json
@@ -176,7 +176,7 @@
   "gsd-core/references/planner-reviews.md": "da39eace09a10743",
   "gsd-core/references/planner-revision.md": "86ba8a511f081f05",
   "gsd-core/references/planner-source-audit.md": "7de5bdb07232ce0b",
-  "gsd-core/references/planning-config.md": "4acefb3c71169c84",
+  "gsd-core/references/planning-config.md": "af0a9694b3c39557",
   "gsd-core/references/prohibition-probe-fixtures/01-streak-reminder/expected.json": "f10df472f2846cc6",
   "gsd-core/references/prohibition-probe-fixtures/02-clean-utility/expected.json": "31e8a781eeffe020",
   "gsd-core/references/prohibition-probe-fixtures/03-multi-prohibition/expected.json": "70a532a7cc1b6ae8",

--- a/tests/fixtures/golden-install-parity/qwen.json
+++ b/tests/fixtures/golden-install-parity/qwen.json
@@ -106,7 +106,7 @@
   "gsd-core/references/planner-reviews.md": "da39eace09a10743",
   "gsd-core/references/planner-revision.md": "86ba8a511f081f05",
   "gsd-core/references/planner-source-audit.md": "7de5bdb07232ce0b",
-  "gsd-core/references/planning-config.md": "32430b855023bfdb",
+  "gsd-core/references/planning-config.md": "e8087cf6aae8d56f",
   "gsd-core/references/prohibition-probe-fixtures/01-streak-reminder/expected.json": "f10df472f2846cc6",
   "gsd-core/references/prohibition-probe-fixtures/02-clean-utility/expected.json": "31e8a781eeffe020",
   "gsd-core/references/prohibition-probe-fixtures/03-multi-prohibition/expected.json": "70a532a7cc1b6ae8",

--- a/tests/fixtures/golden-install-parity/trae.json
+++ b/tests/fixtures/golden-install-parity/trae.json
@@ -106,7 +106,7 @@
   "gsd-core/references/planner-reviews.md": "da39eace09a10743",
   "gsd-core/references/planner-revision.md": "86ba8a511f081f05",
   "gsd-core/references/planner-source-audit.md": "7de5bdb07232ce0b",
-  "gsd-core/references/planning-config.md": "970c47f816acdb30",
+  "gsd-core/references/planning-config.md": "33c5b0685be54e96",
   "gsd-core/references/prohibition-probe-fixtures/01-streak-reminder/expected.json": "f10df472f2846cc6",
   "gsd-core/references/prohibition-probe-fixtures/02-clean-utility/expected.json": "31e8a781eeffe020",
   "gsd-core/references/prohibition-probe-fixtures/03-multi-prohibition/expected.json": "70a532a7cc1b6ae8",

--- a/tests/fixtures/golden-install-parity/windsurf.json
+++ b/tests/fixtures/golden-install-parity/windsurf.json
@@ -106,7 +106,7 @@
   "gsd-core/references/planner-reviews.md": "da39eace09a10743",
   "gsd-core/references/planner-revision.md": "86ba8a511f081f05",
   "gsd-core/references/planner-source-audit.md": "7de5bdb07232ce0b",
-  "gsd-core/references/planning-config.md": "742e11db47c5c0aa",
+  "gsd-core/references/planning-config.md": "062db9fe16ec76f9",
   "gsd-core/references/prohibition-probe-fixtures/01-streak-reminder/expected.json": "f10df472f2846cc6",
   "gsd-core/references/prohibition-probe-fixtures/02-clean-utility/expected.json": "31e8a781eeffe020",
   "gsd-core/references/prohibition-probe-fixtures/03-multi-prohibition/expected.json": "70a532a7cc1b6ae8",


### PR DESCRIPTION
## Fix PR — #2019 (`confirmed-bug`, docs)

`gsd-core/references/planning-config.md` `features.global_learnings` row pointed at `~/.gsd/learnings/`, but the implementation (`src/learnings.cts:4`, `execute-phase.md:1524`) stores/reads global learnings from `~/.gsd/knowledge/`. Anyone following the docs inspected/backed-up/seeded a directory the code never touches.

## Fix
One-line doc correction: `~/.gsd/learnings/` → `~/.gsd/knowledge/`. Verified no other `~/.gsd/learnings/` references exist in docs/references/workflows.

## Testing
- `gsd-test -base next -bench holodeck` → `outcome:"passed"`, 23707/23707, 0 failures.
- Goldens recaptured (planning-config.md is an installed reference).

Closes #2019. Fixed changeset (docs — exempt from docs-required lint).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2026"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785871993&installation_id=134682257&pr_number=2026&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2026&signature=2bae11b1c3a505a237af72971f9d77afc2d6c9dac21144274aa18975c0965b78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->