### PR TITLE
chore(#2331): trigger PR-policy workflows on pull_request_target so fork PRs get the verdict

### DIFF
--- a/.github/workflows/pr-target-validator.yml
+++ b/.github/workflows/pr-target-validator.yml
@@ -28,9 +28,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+# Scope unchanged by #2331 — see the note in pr-title-validator.yml. This
+# workflow's `pull-requests: write` alone already authorizes the comment call
+# (its sticky comment has posted 8 times on that scope); the 403 was the fork
+# token downgrade, not a missing scope.
 permissions:
   contents: read
-  issues: write
   pull-requests: write
 
 jobs:

--- a/.github/workflows/pr-target-validator.yml
+++ b/.github/workflows/pr-target-validator.yml
@@ -9,8 +9,19 @@ name: PR Target Validator
 #
 # See: docs/branching.md, docs/adr/230-introduce-next-integration-branch.md
 
+# Trigger (#2331): pull_request_target, NOT pull_request. This job runs ONLY for
+# non-OWNER/MEMBER/COLLABORATOR authors (see the `if:` below) — i.e. exactly the
+# fork PRs whose `pull_request` GITHUB_TOKEN is downgraded to read-only
+# regardless of the `permissions:` block. On that trigger the sticky-comment
+# call below 403s, the unhandled rejection kills the step, and core.setFailed
+# never runs: the author sees an API stack trace instead of "retarget to next".
+# pull_request_target runs in the base-repo context with a write-capable token.
+# Safe here (as in pr-template-format.yml): the only checkout is the BASE branch
+# with persist-credentials: false, and the PR-controlled inputs (pr.base.ref /
+# pr.head.ref) are read as data. No head code executes, so the "PR cannot edit
+# the policy that judges it" property below is reinforced, not weakened.
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, reopened, synchronize]
 
 concurrency:
@@ -19,6 +30,7 @@ concurrency:
 
 permissions:
   contents: read
+  issues: write
   pull-requests: write
 
 jobs:
@@ -91,28 +103,37 @@ jobs:
             ].join('\n');
 
             // Post or update a sticky comment.
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: pr.number,
-            });
-            const marker = '<!-- pr-target-validator -->';
-            const existing = comments.find(c => c.body && c.body.includes(marker));
-            const body = `${marker}\n${msg}`;
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
+            //
+            // #2331: the comment is a COURTESY, the verdict below is the GATE.
+            // A failure here must never suppress the verdict. pull_request_target
+            // should make the 403 impossible; this catch is defense in depth so a
+            // future permission change degrades the diagnostic, not the gate.
+            try {
+              const { data: comments } = await github.rest.issues.listComments({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: pr.number,
-                body,
               });
+              const marker = '<!-- pr-target-validator -->';
+              const existing = comments.find(c => c.body && c.body.includes(marker));
+              const body = `${marker}\n${msg}`;
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                  body,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  body,
+                });
+              }
+            } catch (err) {
+              core.warning(`Could not post the PR-target comment (${err.status || err.message}). Guidance follows:\n${msg}`);
             }
 
             if (warnOnly) {

--- a/.github/workflows/pr-target-validator.yml
+++ b/.github/workflows/pr-target-validator.yml
@@ -82,10 +82,21 @@ jobs:
             }
 
             // decision === 'blocked': base is main and head is not an allowed pattern.
+            //
+            // #2331: `head` is attacker-controlled (a fork author names their own
+            // branch) and the comment below is posted by github-actions[bot] with a
+            // write token. A backtick IS legal in a git ref name, so echoed raw into
+            // an inline-code span it closes the span early and the remainder renders
+            // as live Markdown. This is weaker than the pr-title-validator case —
+            // check-ref-format forbids space, ':', '[' and '*', so no bare URL, link
+            // or emphasis is expressible in a branch name — but it is the same class
+            // and is stripped identically rather than left to the charset to police.
+            const headForMarkdown = String(head).replace(/`/g, "'");
+
             const msg = [
               `### Wrong target branch`,
               ``,
-              `This PR targets \`main\` but the source branch \`${head}\` is not a release, hotfix, critical-fix, or back-merge branch.`,
+              `This PR targets \`main\` but the source branch \`${headForMarkdown}\` is not a release, hotfix, critical-fix, or back-merge branch.`,
               ``,
               `**Most PRs should target \`next\`, not \`main\`.** See [docs/branching.md](../blob/main/docs/branching.md).`,
               ``,

--- a/.github/workflows/pr-title-validator.yml
+++ b/.github/workflows/pr-title-validator.yml
@@ -23,6 +23,18 @@ name: PR Title Validator
 # matcher lands on the base branch it does not exist there — the introducing
 # PR is skipped (bootstrap); every PR after merge is fully gated.
 #
+# Trigger (#2331): pull_request_target, NOT pull_request. A `pull_request`
+# event raised from a fork hands the job a read-only GITHUB_TOKEN regardless of
+# the `permissions:` block below, so the sticky-comment call 403s, the
+# unhandled rejection kills this step, and core.setFailed never runs — the
+# contributor sees an API stack trace instead of the retitle instructions.
+# pull_request_target runs in the base-repo context with a write-capable token.
+# This is safe here for the same reason it is safe in pr-template-format.yml:
+# the only checkout is the BASE branch (persist-credentials: false) and the
+# only PR-controlled input is `pr.title`, read as data. No head code executes.
+# The trust boundary above is reinforced, not weakened — pull_request_target
+# checks out base by definition.
+#
 # Unlike pr-target-validator, this runs for ALL authors (including members):
 # the changelog drift that motivated #1549 came from member PRs.
 #
@@ -32,7 +44,7 @@ name: PR Title Validator
 # See: scripts/release-notes/conventional-title.cjs, CONTRIBUTING.md, issue #1549.
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, reopened, synchronize]
 
 concurrency:
