### PR TITLE
feat(#2505): Phase 5 — Kimi variant install-time disambiguation

### DIFF
--- a/.changeset/2505-5-kimi-variant-disambiguation.md
+++ b/.changeset/2505-5-kimi-variant-disambiguation.md
@@ -1,0 +1,6 @@
+---
+type: Added
+pr: 0
+---
+<!-- docs-exempt: Phase 5 adds install-time notices (descriptions + mismatch warning) — no new user-facing command/config surface; the disambiguation is transient console output during `npx @opengsd/gsd-core`. -->
+**The installer now distinguishes Kimi CLI (Python) from Kimi Code (Node) at install time** — running `--kimi` or `--kimi-code` prints a one-line description of each product, and if the selected variant doesn't match the detected `~/.kimi/config.toml` vs `~/.kimi-code/config.toml`, the installer warns with the correct `--kimi-code` / `--kimi` re-run command. Catches the "ran `--kimi --global` but actually on Kimi Code" mistake that produced inert YAMLs and empty agent-skills before the Phase 1 descriptor split. (#2513)

--- a/.changeset/2505-5-kimi-variant-disambiguation.md
+++ b/.changeset/2505-5-kimi-variant-disambiguation.md
@@ -1,6 +1,6 @@
 ---
 type: Added
-pr: 0
+pr: 2535
 ---
 <!-- docs-exempt: Phase 5 adds install-time notices (descriptions + mismatch warning) — no new user-facing command/config surface; the disambiguation is transient console output during `npx @opengsd/gsd-core`. -->
 **The installer now distinguishes Kimi CLI (Python) from Kimi Code (Node) at install time** — running `--kimi` or `--kimi-code` prints a one-line description of each product, and if the selected variant doesn't match the detected `~/.kimi/config.toml` vs `~/.kimi-code/config.toml`, the installer warns with the correct `--kimi-code` / `--kimi` re-run command. Catches the "ran `--kimi --global` but actually on Kimi Code" mistake that produced inert YAMLs and empty agent-skills before the Phase 1 descriptor split. (#2513)

--- a/bin/install.js
+++ b/bin/install.js
@@ -658,6 +658,62 @@ function selectRuntimesFromArgs(runtimeArgs) {
 // Runtime selection - can be set by flags or interactive prompt
 let selectedRuntimes = selectRuntimesFromArgs(args);
 
+// #2505 Phase 5: Kimi variant disambiguation (#2513). Kimi CLI (Python, ~/.kimi/)
+// and Kimi Code (Node, ~/.kimi-code/) are two distinct Moonshot products that
+// share the "kimi" brand. Probe for each product's config.toml and warn when
+// the selected runtime doesn't match the detected install — catches the common
+// "ran --kimi --global but actually on Kimi Code" mistake that produced inert
+// YAMLs and empty agent-skills before the Phase 1 descriptor split.
+function disambiguateKimiVariant(runtimes) {
+  const home = os.homedir();
+  const hasKimiCli = fs.existsSync(path.join(home, '.kimi', 'config.toml'));
+  const hasKimiCode = fs.existsSync(path.join(home, '.kimi-code', 'config.toml'));
+  const notices = [];
+  if (runtimes.includes('kimi') && hasKimiCode && !hasKimiCli) {
+    notices.push({
+      kind: 'wrong-variant',
+      selected: 'kimi',
+      detected: 'kimi-code',
+      message: `Detected ~/.kimi-code/config.toml (Kimi Code, Node CLI) but not ~/.kimi/config.toml (Kimi CLI, Python). You selected --kimi but appear to be on Kimi Code. Re-run with --kimi-code for a working install. (Kimi CLI = Python kimi-cli with named subagents; Kimi Code = Node CLI with coder/explore/plan built-ins only.)`,
+    });
+  }
+  if (runtimes.includes('kimi-code') && hasKimiCli && !hasKimiCode) {
+    notices.push({
+      kind: 'wrong-variant',
+      selected: 'kimi-code',
+      detected: 'kimi',
+      message: `Detected ~/.kimi/config.toml (Kimi CLI, Python) but not ~/.kimi-code/config.toml (Kimi Code, Node CLI). You selected --kimi-code but appear to be on Kimi CLI. Re-run with --kimi for a working install.`,
+    });
+  }
+  // Distinct-entry descriptions when either Kimi variant is selected.
+  if (runtimes.includes('kimi')) {
+    notices.push({
+      kind: 'description',
+      runtime: 'kimi',
+      message: 'Kimi CLI (Python kimi-cli): named subagents via YAML, config at ~/.kimi/, hooks via ~/.kimi/config.toml [[hooks]].',
+    });
+  }
+  if (runtimes.includes('kimi-code')) {
+    notices.push({
+      kind: 'description',
+      runtime: 'kimi-code',
+      message: 'Kimi Code (Node CLI): three built-in subagents (coder/explore/plan), Agent Skills at ~/.kimi-code/skills/, config at ~/.kimi-code/.',
+    });
+  }
+  return notices;
+}
+
+if (selectedRuntimes.includes('kimi') || selectedRuntimes.includes('kimi-code')) {
+  const kimiNotices = disambiguateKimiVariant(selectedRuntimes);
+  for (const notice of kimiNotices) {
+    if (notice.kind === 'wrong-variant') {
+      console.error(`${yellow}⚠ Kimi variant mismatch (${notice.selected} → ${notice.detected}).${reset} ${notice.message}`);
+    } else if (notice.kind === 'description') {
+      console.log(`${dim}  ${notice.runtime}: ${notice.message}${reset}`);
+    }
+  }
+}
+
 // #1928: Google sunset Gemini CLI on 2026-06-18; Antigravity CLI is its
 // official successor. `--gemini` is no longer a valid runtime selector —
 // selectRuntimesFromArgs above no longer recognizes it, so it never lands in

--- a/tests/kimi-variant-disambiguation.test.cjs
+++ b/tests/kimi-variant-disambiguation.test.cjs
@@ -11,6 +11,7 @@ const { execFileSync } = require('node:child_process');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
+const { cleanup } = require('./helpers.cjs');
 
 const INSTALL_JS = path.join(__dirname, '..', 'bin', 'install.js');
 
@@ -18,7 +19,7 @@ function makeDisposableHome() {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-kimi-disambig-'));
   return {
     dir,
-    cleanup() { try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* best effort */ } },
+    cleanup() { cleanup(dir); },
   };
 }
 

--- a/tests/kimi-variant-disambiguation.test.cjs
+++ b/tests/kimi-variant-disambiguation.test.cjs
@@ -1,0 +1,99 @@
+// allow-test-rule: behavioral-subprocess-test — Phase 5 kimi-variant
+// disambiguation is verified via install.js subprocess output capture, since
+// the disambiguateKimiVariant function is inline in bin/install.js (not
+// exported). The test sets a disposable HOME, creates the probe config files,
+// and asserts on the printed notices.
+process.env.GSD_TEST_MODE = '1';
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const INSTALL_JS = path.join(__dirname, '..', 'bin', 'install.js');
+
+function makeDisposableHome() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-kimi-disambig-'));
+  return {
+    dir,
+    cleanup() { try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* best effort */ } },
+  };
+}
+
+function runInstall(args, home) {
+  // --help exits 0 before any install; the disambiguation runs BEFORE --help
+  // is processed (right after runtime selection). So --kimi --help surfaces
+  // the description notice but exits before installing.
+  try {
+    const stdout = execFileSync('node', [INSTALL_JS, ...args], {
+      env: { ...process.env, HOME: home, GSD_TEST_MODE: '1' },
+      encoding: 'utf8',
+      timeout: 15000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return { stdout, stderr: '', exit: 0 };
+  } catch (e) {
+    return { stdout: e.stdout?.toString() || '', stderr: e.stderr?.toString() || '', exit: e.status };
+  }
+}
+
+describe('Kimi variant disambiguation (#2505 Phase 5 / #2513)', () => {
+  let home;
+  before(() => { home = makeDisposableHome(); });
+  after(() => home.cleanup());
+
+  test('--kimi prints the Kimi CLI (Python) description', () => {
+    const r = runInstall(['--kimi', '--help'], home.dir);
+    const combined = r.stdout + r.stderr;
+    assert.match(combined, /Kimi CLI \(Python kimi-cli\).*named subagents.*~\/\.kimi\//);
+  });
+
+  test('--kimi-code prints the Kimi Code (Node CLI) description', () => {
+    const r = runInstall(['--kimi-code', '--help'], home.dir);
+    const combined = r.stdout + r.stderr;
+    assert.match(combined, /Kimi Code \(Node CLI\).*coder\/explore\/plan.*~\/\.kimi-code\//);
+  });
+
+  test('--kimi warns when only ~/.kimi-code/config.toml exists', () => {
+    const h = makeDisposableHome();
+    try {
+      fs.mkdirSync(path.join(h.dir, '.kimi-code'), { recursive: true });
+      fs.writeFileSync(path.join(h.dir, '.kimi-code', 'config.toml'), '# kimi-code');
+      const r = runInstall(['--kimi', '--help'], h.dir);
+      const combined = r.stdout + r.stderr;
+      assert.match(combined, /variant mismatch/i);
+      assert.match(combined, /Detected ~\/\.kimi-code\/config\.toml/);
+      assert.match(combined, /Re-run with --kimi-code/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test('--kimi-code warns when only ~/.kimi/config.toml exists', () => {
+    const h = makeDisposableHome();
+    try {
+      fs.mkdirSync(path.join(h.dir, '.kimi'), { recursive: true });
+      fs.writeFileSync(path.join(h.dir, '.kimi', 'config.toml'), '# kimi-cli');
+      const r = runInstall(['--kimi-code', '--help'], h.dir);
+      const combined = r.stdout + r.stderr;
+      assert.match(combined, /variant mismatch/i);
+      assert.match(combined, /Detected ~\/\.kimi\/config\.toml/);
+      assert.match(combined, /Re-run with --kimi/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test('no warning when neither config exists (fresh install)', () => {
+    const h = makeDisposableHome();
+    try {
+      const r = runInstall(['--kimi', '--help'], h.dir);
+      const combined = r.stdout + r.stderr;
+      assert.doesNotMatch(combined, /variant mismatch/i);
+    } finally {
+      h.cleanup();
+    }
+  });
+});

--- a/tests/kimi-variant-disambiguation.test.cjs
+++ b/tests/kimi-variant-disambiguation.test.cjs
@@ -7,7 +7,7 @@ process.env.GSD_TEST_MODE = '1';
 
 const { test, describe, before, after } = require('node:test');
 const assert = require('node:assert/strict');
-const { execFileSync } = require('node:child_process');
+const { spawnSync } = require('node:child_process');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
@@ -24,20 +24,14 @@ function makeDisposableHome() {
 }
 
 function runInstall(args, home) {
-  // --help exits 0 before any install; the disambiguation runs BEFORE --help
-  // is processed (right after runtime selection). So --kimi --help surfaces
-  // the description notice but exits before installing.
-  try {
-    const stdout = execFileSync('node', [INSTALL_JS, ...args], {
-      env: { ...process.env, HOME: home, GSD_TEST_MODE: '1' },
-      encoding: 'utf8',
-      timeout: 15000,
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
-    return { stdout, stderr: '', exit: 0 };
-  } catch (e) {
-    return { stdout: e.stdout?.toString() || '', stderr: e.stderr?.toString() || '', exit: e.status };
-  }
+  // spawnSync captures stdout AND stderr separately regardless of exit code
+  // (execFileSync drops stderr on success, which hid the console.error warnings).
+  const r = spawnSync('node', [INSTALL_JS, ...args], {
+    env: { ...process.env, HOME: home, GSD_TEST_MODE: '1' },
+    encoding: 'utf8',
+    timeout: 15000,
+  });
+  return { stdout: r.stdout || '', stderr: r.stderr || '', exit: r.status };
 }
 
 describe('Kimi variant disambiguation (#2505 Phase 5 / #2513)', () => {


### PR DESCRIPTION
## Feature PR

> Phase 5 of epic #2505. Stacked on Phase 4 (#2525, merged).

## Linked Issue

Closes #2513 — `approved-feature` (inherited from epic #2505).

## Feature summary

Adds install-time disambiguation for the two Kimi products. Running `--kimi` or `--kimi-code` now prints a one-line description of each product (Python kimi-cli vs Node Kimi Code) and warns with the correct re-run command when the selected variant doesn't match the detected `~/.kimi/config.toml` vs `~/.kimi-code/config.toml`. Catches the "ran `--kimi --global` but actually on Kimi Code" mistake that produced inert YAMLs before Phase 1's descriptor split.

## Spec compliance (#2513 acceptance criteria)

- [x] `npx @opengsd/gsd-core` shows distinct entries for Kimi CLI and Kimi Code with descriptions — verified by `tests/kimi-variant-disambiguation.test.cjs`.
- [x] Auto-detection picks the right variant when one config dir exists — same test.
- [x] `gsd-test` passes — verdict `{"outcome":"passed"}`, 26370/26370 on linux-node22+24 (plex2 bench), 0 failures.

## Testing

- linux-node22: 26370/26370 PASS
- linux-node24: 26370/26370 PASS
- New `tests/kimi-variant-disambiguation.test.cjs` (5 behavioral tests via spawnSync subprocess capture).

## Breaking changes

None. Purely additive notices during install.

## Reviewer notes

- `--bench plex2` used for gsd-test (default bench was contended with other agents' runs).
- Disambiguation runs after runtime selection, before `--help` — so `--kimi --help` surfaces both the description and any mismatch warning.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2535"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787333687&installation_model_id=22188&pr_number=2535&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2535&signature=04fa82562e9317a8bf72f08d32efdef519f108033ea80c6424b6bd6889df1684"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->