### PR TITLE
fix: accept adaptive model profile in validate health; warn on invalid models tiers (W022)

### DIFF
--- a/.changeset/kind-geese-parade.md
+++ b/.changeset/kind-geese-parade.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 2064
+pr: 2085
 ---
 **`validate health` accepts the `adaptive` model profile and flags invalid `models.<phase_type>` tiers (new W022)** — `adaptive` was false-flagged by W004, and mistyped tiers were silently ignored by the resolver with no diagnostic.

--- a/.changeset/kind-geese-parade.md
+++ b/.changeset/kind-geese-parade.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 2064
+---
+**`validate health` accepts the `adaptive` model profile and flags invalid `models.<phase_type>` tiers (new W022)** — `adaptive` was false-flagged by W004, and mistyped tiers were silently ignored by the resolver with no diagnostic.

--- a/src/verify.cts
+++ b/src/verify.cts
@@ -1357,7 +1357,7 @@ function cmdValidateHealth(
     try {
       const rawCfg = fs.readFileSync(configPath, 'utf-8');
       const parsed = JSON.parse(rawCfg) as Record<string, unknown>;
-      const validProfiles = ['quality', 'balanced', 'budget', 'inherit'];
+      const validProfiles = ['quality', 'balanced', 'budget', 'adaptive', 'inherit'];
       if (parsed['model_profile'] && !validProfiles.includes(parsed['model_profile'] as string)) {
         addIssue(
           'warning',
@@ -1365,6 +1365,21 @@ function cmdValidateHealth(
           `config.json: invalid model_profile "${parsed['model_profile'] as string}"`,
           `Valid values: ${validProfiles.join(', ')}`,
         );
+      }
+      // models.<phase_type> tiers outside this set are silently ignored by the resolver
+      const validTiers = ['opus', 'sonnet', 'haiku', 'inherit'];
+      const models = parsed['models'];
+      if (models && typeof models === 'object' && !Array.isArray(models)) {
+        for (const [key, value] of Object.entries(models as Record<string, unknown>)) {
+          if (typeof value === 'string' && !validTiers.includes(value)) {
+            addIssue(
+              'warning',
+              'W022',
+              `config.json: models.${key} "${value}" is not a valid tier and will be ignored`,
+              `Valid values: ${validTiers.join(', ')}`,
+            );
+          }
+        }
       }
     } catch (err) {
       addIssue(

--- a/tests/verify-health.test.cjs
+++ b/tests/verify-health.test.cjs
@@ -351,6 +351,68 @@ describe('validate health command', () => {
     );
   });
 
+  test('accepts adaptive model_profile as valid', () => {
+    writeMinimalProjectMd(tmpDir);
+    writeMinimalRoadmap(tmpDir, ['1']);
+    writeMinimalStateMd(tmpDir);
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({ model_profile: 'adaptive' })
+    );
+    fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '01-a'), { recursive: true });
+
+    const result = runGsdTools('validate health', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.ok(
+      !output.warnings.some(w => w.code === 'W004'),
+      `Should not warn for adaptive model_profile: ${JSON.stringify(output.warnings)}`
+    );
+  });
+
+  test('warns W022 when models.<phase_type> has an invalid tier', () => {
+    writeMinimalProjectMd(tmpDir);
+    writeMinimalRoadmap(tmpDir, ['1']);
+    writeMinimalStateMd(tmpDir);
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({ model_profile: 'balanced', models: { planning: 'not-a-tier' } })
+    );
+    fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '01-a'), { recursive: true });
+
+    const result = runGsdTools('validate health', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    const w022 = output.warnings.find(w => w.code === 'W022');
+    assert.ok(w022, `Expected W022 in warnings: ${JSON.stringify(output.warnings)}`);
+    assert.ok(
+      w022.message.includes('models.planning "not-a-tier"'),
+      `Expected W022 to name the offending key and value: ${JSON.stringify(w022)}`
+    );
+  });
+
+  test('does not emit W022 for a valid models tier', () => {
+    writeMinimalProjectMd(tmpDir);
+    writeMinimalRoadmap(tmpDir, ['1']);
+    writeMinimalStateMd(tmpDir);
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({ model_profile: 'balanced', models: { planning: 'haiku' } })
+    );
+    fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '01-a'), { recursive: true });
+
+    const result = runGsdTools('validate health', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.ok(
+      !output.warnings.some(w => w.code === 'W022'),
+      `Should not warn for valid models tier: ${JSON.stringify(output.warnings)}`
+    );
+  });
+
   // ─── Check 6: Phase directory naming (NN-name format) ─────────────────────
 
   test('warns about incorrectly named phase directories', () => {


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #2070

---

## What was broken

1. `validate health` false-flagged `"model_profile": "adaptive"` with W004, though `adaptive` is a valid profile per `model-catalog.json`.
2. Invalid `models.<phase_type>` tiers (e.g. `"planning": "opuss"`) produced no diagnostic anywhere, while the resolver silently ignores them — an undiagnosable silent no-op.

## What this fix does

1. Adds `adaptive` to `validProfiles` (catalog order).
2. Adds a **W022** warning immediately after the W004 block (same `addIssue` style): any string `models.*` value outside the resolver's tier set is flagged — `config.json: models.planning "opuss" is not a valid tier and will be ignored`.

## Root cause

`validProfiles` predates the `adaptive` profile and was never updated; `models.<phase_type>` values had no validation at any layer — the resolver's `VALID_TIERS` gate drops unknown values by design, and health never mirrored that check. W001–W021 are taken; W022 is the next free code.

## Testing

### How I verified the fix

New tests in `tests/verify-health.test.cjs`: `adaptive` produces no W004; an invalid tier produces W022; a valid tier produces nothing. **Fail-first verified**: with `src/verify.cts` stashed, the first two fail exactly as the issue describes; with the fix, all 43 pass.

Full `npm test` on Windows: 2892 pass / 6 fail of 2925 — the 6 failures are pre-existing Windows-environment symlink `EPERM` failures (symlink creation requires elevation on Windows) in capability/migration suites untouched by this PR, reproduced identically on pristine `next` on the same machine. All suites for the modules this PR touches pass fully.

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [ ] macOS
- [x] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None — a new warning code (W022) is additive; `adaptive` configs stop producing a spurious warning.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2085"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786118570&installation_id=134682257&pr_number=2085&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2085&signature=4863571728e4eed6f77c2064d881848ae774ec34136ef2a26ebcbfe3410c47ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->