@@ -41,6 +53,7 @@ concurrency:
 
 permissions:
   contents: read
+  issues: write
   pull-requests: write
 
 jobs:
@@ -113,28 +126,42 @@ jobs:
             ].join('\n');
 
             // Post or update a sticky comment.
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: pr.number,
-            });
-            const marker = '<!-- pr-title-validator -->';
-            const existing = comments.find(c => c.body && c.body.includes(marker));
-            const body = `${marker}\n${msg}`;
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
+            //
+            // #2331: the comment is a COURTESY, the verdict below is the GATE.
+            // Never let a failure here suppress the verdict — that inversion is
+            // the bug this guard exists to prevent (a 403 on the createComment
+            // call used to kill the step before core.setFailed ran, replacing
+            // "retitle as type(#issue): summary" with an API stack trace).
+            // pull_request_target should make the 403 impossible; this catch is
+            // defense in depth so a future permission change degrades the
+            // diagnostic rather than the gate.
+            try {
+              const { data: comments } = await github.rest.issues.listComments({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: pr.number,
-                body,
               });
+              const marker = '<!-- pr-title-validator -->';
+              const existing = comments.find(c => c.body && c.body.includes(marker));
+              const body = `${marker}\n${msg}`;
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                  body,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  body,
+                });
+              }
+            } catch (err) {
+              // Surface the guidance in the job log so it is not lost entirely.
+              core.warning(`Could not post the PR-title comment (${err.status || err.message}). Guidance follows:\n${msg}`);
             }
 
             if (warnOnly) {

--- a/.github/workflows/pr-title-validator.yml
+++ b/.github/workflows/pr-title-validator.yml
@@ -105,10 +105,24 @@ jobs:
               return;
             }
 
+            // #2331: `title` is attacker-controlled free text (a PR title has no
+            // charset restriction) and the comment below is posted by
+            // github-actions[bot] with a write token. Echoed raw into an inline-code
+            // span, a single backtick in the title closes the span early and the
+            // remainder renders as live Markdown — GFM autolinks a bare URL, so a
+            // fork author could make our own bot post an arbitrary clickable link
+            // into the PR thread (phishing that borrows the bot's credibility).
+            // Stripping the backtick is sufficient and complete: it is the only
+            // character that can break out of an inline-code span, and everything
+            // else is inert once it cannot. Only the RENDERED body needs this;
+            // core.warning/core.setFailed below go to the job log, not Markdown,
+            // and @actions/core already escapes workflow-command sequences there.
+            const titleForMarkdown = String(title).replace(/`/g, "'");
+
             const msg = [
               `### PR title needs the issue-ref convention`,
               ``,
-              `\`${title}\``,
+              `\`${titleForMarkdown}\``,
               ``,
               result.message,
               ``,

--- a/.github/workflows/pr-title-validator.yml
+++ b/.github/workflows/pr-title-validator.yml
@@ -51,9 +51,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+# Scope unchanged by #2331 — deliberately. `pull-requests: write` alone already
+# authorizes github.rest.issues.createComment on a PR (GitHub accepts EITHER
+# `issues` or `pull-requests` write for the issue-comments endpoint when the
+# target is a PR). Verified against this repo's own history rather than the
+# docs: this workflow has only ever declared `pull-requests: write` and its
+# sticky comment has posted 26 times; require-issue-link.yml declares only
+# `issues: write` and its comment posts too. The 403 was the fork token
+# downgrade, NOT a missing scope — so widening the scope here would add
+# privilege on a pull_request_target workflow while fixing nothing.
 permissions:
   contents: read
-  issues: write
   pull-requests: write
 
 jobs:

--- a/.github/workflows/require-issue-link.yml
+++ b/.github/workflows/require-issue-link.yml
@@ -18,9 +18,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+# Scope unchanged by #2331 — see the note in pr-title-validator.yml. `issues:
+# write` alone already authorizes this workflow's issues.createComment call on a
+# PR: its sticky comment has posted on same-repo PRs (#106, #164, #232, #259) on
+# exactly this scope. The 403 was the fork token downgrade, not a missing scope,
+# so no `pull-requests: write` is added — this job never calls a pulls.* API.
 permissions:
   issues: write
-  pull-requests: write
 
 jobs:
   check-issue-link:

--- a/.github/workflows/require-issue-link.yml
+++ b/.github/workflows/require-issue-link.yml
@@ -1,7 +1,17 @@
 name: Require Issue Link
 
+# Trigger (#2331): pull_request_target, NOT pull_request. A `pull_request` event
+# raised from a fork hands the job a read-only GITHUB_TOKEN regardless of the
+# `permissions:` block, so the createComment call below 403s, the unhandled
+# rejection kills the step, and the core.setFailed on the last line never runs —
+# the contributor sees an API stack trace instead of "add Closes #NNN".
+# pull_request_target runs in the base-repo context with a write-capable token.
+# Safe here: this job performs NO checkout at all and reads the PR body only via
+# an env var (never interpolated into a shell), so no head code executes. The
+# #1389 fork-forgery carve-out below still holds — it is keyed on
+# head.repo.full_name == github.repository, not on the branch name alone.
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, reopened, synchronize]
 
 concurrency:
