### PR TITLE
chore(#2453): resolve the uniform-router-param conflict and clear the eslint warning floor

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -419,4 +419,33 @@ export default tseslint.config(
     languageOptions: { sourceType: 'commonjs', globals: { ...globals.node } },
     rules: { 'local/no-source-grep': 'error' },
   },
+
+  // ── #2453 Command Routing Hub: uniform handler signature ────────────────────
+  // Every route handler in gsd-tools.cjs is declared with the SAME destructured
+  // signature — `function routeX({ args, cwd, raw, error })` — whether or not it
+  // uses all four members. That uniformity is the point: it is the dispatch
+  // contract, so a handler can be moved or added without re-deriving which
+  // members exist.
+  //
+  // `argsIgnorePattern: '^_'` is structurally in conflict with that convention:
+  // satisfying it would mean `_`-prefixing ~50 parameters, which makes the
+  // signature non-uniform across the table and defeats the contract. So args
+  // checking is disabled HERE ONLY.
+  //
+  // `varsIgnorePattern` is deliberately left intact: genuinely dead *variables*
+  // (the #2379 case — unused `require()` results) must still surface. This
+  // narrows the exemption to the one category the convention actually forces.
+  //
+  // Decision deferred by #732 ("Severities stay `warn` (no config change in this
+  // pass)"), resolved by #2453 option 1.
+  {
+    files: ['gsd-core/bin/gsd-tools.cjs'],
+    rules: {
+      'no-unused-vars': ['warn', {
+        args: 'none',
+        varsIgnorePattern: '^_',
+        caughtErrors: 'none',
+      }],
+    },
+  },
 );

