### PR TITLE
fix(#2620): inject the reference DispatchLogger on the live dispatch seam when observability is enabled

### DIFF
--- a/.changeset/vivid-ibex-bark.md
+++ b/.changeset/vivid-ibex-bark.md
@@ -2,4 +2,4 @@
 type: Fixed
 pr: 2621
 ---
-Wire the reference dispatch logger onto the live command seam so GSD_AUDIT=1 (and config.audit.enabled) actually produce the documented structured stderr line and .planning/.gsd-trace.jsonl audit trail. With observability off, dispatch output is unchanged.
+**`GSD_AUDIT=1` now actually produces an audit trail** — the reference dispatch logger is wired onto the live command seam, so opting in yields the documented structured stderr line and the `.planning/.gsd-trace.jsonl` audit trail. Previously the seam built its dispatch hub without a logger, so it fell back to a no-op and the opt-in signal was inert with no indication why. With observability off, dispatch output is byte-for-byte unchanged. (#2620)

--- a/.changeset/vivid-ibex-bark.md
+++ b/.changeset/vivid-ibex-bark.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 2621
+---
+Wire the reference dispatch logger onto the live command seam so GSD_AUDIT=1 (and config.audit.enabled) actually produce the documented structured stderr line and .planning/.gsd-trace.jsonl audit trail. With observability off, dispatch output is unchanged.

--- a/src/cjs-command-router-adapter.cts
+++ b/src/cjs-command-router-adapter.cts
@@ -13,6 +13,17 @@
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import commandRoutingHub = require('./command-routing-hub.cjs');
 const { createHub, ERROR_KINDS } = commandRoutingHub;
+// #26 (ADR-0174 §6): the Hub defaults to a no-op logger and the live CLI
+// dispatch path never injected the reference DispatchLogger, so GSD_AUDIT and
+// config.audit.enabled were inert. Inject the reference logger ONLY when
+// observability is opt-in enabled; when off, inject nothing so the Hub stays
+// byte-for-byte silent (preserving the default dispatch output contract, incl.
+// --json-errors). Enabling stderr-on-error unconditionally by default is a
+// separate, blast-radius-bearing change (it adds a second stderr line to the
+// --json-errors envelope) — deferred as its own follow-up.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import observabilityLogger = require('./observability/logger.cjs');
+const { createDefaultLogger, isAuditEnabled } = observabilityLogger;
 // Phase 2 (#1646): import ERROR_REASON so the UnknownCommand translation can
 // pass `sdk_unknown_command` as the second arg to error(), preserving the
 // JSON-error envelope contract that capability routers' tests assert on.
@@ -134,6 +145,10 @@ function routeHubCommandFamily({
   const hub = createHub({
     cjsRegistry: { [family]: registryHandlers },
     manifest: { [family]: available },
+    // #26: wire the reference logger onto the live dispatch path (ADR-0174 §6),
+    // but only when observability is opt-in enabled — otherwise leave it unset
+    // so the Hub falls back to the no-op logger and stays byte-for-byte silent.
+    logger: isAuditEnabled() ? createDefaultLogger({ cwd }) : undefined,
   });
 
   const result = hub.dispatch({

--- a/src/cjs-command-router-adapter.cts
+++ b/src/cjs-command-router-adapter.cts
@@ -13,7 +13,7 @@
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import commandRoutingHub = require('./command-routing-hub.cjs');
 const { createHub, ERROR_KINDS } = commandRoutingHub;
-// #26 (ADR-0174 §6): the Hub defaults to a no-op logger and the live CLI
+// #2620 (ADR-0174 §6): the Hub defaults to a no-op logger and the live CLI
 // dispatch path never injected the reference DispatchLogger, so GSD_AUDIT and
 // config.audit.enabled were inert. Inject the reference logger ONLY when
 // observability is opt-in enabled; when off, inject nothing so the Hub stays
@@ -145,7 +145,7 @@ function routeHubCommandFamily({
   const hub = createHub({
     cjsRegistry: { [family]: registryHandlers },
     manifest: { [family]: available },
-    // #26: wire the reference logger onto the live dispatch path (ADR-0174 §6),
+    // #2620: wire the reference logger onto the live dispatch path (ADR-0174 §6),
     // but only when observability is opt-in enabled — otherwise leave it unset
     // so the Hub falls back to the no-op logger and stays byte-for-byte silent.
     logger: isAuditEnabled() ? createDefaultLogger({ cwd }) : undefined,

--- a/src/observability/logger.cts
+++ b/src/observability/logger.cts
@@ -43,7 +43,7 @@ function _safeStringify(value: unknown): string {
 
 /**
  * Determine whether observability is opt-in enabled — via the GSD_AUDIT env var
- * or config.audit.enabled. Exported (#26) so the live dispatch seam can decide
+ * or config.audit.enabled. Exported (#2620) so the live dispatch seam can decide
  * whether to inject the reference logger at all: when observability is off we
  * inject nothing (the Hub stays byte-for-byte silent, preserving the default
  * dispatch output contract, incl. --json-errors); when on, the caller injects

--- a/src/observability/logger.cts
+++ b/src/observability/logger.cts
@@ -42,9 +42,14 @@ function _safeStringify(value: unknown): string {
 }
 
 /**
- * Determine whether the audit file should be written to.
+ * Determine whether observability is opt-in enabled — via the GSD_AUDIT env var
+ * or config.audit.enabled. Exported (#26) so the live dispatch seam can decide
+ * whether to inject the reference logger at all: when observability is off we
+ * inject nothing (the Hub stays byte-for-byte silent, preserving the default
+ * dispatch output contract, incl. --json-errors); when on, the caller injects
+ * createDefaultLogger and gets the stderr-on-error line + opt-in file audit.
  */
-function _isAuditEnabled(config: { audit?: { enabled?: boolean } } | undefined): boolean {
+function _isAuditEnabled(config?: { audit?: { enabled?: boolean } }): boolean {
   if (process.env['GSD_AUDIT'] === '1') return true;
   if (config && config.audit && config.audit.enabled === true) return true;
   return false;
@@ -163,4 +168,4 @@ function createDefaultLogger({ cwd = process.cwd(), config }: DefaultLoggerOptio
   };
 }
 
-export = { createDefaultLogger, createNoOpLogger };
+export = { createDefaultLogger, createNoOpLogger, isAuditEnabled: _isAuditEnabled };

--- a/src/phase-command-router.cts
+++ b/src/phase-command-router.cts
@@ -21,6 +21,12 @@ import { PHASE_SUBCOMMANDS } from './command-aliases.cjs';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import commandRoutingHub = require('./command-routing-hub.cjs');
 const { createHub, ERROR_KINDS, makeInvalidArgs } = commandRoutingHub;
+// #26 (ADR-0174 §6): inject the reference DispatchLogger on the live phase
+// dispatch path, but only when observability is opt-in enabled; otherwise the
+// Hub stays byte-for-byte silent via its no-op fallback.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import observabilityLogger = require('./observability/logger.cjs');
+const { createDefaultLogger, isAuditEnabled } = observabilityLogger;
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -246,7 +252,10 @@ function routePhaseCommand({ phase, args, cwd, raw, error }: RoutePhaseCommandOp
 
   // ── Construct hub ──────────────────────────────────────────────────────────
   // #175: Hub is CJS-only — no mode param, no sdkLoader.
-  const hub = createHub({ cjsRegistry, manifest });
+  // #26: wire the reference logger (ADR-0174 §6) only when observability is
+  // opt-in enabled; otherwise leave it unset so the Hub stays byte-for-byte
+  // silent via its no-op fallback.
+  const hub = createHub({ cjsRegistry, manifest, logger: isAuditEnabled() ? createDefaultLogger({ cwd }) : undefined });
 
   // ── Dispatch ────────────────────────────────────────────────────────────────
   const result = hub.dispatch({

--- a/src/phase-command-router.cts
+++ b/src/phase-command-router.cts
@@ -21,7 +21,7 @@ import { PHASE_SUBCOMMANDS } from './command-aliases.cjs';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import commandRoutingHub = require('./command-routing-hub.cjs');
 const { createHub, ERROR_KINDS, makeInvalidArgs } = commandRoutingHub;
-// #26 (ADR-0174 §6): inject the reference DispatchLogger on the live phase
+// #2620 (ADR-0174 §6): inject the reference DispatchLogger on the live phase
 // dispatch path, but only when observability is opt-in enabled; otherwise the
 // Hub stays byte-for-byte silent via its no-op fallback.
 // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -252,7 +252,7 @@ function routePhaseCommand({ phase, args, cwd, raw, error }: RoutePhaseCommandOp
 
   // ── Construct hub ──────────────────────────────────────────────────────────
   // #175: Hub is CJS-only — no mode param, no sdkLoader.
-  // #26: wire the reference logger (ADR-0174 §6) only when observability is
+  // #2620: wire the reference logger (ADR-0174 §6) only when observability is
   // opt-in enabled; otherwise leave it unset so the Hub stays byte-for-byte
   // silent via its no-op fallback.
   const hub = createHub({ cjsRegistry, manifest, logger: isAuditEnabled() ? createDefaultLogger({ cwd }) : undefined });

--- a/tests/cjs-command-router-adapter.test.cjs
+++ b/tests/cjs-command-router-adapter.test.cjs
@@ -629,3 +629,57 @@ describe('bug #3631 — SDK family routers forward --raw to output()', () => {
 });
   });
 }
+
+
+// ────────────────────────────────────────────────────────────────────────
+// Regression for #26 — the live adapter must inject a real DispatchLogger
+// (ADR-0174 §6: "DispatchLogger is injected; the Hub emits DispatchEvent on
+// every dispatch path"). Before the fix, routeHubCommandFamily built the Hub
+// with no logger, so it fell back to createNoOpLogger and GSD_AUDIT was inert.
+// ────────────────────────────────────────────────────────────────────────
+{
+  const { describe, test } = require('node:test');
+  const assert = require('node:assert/strict');
+  const fs = require('fs');
+  const os = require('os');
+  const path = require('path');
+  const { routeHubCommandFamily } = require('../gsd-core/bin/lib/cjs-command-router-adapter.cjs');
+  const { cleanup } = require('./helpers.cjs');
+
+  describe('cjs-command-router-adapter — observability logger wiring (#26)', () => {
+    test('a dispatch through the live adapter writes the opt-in audit trail when GSD_AUDIT=1', () => {
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-obs-wire-'));
+      const prev = process.env.GSD_AUDIT;
+      process.env.GSD_AUDIT = '1';
+      try {
+        routeHubCommandFamily({
+          family: 'unit',
+          args: ['unit', 'ok'],
+          subcommands: ['ok'],
+          handlers: { ok: () => {} },
+          unknownMessage: (subcommand, available) => `Unknown ${subcommand}. Available: ${available.join(', ')}`,
+          error: () => {},
+          cwd: tmp,
+          raw: false,
+        });
+
+        const auditPath = path.join(tmp, '.planning', '.gsd-trace.jsonl');
+        assert.ok(
+          fs.existsSync(auditPath),
+          'GSD_AUDIT=1 must produce .planning/.gsd-trace.jsonl — the adapter must build the Hub with a real DispatchLogger (ADR-0174 §6), not createNoOpLogger'
+        );
+        const lines = fs.readFileSync(auditPath, 'utf8').trim().split(/\r?\n/).filter(Boolean);
+        assert.equal(lines.length, 1, 'exactly one dispatch event must be recorded');
+        const event = JSON.parse(lines[0]);
+        assert.equal(event.result.kind, 'ok', 'a successful dispatch is recorded with result.kind === "ok"');
+        assert.ok(typeof event.command === 'string' && event.command.length > 0, 'event carries the dispatched command');
+        assert.ok(typeof event.traceId === 'string' && event.traceId.length > 0, 'event carries a traceId');
+        assert.ok(typeof event.timestamp === 'string' && event.timestamp.length > 0, 'event carries an ISO timestamp');
+      } finally {
+        if (prev === undefined) delete process.env.GSD_AUDIT;
+        else process.env.GSD_AUDIT = prev;
+        cleanup(tmp);
+      }
+    });
+  });
+}

--- a/tests/cjs-command-router-adapter.test.cjs
+++ b/tests/cjs-command-router-adapter.test.cjs
@@ -630,7 +630,6 @@ describe('bug #3631 — SDK family routers forward --raw to output()', () => {
   });
 }
 
-
 // ────────────────────────────────────────────────────────────────────────
 // Regression for #26 — the live adapter must inject a real DispatchLogger
 // (ADR-0174 §6: "DispatchLogger is injected; the Hub emits DispatchEvent on
@@ -640,46 +639,46 @@ describe('bug #3631 — SDK family routers forward --raw to output()', () => {
 {
   const { describe, test } = require('node:test');
   const assert = require('node:assert/strict');
-  const fs = require('fs');
-  const os = require('os');
-  const path = require('path');
+  const fs = require('node:fs');
+  const path = require('node:path');
   const { routeHubCommandFamily } = require('../gsd-core/bin/lib/cjs-command-router-adapter.cjs');
-  const { cleanup } = require('./helpers.cjs');
+  const { createTempDir, cleanup } = require('./helpers.cjs');
 
   describe('cjs-command-router-adapter — observability logger wiring (#26)', () => {
-    test('a dispatch through the live adapter writes the opt-in audit trail when GSD_AUDIT=1', () => {
-      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-obs-wire-'));
+    test('a dispatch through the live adapter writes the opt-in audit trail when GSD_AUDIT=1', (t) => {
+      const tmp = createTempDir('gsd-obs-wire-');
       const prev = process.env.GSD_AUDIT;
-      process.env.GSD_AUDIT = '1';
-      try {
-        routeHubCommandFamily({
-          family: 'unit',
-          args: ['unit', 'ok'],
-          subcommands: ['ok'],
-          handlers: { ok: () => {} },
-          unknownMessage: (subcommand, available) => `Unknown ${subcommand}. Available: ${available.join(', ')}`,
-          error: () => {},
-          cwd: tmp,
-          raw: false,
-        });
-
-        const auditPath = path.join(tmp, '.planning', '.gsd-trace.jsonl');
-        assert.ok(
-          fs.existsSync(auditPath),
-          'GSD_AUDIT=1 must produce .planning/.gsd-trace.jsonl — the adapter must build the Hub with a real DispatchLogger (ADR-0174 §6), not createNoOpLogger'
-        );
-        const lines = fs.readFileSync(auditPath, 'utf8').trim().split(/\r?\n/).filter(Boolean);
-        assert.equal(lines.length, 1, 'exactly one dispatch event must be recorded');
-        const event = JSON.parse(lines[0]);
-        assert.equal(event.result.kind, 'ok', 'a successful dispatch is recorded with result.kind === "ok"');
-        assert.ok(typeof event.command === 'string' && event.command.length > 0, 'event carries the dispatched command');
-        assert.ok(typeof event.traceId === 'string' && event.traceId.length > 0, 'event carries a traceId');
-        assert.ok(typeof event.timestamp === 'string' && event.timestamp.length > 0, 'event carries an ISO timestamp');
-      } finally {
+      t.after(() => {
         if (prev === undefined) delete process.env.GSD_AUDIT;
         else process.env.GSD_AUDIT = prev;
         cleanup(tmp);
-      }
+      });
+      process.env.GSD_AUDIT = '1';
+
+      routeHubCommandFamily({
+        family: 'unit',
+        args: ['unit', 'ok'],
+        subcommands: ['ok'],
+        handlers: { ok: () => {} },
+        unknownMessage: (subcommand, available) => `Unknown ${subcommand}. Available: ${available.join(', ')}`,
+        error: () => {},
+        cwd: tmp,
+        raw: false,
+      });
+
+      const auditPath = path.join(tmp, '.planning', '.gsd-trace.jsonl');
+      assert.ok(
+        fs.existsSync(auditPath),
+        'GSD_AUDIT=1 must produce .planning/.gsd-trace.jsonl — the adapter must build the Hub with a real DispatchLogger (ADR-0174 §6), not createNoOpLogger'
+      );
+      const lines = fs.readFileSync(auditPath, 'utf8').trim().split(/\r?\n/).filter(Boolean);
+      assert.ok(lines.length > 0, 'at least one dispatch event must be recorded');
+      assert.equal(lines.length, 1, 'exactly one dispatch event must be recorded');
+      const event = JSON.parse(lines[0]);
+      assert.equal(event.result.kind, 'ok', 'a successful dispatch is recorded with result.kind === "ok"');
+      assert.ok(typeof event.command === 'string' && event.command.length > 0, 'event carries the dispatched command');
+      assert.ok(typeof event.traceId === 'string' && event.traceId.length > 0, 'event carries a traceId');
+      assert.ok(typeof event.timestamp === 'string' && event.timestamp.length > 0, 'event carries an ISO timestamp');
     });
   });
 }

--- a/tests/cjs-command-router-adapter.test.cjs
+++ b/tests/cjs-command-router-adapter.test.cjs
@@ -631,7 +631,7 @@ describe('bug #3631 — SDK family routers forward --raw to output()', () => {
 }
 
 // ────────────────────────────────────────────────────────────────────────
-// Regression for #26 — the live adapter must inject a real DispatchLogger
+// Regression for #2620 — the live adapter must inject a real DispatchLogger
 // (ADR-0174 §6: "DispatchLogger is injected; the Hub emits DispatchEvent on
 // every dispatch path"). Before the fix, routeHubCommandFamily built the Hub
 // with no logger, so it fell back to createNoOpLogger and GSD_AUDIT was inert.
@@ -644,7 +644,7 @@ describe('bug #3631 — SDK family routers forward --raw to output()', () => {
   const { routeHubCommandFamily } = require('../gsd-core/bin/lib/cjs-command-router-adapter.cjs');
   const { createTempDir, cleanup } = require('./helpers.cjs');
 
-  describe('cjs-command-router-adapter — observability logger wiring (#26)', () => {
+  describe('cjs-command-router-adapter — observability logger wiring (#2620)', () => {
     test('a dispatch through the live adapter writes the opt-in audit trail when GSD_AUDIT=1', (t) => {
       const tmp = createTempDir('gsd-obs-wire-');
       const prev = process.env.GSD_AUDIT;

--- a/tests/phase-command-router.test.cjs
+++ b/tests/phase-command-router.test.cjs
@@ -564,3 +564,79 @@ describe('bug-1437 — phase.list-plans is wired in gsd-tools', () => {
 });
   });
 }
+
+// ─── 6. Observability logger wiring (#2620) ──────────────────────────────────
+//
+// The fix wires the reference DispatchLogger at BOTH live createHub() seams.
+// The sibling seam (cjs-command-router-adapter) is covered in its own file;
+// this pins the phase seam so a later refactor that drops the isAuditEnabled()
+// gate or the injection here cannot reintroduce the #2620 defect silently.
+{
+  const fs = require('node:fs');
+  const path = require('node:path');
+  const { createTempDir, cleanup } = require('./helpers.cjs');
+
+  describe('phase-command-router — observability logger wiring (#2620)', () => {
+    test('a dispatch through the phase seam writes the opt-in audit trail when GSD_AUDIT=1', (t) => {
+      const tmp = createTempDir('gsd-obs-phase-');
+      const prevAudit = process.env.GSD_AUDIT;
+      t.after(() => {
+        if (prevAudit === undefined) delete process.env.GSD_AUDIT;
+        else process.env.GSD_AUDIT = prevAudit;
+        cleanup(tmp);
+      });
+      process.env.GSD_AUDIT = '1';
+
+      const phase = makePhase({ cmdPhaseNextDecimal: () => {} });
+      routePhaseCommand({
+        phase,
+        args: ['phase', 'next-decimal', '5'],
+        cwd: tmp,
+        raw: false,
+        error: (m) => { throw new Error(m); },
+      });
+
+      const auditPath = path.join(tmp, '.planning', '.gsd-trace.jsonl');
+      assert.ok(
+        fs.existsSync(auditPath),
+        'GSD_AUDIT=1 must produce .planning/.gsd-trace.jsonl — the phase router must build the Hub with a real DispatchLogger (ADR-0174 §6), not createNoOpLogger'
+      );
+
+      const lines = fs.readFileSync(auditPath, 'utf8').trim().split(/\r?\n/).filter(Boolean);
+      assert.ok(lines.length > 0, 'at least one dispatch event must be recorded');
+      assert.equal(lines.length, 1, 'exactly one dispatch event must be recorded');
+
+      const event = JSON.parse(lines[0]);
+      assert.equal(event.result.kind, 'ok', 'a successful dispatch is recorded with result.kind === "ok"');
+      assert.ok(typeof event.command === 'string' && event.command.length > 0, 'event carries the dispatched command');
+      assert.ok(typeof event.traceId === 'string' && event.traceId.length > 0, 'event carries a traceId');
+      assert.ok(typeof event.timestamp === 'string' && event.timestamp.length > 0, 'event carries an ISO timestamp');
+    });
+
+    test('no audit trail is written when GSD_AUDIT is unset (Hub stays silent via the no-op fallback)', (t) => {
+      const tmp = createTempDir('gsd-obs-phase-off-');
+      const prevAudit = process.env.GSD_AUDIT;
+      t.after(() => {
+        if (prevAudit === undefined) delete process.env.GSD_AUDIT;
+        else process.env.GSD_AUDIT = prevAudit;
+        cleanup(tmp);
+      });
+      delete process.env.GSD_AUDIT;
+
+      const phase = makePhase({ cmdPhaseNextDecimal: () => {} });
+      routePhaseCommand({
+        phase,
+        args: ['phase', 'next-decimal', '5'],
+        cwd: tmp,
+        raw: false,
+        error: (m) => { throw new Error(m); },
+      });
+
+      assert.equal(
+        fs.existsSync(path.join(tmp, '.planning', '.gsd-trace.jsonl')),
+        false,
+        'without the opt-in signal the seam must leave no audit artifact'
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #2620

---

## What was broken

The Command Routing Hub never injected the reference `DispatchLogger`. It defaulted to `createNoOpLogger` and `createDefaultLogger` was injected at no call site, so `GSD_AUDIT=1` wrote no `.planning/.gsd-trace.jsonl` and failed dispatches emitted no structured JSON to stderr — despite ADR-0174 §5/§6, `CONTEXT.md` §"Dispatch Observability Module", and `docs/CONFIGURATION.md` all documenting that behavior as live.

## What this fix does

Injects `createDefaultLogger` at both live `createHub()` call sites, **gated on the existing opt-in signal** (`GSD_AUDIT=1` / `config.audit.enabled`) via a newly exported `isAuditEnabled()`.

- Observability **off** (the default): no logger is injected at all, the Hub keeps its no-op fallback, and stdout/stderr stay **byte-for-byte identical** to current behavior.
- Observability **on**: the structured stderr line and the opt-in file audit both work as documented, for the first time.

## Root cause

`src/command-routing-hub.cts:271-275` falls back to `createNoOpLogger()` when no logger is passed, and the two live callers — `src/cjs-command-router-adapter.cts:134` and `src/phase-command-router.cts:249` — passed none. The `GSD_AUDIT` gate lives *inside* `createDefaultLogger`, which was never instantiated, so the env var could never take effect.

## Testing

### How I verified the fix

Reproduced on `next` @ `7e1c736a` before the change — a Hub-routed error dispatch under `GSD_AUDIT=1` emitted only a plain `Error:` line and created no trace file:

```
$ GSD_AUDIT=1 node gsd-core/bin/gsd-tools.cjs phase remove --cwd /tmp/repro
Error: phase remove accepts exactly one phase number
$ ls /tmp/repro/.planning/.gsd-trace.jsonl
ls: cannot access ...: No such file or directory
```

After the change, the same command emits the specified structured line and writes the record:

```
$ GSD_AUDIT=1 node gsd-core/bin/gsd-tools.cjs phase remove --cwd /tmp/repro
{"traceId":"37bcfc86-…","command":"phase remove","timestamp":"…","kind":"InvalidArgs","ok":false,"arg":"<phase-number>","reason":"phase remove accepts exactly one phase number"}
Error: phase remove accepts exactly one phase number

$ cat /tmp/repro/.planning/.gsd-trace.jsonl
{"traceId":"37bcfc86-…","command":"phase remove","result":{"ok":false,"kind":"InvalidArgs",…},"timestamp":"…"}
```

And with observability off, output is unchanged and no trace file is written.

Suites run locally on this branch:

- `tests/cjs-command-router-adapter.test.cjs`, `tests/command-routing-hub.test.cjs`, `tests/phase-command-router.test.cjs`, `tests/phases-command-router.test.cjs`, `tests/roadmap-command-router.test.cjs`, `tests/claude-orchestration-command-router.test.cjs`, `tests/mvp-phase-command.test.cjs`, `tests/observability/*` — **275 pass, 0 fail**
- `npm run lint:ci` — **exit 0**

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

Added to `tests/cjs-command-router-adapter.test.cjs` (suite: *observability logger wiring (#26)*). Verified RED before the fix on `next` @ `7e1c736a` (`not ok 6 … 1 subtest failed`, 24 pass / 1 fail) and GREEN after (25 pass / 0 fail).

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [ ] N/A (not runtime-specific)

---

## Round-2 review response (2026-07-27)

All three Majors from @trek-e's 2026-07-25 review are addressed. Rebased onto `next` (40 commits, clean).

### Major 1 — `try/finally` inside a test body

`CONTRIBUTING.md:344` is explicit: *"Never use `try/finally` inside test bodies."* Converted the new adapter test to the Pattern-2 `t.after()` form, so a throwing cleanup can no longer replace the original assertion failure. Also switched the inlined `fs.mkdtempSync` to the centralized `createTempDir` helper (`CONTRIBUTING.md` → *Use Centralized Test Helpers*) and dropped the now-unused `os` require.

Scope note: this file carries **pre-existing** `try/finally` blocks in unrelated folded suites. Left untouched — they are outside this PR's concern.

### Major 2 — the second production hunk had no test

Confirmed: `tests/phase-command-router.test.cjs` had **zero** references to `GSD_AUDIT`, `.gsd-trace.jsonl`, `isAuditEnabled`, or `createDefaultLogger`. Added coverage for the `src/phase-command-router.cts:258` seam.

**Fail-first, actually observed** — not asserted. Reverted the production hunk to its pre-fix form (`createHub({ cjsRegistry, manifest })`), rebuilt, and ran:

```
not ok 7 - phase-command-router — observability logger wiring (#2620)
  error: 'GSD_AUDIT=1 must produce .planning/.gsd-trace.jsonl — the phase router
          must build the Hub with a real DispatchLogger (ADR-0174 §6), not createNoOpLogger'
# tests 31   # pass 30   # fail 1
```

Restored the hunk (`git diff` clean against the committed file), rebuilt: **31 pass / 0 fail**.

Honest scope on the second test: *"no audit trail when `GSD_AUDIT` is unset"* **passes pre-fix too**. It is a negative pin against a future refactor dropping the gate, not a demonstration of the regression. Only the positive test is fail-first.

### Major 3 — the changeset shipped a claim that cannot be true

Independently confirmed all three legs of your finding:

- `src/cjs-command-router-adapter.cts:151` and `src/phase-command-router.cts:258` both call `isAuditEnabled()` with **zero arguments**, so `config` is always `undefined` and the `config.audit.enabled === true` branch at `src/observability/logger.cts:54` is unreachable from production.
- `src/config-schema.cts` contains **no `audit` key** — a user setting it in `.planning/config.json` would be silently dropped.

Took the smaller of your two options and scoped the text to `GSD_AUDIT=1`, which is what actually ships. The missing schema key remains a disclosed deferred sub-defect on #2620. Also added the trailing `(#2620)` issue backlink the other fragments carry.

### Nit

Double blank line before the new test block removed.

### Verification (post-rebase, actually run)

`build:lib` clean · `cjs-command-router-adapter` + `phase-command-router` **56 pass / 0 fail / 0 skipped** · `tests/observability/*.test.cjs` **81 pass / 0 fail / 0 skipped** · `npm run lint:ci` **exit 0** · `changeset-lint` exit 0. Full `npm test` was not re-run locally; the CI matrix on this push is the authority.

CI on the previous head showed `changeset-lint` and `docs-lint` as **CANCELLED** rather than passed — this push re-runs them for a real conclusion.

### Not changed, deliberately

The `--json-errors` envelope. Restoring ADR-0174 §5's *ungated* stderr-on-error adds a second JSON line that callers parsing exactly one line would break on (~22 tests fail on `JSON.parse` at line 2). That unconditional form is **D1b** in ADR #2619, ratified there as its own increment carrying an explicit envelope version and migration note. Gating injection instead keeps this PR non-breaking.

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

**None from this PR.** With observability off — the default — dispatch output is byte-for-byte identical, which is precisely why the injection is gated.

Disclosed for reviewers, per CONTRIBUTING's rule that a change intentionally revisiting an ADR decision must call it out: **ADR-0174 §5 specifies stderr-on-error _ungated_** (*"every `Result` with `ok: false` emits a structured JSON line to stderr"*), and this PR does **not** restore that unconditional form. Injecting unconditionally was trialled and adds a **second** line to the `--json-errors` envelope that callers parse as exactly one JSON line — ~22 existing tests fail on `JSON.parse` at line 2. That is a genuine Hyrum's-Law contract break and does not belong inside a bug fix.

Restoring the unconditional form is therefore tracked as its own increment, with an explicit envelope version and migration note, under the observability ADR proposed in #2619 — which states the partial supersede of §5 openly rather than retconning it. Two related sub-defects found during this work are likewise deferred to their own issues rather than smuggled in here: `GSD_AUDIT_ARGS` is doubly-dead (`_notifyLogger` omits `includeArgs`), and `config.audit.enabled` is absent from the config schema.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2621"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787519516&installation_model_id=22188&pr_number=2621&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2621&signature=31fe9c97c3fe96138eb3f0dee2314444c74bb66924f85c3149f8e766809d3028"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
