### PR TITLE
fix(#2206): strip trailing slashes in isGitIgnored to avoid CRLF check-ignore quirk

### DIFF
--- a/.changeset/tidy-voles-glide.md
+++ b/.changeset/tidy-voles-glide.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 2235
 ---
 **`commit_docs` no longer silently disables on CRLF `.gitignore` repos** — git check-ignore falsely reports a trailing-slash path (e.g. `.planning/`) as ignored when the .gitignore has CRLF line endings with blank lines. isGitIgnored now strips trailing slashes before querying, so the false positive cannot occur. (#2206)

--- a/.changeset/tidy-voles-glide.md
+++ b/.changeset/tidy-voles-glide.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`commit_docs` no longer silently disables on CRLF `.gitignore` repos** — git check-ignore falsely reports a trailing-slash path (e.g. `.planning/`) as ignored when the .gitignore has CRLF line endings with blank lines. isGitIgnored now strips trailing slashes before querying, so the false positive cannot occur. (#2206)

--- a/src/config-loader.cts
+++ b/src/config-loader.cts
@@ -175,10 +175,14 @@ interface ParsedConfig {
 const _gitIgnoredCache = new Map<string, boolean>();
 
 function isGitIgnored(cwd: string, targetPath: string): boolean {
-  const key = cwd + '::' + targetPath;
+  // #2206: strip trailing slashes — `git check-ignore` has a quirk where a
+  // CRLF .gitignore with blank lines falsely reports a trailing-slash path
+  // (e.g. `.planning/`) as ignored. Normalizing here protects every call site.
+  const normalized = targetPath.replace(/\/+$/, '');
+  const key = cwd + '::' + normalized;
   if (_gitIgnoredCache.has(key)) return _gitIgnoredCache.get(key)!;
   // --no-index checks .gitignore rules regardless of whether the file is tracked.
-  const result = execGit(['check-ignore', '-q', '--no-index', '--', targetPath], { cwd });
+  const result = execGit(['check-ignore', '-q', '--no-index', '--', normalized], { cwd });
   const ignored = result.exitCode === 0;
   _gitIgnoredCache.set(key, ignored);
   return ignored;


### PR DESCRIPTION
Fixes #2206 — confirmed-bug. One-function normalization: strip trailing slashes from `targetPath` inside `isGitIgnored()` before calling `git check-ignore`. This prevents the CRLF-.gitignore-with-blank-lines false positive where `.planning/` (trailing slash) is reported as ignored even when it's tracked. gsd-test passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2235"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786510488&installation_id=134682257&pr_number=2235&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2235&signature=1ce860fd9473243ca73fec27daaf92cd6189cb7b82c7e74a5631e617e9ffc61e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->