### PR TITLE
fix(#2067): restrict phase-complete checkbox regex gap

### DIFF
--- a/.changeset/2067-phase-complete-checkbox-regex.md
+++ b/.changeset/2067-phase-complete-checkbox-regex.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 2079
 ---
 **`phase complete` no longer ticks the wrong phase's ROADMAP checkbox** — completing a phase whose number also appears in a later phase's description (e.g. an idempotent re-run of an already-complete phase) used to mark the *wrong* phase done, because the checkbox-matching regex greedily spanned from `]` to any later "Phase N" mention instead of only the immediately-following phase title. (#2067)

--- a/.changeset/2067-phase-complete-checkbox-regex.md
+++ b/.changeset/2067-phase-complete-checkbox-regex.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`phase complete` no longer ticks the wrong phase's ROADMAP checkbox** — completing a phase whose number also appears in a later phase's description (e.g. an idempotent re-run of an already-complete phase) used to mark the *wrong* phase done, because the checkbox-matching regex greedily spanned from `]` to any later "Phase N" mention instead of only the immediately-following phase title. (#2067)

--- a/src/phase.cts
+++ b/src/phase.cts
@@ -1467,8 +1467,14 @@ function cmdPhaseComplete(cwd: string, phaseNum: string, raw: boolean): void {
         roadmapContent = originalRoadmapContent;
 
         const phaseEscaped = phaseMarkdownRegexSource(phaseNum);
+        // #2067: the gap between `]` and `Phase N` must allow only whitespace /
+        // markdown bold emphasis — NOT greedy `.*`. A greedy gap matched a later
+        // phase whose description merely mentioned the completed phase number,
+        // so completing an already-checked phase (idempotent re-run) checked the
+        // wrong phase's box. Mirrors the tight pattern used by phase-insert
+        // (`]\\s*(?:\\*\\*)?Phase`).
         const checkboxPattern = new RegExp(
-          `(-\\s*\\[)[ ](\\]\\s*.*Phase\\s+${phaseEscaped}${OPTIONAL_PHASE_TAG_SOURCE}[:\\s][^\\n]*)`,
+          `(-\\s*\\[)[ ](\\]\\s*(?:\\*\\*)?\\s*Phase\\s+${phaseEscaped}${OPTIONAL_PHASE_TAG_SOURCE}[:\\s][^\\n]*)`,
           'i',
         );
         roadmapContent = roadmapContent.replace(

--- a/tests/phase.test.cjs
+++ b/tests/phase.test.cjs
@@ -2530,6 +2530,95 @@ describe('phase complete command', () => {
     assert.ok(roadmap.includes('completed'), 'completion date should be added');
   });
 
+  // #2067: the checkbox regex in cmdPhaseComplete used a greedy `.*` between
+  // `]` and `Phase N`, so completing Phase 1 (already checked → idempotent
+  // re-run) matched a LATER phase whose description merely mentioned "Phase 1".
+  // Non-global replace then checked the wrong phase's box. The gap between `]`
+  // and `Phase` must allow only whitespace / markdown emphasis.
+  test('#2067 — completing a phase must not check a later phase whose description mentions it (idempotent re-run)', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      `# Roadmap
+
+- [x] **Phase 1: Core Feed & Posting** - first slice (completed 2025-01-01)
+- [ ] **Phase 2: Polish & Edge Cases** - hardening (only as needed after Phase 1 verification)
+
+### Phase 1: Core Feed & Posting
+**Goal:** Ship feed
+**Plans:** 1 plans
+
+### Phase 2: Polish & Edge Cases
+**Goal:** Harden
+`
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'STATE.md'),
+      `# State\n\n**Current Phase:** 01\n**Current Phase Name:** Core Feed & Posting\n**Status:** In progress\n**Current Plan:** 01-01\n**Last Activity:** 2025-01-01\n**Last Activity Description:** Working on phase 1\n`
+    );
+
+    const p1 = path.join(tmpDir, '.planning', 'phases', '01-core-feed-posting');
+    fs.mkdirSync(p1, { recursive: true });
+    fs.writeFileSync(path.join(p1, '01-01-PLAN.md'), '# Plan');
+    fs.writeFileSync(path.join(p1, '01-01-SUMMARY.md'), '# Summary');
+    fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '02-polish-edge-cases'), { recursive: true });
+
+    const result = runVerifiedPhaseComplete('phase complete 1', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const roadmap = fs.readFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), 'utf-8');
+    // Phase 2's checkbox MUST remain unchecked — its description mentions
+    // "Phase 1" but it is NOT the phase being completed.
+    const phase2Line = roadmap.match(/^- \[([ x])\] \*\*Phase 2:.*$/m);
+    assert.ok(phase2Line, 'Phase 2 line must still be present in ROADMAP');
+    assert.strictEqual(phase2Line[1], ' ', 'Phase 2 checkbox must remain unchecked (#2067)');
+    // Phase 1 must remain checked.
+    const phase1Line = roadmap.match(/^- \[([ x])\] \*\*Phase 1:.*$/m);
+    assert.ok(phase1Line, 'Phase 1 line must still be present in ROADMAP');
+    assert.strictEqual(phase1Line[1], 'x', 'Phase 1 checkbox must remain checked (#2067)');
+  });
+
+  // #2067 companion: normal completion (Phase 1 unchecked) must still check
+  // Phase 1 — and must NOT also check a later phase whose description mentions
+  // Phase 1. Guards the tightened regex against over-restricting the happy path.
+  test('#2067 — normal completion checks only the target phase when a later phase mentions it', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      `# Roadmap
+
+- [ ] **Phase 1: Core Feed & Posting** - first slice
+- [ ] **Phase 2: Polish & Edge Cases** - hardening (only as needed after Phase 1 verification)
+
+### Phase 1: Core Feed & Posting
+**Goal:** Ship feed
+**Plans:** 1 plans
+
+### Phase 2: Polish & Edge Cases
+**Goal:** Harden
+`
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'STATE.md'),
+      `# State\n\n**Current Phase:** 01\n**Current Phase Name:** Core Feed & Posting\n**Status:** In progress\n**Current Plan:** 01-01\n**Last Activity:** 2025-01-01\n**Last Activity Description:** Working on phase 1\n`
+    );
+
+    const p1 = path.join(tmpDir, '.planning', 'phases', '01-core-feed-posting');
+    fs.mkdirSync(p1, { recursive: true });
+    fs.writeFileSync(path.join(p1, '01-01-PLAN.md'), '# Plan');
+    fs.writeFileSync(path.join(p1, '01-01-SUMMARY.md'), '# Summary');
+    fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '02-polish-edge-cases'), { recursive: true });
+
+    const result = runVerifiedPhaseComplete('phase complete 1', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const roadmap = fs.readFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), 'utf-8');
+    const phase1Line = roadmap.match(/^- \[([ x])\] \*\*Phase 1:.*$/m);
+    assert.ok(phase1Line, 'Phase 1 line must still be present in ROADMAP');
+    assert.strictEqual(phase1Line[1], 'x', 'Phase 1 checkbox must be checked');
+    const phase2Line = roadmap.match(/^- \[([ x])\] \*\*Phase 2:.*$/m);
+    assert.ok(phase2Line, 'Phase 2 line must still be present in ROADMAP');
+    assert.strictEqual(phase2Line[1], ' ', 'Phase 2 checkbox must remain unchecked (#2067)');
+  });
+
   test('#2012 — Progress row updated even when an earlier phase-numbered table precedes ## Progress', () => {
     fs.writeFileSync(
       path.join(tmpDir, '.planning', 'ROADMAP.md'),


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

> **Stacked PR.** This branch is based on `fix/perf-316-lock-holder-holdms` (PR #2078) so its diff stays scoped to #2067 only. Once #2078 merges to `next`, rebase/retarget this PR onto `next` and the perf-316 commit drops out cleanly. gsd-test was run with `-base next -head HEAD` (merging both commits into next) → `outcome:"passed"`.

---

## Linked Issue

Fixes #2067

---

## What was broken

`gsd-tools phase complete <N>` could mark the **wrong phase's** checkbox in ROADMAP.md. When completing a phase whose number also appears in a later phase's description (e.g. an idempotent re-run of an already-`[x]` phase), the checkbox regex's greedy `.*` spanned from `]` to the later "Phase N" mention, and non-global `.replace` then ticked the wrong phase's box.

## What this fix does

Restricts the gap between `]` and `Phase N` in `cmdPhaseComplete`'s `checkboxPattern` to whitespace + optional markdown bold emphasis (`**`), mirroring the tight pattern already used by `cmdPhaseInsert` in the same file. The replacement (`$1x$2 (completed ${today})`) is unchanged.

## Root cause

Old: `` `(-\\s*\\[)[ ](\\]\\s*.*Phase\\s+${phaseEscaped}...)` `` — the greedy `.*` between `]` and `Phase` matched across a later phase's description. `.replace()` is non-global (replaces only the first match); when the target phase's box is already `[x]` (so its line doesn't match `[ ]`), the first match becomes a later phase that merely mentions the number → wrong box checked.

New: `` `(-\\s*\\[)[ ](\\]\\s*(?:\\*\\*)?\\s*Phase\\s+${phaseEscaped}...)` `` — only whitespace / optional `**` may appear between `]` and `Phase N`.

## Testing

### How I verified the fix

- **Failing-first (gsd-test, unfixed tree):** `outcome:"failed"` — the new regression test `#2067 — … (idempotent re-run)` failed with exactly *"Phase 2 checkbox must remain unchecked (#2067)"* (linux-node22, 2 failures).
- **After fix (gsd-test, full matrix):** `{"type":"verdict","outcome":"passed"}` — linux-node22 PASS 24131/24131, linux-node24 PASS 24131/24131 (includes the perf-316 stabilization from #2078).
- **Orthogonal review:** two independent non-authoring reviewers (code + security); both **APPROVE**. Both independently confirmed `phaseNum` is fully escaped via `phaseMarkdownRegexSource`/`escapeRegex` (no regex injection), the new pattern is strictly less backtracking-prone than the old `.*` (ReDoS-safe), and the fix cannot regress the canonical bold/un-bolded checklist forms (verified against the #1591 and #2012 test shapes).

### Regression test added?

- [x] Yes — added `#2067 — … (idempotent re-run)` (fails on old code, passes on new) and a companion happy-path guard `#2067 — normal completion checks only the target phase when a later phase mentions it`.

### Platforms tested

- [x] Linux (gsd-test benches: linux-node22, linux-node24 — both green)
- [ ] macOS / Windows (logic is platform-agnostic markdown regex; not OS-specific)

### Runtimes tested

- [x] N/A (not runtime-specific — pure source regex in `cmdPhaseComplete`)

---

## Checklist

- [x] Issue linked above with `Fixes #2067`
- [x] Linked issue (#2067) has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — only `src/phase.cts` (1 regex + comment) + `tests/phase.test.cjs` (2 tests); the perf-316 commit in this branch belongs to #2078 and drops out on rebase
- [x] Regression test added (failing-first + companion guard)
- [x] All existing tests pass (`gsd-test` → `outcome:"passed"`, 24131/24131 both node targets)
- [x] `.changeset/2067-phase-complete-checkbox-regex.md` added (`Fixed`)
- [x] No unnecessary dependencies added

## Breaking changes

None. The fix only narrows *which* ROADMAP line matches when completing a phase; legitimate completions (bold and un-bolded checklist forms) produce byte-identical output. The old behavior was a latent mis-check on already-complete phases, not a relied-upon contract.

## Follow-up (out of scope)

Both reviewers independently flagged an **identical greedy-`.*`-before-`Phase` defect in `phase remove`** (`updateRoadmapAfterPhaseRemoval`, `src/phase.cts:1184`) — same bug class, different command. A separate issue will be filed for it; it is intentionally not bundled here (one concern per PR).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2079"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786115733&installation_id=134682257&pr_number=2079&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2079&signature=5650745c3306fa564cf10886ca1c186338faf8500887c6d3a45de5a469fa2ca1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->