### PR TITLE
feat: extend UAT checkpoint frame language pack (Dutch, Polish, Russian, Ukrainian, Turkish, Hindi, Arabic, Vietnamese, Indonesian)

### DIFF
--- a/src/uat.cts
+++ b/src/uat.cts
@@ -398,6 +398,42 @@ const CHECKPOINT_FRAMES: Record<string, CheckpointFrame> = {
     banner: 'PUNTO DI CONTROLLO: Verifica richiesta',
     instruction: 'Digita `pass` o descrivi cosa non va.',
   },
+  dutch: {
+    banner: 'CONTROLEPUNT: Verificatie vereist',
+    instruction: 'Typ `pass` of beschrijf wat er mis is.',
+  },
+  polish: {
+    banner: 'PUNKT KONTROLNY: Wymagana weryfikacja',
+    instruction: 'Wpisz `pass` lub opisz, co jest nie tak.',
+  },
+  russian: {
+    banner: 'КОНТРОЛЬНАЯ ТОЧКА: требуется проверка',
+    instruction: 'Введите `pass` или опишите, что не так.',
+  },
+  ukrainian: {
+    banner: 'КОНТРОЛЬНА ТОЧКА: потрібна перевірка',
+    instruction: 'Введіть `pass` або опишіть, що не так.',
+  },
+  turkish: {
+    banner: 'KONTROL NOKTASI: Doğrulama gerekli',
+    instruction: '`pass` yazın veya sorunu açıklayın.',
+  },
+  hindi: {
+    banner: 'चेकपॉइंट: सत्यापन आवश्यक',
+    instruction: '`pass` लिखें या बताएं कि क्या गलत है।',
+  },
+  arabic: {
+    banner: 'نقطة تحقق: المراجعة مطلوبة',
+    instruction: 'اكتب `pass` أو صف المشكلة.',
+  },
+  vietnamese: {
+    banner: 'ĐIỂM KIỂM TRA: Cần xác minh',
+    instruction: 'Nhập `pass` hoặc mô tả vấn đề.',
+  },
+  indonesian: {
+    banner: 'TITIK PEMERIKSAAN: Verifikasi diperlukan',
+    instruction: 'Ketik `pass` atau jelaskan apa yang salah.',
+  },
 };
 
 // Free-form response_language aliases → canonical CHECKPOINT_FRAMES key.
