### PR TITLE
fix: wire dynamic routing into `resolve-execution` model resolution (#3024)

### DIFF
--- a/src/commands.cts
+++ b/src/commands.cts
@@ -30,7 +30,7 @@ import roadmapParserMod = require('./roadmap-parser.cjs');
 const { extractCurrentMilestone, stripShippedMilestones: _stripShippedMilestones, getMilestoneInfo, getMilestonePhaseFilter, getRoadmapPhaseInternal } = roadmapParserMod;
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import modelResolverMod = require('./model-resolver.cjs');
-const { resolveModelInternal, resolveEffortInternal, resolveFastModeInternal, resolveEffortForTier, resolveGranularityInternal, assertValidGranularityOverride } = modelResolverMod;
+const { resolveModelInternal, resolveModelForTier, resolveEffortInternal, resolveFastModeInternal, resolveEffortForTier, resolveGranularityInternal, assertValidGranularityOverride } = modelResolverMod;
 import { renderEffortForRuntime, RUNTIMES_WITH_FAST_MODE } from './model-catalog.cjs';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import planningWorkspace = require('./planning-workspace.cjs');
@@ -487,7 +487,9 @@ function cmdResolveExecution(cwd: string, agentType: string | undefined, raw: bo
   opts = opts || {};
   const config = loadConfig(cwd);
   const profile = (config['model_profile'] as string) || 'balanced';
-  const model = resolveModelInternal(cwd, agentType!);
+  // #3024 — model must escalate from the same tier source as effort; falls back
+  // to resolveModelInternal when dynamic_routing is disabled.
+  const model = resolveModelForTier(cwd, agentType!, (opts.attempt !== undefined && opts.attempt !== null) ? opts.attempt : 0);
 
   const effortOpts: Record<string, unknown> = {};
   if (typeof opts.effortOverride === 'string') effortOpts['override'] = opts.effortOverride;

--- a/tests/model-resolver.test.cjs
+++ b/tests/model-resolver.test.cjs
@@ -2606,6 +2606,59 @@ describe('#443 resolve-execution CLI command', () => {
   });
 });
 
+// ─── resolve-execution model escalation (#3024) ───────────────────────────────
+
+describe('#3024 resolve-execution: dynamic routing escalates model', () => {
+  let tmpDir;
+  beforeEach(() => {
+    tmpDir = createTempProject();
+    // HOME isolation to prevent ~/.gsd/defaults.json bleed
+    process.env._GSD_TEST_HOME_OVERRIDE = tmpDir;
+  });
+  afterEach(() => {
+    cleanup(tmpDir);
+    delete process.env._GSD_TEST_HOME_OVERRIDE;
+  });
+
+  test('--attempt escalates model through tier_models (standard -> heavy)', () => {
+    writeConfig(tmpDir, {
+      dynamic_routing: {
+        enabled: true,
+        tier_models: { light: 'haiku-custom', standard: 'sonnet-custom', heavy: 'opus-custom' },
+        escalate_on_failure: true,
+        max_escalations: 2,
+      },
+    });
+    // gsd-executor is 'standard' tier
+    const result0 = runGsdTools(
+      ['resolve-execution', 'gsd-executor', '--attempt', '0'],
+      tmpDir,
+      { HOME: tmpDir }
+    );
+    const result1 = runGsdTools(
+      ['resolve-execution', 'gsd-executor', '--attempt', '1'],
+      tmpDir,
+      { HOME: tmpDir }
+    );
+    assert.ok(result0.success && result1.success);
+    const out0 = JSON.parse(result0.output);
+    const out1 = JSON.parse(result1.output);
+    assert.strictEqual(out0.model, 'sonnet-custom');
+    assert.strictEqual(out1.model, 'opus-custom');
+  });
+
+  test('dynamic_routing absent -> model matches resolveModelInternal', () => {
+    const result = runGsdTools(
+      ['resolve-execution', 'gsd-executor', '--attempt', '1'],
+      tmpDir,
+      { HOME: tmpDir }
+    );
+    assert.ok(result.success, `Command failed: ${result.error}`);
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.model, resolveModelInternal(tmpDir, 'gsd-executor'));
+  });
+});
+
 // ─── resolve-model now emits effort (replaces reasoning_effort) ───────────────
 
 describe('#443 resolve-model emits effort (unified)', () => {


### PR DESCRIPTION
## Problem

With `dynamic_routing.enabled: true`, `resolve-execution <agent> --attempt N` escalates **effort** through the tier ladder but the **model** is resolved via `resolveModelInternal`, which never reads `dynamic_routing` — so escalation never changes the model. `resolveModelForTier` (#3024) exists in `model-resolver.cts` but has no callers on the CLI path (the new `model-adapter` seam references it, but `cmdResolveExecution` does not go through the adapter).

Repro: config `{"dynamic_routing":{"enabled":true,"tier_models":{"light":"haiku","standard":"sonnet","heavy":"opus"}}}` → `resolve-execution gsd-executor --attempt 1` returns escalated effort but the un-escalated model.

## Fix

`cmdResolveExecution` now resolves the model via `resolveModelForTier(cwd, agentType, attempt ?? 0)`, so model and effort escalate from the same tier source. With `dynamic_routing` disabled the behavior is byte-identical — `resolveModelForTier` falls back to `resolveModelInternal` internally. `cmdResolveModel` untouched.

## Testing

- New tests: standard-tier agent returns standard-tier model at `--attempt 0` and heavy-tier model at `--attempt 1`; control asserts identical behavior when `dynamic_routing` is absent. **Verified fail-first** (escalation test fails on unfixed build).
- Full suite: `tests/model-resolver.test.cjs` 314 pass / 0 fail.

Changeset fragment follows in a fixup commit once the PR number exists.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2062"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786038000&installation_id=134682257&pr_number=2062&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2062&signature=9bfb1589674ea0787ab47c13ea1fcfae149995081795e6e3236b42052a560fbd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->