### PR TITLE
fix(init): reject foreign-prefixed phase fallthrough

### DIFF
--- a/src/init.cts
+++ b/src/init.cts
@@ -73,7 +73,7 @@ const {
   extractCurrentMilestone,
 } = roadmapParser;
 const { pathExistsInternal, generateSlugInternal, toPosixPath } = coreUtils;
-const { normalizePhaseName, phaseTokenMatches, stripProjectCodePrefix } = phaseId;
+const { escapeRegex, normalizePhaseName, phaseTokenMatches, stripProjectCodePrefix } = phaseId;
 const { pruneOrphanedWorktrees } = worktreeSafety;
 
 const {
@@ -94,6 +94,27 @@ void stripShippedMilestones;
 
 // Accept all bold/colon variants of the Requirements header (#2769)
 const REQUIREMENTS_HEADER_RE = /^\*\*Requirements:?\*\*[^\S\n]*:?[^\S\n]*([^\n]*)$/m;
+
+function parsePhasePrefix(phase: unknown): string | null {
+  const match = String(phase).match(/^([A-Z][A-Z0-9_]*)-(?=\d)/i);
+  return match ? match[1] : null;
+}
+
+function isForeignPrefixedPhaseQuery(phase: unknown, projectCode: unknown): boolean {
+  const prefix = parsePhasePrefix(phase);
+  if (!prefix) return false;
+  const configured = typeof projectCode === 'string' ? projectCode.trim() : '';
+  return !configured || prefix.toUpperCase() !== configured.toUpperCase();
+}
+
+function phaseInfoMatchesExactPrefix(phaseInfo: Record<string, unknown> | null, phase: string): boolean {
+  return String(phaseInfo?.['phase_number'] || '').toUpperCase() === String(phase).toUpperCase();
+}
+
+function roadmapPhaseMatchesExactPrefix(roadmapPhase: Record<string, unknown> | null, phase: string): boolean {
+  const section = typeof roadmapPhase?.['section'] === 'string' ? roadmapPhase['section'] as string : '';
+  return new RegExp(`^#{2,4}\\s*Phase\\s+${escapeRegex(phase)}(?:\\b|\\s|:)`, 'i').test(section);
+}
 
 function listPhaseSummaryFiles(phaseDir: string): string[] {
   return (scanPhasePlans(phaseDir) as unknown as Record<string, string[]>)['summaryFiles'];
@@ -429,9 +450,16 @@ function cmdInitPlanPhase(
   }
 
   const config = loadConfig(cwd);
+  const foreignPrefixedPhase = isForeignPrefixedPhaseQuery(phase, config.project_code);
   let phaseInfo = findPhaseInternal(cwd, phase) as unknown as Record<string, unknown> | null;
+  if (foreignPrefixedPhase && !phaseInfoMatchesExactPrefix(phaseInfo, phase)) {
+    phaseInfo = null;
+  }
 
-  const roadmapPhase = getRoadmapPhaseInternal(cwd, phase) as unknown as Record<string, unknown> | null;
+  let roadmapPhase = getRoadmapPhaseInternal(cwd, phase) as unknown as Record<string, unknown> | null;
+  if (foreignPrefixedPhase && !roadmapPhaseMatchesExactPrefix(roadmapPhase, phase)) {
+    roadmapPhase = null;
+  }
 
   if (phaseInfo?.['archived'] && roadmapPhase?.['found']) {
     phaseInfo = null;

--- a/tests/init.test.cjs
+++ b/tests/init.test.cjs
@@ -90,6 +90,46 @@ describe('init commands', () => {
     assert.strictEqual(output.uat_path, '.planning/phases/03-api/03-UAT.md');
   });
 
+  test('init plan-phase does not collapse unrelated prefixed task IDs into numeric phases', () => {
+    seedPhase(tmpDir, '01-stable-baseline-on-main', {
+      '01-CONTEXT.md': '# Phase Context',
+    });
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      '# Roadmap\n\n### Phase 1: Stable Baseline On Main\n**Goal:** Establish baseline\n**Plans:** 1 plan\n',
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({ project_code: 'LKML' }, null, 2),
+    );
+
+    const result = runGsdTools('init plan-phase MEM-01', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.phase_found, false);
+    assert.strictEqual(output.phase_dir, null);
+    assert.strictEqual(output.phase_number, null);
+  });
+
+  test('init plan-phase still accepts configured project-code-prefixed phase dirs', () => {
+    seedPhase(tmpDir, 'LKML-01-stable-baseline-on-main', {
+      'LKML-01-CONTEXT.md': '# Phase Context',
+    });
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({ project_code: 'LKML' }, null, 2),
+    );
+
+    const result = runGsdTools('init plan-phase LKML-01', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.phase_found, true);
+    assert.strictEqual(output.phase_dir, '.planning/phases/LKML-01-stable-baseline-on-main');
+    assert.strictEqual(output.phase_number, 'LKML-01');
+  });
+
   test('init plan-phase exposes text_mode from config (defaults false)', () => {
     const result = runGsdTools('init plan-phase 03', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> -- Enhancement: use [enhancement.md](?template=enhancement.md)
> -- Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

Fixes #2056

> The linked issue must have the `confirmed-bug` label. If it doesn't, ask a maintainer to confirm the bug before continuing.

---

## What was broken

`init plan-phase` could accept a foreign-prefixed task/workstream identifier such as `MEM-01` and fall through to numeric phase matching, resolving it as Phase 01 in a project where `project_code` is different.

## What this fix does

The fix keeps the existing `normalizePhaseName()` project-code-prefix contract intact, but adds an `init plan-phase` guard: foreign-prefixed queries must have exact prefixed phase evidence before fallback results are accepted. Configured project-code-prefixed phase directories such as `LKML-01` still resolve.

## Root cause

`init plan-phase` combined `findPhaseInternal()` and `getRoadmapPhaseInternal()` results without rejecting fallback matches for unrelated prefixes. In current upstream, global prefix stripping is intentional for project-code behavior, so the correction belongs at the lookup call site rather than in `normalizePhaseName()`.

## Testing

### How I verified the fix

- `npm ci --ignore-scripts --cache /tmp/npm-cache-gsd-core-mem01`
- `npm run build:lib`
- `node --test tests/init.test.cjs`
- `node --test tests/phase-id.test.cjs`

### Regression test added?

- [x] Yes -- added a test that would have caught this bug
- [ ] No -- explain why:

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [x] Other: Codex
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` -- **PR will be auto-closed if missing**
- [ ] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug -- no unrelated changes included
- [x] Regression test added (or explained why not)
- [ ] All existing tests pass (`npm test`)
- [ ] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) -- or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None