### PR TITLE
fix(#2427): ground smart-entry completion in ROADMAP-derived counts + tighten status regex

### DIFF
--- a/.changeset/curious-rams-run.md
+++ b/.changeset/curious-rams-run.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`/gsd-next` no longer reports a project as complete while phases are still unchecked** — `smart-entry`'s completion check now grounds in ROADMAP.md's actual Progress table (global, authoritative) instead of STATE.md's stale milestone-scoped total_phases, and its status regex requires milestone-level language (`milestone complete` / `all phases complete` / `complete`) instead of matching any per-phase `shipped` or `done` substring. Together these fix the false-complete misclassification that could route `/gsd-next` toward `/gsd-new-milestone` — which archives still-pending phase directories.

--- a/.changeset/curious-rams-run.md
+++ b/.changeset/curious-rams-run.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 2466
 ---
 **`/gsd-next` no longer reports a project as complete while phases are still unchecked** — `smart-entry`'s completion check now grounds in ROADMAP.md's actual Progress table (global, authoritative) instead of STATE.md's stale milestone-scoped total_phases, and its status regex requires milestone-level language (`milestone complete` / `all phases complete` / `complete`) instead of matching any per-phase `shipped` or `done` substring. Together these fix the false-complete misclassification that could route `/gsd-next` toward `/gsd-new-milestone` — which archives still-pending phase directories.

--- a/src/smart-entry.cts
+++ b/src/smart-entry.cts
@@ -42,6 +42,9 @@ const { planningPaths } = planningWorkspace;
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import frontmatter = require('./frontmatter.cjs');
 const { extractFrontmatter } = frontmatter;
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- phase-lifecycle.cjs is an export= CommonJS module
+import phaseLifecycle = require('./phase-lifecycle.cjs');
+const { deriveProgressFromRoadmap } = phaseLifecycle;
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import stateDocument = require('./state-document.cjs');
 const { stateExtractField } = stateDocument;
@@ -89,6 +92,15 @@ export interface SmartEntrySignals {
   verify_failed: boolean;
   /** last_activity older than IDLE_STALE_MS (computed with the clock seam). */
   stale_activity: boolean;
+  /**
+   * Global phase counts derived from ROADMAP.md's `## Progress` table (#2427).
+   * Preferred over the cached milestone-scoped `total_phases` (which goes stale
+   * when phases are appended after a milestone switch). Null when ROADMAP.md is
+   * absent or has no parseable Progress table — callers fall back to the legacy
+   * STATE.md comparison in that case.
+   */
+  roadmap_total_phases: number | null;
+  roadmap_completed_phases: number | null;
 }
 
 export interface SmartEntryResult {
@@ -294,6 +306,8 @@ export function detectSignals(cwd: string, now: () => number = Date.now): SmartE
     has_git: git.has_git,
     verify_failed: false,
     stale_activity: false,
+    roadmap_total_phases: null,
+    roadmap_completed_phases: null,
   };
   if (!hasPlanning) return empty;
 
@@ -350,6 +364,24 @@ export function detectSignals(cwd: string, now: () => number = Date.now): SmartE
     /\bverify-fail(ed)?|verification-fail|uat-fail\b/i.test(statusRaw || '') ||
     detectVerifyFailed(cwd, currentPhaseRaw);
 
+  // #2427: derive global phase counts from ROADMAP.md's Progress table. These
+  // are preferred over STATE.md's cached milestone-scoped `total_phases` (which
+  // goes stale when phases are appended after a milestone switch) for the
+  // completion check. Null when ROADMAP.md is absent or has no parseable
+  // Progress table — isComplete falls back to the legacy comparison in that case.
+  let roadmapTotalPhases: number | null = null;
+  let roadmapCompletedPhases: number | null = null;
+  if (hasRoadmap) {
+    try {
+      const roadmapContent = fs.readFileSync(paths.roadmap, 'utf8');
+      const derived = deriveProgressFromRoadmap(roadmapContent);
+      roadmapTotalPhases = derived.totalPhases;
+      roadmapCompletedPhases = derived.completedPhases;
+    } catch {
+      /* ROADMAP.md unreadable — leave null; isComplete falls back to legacy. */
+    }
+  }
+
   return {
     current_phase: parseIntOrNull(currentPhaseRaw),
     total_phases: parseIntOrNull(totalPhasesRaw),
@@ -364,15 +396,53 @@ export function detectSignals(cwd: string, now: () => number = Date.now): SmartE
     has_git: git.has_git,
     verify_failed: verifyFailed,
     stale_activity: staleActivity,
+    roadmap_total_phases: roadmapTotalPhases,
+    roadmap_completed_phases: roadmapCompletedPhases,
   };
 }
 
 // ─── Situation classification ─────────────────────────────────────────────────
 
