### PR TITLE
fix(#2069): forward model_policy, model_profile_overrides, runtime from global defaults

### DIFF
--- a/.changeset/sturdy-seals-fly.md
+++ b/.changeset/sturdy-seals-fly.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`~/.gsd/defaults.json` no longer silently drops `model_policy`, `model_profile_overrides`, and `runtime`** — the global-defaults path of config load now forwards these three keys identically to a project's `.planning/config.json`, so a machine-wide model policy / runtime / overrides specified globally is honored even outside a project. (#2069)

--- a/.changeset/sturdy-seals-fly.md
+++ b/.changeset/sturdy-seals-fly.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 2442
 ---
 **`~/.gsd/defaults.json` no longer silently drops `model_policy`, `model_profile_overrides`, and `runtime`** — the global-defaults path of config load now forwards these three keys identically to a project's `.planning/config.json`, so a machine-wide model policy / runtime / overrides specified globally is honored even outside a project. (#2069)

--- a/src/config-loader.cts
+++ b/src/config-loader.cts
@@ -731,6 +731,14 @@ function loadConfigResolved(cwd: string, options: Record<string, unknown> = {}):
         fast_mode: (globalDefaults['fast_mode']) || null,
         agent_skills: (globalDefaults['agent_skills']) || {},
         response_language: (globalDefaults['response_language']) || null,
+        // #2069: forward model_policy / model_profile_overrides / runtime so the global-defaults
+        // path is at parity with the project-config path (which forwards these three from
+        // parsed['…'] at the top of this function). Without these entries, ~/.gsd/defaults.json
+        // silently drops them — model_policy/provider/budget etc. are honored when set in a
+        // project but ignored when set globally.
+        runtime: (globalDefaults['runtime']) || null,
+        model_profile_overrides: (globalDefaults['model_profile_overrides']) || null,
+        model_policy: (globalDefaults['model_policy']) || null,
       };
       // Branch D: global-defaults
       try {

--- a/tests/defaults-json-fallback.test.cjs
+++ b/tests/defaults-json-fallback.test.cjs
@@ -140,4 +140,101 @@ describe('loadConfig ~/.gsd/defaults.json fallback (#1683)', () => {
     assert.strictEqual(config.model_profile, 'balanced');
     assert.strictEqual(config.context_window, 200000);
   });
+
+  // ─── #2069: global-defaults must forward model_policy / model_profile_overrides / runtime ─
+  // The _globalBaseCfg whitelist in Branch D of loadConfigResolved previously omitted these
+  // three keys, so they were silently dropped from ~/.gsd/defaults.json while the identical
+  // keys in a project's .planning/config.json were honored. The tests below are fail-first:
+  // each asserts the global path forwards its key, mirroring the project-config parity test.
+
+  test('#2069 defaults.json model_policy → forwarded from global defaults', (t) => {
+    const tmpDir = createBareTmpDir();
+    const policy = { provider: 'anthropic', budget: 'high' };
+
+    const gsdDir = path.join(tmpDir, '.gsd');
+    fs.mkdirSync(gsdDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(gsdDir, 'defaults.json'),
+      JSON.stringify({ model_policy: policy })
+    );
+
+    process.env.GSD_HOME = tmpDir;
+    t.after(() => { delete process.env.GSD_HOME; cleanup(tmpDir); });
+
+    const config = loadConfig(tmpDir);
+    assert.deepStrictEqual(config.model_policy, policy);
+  });
+
+  test('#2069 defaults.json model_profile_overrides → forwarded from global defaults', (t) => {
+    const tmpDir = createBareTmpDir();
+    const overrides = { claude: { planner: { model: 'claude-opus-4-5' } } };
+
+    const gsdDir = path.join(tmpDir, '.gsd');
+    fs.mkdirSync(gsdDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(gsdDir, 'defaults.json'),
+      JSON.stringify({ model_profile_overrides: overrides })
+    );
+
+    process.env.GSD_HOME = tmpDir;
+    t.after(() => { delete process.env.GSD_HOME; cleanup(tmpDir); });
+
+    const config = loadConfig(tmpDir);
+    assert.deepStrictEqual(config.model_profile_overrides, overrides);
+  });
+
+  test('#2069 defaults.json runtime → forwarded from global defaults', (t) => {
+    const tmpDir = createBareTmpDir();
+    const runtime = 'codex';
+
+    const gsdDir = path.join(tmpDir, '.gsd');
+    fs.mkdirSync(gsdDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(gsdDir, 'defaults.json'),
+      JSON.stringify({ runtime })
+    );
+
+    process.env.GSD_HOME = tmpDir;
+    t.after(() => { delete process.env.GSD_HOME; cleanup(tmpDir); });
+
+    const config = loadConfig(tmpDir);
+    assert.strictEqual(config.runtime, runtime);
+  });
+
+  test('#2069 defaults.json parity: model_policy survives identically to project-config path', (t) => {
+    // Identical policy in ~/.gsd/defaults.json (no .planning/) vs .planning/config.json (no defaults.json)
+    // must produce identical config.model_policy. Previously the global path silently dropped it.
+    const policy = { provider: 'anthropic', budget: 'low' };
+
+    // Global path: ~/.gsd/defaults.json only, no .planning/
+    const globalDir = createBareTmpDir();
+    const globalGsdDir = path.join(globalDir, '.gsd');
+    fs.mkdirSync(globalGsdDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(globalGsdDir, 'defaults.json'),
+      JSON.stringify({ model_policy: policy })
+    );
+
+    process.env.GSD_HOME = globalDir;
+    const globalConfig = loadConfig(globalDir);
+    delete process.env.GSD_HOME;
+    t.after(() => { cleanup(globalDir); });
+
+    // Project path: .planning/config.json only, no defaults.json
+    const projectDir = createBareTmpDir();
+    fs.mkdirSync(path.join(projectDir, '.planning'), { recursive: true });
+    fs.writeFileSync(
+      path.join(projectDir, '.planning', 'config.json'),
+      JSON.stringify({ model_policy: policy })
+    );
+
+    // GSD_HOME pointing somewhere with no defaults.json so the project path is the sole source.
+    const emptyHome = createBareTmpDir();
+    process.env.GSD_HOME = emptyHome;
+    const projectConfig = loadConfig(projectDir);
+    delete process.env.GSD_HOME;
+    t.after(() => { cleanup(projectDir); cleanup(emptyHome); });
+
+    assert.deepStrictEqual(globalConfig.model_policy, projectConfig.model_policy);
+  });
 });

