### PR TITLE
fix: remove duplicate hooks reference from plugin manifest

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -19,6 +19,5 @@
     "gsd"
   ],
   "commands": "./commands/gsd/",
-  "skills": "./skills/",
-  "hooks": "./hooks/hooks.json"
+  "skills": "./skills/"
 }


### PR DESCRIPTION
## What

Remove the explicit `"hooks": "./hooks/hooks.json"` line from `.claude-plugin/plugin.json`.

## Why

Claude Code auto-loads the standard `hooks/hooks.json` by convention. When the manifest **also** declares that same standard path, the current CLI (verified on `2.1.204`) treats it as a collision and refuses to load the plugin:

```
Status: ✘ failed to load
Error: Hook load failed: Duplicate hooks file detected: ./hooks/hooks.json
resolves to already-loaded file .../hooks/hooks.json. The standard
hooks/hooks.json is loaded automatically, so manifest.hooks should only
reference additional hook files.
```

As a result, a fresh `claude plugin marketplace add open-gsd/gsd-core` + `claude plugin install gsd-core@gsd-core` installs the plugin at user scope but leaves it **disabled / failed to load** — no `/gsd-core:*` commands or skills are exposed.

## How

`manifest.hooks` should only point to *additional* hook files. Since `hooks/hooks.json` is the standard path and loads automatically, the explicit reference is redundant. Removing it resolves the collision.

**Hooks remain active** after this change — the SessionStart / PreToolUse / PostToolUse guards in `hooks/hooks.json` are still auto-discovered and loaded.

## Verification

With this manifest, `claude plugin install gsd-core@gsd-core` yields:

```
Status: ✔ enabled
```

and the `/gsd-core:*` commands + skills are exposed as expected.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2077"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786078147&installation_id=134682257&pr_number=2077&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2077&signature=5cc5e826016729a538254c862250a1efd9c118cf4adea49d53c4c25299489997"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->