-/** True when the workflow has fully completed all phases. */
+/**
+ * True when the workflow has fully completed all phases.
+ *
+ * #2427: completion is grounded in ROADMAP.md's Progress table (global,
+ * authoritative, never stale) when available, with a legacy fallback to
+ * STATE.md's cached `total_phases` when the roadmap has no parseable Progress
+ * table (e.g. a fresh project or a non-standard roadmap layout). The status
+ * regex was tightened to require milestone-level completion language
+ * (`milestone complete` / `all phases complete` / `complete(d)`) and no longer
+ * matches per-phase messages like "Phase X shipped — PR #N" that falsely
+ * satisfied the pre-fix alternation (`\bcomplete(d)?|done|shipped\b`).
+ */
 function isComplete(s: SmartEntrySignals): boolean {
-  if (s.total_phases === null || s.current_phase === null) return false;
-  return s.current_phase >= s.total_phases && /\bcomplete(d)?|done|shipped\b/i.test(s.status);
+  // Prefer ROADMAP-derived counts (global, authoritative) over STATE.md's
+  // cached milestone-scoped total_phases (stale-prone). Fall back to legacy
+  // when the roadmap has no Progress table.
+  if (s.roadmap_total_phases !== null && s.roadmap_completed_phases !== null) {
+    if (s.roadmap_total_phases === 0) return false;
+    if (s.roadmap_completed_phases < s.roadmap_total_phases) return false;
+  } else {
+    // Legacy path: STATE.md comparison. Still subject to the two-scale bug,
+    // but only fires when ROADMAP.md is absent or has no Progress table.
+    if (s.total_phases === null || s.current_phase === null) return false;
+    if (s.current_phase < s.total_phases) return false;
+  }
+  // Status regex: require milestone-level completion language. The pre-fix
+  // regex matched any "shipped" / "done" substring (per-phase language).
+  // Tightened to match:
+  //   - "milestone complete" (ADR-2207 terminal status — usually written as
+  //     "<version> milestone complete", e.g. "v1.0 milestone complete"; the
+  //     substring match handles both forms)
+  //   - "all phases complete" (ADR-2207 intermediate terminal)
+  //   - "complete" / "completed" (legacy short form — STATE.md milestone
+  //     status is a single value, not a per-phase log)
+  // Intentionally does NOT match "done" alone even though normalizeStateStatus
+  // (state-document.cts) treats "done" as "completed" — in the milestone
+  // status field, "done" is per-phase noise (e.g. "Phase X done"), not a
+  // milestone-completion signal. Mirrors workstream-inventory-builder.cts's
+  // terminal pattern \bmilestone\s+complete\b.
+  return /\b(milestone\s+complete|all\s+phases\s+complete|complete(d)?)\b/i.test(s.status);
 }
 
 /** Idle-stranded: clean tree, committed work not shipped, optionally stale. */

