### PR TITLE
docs(#2343): list gsd-omp EoS integration

### DIFF
--- a/.changeset/bright-otters-embed.md
+++ b/.changeset/bright-otters-embed.md
@@ -1,0 +1,5 @@
+---
+type: Added
+pr: 2344
+---
+**The EoS Registry now lists GSD for Oh My Pi** — discover the independently maintained `tchivs/gsd-omp` protocol-v1 host integration, including exact install and uninstall commands, supported interface points, and negotiated host axes.

--- a/.changeset/bright-otters-embed.md
+++ b/.changeset/bright-otters-embed.md
@@ -1,5 +1,5 @@
 ---
 type: Added
-pr: 2344
+pr: 2448
 ---
 **The EoS Registry now lists GSD for Oh My Pi** — discover the independently maintained `tchivs/gsd-omp` protocol-v1 host integration, including exact install and uninstall commands, supported interface points, and negotiated host axes.

--- a/docs/registries/eos-registry.md
+++ b/docs/registries/eos-registry.md
@@ -6,4 +6,23 @@
 
 _To add your integration, see the [registry README](./README.md)._
 
-_No entries yet — be the first: see [README](./README.md)._
+| Name | What it is | Latest release | GSD compat | Discussion |
+|---|---|---|---|---|
+| [GSD for Oh My Pi](https://github.com/tchivs/gsd-omp) | Embeds GSD in Oh My Pi through OMP's native ExtensionAPI, programmatic slash commands, task isolation, lifecycle events, filesystem state, and managed agent and skill projection. | ![release](https://img.shields.io/github/v/release/tchivs/gsd-omp?sort=semver&include_prereleases) | `>=1.7.0` | [discuss](https://github.com/open-gsd/gsd-core/discussions/2342) |
+
+## GSD for Oh My Pi
+- **Repository:** https://github.com/tchivs/gsd-omp — [latest release](https://github.com/tchivs/gsd-omp/releases/latest)
+- **What it is:** Embeds GSD in Oh My Pi through OMP's native ExtensionAPI, programmatic slash commands, task isolation, lifecycle events, filesystem state, and managed agent and skill projection.
+- **Author:** tchivs
+- **Every interaction with GSD:** Interface points: command, dispatch, model, hooks, state, artifact; profile: programmatic-cli; protocol v1; axes: embeddingMode=imperative, commandSurface=slash-programmatic, dispatch=Native named and nested OMP task dispatch with background execution, full subagent tools, and host-managed isolation, modelMode=passive, hookBus=host, stateIO=filesystem, transport=native-extension, runtime=bun
+- **Install:**
+```sh
+npm install --global github:tchivs/gsd-omp#v1.0.0 && gsd-omp install
+```
+- **Uninstall:**
+```sh
+gsd-omp uninstall && npm uninstall --global gsd-omp
+```
+- **GSD compatibility:** `>=1.7.0`, protocol v1
+- **License:** MIT
+- **Discussion / ranking:** https://github.com/open-gsd/gsd-core/discussions/2342

--- a/docs/registries/eos.json
+++ b/docs/registries/eos.json
@@ -1,1 +1,37 @@
-[]
+[
+  {
+    "id": "gsd-omp",
+    "name": "GSD for Oh My Pi",
+    "type": "eos",
+    "repo": "tchivs/gsd-omp",
+    "description": "Embeds GSD in Oh My Pi through OMP's native ExtensionAPI, programmatic slash commands, task isolation, lifecycle events, filesystem state, and managed agent and skill projection.",
+    "author": "tchivs",
+    "license": "MIT",
+    "enginesGsd": ">=1.7.0",
+    "protocolVersion": 1,
+    "install": "npm install --global github:tchivs/gsd-omp#v1.0.0 && gsd-omp install",
+    "uninstall": "gsd-omp uninstall && npm uninstall --global gsd-omp",
+    "interactions": {
+      "interfacePoints": [
+        "command",
+        "dispatch",
+        "model",
+        "hooks",
+        "state",
+        "artifact"
+      ],
+      "profile": "programmatic-cli",
+      "axes": {
+        "embeddingMode": "imperative",
+        "commandSurface": "slash-programmatic",
+        "dispatch": "Native named and nested OMP task dispatch with background execution, full subagent tools, and host-managed isolation",
+        "modelMode": "passive",
+        "hookBus": "host",
+        "stateIO": "filesystem",
+        "transport": "native-extension",
+        "runtime": "bun"
+      }
+    },
+    "discussion": "https://github.com/open-gsd/gsd-core/discussions/2342"
+  }
+]


### PR DESCRIPTION
## Registry Entry PR

> **Using the wrong template?**
> — Bug fix: use [fix.md](?template=fix.md)
> — New feature (not a registry listing): use [feature.md](?template=feature.md)
> — Enhancement to existing behavior: use [enhancement.md](?template=enhancement.md)

Full schema and process: [docs/registries/README.md](../../docs/registries/README.md).

Closes #2343

---

## Registry type

- [ ] Capability Registry entry — adds/updates one object in `docs/registries/capabilities.json`
- [x] EoS Registry entry — adds/updates one object in `docs/registries/eos.json`

## The entry

```json
{
  "id": "gsd-omp",
  "name": "GSD for Oh My Pi",
  "type": "eos",
  "repo": "tchivs/gsd-omp",
  "description": "Embeds GSD in Oh My Pi through OMP's native ExtensionAPI, programmatic slash commands, task isolation, lifecycle events, filesystem state, and managed agent and skill projection.",
  "author": "tchivs",
  "license": "MIT",
  "enginesGsd": ">=1.7.0",
  "protocolVersion": 1,
  "install": "npm install --global github:tchivs/gsd-omp#v1.0.0 && gsd-omp install",
  "uninstall": "gsd-omp uninstall && npm uninstall --global gsd-omp",
  "interactions": {
    "interfacePoints": [
      "command",
      "dispatch",
      "model",
      "hooks",
      "state",
      "artifact"
    ],
    "profile": "programmatic-cli",
    "axes": {
      "embeddingMode": "imperative",
      "commandSurface": "slash-programmatic",
      "dispatch": "Native named and nested OMP task dispatch with background execution, full subagent tools, and host-managed isolation",
      "modelMode": "passive",
      "hookBus": "host",
      "stateIO": "filesystem",
      "transport": "native-extension",
      "runtime": "bun"
    }
  },
  "discussion": "https://github.com/open-gsd/gsd-core/discussions/2342"
}
```

---

## Required-field checklist

- [x] `id`, `name`, `type`, `repo`, `description`, `author`, `license`, `enginesGsd`, `install`, `uninstall`, `interactions`, `discussion` are all present and non-empty
- [x] **(EoS entries only)** `protocolVersion` is an integer ≥ 1, `interactions.interfacePoints` is a non-empty subset of the six interface points, `interactions.profile` is `programmatic-cli`, and `interactions.axes` has exactly the eight required axis keys

## Ownership & non-endorsement

- [x] `repo` links to a repository I own and maintain — not a fork, mirror, or someone else's project
- [x] I understand that inclusion means only that a maintainer merged this PR; it is not an endorsement, and GSD has not reviewed, tested, audited, or verified the integration
- [x] I understand the registry's narrow removal policy

## One entry, one PR

- [x] This PR adds exactly one entry in `docs/registries/eos.json`
- [x] I have not bundled another registry entry, code change, or unrelated documentation change

## Generated file in sync

- [x] I ran `npm run gen:registry` after editing the JSON source, and this PR includes regenerated `docs/registries/eos-registry.md`
- [x] I did not hand-edit the generated Markdown

## Documentation

- [x] This PR includes both the JSON source and regenerated Markdown under `docs/registries/`

## Checklist

- [x] `npm run lint:changeset`, `npm run validate:registry`, and `node scripts/gen-registry.cjs --check` pass locally after rebasing onto current `next`
- [x] `discussion` links to https://github.com/open-gsd/gsd-core/discussions/2342. The documented `Registry` category is not currently configured, so the thread transparently notes that it uses `General` and may be moved by a maintainer.
- [x] `.changeset/bright-otters-embed.md` added with an `Added` description and PR number 2448.

## Previous PR

#2344 could not be reopened because GitHub reports that its head branch was force-pushed or recreated. This replacement uses the same approved issue and current prepared branch.
