### PR TITLE
chore(#2496): clear five newly-disclosed production advisories

### DIFF
--- a/.changeset/2496-production-advisories.md
+++ b/.changeset/2496-production-advisories.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 2497
+---
+**Production dependency tree carries no known advisories** — five advisories disclosed against the transitive tree under `@anthropic-ai/claude-agent-sdk` → `@modelcontextprotocol/sdk` were cleared: `fast-uri` (GHSA-4c8g-83qw-93j6, high) and `hono` (GHSA-xgm2-5f3f-mvvc, GHSA-hvrm-45r6-mjfj, GHSA-w62v-xxxg-mg59) re-resolved to patched releases inside their already-declared ranges with no `package.json` change, and `@hono/node-server` (GHSA-frvp-7c67-39w9) pinned to `>=2.0.5` via `overrides` because `@modelcontextprotocol/sdk@1.29.0` — already the latest published version — still declares the vulnerable `^1.19.9` range. `npm audit --omit=dev` reports zero advisories. (#2496)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1098,12 +1098,12 @@
       ]
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.11.tgz",
+      "integrity": "sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -3206,9 +3206,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -3573,9 +3573,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.25",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
-      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
+      "version": "4.12.31",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
+      "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
   },
   "overrides": {
     "qs": ">=6.15.2",
-    "body-parser": ">=2.3.0"
+    "body-parser": ">=2.3.0",
+    "@hono/node-server": ">=2.0.5"
   },
   "optionalDependencies": {
     "fallow": "^2.70.0"


### PR DESCRIPTION
## Chore PR

---

## Linked Issue

Fixes #2496

---

## What is the maintenance task?

Clear five newly-disclosed advisories from the **production** dependency tree so the `#3588: npm audit --omit=dev reports zero advisories` gate passes and the v1.8.0 release can proceed.

Nothing in the dependency tree changed — the advisory database did. The v1.8.0 finalize dry run was green at **17:27:27Z**; `GHSA-frvp-7c67-39w9` published at **18:17:25Z** and `GHSA-xgm2-5f3f-mvvc` at **18:18:13Z**, with `fast-uri` (**high**) and two further `hono` advisories landing in the same window. The count rose from 4 moderate to 5 (incl. 1 high) over the course of a single working session.

All five arrive transitively through one declared dependency:

```
@anthropic-ai/claude-agent-sdk (^0.2.84, direct)
└── @modelcontextprotocol/sdk (>=1.25.0)
    ├── @hono/node-server (^1.19.9)   ← needs >=2.0.5
    ├── hono (^4.11.4)                ← needs >=4.12.27
    └── … → fast-uri (3.0.0–3.1.2)    ← needs >3.1.2
```

## What this does

Two parts, both following existing repo precedent:

1. **`npm audit fix --omit=dev`** (no `--force`) — re-resolves `fast-uri` and `hono` to patched versions *within their already-declared ranges*. `package.json` untouched. Same approach as [`.changeset/witty-badgers-hum.md`](.changeset/witty-badgers-hum.md) (body-parser) and `.changeset/archived/fix-3588-npm-audit-clean.md`. Clears the only **high**.

2. **`overrides: { "@hono/node-server": ">=2.0.5" }`** — the remaining three are one chain that cannot resolve in-range (`^1.19.9` cannot reach `2.0.5`). `@modelcontextprotocol/sdk@1.29.0` is already the **latest** published version and still declares the vulnerable range, so there is no upstream release to move to. Extends the `overrides` block that already pins `qs` and `body-parser`. Resolves to `2.0.11`.

`package.json` diff is 2 lines; `package-lock.json` is 20.

## Rejected alternative — bumping the Agent SDK

Bumping `@anthropic-ai/claude-agent-sdk` to `^0.3.x` was **tested and rejected**: `0.3.216` moves `@modelcontextprotocol/sdk` from `dependencies` to `peerDependencies`, which npm auto-installs, so the vulnerable chain survives *and* resolution pulls additional advisories — measured **5 vulnerabilities including a high**, versus 4 moderate before. Recorded here and in #2496 so the instinctive "just bump the SDK" fix isn't retried.

## Risk

The forced major (`@hono/node-server` 1.x → 2.x) sits under a dependency **no tracked source file imports** — `git grep` for `require(...)`/`import ... from '@anthropic-ai/claude-agent-sdk'` returns no hits, and [`src/mcp-server.cts:22`](src/mcp-server.cts#L22) documents the reason: *"No new runtime dependency — the JSON-RPC stdio loop is hand-rolled (the repo ships only claude-agent-sdk + ws; adding an MCP SDK is a separate packaging decision)."*

The `serve-static` path traversal additionally requires Hono's static file serving on Windows, which GSD's stdio-transport MCP server never exercises. Actual exposure is therefore nil; the gate is nonetheless absolute, and the dependency does ship to consumers.

The override should be revisited — and ideally dropped — once `@modelcontextprotocol/sdk` ships a release depending on patched `@hono/node-server`.

## Testing

- `npm audit --omit=dev` → **found 0 vulnerabilities**
- `tests/npm-integrity-gate.test.cjs` — 14/14
- `sdk-smoke` 4/4, `package-manifest` 5/5, `package-legitimacy` 48/48
- Full `gsd-test` — **26218/26218 passed** on linux-node22 and linux-node24, 0 failures
- `npm run lint:ci` — 0 errors

## Breaking changes

None for GSD consumers. `@hono/node-server` moves 1.19.14 → 2.0.11 in the resolved tree, but it is unreachable from any GSD code path (see Risk above).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2497"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787260946&installation_model_id=22188&pr_number=2497&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2497&signature=829eefb6d8566aa48c7e72ca48ed2b3a04996d03ac21380319da216734be49e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->