### PR TITLE
test(#2081): stabilize perf-316 lock-holder race under load

### DIFF
--- a/tests/perf-316-state-lock-buffer-alloc.test.cjs
+++ b/tests/perf-316-state-lock-buffer-alloc.test.cjs
@@ -173,14 +173,21 @@ describe('perf #316: acquireStateLock hoists sleep buffer — exactly one SAB pe
 
   test(
     'sabCount === 1 after a call that undergoes >= 1 retry (post-fix assertion)',
-    { timeout: 8000 },
+    { timeout: 15000 },
     async () => {
-      // ── Worker A: hold the lock for 1000ms ─────────────────────────────────
+      // ── Worker A: hold the lock until the writer signals contention ─────────
       // The holder releases the lock only when the writer signals its first
       // failed lock attempt (see WRITER_WORKER_CODE), so the writer is guaranteed
-      // to contend at least once regardless of worker-spawn latency. holdMs is now
-      // only a safety cap in case that signal never arrives.
-      const holdMs = 1000;
+      // to contend at least once. holdMs is ONLY a safety cap for a dead/hung
+      // writer — it MUST be large enough that it never elapses while Worker B is
+      // still spawning + requiring state.cjs + installing its stubs. Under load
+      // (full suite in a container) that spawn+init can exceed 1s; a 1s cap let A
+      // time out and remove the lock before B contended, so B's first openSync
+      // succeeded (lockAttempts:1) and the retry-path witness failed. 30s is
+      // comfortably beyond B's worst-case init yet still bounded; the test's own
+      // timeout caps wall-clock, and afterEach terminate()s A the moment B posts
+      // its result, so the normal path adds no delay.
+      const holdMs = 30000;
       const releaseSab = new SharedArrayBuffer(4);
       let resolveLockWritten;
       const lockWritten = new Promise((resolve) => { resolveLockWritten = resolve; });


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #2081

---

## What was broken

`tests/perf-316-state-lock-buffer-alloc.test.cjs` intermittently red-flagged the `gsd-test` / GitHub CI gate on linux-node24 with `lockAttempts: 1`, blocking otherwise-green branches from merging. The flake fired under container load (full suite, node24).

## What this fix does

Bumps Worker A's lock-hold safety cap `holdMs` from `1000` → `30000`, and the per-test timeout from `8000` → `15000`. No production code changes.

## Root cause

Worker A (lock holder) blocks on `Atomics.wait(releaseFlag, 0, 0, holdMs)`. The intended release mechanism is a **handshake**: Worker B signals A (via `releaseFlag` + `Atomics.notify`) only after B's first *failed* atomic-create, guaranteeing B enters the retry path. `holdMs` was only a safety cap for a dead/hung writer.

Under heavy load, Worker B's spawn + `require('state.cjs')` + stub-installation exceeded the 1000 ms cap, so A's wait **timed out and removed the lock before B ever contended**. B's first `openSync(O_CREAT|O_EXCL)` then succeeded → `lockAttempts: 1` → the `lockAttempts >= 2` retry-path witness failed.

Because the handshake is the real release trigger, `holdMs` must be large enough that it never elapses during B's spawn+init. 30 s is ~30× the worst observed spawn latency. `afterEach` calls `holderWorker.terminate()` the moment B posts its result, so the normal path adds **zero** wall-clock delay (nominal ~400–600 ms). The 15 s test timeout bounds wall-clock on any genuine hang.

## Testing

### How I verified the fix

- **Before fix:** `gsd-test -base next -head HEAD` → `outcome:"failed"`, linux-node24 FAIL with exactly `perf-316 … lockAttempts: 1`.
- **After fix:** `gsd-test -base next -head HEAD` (full matrix) → `{"type":"verdict","outcome":"passed"}` — linux-node22 PASS 24129/24129, linux-node24 PASS 24129/24129.
- Two independent reviewers (code + security, both in isolated non-authoring subagent contexts) independently re-verified the root cause and the fix; both returned **APPROVE** with no blocking findings. The code reviewer additionally traced the actual perf-316 hoist to `gsd-core/bin/lib/clock.cjs:23` (module-level `_realSleepBuf`), confirming the test still measures the correct invariant and the change cannot mask a real #316 regression (`sabCount` is measured independently of `holdMs`).

### Regression test added?

- [x] N/A — this *is* the stabilization of an existing regression test; the flake mechanism is non-deterministic under load, and the fix removes the timing race rather than adding a new assertion.

### Platforms tested

- [x] Linux (gsd-test benches: linux-node22, linux-node24 — both green; GitHub CI `test (ubuntu-latest, 22/24)` + `test (windows-latest, 24)` green)
- [ ] macOS (test is platform-agnostic; gsd-test config targets linux)

### Runtimes tested

- [x] N/A (not runtime-specific — Node `worker_threads` test)

---

## Checklist

- [x] Issue linked above with `Fixes #2081`
- [x] Linked issue (#2081) has the `confirmed-bug` label
- [x] Fix is scoped to the reported flake — only `tests/perf-316-state-lock-buffer-alloc.test.cjs` changed (no unrelated changes)
- [x] All existing tests pass (`gsd-test` → `outcome:"passed"`, 24129/24129 on both node targets)
- [x] `no-changelog` label applied — test-only, no user-facing change (changeset-required gate does not fire for `tests/`-only diffs)
- [x] No unnecessary dependencies added

## Breaking changes

None. Test-only change; no production behavior, output format, or API affected.
