### PR TITLE
docs: add gsd-cursor to the EoS registry

### DIFF
--- a/docs/registries/eos-registry.md
+++ b/docs/registries/eos-registry.md
@@ -9,6 +9,7 @@ _To add your integration, see the [registry README](./README.md)._
 | Name | What it is | Latest release | GSD compat | Discussion |
 |---|---|---|---|---|
 | [GSD for Oh My Pi](https://github.com/tchivs/gsd-omp) | Embeds GSD in Oh My Pi through OMP's native ExtensionAPI, programmatic slash commands, task isolation, lifecycle events, filesystem state, and managed agent and skill projection. | ![release](https://img.shields.io/github/v/release/tchivs/gsd-omp?sort=semver&include_prereleases) | `>=1.7.0` | [discuss](https://github.com/open-gsd/gsd-core/discussions/2342) |
+| [GSD Cursor Model Profiles](https://github.com/clezcoding/gsd-cursor) | Adds a Cursor runtime tier map and four ready-to-use model profiles (max / hybrid / value / budget) to a GSD project by writing model_profile_overrides.cursor and the models phase-type block into the user's GSD config, spanning Anthropic, OpenAI, Google Gemini, xAI Grok, Zhipu GLM and Cursor Composer, without modifying gsd-core. | ![release](https://img.shields.io/github/v/release/clezcoding/gsd-cursor?sort=semver&include_prereleases) | `>=1.39.0` | [discuss](https://github.com/open-gsd/gsd-core/discussions/2578) |
 
 ## GSD for Oh My Pi
 - **Repository:** https://github.com/tchivs/gsd-omp — [latest release](https://github.com/tchivs/gsd-omp/releases/latest)
@@ -26,3 +27,20 @@ gsd-omp uninstall && npm uninstall --global gsd-omp
 - **GSD compatibility:** `>=1.7.0`, protocol v1
 - **License:** MIT
 - **Discussion / ranking:** https://github.com/open-gsd/gsd-core/discussions/2342
+
+## GSD Cursor Model Profiles
+- **Repository:** https://github.com/clezcoding/gsd-cursor — [latest release](https://github.com/clezcoding/gsd-cursor/releases/latest)
+- **What it is:** Adds a Cursor runtime tier map and four ready-to-use model profiles (max / hybrid / value / budget) to a GSD project by writing model_profile_overrides.cursor and the models phase-type block into the user's GSD config, spanning Anthropic, OpenAI, Google Gemini, xAI Grok, Zhipu GLM and Cursor Composer, without modifying gsd-core.
+- **Author:** clezcoding
+- **Every interaction with GSD:** Interface points: model, state; profile: declarative-cli; protocol v1; axes: embeddingMode=declarative, commandSurface=prose-only, dispatch=Writes a Cursor model tier map and four profile presets into the GSD config without dispatching tasks, modelMode=active, hookBus=none, stateIO=filesystem, transport=native-extension, runtime=node
+- **Install:**
+```sh
+npm install --global github:clezcoding/gsd-cursor#v1.0.0 && gsd-cursor install
+```
+- **Uninstall:**
+```sh
+gsd-cursor uninstall && npm uninstall --global gsd-cursor
+```
+- **GSD compatibility:** `>=1.39.0`, protocol v1
+- **License:** MIT
+- **Discussion / ranking:** https://github.com/open-gsd/gsd-core/discussions/2578

--- a/docs/registries/eos.json
+++ b/docs/registries/eos.json
@@ -33,5 +33,36 @@
       }
     },
     "discussion": "https://github.com/open-gsd/gsd-core/discussions/2342"
+  },
+  {
+    "id": "gsd-cursor",
+    "name": "GSD Cursor Model Profiles",
+    "type": "eos",
+    "repo": "clezcoding/gsd-cursor",
+    "description": "Adds a Cursor runtime tier map and four ready-to-use model profiles (max / hybrid / value / budget) to a GSD project by writing model_profile_overrides.cursor and the models phase-type block into the user's GSD config, spanning Anthropic, OpenAI, Google Gemini, xAI Grok, Zhipu GLM and Cursor Composer, without modifying gsd-core.",
+    "author": "clezcoding",
+    "license": "MIT",
+    "enginesGsd": ">=1.39.0",
+    "protocolVersion": 1,
+    "install": "npm install --global github:clezcoding/gsd-cursor#v1.0.0 && gsd-cursor install",
+    "uninstall": "gsd-cursor uninstall && npm uninstall --global gsd-cursor",
+    "interactions": {
+      "interfacePoints": [
+        "model",
+        "state"
+      ],
+      "profile": "declarative-cli",
+      "axes": {
+        "embeddingMode": "declarative",
+        "commandSurface": "prose-only",
+        "dispatch": "Writes a Cursor model tier map and four profile presets into the GSD config without dispatching tasks",
+        "modelMode": "active",
+        "hookBus": "none",
+        "stateIO": "filesystem",
+        "transport": "native-extension",
+        "runtime": "node"
+      }
+    },
+    "discussion": "https://github.com/open-gsd/gsd-core/discussions/2578"
   }
 ]


