### PR TITLE
fix(#2455): abort remaining chunks when one hits the per-chunk timeout

### DIFF
--- a/scripts/run-tests.cjs
+++ b/scripts/run-tests.cjs
@@ -673,9 +673,35 @@ function main() {
         );
       }
       const code = err.status || 1;
-      // Run every chunk so the operator sees all failures in one pass; report
-      // the first non-zero exit at the end.
       if (firstFailureExit === 0) firstFailureExit = code;
+      if (timedOut) {
+        // A timeout has already burned a large share of the job's budget
+        // (chunkTimeoutMs defaults to 600000ms, i.e. half the 20m CI job
+        // cap), so — unlike an ordinary test failure — letting the loop
+        // fall through to the remaining chunks risks the CI runner
+        // cancelling the whole job before they finish. That cancellation
+        // replaces the loud, specific diagnostic printed above with an
+        // opaque "The operation was canceled." buried at the very end of
+        // the log, thousands of lines past the real cause (observed live on
+        // CI run 29749380190: chunk 1/5 timed out, the loop pressed on
+        // through chunks 2-4, and the job was cancelled mid-chunk-5 — the
+        // timeout message was ~38,000 log lines from the end and
+        // `gh run view --log-failed` returned nothing). Abort the remaining
+        // chunks instead so the operator actually sees this message.
+        const skipped = chunks.length - (i + 1);
+        if (skipped > 0) {
+          console.error(
+            `run-tests: aborting — skipping the remaining ${skipped} chunk${skipped === 1 ? '' : 's'} ` +
+              `after the chunk ${i + 1}/${chunks.length} timeout rather than risk the CI runner ` +
+              `cancelling the job (and burying this diagnostic) before they finish.`,
+          );
+        }
+        break;
+      }
+      // A non-timeout failure is cheap in wall-clock terms (the child exits
+      // promptly on its own), so — unlike the timeout case above — run every
+      // remaining chunk anyway: the operator sees all failures in one pass,
+      // and the first non-zero exit is reported at the end.
     }
   }
   if (firstFailureExit !== 0) return firstFailureExit;

--- a/tests/run-tests-harness.test.cjs
+++ b/tests/run-tests-harness.test.cjs
@@ -635,6 +635,68 @@ setInterval(() => {}, 1 << 30);
       );
     });
 