--- a/tests/defaults-json-fallback.test.cjs
+++ b/tests/defaults-json-fallback.test.cjs
@@ -201,10 +201,14 @@ describe('loadConfig ~/.gsd/defaults.json fallback (#1683)', () => {
     assert.strictEqual(config.runtime, runtime);
   });
 
-  test('#2069 defaults.json parity: model_policy survives identically to project-config path', (t) => {
-    // Identical policy in ~/.gsd/defaults.json (no .planning/) vs .planning/config.json (no defaults.json)
-    // must produce identical config.model_policy. Previously the global path silently dropped it.
+  test('#2069 defaults.json parity: model_policy / model_profile_overrides / runtime survive identically to project-config path', (t) => {
+    // Identical values in ~/.gsd/defaults.json (no .planning/) vs .planning/config.json (no defaults.json)
+    // must produce identical config.<key> for each of the three previously-dropped keys. A future
+    // regression breaking shape-parity for just one key — e.g. changing the project path to
+    // `parsed['runtime'] ?? null` — would slip a single-key test, so all three are asserted here.
     const policy = { provider: 'anthropic', budget: 'low' };
+    const overrides = { claude: { planner: { model: 'claude-opus-4-5' } } };
+    const runtime = 'codex';
 
     // Global path: ~/.gsd/defaults.json only, no .planning/
     const globalDir = createBareTmpDir();
@@ -212,7 +216,7 @@ describe('loadConfig ~/.gsd/defaults.json fallback (#1683)', () => {
     fs.mkdirSync(globalGsdDir, { recursive: true });
     fs.writeFileSync(
       path.join(globalGsdDir, 'defaults.json'),
-      JSON.stringify({ model_policy: policy })
+      JSON.stringify({ model_policy: policy, model_profile_overrides: overrides, runtime })
     );
 
     process.env.GSD_HOME = globalDir;
@@ -225,7 +229,7 @@ describe('loadConfig ~/.gsd/defaults.json fallback (#1683)', () => {
     fs.mkdirSync(path.join(projectDir, '.planning'), { recursive: true });
     fs.writeFileSync(
       path.join(projectDir, '.planning', 'config.json'),
-      JSON.stringify({ model_policy: policy })
+      JSON.stringify({ model_policy: policy, model_profile_overrides: overrides, runtime })
     );
 
     // GSD_HOME pointing somewhere with no defaults.json so the project path is the sole source.
@@ -236,5 +240,7 @@ describe('loadConfig ~/.gsd/defaults.json fallback (#1683)', () => {
     t.after(() => { cleanup(projectDir); cleanup(emptyHome); });
 
     assert.deepStrictEqual(globalConfig.model_policy, projectConfig.model_policy);
+    assert.deepStrictEqual(globalConfig.model_profile_overrides, projectConfig.model_profile_overrides);
+    assert.strictEqual(globalConfig.runtime, projectConfig.runtime);
   });
 });


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #2069

> The linked issue carries the `confirmed-bug` label (applied during triage by @trek-e).

---

## What was broken

The global-defaults path of `loadConfigResolved` (Branch D — invoked when a user runs GSD from a directory with no `.planning/`) silently dropped three keys from `~/.gsd/defaults.json`: `model_policy`, `model_profile_overrides`, and `runtime`. A machine-wide model policy / runtime / profile-overrides block was honored inside a project (where `.planning/config.json` carries it) but ignored for out-of-project runs, with `resolve-model` falling back to the profile default and emitting no warning.

## What this fix does

Adds the three missing entries to the `_globalBaseCfg` whitelist at `src/config-loader.cts:734-741`, in the same `(globalDefaults['…']) || null` shape used by the sibling keys and by the project-config path. `~/.gsd/defaults.json` is now at parity with `.planning/config.json` for these three keys.

## Root cause

Incomplete whitelist. Branch D builds `_globalBaseCfg` by explicitly forwarding each known key from `globalDefaults['…']`. When `model_policy` / `model_profile_overrides` / `runtime` were introduced (v1.39 / v1.42), they were wired into the project-config path (`src/config-loader.cts:642-644`) but never added to Branch D's whitelist. The docs (`docs/CONFIGURATION.md` "Model Policy Presets" → "**Location:** `~/.gsd/defaults.json`") always described the intended behavior, so this was a straight implementation/docs drift, not an intentional scoping decision.

Cortex decision-memory recall for the asymmetry returned no recorded rationale (CannotProve) — there is no recorded decision to violate.

## Testing

### How I verified the fix

`gsd-test --base next --head 96995d688` → `outcome:"passed"`, 25903/25903 tests green on linux-node22 and linux-node24 (v1.6.2 bench). Demonstrated fail-first on the unfixed source at HEAD `203eabd71` → `outcome:"failed"` with exactly the 4 new regression tests failing on both node lanes (10 total failures, 5 unique). After the source fix at HEAD `4367f1135` → `outcome:"passed"`.

### Regression test added?

- [x] Yes — added 4 tests in `tests/defaults-json-fallback.test.cjs`:
  - `#2069 defaults.json model_policy → forwarded from global defaults` (fail-first demonstrated)
  - `#2069 defaults.json model_profile_overrides → forwarded from global defaults` (fail-first demonstrated)
  - `#2069 defaults.json runtime → forwarded from global defaults` (fail-first demonstrated)
  - `#2069 defaults.json parity: all three keys survive identically to project-config path` (extended after code review to assert all three keys at parity, not just `model_policy`)

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux (via gsd-test bench: linux-node22, linux-node24)
- [ ] N/a (config-load path is platform-agnostic, but the bug reporter is on Windows — a Windows lane pass would be ideal but the code path is OS-independent)

### Runtimes tested

- [x] Claude Code (reporter's runtime; config-load path is runtime-agnostic)
- [ ] Gemini CLI
- [ ] OpenCode
- [x] N/A (the fix is in the runtime-agnostic config layer; it benefits all runtimes)

---

## Checklist

- [x] Issue linked above with `Fixes #2069`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — three keys added to one whitelist; no unrelated changes
- [x] Regression test added (4 new tests, fail-first demonstrated)
- [x] All existing tests pass — `gsd-test` verdict `outcome:"passed"` on HEAD `96995d688`
- [x] `.changeset/` fragment added — `.changeset/sturdy-seals-fly.md` (Fixed type, pr:0 placeholder to be backfilled post-create)
- [x] No unnecessary dependencies added

## Breaking changes

None. The change is purely additive: keys that were previously dropped are now forwarded. No existing caller can have been (correctly) depending on `model_policy` / `model_profile_overrides` / `runtime` being absent from global-defaults output, because the project-config path already produces them — the only behavioral delta is that users who set these keys in `~/.gsd/defaults.json` will now see them take effect (the documented intent).

## Pre-PR gates run

- [x] `gsd-test` — verdict `outcome:"passed"` (recorded in `.gsd/last-pass.json` for sha `96995d688…`)
- [x] `/code-review` (fresh subagent reviewer context) — 1 Low finding addressed (extended parity test), 1 Low out-of-scope note (other keys in `_globalBaseCfg` are documented as project-scoped — not a defect), 1 Info
- [x] `/security-review` (fresh subagent reviewer context) — NO FINDINGS across injection / secret / path traversal / prompt injection / unsafe argv / trust boundary / test isolation
- [x] `memtrace find_code_review_issues` (graph-backed AST + cross-module + YAML) — 0 issues, `_graph_state: ready`
- [x] `npm run lint` — 0 errors in diff (51 pre-existing warnings in unrelated files)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2442"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787102832&installation_id=134682257&pr_number=2442&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2442&signature=2630827caf13e12bfa11a014f239f5f8f0cf8041ecfa5ffc02fa539640486f9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->