### PR TITLE
docs(#2505): Phase 6 — migration guide + built-in-only subagent-toolkit enum

### DIFF
--- a/.changeset/2505-6-migration-docs-schema.md
+++ b/.changeset/2505-6-migration-docs-schema.md
@@ -1,0 +1,6 @@
+---
+type: Added
+pr: 0
+---
+<!-- docs-exempt: Phase 6 is a documentation + schema-enum PR — the changeset IS the doc touch (docs/migration/kimi-to-kimi-code.md). -->
+**New `docs/migration/kimi-to-kimi-code.md` migration guide + `built-in-only` subagent-toolkit enum value** — users who installed via `--kimi` but are actually on Kimi Code (Node CLI) now have a step-by-step migration path (re-install with `--kimi-code`, remove inert YAMLs, verify skills, verify agent-skills query). The `built-in-only` enum value replaces the `undocumented` sentinel on the kimi-code descriptor's `subagentToolkit` axis, making the descriptor self-documenting: Kimi Code's three built-in subagents (coder/explore/plan) are now a first-class negotiated value rather than an escape hatch. (#2512)

--- a/.changeset/2505-6-migration-docs-schema.md
+++ b/.changeset/2505-6-migration-docs-schema.md
@@ -1,6 +1,6 @@
 ---
 type: Added
-pr: 0
+pr: 2538
 ---
 <!-- docs-exempt: Phase 6 is a documentation + schema-enum PR — the changeset IS the doc touch (docs/migration/kimi-to-kimi-code.md). -->
 **New `docs/migration/kimi-to-kimi-code.md` migration guide + `built-in-only` subagent-toolkit enum value** — users who installed via `--kimi` but are actually on Kimi Code (Node CLI) now have a step-by-step migration path (re-install with `--kimi-code`, remove inert YAMLs, verify skills, verify agent-skills query). The `built-in-only` enum value replaces the `undocumented` sentinel on the kimi-code descriptor's `subagentToolkit` axis, making the descriptor self-documenting: Kimi Code's three built-in subagents (coder/explore/plan) are now a first-class negotiated value rather than an escape hatch. (#2512)

--- a/capabilities/kimi-code/capability.json
+++ b/capabilities/kimi-code/capability.json
@@ -58,7 +58,7 @@
         "nested": false,
         "maxDepth": 1,
         "background": true,
-        "subagentToolkit": "undocumented",
+        "subagentToolkit": "built-in-only",
         "backgroundDispatch": true,
         "builtInSubagents": [
           "coder",

--- a/docs/migration/kimi-to-kimi-code.md
+++ b/docs/migration/kimi-to-kimi-code.md
@@ -1,0 +1,66 @@
+# Migrating from `--kimi` to `--kimi-code`
+
+> **When:** you installed GSD via `--kimi --global` but you're actually running **Kimi Code** (Moonshot's Node CLI, `~/.kimi-code/config.toml`), not **Kimi CLI** (Moonshot's Python CLI, `~/.kimi/config.toml`).
+
+## Symptom
+
+Before the Phase 1 descriptor split (epic #2505), GSD conflated both products under a single `kimi` runtime. If you ran `--kimi --global` on Kimi Code:
+
+- `gsd-tools query agent-skills <name>` returned **empty** (the Python kimi-cli agent YAMLs are inert on Kimi Code).
+- Every workflow that called a named GSD subagent (`gsd-planner`, `gsd-executor`, …) **failed at dispatch** (Kimi Code only recognizes `coder`, `explore`, `plan`).
+- Every GSD `PreToolUse` guard (`gsd-prompt-guard`, `gsd-read-guard`, `gsd-worktree-path-guard`, `gsd-read-injection-scanner`) was **silently dormant** (#2304) — the matcher was translated but the payload check wasn't, so the guards exited 0 on every Kimi-vocabulary tool call.
+
+## Which product am I on?
+
+| Check | Kimi CLI (Python) | Kimi Code (Node) |
+|---|---|---|
+| Config file | `~/.kimi/config.toml` | `~/.kimi-code/config.toml` (`KIMI_CODE_HOME`) |
+| Built-in subagents | Custom via YAML (`extend:`, `system_prompt_path`) | Three only: `coder`, `explore`, `plan` |
+| Skills discovery | `~/.config/agents/skills` or `~/.agents/skills` | `~/.kimi-code/skills/` (auto, `merge_all_available_skills = true`) |
+| Language | Python (`kimi-cli`) | Node |
+
+If `~/.kimi-code/config.toml` exists and `~/.kimi/config.toml` does not, you're on Kimi Code.
+
+## Migration steps
+
+### 1. Re-install with `--kimi-code`
+
+```bash
+npx @opengsd/gsd-core --kimi-code --global
+```
+
+This installs the correct Agent Skills surface at `~/.kimi-code/skills/gsd-*/SKILL.md` (Phase 2) and activates the Phase 0 guard normalization (the dormant-guard fix). The Phase 5 installer will warn you if you accidentally pick the wrong variant.
+
+### 2. Remove inert Python-kimi-cli artifacts (if any)
+
+If your prior `--kimi` install wrote agent YAMLs (the `kimi-agents` artifact layout) into your config dir, they're inert on Kimi Code — Kimi Code cannot read them. Safe to remove:
+
+```bash
+# Only if you previously installed via --kimi and are now on --kimi-code:
+rm -rf ~/.config/agents/agents/gsd-*.yaml ~/.agents/agents/gsd-*.yaml 2>/dev/null || true
+```
+
+### 3. Verify skills are discovered
+
+After re-install, launch Kimi Code and confirm the GSD skills appear in the `/skill:` menu (or whatever surface Kimi Code uses for auto-discovered Agent Skills). Each `gsd-*` skill should be present at `~/.kimi-code/skills/gsd-*/SKILL.md`.
+
+### 4. Verify agent-skills query
+
+```bash
+gsd-tools query agent-skills gsd-planner
+```
+
+Should return the planner's prompt content (non-empty) — Phase 3's fallback reads the installed agent prompt on non-Claude runtimes.
+
+## What about workflows that dispatch named subagents?
+
+Phase 4 (epic #2505) added runtime-aware dispatch. Workflows now resolve the subagent type via `gsd_run query resolve-dispatch-type --requested <role> --raw` before dispatching. On Kimi Code, a role like `gsd-planner` resolves to the `plan` built-in; the persona rides `${AGENT_SKILLS_PLANNER}` (Phase 3's fallback) regardless of the resolved type. You do not need to edit any workflow files — the resolution is automatic.
+
+## What about the dormant guards?
+
+Phase 0 (#2304 / PR #2518) fixed all seven Kimi-surface PreToolUse/PostToolUse guards. Re-installing via `--kimi-code --global` picks up the fix automatically — the normalized guard scripts are part of the standard install.
+
+## Questions
+
+- **Can I keep both `--kimi` and `--kimi-code` installs?** Yes — they install to separate config dirs (`~/.kimi/` vs `~/.kimi-code/`). Run both if you genuinely use both products.
+- **Do I need to uninstall the old `--kimi` install first?** No — `--kimi-code --global` writes to `~/.kimi-code/`, which is separate. But if you no longer use Python kimi-cli, uninstalling the old install keeps things clean: `npx @opengsd/gsd-core --kimi --global --uninstall`.

--- a/gsd-core/bin/lib/capability-registry.cjs
+++ b/gsd-core/bin/lib/capability-registry.cjs
@@ -1812,7 +1812,7 @@ const capabilities = {
           "nested": false,
           "maxDepth": 1,
           "background": true,
-          "subagentToolkit": "undocumented",
+          "subagentToolkit": "built-in-only",
           "backgroundDispatch": true,
           "builtInSubagents": [
             "coder",
@@ -5222,7 +5222,7 @@ const runtimes = {
           "nested": false,
           "maxDepth": 1,
           "background": true,
-          "subagentToolkit": "undocumented",
+          "subagentToolkit": "built-in-only",
           "backgroundDispatch": true,
           "builtInSubagents": [
             "coder",

--- a/gsd-core/bin/lib/capability-validator.cjs
+++ b/gsd-core/bin/lib/capability-validator.cjs
@@ -736,7 +736,7 @@ const VALID_HOOK_BUSES        = new Set(['host', 'engine', 'none']);
 const VALID_STATE_IO          = new Set(['filesystem', 'sandboxed-storage', 'session-log-append']);
 const VALID_TRANSPORTS        = new Set(['mcp', 'native-extension']);
 const VALID_HOST_RUNTIMES     = new Set(['node', 'bun', 'sandboxed-web', 'python', 'go', 'rust', 'electron', 'other']);
-const VALID_SUBAGENT_TOOLKITS = new Set(['full', 'read-only']);
+const VALID_SUBAGENT_TOOLKITS = new Set(['full', 'read-only', 'built-in-only']);
 // ADR-1239 amendment (#2481): how reasoning effort reaches the host.
 const VALID_EFFORT_SURFACES   = new Set(['argv', 'none']);
 

--- a/src/host-integration.cts
+++ b/src/host-integration.cts
@@ -44,7 +44,7 @@ const HOST_INTEGRATION_AXES = Object.freeze({
   stateIO:         Object.freeze(['filesystem', 'sandboxed-storage', 'session-log-append'] as const),
   transport:       Object.freeze(['mcp', 'native-extension'] as const),
   runtime:         Object.freeze(['node', 'bun', 'sandboxed-web', 'python', 'go', 'rust', 'electron', 'other'] as const),
-  subagentToolkit: Object.freeze(['full', 'read-only'] as const),
+  subagentToolkit: Object.freeze(['full', 'read-only', 'built-in-only'] as const),
   // ADR-1239 amendment (#2481): how reasoning effort reaches this host.
   // `argv` — deliverable as an argument on the host's own invocation.
   // `none` — the host exposes no reasoning-effort mechanism.

--- a/tests/host-integration.test.cjs
+++ b/tests/host-integration.test.cjs
@@ -161,7 +161,7 @@ describe('CONTRACT-PIN', () => {
   test('subagentToolkit values (sorted)', () => {
     assert.deepStrictEqual(
       [...HOST_INTEGRATION_AXES.subagentToolkit].sort(),
-      ['full', 'read-only'],
+      ['built-in-only', 'full', 'read-only'],
     );
   });
 


### PR DESCRIPTION
## Feature PR

> Phase 6 (final) of epic #2505. Stacked on Phase 5 (#2535, merged).

## Linked Issue

Closes #2512 — `approved-feature` (inherited from epic #2505).

## Feature summary

Adds the `docs/migration/kimi-to-kimi-code.md` migration guide for users who installed via `--kimi` but are actually on Kimi Code, plus the `built-in-only` enum value on the `subagentToolkit` negotiated axis (replacing the `undocumented` sentinel on the kimi-code descriptor — making the three built-in subagents a first-class documented value rather than an escape hatch).

## Spec compliance (#2512 acceptance criteria)

- [x] Migration guide exists and is accurate — `docs/migration/kimi-to-kimi-code.md` (symptom table, which-product check, 4-step migration, FAQ).
- [x] `VALID_SUBAGENT_TOOLKITS` includes `"built-in-only"` — added to both `gsd-core/bin/lib/capability-validator.cjs` and `src/host-integration.cts`.
- [x] kimi-code descriptor updated from `"undocumented"` to `"built-in-only"` — `capabilities/kimi-code/capability.json`.
- [x] `gsd-test` passes — 26371/26371 on linux-node22+24 (plex2 bench), 0 failures.

## Testing

- linux-node22: 26371/26371 PASS
- linux-node24: 26371/26371 PASS
- CONTRACT-PIN test updated for the new vocabulary value.

## Breaking changes

None. The `built-in-only` value is additive to the closed vocabulary; the `undocumented` sentinel still exists for hosts whose docs don't state the toolkit.

## Reviewer notes

- `--bench plex2` used (default bench was contended).
- The `docs/reference/host-integration-interface.md` already documents the dispatch struct; `builtInSubagents` and `namedSubagentsSupported` are descriptor fields documented in the capability-matrix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2538"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787336013&installation_model_id=22188&pr_number=2538&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2538&signature=45c735734006da68811833c1c7079db9dcf850a57bebfd0c9881b0eb00d1df1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->