### PR TITLE
fix: accept adaptive model profile in validate health; warn on invalid models.* tiers (W022)

### DIFF
--- a/src/verify.cts
+++ b/src/verify.cts
@@ -1357,7 +1357,7 @@ function cmdValidateHealth(
     try {
       const rawCfg = fs.readFileSync(configPath, 'utf-8');
       const parsed = JSON.parse(rawCfg) as Record<string, unknown>;
-      const validProfiles = ['quality', 'balanced', 'budget', 'inherit'];
+      const validProfiles = ['quality', 'balanced', 'budget', 'adaptive', 'inherit'];
       if (parsed['model_profile'] && !validProfiles.includes(parsed['model_profile'] as string)) {
         addIssue(
           'warning',
@@ -1365,6 +1365,21 @@ function cmdValidateHealth(
           `config.json: invalid model_profile "${parsed['model_profile'] as string}"`,
           `Valid values: ${validProfiles.join(', ')}`,
         );
+      }
+      // models.<phase_type> tiers outside this set are silently ignored by the resolver
+      const validTiers = ['opus', 'sonnet', 'haiku', 'inherit'];
+      const models = parsed['models'];
+      if (models && typeof models === 'object' && !Array.isArray(models)) {
+        for (const [key, value] of Object.entries(models as Record<string, unknown>)) {
+          if (typeof value === 'string' && !validTiers.includes(value)) {
+            addIssue(
+              'warning',
+              'W022',
+              `config.json: models.${key} "${value}" is not a valid tier and will be ignored`,
+              `Valid values: ${validTiers.join(', ')}`,
+            );
+          }
+        }
       }
     } catch (err) {
       addIssue(

--- a/tests/verify-health.test.cjs
+++ b/tests/verify-health.test.cjs
@@ -351,6 +351,68 @@ describe('validate health command', () => {
     );
   });
 
+  test('accepts adaptive model_profile as valid', () => {
+    writeMinimalProjectMd(tmpDir);
+    writeMinimalRoadmap(tmpDir, ['1']);
+    writeMinimalStateMd(tmpDir);
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({ model_profile: 'adaptive' })
+    );
+    fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '01-a'), { recursive: true });
+
+    const result = runGsdTools('validate health', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.ok(
+      !output.warnings.some(w => w.code === 'W004'),
+      `Should not warn for adaptive model_profile: ${JSON.stringify(output.warnings)}`
+    );
+  });
+
+  test('warns W022 when models.<phase_type> has an invalid tier', () => {
+    writeMinimalProjectMd(tmpDir);
+    writeMinimalRoadmap(tmpDir, ['1']);
+    writeMinimalStateMd(tmpDir);
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({ model_profile: 'balanced', models: { planning: 'not-a-tier' } })
+    );
+    fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '01-a'), { recursive: true });
+
+    const result = runGsdTools('validate health', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    const w022 = output.warnings.find(w => w.code === 'W022');
+    assert.ok(w022, `Expected W022 in warnings: ${JSON.stringify(output.warnings)}`);
+    assert.ok(
+      w022.message.includes('models.planning "not-a-tier"'),
+      `Expected W022 to name the offending key and value: ${JSON.stringify(w022)}`
+    );
+  });
+
+  test('does not emit W022 for a valid models tier', () => {
+    writeMinimalProjectMd(tmpDir);
+    writeMinimalRoadmap(tmpDir, ['1']);
+    writeMinimalStateMd(tmpDir);
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({ model_profile: 'balanced', models: { planning: 'haiku' } })
+    );
+    fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '01-a'), { recursive: true });
+
+    const result = runGsdTools('validate health', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.ok(
+      !output.warnings.some(w => w.code === 'W022'),
+      `Should not warn for valid models tier: ${JSON.stringify(output.warnings)}`
+    );
+  });
+
   // ─── Check 6: Phase directory naming (NN-name format) ─────────────────────
 
   test('warns about incorrectly named phase directories', () => {


### PR DESCRIPTION
## Problem

Two related `validate health` gaps:

1. `validProfiles` omits `adaptive` — a valid profile per `model-catalog.json` — so W004 false-flags `"model_profile": "adaptive"`.
2. `models.<phase_type>` values are validated nowhere: the resolver's `VALID_TIERS` silently ignores anything outside `{opus, sonnet, haiku, inherit}`, and health says nothing — a typo like `"models": {"planning": "opuss"}` is a silent no-op that is painful to diagnose.

## Fix

1. Add `adaptive` to `validProfiles` (catalog order).
2. New **W022** warning (W001–W021 are taken) after the W004 block, same `addIssue` style: flags any string `models.*` value outside the resolver's tier set.

## Testing

- New tests: `adaptive` produces no W004; invalid tier produces W022; valid tier produces nothing. **Verified fail-first** (both fail on unfixed code).
- `tests/verify-health.test.cjs` 43 pass / 0 fail.

Changeset fragment follows in a fixup commit once the PR number exists.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2064"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786038003&installation_id=134682257&pr_number=2064&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2064&signature=8edc219affefb1c383c1d70c8b9ed2d2db0a00b26a2aff6b7ef63d5cd8349bb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->