### PR DESCRIPTION
## Registry Entry PR

Full schema and process: [docs/registries/README.md](../../docs/registries/README.md).

---

## Registry type

- [x] EoS Registry entry — adds one object in `docs/registries/eos.json`

## The entry

```json
{
  "id": "gsd-cursor",
  "name": "GSD Cursor Model Profiles",
  "type": "eos",
  "repo": "clezcoding/gsd-cursor",
  "description": "Adds a Cursor runtime tier map and four ready-to-use model profiles (max / hybrid / value / budget) to a GSD project by writing model_profile_overrides.cursor and the models phase-type block into the user's GSD config, spanning Anthropic, OpenAI, Google Gemini, xAI Grok, Zhipu GLM and Cursor Composer, without modifying gsd-core.",
  "author": "clezcoding",
  "license": "MIT",
  "enginesGsd": ">=1.39.0",
  "protocolVersion": 1,
  "install": "npm install --global github:clezcoding/gsd-cursor#v1.0.0 && gsd-cursor install",
  "uninstall": "gsd-cursor uninstall && npm uninstall --global gsd-cursor",
  "interactions": {
    "interfacePoints": ["model", "state"],
    "profile": "declarative-cli",
    "axes": {
      "embeddingMode": "declarative",
      "commandSurface": "prose-only",
      "dispatch": "Writes a Cursor model tier map and four profile presets into the GSD config without dispatching tasks",
      "modelMode": "active",
      "hookBus": "none",
      "stateIO": "filesystem",
      "transport": "native-extension",
      "runtime": "node"
    }
  },
  "discussion": "https://github.com/open-gsd/gsd-core/discussions/2578"
}
```

---

## Required-field checklist

- [x] `id`, `name`, `type`, `repo`, `description`, `author`, `license`, `enginesGsd`, `install`, `uninstall`, `interactions`, `discussion` are all present and non-empty
- [x] **(EoS entries only)** `protocolVersion` is an integer ≥ 1, `interactions.interfacePoints` is a non-empty subset of the six interface points (`model`, `state`), `interactions.profile` is `declarative-cli`, and `interactions.axes` has exactly the eight required axis keys

## Ownership & non-endorsement

- [x] `repo` links to a repository I own (`clezcoding/gsd-cursor`) — not a fork or mirror
- [x] I understand inclusion is **not** an endorsement and GSD has not reviewed/tested/verified the solution or its claimed interactions
- [x] I understand this entry is removed only for illegal content, malware, spam, or a dead link — never for quality

## One entry, one PR

- [x] This PR adds exactly **one** entry, only in `eos.json`
- [x] No other registry entry, code change, or unrelated docs change is bundled

## Generated file in sync

- [x] This PR includes both `docs/registries/eos.json` and the regenerated `docs/registries/eos-registry.md`
- [x] I did not hand-edit the generated `.md` beyond mirroring `scripts/gen-registry.cjs` output

> Note: the regenerated markdown was produced to mirror `scripts/gen-registry.cjs` exactly. If the `gen:registry --check` drift gate flags any formatting delta, I'll re-run `npm run gen:registry` and push — happy to adjust.

## Documentation

- [x] This PR includes both the JSON source and the regenerated markdown under `docs/registries/`

## Checklist

- [x] `discussion` links to a GitHub Discussion in the EoS Registry category: https://github.com/open-gsd/gsd-core/discussions/2578
- [ ] `.changeset/` fragment — not required: this PR touches only `docs/registries/`, so the `Changeset Required` gate does not trigger. Happy to add one or the `no-changelog` label if preferred.

---

**About the entry:** `gsd-cursor` is a small EoS CLI that writes a Cursor model tier map and four profiles (`max` / `hybrid` / `value` / `budget`) into a GSD project's config — filling the Group-B “no built-in Cursor tier map” gap **without** touching gsd-core, per the maintainer directive on #2533. The default (`hybrid`) and `max` profiles use only Cursor Cloud-Agents API-verified model IDs; `value`/`budget` include Gemini/GLM IDs that the CLI warns the user to confirm in Cursor's model picker first.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2579"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787444218&installation_model_id=22188&pr_number=2579&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2579&signature=6c31ad063879be71854bb6f5ba3c6f9a83abc957c31a3a9fa74e761b9957eee0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->