### PR TITLE
fix(#2429): scope Codex skills home override to --global only

### DIFF
--- a/.changeset/2429-codex-local-install-scope.md
+++ b/.changeset/2429-codex-local-install-scope.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**Codex `--local` installation no longer writes skills to `$HOME/.agents/skills`** — the skills-kind `home` override (which redirects skills to the user-global `.agents` directory) is now only applied for `--global` scope. When `--local` is specified, skills are installed under the project-local config directory, matching the scope the user selected. Previously, a `--local` Codex install created a split installation: project-local config but user-global skills. (#2429)

--- a/.changeset/2429-codex-local-install-scope.md
+++ b/.changeset/2429-codex-local-install-scope.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 2553
 ---
 **Codex `--local` installation no longer writes skills to `$HOME/.agents/skills`** — the skills-kind `home` override (which redirects skills to the user-global `.agents` directory) is now only applied for `--global` scope. When `--local` is specified, skills are installed under the project-local config directory, matching the scope the user selected. Previously, a `--local` Codex install created a split installation: project-local config but user-global skills. (#2429)

--- a/src/runtime-artifact-layout.cts
+++ b/src/runtime-artifact-layout.cts
@@ -521,7 +521,7 @@ function dispatchKindEntry(entry: ArtifactKindDescriptor, runtime: string, confi
       );
   }
 
-  if (typeof entry.home === 'string' && entry.home !== '') {
+  if (scope === 'global' && typeof entry.home === 'string' && entry.home !== '') {
     result.home = path.join(os.homedir(), entry.home);
   }
 


### PR DESCRIPTION
## Fix PR

Fixes #2429

## What was broken

Codex `--local` installation wrote GSD skills to `$HOME/.agents/skills` (user-global) instead of the project-local config directory, creating a split installation.

## What this fix does

Gates the skills-kind `home` override behind `scope === 'global'` in `dispatchKindEntry`. When `--local` is specified, skills are installed under the runtime's normal configDir (project-local).

## Testing

- `gsd-test`: 26372/26372 passed (Node 22 + Node 24)

## Checklist

- [x] Issue linked with `Fixes #2429`
- [x] All tests pass
- [x] `.changeset/` fragment added

## Breaking changes

None — `--global` installs are unaffected; `--local` now correctly stays project-scoped.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2553"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787378843&installation_model_id=22188&pr_number=2553&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2553&signature=63e97a05c7861bfb4ba007692284bfffc60bab5a8817de467def5c73a647aaf7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->