--- a/tests/smart-entry.unit.test.cjs
+++ b/tests/smart-entry.unit.test.cjs
@@ -35,7 +35,12 @@ function makeProject({ state, roadmap = false, git = false, verifyFail = false }
     fs.writeFileSync(path.join(tmpDir, '.planning', 'STATE.md'), state);
   }
   if (roadmap) {
-    fs.writeFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), '# Roadmap\n');
+    // `roadmap === true` writes a minimal empty roadmap (no Progress table —
+    // the legacy test default). A string is written verbatim so tests can
+    // supply a real Progress table for the #2427 roadmap-derived completion
+    // check.
+    const content = typeof roadmap === 'string' ? roadmap : '# Roadmap\n';
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), content);
   }
   if (git) {
     execFileSync('git', ['init'], { cwd: tmpDir, stdio: 'pipe' });
@@ -426,5 +431,121 @@ describe('smart-entry: CLI dispatch (gsd-tools smart-entry)', () => {
     assert.ok(!out.startsWith('{'), 'human mode is not JSON');
     assert.match(out, /No project yet/);
     assert.match(out, /Recommended:/);
+  });
+});
+
+// ─── #2427: roadmap-grounded completion + tightened status regex ─────────────
+//
+// Pre-fix bug: isComplete compared global current_phase against stale
+// milestone-scoped total_phases (written once at milestone-switch time) and
+// matched any "shipped"/"done" substring in the status line — so a project
+// mid-milestone with current_phase=7 > stale total_phases=4 AND a per-phase
+// "Phase X shipped" status was falsely classified as "complete". The fix
+// grounds completion in ROADMAP.md's Progress table (global, authoritative)
+// and tightens the regex to require milestone-level language.
+
+describe('#2427 — roadmap-grounded completion + tightened status regex', () => {
+  afterEach(removeAll);
+
+  /**
+   * Build a ROADMAP.md with a `## Progress` table of N rows, M of which are
+   * `Complete` and the rest `In Progress`. Matches the column-name-driven
+   * Progress table shape deriveProgressFromRoadmap scans.
+   */
+  function roadmapWithProgress(total, completed) {
+    const rows = [];
+    for (let i = 1; i <= total; i++) {
+      const status = i <= completed ? 'Complete' : 'In Progress';
+      const phase = String(i).padStart(2, '0');
+      rows.push(`| ${phase} | 0/1 | ${status} | ${status === 'Complete' ? '2026-01-01' : ''} |`);
+    }
+    return [
+      '# Roadmap',
+      '',
+      '## Milestone v1.0',
+      '',
+      '## Progress',
+      '',
+      '| Phase | Plans Complete | Status | Completed |',
+      '|-------|---------------|--------|-----------|',
+      ...rows,
+    ].join('\n') + '\n';
+  }
+
+  test('mid-milestone with stale total_phases + unchecked roadmap phases is NOT complete', () => {
+    // The core bug: STATE.md says current_phase=7 >= total_phases=4 (stale,
+    // from a milestone switch when only 4 phases existed). Status contains
+    // "shipped" from a per-phase message. ROADMAP has 7 phases, only 4 done.
+    // MUST classify as something OTHER than "complete".
+    const dir = track(makeProject({
+      state: state({ status: 'Phase 7 shipped — PR #42', total_phases: 4, current_phase: 7 }),
+      roadmap: roadmapWithProgress(7, 4),
+    }));
+    const result = classifyProject(dir);
+    assert.notEqual(result.situation, 'complete',
+      `mid-milestone (7 phases, 4 done) must NOT be "complete" even with stale total_phases=4 + current_phase=7. Got: ${result.situation}`);
+  });
+
+  test('all roadmap phases complete classifies as complete even with stale cached total_phases', () => {
+    // ROADMAP says all 5 phases are done. STATE.md has stale total_phases=3
+    // (from an earlier milestone switch). The roadmap-derived check should
+    // win and classify as complete. Status uses ADR-2207's actual terminal
+    // written form "<version> milestone complete" (state-transition.cts:1303).
+    const dir = track(makeProject({
+      state: state({ status: 'v1.0 milestone complete', total_phases: 3, current_phase: 5 }),
+      roadmap: roadmapWithProgress(5, 5),
+    }));
+    const result = classifyProject(dir);
+    assert.equal(result.situation, 'complete',
+      `all roadmap phases complete must classify as "complete" regardless of stale cached total_phases. Got: ${result.situation}`);
+  });
+
+  test('per-phase "shipped" status alone does NOT satisfy the completion regex', () => {
+    // The pre-fix regex matched "shipped" as a standalone alternation branch.
+    // Tightened regex requires milestone-level language. With some phases
+    // unchecked AND status="shipped", must NOT be complete.
+    const dir = track(makeProject({
+      state: state({ status: 'shipped', total_phases: 5, current_phase: 5 }),
+      roadmap: roadmapWithProgress(5, 3),
+    }));
+    const result = classifyProject(dir);
+    assert.notEqual(result.situation, 'complete',
+      `status "shipped" alone (per-phase language) must NOT satisfy completion when roadmap has unchecked phases. Got: ${result.situation}`);
+  });
+
+  test('per-phase "done" status alone does NOT satisfy the completion regex', () => {
+    // Same as above but with "done" — the other over-broad branch the pre-fix
+    // regex matched.
+    const dir = track(makeProject({
+      state: state({ status: 'done', total_phases: 5, current_phase: 5 }),
+      roadmap: roadmapWithProgress(5, 3),
+    }));
+    const result = classifyProject(dir);
+    assert.notEqual(result.situation, 'complete',
+      `status "done" alone must NOT satisfy completion when roadmap has unchecked phases. Got: ${result.situation}`);
+  });
+
+  test('legacy fallback: empty roadmap still classifies via STATE.md comparison', () => {
+    // When ROADMAP.md has no Progress table (fresh project, non-standard
+    // layout), isComplete falls back to the legacy current_phase >= total_phases
+    // check. This preserves backward compat for projects that haven't adopted
+    // the Progress-table convention.
+    const dir = track(makeProject({
+      state: state({ status: 'complete', total_phases: 5, current_phase: 5 }),
+      roadmap: true, // empty roadmap — no Progress table
+    }));
+    const result = classifyProject(dir);
+    assert.equal(result.situation, 'complete',
+      `legacy fallback (no roadmap Progress table) must still classify complete via STATE.md. Got: ${result.situation}`);
+  });
+
+  test('legacy fallback: empty roadmap with current_phase < total_phases is NOT complete', () => {
+    const dir = track(makeProject({
+      state: state({ status: 'complete', total_phases: 5, current_phase: 3 }),
+      roadmap: true,
+    }));
+    const result = classifyProject(dir);
+    assert.notEqual(result.situation, 'complete',
+      `legacy fallback must still reject completion when current_phase < total_phases. Got: ${result.situation}`);
   });
 });


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #2427

