### PR TITLE
fix(#2515): auto-merge the release/hotfix → main PR when clean

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -669,6 +669,49 @@ jobs:
           VERSION: ${{ inputs.version }}
         run: node scripts/verify-npm-publish.cjs --package @opengsd/gsd-core --version "$VERSION" --dist-tag latest
 
+      # Auto-merge the release/hotfix → main PR when it is cleanly mergeable, so
+      # the release's own branch lands on `main` without a manual merge click
+      # every release (#2515). Symmetric with auto-backmerge.yml's admin-merge of
+      # the main → next PR; the `main`-is-ancestor-of-`next` invariant restored
+      # by #2504 makes this merge clean every release. Runs only after the tag +
+      # npm publish are verified, so `main` never absorbs an unpublished release.
+      # A non-clean PR (a genuine divergence) is left OPEN for manual resolution
+      # rather than force-merged. Non-fatal: a published release must stand even
+      # if the merge-back can't auto-complete (org PR-policy, token, etc.).
+      - name: Auto-merge the release → main PR when clean
+        if: ${{ !inputs.dry_run }}
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GSD_BOT_PR_TOKEN || secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ needs.validate-version.outputs.branch }}
+        run: |
+          set -uo pipefail
+          PR=$(gh pr list --base main --head "$BRANCH" --state open --json number --jq '.[0].number // empty' 2>/dev/null || echo "")
+          if [ -z "$PR" ]; then
+            echo "No open release→main PR for $BRANCH (creation may be blocked by org policy); nothing to auto-merge."
+            exit 0
+          fi
+          # GitHub computes mergeability asynchronously; poll until it settles to
+          # a terminal state before deciding.
+          STATE="UNKNOWN"
+          for _ in 1 2 3 4 5 6 7 8; do
+            STATE=$(gh pr view "$PR" --json mergeable --jq '.mergeable' 2>/dev/null || echo "UNKNOWN")
+            if [ "$STATE" = "MERGEABLE" ] || [ "$STATE" = "CONFLICTING" ]; then break; fi
+            sleep 5
+          done
+          if [ "$STATE" = "MERGEABLE" ]; then
+            # Merge commit (not squash) keeps the release branch + its version tag
+            # in main's ancestry. --admin bypasses the review gate for this
+            # already-tested, already-published release branch.
+            if gh pr merge "$PR" --admin --merge; then
+              echo "Auto-merged release→main PR #$PR."
+            else
+              echo "::warning::PR #$PR is mergeable but admin-merge failed (token/policy?). Merge it manually."
+            fi
+          else
+            echo "::warning::Release→main PR #$PR is not cleanly mergeable (state: $STATE). Left open for manual resolution."
+          fi
+
       # Regression #2423: keep `next` at the last published release for final
       # releases, not just rc/hotfix. Without this, `next` drifts to whatever
       # rc.N the release branch forked from, and every npm script banner on

--- a/tests/release-backmerge-invariants.test.cjs
+++ b/tests/release-backmerge-invariants.test.cjs
@@ -119,4 +119,59 @@ describe('release backmerge invariants (#2504) — release.yml finalize', () => 
         'cancels finalize mid-test before tag/publish as the unit suite grows. See #2280/#2281.'
     );
   });
