### PR TITLE
fix(#2400): warn on planned-phase no-op + sync progress.total_plans

### DIFF
--- a/.changeset/2400-planned-phase-empty-transition.md
+++ b/.changeset/2400-planned-phase-empty-transition.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 2552
 ---
 **`state.planned-phase` now warns on no-op transitions and syncs `progress.total_plans`** — when STATE.md's Current Position has no recognized labels (narrative prose), the command emits a `warning` field so the workflow can detect the no-op instead of continuing with stale state. When a plan count is provided, `progress.total_plans` in the YAML frontmatter is updated alongside the body `Total Plans in Phase` field, preventing contradictory state between the two representations. Previously, the command silently returned success with an empty `updated` array and zero bytes written, and left `progress.total_plans` at 0 while the body reported the actual count. (#2400)

--- a/.changeset/2400-planned-phase-empty-transition.md
+++ b/.changeset/2400-planned-phase-empty-transition.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`state.planned-phase` now warns on no-op transitions and syncs `progress.total_plans`** — when STATE.md's Current Position has no recognized labels (narrative prose), the command emits a `warning` field so the workflow can detect the no-op instead of continuing with stale state. When a plan count is provided, `progress.total_plans` in the YAML frontmatter is updated alongside the body `Total Plans in Phase` field, preventing contradictory state between the two representations. Previously, the command silently returned success with an empty `updated` array and zero bytes written, and left `progress.total_plans` at 0 while the body reported the actual count. (#2400)

--- a/src/state-transition.cts
+++ b/src/state-transition.cts
@@ -1117,6 +1117,19 @@ function plannedPhaseCore(
   );
   if (body !== beforePos) updated.push('Current Position');
 
+  // #2400 Bug B: sync progress.total_plans to the frontmatter when a plan count
+  // is given. This writes the explicitly-provided count — it is NOT a re-derivation
+  // from disk (#500 RC1 is about deriving from a half-planned snapshot, not about
+  // refusing to write an explicitly-passed argument).
+  if (intent.planCount !== null && intent.planCount !== undefined && hasFrontmatter) {
+    const fmProgress = (existingFm['progress'] as Record<string, unknown> | undefined) || {};
+    if (fmProgress['total_plans'] !== intent.planCount) {
+      fmProgress['total_plans'] = intent.planCount;
+      existingFm['progress'] = fmProgress;
+      updated.push('progress.total_plans');
+    }
+  }
+
   return { content: reassemble(body), updated };
 }
 

--- a/src/state.cts
+++ b/src/state.cts
@@ -2529,7 +2529,10 @@ function cmdStatePlannedPhase(cwd: string, phaseNumber: string | number, planCou
     return result.content;
   }, cwd, { resync: false, deriveProgressKeys: true });
 
-  output({ updated, phase: phaseNumber, plan_count: planCount }, raw, updated.length > 0 ? 'true' : 'false');
+  const result = updated.length === 0
+    ? { updated, phase: phaseNumber, plan_count: planCount, warning: 'STATE.md Current Position has no recognized labels — transition was a no-op. Verify STATE.md uses the canonical labeled format (Status:, Total Plans in Phase:, etc.).' }
+    : { updated, phase: phaseNumber, plan_count: planCount };
+  output(result, raw, updated.length > 0 ? 'true' : 'false');
 }
 
 /**


### PR DESCRIPTION
## Fix PR

Fixes #2400

## What was broken

`state.planned-phase` had two defects: (A) when STATE.md Current Position had narrative prose instead of canonical labels, the transition was a silent no-op (empty `updated`, zero bytes written, exit 0); (B) on the canonical shape, `progress.total_plans` in YAML frontmatter stayed 0 while the body reported the actual count — contradictory state.

## What this fix does

Bug A: `cmdStatePlannedPhase` now emits a `warning` field when `updated` is empty, so the workflow can detect the no-op. Bug B: `plannedPhaseCore` now writes the explicitly-provided plan count to `progress.total_plans` in the frontmatter (not a re-derivation from disk — #500 safe).

## Testing

- `gsd-test`: 26372/26372 passed (Node 22 + Node 24)

## Checklist

- [x] Issue linked with `Fixes #2400`
- [x] All tests pass
- [x] `.changeset/` fragment added

## Breaking changes

None — the warning is additive; the frontmatter sync writes the explicitly-provided argument value.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2552"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787376842&installation_model_id=22188&pr_number=2552&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2552&signature=f3d239982c923bc11d576a3cc7b9d4bb9ea36b9607bc4d12a5fd2b8b2c260cb1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->