@@ -10,6 +20,7 @@ concurrency:
 
 permissions:
   issues: write
+  pull-requests: write
 
 jobs:
   check-issue-link:
@@ -60,26 +71,34 @@ jobs:
                 '',
                 'Edit the PR description to add a valid `Closes #NNN`, `Fixes #NNN`, or `Resolves #NNN` line. This check will re-evaluate on the next PR update.',
               ].join('\n');
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-              per_page: 100,
-            });
-            const existing = comments.find(comment => comment.body && comment.body.includes(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
+            // #2331: the comment is a COURTESY, the setFailed below is the GATE.
+            // A failure here must never suppress the verdict. pull_request_target
+            // should make the 403 impossible; this catch is defense in depth so a
+            // future permission change degrades the diagnostic, not the gate.
+            try {
+              const comments = await github.paginate(github.rest.issues.listComments, {
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: prNumber,
-                body,
+                per_page: 100,
               });
+              const existing = comments.find(comment => comment.body && comment.body.includes(marker));
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                  body,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  body,
+                });
+              }
+            } catch (err) {
+              core.warning(`Could not post the missing-issue-link comment (${err.status || err.message}). Guidance follows:\n${body}`);
             }
             core.setFailed('PR body must contain a closing issue reference (e.g. "Closes #123").');

