### PR TITLE
docs(#2357): fix Registry Discussions category name and state its format

### DIFF
--- a/docs/registries/README.md
+++ b/docs/registries/README.md
@@ -202,9 +202,11 @@ There is no re-registration on new releases: register once, and your GitHub Rele
 
 ## Ranking + comments
 
-Ranking and community feedback live in **GitHub Discussions**, not in the registry markdown. Each merged entry gets exactly one Discussion in a dedicated `Registry` Discussions category:
+Ranking and community feedback live in **GitHub Discussions**, not in the registry markdown. Each merged entry — from either registry — gets exactly one Discussion in the dedicated `EoS Registry` Discussions category:
 
 - **Upvotes** on the Discussion post and on individual comments, with GitHub's built-in **Top** sort surfacing the most-upvoted community feedback first.
 - **Threaded comments** for experience reports, questions, and follow-up from other users.
 
-**Operational setup (one-time, per repo):** a repo admin creates the `Registry` category under this repository's Discussions settings. From then on, every merged entry gets its own Discussion thread created in that category, and the thread's URL is recorded in the entry's `discussion` field (see [Entry schema](#entry-schema) above) so the generated catalog links directly to it.
+**Operational setup (one-time, per repo):** a repo admin creates the `EoS Registry` category under this repository's Discussions settings, using the **open-ended discussion** format. From then on, every merged entry gets its own Discussion thread created in that category, and the thread's URL is recorded in the entry's `discussion` field (see [Entry schema](#entry-schema) above) so the generated catalog links directly to it. Despite its name, the category carries threads for **both** registries — `discussion` is required on Capability entries exactly as it is on EoS entries.
+
+**The open-ended format is required, and the choice is not cosmetic.** Because `discussion` is a required field, the thread must exist *before* the entry's PR is opened — and the person opening it is the entry's author, an outside contributor holding neither `maintain` nor `admin` permission on this repository. GitHub's **Announcement** format restricts starting new discussions to those two permission levels, so choosing it blocks every external submission at the first step, while still looking correctly configured to the admin who set it up. **Question/Answer** adds answer-marking, which pins one reply above the rest of a thread — a directory entry has no answer, and the pinning cuts across the upvote **Top** ordering described above. Open-ended is the format this process requires.


### PR DESCRIPTION
Closes #2357

## What was wrong

`docs/registries/README.md` documents a one-time setup step — create the Discussions category that every registry entry's thread lives in — and got two things wrong that a correct reading of the docs could not catch.

**The category name was stale.** The docs said to create a category named `Registry`. The category is named `EoS Registry`. An admin following the instruction would have created a second, duplicate category alongside the real one.

**The format was never stated at all.** The docs named the category and stopped there. The format is load-bearing, and one of the four choices silently breaks the process:

`discussion` is a **required** field on every entry in both registries (`scripts/registry-schema.cjs:106` and `:121`), so the thread must exist *before* the entry's PR is opened — and the person opening it is the entry's author, an outside contributor holding neither `maintain` nor `admin` on this repository. GitHub's **Announcement** format restricts starting new discussions to exactly those two permission levels. An admin who picked it would block every external submission at the first step, and the category would look correctly configured. Nothing in the docs steered them away from it.

## What changed

One file, prose only:

- Names the category `EoS Registry`, matching the live repository.
- Records that it carries threads for **both** registries — `discussion` is required on Capability entries exactly as it is on EoS entries, so the name is narrower than the scope, and a Capability author needs to know that.
- States **open-ended discussion** as the required format, and why Announcement and Question/Answer do not work — so the setup cannot be performed wrongly from a correct reading, and a future admin does not "correct" it back.

## Verification

Every factual claim in the added prose was verified against a primary source, not asserted:

| Claim | Source |
|---|---|
| Announcement restricts creation to maintain/admin | GitHub docs, fetched live — "only people with maintain or admin permissions can create new discussions, but anyone can comment and reply" |
| `discussion` required on both registries | `scripts/registry-schema.cjs:106` (`CAPABILITY_REQUIRED`), `:121` (`EOS_REQUIRED`) |
| The author, not a maintainer, opens the thread | `docs/registries/README.md` § Submission process — merging is the only maintainer action described |
| Category is `EoS Registry`, open-ended | `gh api graphql` against this repo; discussion #2342 was opened in it by an outside contributor, which Announcement would forbid |

**Reviews:** `/code-review` + `/security-review`, the second in an isolated context that did not author the change. Four findings, all fixed before this PR:

1. The category-name mismatch above — caught by the reviewer, not the author.
2. Question/Answer was described as reordering *threads*; answer-pinning is within a single thread. Corrected.
3. `maintain` was ambiguous against "maintainer" used elsewhere in the file to mean the human reviewer. Now code-formatted and disambiguated.
4. Redundant repetition of "load-bearing". Trimmed.

**Gates:**

- `npm run lint:ci` — green, eslint cache cleared first.
- No changeset: `scripts/changeset/lint.cjs` scans `bin/`, `gsd-core/`, `src/`, `agents/`, `commands/`, `hooks/`, `sdk/*`; `docs/` is not among them. Verified with `GITHUB_BASE_REF=next` → `ok_no_user_facing_changes`.
- No Docs-Required lint — it triggers off changeset types, and there is no fragment.
- No template — `scripts/pr-template-policy.cjs` auto-skips enforcement when every changed path matches `TOOLING_PATH_ALLOWLIST`, which includes `docs/**`.
- `docs/registries/README.md` is hand-authored, not generated; `gen-registry.cjs` only writes `capability-registry.md` / `eos-registry.md`. `lint:generated-sync` confirms no drift.
- No tests: nothing under `tests/` asserts this file's prose, and asserting it would be a source-grep test the repo prohibits.

## Acceptance criteria

All seven of #2357's `Done when` items are now satisfied — four by the maintainer's setup of the category, three by this PR:

- [x] Discussions categories and `docs/registries/README.md` agree on where entry Discussions live
- [x] Category format is open-ended discussion
- [x] `docs/registries/README.md` states the required category format explicitly
- [x] Discussion #2342 sits in the category the process names
- [x] A submitter can open their entry Discussion in a category that exists and permits them to post
- [x] The category description describes per-entry feedback threads across both registries
- [x] No change to user-facing behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2361"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786882635&installation_id=134682257&pr_number=2361&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2361&signature=4da29de70c53511ab7e5b8a3dce7d554bdbdd9537609af9de18f8e5ca5770ae0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->