### PR TITLE
fix(#2018): use helpers.cleanup() not raw fs.rmSync in surface test

### DIFF
--- a/tests/gate-predicate-evaluator.test.cjs
+++ b/tests/gate-predicate-evaluator.test.cjs
@@ -22,8 +22,6 @@ const fc = require('fast-check');
 
 const {
   evaluatePredicate,
-  evaluateCommandExitZero,
-  interpolate,
   COMMAND_EXIT_ZERO_DEFAULT_TIMEOUT_MS,
   COMMAND_MAX_OUTPUT_CHARS,
   COMMAND_MAX_LENGTH,

--- a/tests/surface-empty-manifest-agents.test.cjs
+++ b/tests/surface-empty-manifest-agents.test.cjs
@@ -13,6 +13,7 @@ const os = require('os');
 const path = require('path');
 
 const { _syncGsdDir } = require('../gsd-core/bin/lib/surface.cjs');
+const { cleanup } = require('./helpers.cjs');
 
 function tmp() { return fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-surface-empty-')); }
 
@@ -26,7 +27,7 @@ describe('#2018 — empty manifest must not delete gsd-* agents', () => {
     }
     // Staged dir is EMPTY (unresolvable manifest → nothing staged)
   });
-  afterEach(() => { try { fs.rmSync(dest, { recursive: true, force: true }); } catch {} try { fs.rmSync(staged, { recursive: true, force: true }); } catch {} });
+  afterEach(() => { cleanup(dest); cleanup(staged); });
 
   test('empty manifest → agents preserved (not deleted)', () => {
     _syncGsdDir(staged, dest, 'agents', new Map());


### PR DESCRIPTION
## Summary

Fixes a `lint-tests` failure on `next` introduced by #2031 (#2018): the regression
test `tests/surface-empty-manifest-agents.test.cjs` used **raw `fs.rmSync()`** in
`afterEach`, which trips the `local/no-raw-rmsync-in-tests` eslint rule (raw rmSync
in tests lacks the Windows-EBUSY retry budget carried by `helpers.cleanup()`).

The error slipped through because local `npm run lint:ci` uses `eslint --cache`,
which false-greened the file across the merge sequence; CI's `lint-tests` job runs
without a cache and caught it once merged to `next`.

## Linked Issue

Fixes #2018 — corrects a lint defect in the regression test shipped with that fix.

## Changes

- `tests/surface-empty-manifest-agents.test.cjs` — `afterEach` now calls
  `helpers.cleanup(dest); helpers.cleanup(staged)` instead of two raw `fs.rmSync()`.
- `tests/gate-predicate-evaluator.test.cjs` — drop two unused destructured imports
  (`evaluateCommandExitZero`, `interpolate`) that emitted `no-unused-vars` warnings.

## Testing

- `npx eslint . --no-cache` → **No issues found** (0 errors, 0 warnings).
- `node --test` on both touched files → 30/30 pass.
- Full `npm run lint:ci` (eslint cache cleared, CI-parity) → clean.
- gsd-test (linux node22+node24) → `outcome:"passed"`, 0 failures.

## Platforms tested

- [x] macOS (local)
- [x] Linux (gsd-test)
- [ ] Windows — test-only lint fix; `helpers.cleanup()` is the Windows-safe path.
