### PR TITLE
fix: forward model_policy, model_profile_overrides, runtime from ~/.gsd/defaults.json

### DIFF
--- a/src/config-loader.cts
+++ b/src/config-loader.cts
@@ -722,6 +722,9 @@ function loadConfigResolved(cwd: string, options: Record<string, unknown> = {}):
         fast_mode: (globalDefaults['fast_mode']) || null,
         agent_skills: (globalDefaults['agent_skills']) || {},
         response_language: (globalDefaults['response_language']) || null,
+        model_policy: (globalDefaults['model_policy']) || null,
+        model_profile_overrides: (globalDefaults['model_profile_overrides']) || null,
+        runtime: (globalDefaults['runtime']) || null,
       };
       // Branch D: global-defaults
       try {

--- a/tests/defaults-json-fallback.test.cjs
+++ b/tests/defaults-json-fallback.test.cjs
@@ -13,7 +13,7 @@ const path = require('path');
 const os = require('os');
 const { cleanup } = require('./helpers.cjs');
 
-const { loadConfig } = require('../gsd-core/bin/lib/config-loader.cjs');
+const { loadConfig, loadConfigResolved } = require('../gsd-core/bin/lib/config-loader.cjs');
 
 /** Create a bare temp dir (no .planning/) to simulate pre-project context */
 function createBareTmpDir() {
@@ -124,6 +124,33 @@ describe('loadConfig ~/.gsd/defaults.json fallback (#1683)', () => {
     assert.strictEqual(config.model_profile, 'quality');
     assert.strictEqual(config.unknown_key, undefined);
     assert.strictEqual(config.another_unknown, undefined);
+  });
+
+  test('pre-project, defaults.json with model_policy/model_profile_overrides/runtime → forwarded', (t) => {
+    const tmpDir = createBareTmpDir();
+
+    const gsdDir = path.join(tmpDir, '.gsd');
+    fs.mkdirSync(gsdDir, { recursive: true });
+    const modelPolicy = { provider: 'anthropic', budget: 'standard' };
+    const profileOverrides = { quality: { planner: 'opus' } };
+    const runtime = { name: 'claude-code' };
+    fs.writeFileSync(
+      path.join(gsdDir, 'defaults.json'),
+      JSON.stringify({
+        model_policy: modelPolicy,
+        model_profile_overrides: profileOverrides,
+        runtime,
+      })
+    );
+
+    process.env.GSD_HOME = tmpDir;
+    t.after(() => { delete process.env.GSD_HOME; cleanup(tmpDir); });
+
+    const result = loadConfigResolved(tmpDir);
+    assert.strictEqual(result.source, 'global-defaults');
+    assert.deepStrictEqual(result.config.model_policy, modelPolicy);
+    assert.deepStrictEqual(result.config.model_profile_overrides, profileOverrides);
+    assert.deepStrictEqual(result.config.runtime, runtime);
   });
 
   test('defaults.json with invalid JSON → returns hardcoded defaults', (t) => {


### PR DESCRIPTION
## Problem

The global-defaults path (Branch D: no `.planning/`, read `~/.gsd/defaults.json`) forwards `model_overrides`, `models`, `dynamic_routing`, `effort`, `fast_mode`, … but silently **drops `model_policy`, `model_profile_overrides`, and `runtime`**. A machine-wide model policy in `~/.gsd/defaults.json` is honored inside projects (where `.planning/config.json` carries it) but silently ignored for out-of-project runs — `resolve-model` falls back to the profile default with no warning.

## Fix

Forward the three keys in `_globalBaseCfg`, in the same `(globalDefaults['…']) || null` style as the neighboring entries (matching how the project-config path handles the same keys).

## Testing

- New test in `tests/defaults-json-fallback.test.cjs`: `GSD_HOME` temp dir with a `defaults.json` carrying all three keys; `loadConfigResolved` from a cwd without `.planning/` asserts they come through with `source === 'global-defaults'`. **Verified fail-first** (`config.model_policy` is `undefined` on unfixed code).
- `tests/defaults-json-fallback.test.cjs` 7/7; `config-loader` + `federated-config-loadconfig` suites 66/66.

Changeset fragment follows in a fixup commit once the PR number exists.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2063"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786038001&installation_id=134682257&pr_number=2063&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2063&signature=6c6d6d63c0267d89550b9dba8389af7127d0a4cfb4f50374c9fc9eb74ac5fc29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->