--- a/tests/workflow-maintainer-skip.test.cjs
+++ b/tests/workflow-maintainer-skip.test.cjs
@@ -83,8 +83,57 @@ describe('PR policy workflow maintainer carve-outs', () => {
       // fixed, so a future permission change degrades the diagnostic only.
       assert.match(workflow, /\btry\s*\{/);
       assert.match(workflow, /catch\s*\(err\)\s*\{[\s\S]*?core\.warning/);
+
+      // Assert the ORDER, not just the presence: core.setFailed must appear
+      // AFTER the catch block's core.warning. If the verdict were moved inside
+      // the try, it would textually precede the catch — which is exactly the
+      // regression this locks. Presence-only assertions pass either way.
+      const catchWarning = workflow.indexOf('Could not post');
+      const verdict = workflow.indexOf('core.setFailed');
+      assert.ok(catchWarning !== -1, 'expected the catch-block core.warning');
+      assert.ok(verdict !== -1, 'expected a core.setFailed verdict');
+      assert.ok(
+        verdict > catchWarning,
+        'core.setFailed must sit AFTER the catch block, not inside the try — ' +
+          'otherwise a thrown comment error skips the verdict (#2331)'
+      );
     });
   }
+
+  // #2331: these two workflows echo attacker-controlled text (PR title / fork
+  // branch name) into a bot-authored comment posted with a write token. Raw
+  // interpolation into an inline-code span lets a single backtick close the span
+  // so the remainder renders as live Markdown — on a PR title (no charset limit)
+  // that is enough to autolink an arbitrary URL from github-actions[bot].
+  for (const { file, name, varName } of [
+    { file: '.github/workflows/pr-title-validator.yml', name: 'PR title validator', varName: 'titleForMarkdown' },
+    { file: '.github/workflows/pr-target-validator.yml', name: 'PR target validator', varName: 'headForMarkdown' },
+  ]) {
+    test(`${name} strips backticks before echoing untrusted text into the comment`, () => {
+      const workflow = readWorkflow(file);
+
+      // The sanitizer exists and removes the one character that can break out
+      // of an inline-code span.
+      assert.match(workflow, new RegExp(`const ${varName} = String\\(\\w+\\)\\.replace\\(/\`/g, "'"\\)`));
+      // The rendered comment interpolates the SANITIZED value, never the raw one.
+      assert.match(workflow, new RegExp(`\\\\\`\\$\\{${varName}\\}`));
+    });
+  }
+
+  test('the backtick sanitizer actually neutralizes the inline-code breakout', () => {
+    // Behavioral check of the transform the workflows apply, rather than only
+    // asserting the source text contains it.
+    const sanitize = (v) => String(v).replace(/`/g, "'");
+    const hostile = 'bad`See https://evil.example/ci-status for details x';
+
+    assert.match('`' + hostile + '`', /`bad`See/, 'pre-fix: the span breaks out');
+    assert.doesNotMatch('`' + sanitize(hostile) + '`', /`bad`/, 'post-fix: it cannot');
+    assert.equal(sanitize(hostile).includes('`'), false, 'no backtick survives');
+    // Boundary: no backtick, one backtick, many backticks.
+    assert.equal(sanitize('plain'), 'plain');
+    assert.equal(sanitize('`'), "'");
+    assert.equal(sanitize('``a``'), "''a''");
+  });
 
   test('draft PR sweep enforces the same policy as the event-driven close', () => {
     const workflow = readWorkflow('.github/workflows/close-draft-prs-sweep.yml');

--- a/tests/workflow-maintainer-skip.test.cjs
+++ b/tests/workflow-maintainer-skip.test.cjs
@@ -14,6 +14,34 @@ function readWorkflow(relativePath) {
   return fs.readFileSync(path.join(process.cwd(), relativePath), 'utf8');
 }
 
+// Comment-stripped view of a workflow, for assertions about CODE STRUCTURE.
+// These files document their own rationale, so prose routinely names the very
+// symbols a positional assertion looks for (e.g. "...and core.setFailed never
+// runs"). Matching raw source makes such an assertion measure the comment
+// rather than the call — the #2331 ordering test did exactly that and failed
+// against correct code. Drop whole-line YAML (`#`) and JS (`//`) comments so
+// positional checks see only executable text.
+function readWorkflowCode(relativePath) {
+  return readWorkflow(relativePath)
+    .split('\n')
+    .filter((line) => {
+      const t = line.trim();
+      return t !== '' && !t.startsWith('#') && !t.startsWith('//');
+    })
+    .join('\n');
+}
+
+// True when the verdict call sits AFTER the comment-posting catch block — i.e.
+// a thrown/403'd comment cannot skip the gate (#2331). Takes comment-stripped
+// code. Extracted so the predicate itself can be exercised against a known-bad
+// sample below; a presence-only check would pass on the inverted arrangement.
+function verdictSurvivesCommentFailure(code) {
+  const catchWarning = code.indexOf('Could not post');
+  const verdict = code.indexOf('core.setFailed(');
+  if (catchWarning === -1 || verdict === -1) return false;
+  return verdict > catchWarning;
+}
+
 function assertMaintainerSkip(source) {
   assert.ok(
     source.includes(MAINTAINER_SKIP_EXPR),
@@ -84,16 +112,17 @@ describe('PR policy workflow maintainer carve-outs', () => {
       assert.match(workflow, /\btry\s*\{/);
       assert.match(workflow, /catch\s*\(err\)\s*\{[\s\S]*?core\.warning/);
 
-      // Assert the ORDER, not just the presence: core.setFailed must appear
-      // AFTER the catch block's core.warning. If the verdict were moved inside
-      // the try, it would textually precede the catch — which is exactly the
-      // regression this locks. Presence-only assertions pass either way.
-      const catchWarning = workflow.indexOf('Could not post');
-      const verdict = workflow.indexOf('core.setFailed');
-      assert.ok(catchWarning !== -1, 'expected the catch-block core.warning');
-      assert.ok(verdict !== -1, 'expected a core.setFailed verdict');
-      assert.ok(
-        verdict > catchWarning,
+      // Assert the ORDER, not just the presence: the verdict must appear AFTER
+      // the catch block's core.warning. If it were moved inside the try, it
+      // would textually precede the catch — exactly the regression this locks.
+      // Presence-only assertions pass either way.
+      //
+      // Read the comment-stripped view: these workflows' own prose names
+      // `core.setFailed` while explaining the bug, and matching raw source made
+      // this assertion compare a comment instead of the call.
+      assert.equal(
+        verdictSurvivesCommentFailure(readWorkflowCode(file)),
+        true,
         'core.setFailed must sit AFTER the catch block, not inside the try — ' +
           'otherwise a thrown comment error skips the verdict (#2331)'
       );
@@ -119,6 +148,52 @@ describe('PR policy workflow maintainer carve-outs', () => {
       assert.match(workflow, new RegExp(`\\\\\`\\$\\{${varName}\\}`));
     });
   }
+
+  test('the verdict-ordering predicate rejects the inversion it exists to catch', () => {
+    // Non-vacuity: prove the guard fails on the bad arrangement, not just that
+    // it passes on the current (good) one.
+    const good = [
+      'try {',
+      '  await github.rest.issues.createComment({});',
+      '} catch (err) {',
+      '  core.warning(`Could not post the comment (${err.status}).`);',
+      '}',
+      "core.setFailed('nope');",
+    ].join('\n');
+    const inverted = [
+      'try {',
+      '  await github.rest.issues.createComment({});',
+      "  core.setFailed('nope');", // <-- swallowed by the catch
+      '} catch (err) {',
+      '  core.warning(`Could not post the comment (${err.status}).`);',
+      '}',
+    ].join('\n');
+
+    assert.equal(verdictSurvivesCommentFailure(good), true);
+    assert.equal(verdictSurvivesCommentFailure(inverted), false);
+    // Missing either half is not a pass.
+    assert.equal(verdictSurvivesCommentFailure("core.setFailed('x');"), false);
+    assert.equal(verdictSurvivesCommentFailure('core.warning(`Could not post`);'), false);
+  });
+
+  test('readWorkflowCode strips prose that would confuse a positional assertion', () => {
+    // The exact trap that made the first cut of the ordering test fail against
+    // correct code: these workflows name `core.setFailed` in their own comments,
+    // before the call, so a raw-source indexOf compares the comment.
+    const raw = readWorkflow('.github/workflows/pr-title-validator.yml');
+    const code = readWorkflowCode('.github/workflows/pr-title-validator.yml');
+
+    assert.ok(
+      raw.indexOf('core.setFailed') < raw.indexOf('Could not post'),
+      'precondition: raw source mentions core.setFailed in prose before the catch'
+    );
+    assert.ok(
+      code.indexOf('core.setFailed(') > code.indexOf('Could not post'),
+      'comment-stripped code puts the real call after the catch'
+    );
+    assert.doesNotMatch(code, /^\s*#/m, 'no YAML comment lines survive');
+    assert.doesNotMatch(code, /^\s*\/\//m, 'no JS comment lines survive');
+  });
 
   test('the backtick sanitizer actually neutralizes the inline-code breakout', () => {
     // Behavioral check of the transform the workflows apply, rather than only

--- a/tests/workflow-maintainer-skip.test.cjs
+++ b/tests/workflow-maintainer-skip.test.cjs
@@ -82,10 +82,10 @@ describe('PR policy workflow maintainer carve-outs', () => {
   // unhandled rejection kills the github-script step, and the verdict
   // (core.setFailed) never runs — the contributor gets an API stack trace
   // instead of the instructions the comment exists to deliver.
-  for (const { file, name } of [
-    { file: '.github/workflows/pr-title-validator.yml', name: 'PR title validator' },
-    { file: '.github/workflows/pr-target-validator.yml', name: 'PR target validator' },
-    { file: '.github/workflows/require-issue-link.yml', name: 'Require issue link' },
+  for (const { file, name, scope, otherScope } of [
+    { file: '.github/workflows/pr-title-validator.yml', name: 'PR title validator', scope: 'pull-requests', otherScope: 'issues' },
+    { file: '.github/workflows/pr-target-validator.yml', name: 'PR target validator', scope: 'pull-requests', otherScope: 'issues' },
+    { file: '.github/workflows/require-issue-link.yml', name: 'Require issue link', scope: 'issues', otherScope: 'pull-requests' },
   ]) {
     test(`${name} triggers on pull_request_target so fork PRs get the verdict, not a 403`, () => {
       const workflow = readWorkflow(file);
@@ -94,13 +94,30 @@ describe('PR policy workflow maintainer carve-outs', () => {
       assert.doesNotMatch(workflow, /^\s*pull_request:\s*$/m);
     });
 
-    test(`${name} declares a write permission for the endpoint it calls`, () => {
+    test(`${name} keeps exactly the one write scope its comment call needs`, () => {
       const workflow = readWorkflow(file);
 
-      // pull_request_target only grants what `permissions:` declares. These
-      // workflows comment via the issue-comments endpoint, so the write scope
-      // must be present or the trigger change alone would not fix the 403.
-      assert.match(workflow, /^\s*(issues|pull-requests):\s*write\s*$/m);
+      // pull_request_target only grants what `permissions:` declares, so the
+      // write scope must be present or the trigger change alone would not fix
+      // the 403. Assert the SPECIFIC scope, not an `(issues|pull-requests)`
+      // alternation — an alternation is satisfied by whichever scope happens to
+      // be there and would not catch its removal.
+      //
+      // Each file needs only ONE: GitHub accepts either `issues: write` or
+      // `pull-requests: write` for issues.createComment when the target is a
+      // PR. Verified from this repo's history, not the docs — pr-title-validator
+      // has posted on `pull-requests: write` alone, require-issue-link on
+      // `issues: write` alone. The 403 was the fork downgrade, not the scope.
+      //
+      // The negative half is the point of this test: a pull_request_target
+      // workflow must not carry privilege it never exercises, so adding the
+      // other scope "to be safe" is a regression this catches.
+      assert.match(workflow, new RegExp(`^\\s*${scope}:\\s*write\\s*$`, 'm'));
+      assert.doesNotMatch(
+        workflow,
+        new RegExp(`^\\s*${otherScope}:\\s*write\\s*$`, 'm'),
+        `${file} does not call a ${otherScope}.* API — do not grant it write on a pull_request_target workflow`
+      );
     });
 
     test(`${name} cannot let a failed comment suppress its verdict`, () => {

--- a/tests/workflow-maintainer-skip.test.cjs
+++ b/tests/workflow-maintainer-skip.test.cjs
@@ -47,6 +47,45 @@ describe('PR policy workflow maintainer carve-outs', () => {
     assertMaintainerSkip(workflow);
   });
 
+  // #2331: same defect class as the close-draft-prs.yml trigger lock above,
+  // swept across the three PR-policy workflows it had never covered. Each one
+  // comments on the PR and THEN emits its verdict; on a bare `pull_request`
+  // trigger a fork PR's read-only GITHUB_TOKEN 403s the comment call, the
+  // unhandled rejection kills the github-script step, and the verdict
+  // (core.setFailed) never runs — the contributor gets an API stack trace
+  // instead of the instructions the comment exists to deliver.
+  for (const { file, name } of [
+    { file: '.github/workflows/pr-title-validator.yml', name: 'PR title validator' },
+    { file: '.github/workflows/pr-target-validator.yml', name: 'PR target validator' },
+    { file: '.github/workflows/require-issue-link.yml', name: 'Require issue link' },
+  ]) {
+    test(`${name} triggers on pull_request_target so fork PRs get the verdict, not a 403`, () => {
+      const workflow = readWorkflow(file);
+
+      assert.match(workflow, /^\s*pull_request_target:/m);
+      assert.doesNotMatch(workflow, /^\s*pull_request:\s*$/m);
+    });
+
+    test(`${name} declares a write permission for the endpoint it calls`, () => {
+      const workflow = readWorkflow(file);
+
+      // pull_request_target only grants what `permissions:` declares. These
+      // workflows comment via the issue-comments endpoint, so the write scope
+      // must be present or the trigger change alone would not fix the 403.
+      assert.match(workflow, /^\s*(issues|pull-requests):\s*write\s*$/m);
+    });
+
+    test(`${name} cannot let a failed comment suppress its verdict`, () => {
+      const workflow = readWorkflow(file);
+
+      // Defense in depth: the comment is a courtesy, the verdict is the gate.
+      // Guard the inversion (comment throws -> setFailed skipped) that #2331
+      // fixed, so a future permission change degrades the diagnostic only.
+      assert.match(workflow, /\btry\s*\{/);
+      assert.match(workflow, /catch\s*\(err\)\s*\{[\s\S]*?core\.warning/);
+    });
+  }
+
   test('draft PR sweep enforces the same policy as the event-driven close', () => {
     const workflow = readWorkflow('.github/workflows/close-draft-prs-sweep.yml');
 


### PR DESCRIPTION
## Fix PR

> Filed as a chore (issue #2331 carries `type: chore`), but using the Fix template — this repo has no `chore.md` PR template and the format gate accepts fix/enhancement/feature only. This genuinely fixes broken behavior, so `fix.md` is the honest match.

---

## Linked Issue

Closes #2331

> #2331 carries `type: chore`, not `confirmed-bug` — this is CI/tooling maintenance, not a product bug, so the bug-confirmation gate doesn't apply. The defect is nonetheless reproduced from a live CI log (below).

---

## What was broken

Three PR-policy workflows triggered on plain `pull_request`, which hands a **fork** PR a read-only `GITHUB_TOKEN` regardless of the declared `permissions:`. Each one comments on the PR and *then* emits its verdict, so `issues.createComment` 403'd, the unhandled rejection killed the `github-script` step, and **`core.setFailed` never ran** — the contributor got an API stack trace instead of the instructions the comment exists to deliver.

| Workflow | Verdict never reached |
|---|---|
| `.github/workflows/pr-title-validator.yml` | `:143` (comment at `:132`) |
| `.github/workflows/pr-target-validator.yml` | `:121` (comment at `:110`) |
| `.github/workflows/require-issue-link.yml` | `:85` (comment at `:78`) |

Reproduced from a live run — PR #2084, job [86573823878](https://github.com/open-gsd/gsd-core/actions/runs/29163977799/job/86573823878):

```
##[group]GITHUB_TOKEN Permissions
Contents: read
Metadata: read
PullRequests: read          <-- declared `pull-requests: write`, granted read
##[endgroup]
...
data: { message: 'Resource not accessible by integration', status: '403' }
```

The check still went red (fail-closed — no gate was bypassed), but the diagnostic was destroyed. #2084 is the live casualty: approved code, a non-compliant title since 2026-07-08, and the sticky comment explaining exactly that has 403'd on every run since.

## What this fix does

Switches all three to `pull_request_target` (base-repo context, write-capable token), and wraps each comment in `try/catch` so a comment failure degrades the *diagnostic* rather than the *gate*.

**This is a sweep, not a new diagnosis.** Three sibling workflows already do this correctly (`pr-template-format.yml`, `close-draft-prs.yml`, `auto-close-unsolicited-prs.yml`), and `tests/workflow-maintainer-skip.test.cjs:32-42` already locks `close-draft-prs.yml` to `pull_request_target` for this exact reason:

> A bare `pull_request` trigger hands fork PRs [...] a read-only GITHUB_TOKEN, so the close/comment API calls 403 [...] `pull_request_target` runs in the base-repo context with a write-capable token.

The three workflows here were simply never covered.

## Root cause

`pull_request` from a fork is a read-only-token event by GitHub platform design; the `permissions:` block cannot override it. The workflows were written as if it could. The second-order defect is ordering: the courtesy (comment) ran *before* the gate (verdict), so a failure in the courtesy took the gate with it.

### Security: why `pull_request_target` is safe here

It's a privilege-escalation footgun **only when a workflow checks out and executes PR-head code with the elevated token**. None of these do:

| Workflow | Checkout | Executes PR-controlled code? |
|---|---|---|
| `pr-title-validator.yml` | `ref: base.ref`, `persist-credentials: false` (`:74-77`) | No — `require`s the matcher from the **base** checkout; reads `pr.title` as data |
| `pr-target-validator.yml` | `ref: base.ref`, `persist-credentials: false` (`:48-51`) | No — `require`s the policy from **base**; reads `pr.base.ref`/`pr.head.ref` as data |
| `require-issue-link.yml` | **none at all** | No — reads `PR_BODY` via `env:`, never spliced into a shell |

No PR-controlled value is interpolated via `${{ }}` into a `run:` block or a `script:` body. The "a PR cannot edit the ruler that measures it" property is *reinforced* — `pull_request_target` checks out base by definition. The #1389 fork-forgery carve-out in `require-issue-link.yml` still holds: it keys on `head.repo.full_name == github.repository`, which a fork can never satisfy.

### Markdown injection — found by review, fixed here

The orthogonal security pass caught a real bug in the first cut. `pr-title-validator.yml` echoed the PR title into an inline-code span:

```js
`\`${title}\``
```

A PR title is free text, so a single backtick closes the span and the remainder renders as live Markdown — GFM autolinks a bare URL. A fork author could make `github-actions[bot]` post an arbitrary clickable link, borrowing the bot's credibility:

```
title : bad`See https://evil.example/ci-status for details x
posted: `bad`See https://evil.example/ci-status for details x`
        ^^^^^ span closes here; the rest renders, URL autolinks
```

The interpolation is unchanged from `next` — but it was **not previously reachable from forks**, because the comment 403'd and was never posted. This PR's trigger switch is what makes it reachable by untrusted authors, using the token it grants, so it's in scope and fixed here rather than deferred. Both validators now strip backticks before interpolating. That's complete, not a band-aid: a backtick is the only character that can break out of a code span, and backslash escapes are inert inside one. The branch-name vector (`pr-target-validator`) is weaker — `check-ref-format` forbids space, `:`, `[` and `*`, so no URL/link/emphasis is expressible — but is stripped identically rather than left to the charset to police.

### Permissions: deliberately unchanged

Both review passes flagged the permissions block, from opposite directions — one called `issues: write` dead surface, the other called it the load-bearing scope the validators lacked. **Neither is right**, and the repo's own history settles it: `issues.createComment` on a PR accepts **either** scope.

| Workflow | Declares | Its comment has posted |
|---|---|---|
| `pr-title-validator.yml` | `pull-requests: write` only | 26 times |
| `pr-target-validator.yml` | `pull-requests: write` only | 8 times |
| `require-issue-link.yml` | `issues: write` only | on #106, #164, #232, #259 |

All three already had a sufficient scope; the 403 was purely the fork downgrade. My first cut added the other scope to each "to be safe" — which fixed nothing and widened privilege on precisely the workflows now running as `pull_request_target`. Reverted: **`permissions:` is byte-identical to `next`**, and the diff is trigger + try/catch + sanitizer only.

### Known limitation: bootstrap

`pull_request_target` reads the workflow from the **base** ref, so this takes effect once merged to `next` (the default branch and target for ~all contributor PRs). PRs targeting `main` — release/hotfix/backmerge branches — keep running the old copy until a release backmerges. Bounded: the gate still fires red, only the diagnostic stays opaque, i.e. status quo.

## Testing

### How I verified the fix

- **`gsd-test` green on the final head** (`2bcc395c`): `outcome: "passed"`, **25156/25156** on both `linux-node22` and `linux-node24`.
- **Fail-first, demonstrated**: the trigger assertions fail against `origin/next` for all three workflows and pass on head. Verified per-file rather than asserted.
- **`gsd-test` caught a bug in my own test**: the first cut of the verdict-ordering check used `indexOf('core.setFailed')` on raw source — and these workflows name `core.setFailed` in their *own comments* (lines 29/118/147, 16, 6), all before the catch. It compared a comment to the call and failed against correct code (4 unique failures, both legs). Fixed by asserting on a comment-stripped view.
- **YAML parse-checked** for all three; `npm run lint`, `lint:ci`, `lint:docs`, and `changeset-lint` all exit 0.
- **Permission claims verified empirically** against the comment history above, not from the docs.

### Regression test added?

- [x] Yes — added a test that would have caught this bug

`tests/workflow-maintainer-skip.test.cjs`, following the pattern already applied to `close-draft-prs.yml`:

- Trigger lock (`pull_request_target` present, bare `pull_request` absent) for all three — **fails-first**.
- Backtick sanitizer present *and* used, for both validators — **fails-first**.
- Verdict-ordering: `core.setFailed` sits **after** the catch, so a thrown comment can't skip it. Extracted to `verdictSurvivesCommentFailure()` and exercised against **both a good and an inverted sample**, so the guard is proven non-vacuous rather than merely passing.
- `readWorkflowCode()` strips comments; a test pins the trap itself (raw source *does* mention `core.setFailed` before the catch; the stripped view doesn't).
- Least-privilege lock: each file declares its **specific** scope and **not** the other. This one is a forward lock, not fails-first — the previous `(issues|pull-requests)` alternation passed on the pre-fix tree and would not have caught removal of the scope that matters.
- Behavioral sanitizer test with 0 / 1 / many backtick boundaries.

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [x] N/A (not platform-specific)

> `gsd-test` ran the full suite on linux-node22 + linux-node24. GitHub Actions workflow YAML is not platform-specific.

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Closes #NNN`
- [ ] Linked issue has the `confirmed-bug` label — **N/A**: #2331 is `type: chore` (CI/tooling), not a product bug. Reproduced from a live CI log instead.
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass — `gsd-test` 25156/25156 on linux-node22 + linux-node24
- [x] `.changeset/` fragment added if this is a user-facing fix — **N/A**: `changeset-lint` returns `ok_no_user_facing_changes`; `.github/**` and `tests/**` are outside `USER_FACING_PREFIXES`
- [x] No unnecessary dependencies added

## Breaking changes

None. No gate changes what it accepts or rejects — only whether the contributor can read why. Job IDs and check names are unchanged, so branch-protection required-check names are unaffected.

---

## Notes for reviewers

- **Sweep completeness**: I enumerated all 23 workflows. The others on plain `pull_request` either only `core.warning` (`branch-naming.yml`) or exit via shell with no comment API (`changeset-required`, `docs-required`, `install-smoke`, `mutation`, `security-scan`, `test`). `branch-cleanup.yml` calls `git.deleteRef`/`pulls.list`, not `issues.createComment`, and already rethrows non-422 loudly. **No other workflow carries this defect.**
- **Adjacent, deliberately not touched**: `pr-template-format.yml` has the same comment-then-`setFailed` shape with **no try/catch**. It's already on `pull_request_target` so it isn't exposed to the original bug, but the defense-in-depth rationale applies equally. Out of scope here; happy to fold it in if you'd rather.
- **Broad catch**: the catch swallows *any* error, not just 403. Intentional ("comment is a courtesy, verdict is the gate"), but it means a future 422 from a malformed body degrades to a `core.warning` nothing monitors. Flagging for explicit sign-off rather than burying it.
- **Transient infra note**: the first `gsd-test` run returned `infra_error` (`exit=137`, SIGKILL, zero tests executed on both legs). It did not reproduce across two subsequent full-matrix runs on the same tree (25154 and 25156 tests executed), and this diff — three YAML files and a test — cannot OOM a runner. Recording it rather than dropping it silently.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2333"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786815013&installation_id=134682257&pr_number=2333&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2333&signature=4b29e4085ea1587acd0e2483b018e7325dddab1c34d58554798bef5936213ce9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->