### PR TITLE
fix(#2347): make the decision-shape evidence test format-agnostic

### DIFF
--- a/.changeset/lucky-mice-wake.md
+++ b/.changeset/lucky-mice-wake.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**The decision-coverage gate no longer fails open on unrecognized decision-ID prefixes** — `check.decision-coverage-plan` classified a populated `<decisions>` block as "no trackable decisions" (a clean pass) whenever its IDs used a prefix the parser couldn't read (e.g. `D5-01` instead of `D-01`), silently skipping the gate on real decisions. The gate now recognizes any bold-lead-in decision bullet as evidence and fails loud (`could-not-parse`) when it can't read a populated block, instead of passing. (#2347)

--- a/.changeset/lucky-mice-wake.md
+++ b/.changeset/lucky-mice-wake.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 2389
 ---
 **The decision-coverage gate no longer fails open on unrecognized decision-ID prefixes** — `check.decision-coverage-plan` classified a populated `<decisions>` block as "no trackable decisions" (a clean pass) whenever its IDs used a prefix the parser couldn't read (e.g. `D5-01` instead of `D-01`), silently skipping the gate on real decisions. The gate now recognizes any bold-lead-in decision bullet as evidence and fails loud (`could-not-parse`) when it can't read a populated block, instead of passing. (#2347)

--- a/src/decisions.cts
+++ b/src/decisions.cts
@@ -86,16 +86,24 @@ const bulletTitledColonRe = /^\s*-\s+\*\*D-([A-Za-z0-9][A-Za-z0-9_-]*)(?:\s*\[([
 
 /**
  * #2347: format-agnostic evidence that a block/section holds real decision
- * ENTRIES the parser could not read — a bold-lead-in bullet (`- **…**`),
- * whatever the ID grammar. The three parser grammars above all require a `D-`
+ * ENTRIES the parser could not read — a bullet whose bold lead-in is an
+ * ID-SHAPED token (uppercase prefix, optional digits, hyphen, alnum), whatever
+ * the exact ID grammar. The three parser grammars above all require a `D-`
  * prefix; #1365's fail-loud guard reused that same `\bD-` test as its "is this
  * decision-shaped?" evidence, so any other prefix (e.g. `D5-01`) was invisible
  * to BOTH parser and guard, collapsing `could-not-parse` into a clean
- * `none-present` pass. This regex matches only the bullet's leading bold token
- * (`-\s+\*\*…\*\*`), so prose that merely contains bold (`- some **word**`) does
- * NOT trip it — only decision-entry-shaped bullets do.
+ * `none-present` pass.
+ *
+ * The ID-shape requirement (not "any bold bullet") is deliberate: a decisions
+ * block or `### Claude's Discretion` sub-section legitimately contains prose
+ * bullets with bold labels (`- **Scope:** …`, `- **Why:** …`, `- **Note:** …`).
+ * Those are NOT decision entries and must stay `none-present` — a false
+ * `could-not-parse` hard-blocks the plan gate. `[A-Z]+[0-9]*-[A-Za-z0-9]` matches
+ * `D-01` / `D5-01` / `DEC-01` but not `Scope:` / `Why:` / `Follow-up:` (mixed
+ * case) / `TODO:` (no `-<alnum>` id) — mirroring the parser's own `D-<alnum>`
+ * shape without hardcoding the `D`.
  */
-const boldLeadInBulletRe = /^\s*-\s+\*\*[^*\n]+\*\*/m;
+const boldLeadInBulletRe = /^\s*-\s+\*\*[A-Z]+[0-9]*-[A-Za-z0-9]/m;
 
 interface ParseDecisionLinesResult {
   decisions: Decision[];

--- a/src/decisions.cts
+++ b/src/decisions.cts
@@ -84,6 +84,19 @@ const bulletEmDashRe = /^\s*-\s+\*\*D-([A-Za-z0-9][A-Za-z0-9_-]*)(?:\s*\[([^\]]+
  */
 const bulletTitledColonRe = /^\s*-\s+\*\*D-([A-Za-z0-9][A-Za-z0-9_-]*)(?:\s*\[([^\]]+)\])?[^:*]*:[^:*]*\*\*\s*(.*)$/;
 
+/**
+ * #2347: format-agnostic evidence that a block/section holds real decision
+ * ENTRIES the parser could not read — a bold-lead-in bullet (`- **…**`),
+ * whatever the ID grammar. The three parser grammars above all require a `D-`
+ * prefix; #1365's fail-loud guard reused that same `\bD-` test as its "is this
+ * decision-shaped?" evidence, so any other prefix (e.g. `D5-01`) was invisible
+ * to BOTH parser and guard, collapsing `could-not-parse` into a clean
+ * `none-present` pass. This regex matches only the bullet's leading bold token
+ * (`-\s+\*\*…\*\*`), so prose that merely contains bold (`- some **word**`) does
+ * NOT trip it — only decision-entry-shaped bullets do.
+ */
+const boldLeadInBulletRe = /^\s*-\s+\*\*[^*\n]+\*\*/m;
+
 interface ParseDecisionLinesResult {
   decisions: Decision[];
   parseMisses: number;
@@ -241,11 +254,13 @@ export function extractDecisions(content: unknown): DecisionExtraction {
     }
     // FIX A: Block present but 0 extracted and no parse-misses.
     // Only report could-not-parse when there is genuine evidence of real decisions
-    // that failed to parse: a \bD- token in the block text, or an unterminated fence.
-    // An empty scaffold (<decisions></decisions>) or an all-prose block has no such
-    // evidence — treat as none-present so the gate passes cleanly.
+    // that failed to parse: a bold-lead-in bullet (`- **…**`, any ID grammar — #2347),
+    // a \bD- token in the block text, or an unterminated fence. An empty scaffold
+    // (<decisions></decisions>) or an all-prose block has no such evidence — treat
+    // as none-present so the gate passes cleanly.
     const hasDecisionTokenInBlock = /\bD-[A-Za-z0-9]/m.test(combined);
-    if (hasDecisionTokenInBlock || unterminatedFence) {
+    const hasBoldLeadInBullet = boldLeadInBulletRe.test(combined);
+    if (hasDecisionTokenInBlock || hasBoldLeadInBullet || unterminatedFence) {
       return { decisions: [], outcome: 'could-not-parse' };
     }
     return { decisions: [], outcome: 'none-present' };
@@ -271,11 +286,13 @@ export function extractDecisions(content: unknown): DecisionExtraction {
       return { decisions, outcome: 'could-not-parse' };
     }
     // FIX A: Heading found but 0 extracted and no parse-misses.
-    // Only report could-not-parse when the section body contains a D- token.
-    // A heading with only prose, sub-headings, or all-discretion content
-    // (no trackable D- tokens) is a legitimate empty/discretion section → none-present.
+    // Report could-not-parse when the section body holds a decision-entry-shaped
+    // bold-lead-in bullet (`- **…**`, any ID grammar — #2347) or a D- token. A
+    // heading with only prose, sub-headings, or all-discretion content (no such
+    // evidence) is a legitimate empty/discretion section → none-present.
     const hasDecisionTokenInSection = /\bD-[A-Za-z0-9]/m.test(section.body);
-    if (hasDecisionTokenInSection) {
+    const hasBoldLeadInBulletInSection = boldLeadInBulletRe.test(section.body);
+    if (hasDecisionTokenInSection || hasBoldLeadInBulletInSection) {
       return { decisions: [], outcome: 'could-not-parse' };
     }
     return { decisions: [], outcome: 'none-present' };

--- a/tests/decisions.test.cjs
+++ b/tests/decisions.test.cjs
@@ -276,6 +276,42 @@ describe('extractDecisions — format-agnostic evidence test (#2347)', () => {
     assert.strictEqual(r.outcome, 'parsed');
     assert.strictEqual(r.decisions.length, 1);
   });
+
+  // ── The evidence must be ID-SHAPED, not "any bold bullet" ────────────────────
+  // A decisions block / discretion section legitimately uses bold LABELS on prose
+  // bullets (- **Why:** …, - **Scope:** …). Those are not decision entries; a
+  // false could-not-parse here hard-blocks the plan gate. Guards against the
+  // over-broad evidence regex an earlier iteration shipped.
+  test('bold prose-label bullets (Why/Note/Scope) are NOT evidence — stay none-present', () => {
+    const md = '<decisions>\n'
+      + '- **Why:** rationale for inheriting prior decisions\n'
+      + '- **Scope:** everything from the previous phase carries over\n'
+      + '- **Note:** nothing new was decided here\n'
+      + '</decisions>\n';
+    assert.strictEqual(extractDecisions(md).outcome, 'none-present',
+      'bold LABELS on prose bullets must not be mistaken for decision entries');
+  });
+
+  test("a Claude's Discretion sub-section with bold-label bullets stays none-present", () => {
+    const md = '<decisions>\n'
+      + "### Claude's Discretion\n"
+      + '- **Scope:** left to judgment, no specific preference\n'
+      + '- **Follow-up:** revisit if performance regresses\n'
+      + '</decisions>\n';
+    assert.strictEqual(extractDecisions(md).outcome, 'none-present',
+      'a discretion section of bold-label prose bullets must pass the gate cleanly');
+  });
+
+  test('a bold ALL-CAPS label with no id-shape (TODO/NOTE) is not evidence', () => {
+    const md = '<decisions>\n- **TODO:** decide the datastore next phase\n- **NOTE:** blocked on infra\n</decisions>\n';
+    assert.strictEqual(extractDecisions(md).outcome, 'none-present',
+      'a bold ALL-CAPS label with no -<alnum> id structure is not a decision entry');
+  });
+
+  test('heading path: bold prose-label bullets under a Decisions heading stay none-present', () => {
+    const md = '## Decisions\n\n- **Why:** we kept the prior stack\n- **Scope:** no new choices this phase\n';
+    assert.strictEqual(extractDecisions(md).outcome, 'none-present');
+  });
 });
 
 // ─── QA matrix for parser correctness ────────────────────────────────────────

--- a/tests/decisions.test.cjs
+++ b/tests/decisions.test.cjs
@@ -220,6 +220,64 @@ describe('extractDecisions — typed outcome (#1364 + #1365)', () => {
   });
 });
 
+// ─── #2347: evidence test must not reuse the parser's own D- grammar ──────────
+// #1365's fail-loud guard used `/\bD-[A-Za-z0-9]/` as its "is this decision-
+// shaped?" evidence test — the SAME D- prefix the parser requires. So for any
+// ID prefix the parser can't read (e.g. `D5-01`), BOTH the parser and the guard
+// see nothing, the outcome collapses to none-present (clean pass) instead of
+// could-not-parse, and the gate fails OPEN against a populated block of real
+// decisions. Fix: a bold-lead-in bullet (`- **...**`, any ID) is format-agnostic
+// evidence of a decision entry. Note none of these bullet texts contain a
+// literal "D-" token, so they isolate the bold-bullet evidence from the old
+// D--token path.
+describe('extractDecisions — format-agnostic evidence test (#2347)', () => {
+  test('populated <decisions> block with a non-D- ID prefix is could-not-parse, not none-present', () => {
+    const md = '<decisions>\n'
+      + '- **D5-01:** choose the primary datastore\n'
+      + '- **D5-02:** pick the queue technology\n'
+      + '- **D5-03:** settle on the auth model\n'
+      + '</decisions>\n';
+    const r = extractDecisions(md);
+    assert.strictEqual(r.decisions.length, 0, 'parser cannot read the D5- prefix (0 extracted)');
+    assert.strictEqual(r.outcome, 'could-not-parse',
+      'a populated block the parser cannot read must FAIL LOUD, not pass as none-present');
+  });
+
+  test('decisions HEADING section with a non-D- ID prefix is could-not-parse', () => {
+    const md = '## Decisions\n\n- **DEC-01: the chosen approach** rationale\n';
+    const r = extractDecisions(md);
+    assert.strictEqual(r.decisions.length, 0);
+    assert.strictEqual(r.outcome, 'could-not-parse',
+      'a decision-shaped heading section the parser cannot read must fail loud');
+  });
+
+  test('em-dash bullet with a non-D- ID prefix is still evidence (could-not-parse)', () => {
+    const md = '<decisions>\n- **DEC-02 — the chosen approach** body\n</decisions>\n';
+    assert.strictEqual(extractDecisions(md).outcome, 'could-not-parse');
+  });
+
+  // ── Regression guards: the broadened evidence must NOT create false fail-loud ─
+  test('empty <decisions> scaffold stays none-present (no false fail-loud)', () => {
+    assert.strictEqual(extractDecisions('<decisions>\n</decisions>\n').outcome, 'none-present');
+    assert.strictEqual(
+      extractDecisions('<decisions>\n\n(no decisions this phase)\n\n</decisions>\n').outcome,
+      'none-present',
+      'a prose-only scaffold with no bold-lead-in bullet must still pass cleanly');
+  });
+
+  test('an all-prose decisions block with no bold bullet stays none-present', () => {
+    const md = '<decisions>\n\nThis phase inherits every prior decision; nothing new.\n\n</decisions>\n';
+    assert.strictEqual(extractDecisions(md).outcome, 'none-present');
+  });
+
+  test('canonical D- decisions still parse (no regression)', () => {
+    const md = '<decisions>\n- **D-01:** a real decision\n</decisions>\n';
+    const r = extractDecisions(md);
+    assert.strictEqual(r.outcome, 'parsed');
+    assert.strictEqual(r.decisions.length, 1);
+  });
+});
+
 // ─── QA matrix for parser correctness ────────────────────────────────────────
 
 describe('parseDecisions — parser QA matrix', () => {

--- a/tests/fixtures/representative/decision-coverage-guard/MANIFEST.json
+++ b/tests/fixtures/representative/decision-coverage-guard/MANIFEST.json
@@ -6,13 +6,7 @@
       "file": "d5-prefix-context.md",
       "expectedReason": "could-not-parse",
       "expectedPassed": false,
-      "currentBuggyOutput": {
-        "passed": true,
-        "skipped": true,
-        "reason": "no trackable decisions",
-        "total": 0
-      },
-      "note": "A <decisions> block using the D5-01 ID-prefix shape from #2347's own reproduction ('- **D5-01:** some decision'), repeated twice so 'populated but 0 extracted' is unambiguous. The original report used 23 real decisions under a project-specific D5- prefix convention; this fixture preserves the exact grammar mismatch, not the count. The #1365 guard's evidence test (/\\bD-[A-Za-z0-9]/) shares the parser's own D- grammar, so it is blind to exactly the input class it exists to catch: both see nothing, and the gate reports passed:true, skipped:true, reason:'no trackable decisions' instead of failing loud."
+      "note": "A <decisions> block using the D5-01 ID-prefix shape from #2347's own reproduction ('- **D5-01:** some decision'), repeated twice so 'populated but 0 extracted' is unambiguous. The original report used 23 real decisions under a project-specific D5- prefix convention; this fixture preserves the exact grammar mismatch, not the count. FIXED by #2347: the guard's evidence test no longer reuses the parser's D- grammar — a bold ID-shaped lead-in bullet (any prefix) is now evidence, so this populated block correctly fails loud (could-not-parse). currentBuggyOutput removed and the assertion graduated to expected* per this corpus's contract."
     }
   ]
 }


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #2347

---

## What was broken

`check.decision-coverage-plan` — the blocking gate at plan-phase that refuses to mark a phase planned when a discuss-phase decision was silently dropped — **failed open** on any decision-ID prefix the parser can't read. #1365 added a fail-loud guard (`none-present` vs `could-not-parse`), but its "is this decision-shaped?" evidence test was `/\bD-[A-Za-z0-9]/` — the *same* `D-` grammar `parseDecisions` requires. So for a prefix like `D5-01`, both the parser **and** the guard saw nothing, the outcome collapsed to `none-present` (a clean pass), and the gate returned `passed: true` against a populated `<decisions>` block of 23 real decisions. A gate that fails open is worse than no gate.

## What this fix does

Adds a format-agnostic evidence probe: a bullet whose bold lead-in is **ID-shaped** — `/^\s*-\s+\*\*[A-Z]+[0-9]*-[A-Za-z0-9]/` (uppercase prefix, optional digits, hyphen, alnum) — is evidence of a real decision entry regardless of the exact ID grammar. Applied to both the `<decisions>`-block path and the decisions-heading path. When such a bullet is present but 0 decisions parse, the gate now fails loud (`could-not-parse`) instead of passing.

The probe is deliberately ID-shaped, not "any bold bullet": a decisions block or `### Claude's Discretion` sub-section legitimately uses bold **labels** on prose bullets (`- **Why:** …`, `- **Scope:** …`, `- **Note:** …`). Those match `[A-Z]+…` no further (no `-<alnum>` id) and stay `none-present`, so a decision-free phase is never wrongly hard-blocked.

## Root cause

The evidence test shared the grammar of the parser it guards, so it could only ever confirm that parser's own blind spots — for every prefix the parser can't read, the guard is equally blind, and the two outcomes it exists to distinguish (`none-present` vs `could-not-parse`) collapse.

## Testing

### How I verified the fix

Failing-first TDD via `gsd-test`: red on the tests-only commit (the `D5-`/`DEC-` populated-block/heading cases misclassify as `none-present`), green on the fix. Two orthogonal reviews; the code review caught an over-broad first regex (matched any bold bullet, would false-block prose-label bullets), which was tightened to the ID-shaped form and independently re-reviewed clean.

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

`tests/decisions.test.cjs` (`#2347` block): a populated block/heading with a non-`D-` prefix (`D5-01`, `DEC-01`, em-dash `DEC-02 —`) → `could-not-parse`; **and** the false-positive guards — bold prose-label bullets (`Why:`/`Scope:`/`Note:`/`TODO:`), a `Claude's Discretion` sub-section, and the heading path — stay `none-present`; empty scaffolds stay `none-present`; canonical `D-` still parses. No test string contains a literal `D-` token, so they exercise the new evidence path, not the old `\bD-` one.

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux — `gsd-test`, node 22 + 24
- [ ] N/A (not platform-specific)

Pure markdown parsing; no platform-specific behavior.

### Runtimes tested

- [x] N/A (not runtime-specific) — `decisions.cts` is shared parsing logic behind the plan gate

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass — full suite green on `linux-node22` + `linux-node24` via `gsd-test`
- [x] `.changeset/` fragment added (user-facing fix)
- [x] No unnecessary dependencies added

Single source of truth: `src/decisions.cts` (compiled to gitignored `bin/lib/decisions.cjs`); no hand-authored duplicate. No golden/size ripple (decisions is `bin/lib`, excluded from install goldens).

## Breaking changes

None functional — the gate now fails loud where it previously passed silently. A CONTEXT.md whose decisions use a non-`D-` prefix will now correctly report `could-not-parse` (prompting a fix) instead of a false clean pass; canonical `D-` behavior is unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2389"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786909740&installation_id=134682257&pr_number=2389&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2389&signature=4951853142622687a48ab96460925793dda87405bb09bd12c9e5898f60cb7fb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->