### PR TITLE
fix: preserve registered worktrees in W017 health

### DIFF
--- a/src/verify.cts
+++ b/src/verify.cts
@@ -1935,22 +1935,12 @@ function cmdValidateHealth(
           continue;
         }
 
-        if (finding['kind'] === 'stale') {
-          // Do not flag the active session's worktree — removing it would be harmful.
-          const worktreePath = finding['path'] as string;
-          const activeCwd = process.cwd();
-          const normalizedWorktree = path.resolve(worktreePath);
-          const normalizedCwd = path.resolve(activeCwd);
-          // Skip if the worktree IS the cwd or is an ancestor of it.
-          const isActiveWorktree =
-            normalizedCwd === normalizedWorktree ||
-            normalizedCwd.startsWith(normalizedWorktree + path.sep);
-          if (isActiveWorktree) continue;
+        if (finding['kind'] === 'locked_initializing_residue') {
           addIssue(
             'warning',
             'W017',
-            `Stale git worktree: ${worktreePath} (last modified ${finding['ageMinutes'] as number} minutes ago)`,
-            `Run: git worktree remove ${worktreePath} --force`,
+            `Locked initializing git worktree metadata residue: ${finding['path'] as string} (path no longer exists on disk)`,
+            `Recovery: git worktree unlock ${finding['path'] as string} && git worktree prune`,
           );
         }
       }

