### PR TITLE
ci(#2280): fix release-pipeline workflow defects (finalize timeout + auto-backmerge build:lib)

### DIFF
--- a/.github/workflows/auto-backmerge.yml
+++ b/.github/workflows/auto-backmerge.yml
@@ -141,6 +141,16 @@ jobs:
             echo "dropped_oneline=" >> "$GITHUB_OUTPUT"
           fi
 
+      # The version bump below fires the `version` npm lifecycle hook, which runs
+      # gen-capability-registry.cjs. That validator lazily require()s the built
+      # gsd-core/bin/lib/capability-ledger.cjs (a build:lib output, gitignored);
+      # when it is absent the bounded fragment reader falls back to a fail-closed
+      # stub and every capability fragment reports "could not be read", failing
+      # the sync. Build the ledger first so fragments materialize.
+      - name: Install dependencies and build (required by the version-sync hook)
+        if: steps.check.outputs.next_exists == 'true'
+        run: npm ci --silent && npm run build:lib
+
       - name: Sync next's version to main's released version
         if: steps.check.outputs.next_exists == 'true'
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -507,7 +507,10 @@ jobs:
     needs: [validate-version, install-smoke-finalize]
     if: inputs.action == 'finalize'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # Matches the rc job's budget: `npm ci` + `npm run test:coverage:unit` now
+    # exceeds 10m as the unit suite grows, so a 10m cap cancels the job mid-test
+    # before tag/publish. 30m gives the same headroom rc already relies on.
+    timeout-minutes: 30
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
<!-- pr-template-exempt: CI/tooling — changes only .github/workflows/*.yml -->

Closes #2280

## What was broken
Two release-pipeline workflow defects surfaced while cutting **v1.7.0**:

1. **`release.yml` finalize job `timeout-minutes: 10`** — the `Install and test` step (`npm ci` + `npm run test:coverage:unit`) now exceeds 10 minutes as the unit suite has grown, so the `finalize` job is **cancelled mid-test** before the tag/publish steps. Tests were passing right up to the cancellation (pure wall-clock). The sibling `rc` job already uses `timeout-minutes: 30`; finalize's stale `10` went unexercised because recent releases only ran `rc`. This blocks any stable release from completing.
2. **`auto-backmerge.yml` version-sync runs before `build:lib`** — the `Sync next's version` step fires `npm version`, whose lifecycle hook runs `gen-capability-registry.cjs`. That validator (`materializeHookFragments`) lazily `require()`s the **gitignored `build:lib` output `gsd-core/bin/lib/capability-ledger.cjs`**; when absent, the bounded fragment reader falls back to a **fail-closed stub** and every `capabilities/*/fragments/*.md` reports "could not be read", failing every `main → next` back-merge.

## What this fix does
- `release.yml`: raise the `finalize` job `timeout-minutes` from `10` to `30` (match `rc`).
- `auto-backmerge.yml`: add an `Install dependencies and build` (`npm ci --silent && npm run build:lib`) step immediately before the version-sync step so `capability-ledger.cjs` exists when the version hook runs.

## Root cause
Both are release-engineering plumbing. The finalize timeout was too tight for the grown suite; the auto-backmerge omitted the `npm ci && build:lib` prerequisite (a regression of `329233fc8`). The finalize fix already landed on `main` via the v1.7.0 release cut, but `next`'s copies of both workflows still carried the bugs because the `-s ours` back-merge model never carries workflow fixes from `main` back to `next`.

## Testing
Verified against the live v1.7.0 release: the identical timeout fix (applied to the release branch) took the `finalize` dry-run from **cancelled** to **green**, then the real finalize published `1.7.0` successfully. The auto-backmerge failure log confirms the `capability-ledger.cjs` fail-closed path; adding `build:lib` restores the materialization the reader needs.

Regression test: not added — these are GitHub Actions workflow-runner config changes (job timeout budget; step ordering) with no unit-testable surface.

## Notes
- **CI-only** change (`.github/workflows/` only) — no user-facing behavior change, so `no-changelog` (not a changeset).
- Reviewed for security: the added `npm ci`/`build:lib` step introduces no new secrets, untrusted input, or injection surface; the release change is a numeric timeout.

## Breaking changes
None.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2281"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786674606&installation_id=134682257&pr_number=2281&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2281&signature=ecd0079535923e92c484d459c9d4812d911cb2173bb3971ce1c053de42bafce7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->