### PR TITLE
fix(#2043): extractPhaseToken rejects single-digit slug words after first segment

### DIFF
--- a/.changeset/agile-pumas-dart.md
+++ b/.changeset/agile-pumas-dart.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 2047
+---
+phase dir whose slug begins with a single-digit word was unresolvable by phase number — e.g. `46-6-rs-pipeline-orchestrator` could not be found via `gsd-tools query init.plan-phase 46` despite being committed and present on disk

--- a/src/phase-id.cts
+++ b/src/phase-id.cts
@@ -207,7 +207,13 @@ function extractPhaseToken(dirName: string): string {
   const tokenSegments: string[] = [];
   for (let i = 0; i < segments.length; i++) {
     const seg = segments[i];
-    if (/^\d/.test(seg) || (i === 0 && /^[A-Za-z]{1,3}\d/.test(seg))) {
+    if (i === 0 && /^[A-Za-z]{1,3}\d/.test(seg)) {
+      tokenSegments.push(seg);
+      continue;
+    }
+    const numericPrefix = seg.match(/^\d+/);
+    if (!numericPrefix) break;
+    if (i === 0 || numericPrefix[0].length >= 2) {
       tokenSegments.push(seg);
     } else {
       break;

--- a/tests/phase-id.test.cjs
+++ b/tests/phase-id.test.cjs
@@ -217,6 +217,13 @@ describe('extractPhaseToken', () => {
   test('stops at first non-numeric-starting segment', () => {
     assert.strictEqual(phaseId.extractPhaseToken('01-02-name-03'), '01-02');
   });
+
+  test('does not treat a single-digit slug word as part of the phase token', () => {
+    assert.strictEqual(
+      phaseId.extractPhaseToken('46-6-rs-pipeline-orchestrator'),
+      '46'
+    );
+  });
 });
 
 // ─── phaseTokenMatches ────────────────────────────────────────────────────────


### PR DESCRIPTION

## Linked Issue

Fixes #2043

## What was broken

`gsd-tools query init.plan-phase 46` failed to locate `.planning/phases/46-6-rs-pipeline-orchestrator` even though the directory and context file existed. `extractPhaseToken()` incorrectly parsed the directory name as phase token `46-6` instead of `46`, causing phase lookup to fail.

## What this fix does

`extractPhaseToken()` now treats only the first numeric segment as part of the phase token unconditionally. Subsequent numeric segments are collected only when their numeric prefix contains at least two digits, preventing single-digit slug words from being interpreted as sub-phase tokens while preserving existing multi-segment phase IDs.

## Root cause

The extraction loop matched every digit-leading segment using `/^\d/`, so a slug beginning with a single-digit word (for example, `46-6-rs-pipeline-orchestrator`) was over-collected into the phase token. This produced `46-6` instead of `46`, causing `phaseTokenMatches()` to fail and preventing the phase directory from being resolved.

## Testing

### How I verified the fix

Verified manually before and after the change:

```text
extractPhaseToken('46-6-rs-pipeline-orchestrator')
// before: '46-6'
// after:  '46'

phaseTokenMatches('46-6-rs-pipeline-orchestrator', '46')
// before: false
// after:  true
```

Added a regression test covering a phase directory whose slug begins with a single-digit word.
$ node --test tests/phase-id.test.cjs 2>&1 (all tests passed).

### Regression test added?

* [x] Yes — added a test that would have caught this bug
* [ ] No — explain why:

### Platforms tested

* [ ] macOS
* [x] Windows (including backslash path handling)
* [ ] Linux
* [x] N/A (not platform-specific)

### Runtimes tested

* [ ] Claude Code
* [ ] Gemini CLI
* [x] OpenCode
* [ ] Other: ___
* [ ] N/A (not runtime-specific)

---

## Checklist

* [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
* [x] Linked issue has the `confirmed-bug` label
* [x] Fix is scoped to the reported bug — no unrelated changes included
* [x] Regression test added (or explained why not)
* [x] All existing tests pass (`npm test`)
* [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
* [x] No unnecessary dependencies added

## Breaking changes

None