### PR TITLE
ci(#2438): add explicit retention-days to artifact uploads

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -222,6 +222,9 @@ jobs:
             !coverage/tmp
             .nyc_output/
           if-no-files-found: ignore
+          # ~440 MB per full run; same-run diagnostic never consumed by other
+          # jobs — keep short so it cannot accumulate against the org quota.
+          retention-days: 3
 
       - name: Run integration tests
         if: matrix.scope == 'full'


### PR DESCRIPTION
## TL;DR

Adds `retention-days: 3` to the `coverage-unit` artifact upload in `test.yml` — the only upload step in this repo still on the 90-day default.

Closes #2438

## What

- `.github/workflows/test.yml` → `Upload coverage artifact` step (`coverage-unit`): `retention-days: 3`, with a short comment explaining the choice (the step already comments its non-obvious options).

No other changes. The other two upload steps in the repo already set explicit retention and are left as-is:

- `.github/workflows/mutation.yml` → `mutation-report-*`: `retention-days: 14` (small single HTML report)
- `.github/workflows/install-smoke.yml` → `release-smoke-*`: `retention-days: 7` (tiny failure-only JSON)

## Why

The open-gsd org's artifact storage hit ~204 GB and blocked **all** artifact uploads org-wide ("Artifact storage quota has been hit"), breaking CI on unrelated PRs across repos. ~1,460 stale artifacts had to be mass-deleted. The worst offender was gsd-core's `coverage-unit`: ~440 MB per full run, 1,148 accumulated under the default 90-day retention.

## How

Retention chosen per artifact class: `coverage-unit` is a huge, transient, same-run diagnostic — 3 days is ample for inspecting a run's coverage and prevents accumulation. Before choosing, I grepped all workflows and scripts for any download of this artifact (`actions/download-artifact`, `dawidd6/action-download-artifact`, `run_id`): **no consumer exists in any job or flow**, so short retention is safe. YAML validated with `yaml.safe_load`.

<!-- pr-template-exempt: all changed files are under .github/ (tooling path allowlist) -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2439"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change to artifact retention; no application or test logic is modified.
> 
> **Overview**
> Sets **`retention-days: 3`** on the **`coverage-unit`** upload in `test.yml`, replacing the default 90-day retention for a large (~440 MB) same-run diagnostic artifact.
> 
> Adds a short inline comment that the artifact is not consumed by downstream jobs, so a brief retention window is enough to limit org-wide artifact storage buildup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f33517c68270ea5b3bb4f4f809e4334ed58b7b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->