### PR TITLE
fix: phase complete checkbox regex matches later phases that mention the target phase

### DIFF
--- a/.changeset/nimble-yaks-parade.md
+++ b/.changeset/nimble-yaks-parade.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 2061
+pr: 2082
 ---
 **`phase complete` no longer marks the wrong phase as complete** — the ROADMAP checkbox regex matched any unchecked line that merely mentioned the completed phase (e.g. "after Phase 1 verification"), so re-running completion when the target box was already checked corrupted the next phase entry.

--- a/.changeset/nimble-yaks-parade.md
+++ b/.changeset/nimble-yaks-parade.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 2061
+---
+**`phase complete` no longer marks the wrong phase as complete** — the ROADMAP checkbox regex matched any unchecked line that merely mentioned the completed phase (e.g. "after Phase 1 verification"), so re-running completion when the target box was already checked corrupted the next phase entry.

--- a/src/phase.cts
+++ b/src/phase.cts
@@ -1447,8 +1447,11 @@ function cmdPhaseComplete(cwd: string, phaseNum: string, raw: boolean): void {
         roadmapContent = originalRoadmapContent;
 
         const phaseEscaped = phaseMarkdownRegexSource(phaseNum);
+        // Only whitespace/markdown emphasis may sit between "]" and "Phase" —
+        // a greedy `.*` lets an unchecked later phase match when its text
+        // merely mentions this phase (e.g. "after Phase 1 verification").
         const checkboxPattern = new RegExp(
-          `(-\\s*\\[)[ ](\\]\\s*.*Phase\\s+${phaseEscaped}${OPTIONAL_PHASE_TAG_SOURCE}[:\\s][^\\n]*)`,
+          `(-\\s*\\[)[ ](\\]\\s*[*_~\`]*\\s*Phase\\s+${phaseEscaped}${OPTIONAL_PHASE_TAG_SOURCE}[:\\s][^\\n]*)`,
           'i',
         );
         roadmapContent = roadmapContent.replace(

--- a/tests/phase.test.cjs
+++ b/tests/phase.test.cjs
@@ -2577,6 +2577,90 @@ describe('phase complete command', () => {
     assert.ok(progressRow, 'Progress row must be updated to Complete with a date');
   });
 
+  test('already-checked phase is a checkbox no-op — later phase mentioning it stays unchecked', () => {
+    // Regression: the checkbox regex used a greedy `.*` between "]" and
+    // "Phase N", so with Phase 1 already [x] the first match was Phase 2's
+    // unchecked line (its text mentions "Phase 1") and Phase 2 got marked
+    // complete even though it never ran.
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      `# Roadmap
+
+- [x] **Phase 1: Core** - foundations
+- [ ] **Phase 2: Polish** - hardening (only as needed after Phase 1 verification)
+
+### Phase 1: Core
+**Goal:** Foundations
+**Plans:** 1 plans
+
+### Phase 2: Polish
+**Goal:** Hardening
+`
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'STATE.md'),
+      `# State\n\n**Current Phase:** 01\n**Current Phase Name:** Core\n**Status:** In progress\n**Current Plan:** 01-01\n**Last Activity:** 2025-01-01\n**Last Activity Description:** Working on phase 1\n`
+    );
+
+    const p1 = path.join(tmpDir, '.planning', 'phases', '01-core');
+    fs.mkdirSync(p1, { recursive: true });
+    fs.writeFileSync(path.join(p1, '01-01-PLAN.md'), '# Plan');
+    fs.writeFileSync(path.join(p1, '01-01-SUMMARY.md'), '# Summary');
+    fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '02-polish'), { recursive: true });
+
+    const result = runVerifiedPhaseComplete('phase complete 1', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const roadmap = fs.readFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), 'utf-8');
+    assert.ok(
+      roadmap.includes('- [ ] **Phase 2: Polish** - hardening (only as needed after Phase 1 verification)'),
+      `Phase 2 line must stay unchecked and unmodified; got:\n${roadmap}`
+    );
+    assert.ok(
+      roadmap.includes('- [x] **Phase 1: Core** - foundations'),
+      'Phase 1 line must stay checked'
+    );
+  });
+
+  test('checkbox with bold **Phase N:** style is still checked off', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      `# Roadmap
+
+- [ ] **Phase 1: Core** - foundations
+- [ ] **Phase 2: Polish** - hardening
+
+### Phase 1: Core
+**Goal:** Foundations
+**Plans:** 1 plans
+
+### Phase 2: Polish
+**Goal:** Hardening
+`
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'STATE.md'),
+      `# State\n\n**Current Phase:** 01\n**Current Phase Name:** Core\n**Status:** In progress\n**Current Plan:** 01-01\n**Last Activity:** 2025-01-01\n**Last Activity Description:** Working on phase 1\n`
+    );
+
+    const p1 = path.join(tmpDir, '.planning', 'phases', '01-core');
+    fs.mkdirSync(p1, { recursive: true });
+    fs.writeFileSync(path.join(p1, '01-01-PLAN.md'), '# Plan');
+    fs.writeFileSync(path.join(p1, '01-01-SUMMARY.md'), '# Summary');
+    fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '02-polish'), { recursive: true });
+
+    const result = runVerifiedPhaseComplete('phase complete 1', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const roadmap = fs.readFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), 'utf-8');
+    assert.match(
+      roadmap,
+      /- \[x\] \*\*Phase 1: Core\*\* - foundations \(completed \d{4}-\d{2}-\d{2}\)/,
+      `bold Phase 1 line must be checked with a completion date; got:\n${roadmap}`
+    );
+    assert.ok(roadmap.includes('- [ ] **Phase 2: Polish** - hardening'), 'Phase 2 must stay unchecked');
+  });
+
   test('detects last phase in milestone', () => {
     fs.writeFileSync(
       path.join(tmpDir, '.planning', 'ROADMAP.md'),


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #2067

---

## What was broken

`gsd-tools phase complete <N>` could mark the **wrong phase's** checkbox in ROADMAP.md: when the target phase's box was already checked, any later unchecked phase whose description merely mentions the completed phase (e.g. "…after Phase 1 verification") got marked `[x] … (completed <date>)`.

## What this fix does

Narrows the checkbox regex so only whitespace/markdown emphasis may sit between `]` and `Phase N` — a line can now only match on its own phase title, never on a mention inside its description. An already-checked target becomes a checkbox no-op.

## Root cause

The pattern `` `(\-\s*\[)[ ](\]\s*.*Phase\s+${phaseEscaped}…)` `` used a greedy `.*` between the checkbox and the phase token. In the normal case the target line matches first, which masked the bug; once the target box was checked (idempotent re-run, or ticked earlier in the flow), the first match slid to the next unchecked line mentioning the phase.

## Testing

### How I verified the fix

Regression test reproduces the exact corruption from the issue (Phase 1 `[x]`, Phase 2 unchecked and mentioning "Phase 1"; run `phase complete 1`; assert Phase 2 stays unchecked). **Fail-first verified**: with `src/phase.cts` reverted to `next`, the test fails with Phase 2 marked `(completed …)`; with the fix it passes. Bold (`**Phase N:**`) and plain checkbox styles both covered.

Full `npm test` on Windows: 2892 pass / 6 fail of 2925 — the 6 failures are pre-existing Windows-environment symlink `EPERM` failures (symlink creation requires elevation on Windows) in capability/migration suites untouched by this PR, reproduced identically on pristine `next` on the same machine. All suites for the modules this PR touches pass fully.

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [ ] macOS
- [x] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2082"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786118563&installation_id=134682257&pr_number=2082&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2082&signature=8bfc8c0acd7439f823d646a9b0a76c794a89d6ed770aeef2cf77c1d53ef234a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->