### PR TITLE
fix: `phase complete` checkbox regex matches later phases that mention the target phase

### DIFF
--- a/src/phase.cts
+++ b/src/phase.cts
@@ -1447,8 +1447,11 @@ function cmdPhaseComplete(cwd: string, phaseNum: string, raw: boolean): void {
         roadmapContent = originalRoadmapContent;
 
         const phaseEscaped = phaseMarkdownRegexSource(phaseNum);
+        // Only whitespace/markdown emphasis may sit between "]" and "Phase" —
+        // a greedy `.*` lets an unchecked later phase match when its text
+        // merely mentions this phase (e.g. "after Phase 1 verification").
         const checkboxPattern = new RegExp(
-          `(-\\s*\\[)[ ](\\]\\s*.*Phase\\s+${phaseEscaped}${OPTIONAL_PHASE_TAG_SOURCE}[:\\s][^\\n]*)`,
+          `(-\\s*\\[)[ ](\\]\\s*[*_~\`]*\\s*Phase\\s+${phaseEscaped}${OPTIONAL_PHASE_TAG_SOURCE}[:\\s][^\\n]*)`,
           'i',
         );
         roadmapContent = roadmapContent.replace(

--- a/tests/phase.test.cjs
+++ b/tests/phase.test.cjs
@@ -2577,6 +2577,90 @@ describe('phase complete command', () => {
     assert.ok(progressRow, 'Progress row must be updated to Complete with a date');
   });
 
+  test('already-checked phase is a checkbox no-op — later phase mentioning it stays unchecked', () => {
+    // Regression: the checkbox regex used a greedy `.*` between "]" and
+    // "Phase N", so with Phase 1 already [x] the first match was Phase 2's
+    // unchecked line (its text mentions "Phase 1") and Phase 2 got marked
+    // complete even though it never ran.
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      `# Roadmap
+
+- [x] **Phase 1: Core** - foundations
+- [ ] **Phase 2: Polish** - hardening (only as needed after Phase 1 verification)
+
+### Phase 1: Core
+**Goal:** Foundations
+**Plans:** 1 plans
+
+### Phase 2: Polish
+**Goal:** Hardening
+`
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'STATE.md'),
+      `# State\n\n**Current Phase:** 01\n**Current Phase Name:** Core\n**Status:** In progress\n**Current Plan:** 01-01\n**Last Activity:** 2025-01-01\n**Last Activity Description:** Working on phase 1\n`
+    );
+
+    const p1 = path.join(tmpDir, '.planning', 'phases', '01-core');
+    fs.mkdirSync(p1, { recursive: true });
+    fs.writeFileSync(path.join(p1, '01-01-PLAN.md'), '# Plan');
+    fs.writeFileSync(path.join(p1, '01-01-SUMMARY.md'), '# Summary');
+    fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '02-polish'), { recursive: true });
+
+    const result = runVerifiedPhaseComplete('phase complete 1', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const roadmap = fs.readFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), 'utf-8');
+    assert.ok(
+      roadmap.includes('- [ ] **Phase 2: Polish** - hardening (only as needed after Phase 1 verification)'),
+      `Phase 2 line must stay unchecked and unmodified; got:\n${roadmap}`
+    );
+    assert.ok(
+      roadmap.includes('- [x] **Phase 1: Core** - foundations'),
+      'Phase 1 line must stay checked'
+    );
+  });
+
+  test('checkbox with bold **Phase N:** style is still checked off', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      `# Roadmap
+
+- [ ] **Phase 1: Core** - foundations
+- [ ] **Phase 2: Polish** - hardening
+
+### Phase 1: Core
+**Goal:** Foundations
+**Plans:** 1 plans
+
+### Phase 2: Polish
+**Goal:** Hardening
+`
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'STATE.md'),
+      `# State\n\n**Current Phase:** 01\n**Current Phase Name:** Core\n**Status:** In progress\n**Current Plan:** 01-01\n**Last Activity:** 2025-01-01\n**Last Activity Description:** Working on phase 1\n`
+    );
+
+    const p1 = path.join(tmpDir, '.planning', 'phases', '01-core');
+    fs.mkdirSync(p1, { recursive: true });
+    fs.writeFileSync(path.join(p1, '01-01-PLAN.md'), '# Plan');
+    fs.writeFileSync(path.join(p1, '01-01-SUMMARY.md'), '# Summary');
+    fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '02-polish'), { recursive: true });
+
+    const result = runVerifiedPhaseComplete('phase complete 1', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const roadmap = fs.readFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), 'utf-8');
+    assert.match(
+      roadmap,
+      /- \[x\] \*\*Phase 1: Core\*\* - foundations \(completed \d{4}-\d{2}-\d{2}\)/,
+      `bold Phase 1 line must be checked with a completion date; got:\n${roadmap}`
+    );
+    assert.ok(roadmap.includes('- [ ] **Phase 2: Polish** - hardening'), 'Phase 2 must stay unchecked');
+  });
+
   test('detects last phase in milestone', () => {
     fs.writeFileSync(
       path.join(tmpDir, '.planning', 'ROADMAP.md'),


### PR DESCRIPTION
## Problem

`cmdPhaseComplete`'s ROADMAP checkbox regex uses a greedy `.*` between `]` and `Phase N`, so any **unchecked** line that merely *mentions* the completed phase also matches. Concrete failure (observed in a real project):

```markdown
- [x] **Phase 1: Core Feed & Posting** - ...
- [ ] **Phase 2: Polish & Edge Cases** - hardening (only as needed after Phase 1 verification)
```

Running `phase complete 1` when Phase 1's box is already checked (idempotent re-run, or the box was ticked earlier in the flow) makes Phase 2's line the first match — Phase 2 gets marked `[x] ... (completed <date>)` even though it never ran. The normal case (target box still unchecked) masked the bug because the target line matches first.

## Fix

Only whitespace/markdown emphasis may sit between `]` and `Phase`: `\]\s*.*Phase\s+` → `` \]\s*[*_~`]*\s*Phase\s+ ``. Both `- [ ] **Phase 1: X**` and `- [ ] Phase 1: X` styles still match; `${OPTIONAL_PHASE_TAG_SOURCE}` untouched. An already-checked target is now a checkbox no-op.

## Testing

- New regression test reproduces the exact corruption; **verified fail-first** (fails on unfixed code with Phase 2 marked complete, passes with the fix).
- Added a bold-style coverage guard.
- Full suite: `tests/phase.test.cjs` 235 pass / 0 fail (1 pre-existing skip).

Changeset fragment follows in a fixup commit once the PR number exists.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2061"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786037999&installation_id=134682257&pr_number=2061&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2061&signature=00ba3b331cbb0dacb7e8a95ff89991013aa4e2c3571d8d4a06cb4bec664c339e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->