> The linked issue carries the `confirmed-bug` label (triaged with diagnosis + agent brief).

## What was broken

`gsd-tools smart-entry --json` (the command `/gsd-next` uses to decide routing) reported `situation: "complete"` for a project still mid-milestone, with real work outstanding. Two coupled defects in `isComplete` (`src/smart-entry.cts`):

1. **Two-scale comparison**: `current_phase` (global, cross-milestone counter from STATE.md body) was compared with `>=` against `total_phases` (milestone-scoped counter from STATE.md frontmatter, written once at milestone-switch time and going stale as soon as new phases are appended to the roadmap). When `current_phase >= stale total_phases` (e.g. `7 >= 4`), `isComplete` tripped true even though later phases were still unchecked in ROADMAP.md.

2. **Over-broad status regex**: `/\bcomplete(d)?|done|shipped\b/i` matched any "shipped" or "done" substring — including per-phase status like `"Phase X shipped — PR #2"` — and falsely satisfied the status side of the completion check.

Together these could make an in-progress project register as `"complete"`, routing `/gsd-next` toward `/gsd-new-milestone` — which archives still-pending phase directories (`phases.clear --confirm --archive-version`).

## What this fix does

1. **Added two new `SmartEntrySignals` fields**: `roadmap_total_phases` and `roadmap_completed_phases`, populated by calling the existing `deriveProgressFromRoadmap` helper (from `phase-lifecycle.cts:60`) on ROADMAP.md content. These are global, authoritative counts from the `## Progress` table — never stale.