@@ -411,6 +447,15 @@ const CHECKPOINT_LANGUAGE_ALIASES: Record<string, string> = {
   chinese: 'chinese', zh: 'chinese', 'zh-cn': 'chinese', 'zh-tw': 'chinese', mandarin: 'chinese', 'simplified chinese': 'chinese', 'traditional chinese': 'chinese', '中文': 'chinese',
   korean: 'korean', ko: 'korean', '한국어': 'korean',
   italian: 'italian', it: 'italian', italiano: 'italian',
+  dutch: 'dutch', nl: 'dutch', nederlands: 'dutch', flemish: 'dutch', vlaams: 'dutch',
+  polish: 'polish', pl: 'polish', polski: 'polish',
+  russian: 'russian', ru: 'russian', 'ru-ru': 'russian', 'русский': 'russian',
+  ukrainian: 'ukrainian', uk: 'ukrainian', ua: 'ukrainian', 'українська': 'ukrainian',
+  turkish: 'turkish', tr: 'turkish', 'türkçe': 'turkish', turkce: 'turkish',
+  hindi: 'hindi', hi: 'hindi', 'हिन्दी': 'hindi', 'हिंदी': 'hindi',
+  arabic: 'arabic', ar: 'arabic', 'العربية': 'arabic',
+  vietnamese: 'vietnamese', vi: 'vietnamese', 'tiếng việt': 'vietnamese', 'tieng viet': 'vietnamese',
+  indonesian: 'indonesian', id: 'indonesian', 'bahasa indonesia': 'indonesian',
 };
 
 function resolveCheckpointFrame(responseLanguage: string | undefined): CheckpointFrame {

--- a/tests/uat.test.cjs
+++ b/tests/uat.test.cjs
@@ -861,6 +861,32 @@ describe('uat render-checkpoint', () => {
     assert.notStrictEqual(japanese, english);
   });
 
+  test('buildCheckpoint: extended language pack resolves localized frames, not the English fallback', () => {
+    const currentTest = { number: 1, name: 'Sample', expected: 'Something happens.' };
+    const english = buildCheckpoint(currentTest);
+    // One spot-check string per added language: the banner must appear and the
+    // output must differ from the English frame (i.e. the alias resolved, the
+    // language did not silently fall back to English).
+    const cases = [
+      ['Dutch', 'CONTROLEPUNT'],
+      ['Polish', 'PUNKT KONTROLNY'],
+      ['Russian', 'КОНТРОЛЬНАЯ ТОЧКА'],
+      ['Ukrainian', 'КОНТРОЛЬНА ТОЧКА'],
+      ['Turkish', 'KONTROL NOKTASI'],
+      ['Hindi', 'चेकपॉइंट'],
+      ['Arabic', 'نقطة تحقق'],
+      ['Vietnamese', 'ĐIỂM KIỂM TRA'],
+      ['Indonesian', 'TITIK PEMERIKSAAN'],
+    ];
+    for (const [language, bannerFragment] of cases) {
+      const localized = buildCheckpoint(currentTest, language);
+      assert.ok(localized.includes(bannerFragment), `${language} banner missing`);
+      assert.ok(localized.includes('`pass`'), `${language} instruction lost the \`pass\` literal`);
+      assert.ok(localized.includes('**Test 1: Sample**'), `${language} structural heading changed`);
+      assert.notStrictEqual(localized, english, `${language} fell back to the English frame`);
+    }
+  });
+
   // Regression: #2402 review medium finding — checkpointBoxLine() padded using
   // JS string `.length` (UTF-16 code units), not display width. Japanese/
   // Chinese/Korean use full-width characters that render at 2 terminal


### PR DESCRIPTION
## What

Follow-up to #2402 / PR #2457. The localized UAT checkpoint renderer added in 1.8.0 ships `CHECKPOINT_FRAMES` for 9 languages (en/es/fr/de/pt/ja/zh/ko/it). But `response_language` is a **free-form** config value — any language outside that table silently falls back to the English frame, which reads as "the fix didn't work" to users who configured, say, `response_language: "Polish"`.

This PR extends the pack with 9 more widely-used languages:

| Language | Banner |
|---|---|
| Dutch | `CONTROLEPUNT: Verificatie vereist` |
| Polish | `PUNKT KONTROLNY: Wymagana weryfikacja` |
| Russian | `КОНТРОЛЬНАЯ ТОЧКА: требуется проверка` |
| Ukrainian | `КОНТРОЛЬНА ТОЧКА: потрібна перевірка` |
| Turkish | `KONTROL NOKTASI: Doğrulama gerekli` |
| Hindi | `चेकपॉइंट: सत्यापन आवश्यक` |
| Arabic | `نقطة تحقق: المراجعة مطلوبة` |
| Vietnamese | `ĐIỂM KIỂM TRA: Cần xác minh` |
| Indonesian | `TITIK PEMERIKSAAN: Verifikasi diperlukan` |

Each with the usual alias set (endonym + ISO codes, mirroring the existing entries).

## Notes

- Only the two frame strings (banner/instruction) are localized, exactly like the existing entries — structure, `Test N` heading, and byte-identical English fallback are untouched.
- None of the added scripts contain East Asian Wide/Fullwidth code points, so `displayWidth === length` for all of them and the #2402-review padding path is unaffected (Devanagari combining marks render at ≤1 column; the box alignment matches the existing Latin frames).
- Added a regression test: every new language must resolve to a localized frame (banner fragment present, `` `pass` `` literal preserved, output ≠ English frame). `tests/uat.test.cjs`: 41/41 pass locally.
- Longer term the table could read user-supplied frames from config (`uat.checkpoint_frame`?) so no language is ever "missing" — happy to sketch that in a follow-up if there's interest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2527"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787322424&installation_model_id=22188&pr_number=2527&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2527&signature=2500bcf53d826a80435c714b76db9a06c16cb796aa2b51c71bd3c4c19c778685"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->