### PR TITLE
fix: wire dynamic routing into resolve-execution model resolution

### DIFF
--- a/.changeset/lively-herons-rally.md
+++ b/.changeset/lively-herons-rally.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 2062
+---
+**`resolve-execution --attempt` now escalates the model through `dynamic_routing.tier_models`** — previously only effort escalated; the model was resolved outside the tier table and never changed on retry.

--- a/.changeset/lively-herons-rally.md
+++ b/.changeset/lively-herons-rally.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 2062
+pr: 2083
 ---
 **`resolve-execution --attempt` now escalates the model through `dynamic_routing.tier_models`** — previously only effort escalated; the model was resolved outside the tier table and never changed on retry.

--- a/src/commands.cts
+++ b/src/commands.cts
@@ -30,7 +30,7 @@ import roadmapParserMod = require('./roadmap-parser.cjs');
 const { extractCurrentMilestone, stripShippedMilestones: _stripShippedMilestones, getMilestoneInfo, getMilestonePhaseFilter, getRoadmapPhaseInternal } = roadmapParserMod;
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import modelResolverMod = require('./model-resolver.cjs');
-const { resolveModelInternal, resolveEffortInternal, resolveFastModeInternal, resolveEffortForTier, resolveGranularityInternal, assertValidGranularityOverride } = modelResolverMod;
+const { resolveModelInternal, resolveModelForTier, resolveEffortInternal, resolveFastModeInternal, resolveEffortForTier, resolveGranularityInternal, assertValidGranularityOverride } = modelResolverMod;
 import { renderEffortForRuntime, RUNTIMES_WITH_FAST_MODE } from './model-catalog.cjs';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import planningWorkspace = require('./planning-workspace.cjs');
@@ -487,7 +487,9 @@ function cmdResolveExecution(cwd: string, agentType: string | undefined, raw: bo
   opts = opts || {};
   const config = loadConfig(cwd);
   const profile = (config['model_profile'] as string) || 'balanced';
-  const model = resolveModelInternal(cwd, agentType!);
+  // #3024 — model must escalate from the same tier source as effort; falls back
+  // to resolveModelInternal when dynamic_routing is disabled.
+  const model = resolveModelForTier(cwd, agentType!, (opts.attempt !== undefined && opts.attempt !== null) ? opts.attempt : 0);
 
   const effortOpts: Record<string, unknown> = {};
   if (typeof opts.effortOverride === 'string') effortOpts['override'] = opts.effortOverride;

--- a/tests/model-resolver.test.cjs
+++ b/tests/model-resolver.test.cjs
@@ -2606,6 +2606,59 @@ describe('#443 resolve-execution CLI command', () => {
   });
 });
 
+// ─── resolve-execution model escalation (#3024) ───────────────────────────────
+
+describe('#3024 resolve-execution: dynamic routing escalates model', () => {
+  let tmpDir;
+  beforeEach(() => {
+    tmpDir = createTempProject();
+    // HOME isolation to prevent ~/.gsd/defaults.json bleed
+    process.env._GSD_TEST_HOME_OVERRIDE = tmpDir;
+  });
+  afterEach(() => {
+    cleanup(tmpDir);
+    delete process.env._GSD_TEST_HOME_OVERRIDE;
+  });
+
+  test('--attempt escalates model through tier_models (standard -> heavy)', () => {
+    writeConfig(tmpDir, {
+      dynamic_routing: {
+        enabled: true,
+        tier_models: { light: 'haiku-custom', standard: 'sonnet-custom', heavy: 'opus-custom' },
+        escalate_on_failure: true,
+        max_escalations: 2,
+      },
+    });
+    // gsd-executor is 'standard' tier
+    const result0 = runGsdTools(
+      ['resolve-execution', 'gsd-executor', '--attempt', '0'],
+      tmpDir,
+      { HOME: tmpDir }
+    );
+    const result1 = runGsdTools(
+      ['resolve-execution', 'gsd-executor', '--attempt', '1'],
+      tmpDir,
+      { HOME: tmpDir }
+    );
+    assert.ok(result0.success && result1.success);
+    const out0 = JSON.parse(result0.output);
+    const out1 = JSON.parse(result1.output);
+    assert.strictEqual(out0.model, 'sonnet-custom');
+    assert.strictEqual(out1.model, 'opus-custom');
+  });
+
+  test('dynamic_routing absent -> model matches resolveModelInternal', () => {
+    const result = runGsdTools(
+      ['resolve-execution', 'gsd-executor', '--attempt', '1'],
+      tmpDir,
+      { HOME: tmpDir }
+    );
+    assert.ok(result.success, `Command failed: ${result.error}`);
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.model, resolveModelInternal(tmpDir, 'gsd-executor'));
+  });
+});
+
 // ─── resolve-model now emits effort (replaces reasoning_effort) ───────────────
 
 describe('#443 resolve-model emits effort (unified)', () => {


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #2068

---

## What was broken

With `dynamic_routing.enabled: true`, `resolve-execution <agent> --attempt N` escalated **effort** through the tier ladder but the **model** never changed — heavy-tier model escalation was dead on the CLI path.

## What this fix does

`cmdResolveExecution` now resolves the model via `resolveModelForTier(cwd, agentType, attempt ?? 0)` (added to the existing destructured import), so model and effort escalate from the same tier source. `cmdResolveModel` is untouched.

## Root cause

`resolveModelForTier` (#3024) was implemented in `model-resolver.cts` but never wired into any CLI caller — `cmdResolveExecution` resolved the model through `resolveModelInternal`, which does not read `dynamic_routing`. (The `model-adapter` seam references `resolveModelForTier`, but `cmdResolveExecution` does not go through the adapter.) With `dynamic_routing` disabled, behavior is byte-identical because `resolveModelForTier` falls back to `resolveModelInternal` internally.

## Testing

### How I verified the fix

New tests: with `tier_models {light: haiku, standard: sonnet, heavy: opus-variant}` a standard-tier agent (`gsd-executor`) returns the standard-tier model at `--attempt 0` and the heavy-tier model at `--attempt 1`; a control asserts identical output to `resolveModelInternal` when `dynamic_routing` is absent. **Fail-first verified**: against the pristine `next` build the escalation test fails (model stays un-tiered); with the fix both pass.

Full `npm test` on Windows: 2892 pass / 6 fail of 2925 — the 6 failures are pre-existing Windows-environment symlink `EPERM` failures (symlink creation requires elevation on Windows) in capability/migration suites untouched by this PR, reproduced identically on pristine `next` on the same machine. All suites for the modules this PR touches pass fully.

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [ ] macOS
- [x] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None — with `dynamic_routing` disabled (the default), `resolveModelForTier` falls back to `resolveModelInternal`, so output is unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2083"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786118565&installation_id=134682257&pr_number=2083&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2083&signature=271090d903008b894dcbdeb92d966a8fb5b9c3b31da236292830db3b39e23acb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->