--- a/src/worktree-safety.cts
+++ b/src/worktree-safety.cts
@@ -54,6 +54,7 @@ interface WorktreeBranchEntry {
 interface WorktreeEntry {
   path: string;
   branch: string | null;
+  lockReason?: string;
 }
 
 function parseWorktreePorcelain(porcelain: string): WorktreeBranchEntry[] {
@@ -74,7 +75,9 @@ function parseWorktreeEntries(porcelain: string): WorktreeEntry[] {
     if (!worktreePath) continue;
     const branchLine = lines.find((l) => l.startsWith('branch refs/heads/'));
     const branch = branchLine ? branchLine.slice('branch refs/heads/'.length).trim() : null;
-    entries.push({ path: worktreePath, branch });
+    const lockedLine = lines.find((l) => l.startsWith('locked'));
+    const lockReason = lockedLine ? lockedLine.slice('locked'.length).trim() : '';
+    entries.push(lockReason ? { path: worktreePath, branch, lockReason } : { path: worktreePath, branch });
   }
   return entries;
 }
@@ -299,9 +302,8 @@ function listLinkedWorktreePaths(repoRoot: string, deps: WorktreeDeps = {}): Lin
 }
 
 interface WorktreeFinding {
-  kind: 'orphan' | 'stale';
+  kind: 'orphan' | 'locked_initializing_residue';
   path: string;
-  ageMinutes?: number;
 }
 
 interface HealthResult {
@@ -324,18 +326,13 @@ function inspectWorktreeHealth(repoRoot: string, options: { staleAfterMs?: numbe
   for (const entry of inventory.entries) {
     if (!entry.exists) {
       findings.push({
-        kind: 'orphan',
+        kind: entry.lockReason === 'initializing' ? 'locked_initializing_residue' : 'orphan',
         path: entry.path,
       });
       continue;
     }
-    if (entry.isStale) {
-      findings.push({
-        kind: 'stale',
-        path: entry.path,
-        ageMinutes: entry.ageMinutes ?? undefined,
-      });
-    }
+    // Git has registered this existing worktree. Its directory mtime is not a
+    // liveness signal: an idle but valid worktree can be older than an hour.
   }
 
   return {
@@ -350,6 +347,7 @@ interface InventoryEntry {
   exists: boolean;
   isStale: boolean;
   ageMinutes: number | null;
+  lockReason?: string;
 }
 
 interface InventoryResult {
@@ -363,7 +361,7 @@ function snapshotWorktreeInventory(repoRoot: string, options: { staleAfterMs?: n
   const statSync = deps.statSync || fs.statSync;
   const staleAfterMs = options.staleAfterMs ?? (60 * 60 * 1000);
   const nowMs = options.nowMs ?? Date.now();
-  const listed = listLinkedWorktreePaths(repoRoot, { execGit: deps.execGit || execGitDefault });
+  const listed = readWorktreeList(repoRoot, { execGit: deps.execGit || execGitDefault });
   if (!listed.ok) {
     return {
       ok: false,
@@ -373,18 +371,22 @@ function snapshotWorktreeInventory(repoRoot: string, options: { staleAfterMs?: n
   }
 
   const entries: InventoryEntry[] = [];
-  for (const worktreePath of listed.paths) {
+  // git worktree list always reports the primary worktree first.
+  for (const worktree of listed.entries.slice(1)) {
+    const worktreePath = worktree.path;
     let exists = false;
     let isStale = false;
     let ageMinutes: number | null = null;
 
     if (!existsSync(worktreePath)) {
-      entries.push({
+      const entry: InventoryEntry = {
         path: worktreePath,
         exists,
         isStale,
         ageMinutes,
-      });
+      };
+      if (worktree.lockReason) entry.lockReason = worktree.lockReason;
+      entries.push(entry);
       continue;
     }
 
@@ -399,12 +401,14 @@ function snapshotWorktreeInventory(repoRoot: string, options: { staleAfterMs?: n
     } catch {
       // Keep historical behavior: stat failures are ignored.
     }
-    entries.push({
+    const entry: InventoryEntry = {
       path: worktreePath,
       exists,
       isStale,
       ageMinutes,
-    });
+    };
+    if (worktree.lockReason) entry.lockReason = worktree.lockReason;
+    entries.push(entry);
   }
 
   return {

--- a/tests/worktree-safety.test.cjs
+++ b/tests/worktree-safety.test.cjs
@@ -376,7 +376,7 @@ describe('listLinkedWorktreePaths', () => {
 // ─── inspectWorktreeHealth ────────────────────────────────────────────────────
 
 describe('inspectWorktreeHealth', () => {
-  test('reports orphan and stale findings', () => {
+  test('does not classify an old registered worktree as stale', () => {
     const health = inspectWorktreeHealth(
       '/repo/main',
       { staleAfterMs: 60 * 60 * 1000, nowMs: 2 * 60 * 60 * 1000 },
@@ -404,9 +404,42 @@ describe('inspectWorktreeHealth', () => {
       }
     );
     assert.strictEqual(health.ok, true);
+    assert.deepStrictEqual(health.findings, [{ kind: 'orphan', path: '/repo/wt-orphan' }]);
+  });
+
+  test('reports a missing unlocked worktree as an orphan', () => {
+    const health = inspectWorktreeHealth('/repo/main', {}, {
+      execGit: () => ({
+        exitCode: 0,
+        stdout: ['worktree /repo/main', 'HEAD aaa', '', 'worktree /repo/wt-orphan', 'HEAD bbb', ''].join('\n'),
+        stderr: '',
+      }),
+      existsSync: p => p !== '/repo/wt-orphan',
+    });
+    assert.strictEqual(health.ok, true);
+    assert.deepStrictEqual(health.findings, [{ kind: 'orphan', path: '/repo/wt-orphan' }]);
+  });
+
+  test('reports missing locked initializing metadata as recoverable residue', () => {
+    const health = inspectWorktreeHealth('/repo/main', {}, {
+      execGit: () => ({
+        exitCode: 0,
+        stdout: [
+          'worktree /repo/main',
+          'HEAD aaa',
+          '',
+          'worktree /repo/wt-initializing',
+          'HEAD ddd',
+          'locked initializing',
+          '',
+        ].join('\n'),
+        stderr: '',
+      }),
+      existsSync: p => p !== '/repo/wt-initializing',
+    });
+    assert.strictEqual(health.ok, true);
     assert.deepStrictEqual(health.findings, [
-      { kind: 'orphan', path: '/repo/wt-orphan' },
-      { kind: 'stale', path: '/repo/wt-stale', ageMinutes: 120 },
+      { kind: 'locked_initializing_residue', path: '/repo/wt-initializing' },
     ]);
   });
 


### PR DESCRIPTION
## What changes

W017 no longer treats an existing Git-registered linked worktree as stale solely because its directory mtime is older than one hour. Directory mtime is not a liveness signal for an otherwise registered worktree.

Missing registrations remain visible:

- missing unlocked path: W017 reports an orphan with `git worktree prune`
- missing path locked with reason `initializing`: W017 reports recoverable metadata residue with `git worktree unlock <path> && git worktree prune`

## Regression coverage

- old-but-existing registered worktree: no W017 finding
- missing unlocked worktree: orphan finding
- missing `locked initializing` worktree: recoverable-residue finding

Validated with:

```text
npm run build:lib
node --test --test-name-pattern "inspectWorktreeHealth" tests/worktree-safety.test.cjs
node --test tests/orphan-worktree-detection.test.cjs
npm run lint -- --no-cache
```

## Windows fixture follow-up

The full `tests/worktree-safety.test.cjs` suite has 15 pre-existing Windows/Git-Bash submodule fixture failures unrelated to this change. They are documented with reproduction and acceptance criteria in #2582; this PR keeps W017 coverage independently green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2583"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787449757&installation_model_id=22188&pr_number=2583&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2583&signature=68355a077cdd5ad729e916d9b6831d5d19d7488740ab692386189583bcaf8580"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->