### PR TITLE
feat(#2505): Phase 3 — agent-skills fallback for non-dispatchable runtimes

### DIFF
--- a/.changeset/2505-3-agent-skills-fallback.md
+++ b/.changeset/2505-3-agent-skills-fallback.md
@@ -1,0 +1,6 @@
+---
+type: Added
+pr: 0
+---
+<!-- docs-exempt: Phase 3 is an internal behavior fallback for `gsd-tools query agent-skills` on non-Claude runtimes — no user-facing command surface or config to document. -->
+**`gsd-tools query agent-skills <name>` returns the installed agent's prompt content on non-Claude runtimes** — previously, when a non-Claude runtime (kimi, kimi-code, opencode, kilo, etc.) had no explicit `agent_skills` config entry, `buildAgentSkillsBlock` returned empty and the `${AGENT_SKILLS_*}` workflow injection carried no persona. Phase 3 adds a fallback in `cmdAgentSkills`: on non-Claude runtimes, when the configured block is empty, resolve the runtime's agents directory via `checkAgentsInstalled(runtime)` and read `<agentsDir>/<agentType>.md` as the block. Gated to `runtime !== 'claude'` (Claude supports named dispatch and its `${AGENT_SKILLS_*}` contract is a skills-injection path, not a persona fallback). (#2510)

--- a/.changeset/2505-3-agent-skills-fallback.md
+++ b/.changeset/2505-3-agent-skills-fallback.md
@@ -1,6 +1,6 @@
 ---
 type: Added
-pr: 0
+pr: 2521
 ---
 <!-- docs-exempt: Phase 3 is an internal behavior fallback for `gsd-tools query agent-skills` on non-Claude runtimes — no user-facing command surface or config to document. -->
 **`gsd-tools query agent-skills <name>` returns the installed agent's prompt content on non-Claude runtimes** — previously, when a non-Claude runtime (kimi, kimi-code, opencode, kilo, etc.) had no explicit `agent_skills` config entry, `buildAgentSkillsBlock` returned empty and the `${AGENT_SKILLS_*}` workflow injection carried no persona. Phase 3 adds a fallback in `cmdAgentSkills`: on non-Claude runtimes, when the configured block is empty, resolve the runtime's agents directory via `checkAgentsInstalled(runtime)` and read `<agentsDir>/<agentType>.md` as the block. Gated to `runtime !== 'claude'` (Claude supports named dispatch and its `${AGENT_SKILLS_*}` contract is a skills-injection path, not a persona fallback). (#2510)

--- a/src/init.cts
+++ b/src/init.cts
@@ -2258,12 +2258,43 @@ function cmdAgentSkills(
   const projectRoot = findProjectRoot(cwd);
   const { config, source, degraded } = loadConfigResolved(projectRoot);
   const diagnostics = { warnings: [] as string[] };
-  const block = buildAgentSkillsBlock(
+  let block = buildAgentSkillsBlock(
     config,
     agentType,
     projectRoot,
     diagnostics,
   );
+
+  // #2454: Agent prompt fallback for AGENTS-native runtimes where named
+  // subagents are NOT dispatchable (kimi-code, kimi, opencode, kilo, etc.).
+  // On these runtimes, workflows inject ${AGENT_SKILLS_*} into the dispatch
+  // prompt of a built-in subagent (coder/explore/plan). If no
+  // model_profile_overrides or agent_skills config entry exists, the block
+  // is empty — but the agent's prompt CONTENT is installed on disk at the
+  // runtime's agents directory. Read it as a fallback so the persona survives
+  // the dispatch even without explicit config opt-in.
+  //
+  // GATED to non-claude runtimes: Claude Code supports named subagent dispatch
+  // and its ${AGENT_SKILLS_*} contract is a skills-injection path, not a
+  // persona fallback. Triggering the fallback for claude would change the
+  // documented "unconfigured → empty block" contract that agent-skills tests
+  // pin.
+  if (!block) {
+    const runtime = (config && (config['runtime'] as string)) || process.env['GSD_RUNTIME'] || 'claude';
+    if (runtime !== 'claude') {
+      const agentCheck = checkAgentsInstalled(runtime) as unknown as { agents_dir?: string } | null;
+      const agentsDir = agentCheck?.agents_dir;
+      if (typeof agentsDir === 'string' && agentsDir.length > 0) {
+        const agentFile = path.join(agentsDir, `${agentType}.md`);
+        try {
+          const content = platformReadSync(agentFile);
+          if (content && content.length > 0) {
+            block = content;
+          }
+        } catch { /* agent file not found — fall through to empty block */ }
+      }
+    }
+  }
 
   // Compute configured + reason for diagnostic output.
   const agentSkillsMap = (config && config['agent_skills'] && typeof config['agent_skills'] === 'object')


### PR DESCRIPTION
## Feature PR

> Phase 3 of epic #2505. Stacked on Phase 2 (#2520, merged).

## Linked Issue

Closes #2510 — `approved-feature` (inherited from epic #2505).

## Feature summary

Adds a fallback in `cmdAgentSkills` (`src/init.cts`) so `gsd-tools query agent-skills <name>` returns the installed agent's prompt content on non-Claude runtimes. When `buildAgentSkillsBlock` returns empty (no `agent_skills` config entry) AND `runtime !== 'claude'`, resolve the runtime's agents directory via `checkAgentsInstalled(runtime)` and read `<agentsDir>/<agentType>.md` as the block. The `${AGENT_SKILLS_*}` workflow injection now carries the persona even when named dispatch isn't available.

Gated to non-Claude runtimes: Claude supports named dispatch and its `${AGENT_SKILLS_*}` contract is a skills-injection path, not a persona fallback.

## What changed

| File | What changed |
|------|-------------|
| `src/init.cts` | `cmdAgentSkills` (+32 lines): after `buildAgentSkillsBlock` returns empty, on non-Claude runtimes resolve `<agentsDir>/<agentType>.md` via `checkAgentsInstalled(runtime)` and use its content as the block. No-op for Claude; no-op when the agent file is absent (falls through to empty block). |
| `.changeset/2505-3-agent-skills-fallback.md` | User-facing changeset (`type: Added`, `pr: 0` — backfilled after PR open). |

## Spec compliance (#2510 acceptance criteria)

- [x] On a project with `runtime: "kimi-code"` in `.planning/config.json`, `gsd-tools query agent-skills gsd-planner` returns the planner's prompt content (not empty).
- [x] On a project with `runtime: "claude"` (or no runtime set), existing behavior is unchanged (empty block for unconfigured agents).
- [x] `gsd-test` passes — verdict `{"outcome":"passed"}`, 26348/26348 on linux-node22+24, 0 failures.

## Testing

gsd-test HEAD `50239e16e` vs `--base next`:
- linux-node22: 26348/26348 PASS
- linux-node24: 26348/26348 PASS
- 0 failures

GitHub Actions CI additionally exercises windows-latest + macos-latest.

## Documentation

- [x] `<!-- docs-exempt: ... -->` marker on the changeset — Phase 3 is internal behavior (no new user-facing command/config surface to document).

## Checklist

- [x] Closes #2510
- [x] Linked issue has `approved-feature`
- [x] All acceptance criteria met
- [x] All existing tests pass
- [x] `.changeset/2505-3-agent-skills-fallback.md` added
- [x] No unnecessary dependencies added

## Breaking changes

None. The fallback only activates on non-Claude runtimes with no explicit `agent_skills` config — those previously returned empty, now return the installed prompt.

## Reviewer notes

- Carries forward 1 commit from closed PR #2487 (`5a06ba631`).
- Hot zone: `cmdAgentSkills` was flagged by `get_daily_briefing` as recently churned (+19 cognitive, +10 cyclomatic). The cherry-pick adds an additive fallback block — clean diff vs current `origin/next`.
- Fresh isolated review recommended.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2521"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787289165&installation_model_id=22188&pr_number=2521&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2521&signature=6bad46063a2a9012c419cb11b63f9f36a3a721e70750b3abaa28d1dde19d2d75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->