### PR TITLE
fix(#2460): pi before_provider_request fail-opens without explicit model_profile_overrides

### DIFF
--- a/.changeset/two-otters-jog.md
+++ b/.changeset/two-otters-jog.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 2499
+---
+**pi no longer silently hijacks non-Anthropic providers' model choices** — `pi/gsd.cjs`'s `before_provider_request` handler unconditionally rewrote `payload.model` to the built-in pi/sonnet tier default (`claude-sonnet-5`) via the model-catalog fallback, breaking every outgoing request for pi users on non-Anthropic providers (kimi-coding, zai, openrouter, openai-codex, minimax). The handler now inspects `model_profile_overrides.pi[tier]` explicitly *before* calling `resolveTierEntry` (whose catalog fallback previously masked the "user did not opt in" signal) and fail-opens (`return undefined`) when the user has not set an override — including explicit `null` and `''` (clearing a previously-set value). An explicit opt-in via `model_profile_overrides.pi[tier]` still steers, preserving the legitimate use case. (#2460)

--- a/pi/gsd.cjs
+++ b/pi/gsd.cjs
@@ -215,7 +215,13 @@ function buildBeforeProviderRequestHandler({ tier = 'sonnet' } = {}) {
       // set model_profile_overrides[runtime][tier] do we steer; otherwise we
       // return undefined and pi's chosen model flows through untouched.
       const userRaw = overrides && overrides.pi ? overrides.pi[tier] : undefined;
-      if (userRaw === undefined || userRaw === null) {
+      // `''` is treated the same as null/undefined: an explicit empty-string
+      // override is the user clearing a previously-set value, NOT opting in to
+      // steering. Without this guard, `resolveTierEntry`'s falsy `if (userRaw)`
+      // check would silently fall back to the built-in catalog and rewrite
+      // payload.model to claude-sonnet-5 — re-introducing the exact bug this
+      // handler exists to prevent.
+      if (userRaw === undefined || userRaw === null || userRaw === '') {
         return undefined; // fail-open — leave pi's model untouched
       }
 

--- a/pi/gsd.cjs
+++ b/pi/gsd.cjs
@@ -197,10 +197,29 @@ function buildBeforeProviderRequestHandler({ tier = 'sonnet' } = {}) {
   return async function onBeforeProviderRequest(event, ctx) {
     try {
       const effectiveCwd = (ctx && ctx.cwd) || process.cwd();
-      const { resolveTierEntry } = require(path.join(GSD_CORE, 'bin', 'lib', 'model-resolver.cjs'));
       const { loadConfig } = require(path.join(GSD_CORE, 'bin', 'lib', 'config-loader.cjs'));
       const config = loadConfig(effectiveCwd);
       const overrides = (config && config.model_profile_overrides) || undefined;
+
+      // #2460: FAIL-OPEN when the user has not explicitly configured
+      // model_profile_overrides[runtime][tier]. pi is provider-agnostic
+      // (kimi-coding, zai, openrouter, openai-codex, minimax, anthropic, …);
+      // the built-in RUNTIME_PROFILE_MAP.pi.sonnet default is `claude-sonnet-5`,
+      // an Anthropic-ecosystem assumption that is wrong for every non-Anthropic
+      // provider. Returning the built-in default unconditionally rewrote every
+      // outgoing request to a model the active provider did not know.
+      //
+      // resolveTierEntry falls back to the built-in catalog when no override is
+      // present, so we cannot call it to detect "did the user opt in?" — we
+      // inspect the override map directly. Only when the user has explicitly
+      // set model_profile_overrides[runtime][tier] do we steer; otherwise we
+      // return undefined and pi's chosen model flows through untouched.
+      const userRaw = overrides && overrides.pi ? overrides.pi[tier] : undefined;
+      if (userRaw === undefined || userRaw === null) {
+        return undefined; // fail-open — leave pi's model untouched
+      }
+
+      const { resolveTierEntry } = require(path.join(GSD_CORE, 'bin', 'lib', 'model-resolver.cjs'));
       const entry = resolveTierEntry({ runtime: 'pi', tier, overrides });
       const modelId = entry && typeof entry.model === 'string' && entry.model.length > 0 ? entry.model : null;
       if (!modelId) return undefined; // fail-open — leave pi's model untouched

--- a/tests/fixtures/golden-install-parity/pi.json
+++ b/tests/fixtures/golden-install-parity/pi.json
@@ -1,7 +1,7 @@
 {
   ".gsd-profile": "0e716a5fef4e6dc1",
   ".gsd/defaults.json": "615261cfd3ae1c96",
-  "extensions/gsd.js": "208006df3786abfb",
+  "extensions/gsd.js": "af5deeefff6a0a6a",
   "gsd-core/.gsd-runtime": "94e95f0bb38f8e0f",
   "gsd-core/VERSION": "ef0deccd81a6723c",
   "gsd-core/bin/check-latest-version.cjs": "e4a224058c8f4d74",

--- a/tests/fixtures/golden-install-parity/pi.json
+++ b/tests/fixtures/golden-install-parity/pi.json
@@ -1,7 +1,7 @@
 {
   ".gsd-profile": "0e716a5fef4e6dc1",
   ".gsd/defaults.json": "615261cfd3ae1c96",
-  "extensions/gsd.js": "976c6546391caf8f",
+  "extensions/gsd.js": "208006df3786abfb",
   "gsd-core/.gsd-runtime": "94e95f0bb38f8e0f",
   "gsd-core/VERSION": "ef0deccd81a6723c",
   "gsd-core/bin/check-latest-version.cjs": "e4a224058c8f4d74",

--- a/tests/pi-upgrades.test.cjs
+++ b/tests/pi-upgrades.test.cjs
@@ -154,19 +154,24 @@ test('before_provider_request steers to the override model when model_profile_ov
 
 test('before_provider_request fail-opens when override is explicitly null or empty (#2460)', async () => {
   // Defensive: an explicit null/empty override entry must NOT be treated as
-  // "user opted in". The user might null out a previously-set override.
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pi-null-override-'));
-  try {
-    fs.mkdirSync(path.join(tmpDir, '.planning'), { recursive: true });
-    fs.writeFileSync(
-      path.join(tmpDir, '.planning', 'config.json'),
-      JSON.stringify({ model_profile_overrides: { pi: { sonnet: null } } }),
-    );
-    const handler = _internals.buildBeforeProviderRequestHandler({ tier: 'sonnet' });
-    const result = await handler({ payload: { model: 'k3' } }, { cwd: tmpDir });
-    assert.equal(result, undefined, 'null override → must fail-open');
-  } finally {
-    cleanup(tmpDir);
+  // "user opted in". The user might null/empty out a previously-set override.
+  // Without the empty-string guard, resolveTierEntry's falsy `if (userRaw)`
+  // would silently fall back to the built-in catalog and rewrite payload.model
+  // to claude-sonnet-5 — re-introducing the bug this PR fixes.
+  for (const emptyValue of [null, '']) {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), `pi-empty-override-${emptyValue === null ? 'null' : 'empty'}-`));
+    try {
+      fs.mkdirSync(path.join(tmpDir, '.planning'), { recursive: true });
+      fs.writeFileSync(
+        path.join(tmpDir, '.planning', 'config.json'),
+        JSON.stringify({ model_profile_overrides: { pi: { sonnet: emptyValue } } }),
+      );
+      const handler = _internals.buildBeforeProviderRequestHandler({ tier: 'sonnet' });
+      const result = await handler({ payload: { model: 'k3' } }, { cwd: tmpDir });
+      assert.equal(result, undefined, `override === ${JSON.stringify(emptyValue)} → must fail-open (got ${JSON.stringify(result)})`);
+    } finally {
+      cleanup(tmpDir);
+    }
   }
 });
 

--- a/tests/pi-upgrades.test.cjs
+++ b/tests/pi-upgrades.test.cjs
@@ -24,13 +24,14 @@ const { test } = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
+const os = require('node:os');
+const { cleanup } = require('./helpers.cjs');
 
 const {
   extensionEventSurfaceFor,
   negotiateHostCapabilities,
   UNDOCUMENTED,
 } = require('../gsd-core/bin/lib/host-integration.cjs');
-const { RUNTIME_PROFILE_MAP } = require('../gsd-core/bin/lib/model-catalog.cjs');
 
 const gsdPiExtension = require('../pi/gsd.cjs');
 const { _internals } = require('../pi/gsd.cjs');
@@ -99,37 +100,74 @@ test('gsdPiExtension does NOT call registerProvider (GSD steers pi\'s existing a
 // handler ACTUALLY REGISTERED via pi.on('before_provider_request', ...) in
 // gsdPiExtension. This ties the bound handler (default tier = 'sonnet') to
 // the real model-catalog steering end-to-end.
-test('the ACTUALLY-REGISTERED before_provider_request handler steers to the default-tier model-catalog pi id', async () => {
+//
+// #2460: the bound handler now FAILS-OPENS when no explicit
+// model_profile_overrides.pi[tier] is configured. pi is provider-agnostic;
+// the built-in tier default (claude-sonnet-5) is an Anthropic-ecosystem
+// assumption that broke every non-Anthropic provider. The test below
+// asserts the fail-open contract for the no-override case.
+test('the ACTUALLY-REGISTERED before_provider_request handler fail-opens when no model_profile_overrides is configured (#2460)', async () => {
   const pi = mockPi();
   gsdPiExtension(pi);
   const boundHandler = pi._recorded.events['before_provider_request'][0];
   assert.equal(typeof boundHandler, 'function');
 
-  const out = await boundHandler({ payload: {} }, { cwd: __dirname });
-  assert.ok(out, 'expected a modified payload, not undefined');
-  assert.equal(out.model, RUNTIME_PROFILE_MAP.pi.sonnet.model, 'the bound handler steers to the default (sonnet) tier\'s model-catalog pi id');
-  assert.equal(out.model, 'claude-sonnet-5');
+  // __dirname has no .planning/config.json with model_profile_overrides, so
+  // the handler must NOT steer — returns undefined so pi's chosen model flows
+  // through untouched.
+  const out = await boundHandler({ payload: { model: 'k3' } }, { cwd: __dirname });
+  assert.equal(out, undefined, 'no override configured → must fail-open (return undefined), not steer to claude-sonnet-5');
 });
 
 // -- (3) before_provider_request: active-model steering ----------------------
+//
+// #2460: the handler ONLY steers when the user has explicitly opted in via
+// model_profile_overrides. The fail-open path (no override) is the bug fix;
+// the override path below documents the opt-in contract.
 
-test('before_provider_request resolves a tier that maps to a model → returns a payload with the bare anthropic model id (model-catalog pi ids)', async () => {
+test('before_provider_request fail-opens when no model_profile_overrides is configured (#2460 bug discriminator)', async () => {
   const handler = _internals.buildBeforeProviderRequestHandler({ tier: 'sonnet' });
-  const result = await handler({ payload: { existing: 'field' } }, { cwd: __dirname });
-  assert.ok(result, 'expected a modified payload, not undefined');
-  assert.equal(result.existing, 'field', 'original payload fields are preserved');
-  assert.equal(result.model, RUNTIME_PROFILE_MAP.pi.sonnet.model, 'model id matches the model-catalog pi entry');
-  assert.equal(result.model, 'claude-sonnet-5');
+  // Reproduces the issue reporter\'s exact repro: user-selected model 'k3'
+  // (or any non-Anthropic id) must NOT be rewritten to claude-sonnet-5.
+  const result = await handler({ payload: { model: 'k3', messages: [{ role: 'user', content: 'hi' }] } }, { cwd: __dirname });
+  assert.equal(result, undefined, 'no override configured → must NOT rewrite payload.model');
 });
 
-test('before_provider_request resolves opus/haiku tiers to their model-catalog pi ids too', async () => {
-  const opusHandler = _internals.buildBeforeProviderRequestHandler({ tier: 'opus' });
-  const opusResult = await opusHandler({ payload: {} }, { cwd: __dirname });
-  assert.equal(opusResult.model, RUNTIME_PROFILE_MAP.pi.opus.model);
+test('before_provider_request steers to the override model when model_profile_overrides.pi[tier] is explicitly configured', async () => {
+  // Build a temp project with an explicit override and point the handler at it.
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pi-steer-'));
+  try {
+    fs.mkdirSync(path.join(tmpDir, '.planning'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({ model_profile_overrides: { pi: { sonnet: 'kimi-coding/k3' } } }),
+    );
+    const handler = _internals.buildBeforeProviderRequestHandler({ tier: 'sonnet' });
+    const result = await handler({ payload: { existing: 'field', model: 'will-be-overwritten' } }, { cwd: tmpDir });
+    assert.ok(result, 'explicit override configured → expected a modified payload, not undefined');
+    assert.equal(result.existing, 'field', 'original payload fields are preserved');
+    assert.equal(result.model, 'kimi-coding/k3', 'model id matches the user-configured override');
+  } finally {
+    cleanup(tmpDir);
+  }
+});
 
-  const haikuHandler = _internals.buildBeforeProviderRequestHandler({ tier: 'haiku' });
-  const haikuResult = await haikuHandler({ payload: {} }, { cwd: __dirname });
-  assert.equal(haikuResult.model, RUNTIME_PROFILE_MAP.pi.haiku.model);
+test('before_provider_request fail-opens when override is explicitly null or empty (#2460)', async () => {
+  // Defensive: an explicit null/empty override entry must NOT be treated as
+  // "user opted in". The user might null out a previously-set override.
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pi-null-override-'));
+  try {
+    fs.mkdirSync(path.join(tmpDir, '.planning'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({ model_profile_overrides: { pi: { sonnet: null } } }),
+    );
+    const handler = _internals.buildBeforeProviderRequestHandler({ tier: 'sonnet' });
+    const result = await handler({ payload: { model: 'k3' } }, { cwd: tmpDir });
+    assert.equal(result, undefined, 'null override → must fail-open');
+  } finally {
+    cleanup(tmpDir);
+  }
 });
 
 test('before_provider_request given a tier that resolves to null returns undefined (fail-open, never a wrong/empty id)', async () => {


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #2460

> The linked issue carries the `confirmed-bug` label.

---

## What was broken

`pi/gsd.cjs`'s `buildBeforeProviderRequestHandler` unconditionally rewrote `payload.model` to the built-in pi/sonnet tier default (`claude-sonnet-5`) via `resolveTierEntry`'s catalog fallback. Per pi's extension docs, returning any non-`undefined` value from `before_provider_request` replaces the request payload — so every outgoing request for any pi user on a non-Anthropic provider (kimi-coding, zai, openrouter, openai-codex, minimax) had its model silently rewritten to one the active provider did not know. The header comment in `gsd.cjs` already flagged this area as needing a live-host smoke test; this PR is that live-host finding + fix.

## What this fix does

Implements the reporter's suggested fix #1: the handler inspects `model_profile_overrides.pi[tier]` **explicitly before** calling `resolveTierEntry` (whose catalog fallback previously masked the "user did not opt in" signal). When the user has not set an override — or has explicitly set it to `null` or `''` (clearing a previously-set value) — the handler returns `undefined` so pi's chosen model flows through untouched. Only an explicit non-empty opt-in via `model_profile_overrides.pi[tier]` steers, preserving the legitimate use case.

## Root cause

`resolveTierEntry({ runtime, tier, overrides })` returns the built-in `RUNTIME_PROFILE_MAP.pi.sonnet` (`claude-sonnet-5`) when no user override is present. The handler's prior check `if (!modelId) return undefined` only caught the case where `resolveTierEntry` returned null/empty — but `claude-sonnet-5` is a valid non-empty string, so the gate fired and rewrote the payload. The built-in tier default is a Claude-ecosystem assumption that is wrong for pi (which is provider-agnostic by design). The bug was armed but dormant for users who happened to be on the Anthropic provider; it failed loudly for every non-Anthropic user.

## Testing

### How I verified the fix

1. **Failing-first regression tests** added to `tests/pi-upgrades.test.cjs`:
   - Bug discriminator: handler returns `undefined` for `{ model: 'k3' }` payload when no override is configured (was: rewrote to `claude-sonnet-5`)
   - Bound handler fail-open: the ACTUALLY-REGISTERED `pi.on('before_provider_request', …)` handler returns `undefined` for the no-override case
   - Override path: explicit `model_profile_overrides.pi.sonnet = 'kimi-coding/k3'` correctly steers to that id, preserving original payload fields
   - Defensive: explicit `null` AND `''` overrides both fail-open (closes the empty-string edge case flagged by both reviewers)
2. **gsd-test verdict on fix commit:** `outcome:"passed"`, 26,219/26219 on both linux-node22 and linux-node24.
3. **Orthogonal review:** `/code-review` (Standards + Spec) and `/security-review` subagents. Initial REQUEST_CHANGES (Medium M1: empty-string override bypasses the fix via `resolveTierEntry`'s falsy check) addressed inline; both reviewers then APPROVE.
4. **Graph-backed deterministic review** (`memtrace_find_code_review_issues`): 0 issues.
5. **Updated the pre-existing tests** that encoded the buggy behavior (`'steers to the default-tier model-catalog pi id'` → `'fail-opens when no model_profile_overrides is configured'`).

### Regression test added?

- [x] Yes — added 3 new tests (fail-open discriminator, override-path positive, defensive null/empty loop) and rewrote 2 prior tests that had encoded the bug.

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux (gsd-test matrix: linux-node22, linux-node24)
- [ ] N/A (the bug is provider-agnostic, runs on any pi host)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [x] pi (this PR fixes pi's `before_provider_request` handler)
- [ ] N/A

---

## Checklist

- [x] Issue linked above with `Fixes #2460`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — plus one bundled dependency-advisory fix (see note below)
- [x] Regression test added
- [x] All existing tests pass (`gsd-test` 26,219/26219 on linux-node22 + linux-node24)
- [x] `.changeset/` fragment added (`two-otters-jog.md`)
- [x] No unnecessary dependencies added (the lockfile override is a security-mitigation, not a new feature dep)

## Bundled dependency-advisory fix (per CLAUDE.md "fix defects anywhere in the tree")

This PR also adds an `npm overrides` entry for `@hono/node-server@^2.0.5` to clear 3 moderate advisories that surfaced during the PR's gsd-test run (GHSA-class path-traversal on Windows + API-gateway header-drop). Distinct from the body-parser case in #2473: there, express's declared `^2.2.1` range allowed a natural re-resolution; here, `@modelcontextprotocol/sdk@1.29.0` pins `@hono/node-server@^1.19.9` and there is no upstream path to 2.x (latest MCP SDK is 1.29.0; bumping `@anthropic-ai/claude-agent-sdk` to 0.3.x doesn't help since its peerDep is still `^1.29.0`). The override is the only available tool. Verified: `npm audit --omit=dev` reports 0/0/0/0. Sibling to the existing `qs` and `body-parser` override entries.

## Breaking changes

None. The fix changes when the handler rewrites the payload (only on explicit opt-in via `model_profile_overrides.pi[tier]`); for users who never set an override, the behavior change is "pi's chosen model now flows through untouched" (the documented-correct behavior). For users who did set an override, behavior is unchanged. No public API change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2499"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787265598&installation_model_id=22188&pr_number=2499&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2499&signature=fdaa99e0ea49bb169f0741a5c6cffcff6ef701a87255771357bf8760a39b8592"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->