### PR TITLE
fix(#2315): respect review.default_reviewers in plan-review-convergence

### DIFF
--- a/.changeset/curious-otters-dance.md
+++ b/.changeset/curious-otters-dance.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 1
+---
+**`/gsd-plan-review-convergence` bare invocation no longer silently overrides `review.default_reviewers` with `--codex`** — when no reviewer flags are provided, the orchestrator now defers to `review.default_reviewers` (and configured `review.reviewer_instances`) and only falls back to `--codex` when that config is unset/empty. (#2315)

--- a/.changeset/curious-otters-dance.md
+++ b/.changeset/curious-otters-dance.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 1
+pr: 2321
 ---
 **`/gsd-plan-review-convergence` bare invocation no longer silently overrides `review.default_reviewers` with `--codex`** — when no reviewer flags are provided, the orchestrator now defers to `review.default_reviewers` (and configured `review.reviewer_instances`) and only falls back to `--codex` when that config is unset/empty. (#2315)

--- a/commands/gsd/plan-review-convergence.md
+++ b/commands/gsd/plan-review-convergence.md
@@ -40,7 +40,7 @@ Replaces gsd-plan-phase's internal gsd-plan-checker with external AI reviewers (
 Phase number: extracted from $ARGUMENTS (required)
 
 **Flags:**
-- `--codex` — Use Codex CLI as reviewer (default if no reviewer specified)
+- `--codex` — Use Codex CLI as reviewer (default if no reviewer specified and `review.default_reviewers` is unset/empty)
 - `--gemini` — Use Gemini CLI as reviewer
 - `--claude` — Use Claude CLI as reviewer (separate session)
 - `--opencode` — Use OpenCode as reviewer
@@ -49,6 +49,8 @@ Phase number: extracted from $ARGUMENTS (required)
 - `--llama-cpp` — Use local llama.cpp server as reviewer (OpenAI-compatible, default host `http://localhost:8080`; configure model via `review.models.llama_cpp`)
 - `--all` — Use all available CLIs and running local model servers
 - `--max-cycles N` — Maximum replan→review cycles (default: 3)
+
+**Bare invocation (no reviewer flags):** Uses `review.default_reviewers` when configured; otherwise defaults to `--codex`. Explicit reviewer flags always override the config.
 
 **Feature gate:** This command requires `workflow.plan_review_convergence=true`. Enable with:
 `gsd config-set workflow.plan_review_convergence true`

--- a/gsd-core/workflows/plan-review-convergence.md
+++ b/gsd-core/workflows/plan-review-convergence.md
@@ -32,7 +32,8 @@ echo "$ARGUMENTS" | grep -q '\-\-ollama' && REVIEWER_FLAGS="$REVIEWER_FLAGS --ol
 echo "$ARGUMENTS" | grep -q '\-\-lm-studio' && REVIEWER_FLAGS="$REVIEWER_FLAGS --lm-studio"
 echo "$ARGUMENTS" | grep -q '\-\-llama-cpp' && REVIEWER_FLAGS="$REVIEWER_FLAGS --llama-cpp"
 echo "$ARGUMENTS" | grep -q '\-\-all' && REVIEWER_FLAGS="$REVIEWER_FLAGS --all"
-if [ -z "$REVIEWER_FLAGS" ]; then REVIEWER_FLAGS="--codex"; fi
+# Do NOT default REVIEWER_FLAGS to --codex here. When empty, step 1.6 either
+# falls through to review.default_reviewers (via gsd-review) or applies --codex.
 
 MAX_CYCLES=$(echo "$ARGUMENTS" | grep -oE '\-\-max-cycles\s+[0-9]+' | awk '{print $2}')
 if [ -z "$MAX_CYCLES" ]; then MAX_CYCLES=3; fi
@@ -59,6 +60,23 @@ Enable it with:
   gsd config-set workflow.plan_review_convergence true
 
 Then re-run: /gsd:plan-review-convergence {PHASE}
+```
+
+## 1.6. Default reviewer resolution (after gsd_run is available)
+
+When no explicit reviewer flags were provided, respect `review.default_reviewers`
+instead of unconditionally forcing `--codex` (which would always win gsd-review's
+flag precedence and skip configured defaults / reviewer instances).
+
+```bash
+if [ -z "$REVIEWER_FLAGS" ]; then
+  DEFAULT_REVIEWERS_COUNT=$(gsd_run query config-get review.default_reviewers 2>/dev/null | jq 'if type=="array" then length else 0 end' 2>/dev/null)
+  if [ "${DEFAULT_REVIEWERS_COUNT:-0}" -gt 0 ] 2>/dev/null; then
+    : # leave REVIEWER_FLAGS empty — gsd-review applies review.default_reviewers itself
+  else
+    REVIEWER_FLAGS="--codex"
+  fi
+fi
 ```
 
 ## 2. Initialize

--- a/skills/gsd-plan-review-convergence/SKILL.md
+++ b/skills/gsd-plan-review-convergence/SKILL.md
@@ -40,7 +40,7 @@ Replaces gsd-plan-phase's internal gsd-plan-checker with external AI reviewers (
 Phase number: extracted from $ARGUMENTS (required)
 
 **Flags:**
-- `--codex` — Use Codex CLI as reviewer (default if no reviewer specified)
+- `--codex` — Use Codex CLI as reviewer (default if no reviewer specified and `review.default_reviewers` is unset/empty)
 - `--gemini` — Use Gemini CLI as reviewer
 - `--claude` — Use Claude CLI as reviewer (separate session)
 - `--opencode` — Use OpenCode as reviewer
@@ -49,6 +49,8 @@ Phase number: extracted from $ARGUMENTS (required)
 - `--llama-cpp` — Use local llama.cpp server as reviewer (OpenAI-compatible, default host `http://localhost:8080`; configure model via `review.models.llama_cpp`)
 - `--all` — Use all available CLIs and running local model servers
 - `--max-cycles N` — Maximum replan→review cycles (default: 3)
+
+**Bare invocation (no reviewer flags):** Uses `review.default_reviewers` when configured; otherwise defaults to `--codex`. Explicit reviewer flags always override the config.
 
 **Feature gate:** This command requires `workflow.plan_review_convergence=true`. Enable with:
 `gsd config-set workflow.plan_review_convergence true`

--- a/tests/plan-review-convergence.test.cjs
+++ b/tests/plan-review-convergence.test.cjs
@@ -118,6 +118,13 @@ describe('plan-review-convergence command source (#2306)', () => {
     );
   });
 
+  test('command documents bare-invocation fallback to review.default_reviewers (#2315)', () => {
+    assert.ok(
+      command.includes('review.default_reviewers'),
+      'command must document that bare invocation uses review.default_reviewers when configured (#2315)'
+    );
+  });
+
   test('command documents the workflow.plan_review_convergence config key', () => {
     assert.ok(
       command.includes('workflow.plan_review_convergence') ||
@@ -150,6 +157,49 @@ describe('plan-review-convergence workflow: initialization (#2306)', () => {
     assert.ok(
       workflow.includes('PLAN CONVERGENCE') || workflow.includes('Plan Convergence'),
       'workflow must display a startup banner'
+    );
+  });
+});
+
+// ─── Workflow: default reviewer resolution (#2315) ─────────────────────────
+
+describe('plan-review-convergence workflow: default reviewer resolution (#2315)', () => {
+  const workflow = fs.readFileSync(WORKFLOW_PATH, 'utf8');
+
+  test('step 1 does not unconditionally force --codex when no reviewer flags match', () => {
+    // The early parse block must leave REVIEWER_FLAGS empty so step 1.6 can
+    // honor review.default_reviewers. Detect the old bug pattern:
+    //   if [ -z "$REVIEWER_FLAGS" ]; then REVIEWER_FLAGS="--codex"; fi
+    // appearing BEFORE the default_reviewers config-get.
+    const step1End = workflow.indexOf('## 1.5.');
+    assert.ok(step1End > 0, 'workflow must have step 1.5');
+    const step1 = workflow.slice(0, step1End);
+    assert.equal(
+      /if \[ -z "\$REVIEWER_FLAGS" \]; then REVIEWER_FLAGS="--codex"; fi/.test(step1),
+      false,
+      'step 1 must not force REVIEWER_FLAGS=--codex before config resolution (#2315)'
+    );
+  });
+
+  test('workflow resolves empty REVIEWER_FLAGS via review.default_reviewers after gsd_run is available', () => {
+    assert.ok(
+      workflow.includes('review.default_reviewers'),
+      'workflow must read review.default_reviewers when no reviewer flags are set (#2315)'
+    );
+    assert.ok(
+      workflow.includes('DEFAULT_REVIEWERS_COUNT'),
+      'workflow must compute DEFAULT_REVIEWERS_COUNT from review.default_reviewers (#2315)'
+    );
+  });
+
+  test('workflow still defaults to --codex when review.default_reviewers is empty', () => {
+    // After the default_reviewers gate, empty config must still set --codex
+    const resolutionIdx = workflow.indexOf('DEFAULT_REVIEWERS_COUNT');
+    assert.ok(resolutionIdx > 0, 'must contain DEFAULT_REVIEWERS_COUNT resolution block');
+    const after = workflow.slice(resolutionIdx);
+    assert.ok(
+      after.includes('REVIEWER_FLAGS="--codex"'),
+      'when default_reviewers is empty, workflow must still default REVIEWER_FLAGS to --codex (#2315)'
     );
   });
 });


### PR DESCRIPTION
## Linked Issue

Closes #2315

## What was broken

`plan-review-convergence` workflow 里 `resolveReviewerSelection` 永远会命中 `explicitFlags` 分支，导致 `review.default_reviewers` 配置完全无法生效。

## What this fix does

把 step 1 的 `--codex` flag 移除，改用 `config-get review.default_reviewers` + `jq` 来判断是否配置了默认 reviewer。

## Root cause

`REVIEWER_FLAGS="--codex"` 是无条件写入的，导致 `explicitFlags.size > 0` 永远为 true，`config_default` 分支永远走不到。

## Testing

- 在 `next` 上验证了 `resolveReviewerSelection` 的实际逻辑
- 本地使用 `node --test` 验证了修改后的行为

## Checklist

- [x] Changeset 已添加
- [x] 符合 PR 模板要求