### PR TITLE
docs(#2614): record general-purpose agent-prompt skills as out-of-scope

### DIFF
--- a/.out-of-scope/general-purpose-agent-prompt-skills.md
+++ b/.out-of-scope/general-purpose-agent-prompt-skills.md
@@ -1,0 +1,128 @@
+# General-Purpose Agent-Discipline Prompt Modules as Core Skills
+
+**Source:** [#2614](https://github.com/open-gsd/gsd-core/issues/2614)
+**Decision:** wontfix — routed to the capability ecosystem, closed on scope ownership
+**Date:** 2026-07-24
+
+GSD core does not accept standalone, general-purpose agent-discipline prompt
+modules — prose instructing an agent *how to think* (epistemic hygiene,
+confidence framing, assumption surfacing, reasoning style) that is not attached
+to a specific GSD command or loop step. These belong in the capability
+ecosystem, authored and distributed by their authors, not in the core skill
+layer.
+
+## What this does NOT cover
+
+Read this scope boundary before applying the entry — the keyword surface below
+("confidence", "assumptions", "reasoning style") overlaps request types this
+decision deliberately does **not** deny:
+
+- **Fixing an existing first-party agent's own language at a specific loop
+  step** — e.g. "`gsd-verifier` overstates confidence at `verify:post`, tighten
+  its prompt". That is command/loop-step-attached and is ordinary bug-fix or
+  enhancement work. This entry denies *standalone, unattached* modules only.
+- **Objectively-measured or externally-triggered calibration** — anything
+  routing on an exogenous signal the way `honest-verifier.md` does. Reason 4
+  below rejects *self-rated* confidence specifically; the evidence it cites
+  measures the self-abstention gate and says nothing about externally-measured
+  calibration, which is a categorically different mechanism.
+- **Structural output-format instructions** attached to a real surface —
+  separating facts from inferences from assumptions from unknowns is a
+  formatting contract, not a self-assessment mechanism.
+
+If an incoming request falls in any of the three above, this entry does not
+apply to it.
+
+## Why this is out of scope
+
+### 1. `skills/` is a generated projection, not an authoring surface
+
+`skills/` is build-generated from `commands/gsd/*.md` by
+`scripts/gen-plugin-skills.cjs` — 71 commands to 71 skills, identical
+membership — and `npm run lint:generated-sync` runs `gen-plugin-skills.cjs
+--check`, which fails whenever the committed tree diverges from generator
+output. A hand-authored `skills/<name>/SKILL.md` breaks CI and is not
+reproduced by a regeneration.
+
+Shipping such a module as a skill therefore requires authoring a backing
+command. That converts an "adds no command surface" proposal into a new
+user-facing command, which is a materially different and larger ask than the
+one submitted. The skill layer's 1:1 correspondence with commands is a
+load-bearing invariant read independently by `gen-plugin-skills.cjs`,
+`gen-inventory-manifest.cjs`, `update-size-baseline.cjs`,
+`runtime-artifact-conversion.cts`, and `install-engine.cts`. Adding the first
+exception weakens it permanently for every downstream tool.
+
+### 2. The capability system was built for exactly this
+
+ADR-857 Decision 4 defines the `contribution` hook kind specifically so that
+prompt-woven behavior can live outside core: *"without `contribution`,
+prompt-woven features (security threat-model, TDD, schema gate) could never
+leave the core."* Decision 5 delivers the prose to the agent via
+`loop.render-hooks <point>`, which returns fully-rendered ordered markdown.
+
+Contribution-only capabilities already ship — `capabilities/assumption-delta/`
+and `capabilities/schema-gate/` declare `skills: []`, `agents: []`, `hooks:
+[]`, `steps: []`, `gates: []` and extend solely through a `contributions` entry
+pointing at a prose fragment, gated on a config key. That is the same shape
+these proposals ask for, at roughly one-sixth the file cost of a skill: ~7
+files against ~45. The skill side is dominated by per-runtime fixtures — 19
+under `tests/fixtures/install-tree/` plus 19 under
+`tests/fixtures/golden-install-parity/`, one per supported runtime, 38 in
+total — then `docs/INVENTORY.md`, `docs/INVENTORY-MANIFEST.json`,
+`docs/COMMANDS.md`, `docs/FEATURES.md`, and `workflow-size-baseline.json` on
+top. (Fixture counts verified 2026-07-24; they grow with each supported
+runtime, so re-count rather than citing these numbers forward.)
+
+Since 1.6.0, capabilities install from a URL, git ref, npm package, or local
+path with no core repo modification (ADR-1244 D3), and the Community Capability
+Registry provides non-endorsing public discoverability through a documentation
+PR. The author retains ownership, versioning, and release cadence.
+
+### 3. Delivering it as a flag on existing commands is strictly worse
+
+Evaluated and rejected as the alternative. Flag-gated prose injection is an
+established idiom (`gsd-core/workflows/plan-phase.md:792-796` injects a whole
+instruction block under `${MVP_MODE === 'true' ? … : ''}`), but the cost
+multiplies by subset size: each command needs frontmatter `argument-hint`, a
+workflow parse-and-branch, a `help/modes/full.md` entry, a `docs/COMMANDS.md`
+row, and a hand-written test — there is no generic `COMMANDS.md` parity gate,
+so enforcement is bespoke per feature. It also requires the flag on every
+invocation, where a capability config key is set once. A capability's
+`contributions[]` array already expresses "apply at this chosen subset of
+surfaces" natively, declared once.
+
+### 4. The core of these asks is measured as weak
+
+Self-judged confidence reporting — the usual centerpiece of these proposals —
+was measured in this project and found weak.
+`gsd-core/references/honest-verifier.md:25-29`: *"Asking the verifier to
+'abstain if unsure' barely moves the number (100% → 67%) and only on ambiguity
+it already notices; on a true blind spot it stays confidently wrong."* That
+result is why `honest-verifier.md` routes on an exogenous upstream tag and
+contains no "are you sure?" prompt.
+
+Structural output instructions (separate facts from inferences from assumptions
+from unknowns; do not invent evidence; skip on casual work) are unaffected by
+this finding. Self-rated confidence is not. Core will not adopt a discipline
+whose central mechanism its own evidence rates as ineffective; a capability is
+the correct venue to try it and gather real data.
+
+**Revisit if** either of these becomes true — both are checkable, not
+judgment calls:
+
+1. A general agent-discipline module ships as a capability and reports a
+   measured result on the same axis `honest-verifier.md:25-29` measured: a
+   blind-spot set the model does *not* already flag as ambiguous, scored
+   against a held-out reference set, beating the ~67% baseline recorded there.
+   Self-reported improvement, anecdotes, or gains only on
+   already-noticed ambiguity do not meet this bar — that is precisely the
+   result the existing evidence already produced.
+2. `skills/` stops being a 1:1 projection of `commands/gsd/` — i.e.
+   `scripts/gen-plugin-skills.cjs` no longer generates the tree, or an ADR
+   ratifies hand-authored skills. At that point reason 1 lapses on its own and
+   this entry must be re-derived from reasons 2-4 alone.
+
+## Prior requests
+
+- #2614 — "feat: add an opt-in truth-prompt skill for evidence-aware decisions"


### PR DESCRIPTION
<!-- pr-template-exempt: doc-only — adds one `.out-of-scope/` knowledge-base document. No code, no runtime-loaded text, no behavior change. None of the fix/enhancement/feature templates applies to a documentation record. -->

## What this does

Records the `wontfix` disposition for #2614 in the rejected-capability knowledge base: `.out-of-scope/general-purpose-agent-prompt-skills.md`.

GSD core does not take standalone, general-purpose agent-discipline prompt modules — prose instructing an agent *how to think* that is not attached to a specific command or loop step. Those belong in the capability ecosystem, authored and distributed by their authors. The issue was closed with the full routing (capability docs, publishing flow, registry submission steps) posted for the reporter.

Doc-only: one new markdown file, no code, nothing the runtime loads.

## Why this entry exists

`.out-of-scope/` is consulted by `/triage-review` on every future triage run, so the reasoning has to be recorded rather than left in a closed-issue comment. Three grounds, each verified against the live tree:

1. **`skills/` is a generated projection, not an authoring surface.** Built from `commands/gsd/*.md` by `scripts/gen-plugin-skills.cjs` (71 → 71, identical membership) and gated by `npm run lint:generated-sync` → `gen-plugin-skills.cjs --check`. A hand-authored `SKILL.md` fails CI and is not reproduced by a regeneration.
2. **The capability system was built for exactly this.** ADR-857 Decision 4: *"without `contribution`, prompt-woven features (security threat-model, TDD, schema gate) could never leave the core."* `capabilities/assumption-delta/` and `capabilities/schema-gate/` already ship as contribution-only capabilities — all five extension arrays empty, extending solely through a prose fragment gated on a config key.
3. **The mechanism at the center of these asks is measured weak.** `gsd-core/references/honest-verifier.md:25-29` records that self-judged confidence framing *"barely moves the number (100% → 67%) and only on ambiguity it already notices; on a true blind spot it stays confidently wrong."* That is why `honest-verifier.md` routes on an exogenous tag instead.

## Scope guard

The entry carries an explicit **"What this does NOT cover"** section, because its keyword surface ("confidence", "assumptions", "reasoning style") overlaps request types this decision deliberately does not deny — loop-step-attached fixes to an existing agent's own language, externally-measured calibration, and structural output-format contracts attached to a real surface. Without that section a future keyword match could misapply the entry.

The **Revisit if** condition is stated as two checkable tests rather than a judgment call, one of them scored against the `honest-verifier.md` baseline.

## Verification

- `npm run lint:ci` — exits 0 (full gate: eslint, skill-deps, generated-sync, test-file-count, command-contract, regression-test-names, portable-timeout, registry validation, table-schema-drift, and the rest).
- `node scripts/changeset/lint.cjs` — `ok_no_user_facing_changes` (no changeset required; no user-facing code diff).
- `node scripts/lint-docs-required.cjs` — `ok_no_triggering_fragments`.
- Two orthogonal review passes, both in isolated reviewer contexts that did not author the change:
  - **Correctness** — verified all 11 factual claims against the live tree. Found two real defects, both fixed here: the per-runtime fixture count was wrong (**19 + 19 = 38**, not 15 + 15) and the denial scope was under-qualified. The corrected entry also flags that the counts grow per supported runtime and should be re-counted rather than cited forward.
  - **Security** — clean, no findings. Checked instruction smuggling, tag/markup collision, secrets/PII, link safety, untrusted-content provenance against the source issue, and control disclosure.

## Note for maintainers (not fixed here)

`CLAUDE.md` describes the installer as covering "all 15 runtimes"; the live fixture set is 19. That line is stale. Not touched by this PR — flagging so the decision is yours.

Closes #2614

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2633"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787539411&installation_model_id=22188&pr_number=2633&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2633&signature=dfa5ff0f3dde01a897f0a232cf4cb6c6795364f5727f1ef521384438072e9b11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->