+
+  // #2515: the release/hotfix → main merge-back must complete automatically when
+  // clean, not sit as a manual merge every release. This locks in that step and
+  // its guardrails: it merges only a MERGEABLE PR (never force-merges a
+  // conflict), and is non-fatal (a published release stands even if the
+  // merge-back can't auto-complete).
+  const finalizeSteps = (wf.jobs && wf.jobs.finalize && wf.jobs.finalize.steps) || [];
+  const automerge = finalizeSteps.find(
+    (s) => typeof s.name === 'string' && s.name.includes('Auto-merge the release')
+  );
+
+  test('finalize auto-merges the release/hotfix → main PR', () => {
+    assert.ok(automerge, "expected a finalize step named like 'Auto-merge the release → main PR'");
+    assert.match(
+      automerge.run || '',
+      /pr merge\b[^\n]*--admin/,
+      'the auto-merge step must admin-merge the merge-back PR (symmetric with auto-backmerge main→next). See #2515.'
+    );
+  });
+
+  test('the auto-merge only fires on a cleanly MERGEABLE PR (never force-merges a conflict)', () => {
+    assert.ok(automerge, "expected the 'Auto-merge the release → main PR' step");
+    assert.match(
+      automerge.run || '',
+      /MERGEABLE/,
+      'the auto-merge must gate on the PR being MERGEABLE so a genuine divergence is left open for ' +
+        'manual resolution rather than force-merged into main. See #2515.'
+    );
+  });
+
+  test('the auto-merge step is non-fatal (a published release stands even if it cannot complete)', () => {
+    assert.ok(automerge, "expected the 'Auto-merge the release → main PR' step");
+    assert.equal(
+      automerge['continue-on-error'],
+      true,
+      'the merge-back auto-merge must be continue-on-error: the tag + npm publish already happened, ' +
+        'so a merge-back that cannot complete (org policy, token) must not fail the release. See #2515.'
+    );
+  });
+
+  test('the auto-merge runs AFTER "Verify publish" (main only absorbs a published release)', () => {
+    const verifyIdx = finalizeSteps.findIndex(
+      (s) => typeof s.name === 'string' && s.name.includes('Verify publish')
+    );
+    const automergeIdx = finalizeSteps.findIndex(
+      (s) => typeof s.name === 'string' && s.name.includes('Auto-merge the release')
+    );
+    assert.ok(verifyIdx !== -1, "expected a 'Verify publish' step");
+    assert.ok(automergeIdx !== -1, "expected the 'Auto-merge the release → main PR' step");
+    assert.ok(
+      automergeIdx > verifyIdx,
+      'the auto-merge must run after "Verify publish" so main never absorbs a release whose npm ' +
+        'publish was not confirmed. Order is the invariant, not just a comment. See #2515.'
+    );
+  });
 });


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #2515

---

## What was broken

The `finalize` job **created** the `release/X.Y.0 → main` (and `hotfix/X.Y.Z → main`) merge-back PR but never merged it — so every release and hotfix needed a **manual merge click on `main`**. The opposite direction (`main → next`) is already admin-merged by `auto-backmerge.yml`; this direction was the asymmetric manual step where the recurring divergence got hand-reconciled.

## What this fix does

Adds a finalize step (after "Verify publish", so `main` only absorbs a **confirmed-published** release) that finds the open merge-back PR, polls until GitHub settles its mergeability, and admin-merges it with a **merge commit** — but **only when `MERGEABLE`**. A `CONFLICTING` PR is left open for manual resolution rather than force-merged. Non-fatal (`continue-on-error`): the tag + npm publish already happened, so a merge-back that can't complete (org PR policy, token) must not fail the release.

Symmetric with `auto-backmerge.yml`'s `main → next` admin-merge; the `--merge` (not squash) keeps the version tag in main's ancestry.

## Root cause

Asymmetry in the release automation. With the `main`-is-ancestor-of-`next` invariant restored (#2504), the merge-back is cleanly mergeable every release, so it can complete automatically in the common case — verified below.

## Testing

### How I verified the fix

- **Reproduced the merge first** (before writing any fix): a simulated 1.8.1 hotfix merges to `main` with **no conflict**, producing `[1.8.1] → [1.8.0] → [1.7.0] → [1.6.1]`, version 1.8.1, and preserving main's hardened `auto-backmerge.yml`. (This is why the PR does *not* include a CHANGELOG-conflict resolver — that conflict does not occur.)
- 4 new assertions in `release-backmerge-invariants.test.cjs`: the step is present + admin-merges, gates on `MERGEABLE`, is `continue-on-error`, and runs **after** "Verify publish". Verified they **fail** when `--admin`, the `MERGEABLE` guard, or the `continue-on-error` is removed.
- `npm run lint:ci` — 0 errors.
- Full `gsd-test` — **26282/26282** passed on linux-node22 and linux-node24, 0 failures.

### Regression test added?

- [x] Yes — locks in the step and its guardrails (mergeable-only, non-fatal, ordering).

### Platforms tested

- [x] N/A (not platform-specific)

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass
- [x] `.changeset/` fragment — N/A (`.github/` + `tests/` are outside the changeset lint's user-facing prefixes)
- [x] No unnecessary dependencies added

## Breaking changes

None for consumers. Release behavior change: the `release/hotfix → main` merge-back now completes automatically when clean, instead of waiting for a manual merge. A conflicting merge-back is still left open for manual resolution (unchanged from today).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2516"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787281687&installation_model_id=22188&pr_number=2516&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2516&signature=035d29c81e232b3e84075f4375daa6760e5a435e18d99d5b760c0f21778f1c89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->