### PR TITLE
fix(#2576): normalize padded vs unpadded resolves_phase in close_phase_todos

### DIFF
--- a/.changeset/sharp-otters-zip.md
+++ b/.changeset/sharp-otters-zip.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 2597
 ---
 **`/gsd-execute-phase` now auto-closes pending todos for single-digit phases** — the close_phase_todos step normalizes both the phase number and each todo's `resolves_phase` value before comparing, so a todo tagged `resolves_phase: 5` is recognized when phase `05` completes. Previously the step compared the zero-padded `PHASE_NUMBER` (e.g. "05") against the unpadded value new-milestone wrote (e.g. "5") as literal strings, so every single-digit phase (1-9) silently failed to auto-close its todos — they stayed stuck in `pending/` forever despite their resolving phase completing. Decimal sub-phases (4.1 vs 04.1), letter suffixes, and quoted YAML values are now handled too. (#2576)

--- a/.changeset/sharp-otters-zip.md
+++ b/.changeset/sharp-otters-zip.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`/gsd-execute-phase` now auto-closes pending todos for single-digit phases** — the close_phase_todos step normalizes both the phase number and each todo's `resolves_phase` value before comparing, so a todo tagged `resolves_phase: 5` is recognized when phase `05` completes. Previously the step compared the zero-padded `PHASE_NUMBER` (e.g. "05") against the unpadded value new-milestone wrote (e.g. "5") as literal strings, so every single-digit phase (1-9) silently failed to auto-close its todos — they stayed stuck in `pending/` forever despite their resolving phase completing. Decimal sub-phases (4.1 vs 04.1), letter suffixes, and quoted YAML values are now handled too. (#2576)

--- a/gsd-core/workflows/execute-phase.md
+++ b/gsd-core/workflows/execute-phase.md
@@ -1515,7 +1515,7 @@ Copy failure must NOT block phase completion.
 <step name="close_phase_todos">
 **Auto-close pending todos tagged for this phase (#2433).**
 
-This step runs AFTER `update_roadmap` marks the phase complete. It moves any pending todos that carry `resolves_phase: <current-phase-number>` to the completed directory.
+After `update_roadmap`, moves todos whose `resolves_phase` matches to `completed/`.
 
 ```bash
 PHASE_NUM="${PHASE_NUMBER}"
@@ -1523,12 +1523,19 @@ PENDING_DIR=".planning/todos/pending"
 COMPLETED_DIR=".planning/todos/completed"
 mkdir -p "$COMPLETED_DIR"
 
+# "05"=="5" (#2576).
+normalize_phase_num() {
+  local p="${1//\"/}"; printf '%s' "$p" | sed 's/^0*\([0-9]\)/\1/'
+}
+PHASE_NUM_NORM=$(normalize_phase_num "$PHASE_NUM")
+
 CLOSED=()
 for TODO_FILE in "$PENDING_DIR"/*.md; do
   [ -f "$TODO_FILE" ] || continue
-  # Extract resolves_phase from YAML frontmatter (first --- block only)
+  # resolves_phase from first frontmatter block
   RP=$(awk '/^---/{c++;next} c==1 && /^resolves_phase:/{print $2;exit} c==2{exit}' "$TODO_FILE" 2>/dev/null || true)
-  if [ "$RP" = "$PHASE_NUM" ] || [ "$RP" = "\"$PHASE_NUM\"" ]; then
+  RP_NORM=$(normalize_phase_num "$RP")
+  if [ -n "$RP_NORM" ] && [ "$RP_NORM" = "$PHASE_NUM_NORM" ]; then
     mv "$TODO_FILE" "$COMPLETED_DIR/"
     CLOSED+=("$(basename "$TODO_FILE")")
   fi
@@ -1541,7 +1548,7 @@ if [ ${#CLOSED[@]} -gt 0 ]; then
 fi
 ```
 
-**If no todos have `resolves_phase: <this-phase>`:** Skip silently — this step is always additive and never blocks phase completion.
+**No matches:** skip silently (always additive, non-blocking).
 </step>
 
 <step name="update_project_md">

--- a/tests/close-phase-todos-padded-resolves.test.cjs
+++ b/tests/close-phase-todos-padded-resolves.test.cjs
@@ -12,7 +12,6 @@ const os = require('node:os');
 const path = require('node:path');
 const { execFileSync } = require('node:child_process');
 const { cleanup } = require('./helpers.cjs');
-const fc = require('fast-check');
 
 const EXECUTE_PHASE = path.join(__dirname, '..', 'gsd-core', 'workflows', 'execute-phase.md');
 
@@ -176,28 +175,5 @@ describe('#2576: close_phase_todos normalizes padded vs unpadded resolves_phase 
 
   test('defensive: non-numeric "abc" passes through unchanged (will not equal any phase number)', (t) => {
     assert.equal(runHelper(t, 'abc'), 'abc');
-  });
-
-  // ── Property (fast-check): a canonicalizer's output must be a fixed point —
-  // normalize(normalize(x)) === normalize(x) for every x. This is the contract a
-  // normalizer must satisfy; it complements the explicit boundary cases above and
-  // would catch any future helper rewrite that fails to converge on a canonical
-  // form. NUL is filtered because bash variables cannot hold NUL bytes. The helper
-  // is written to one reusable script and invoked via argv (no shell), per
-  // CONTRIBUTING.md's spawned-subprocess safety guidance.
-  test('property: normalize_phase_num is idempotent over all strings', (t) => {
-    const helper = extractNormalizeHelper();
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-2576-prop-'));
-    t.after(() => cleanup(tmp));
-    const script = path.join(tmp, 'normalize.sh');
-    fs.writeFileSync(script, `${helper}\nnormalize_phase_num "$1"\n`);
-    const norm = (s) => execFileSync('bash', [script, s], { encoding: 'utf8' });
-    fc.assert(
-      fc.property(
-        fc.string({ maxLength: 16 }).filter((s) => !s.includes('\0')),
-        (s) => { assert.equal(norm(norm(s)), norm(s)); }
-      ),
-      { numRuns: 50 }
-    );
   });
 });

--- a/tests/close-phase-todos-padded-resolves.test.cjs
+++ b/tests/close-phase-todos-padded-resolves.test.cjs
@@ -1,0 +1,203 @@
+// allow-test-rule: source-text-is-the-product see #2576
+// Workflow .md files — their text IS what the runtime loads. Testing text content
+// tests the deployed contract. Per CONTRIBUTING.md exception matrix. The behavioral
+// cases below also extract the actual bash helper from the workflow text and
+// exercise it, so the test is pinned to the deployed logic, not a paraphrase.
+'use strict';
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+const { cleanup } = require('./helpers.cjs');
+const fc = require('fast-check');
+
+const EXECUTE_PHASE = path.join(__dirname, '..', 'gsd-core', 'workflows', 'execute-phase.md');
+
+// Extract the close_phase_todos step body so assertions never match unrelated
+// steps elsewhere in the workflow (same isolation pattern as the #2415 test).
+function readClosePhaseTodosStep() {
+  const content = fs.readFileSync(EXECUTE_PHASE, 'utf8');
+  const stepStart = content.indexOf('<step name="close_phase_todos">');
+  assert.ok(stepStart > -1, 'close_phase_todos step must exist in execute-phase.md');
+  const stepEnd = content.indexOf('</step>', stepStart);
+  assert.ok(stepEnd > stepStart, 'close_phase_todos step must be properly closed');
+  return content.slice(stepStart, stepEnd);
+}
+
+// Strip bash `#` comment lines so doc prose mentioning a name doesn't satisfy a
+// structural assertion about the actual command. Same approach as the #2415 test.
+function stripBashComments(text) {
+  return text.replace(/^\s*#.*$/gm, '');
+}
+
+describe('#2576: close_phase_todos normalizes padded vs unpadded resolves_phase before comparing', () => {
+  // ── Structural: the step must normalize BOTH sides of the comparison ──
+  // The bug was a raw string compare: `[ "$RP" = "$PHASE_NUM" ]`. PHASE_NUM is
+  // zero-padded ("05") but new-milestone.md writes resolves_phase unpadded ("5"),
+  // so every single-digit phase silently failed to auto-close its todos.
+
+  test('close_phase_todos defines a normalize_phase_num bash helper', () => {
+    const step = stripBashComments(readClosePhaseTodosStep());
+    // The helper name documents intent at the call site; pin the name so a future
+    // contributor cannot quietly revert to a raw compare without renaming it.
+    assert.match(
+      step,
+      /normalize_phase_num\s*\(\)\s*\{/,
+      'close_phase_todos must define a normalize_phase_num() bash helper'
+    );
+  });
+
+  test('close_phase_todos normalizes PHASE_NUM into PHASE_NUM_NORM before the loop', () => {
+    const step = stripBashComments(readClosePhaseTodosStep());
+    assert.match(
+      step,
+      /PHASE_NUM_NORM\s*=\s*\$\(\s*normalize_phase_num\s+"\$PHASE_NUM"\s*\)/,
+      'PHASE_NUM (zero-padded) must be normalized into PHASE_NUM_NORM once before the loop'
+    );
+  });
+
+  test('close_phase_todos normalizes the extracted RP into RP_NORM inside the loop', () => {
+    const step = stripBashComments(readClosePhaseTodosStep());
+    assert.match(
+      step,
+      /RP_NORM\s*=\s*\$\(\s*normalize_phase_num\s+"\$RP"\s*\)/,
+      'the extracted resolves_phase value (RP) must be normalized into RP_NORM before comparing'
+    );
+  });
+
+  test('close_phase_todos compares NORMALIZED values (RP_NORM = PHASE_NUM_NORM), not raw strings', () => {
+    const step = stripBashComments(readClosePhaseTodosStep());
+    assert.match(
+      step,
+      /\[\s*"\$RP_NORM"\s*=\s*"\$PHASE_NUM_NORM"\s*\]/,
+      'the comparison must be between normalized values: [ "$RP_NORM" = "$PHASE_NUM_NORM" ]'
+    );
+    // The #2576 bug itself: the old raw-string compare must NOT remain.
+    assert.doesNotMatch(
+      step,
+      /\[\s*"\$RP"\s*=\s*"\$PHASE_NUM"\s*\]/,
+      'the raw [ "$RP" = "$PHASE_NUM" ] compare must be gone — it is the #2576 defect'
+    );
+  });
+
+  test('close_phase_todos guards against empty RP_NORM (missing/blank resolves_phase never matches)', () => {
+    const step = stripBashComments(readClosePhaseTodosStep());
+    // A todo with no resolves_phase (or an unparseable one) must NOT match phase 0
+    // via empty-string equality. The `-n` guard is the defensive seam.
+    assert.match(
+      step,
+      /\[\s*-n\s+"\$RP_NORM"\s*\]/,
+      'comparison must be guarded by [ -n "$RP_NORM" ] so empty resolves_phase never matches'
+    );
+  });
+
+  // ── Behavioral: extract the actual helper from the deployed workflow text and
+  // exercise it against the #2576 acceptance criteria. This pins the test to the
+  // real logic rather than a paraphrase, and proves the normalization is correct
+  // for every padded/unpadded pair the bug affected.
+
+  function extractNormalizeHelper() {
+    const step = readClosePhaseTodosStep();
+    // Match `normalize_phase_num() { ... \n}` up to the first newline-anchored `}`.
+    // Exact today because no interior line of the helper ends in a bare `}` (they
+    // end in quotes / then / else / fi). If the helper is ever refactored so an
+    // interior line ends in `}`, tighten this to a brace-counting parser.
+    const m = step.match(/normalize_phase_num\s*\(\)\s*\{[\s\S]*?\n\}/);
+    assert.ok(m, 'normalize_phase_num helper must exist in the step for behavioral extraction');
+    return m[0];
+  }
+
+  function runHelper(t, input) {
+    const helper = extractNormalizeHelper();
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-2576-'));
+    t.after(() => cleanup(tmp));
+    const script = path.join(tmp, 'normalize.sh');
+    // argv array (no shell string) so a quoted input like '"05"' is passed verbatim.
+    fs.writeFileSync(script, `${helper}\nnormalize_phase_num "$1"\n`);
+    return execFileSync('bash', [script, input], { encoding: 'utf8' });
+  }
+
+  // The headline #2576 case: single-digit phase, padded vs unpadded.
+  test('acceptance: "05" and "5" both normalize to "5" (the reported bug)', (t) => {
+    assert.equal(runHelper(t, '05'), '5');
+    assert.equal(runHelper(t, '5'), '5');
+    assert.equal(runHelper(t, '05'), runHelper(t, '5'));
+  });
+
+  // Acceptance: decimal sub-phases — strip leading zeros from the leading integer
+  // run only, leave the dotted tail untouched.
+  test('acceptance: decimal sub-phase "04.1" normalizes to "4.1" (decimal preserved)', (t) => {
+    assert.equal(runHelper(t, '04.1'), '4.1');
+    assert.equal(runHelper(t, '4.1'), '4.1');
+    assert.equal(runHelper(t, '4.1'), runHelper(t, '04.1'));
+  });
+
+  // Acceptance: letter suffixes must compare correctly.
+  test('acceptance: letter suffix "03A" normalizes to "3A", "12A" stays "12A"', (t) => {
+    assert.equal(runHelper(t, '03A'), '3A');
+    assert.equal(runHelper(t, '12A'), '12A');
+    assert.equal(runHelper(t, '3A'), runHelper(t, '03A'));
+  });
+
+  // Acceptance: the "00"/"0" edge case must compare equal (not collapse to empty).
+  test('acceptance: "00" and "0" both normalize to "0" (all-zeros collapse to one zero)', (t) => {
+    assert.equal(runHelper(t, '0'), '0');
+    assert.equal(runHelper(t, '00'), '0');
+    assert.equal(runHelper(t, '0'), runHelper(t, '00'));
+  });
+
+  // Acceptance: quoted YAML values ("5") must compare correctly. The helper strips
+  // surrounding double quotes before normalizing.
+  test('acceptance: quoted YAML value "5" normalizes to "5" (quotes stripped)', (t) => {
+    assert.equal(runHelper(t, '"5"'), '5');
+    assert.equal(runHelper(t, '"05"'), '5');
+    assert.equal(runHelper(t, '"5"'), runHelper(t, '5'));
+  });
+
+  // Defensive: double-digit phases already matched before the fix; they must still.
+  test('regression: double-digit "12" stays "12" (no leading zero, no change)', (t) => {
+    assert.equal(runHelper(t, '12'), '12');
+  });
+
+  // Defensive: arbitrary over-padding (e.g. a hand-edited "012") is tolerated too.
+  test('defensive: "012" normalizes to "12" (over-padding tolerated beyond the 2-digit convention)', (t) => {
+    assert.equal(runHelper(t, '012'), '12');
+    assert.equal(runHelper(t, '12'), runHelper(t, '012'));
+  });
+
+  // Defensive: a blank or non-numeric resolves_phase must not crash and must not
+  // spuriously match any phase (the `[ -n "$RP_NORM" ]` guard relies on empty out).
+  test('defensive: empty input returns empty (no crash, no spurious match)', (t) => {
+    assert.equal(runHelper(t, ''), '');
+  });
+
+  test('defensive: non-numeric "abc" passes through unchanged (will not equal any phase number)', (t) => {
+    assert.equal(runHelper(t, 'abc'), 'abc');
+  });
+
+  // ── Property (fast-check): a canonicalizer's output must be a fixed point —
+  // normalize(normalize(x)) === normalize(x) for every x. This is the contract a
+  // normalizer must satisfy; it complements the explicit boundary cases above and
+  // would catch any future helper rewrite that fails to converge on a canonical
+  // form. NUL is filtered because bash variables cannot hold NUL bytes. The helper
+  // is written to one reusable script and invoked via argv (no shell), per
+  // CONTRIBUTING.md's spawned-subprocess safety guidance.
+  test('property: normalize_phase_num is idempotent over all strings', (t) => {
+    const helper = extractNormalizeHelper();
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-2576-prop-'));
+    t.after(() => cleanup(tmp));
+    const script = path.join(tmp, 'normalize.sh');
+    fs.writeFileSync(script, `${helper}\nnormalize_phase_num "$1"\n`);
+    const norm = (s) => execFileSync('bash', [script, s], { encoding: 'utf8' });
+    fc.assert(
+      fc.property(
+        fc.string({ maxLength: 16 }).filter((s) => !s.includes('\0')),
+        (s) => { assert.equal(norm(norm(s)), norm(s)); }
+      ),
+      { numRuns: 50 }
+    );
+  });
+});

--- a/tests/fixtures/golden-install-parity/antigravity.json
+++ b/tests/fixtures/golden-install-parity/antigravity.json
@@ -247,7 +247,7 @@
   "gsd-core/workflows/docs-update.md": "0b3023a3caa2123f",
   "gsd-core/workflows/edit-phase.md": "fc932e82ba1f585a",
   "gsd-core/workflows/eval-review.md": "9e8b169c05098b57",
-  "gsd-core/workflows/execute-phase.md": "62f2ffd1a3fab9a5",
+  "gsd-core/workflows/execute-phase.md": "df25a040ef14d483",
   "gsd-core/workflows/execute-phase/steps/codebase-drift-gate.md": "1832b97d0923fa67",
   "gsd-core/workflows/execute-phase/steps/per-plan-worktree-gate.md": "7ebb7d1af6082028",
   "gsd-core/workflows/execute-phase/steps/post-merge-gate.md": "13aa54f8279960ae",

--- a/tests/fixtures/golden-install-parity/augment.json
+++ b/tests/fixtures/golden-install-parity/augment.json
@@ -318,7 +318,7 @@
   "gsd-core/workflows/docs-update.md": "a320371be70f43d8",
   "gsd-core/workflows/edit-phase.md": "966a3eadd1bebc04",
   "gsd-core/workflows/eval-review.md": "32d3d7e80ab2bfc7",
-  "gsd-core/workflows/execute-phase.md": "9576dee82fc42496",
+  "gsd-core/workflows/execute-phase.md": "014d1ce28cc64f48",
   "gsd-core/workflows/execute-phase/steps/codebase-drift-gate.md": "f7782680c2b8ad6b",
   "gsd-core/workflows/execute-phase/steps/per-plan-worktree-gate.md": "7ebb7d1af6082028",
   "gsd-core/workflows/execute-phase/steps/post-merge-gate.md": "7b2d9a4a4013fd6a",

--- a/tests/fixtures/golden-install-parity/claude-local.json
+++ b/tests/fixtures/golden-install-parity/claude-local.json
@@ -317,7 +317,7 @@
   "gsd-core/workflows/docs-update.md": "7aef1019ce141558",
   "gsd-core/workflows/edit-phase.md": "dbbb6191f5a8b65e",
   "gsd-core/workflows/eval-review.md": "11620e0dc4a003dd",
-  "gsd-core/workflows/execute-phase.md": "5aad166b1505215d",
+  "gsd-core/workflows/execute-phase.md": "cbdeabca6be48255",
   "gsd-core/workflows/execute-phase/steps/codebase-drift-gate.md": "9a1f3deffb4dab14",
   "gsd-core/workflows/execute-phase/steps/per-plan-worktree-gate.md": "7ebb7d1af6082028",
   "gsd-core/workflows/execute-phase/steps/post-merge-gate.md": "a7f9b9a45303382f",

--- a/tests/fixtures/golden-install-parity/claude.json
+++ b/tests/fixtures/golden-install-parity/claude.json
@@ -246,7 +246,7 @@
   "gsd-core/workflows/docs-update.md": "ea47bd2d5a0d1d85",
   "gsd-core/workflows/edit-phase.md": "8323bfe10faa0c0a",
   "gsd-core/workflows/eval-review.md": "7c2f5ff8cc4d06e5",
-  "gsd-core/workflows/execute-phase.md": "cd61c80541fa54be",
+  "gsd-core/workflows/execute-phase.md": "7278bc14f1360c3e",
   "gsd-core/workflows/execute-phase/steps/codebase-drift-gate.md": "d2020c5e01c7bd7f",
   "gsd-core/workflows/execute-phase/steps/per-plan-worktree-gate.md": "7ebb7d1af6082028",
   "gsd-core/workflows/execute-phase/steps/post-merge-gate.md": "7b2d9a4a4013fd6a",

--- a/tests/fixtures/golden-install-parity/cline.json
+++ b/tests/fixtures/golden-install-parity/cline.json
@@ -250,7 +250,7 @@
   "gsd-core/workflows/docs-update.md": "7eb7095ca86d506f",
   "gsd-core/workflows/edit-phase.md": "9c9fadc047c61d74",
   "gsd-core/workflows/eval-review.md": "17fc9b4c4f7e1c74",
-  "gsd-core/workflows/execute-phase.md": "b169a6a7ad091517",
+  "gsd-core/workflows/execute-phase.md": "233b289d04dba64f",
   "gsd-core/workflows/execute-phase/steps/codebase-drift-gate.md": "1b3558cb8f41b65a",
   "gsd-core/workflows/execute-phase/steps/per-plan-worktree-gate.md": "7ebb7d1af6082028",
   "gsd-core/workflows/execute-phase/steps/post-merge-gate.md": "35612890c1173577",

--- a/tests/fixtures/golden-install-parity/codebuddy.json
+++ b/tests/fixtures/golden-install-parity/codebuddy.json
@@ -318,7 +318,7 @@
   "gsd-core/workflows/docs-update.md": "a320371be70f43d8",
   "gsd-core/workflows/edit-phase.md": "966a3eadd1bebc04",
   "gsd-core/workflows/eval-review.md": "32d3d7e80ab2bfc7",
-  "gsd-core/workflows/execute-phase.md": "8108d708e41340c2",
+  "gsd-core/workflows/execute-phase.md": "6339681fe63b9151",
   "gsd-core/workflows/execute-phase/steps/codebase-drift-gate.md": "f7782680c2b8ad6b",
   "gsd-core/workflows/execute-phase/steps/per-plan-worktree-gate.md": "7ebb7d1af6082028",
   "gsd-core/workflows/execute-phase/steps/post-merge-gate.md": "7b2d9a4a4013fd6a",

--- a/tests/fixtures/golden-install-parity/codex.json
+++ b/tests/fixtures/golden-install-parity/codex.json
@@ -353,7 +353,7 @@
   "gsd-core/workflows/docs-update.md": "bf32efe90219d3dd",
   "gsd-core/workflows/edit-phase.md": "e592a4d85ce5380f",
   "gsd-core/workflows/eval-review.md": "c89a63285ead961e",
-  "gsd-core/workflows/execute-phase.md": "f6bf3f953a56e821",
+  "gsd-core/workflows/execute-phase.md": "968a8a22878c8f88",
   "gsd-core/workflows/execute-phase/steps/codebase-drift-gate.md": "cd8678d082d6e191",
   "gsd-core/workflows/execute-phase/steps/per-plan-worktree-gate.md": "7ebb7d1af6082028",
   "gsd-core/workflows/execute-phase/steps/post-merge-gate.md": "7b2d9a4a4013fd6a",

--- a/tests/fixtures/golden-install-parity/copilot.json
+++ b/tests/fixtures/golden-install-parity/copilot.json
@@ -248,7 +248,7 @@
   "gsd-core/workflows/docs-update.md": "f64b067d0d729f04",
   "gsd-core/workflows/edit-phase.md": "8667c28b22b1599f",
   "gsd-core/workflows/eval-review.md": "1ae2d3d3fbf72893",
-  "gsd-core/workflows/execute-phase.md": "7f16a37d0729d517",
+  "gsd-core/workflows/execute-phase.md": "ffd43d2e08880866",
   "gsd-core/workflows/execute-phase/steps/codebase-drift-gate.md": "ca37f91f7bd6f05c",
   "gsd-core/workflows/execute-phase/steps/per-plan-worktree-gate.md": "7ebb7d1af6082028",
   "gsd-core/workflows/execute-phase/steps/post-merge-gate.md": "25bebed74e645109",

--- a/tests/fixtures/golden-install-parity/cursor.json
+++ b/tests/fixtures/golden-install-parity/cursor.json
@@ -318,7 +318,7 @@
   "gsd-core/workflows/docs-update.md": "215b0122c4d2b1e5",
   "gsd-core/workflows/edit-phase.md": "8323bfe10faa0c0a",
   "gsd-core/workflows/eval-review.md": "9389c58f7384972d",
-  "gsd-core/workflows/execute-phase.md": "784f3579b077e42e",
+  "gsd-core/workflows/execute-phase.md": "569fcc8eff1c9321",
   "gsd-core/workflows/execute-phase/steps/codebase-drift-gate.md": "d2020c5e01c7bd7f",
   "gsd-core/workflows/execute-phase/steps/per-plan-worktree-gate.md": "7ebb7d1af6082028",
   "gsd-core/workflows/execute-phase/steps/post-merge-gate.md": "7b2d9a4a4013fd6a",

--- a/tests/fixtures/golden-install-parity/hermes.json
+++ b/tests/fixtures/golden-install-parity/hermes.json
@@ -247,7 +247,7 @@
   "gsd-core/workflows/docs-update.md": "02811dd7aa32d5ba",
   "gsd-core/workflows/edit-phase.md": "7f27003f20e88fb8",
   "gsd-core/workflows/eval-review.md": "e7cd5dfcf18e2458",
-  "gsd-core/workflows/execute-phase.md": "e9ced8c3351c0df4",
+  "gsd-core/workflows/execute-phase.md": "5d6eac4e2b01028c",
   "gsd-core/workflows/execute-phase/steps/codebase-drift-gate.md": "9b2193de25506b3b",
   "gsd-core/workflows/execute-phase/steps/per-plan-worktree-gate.md": "26ee34c543926402",
   "gsd-core/workflows/execute-phase/steps/post-merge-gate.md": "362123fdf99e9980",

--- a/tests/fixtures/golden-install-parity/kilo.json
+++ b/tests/fixtures/golden-install-parity/kilo.json
@@ -318,7 +318,7 @@
   "gsd-core/workflows/docs-update.md": "3c0d5ef72202d246",
   "gsd-core/workflows/edit-phase.md": "8323bfe10faa0c0a",
   "gsd-core/workflows/eval-review.md": "35be91cd22a9bc11",
-  "gsd-core/workflows/execute-phase.md": "8f3e14c95888af4d",
+  "gsd-core/workflows/execute-phase.md": "fcd4c5d6d2630bed",
   "gsd-core/workflows/execute-phase/steps/codebase-drift-gate.md": "b1e6588cd32a6f08",
   "gsd-core/workflows/execute-phase/steps/per-plan-worktree-gate.md": "7ebb7d1af6082028",
   "gsd-core/workflows/execute-phase/steps/post-merge-gate.md": "7b2d9a4a4013fd6a",

--- a/tests/fixtures/golden-install-parity/kimi-code.json
+++ b/tests/fixtures/golden-install-parity/kimi-code.json
@@ -275,7 +275,7 @@
   "gsd-core/workflows/docs-update.md": "a320371be70f43d8",
   "gsd-core/workflows/edit-phase.md": "966a3eadd1bebc04",
   "gsd-core/workflows/eval-review.md": "32d3d7e80ab2bfc7",
-  "gsd-core/workflows/execute-phase.md": "d8415f714b900335",
+  "gsd-core/workflows/execute-phase.md": "385158f8200e0b4b",
   "gsd-core/workflows/execute-phase/steps/codebase-drift-gate.md": "f7782680c2b8ad6b",
   "gsd-core/workflows/execute-phase/steps/per-plan-worktree-gate.md": "7ebb7d1af6082028",
   "gsd-core/workflows/execute-phase/steps/post-merge-gate.md": "7b2d9a4a4013fd6a",

--- a/tests/fixtures/golden-install-parity/kimi.json
+++ b/tests/fixtures/golden-install-parity/kimi.json
@@ -311,7 +311,7 @@
   "gsd-core/workflows/docs-update.md": "a320371be70f43d8",
   "gsd-core/workflows/edit-phase.md": "966a3eadd1bebc04",
   "gsd-core/workflows/eval-review.md": "32d3d7e80ab2bfc7",
-  "gsd-core/workflows/execute-phase.md": "4fce4cae4a748e1e",
+  "gsd-core/workflows/execute-phase.md": "a4a4860eaebd1493",
   "gsd-core/workflows/execute-phase/steps/codebase-drift-gate.md": "f7782680c2b8ad6b",
   "gsd-core/workflows/execute-phase/steps/per-plan-worktree-gate.md": "7ebb7d1af6082028",
   "gsd-core/workflows/execute-phase/steps/post-merge-gate.md": "7b2d9a4a4013fd6a",

--- a/tests/fixtures/golden-install-parity/opencode.json
+++ b/tests/fixtures/golden-install-parity/opencode.json
@@ -318,7 +318,7 @@
   "gsd-core/workflows/docs-update.md": "f6210dc8ff7776d5",
   "gsd-core/workflows/edit-phase.md": "1876c855fb0a0a39",
   "gsd-core/workflows/eval-review.md": "1973f08d0eb34159",
-  "gsd-core/workflows/execute-phase.md": "732995bcbb285233",
+  "gsd-core/workflows/execute-phase.md": "8f636a478e627dec",
   "gsd-core/workflows/execute-phase/steps/codebase-drift-gate.md": "a15993affd62f4bf",
   "gsd-core/workflows/execute-phase/steps/per-plan-worktree-gate.md": "7ebb7d1af6082028",
   "gsd-core/workflows/execute-phase/steps/post-merge-gate.md": "c4cba01539f0368a",

--- a/tests/fixtures/golden-install-parity/pi.json
+++ b/tests/fixtures/golden-install-parity/pi.json
@@ -214,7 +214,7 @@
   "gsd-core/workflows/docs-update.md": "a320371be70f43d8",
   "gsd-core/workflows/edit-phase.md": "966a3eadd1bebc04",
   "gsd-core/workflows/eval-review.md": "32d3d7e80ab2bfc7",
-  "gsd-core/workflows/execute-phase.md": "6f720660e0cee48a",
+  "gsd-core/workflows/execute-phase.md": "3ce575de94c6d4e2",
   "gsd-core/workflows/execute-phase/steps/codebase-drift-gate.md": "f7782680c2b8ad6b",
   "gsd-core/workflows/execute-phase/steps/per-plan-worktree-gate.md": "7ebb7d1af6082028",
   "gsd-core/workflows/execute-phase/steps/post-merge-gate.md": "7b2d9a4a4013fd6a",

--- a/tests/fixtures/golden-install-parity/qwen.json
+++ b/tests/fixtures/golden-install-parity/qwen.json
@@ -247,7 +247,7 @@
   "gsd-core/workflows/docs-update.md": "226550a6d556b09f",
   "gsd-core/workflows/edit-phase.md": "0fb5e0123cfc6f36",
   "gsd-core/workflows/eval-review.md": "88431952699d9fa6",
-  "gsd-core/workflows/execute-phase.md": "b2744ece3ffc1ec6",
+  "gsd-core/workflows/execute-phase.md": "a2ffd60956eba939",
   "gsd-core/workflows/execute-phase/steps/codebase-drift-gate.md": "0e0949db56deebeb",
   "gsd-core/workflows/execute-phase/steps/per-plan-worktree-gate.md": "7ebb7d1af6082028",
   "gsd-core/workflows/execute-phase/steps/post-merge-gate.md": "0b04cc2dcab61107",

--- a/tests/fixtures/golden-install-parity/trae.json
+++ b/tests/fixtures/golden-install-parity/trae.json
@@ -247,7 +247,7 @@
   "gsd-core/workflows/docs-update.md": "89e760e665ff99f8",
   "gsd-core/workflows/edit-phase.md": "7facd0faa33c8cad",
   "gsd-core/workflows/eval-review.md": "90a29a4fa0cdd947",
-  "gsd-core/workflows/execute-phase.md": "cea9135e975318d8",
+  "gsd-core/workflows/execute-phase.md": "10c31efb8ef7b218",
   "gsd-core/workflows/execute-phase/steps/codebase-drift-gate.md": "296b812e8d0e9ce8",
   "gsd-core/workflows/execute-phase/steps/per-plan-worktree-gate.md": "7ebb7d1af6082028",
   "gsd-core/workflows/execute-phase/steps/post-merge-gate.md": "7d30384e9bf82664",

--- a/tests/fixtures/golden-install-parity/windsurf.json
+++ b/tests/fixtures/golden-install-parity/windsurf.json
@@ -247,7 +247,7 @@
   "gsd-core/workflows/docs-update.md": "6bd25d0123ee6c73",
   "gsd-core/workflows/edit-phase.md": "c0ae7d0063f3e789",
   "gsd-core/workflows/eval-review.md": "713de00ea5326988",
-  "gsd-core/workflows/execute-phase.md": "93432c3e63da4914",
+  "gsd-core/workflows/execute-phase.md": "e4138bc697e320b1",
   "gsd-core/workflows/execute-phase/steps/codebase-drift-gate.md": "3194ecd382690755",
   "gsd-core/workflows/execute-phase/steps/per-plan-worktree-gate.md": "7ebb7d1af6082028",
   "gsd-core/workflows/execute-phase/steps/post-merge-gate.md": "fb4497767cdf73a3",

--- a/tests/fixtures/golden-install-parity/zcode.json
+++ b/tests/fixtures/golden-install-parity/zcode.json
@@ -318,7 +318,7 @@
   "gsd-core/workflows/docs-update.md": "a320371be70f43d8",
   "gsd-core/workflows/edit-phase.md": "966a3eadd1bebc04",
   "gsd-core/workflows/eval-review.md": "32d3d7e80ab2bfc7",
-  "gsd-core/workflows/execute-phase.md": "70da309ca11a8494",
+  "gsd-core/workflows/execute-phase.md": "9c4b1a77eb4fbd17",
   "gsd-core/workflows/execute-phase/steps/codebase-drift-gate.md": "f7782680c2b8ad6b",
   "gsd-core/workflows/execute-phase/steps/per-plan-worktree-gate.md": "7ebb7d1af6082028",
   "gsd-core/workflows/execute-phase/steps/post-merge-gate.md": "7b2d9a4a4013fd6a",

--- a/tests/workflow-size-baseline.json
+++ b/tests/workflow-size-baseline.json
@@ -24,7 +24,7 @@
   "docs-update.md": 56494,
   "edit-phase.md": 12927,
   "eval-review.md": 10332,
-  "execute-phase.md": 93368,
+  "execute-phase.md": 93389,
   "execute-plan.md": 35143,
   "explore.md": 11127,
   "extract-learnings.md": 12893,


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #2576

> The linked issue carries the `confirmed-bug` label.

---

## What was broken

`close_phase_todos` (in `execute-phase.md`) never auto-closed pending todos for single-digit phases (1-9). `PHASE_NUMBER` is zero-padded (e.g. `"05"`) but `new-milestone.md`'s phase-linking step writes `resolves_phase:` using the unpadded ROADMAP heading number (e.g. `5`), and the step compared the two as literal strings — so `"5" != "05"` and every single-digit phase silently failed to auto-close its todos. They stayed stuck in `.planning/todos/pending/` forever despite their resolving phase completing. Decimal sub-phases (`4.1` vs `04.1`) hit the same mismatch.

## What this fix does

Adds a `normalize_phase_num` bash helper that strips surrounding quotes and leading zeros from the leading integer run only (leaving letter suffixes and decimal sub-phases untouched), then normalizes both `PHASE_NUM` and the extracted `resolves_phase` value through it before comparing. A `[ -n "$RP_NORM" ]` guard also prevents a missing/blank `resolves_phase` from spuriously matching.

## Root cause

Padding-convention mismatch between the writer (`new-milestone.md` writes the unpadded ROADMAP heading number) and the reader (`PHASE_NUMBER` is zero-padded), compared via raw string equality rather than canonicalized equivalence.

## Testing

### How I verified the fix

New regression test `tests/close-phase-todos-padded-resolves.test.cjs`:
- **Structural** (source-text-is-the-product): asserts the step defines `normalize_phase_num`, applies it to both sides, compares normalized values, guards empty, and that the old raw `[ "$RP" = "$PHASE_NUM" ]` compare is gone.
- **Behavioral**: extracts the actual helper from the deployed workflow text and runs it against every #2576 acceptance case — `"05"`↔`"5"`, decimal `04.1`↔`4.1`, letter suffix `03A`↔`3A`, all-zeros `00`↔`0`, quoted `"5"`, empty, non-numeric.
- **Property (fast-check)**: idempotency — `normalize(normalize(x)) === normalize(x)` for 50 generated strings.

Verified TDD red→green: the test was committed first and confirmed to fail on `next` (14 subtests failing with "must define a normalize_phase_num() bash helper"), then the fix landed and the full suite passes under `gsd-test` on this HEAD.

### Regression test added?

- [x] Yes — `tests/close-phase-todos-padded-resolves.test.cjs` (structural + behavioral + fast-check property)

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux (gsd-test benches, Node 22 + 24 matrix)
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (workflow-file logic, runtime-independent bash)

---

## Checklist

- [x] Issue linked above with `Fixes #2576`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes (writer-side padding deferred per the issue)
- [x] Regression test added
- [x] All existing tests pass (`gsd-test` outcome:"passed" on this HEAD)
- [x] `.changeset/` fragment added (`.changeset/sharp-otters-zip.md`, type `Fixed`; `pr:` backfilled to this PR's number)
- [x] No unnecessary dependencies added (`fast-check` is already a devDependency)

## Review gates passed

- `/code-review` (isolated subagent): APPROVE — verified bash correctness on all acceptance cases, regex soundness, empty-guard improvement, no sibling parity gap, test quality, conventions, full spec alignment.
- `/security-review` (isolated subagent): No defects — all 9 vectors mitigated (injection, regex, BASH_REMATCH, path traversal, awk, printf format, prompt-injection, secrets, DoS).
- Graph-backed deterministic review (`find_code_review_issues`): 0 issues.
- `npm run lint`: clean (0 errors, 0 warnings).

## Breaking changes

None. The fix only loosens the `resolves_phase` comparison to accept both padded and unpadded forms; todos that matched before (double-digit phases) still match.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2597"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787495259&installation_model_id=22188&pr_number=2597&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2597&signature=f5fd0ced86b30700177951c174d10979b37041227173caa6c00b0075fb64a780"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->