### PR TITLE
fix(#2517): plan-phase omits model= when *_model is inherit/empty (port execute-phase fix)

### DIFF
--- a/.changeset/quick-eagles-wander.md
+++ b/.changeset/quick-eagles-wander.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`/gsd-plan-phase` no longer 404s on non-Claude runtimes with `model_profile:"inherit"` + `resolve_model_ids:"omit"`** — the workflow passed `model="{planner_model}"` (and researcher_model/checker_model) verbatim into Agent() calls, so when the resolved model was empty it sent `model=""` and the runtime fell back to an unavailable Claude model → 404. plan-phase now mirrors execute-phase: when a `*_model` is "inherit" or empty, the `model=` param is omitted so the subagent inherits the orchestrator model. (#2517)

--- a/.changeset/quick-eagles-wander.md
+++ b/.changeset/quick-eagles-wander.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 2634
 ---
 **`/gsd-plan-phase` no longer 404s on non-Claude runtimes with `model_profile:"inherit"` + `resolve_model_ids:"omit"`** — the workflow passed `model="{planner_model}"` (and researcher_model/checker_model) verbatim into Agent() calls, so when the resolved model was empty it sent `model=""` and the runtime fell back to an unavailable Claude model → 404. plan-phase now mirrors execute-phase: when a `*_model` is "inherit" or empty, the `model=` param is omitted so the subagent inherits the orchestrator model. (#2517)

--- a/gsd-core/workflows/plan-phase.md
+++ b/gsd-core/workflows/plan-phase.md
@@ -79,9 +79,11 @@ MVP_MODE_CFG=$(gsd_run query config-get workflow.mvp_mode 2>/dev/null || echo "f
 
 When the tdd capability's `workflow.tdd_mode` is active (resolved via the plan:pre render-hooks), the planner agent is instructed to apply `type: tdd` to eligible tasks using heuristics from `references/tdd.md`. The TDD guidance is injected via the tdd capability's contribution hook at §5.6; no inline config-get is needed.
 
-When `CONTEXT_WINDOW >= 500000`, the planner prompt includes the 3 most recent prior phase CONTEXT.md and SUMMARY.md files PLUS any phases explicitly listed in the current phase's `Depends on:` field in ROADMAP.md. Explicit dependencies always load regardless of recency (e.g., Phase 7 declaring `Depends on: Phase 2` always sees Phase 2's context). Bounded recency keeps the planner's context budget focused on recent work.
+When `CONTEXT_WINDOW >= 500000`, the planner prompt includes the 3 most recent prior-phase CONTEXT.md/SUMMARY.md files plus any phases in the current phase's `Depends on:` field (explicit deps load regardless of recency).
 
 Parse JSON for: `researcher_model`, `planner_model`, `checker_model`, `research_enabled`, `plan_checker_enabled`, `nyquist_validation_enabled`, `commit_docs`, `text_mode`, `phase_found`, `phase_dir`, `phase_number`, `phase_name`, `phase_slug`, `padded_phase`, `has_research`, `has_context`, `has_reviews`, `has_plans`, `plan_count`, `phase_status` (#3569), `planning_exists`, `roadmap_exists`, `phase_req_ids`, `response_language`, `granularity`.
+
+**#2517:** omit the `model=` param from an `Agent()` call when its `researcher`/`planner`/`checker`_model is `"inherit"` or empty — passing `model=""` 404s on non-Claude runtimes; omitting inherits the orchestrator model (mirrors execute-phase).
 
 **If `response_language` is set:** All user-facing orchestrator output MUST be in `{response_language}`; technical terms, code, paths, and subagent prompts stay in English. Pass `response_language: {value}` into every spawned subagent prompt.
 

--- a/tests/fixtures/golden-install-parity/antigravity.json
+++ b/tests/fixtures/golden-install-parity/antigravity.json
@@ -285,7 +285,7 @@
   "gsd-core/workflows/onboard.md": "af12b0573b14ce7f",
   "gsd-core/workflows/pause-work.md": "564de32981a24337",
   "gsd-core/workflows/plan-milestone-gaps.md": "dd6a4b3a8b05ab6e",
-  "gsd-core/workflows/plan-phase.md": "53496a9c8579f1b3",
+  "gsd-core/workflows/plan-phase.md": "7c75d6eaccd0d393",
   "gsd-core/workflows/plan-phase/steps/closed-phase-gate.md": "4099ef6d0868de60",
   "gsd-core/workflows/plan-phase/steps/prd-express-path.md": "ab0b22244c3389aa",
   "gsd-core/workflows/plan-phase/steps/windows-troubleshooting.md": "e9de7a96bbfff261",

--- a/tests/fixtures/golden-install-parity/augment.json
+++ b/tests/fixtures/golden-install-parity/augment.json
@@ -356,7 +356,7 @@
   "gsd-core/workflows/onboard.md": "f29c4fbef3b473fd",
   "gsd-core/workflows/pause-work.md": "f2b33bba5593d422",
   "gsd-core/workflows/plan-milestone-gaps.md": "852f6d7c0c4299dc",
-  "gsd-core/workflows/plan-phase.md": "3cbfe22b74af0c9e",
+  "gsd-core/workflows/plan-phase.md": "7487bfc69d75cdfa",
   "gsd-core/workflows/plan-phase/steps/closed-phase-gate.md": "b36f77ac7344a072",
   "gsd-core/workflows/plan-phase/steps/prd-express-path.md": "197c0590326371b2",
   "gsd-core/workflows/plan-phase/steps/windows-troubleshooting.md": "49f58c3f75be3eb5",

--- a/tests/fixtures/golden-install-parity/claude-local.json
+++ b/tests/fixtures/golden-install-parity/claude-local.json
@@ -355,7 +355,7 @@
   "gsd-core/workflows/onboard.md": "f7d0dbcfd94ab130",
   "gsd-core/workflows/pause-work.md": "da902807d2213204",
   "gsd-core/workflows/plan-milestone-gaps.md": "7679fac068d1009d",
-  "gsd-core/workflows/plan-phase.md": "03899e27eae202b7",
+  "gsd-core/workflows/plan-phase.md": "06016fe9285bf9db",
   "gsd-core/workflows/plan-phase/steps/closed-phase-gate.md": "4099ef6d0868de60",
   "gsd-core/workflows/plan-phase/steps/prd-express-path.md": "b810f9f2374e23a5",
   "gsd-core/workflows/plan-phase/steps/windows-troubleshooting.md": "e9de7a96bbfff261",

--- a/tests/fixtures/golden-install-parity/claude.json
+++ b/tests/fixtures/golden-install-parity/claude.json
@@ -284,7 +284,7 @@
   "gsd-core/workflows/onboard.md": "0f0af11294d31715",
   "gsd-core/workflows/pause-work.md": "5716362557f44ce4",
   "gsd-core/workflows/plan-milestone-gaps.md": "1b43d12812f7bc1e",
-  "gsd-core/workflows/plan-phase.md": "ca7715514cde5746",
+  "gsd-core/workflows/plan-phase.md": "b83d7c220f132cc9",
   "gsd-core/workflows/plan-phase/steps/closed-phase-gate.md": "4099ef6d0868de60",
   "gsd-core/workflows/plan-phase/steps/prd-express-path.md": "197c0590326371b2",
   "gsd-core/workflows/plan-phase/steps/windows-troubleshooting.md": "e9de7a96bbfff261",

--- a/tests/fixtures/golden-install-parity/cline.json
+++ b/tests/fixtures/golden-install-parity/cline.json
@@ -288,7 +288,7 @@
   "gsd-core/workflows/onboard.md": "f29c4fbef3b473fd",
   "gsd-core/workflows/pause-work.md": "3530607514b0ac00",
   "gsd-core/workflows/plan-milestone-gaps.md": "bafdc6945cd2bd87",
-  "gsd-core/workflows/plan-phase.md": "21524c06360149fd",
+  "gsd-core/workflows/plan-phase.md": "acb779981626bef8",
   "gsd-core/workflows/plan-phase/steps/closed-phase-gate.md": "b36f77ac7344a072",
   "gsd-core/workflows/plan-phase/steps/prd-express-path.md": "4b0a2cb0f4f28179",
   "gsd-core/workflows/plan-phase/steps/windows-troubleshooting.md": "090c31e22b1508fe",

--- a/tests/fixtures/golden-install-parity/codebuddy.json
+++ b/tests/fixtures/golden-install-parity/codebuddy.json
@@ -356,7 +356,7 @@
   "gsd-core/workflows/onboard.md": "f29c4fbef3b473fd",
   "gsd-core/workflows/pause-work.md": "f2b33bba5593d422",
   "gsd-core/workflows/plan-milestone-gaps.md": "852f6d7c0c4299dc",
-  "gsd-core/workflows/plan-phase.md": "928bb3063d1507f6",
+  "gsd-core/workflows/plan-phase.md": "ad8c507f0c8910ad",
   "gsd-core/workflows/plan-phase/steps/closed-phase-gate.md": "b36f77ac7344a072",
   "gsd-core/workflows/plan-phase/steps/prd-express-path.md": "197c0590326371b2",
   "gsd-core/workflows/plan-phase/steps/windows-troubleshooting.md": "49f58c3f75be3eb5",

--- a/tests/fixtures/golden-install-parity/codex.json
+++ b/tests/fixtures/golden-install-parity/codex.json
@@ -391,7 +391,7 @@
   "gsd-core/workflows/onboard.md": "f022a379ede13512",
   "gsd-core/workflows/pause-work.md": "a217770ecafcb2e0",
   "gsd-core/workflows/plan-milestone-gaps.md": "73d46f77c50a0690",
-  "gsd-core/workflows/plan-phase.md": "db2321e1fe2d6dc1",
+  "gsd-core/workflows/plan-phase.md": "7302646bb14b5326",
   "gsd-core/workflows/plan-phase/steps/closed-phase-gate.md": "d838b87563feedf6",
   "gsd-core/workflows/plan-phase/steps/prd-express-path.md": "f10975692cbd036e",
   "gsd-core/workflows/plan-phase/steps/windows-troubleshooting.md": "f5edc589cab52a7b",

--- a/tests/fixtures/golden-install-parity/copilot.json
+++ b/tests/fixtures/golden-install-parity/copilot.json
@@ -286,7 +286,7 @@
   "gsd-core/workflows/onboard.md": "357b7ae1367560dd",
   "gsd-core/workflows/pause-work.md": "9ce66367be6c40db",
   "gsd-core/workflows/plan-milestone-gaps.md": "5cf589802d08bdf3",
-  "gsd-core/workflows/plan-phase.md": "4f7029a1fa02ab44",
+  "gsd-core/workflows/plan-phase.md": "4bf4ae1e25fc3a11",
   "gsd-core/workflows/plan-phase/steps/closed-phase-gate.md": "4099ef6d0868de60",
   "gsd-core/workflows/plan-phase/steps/prd-express-path.md": "bb052483744f0a6d",
   "gsd-core/workflows/plan-phase/steps/windows-troubleshooting.md": "e9de7a96bbfff261",

--- a/tests/fixtures/golden-install-parity/cursor.json
+++ b/tests/fixtures/golden-install-parity/cursor.json
@@ -356,7 +356,7 @@
   "gsd-core/workflows/onboard.md": "7d0c7449b84c7997",
   "gsd-core/workflows/pause-work.md": "5716362557f44ce4",
   "gsd-core/workflows/plan-milestone-gaps.md": "1b43d12812f7bc1e",
-  "gsd-core/workflows/plan-phase.md": "d2ef5faae799aed1",
+  "gsd-core/workflows/plan-phase.md": "aaf2a8f5851b9d62",
   "gsd-core/workflows/plan-phase/steps/closed-phase-gate.md": "e06ccd4d4c0703fb",
   "gsd-core/workflows/plan-phase/steps/prd-express-path.md": "197c0590326371b2",
   "gsd-core/workflows/plan-phase/steps/windows-troubleshooting.md": "3bed01c3c906ac52",

--- a/tests/fixtures/golden-install-parity/hermes.json
+++ b/tests/fixtures/golden-install-parity/hermes.json
@@ -285,7 +285,7 @@
   "gsd-core/workflows/onboard.md": "0f0af11294d31715",
   "gsd-core/workflows/pause-work.md": "ae2d5789a95f70fe",
   "gsd-core/workflows/plan-milestone-gaps.md": "c86cdc1964256b98",
-  "gsd-core/workflows/plan-phase.md": "90211e1a215b934f",
+  "gsd-core/workflows/plan-phase.md": "0e72c03f10c29c7e",
   "gsd-core/workflows/plan-phase/steps/closed-phase-gate.md": "4099ef6d0868de60",
   "gsd-core/workflows/plan-phase/steps/prd-express-path.md": "9607e6d03e93c1c2",
   "gsd-core/workflows/plan-phase/steps/windows-troubleshooting.md": "62f8e4f3b475fe5f",

--- a/tests/fixtures/golden-install-parity/kilo.json
+++ b/tests/fixtures/golden-install-parity/kilo.json
@@ -356,7 +356,7 @@
   "gsd-core/workflows/onboard.md": "c8d9795021d4fce6",
   "gsd-core/workflows/pause-work.md": "a6e5336c409fdc8b",
   "gsd-core/workflows/plan-milestone-gaps.md": "1b43d12812f7bc1e",
-  "gsd-core/workflows/plan-phase.md": "9f00e15cf5836178",
+  "gsd-core/workflows/plan-phase.md": "a149455c8d3a293c",
   "gsd-core/workflows/plan-phase/steps/closed-phase-gate.md": "4099ef6d0868de60",
   "gsd-core/workflows/plan-phase/steps/prd-express-path.md": "f10975692cbd036e",
   "gsd-core/workflows/plan-phase/steps/windows-troubleshooting.md": "e9de7a96bbfff261",

--- a/tests/fixtures/golden-install-parity/kimi-code.json
+++ b/tests/fixtures/golden-install-parity/kimi-code.json
@@ -313,7 +313,7 @@
   "gsd-core/workflows/onboard.md": "f29c4fbef3b473fd",
   "gsd-core/workflows/pause-work.md": "f2b33bba5593d422",
   "gsd-core/workflows/plan-milestone-gaps.md": "852f6d7c0c4299dc",
-  "gsd-core/workflows/plan-phase.md": "2fec63c2e99a16a7",
+  "gsd-core/workflows/plan-phase.md": "2809df9f75f00676",
   "gsd-core/workflows/plan-phase/steps/closed-phase-gate.md": "b36f77ac7344a072",
   "gsd-core/workflows/plan-phase/steps/prd-express-path.md": "197c0590326371b2",
   "gsd-core/workflows/plan-phase/steps/windows-troubleshooting.md": "49f58c3f75be3eb5",

--- a/tests/fixtures/golden-install-parity/kimi.json
+++ b/tests/fixtures/golden-install-parity/kimi.json
@@ -349,7 +349,7 @@
   "gsd-core/workflows/onboard.md": "f29c4fbef3b473fd",
   "gsd-core/workflows/pause-work.md": "f2b33bba5593d422",
   "gsd-core/workflows/plan-milestone-gaps.md": "852f6d7c0c4299dc",
-  "gsd-core/workflows/plan-phase.md": "2fec63c2e99a16a7",
+  "gsd-core/workflows/plan-phase.md": "2809df9f75f00676",
   "gsd-core/workflows/plan-phase/steps/closed-phase-gate.md": "b36f77ac7344a072",
   "gsd-core/workflows/plan-phase/steps/prd-express-path.md": "197c0590326371b2",
   "gsd-core/workflows/plan-phase/steps/windows-troubleshooting.md": "49f58c3f75be3eb5",

--- a/tests/fixtures/golden-install-parity/opencode.json
+++ b/tests/fixtures/golden-install-parity/opencode.json
@@ -356,7 +356,7 @@
   "gsd-core/workflows/onboard.md": "ca3a59a2e36b829a",
   "gsd-core/workflows/pause-work.md": "70c72beca55c080a",
   "gsd-core/workflows/plan-milestone-gaps.md": "0a9dacd422cd9533",
-  "gsd-core/workflows/plan-phase.md": "a8ea957ca0248763",
+  "gsd-core/workflows/plan-phase.md": "8cc195c679a9349a",
   "gsd-core/workflows/plan-phase/steps/closed-phase-gate.md": "4099ef6d0868de60",
   "gsd-core/workflows/plan-phase/steps/prd-express-path.md": "3a09141de7f3dedb",
   "gsd-core/workflows/plan-phase/steps/windows-troubleshooting.md": "e9de7a96bbfff261",

--- a/tests/fixtures/golden-install-parity/pi.json
+++ b/tests/fixtures/golden-install-parity/pi.json
@@ -252,7 +252,7 @@
   "gsd-core/workflows/onboard.md": "f29c4fbef3b473fd",
   "gsd-core/workflows/pause-work.md": "f2b33bba5593d422",
   "gsd-core/workflows/plan-milestone-gaps.md": "852f6d7c0c4299dc",
-  "gsd-core/workflows/plan-phase.md": "0ce663fd2e5b81db",
+  "gsd-core/workflows/plan-phase.md": "4c9670c21445ef15",
   "gsd-core/workflows/plan-phase/steps/closed-phase-gate.md": "b36f77ac7344a072",
   "gsd-core/workflows/plan-phase/steps/prd-express-path.md": "197c0590326371b2",
   "gsd-core/workflows/plan-phase/steps/windows-troubleshooting.md": "49f58c3f75be3eb5",

--- a/tests/fixtures/golden-install-parity/qwen.json
+++ b/tests/fixtures/golden-install-parity/qwen.json
@@ -285,7 +285,7 @@
   "gsd-core/workflows/onboard.md": "0f0af11294d31715",
   "gsd-core/workflows/pause-work.md": "be33f84dc1d4822f",
   "gsd-core/workflows/plan-milestone-gaps.md": "d98e98486123eb97",
-  "gsd-core/workflows/plan-phase.md": "85db7d3b0e90dcaf",
+  "gsd-core/workflows/plan-phase.md": "4ba6968762e95ac6",
   "gsd-core/workflows/plan-phase/steps/closed-phase-gate.md": "4099ef6d0868de60",
   "gsd-core/workflows/plan-phase/steps/prd-express-path.md": "c22ff5ea46de665a",
   "gsd-core/workflows/plan-phase/steps/windows-troubleshooting.md": "d050d8d551ed1756",

--- a/tests/fixtures/golden-install-parity/trae.json
+++ b/tests/fixtures/golden-install-parity/trae.json
@@ -285,7 +285,7 @@
   "gsd-core/workflows/onboard.md": "015695a7e9cf59bc",
   "gsd-core/workflows/pause-work.md": "c20d267e28ce92f0",
   "gsd-core/workflows/plan-milestone-gaps.md": "26db7b9329b7ddc8",
-  "gsd-core/workflows/plan-phase.md": "e12bc84e84c75bd4",
+  "gsd-core/workflows/plan-phase.md": "199e9ac7147cdafb",
   "gsd-core/workflows/plan-phase/steps/closed-phase-gate.md": "e06ccd4d4c0703fb",
   "gsd-core/workflows/plan-phase/steps/prd-express-path.md": "778b73a8db6f7c32",
   "gsd-core/workflows/plan-phase/steps/windows-troubleshooting.md": "619946c879f33b9d",

--- a/tests/fixtures/golden-install-parity/windsurf.json
+++ b/tests/fixtures/golden-install-parity/windsurf.json
@@ -285,7 +285,7 @@
   "gsd-core/workflows/onboard.md": "7d0c7449b84c7997",
   "gsd-core/workflows/pause-work.md": "93fcc1c845da6396",
   "gsd-core/workflows/plan-milestone-gaps.md": "7880866ee1caf923",
-  "gsd-core/workflows/plan-phase.md": "99587a639eb7b88b",
+  "gsd-core/workflows/plan-phase.md": "a47b8a4e649fbc14",
   "gsd-core/workflows/plan-phase/steps/closed-phase-gate.md": "e06ccd4d4c0703fb",
   "gsd-core/workflows/plan-phase/steps/prd-express-path.md": "80b1ba493a9a967f",
   "gsd-core/workflows/plan-phase/steps/windows-troubleshooting.md": "3fed4740a91d0443",

--- a/tests/fixtures/golden-install-parity/zcode.json
+++ b/tests/fixtures/golden-install-parity/zcode.json
@@ -356,7 +356,7 @@
   "gsd-core/workflows/onboard.md": "f29c4fbef3b473fd",
   "gsd-core/workflows/pause-work.md": "f2b33bba5593d422",
   "gsd-core/workflows/plan-milestone-gaps.md": "852f6d7c0c4299dc",
-  "gsd-core/workflows/plan-phase.md": "a0b77f6c2d9b9dd4",
+  "gsd-core/workflows/plan-phase.md": "c5ef714f47d857dc",
   "gsd-core/workflows/plan-phase/steps/closed-phase-gate.md": "b36f77ac7344a072",
   "gsd-core/workflows/plan-phase/steps/prd-express-path.md": "197c0590326371b2",
   "gsd-core/workflows/plan-phase/steps/windows-troubleshooting.md": "49f58c3f75be3eb5",

--- a/tests/model-omit-when-inherit-guard.test.cjs
+++ b/tests/model-omit-when-inherit-guard.test.cjs
@@ -1,0 +1,35 @@
+// allow-test-rule: structural-regression-guard see #2517
+// Guards the omit-when-inherit fix: plan-phase.md and execute-phase.md must instruct
+// the agent to OMIT the model= param from Agent() calls when the *_model var is
+// "inherit" or empty. Without it, model="" is passed verbatim and 404s on non-Claude
+// runtimes (resolve_model_ids:"omit" + model_profile:"inherit" → empty model string).
+// execute-phase had the fix; plan-phase was missing it (#2517).
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '..');
+
+// Each orchestrator that spawns model-tagged subagents must carry the rule.
+const GUARDED = [
+  'gsd-core/workflows/plan-phase.md',
+  'gsd-core/workflows/execute-phase.md',
+];
+
+test('#2517: plan-phase/execute-phase document omitting model= when *_model is inherit/empty', () => {
+  for (const rel of GUARDED) {
+    const content = fs.readFileSync(path.join(ROOT, rel), 'utf8');
+    // The rule: "omit the model= param ... when *_model is inherit/empty".
+    // Require "omit" near "model=" AND "inherit" present — the three signals of the rule.
+    const omitNearModel = /omit[\s\S]{0,200}model=|model=[\s\S]{0,200}omit/i.test(content);
+    assert.ok(
+      omitNearModel && /inherit/i.test(content),
+      `${rel}: must instruct the agent to OMIT the model= param from Agent() calls when the ` +
+        `*_model var is "inherit" or empty (#2517) — else model="" 404s on non-Claude runtimes ` +
+        `(resolve_model_ids:"omit" + model_profile:"inherit" yields an empty model string).`,
+    );
+  }
+});

--- a/tests/workflow-size-baseline.json
+++ b/tests/workflow-size-baseline.json
@@ -53,7 +53,7 @@
   "onboard.md": 8877,
   "pause-work.md": 14441,
   "plan-milestone-gaps.md": 11809,
-  "plan-phase.md": 94399,
+  "plan-phase.md": 94445,
   "plan-review-convergence.md": 26285,
   "plant-seed.md": 12150,
   "pr-branch.md": 15963,


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #2517

> The linked issue carries the `confirmed-bug` label.

---

## What was broken

`/gsd-plan-phase` passed `model="{planner_model}"` (and `researcher_model`/`checker_model`) verbatim into its `Agent()` calls. With `model_profile:"inherit"` + `resolve_model_ids:"omit"`, the resolved model is an empty string → `model=""` is sent to the runtime, which falls back to an unavailable Claude model → **404 on non-Claude runtimes** (e.g. Oh My Pi). `execute-phase.md` already had the fix (a "Model resolution" note instructing the agent to omit `model=` when the value is `"inherit"`); `plan-phase.md` was missing it.

## What this fix does

- Added a centralized note in `gsd-core/workflows/plan-phase.md` (at the model-var parse context): **omit the `model=` param from an `Agent()` call when its `researcher`/`planner`/`checker`_model is `"inherit"` or empty** — `model=""` 404s on non-Claude runtimes; omitting inherits the orchestrator model (mirrors execute-phase).
- Compressed a verbose CONTEXT_WINDOW prose line to keep `plan-phase.md` under its 94,519-byte frozen ceiling (74-byte headroom post-fix). Per-site inline comments (8 sites) were intentionally omitted — they're mathematically infeasible against the ~120-byte pre-fix headroom, and execute-phase itself relies on its centralized note rather than annotating every site.
- Added `tests/model-omit-when-inherit-guard.test.cjs` — asserts **both** plan-phase.md and execute-phase.md document the omit-when-inherit `model=` rule.
- Regenerated install-parity goldens + the workflow-size baseline.

## Root cause

plan-phase.md never received the omit-when-inherit/empty guard that execute-phase.md got; the empty model string flowed straight into `Agent()`.

## Testing

### How I verified the fix

- The guard test passes on the fixed tree and fails if the note is removed from plan-phase.md (`inherit` appears only in the new note).
- All three `*_model` vars used in plan-phase Agent() calls (researcher/planner/checker) are named by the note — no missed var.
- `gsd-test` outcome:"passed" on this HEAD (both Linux lanes, 0 failures).

### Regression test added?

- [x] Yes — `tests/model-omit-when-inherit-guard.test.cjs` pins the rule in both plan-phase.md and execute-phase.md.

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux (gsd-test benches, Node 22 + 24)
- [ ] N/A

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [x] Other: the bug is non-Claude-runtime-specific (OMP); the fix is runtime-agnostic workflow prose.
- [ ] N/A

---

## Checklist

- [x] Issue linked above with `Fixes #2517`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug (plan-phase.md only; execute-phase already had the fix)
- [x] Regression test added
- [x] All existing tests pass (`gsd-test` outcome:"passed" on this HEAD)
- [x] `.changeset/` fragment added (`Fixed`)
- [x] No unnecessary dependencies added

## Review gates passed

- `/code-review` + `/security-review` (isolated subagent, combined): **APPROVE** — root-cause fix sound; all 8 `*_model` Agent sites covered by the centralized note; note-only approach justified by the strict 94,519-byte ceiling (74-byte headroom; per-site comments infeasible) and consistent with execute-phase's own pattern; guard genuinely fails if the note is removed; byte budget under the ceiling; no security surface.
- Full `lint-tests` chain: clean.

## Breaking changes

None. The note only changes behavior when a `*_model` resolves to `"inherit"`/empty (the broken case) — those calls now correctly omit `model=` instead of 404-ing.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2634"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787542072&installation_model_id=22188&pr_number=2634&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2634&signature=3f1b8cef7d05952f8286d7dad019e118a654c4c2446428d7be16d566aa6c024b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->