### PR TITLE
fix(#2203): traceability parser matches REQ-IDs in any column

### DIFF
--- a/.changeset/noble-wasps-greet.md
+++ b/.changeset/noble-wasps-greet.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`phase complete` no longer false-reports REQ-IDs as missing when the traceability table leads with a status column** — the parser required the REQ-ID in the first column, so a table shaped `| ☐ | REQ-01 | …` matched zero rows and every body REQ-ID was reported missing. It now matches REQ-IDs in any column. (#2203)

--- a/.changeset/noble-wasps-greet.md
+++ b/.changeset/noble-wasps-greet.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 2234
 ---
 **`phase complete` no longer false-reports REQ-IDs as missing when the traceability table leads with a status column** — the parser required the REQ-ID in the first column, so a table shaped `| ☐ | REQ-01 | …` matched zero rows and every body REQ-ID was reported missing. It now matches REQ-IDs in any column. (#2203)

--- a/src/phase.cts
+++ b/src/phase.cts
@@ -1672,7 +1672,11 @@ function cmdPhaseComplete(cwd: string, phaseNum: string, raw: boolean): void {
             ? reqContent.slice(traceabilityHeadingMatch.index)
             : '';
           const tableReqIds = new Set<string>();
-          const tableRowPat = /^\|\s*([A-Z][A-Z0-9]*-\d+)\s*\|/gm;
+          // #2203: match REQ-IDs in any pipe-delimited cell (not just the first
+          // column) so a traceability table that leads with a status column (e.g.
+          // | ☐ | REQ-01 | …) is parsed correctly instead of reporting every row
+          // as missing.
+          const tableRowPat = /\|\s*([A-Z][A-Z0-9]*-\d+)\s*\|/g;
           let tableMatch: RegExpExecArray | null;
           while ((tableMatch = tableRowPat.exec(traceabilitySection)) !== null) {
             tableReqIds.add(tableMatch[1]);


### PR DESCRIPTION
Fixes #2203. One-line regex fix: drop the `^` line-anchor so REQ-IDs in any pipe-delimited cell are matched, not just the first column. gsd-test passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2234"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786510360&installation_id=134682257&pr_number=2234&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2234&signature=58487c3142942bb40c3de9c85e70b3241b438e6dc1c37eebcf22385ee7dc68a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->