--- a/tests/debugger-prevention.test.cjs
+++ b/tests/debugger-prevention.test.cjs
@@ -96,7 +96,6 @@ describe('prevention / blameless-postmortem output (#1963, epic #1957 Phase 3B)'
       const content = fs.readFileSync(AGENT, 'utf8');
       const requiredFields = ['Date', 'Error patterns', 'Root cause', 'Fix', 'Files changed', 'Why not caught', 'Recurrence guard'];
       for (const field of requiredFields) {
-        const re = new RegExp(`\\*\\*${field}`, 'i');
         const matches = content.match(new RegExp(`\\*\\*${field}`, 'gi'));
         assert.ok(
           matches && matches.length >= 2,

--- a/tests/installer-migrations.test.cjs
+++ b/tests/installer-migrations.test.cjs
@@ -2654,36 +2654,34 @@ describe('migration.plan()', () => {
 
   test('a regular managed file is still backed up by content (no behavior change)', (t) => {
     const configDir = createTempInstall();
-    try {
-      writeFile(configDir, 'extensions/gsd.cjs', 'locally patched extension\n');
-      writeManifest(configDir, { 'extensions/gsd.cjs': sha256('the original extension\n') });
+    t.after(() => cleanup(configDir));
 
-      const result = runInstallerMigrations({
-        configDir,
-        runtime: 'pi',
-        scope: 'global',
-        migrations: [piExtensionMigration],
-        now: () => '2026-07-20T00:00:00.000Z',
-      });
+    writeFile(configDir, 'extensions/gsd.cjs', 'locally patched extension\n');
+    writeManifest(configDir, { 'extensions/gsd.cjs': sha256('the original extension\n') });
 
-      const backupAction = result.plan.actions.find((a) => a.type === 'backup-and-remove');
-      assert.ok(backupAction, 'expected backup-and-remove for the locally patched file');
+    const result = runInstallerMigrations({
+      configDir,
+      runtime: 'pi',
+      scope: 'global',
+      migrations: [piExtensionMigration],
+      now: () => '2026-07-20T00:00:00.000Z',
+    });
 
-      // The PLAN carries backupRelPath: null — the concrete backup location is
-      // chosen during apply and recorded in the journal, so read it from there.
-      const journal = JSON.parse(fs.readFileSync(path.join(configDir, result.journalRelPath), 'utf8'));
-      const journalled = journal.actions.find((a) => a.backupRelPath);
-      assert.ok(journalled, 'apply must record the backup path in the journal for the user');
-      const backupPath = path.join(configDir, journalled.backupRelPath);
-      assert.equal(
-        fs.readFileSync(backupPath, 'utf8'),
-        'locally patched extension\n',
-        'a real file must still be backed up by content so the user can recover it',
-      );
-      assert.ok(!fs.existsSync(path.join(configDir, 'extensions', 'gsd.cjs')));
-    } finally {
-      cleanup(configDir);
-    }
+    const backupAction = result.plan.actions.find((a) => a.type === 'backup-and-remove');
+    assert.ok(backupAction, 'expected backup-and-remove for the locally patched file');
+
+    // The PLAN carries backupRelPath: null — the concrete backup location is
+    // chosen during apply and recorded in the journal, so read it from there.
+    const journal = JSON.parse(fs.readFileSync(path.join(configDir, result.journalRelPath), 'utf8'));
+    const journalled = journal.actions.find((a) => a.backupRelPath);
+    assert.ok(journalled, 'apply must record the backup path in the journal for the user');
+    const backupPath = path.join(configDir, journalled.backupRelPath);
+    assert.equal(
+      fs.readFileSync(backupPath, 'utf8'),
+      'locally patched extension\n',
+      'a real file must still be backed up by content so the user can recover it',
+    );
+    assert.ok(!fs.existsSync(path.join(configDir, 'extensions', 'gsd.cjs')));
   });
 
   // In-flight failure recovery: when a later step of the SAME apply() attempt

--- a/tests/workflow-compat.test.cjs
+++ b/tests/workflow-compat.test.cjs
@@ -161,7 +161,11 @@ describe('feat-41: ship.md TDD Audit gate_status extraction', () => {
   test('#2431: step 9 (aggregate trailer) is also gated on real values existing', () => {
     // The aggregate gate_status trailer is the companion to the TDD Audit
     // section; both must be skipped together when no real gate_status exists.
-    const step9 = workflow.match(/\*\*9\.\s*Aggregate gate_status trailer[\s\S]*?(?=\*\*10\.|\z)/);
+    // `\z` is a Perl/Ruby end-of-input anchor with NO meaning in JavaScript — it
+    // matched a literal `z`, so the lazy span silently stopped at the first `z`
+    // whenever `**10.` was absent, truncating the captured step. `$` (no /m flag)
+    // is the JS end-of-input anchor.
+    const step9 = workflow.match(/\*\*9\.\s*Aggregate gate_status trailer[\s\S]*?(?=\*\*10\.|$)/);
     assert.ok(step9, 'step 9 must exist in the workflow');
     assert.match(step9[0], /step 8|at least one|real/i,
       'step 9 must reference step 8 or require at least one real gate_status value (#2431)');


### PR DESCRIPTION
## Enhancement PR

---

## Linked Issue

Closes #2453

---

## What this enhancement improves

`npx eslint .` — the repo-wide lint signal. It reported **0 errors, 53 warnings**; this takes it to **0 warnings**.

## Before / After

**Before:**

```
✖ 53 problems (0 errors, 53 warnings)

  50  gsd-core/bin/gsd-tools.cjs
   1  tests/debugger-prevention.test.cjs
   1  tests/installer-migrations.test.cjs
   1  tests/workflow-compat.test.cjs
```

A standing floor means a genuinely new warning has to be spotted against noise, so "lint is clean" was not usable as a check.

**After:**

```
✖ 0 problems (0 errors, 0 warnings)
```

## How it was implemented

**The 50 in `gsd-tools.cjs` — the config decision, resolved.**

All 50 are unused **arguments**, never unused variables: `error` ×30, `cwd` ×10, `raw` ×7, `args` ×3. They are the Command Routing Hub's uniform handler signature — `function routeX({ args, cwd, raw, error })` — declared identically whether or not a handler uses all four members. That uniformity is the dispatch contract.

`argsIgnorePattern: '^_'` is structurally in conflict with it: satisfying the rule would mean `_`-prefixing ~50 parameters, making the signature non-uniform across the table. Per the issue's recommended **option 1**, `eslint.config.mjs` gains a `files: ['gsd-core/bin/gsd-tools.cjs']` override setting `args: 'none'`.

`varsIgnorePattern` is deliberately **left intact**, so genuinely dead variables (the #2379 case) still surface. Verified rather than assumed — injecting `const trulyUnusedVariable = 42` into that file still warns:

```
2639:34  warning  'trulyUnusedVariable' is assigned a value but never used  no-unused-vars
```

This is the config question #732 explicitly deferred (*"Severities stay `warn` (no config change in this pass)"*).

**The other 3 are real defects, not suppressions.** They postdate the issue's count of 51:

- **`tests/workflow-compat.test.cjs:164`** — the step-9 lookahead was `(?=\*\*10\.|\z)`. `\z` is a Perl/Ruby end-of-input anchor with **no meaning in JavaScript**; it matched a literal `z`. So whenever `**10.` was absent the lazy span stopped at the first `z`, truncating the captured step and letting the assertion pass against a partial block. Demonstrated:

  ```
  input:  '**9. Aggregate gate_status trailer AAA zzz BBB'
  with \z -> '**9. Aggregate gate_status trailer AAA '     ← truncated
  with $  -> '**9. Aggregate gate_status trailer AAA zzz BBB'
  ```

  Corrected to `$`. This one was a live bug wearing a style warning.

- **`tests/debugger-prevention.test.cjs:99`** — a `RegExp` built and never used, one line above the one actually used. Removed.

- **`tests/installer-migrations.test.cjs:2655`** — `try { … } finally { … }` inside a test body, which CONTRIBUTING prohibits (*"verbose, masks test failures, and is not an approved pattern in this project"*). The unused `t` was the symptom. Converted to the approved `t.after()`, which uses `t` and removes the banned pattern.

Key files: `eslint.config.mjs`, and the three test files above.

## Testing

### How I verified the enhancement works

- `npx eslint .` → `0 problems`, down from 53 warnings.
- Narrowness of the exemption proven by injecting a dead variable into `gsd-tools.cjs` and confirming it still warns; probe reverted.
- The `\z` defect demonstrated with a concrete input before and after the fix (above).
- `gsd-test --base next --head a0c658d803b306e9218e73e4561903512d7a5a35` → `outcome:"passed"`, **0 failures** across `linux-node22` and `linux-node24`.

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [x] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [x] N/A (not runtime-specific)

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue — no additions or removals
- [x] If scope changed during implementation, I updated the issue and got re-approval before continuing

The issue scoped the 50 router-param warnings and named option 1. The three additional fixes are the remainder of the same warning floor the issue set out to clear — its own count of 51 predates them — and are noted above rather than folded in silently.

---

## Documentation

- [ ] Updated the relevant file(s) under `docs/` to reflect this change
- [x] All `docs/` content added in this PR is written in English
- [x] If genuinely no user-facing docs impact (infrastructure / internal refactor / test-only), apply the `no-docs` label **or** add `<!-- docs-exempt: <reason> -->`

No user-facing behavior changes: the diff is a lint-config override plus three test corrections. No `docs/` impact, and no changeset — the diff touches only `eslint.config.mjs` and `tests/`, neither of which is a changeset-triggering prefix (`bin/`, `gsd-core/`, `src/`, `agents/`, `commands/`, `hooks/`, `sdk/src/`, `sdk/prompts/`).

## Checklist

- [x] Issue linked above with `Closes #NNN`
- [x] Linked issue has the `approved-enhancement` label
- [x] Changes are scoped to the approved enhancement
- [x] All existing tests pass — `gsd-test` verdict `passed`, 0 failures on both Node lanes
- [x] New or updated tests cover the enhanced behavior — the three corrected tests continue to assert their original contracts, one of them correctly for the first time
- [x] `.changeset/` fragment added — **N/A**, no changeset-triggering path touched; `no-changelog` applies
- [x] No unnecessary dependencies added

## Breaking changes

None. The lint override is scoped to a single file and narrows only argument checking; dead-variable detection is unchanged and was verified still active.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2489"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787249452&installation_model_id=22188&pr_number=2489&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2489&signature=930da74254f27e6ae2569550deb185dc53354a1e5c28c471caf0826b380a1270"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->