2. **Rewrote `isComplete`** to prefer the roadmap-derived counts when available (`roadmap_completed_phases >= roadmap_total_phases`) and fall back to the legacy STATE.md comparison only when the roadmap has no parseable Progress table (backward compat for fresh or non-standard projects).

3. **Tightened the status regex** to `/\b(milestone\s+complete|all\s+phases\s+complete|complete(d)?)\b/i` — drops `done` and `shipped` (per-phase language), keeps milestone-level signals per ADR-2207 (`<version> milestone complete`, `all phases complete`) plus the legacy short form `complete`/`completed`. Mirrors `workstream-inventory-builder.cts`'s terminal pattern.

## Root cause

`isComplete` has always compared these two scales — Memtrace's timeline shows the function unchanged across all 3 indexed versions since 2026-07-03. The `total_phases` field in STATE.md is correctly milestone-scoped (per the state-transition module's milestone-switch write path), but `isComplete` was the wrong consumer for it: completion is a global property, not milestone-scoped. The correct helper (`deriveProgressFromRoadmap`) already existed and was used by other surfaces — `smart-entry.cts` just never imported it.

The status regex was an over-broad alternation where `\b` only gated the `shipped` branch (regex precedence), so `done` matched anywhere and `complete` matched substrings. The rewrite brackets the whole group in `\b` so every branch is word-bounded.

## Testing

### How I verified the fix

- **`tests/smart-entry.unit.test.cjs` gains a `#2427` describe block** with 6 tests:
  - Mid-milestone with stale `total_phases=4`, `current_phase=7`, per-phase `"Phase 7 shipped — PR #42"` status, and 3 unchecked roadmap phases → NOT complete (core bug scenario; **fails pre-fix**).
  - All roadmap phases complete classifies as complete even with stale cached `total_phases` (roadmap wins; uses ADR-2207's actual `"v1.0 milestone complete"` written form).
  - Per-phase `"shipped"` alone does NOT satisfy completion when roadmap phases are unchecked (**fails pre-fix**).
  - Per-phase `"done"` alone does NOT satisfy completion (**fails pre-fix**).
  - Legacy fallback: empty roadmap (no Progress table) still classifies via STATE.md comparison.
  - Legacy fallback: empty roadmap with `current_phase < total_phases` is NOT complete.
- **Regression-first verified**: 3 of 6 tests fail against the pre-fix `isComplete`; the other 3 are correctness sanity checks for the backward-compat fallback path.
- **gsd-test verdict**: `outcome:"passed"` — 25965/25965 on linux-node22 and linux-node24 (recorded against HEAD sha `8f90d660d` after rebasing onto the latest `next`).

### Regression test added?

- [x] Yes — 6 tests covering the core bug scenario, the roadmap-derived path, the tightened regex (both dropped branches), and the legacy fallback (both polarities)

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux (gsd-test linux-node22 + linux-node24 containers)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [x] N/A (fix is in pure CLI code shared across all runtimes)

---

## Checklist

- [x] Issue linked above with `Fixes #2427`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (6 tests, 3 regression-first)
- [x] All existing tests pass (`gsd-test` verdict: passed, 25965/25965 on linux-node22 + linux-node24)
- [x] `.changeset/` fragment added (`.changeset/curious-rams-run.md`, type `Fixed`)
- [x] No unnecessary dependencies added

## Breaking changes

None. The `SmartEntrySignals` interface gained two nullable fields (backward-compatible widening). With no ROADMAP.md Progress table, `isComplete` falls back to the byte-identical legacy comparison. The status regex tightening drops per-phase `shipped`/`done` from satisfying completion — but those were always false positives (per-phase language in the milestone status field), never legitimate milestone-complete signals.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2466"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787174020&installation_model_id=22188&pr_number=2466&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2466&signature=0d3b900a45769730dc5b0dd0027c1c863822785c844a909dd03e731c6df59ddf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->