### PR TITLE
docs(#2240): clarify PLAN.md <execution_context> is install-relative, not clone-portable

### DIFF
--- a/.out-of-scope/plan-md-execution-context-portability.md
+++ b/.out-of-scope/plan-md-execution-context-portability.md
@@ -1,0 +1,42 @@
+# Clone-Portable `<execution_context>` in Committed PLAN.md
+
+GSD does not make the `<execution_context>` block in committed `PLAN.md` files
+clone-portable — it does not rewrite the planner's install-relative
+`@…/gsd-core/…` references into repository-relative or install-neutral paths so
+that a committed plan reads identically across developers, machines, or runtimes.
+
+## Why this is out of scope
+
+PLAN.md is a **machine artifact**, not a human- or clone-facing document — the
+same principle that governs [plan-md-human-rendering.md](./plan-md-human-rendering.md)
+(from #2158). A committed PLAN.md is a per-run agent instruction set, produced by
+`gsd-planner` and consumed in place by `gsd-executor`, `gsd-plan-checker`, and
+`gsd-verifier`. There is no documented step in which a plan is read on another
+machine after `git clone` without a local GSD install.
+
+Under that model, `<execution_context>`'s `@` references point at the reader's
+own local GSD install (Claude `~/.claude/gsd-core/…`, Cursor `.cursor/gsd-core/…`,
+or an absolute path for a `--local` install). They are install-relative by design,
+and the executor loads those workflows from its own installed copy — it never
+consumes the paths a *different* machine wrote into a committed plan.
+`/gsd-execute-phase` builds its own `<execution_context>` inline from the
+orchestrator's installed workflow (`workflows/execute-phase.md`), so the block a
+planner writes into a committed plan does not gate execution anywhere.
+
+Making committed plans clone-portable would treat PLAN.md as a shared
+cross-developer document — the boundary #2158 declined to cross — for a block that
+no consumer reads across machines.
+
+**Revisit if** GSD introduces a documented cross-developer / cross-machine contract
+for committed PLAN.md — a human- or teammate-facing use where plans are read after
+`git clone` without a local install — at which point `<execution_context>`
+portability becomes in scope.
+
+## Prior requests
+
+- #2238 — "Planner embeds machine-specific gsd-core paths in committed PLAN.md execution_context"
+
+## Related
+
+- `.out-of-scope/plan-md-human-rendering.md` — #2158, the governing "PLAN.md is a machine artifact" precedent.
+- `docs/reference/plan-md.md` — the `<execution_context>` reference, which describes the install-relative behaviour.

--- a/docs/reference/plan-md.md
+++ b/docs/reference/plan-md.md
@@ -118,7 +118,7 @@ Output: PostFeed and PostCard components wired to /api/feed.
 
 ### `<execution_context>`
 
-Lists workflow files the executor reads before starting. Always includes the execute-plan workflow; adds the checkpoints reference when the plan contains checkpoint tasks:
+Lists the workflow files associated with executing the plan. Always includes the execute-plan workflow; adds the checkpoints reference when the plan contains checkpoint tasks:
 
 ```xml
 <execution_context>
@@ -126,6 +126,8 @@ Lists workflow files the executor reads before starting. Always includes the exe
 @~/.claude/gsd-core/templates/summary.md
 </execution_context>
 ```
+
+These `@` paths point at the local GSD install, not at repository files. The prefix shown here (`~/.claude/gsd-core/…`) is the Claude global-install location; other runtimes and local installs resolve to their own install directory — for example `.cursor/gsd-core/…`, or an absolute project path for a `--local` install. Because the prefix is install-relative, this block is not clone-portable: a committed plan carries whichever prefix the authoring install had. Execution does not depend on it — `/gsd-execute-phase` loads the execute-plan workflow from its own installed copy — so the block records the execution context rather than resolvable repository references. Contrast `<context>` (below), whose repository-relative `@` paths resolve after a `git clone`.
 
 ### `<context>`
 


### PR DESCRIPTION
<!-- pr-template-exempt: docs-only — reference-doc clarification + out-of-scope decision record, no code changed -->

## Docs-only: PLAN.md `<execution_context>` is install-relative

Closes #2240. Refs #2238 (wontfix), #2158.

Documents accurately — **no behaviour change** — that a committed PLAN.md's `<execution_context>` block is install-relative and not clone-portable, following the #2238 wontfix (PLAN.md is a machine artifact; the `.out-of-scope/plan-md-human-rendering.md` / #2158 precedent).

### Changes

- **`docs/reference/plan-md.md`** — Reference-voice clarification: the `<execution_context>` `@` paths point at the reader's local GSD install, vary by runtime/install (`~/.claude/gsd-core` vs `.cursor/gsd-core` vs an absolute `--local` path), are **not** clone-portable, and are loaded by the executor from its own installed copy (execution does not depend on the committed block). Contrasted with repository-relative `<context>`.
- **`.out-of-scope/plan-md-execution-context-portability.md`** — new decision record mirroring `plan-md-human-rendering.md`, citing the #2158 machine-artifact precedent, with a `Revisit if` condition and #2238 under Prior requests.

### Notes

- Docs-only (two `.md` files, zero code/tests) → `no-changelog` applied; `gsd-test` is N/A.
- The reference doc follows Diátaxis (descriptive/neutral voice, British English).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2241"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786550068&installation_id=134682257&pr_number=2241&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2241&signature=9566c2f44d74ce91345d9c01fc532ee980e62efb45e6e6628dad05a6cbef3846"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->