+    test('a timed-out chunk aborts the remaining chunks instead of burning the job budget', () => {
+      // Guards against a real CI failure mode (observed live on CI run
+      // 29749380190, windows-latest full-lane shard 2/3): the per-chunk
+      // timeout is HALF the 20m CI job cap (600000ms default vs a 1,200,000ms
+      // job), so if the loop pressed on to the next chunk after a timeout
+      // instead of aborting, a healthy full pass (~11m42s on that lane) could
+      // never finish and the CI runner cancels the whole job. That
+      // cancellation surfaces as an opaque "The operation was canceled."
+      // and buries the actual timeout diagnostic thousands of lines back in
+      // the log (in the real incident, ~38,000 lines from the end — and
+      // `gh run view --log-failed` returned nothing). Proving chunk 2 never
+      // runs pins the fix: abort the remaining chunks as soon as one times
+      // out, so the loud diagnostic above survives as the visible failure.
+      //
+      // Force exactly one file per chunk so chunk 1 = the hanging file and
+      // chunk 2 = a marker-writing file; sorted order (a- before b-, and
+      // walkTestFiles(...).sort() sorts selection) fixes which chunk runs
+      // first, deterministically — the margin between a 2s timeout and a
+      // file that never terminates is unbounded, so there is no race.
+      fs.writeFileSync(path.join(tmpDir, 'a-leaky.test.cjs'), LEAKY_BODY, 'utf8');
+      const markerPath = path.join(tmpDir, 'chunk-2-ran.marker');
+      const secondBody = `'use strict';
+const fs = require('fs');
+const { test } = require('node:test');
+fs.writeFileSync(${JSON.stringify(markerPath)}, 'ran');
+test('noop', () => {});
+`;
+      fs.writeFileSync(path.join(tmpDir, 'b-marker.test.cjs'), secondBody, 'utf8');
+
+      const r = runHarness(tmpDir, [], {
+        RUN_TESTS_NO_FORCE_EXIT: '1',
+        RUN_TESTS_CHUNK_TIMEOUT_MS: '2000',
+        RUN_TESTS_MAX_FILES_PER_CHUNK: '1',
+      });
+
+      assert.notStrictEqual(
+        r.status,
+        0,
+        `expected non-zero exit from an aborted run; got status=${r.status}\nSTDERR:\n${r.stderr}`,
+      );
+      assert.match(
+        r.stderr,
+        /exceeded the per-chunk timeout/,
+        `expected timeout diagnostic in stderr; STDERR:\n${r.stderr}`,
+      );
+      assert.match(
+        r.stderr,
+        /aborting — skipping the remaining 1 chunk/,
+        `expected the new abort message in stderr; STDERR:\n${r.stderr}`,
+      );
+      assert.strictEqual(
+        fs.existsSync(markerPath),
+        false,
+        `chunk 2's marker file must NOT exist — proves the second chunk's test file never executed; STDERR:\n${r.stderr}`,
+      );
+      assert.doesNotMatch(
+        r.stderr,
+        /chunk 2\/2/,
+        `chunk 2's progress line must never print — proves the loop broke before starting chunk 2; STDERR:\n${r.stderr}`,
+      );
+    });
+
     test('force-exit lets a chunk with a leaked handle exit cleanly', () => {
       const nodeMajor = Number(process.versions.node.split('.')[0]);
       // --test-force-exit was added in Node 22; skip on older engines.


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #2455

> The linked issue carries the `confirmed-bug` label.

---

## What was broken

When a chunk was killed by the per-chunk timeout, `scripts/run-tests.cjs` recorded the failure and then **continued running the remaining chunks**. Because the timeout (600000ms) is half the 20-minute CI job cap and a healthy full Windows pass takes ~11m42s, continuing after a timeout could essentially never finish — so the job died as a GitHub Actions **cancellation** rather than a clean test failure, discarding the timeout diagnostic as the visible error.

## What this fix does

On a timeout, aborts the remaining chunks and returns immediately, so the loud diagnostic survives as the visible failure and the job ends cleanly at ~10 minutes instead of being cancelled at 20.

Ordinary (non-timeout) test failures keep their existing behavior — every remaining chunk still runs, so the operator sees all failures in one pass. A normal failure exits promptly and costs no meaningful wall-clock, so it never had this problem.

## Root cause

The control flow contradicted the code's own documented contract at `scripts/run-tests.cjs:633-637`:

> A chunk that still hangs ... must fail loudly **rather than silently burn the job's wall-clock budget until the CI runner cancels the whole job.** Default 10 min per chunk: well above a healthy chunk (~4-5 min on the windows lane) but below the 20m job cap.

The timeout was built specifically to prevent job cancellation, and the loop caused it. The math made this near-deterministic rather than incidental: a timeout consumes 10 of the 20 available minutes, and the remaining chunks then need roughly the balance of a full pass.

### Observed instance

Run [29749380190](https://github.com/open-gsd/gsd-core/actions/runs/29749380190), job `full test (windows-latest, 22, shard 2/3)`:

| Event | Time | Note |
|---|---|---|
| chunk 1/5 starts | 14:13:34 | 49 files |
| chunk 1/5 killed | 14:23:34 | exactly 600s; output flowed until the kill, so slow, not hung |
| chunks 2, 3, 4 run | 14:23:34 – 14:29:52 | all report `# fail 0` |
| chunk 5/5 starts | 14:29:52 | |
| job cancelled | 14:30:04 | 20m job cap |

What made it expensive to diagnose: the surfaced error was `##[error]The operation was canceled.` with no indication a timeout occurred; `gh run view --job <id> --log-failed` returned **nothing at all**; and the real diagnostic sat ~38,000 lines from the end of a 49,270-line log.

## Testing

### How I verified the fix

- Full suite: `outcome:"passed"` — 25948/25948 on linux-node22 and linux-node24 (recorded against `125ea7d07`).
- `npm run lint` / `npm run lint:ci`: 0 errors. The 51 warnings are pre-existing, verified identical against `origin/next` by stash-and-recheck, and live in files this PR does not touch.

### Regression test added?

- [x] Yes — added a test that would have caught this bug

`tests/run-tests-harness.test.cjs`, in the existing `per-chunk timeout + force-exit (windows hang guard, #1051)` block. It forces one file per chunk via `RUN_TESTS_MAX_FILES_PER_CHUNK`, puts a hanging file in chunk 1 (sorted first) and a marker-writing file in chunk 2, then asserts chunk 2 never ran.

The proof is deliberately filesystem-level, not log-level: it asserts the **marker file does not exist**, so a fix that merely suppressed the `chunk 2/2` log line while still executing the chunk would fail the test. The absent `chunk 2/2` progress line is asserted too, as an independent second signal.

It is also deterministic by construction — the margin between a 2s timeout and a file that never terminates is unbounded, so there is no race.

### Platforms tested

- [ ] macOS
- [x] Linux (full suite, linux-node22 + linux-node24 containers)
- [ ] Windows (including backslash path handling)

> The defect was *observed* on the Windows lane, but the control-flow bug and its fix are platform-independent — the per-chunk timeout path is shared by all lanes.

### Runtimes tested

- [x] N/A (not runtime-specific — CI test harness only)

---

## Checklist

- [x] Issue linked above with `Fixes #2455`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass (25948/25948 on both node lines)
- [x] `.changeset/` fragment — **not applicable**: touches only `scripts/` and `tests/`, outside the changeset lint's enforced path list (`bin/`, `gsd-core/`, `agents/`, `commands/`, `hooks/`, `sdk/src/`), and CONTRIBUTING lists CI tweaks as an explicit changelog opt-out.
- [x] No unnecessary dependencies added

## Breaking changes

None for users. The only behavior change is in the CI harness: after a per-chunk timeout, remaining chunks are skipped rather than run. Anyone relying on seeing later chunks' results *after* a timeout will no longer get them — but in practice they did not get them anyway, because the job was cancelled before finishing.

---

## Related

This is one of two fixes from investigating a CI failure on #2451. The companion is #2456 — chunk weights ignore measured cost, leaving the slowest chunk 3.9x the lightest. That is *why* this timeout fires at all: the margin on the Windows lane was 2.35x against an observed 2.4x slowdown. **This PR makes a timeout legible; #2456 makes it rarer.** They are independent and can land in either order.

For the record, the failure that started this investigation was itself transient — a re-run of #2451 went green, and that PR needed no code changes. This defect is what made establishing that take as long as it did.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2465"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787172047&installation_model_id=22188&pr_number=2465&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2465&signature=c940c328d3bc94203519ec962b2590e1f3bb0ac1f6f6d02352305189268b77f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->