### PR TITLE
fix(#2449): make tdd.review-checkpoint frontmatter regex CRLF-tolerant

### DIFF
--- a/.changeset/lazy-lemurs-jump.md
+++ b/.changeset/lazy-lemurs-jump.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 2477
 ---
 **`check tdd.review-checkpoint` no longer silently skips TDD plans with CRLF line endings** — the frontmatter regex at `src/check-command-router.cts:751` used literal `\n` which couldn't match a CRLF PLAN.md delimiter (`---\r\n`), so a Windows-authored `type: tdd` plan was silently classified as "no type:tdd plans found" and the advisory gate short-circuited to a confident pass with no violations table. The regex now uses the same CRLF-tolerant form (`/^---\r?\n([\s\S]*?)\r?\n---/`) already in use elsewhere in the same file (line 205, `extractPlanDesignatedSections`). With `core.autocrlf=input`, the triggering CRLF was invisible to `git diff`/`git status`, so the contributor had no way to tell their plan was being misclassified.

--- a/.changeset/lazy-lemurs-jump.md
+++ b/.changeset/lazy-lemurs-jump.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`check tdd.review-checkpoint` no longer silently skips TDD plans with CRLF line endings** — the frontmatter regex at `src/check-command-router.cts:751` used literal `\n` which couldn't match a CRLF PLAN.md delimiter (`---\r\n`), so a Windows-authored `type: tdd` plan was silently classified as "no type:tdd plans found" and the advisory gate short-circuited to a confident pass with no violations table. The regex now uses the same CRLF-tolerant form (`/^---\r?\n([\s\S]*?)\r?\n---/`) already in use elsewhere in the same file (line 205, `extractPlanDesignatedSections`). With `core.autocrlf=input`, the triggering CRLF was invisible to `git diff`/`git status`, so the contributor had no way to tell their plan was being misclassified.

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
       "bin": {
         "gsd_run": "gsd-core/bin/gsd_run",
         "gsd-core": "bin/install.js",
+        "gsd-mcp-server": "bin/gsd-mcp-server.js",
         "gsd-tools": "gsd-core/bin/gsd-tools.cjs"
       },
       "devDependencies": {
@@ -2160,21 +2161,34 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -4981,17 +4995,34 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typed-inject": {

--- a/src/check-command-router.cts
+++ b/src/check-command-router.cts
@@ -748,7 +748,11 @@ function cmdTddReviewCheckpoint(projectDir: string, args: string[], raw: boolean
         const planPath = path.join(phaseDir, file);
         const content = readIfExists(planPath);
         // Check frontmatter for type: tdd
-        const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---/);
+        // CRLF-tolerant: a PLAN.md written with Windows line endings (---\r\n...---)
+        // must still match. The same CRLF-tolerant form is already used at line 205
+        // (extractPlanDesignatedSections); this is the same canonical pattern, applied
+        // here for the tdd-classification path. Fixes #2449.
+        const frontmatterMatch = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
         if (frontmatterMatch) {
           const fm = frontmatterMatch[1];
           if (/^type:\s*tdd\s*$/m.test(fm)) {

--- a/tests/check-tdd-review-checkpoint-e2e.test.cjs
+++ b/tests/check-tdd-review-checkpoint-e2e.test.cjs
@@ -97,6 +97,17 @@ function tddPlan(phaseNum, planId) {
 }
 
 /**
+ * Same as tddPlan but with CRLF line endings — reproduces #2449.
+ * Some Windows editors / toolchains write PLAN.md with CRLF; with
+ * core.autocrlf=input the working-tree CRLF is invisible to git diff/status
+ * (the blob is normalized on commit), so the contributor cannot tell their
+ * plan is being silently misclassified.
+ */
+function tddPlanCrlf(phaseNum, planId) {
+  return `---\r\ntype: tdd\r\nphase: ${phaseNum}\r\nslug: ${planId}\r\n---\r\n# Task: ${planId}\r\n`;
+}
+
+/**
  * Build a type:execute PLAN.md (non-TDD) content.
  */
 function executePlan(phaseNum, planId) {
@@ -392,6 +403,37 @@ describe('check tdd.review-checkpoint — CLI subprocess E2E with git fixtures',
       assert.strictEqual(out.violations, 0, 'violations must be 0');
       assert.strictEqual(out.rows.length, 0, 'rows must be empty array');
       assert.strictEqual(out.table, '', 'table must be empty string when no tdd plans');
+    } finally {
+      cleanup(tmpDir);
+    }
+  });
+
+  test('[crlf] type:tdd plan with CRLF endings is still detected (#2449)', () => {
+    // src/check-command-router.cts:751 used /^---\n...\n---/ which can't match
+    // CRLF frontmatter delimiters, so a CRLF PLAN.md was silently classified
+    // as "no type:tdd plans" — output indistinguishable from a phase that
+    // genuinely contains no TDD plans. The advisory gate then short-circuited
+    // to a confident pass with no violations table.
+    const { tmpDir } = createTddGitFixture({
+      planFiles: [
+        { dir: '01-phase1', filename: '01-01-PLAN.md', content: tddPlanCrlf(1, '01-01') },
+      ],
+    });
+
+    try {
+      const result = runTools('check tdd.review-checkpoint 1 --raw', tmpDir);
+      assert.ok(result.success, `check should succeed. stderr: ${result.error}`);
+
+      const out = JSON.parse(result.output);
+      // SPECIFIC assertion: tddPlans must be 1, not 0 — this is the bug.
+      // Before the fix, the CRLF frontmatter regex returned null, the plan was
+      // never classified type:tdd, and tddPlanFiles stayed empty.
+      assert.strictEqual(out.tddPlans, 1, 'CRLF type:tdd plan must be detected (was silently 0 before #2449 fix)');
+      // No RED/GREEN commits in the fixture → block:true, violations:1.
+      assert.strictEqual(out.block, true, 'no commits on the detected plan: block must be TRUE');
+      assert.strictEqual(out.violations, 1, 'one violation expected for the detected plan');
+      assert.strictEqual(out.rows.length, 1, 'the detected plan must produce a row');
+      assert.strictEqual(out.rows[0].planId, '01-01', 'planId must be 01-01');
     } finally {
       cleanup(tmpDir);
     }

--- a/tests/check-tdd-review-checkpoint-e2e.test.cjs
+++ b/tests/check-tdd-review-checkpoint-e2e.test.cjs
@@ -108,6 +108,17 @@ function tddPlanCrlf(phaseNum, planId) {
 }
 
 /**
+ * Mixed-endings variant: CRLF frontmatter + LF body. Realistic when a Windows
+ * editor normalizes Markdown body text but preserves frontmatter byte-for-byte,
+ * or when tooling concatenates CRLF + LF fragments. The frontmatter delimiter
+ * still must match (the bug class), and the LF body must not be confused by
+ * downstream code that splits on \n (it gets an LF-prefixed body).
+ */
+function tddPlanMixedCrlfLf(phaseNum, planId) {
+  return `---\r\ntype: tdd\r\nphase: ${phaseNum}\r\nslug: ${planId}\r\n---\n# Task: ${planId}\n`;
+}
+
+/**
  * Build a type:execute PLAN.md (non-TDD) content.
  */
 function executePlan(phaseNum, planId) {
@@ -433,6 +444,31 @@ describe('check tdd.review-checkpoint — CLI subprocess E2E with git fixtures',
       assert.strictEqual(out.block, true, 'no commits on the detected plan: block must be TRUE');
       assert.strictEqual(out.violations, 1, 'one violation expected for the detected plan');
       assert.strictEqual(out.rows.length, 1, 'the detected plan must produce a row');
+      assert.strictEqual(out.rows[0].planId, '01-01', 'planId must be 01-01');
+    } finally {
+      cleanup(tmpDir);
+    }
+  });
+
+  test('[crlf-mixed] type:tdd plan with CRLF frontmatter + LF body is still detected (#2449)', () => {
+    // Mixed-endings variant of the [crlf] test: frontmatter delimiters are CRLF
+    // (the bug class) but the body is LF (e.g. an editor that normalizes body
+    // text but preserves frontmatter bytes, or a toolchain that concatenates
+    // CRLF + LF fragments). The classifier only reads frontmatter, so the LF
+    // body must not change detection — but verify, since the original bug was
+    // a parser differential and mixed endings are the most adversarial case.
+    const { tmpDir } = createTddGitFixture({
+      planFiles: [
+        { dir: '01-phase1', filename: '01-01-PLAN.md', content: tddPlanMixedCrlfLf(1, '01-01') },
+      ],
+    });
+
+    try {
+      const result = runTools('check tdd.review-checkpoint 1 --raw', tmpDir);
+      assert.ok(result.success, `check should succeed. stderr: ${result.error}`);
+
+      const out = JSON.parse(result.output);
+      assert.strictEqual(out.tddPlans, 1, 'CRLF-frontmatter + LF-body type:tdd plan must be detected');
       assert.strictEqual(out.rows[0].planId, '01-01', 'planId must be 01-01');
     } finally {
       cleanup(tmpDir);


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #2449

> The linked issue carries the `confirmed-bug` label.

---

## What was broken

`gsd-tools check tdd.review-checkpoint <phase>` could not see `type: tdd` plans whose `*-PLAN.md` files use CRLF line endings. It reported `No type:tdd plans found in phase <phase>. TDD review skipped.` — output indistinguishable from a phase that genuinely contains no TDD plans. The advisory gate then short-circuited to a confident pass with no violations table.

## What this fix does

Replaces the literal-`\n` frontmatter regex at `src/check-command-router.cts:751`:

```diff
-const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---/);
+const frontmatterMatch = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
```

The CRLF-tolerant form is already in use elsewhere in the same file at line 205 (`extractPlanDesignatedSections`); this is the same canonical pattern, applied here for the tdd-classification path. The reporter's suggested diff is adopted verbatim.

## Root cause

The literal `\n` in the regex could not match a CRLF PLAN.md delimiter (`---\r\n`). `frontmatterMatch` was `null`, the plan was never classified `type: tdd`, `tddPlanFiles` stayed empty, and the gate short-circuited to a pass. With `core.autocrlf=input`, the working-tree CRLF that triggered this was invisible to `git diff` / `git status` (the blob is normalized on commit), so the contributor had no way to tell their plan was being silently misclassified.

Same bug class previously triaged and fixed: #1658, #1668, #2206. This instance is in a different file and is not a duplicate.

## Testing

### How I verified the fix

TDD loop driven through `gsd-test --base next --head <sha>` (26,089 tests, both linux-node22 and linux-node24 green):

1. **Failing-first regression test** added in `tests/check-tdd-review-checkpoint-e2e.test.cjs` — `[crlf] type:tdd plan with CRLF endings is still detected (#2449)`. Asserts `out.tddPlans === 1` (was `0` before the fix) for a pure-CRLF PLAN.md. Would have failed on the pre-fix commit; passes on the fix commit.
2. **Mixed-endings variant** (`[crlf-mixed]`) added per code-review Low finding: CRLF frontmatter + LF body. Closes CONTRIBUTING.md:490's "Mixed CRLF/LF newlines" adversarial-fixture requirement.
3. **gsd-test verdict on fix commit:** `outcome:"passed"`, 26,089/26,089 on both lanes.
4. **Orthogonal review:** `/code-review` and `/security-review` subagents both returned APPROVE. The single Low finding (mixed-ending variant) was addressed inline.
5. **Graph-backed deterministic review** (`memtrace_find_code_review_issues`): 0 issues.

### Regression test added?

- [x] Yes — added two tests that would have caught this bug: `[crlf]` (pure CRLF, the reported case) and `[crlf-mixed]` (CRLF frontmatter + LF body, the more adversarial case).

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux (gsd-test matrix: linux-node22, linux-node24)
- [ ] N/A (the bug is Windows-line-endings-specific, but the regression is platform-independent and is exercised on Linux via synthetic `\r\n` content)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific — pure Node test suite via `gsd-test`)

---

## Checklist

- [x] Issue linked above with `Fixes #2449`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — plus one bundled dependency-tree fix (see note below)
- [x] Regression test added
- [x] All existing tests pass (`gsd-test` 26,089/26089 on linux-node22 + linux-node24)
- [x] `.changeset/` fragment added (`lazy-lemurs-jump.md` for the CRLF fix)
- [x] No unnecessary dependencies added (the lockfile change is a re-resolution within express's existing `^2.2.1` range — `package.json` is unchanged)

## Bundled dependency-tree fix (per CLAUDE.md "fix defects anywhere in the tree")

This PR also includes a cherry-pick of the body-parser 2.2.2 → 2.3.0 lockfile re-resolution from PR #2473 (issue #2444). GHSA-v422-hmwv-36x6 (low-severity DoS in body-parser, published 2026-07-20T23:23:26Z) makes `tests/npm-integrity-gate.test.cjs` fail any `npm audit --omit=dev`, blocking the push gate. The fix is a re-resolution within `express@5.2.1`'s already-declared `^2.2.1` range — no `overrides`, no `package.json` change. Bundled here per CLAUDE.md "No Deferrals" rather than deferred. If #2473 merges first, this commit becomes a no-op on rebase (the lockfile will already have body-parser@2.3.0); if #2449 merges first, #2473's body-parser commit becomes the no-op.

## Breaking changes

None. The fix only loosens the regex (accepts a strict superset of inputs: every LF-only PLAN.md that matched before still matches; CRLF PLAN.md that was rejected before now matches). No downstream code change, no output-format change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2477"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787226795&installation_model_id=22188&pr_number=2477&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2477&signature=be8435fb6429c81feb37c835999debdf228c1fbac186df4ecd06bc584761dc79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->