### PR TITLE
fix(#2522): fold wrapped success-criteria lines into their criterion

### DIFF
--- a/.changeset/agile-elks-glide.md
+++ b/.changeset/agile-elks-glide.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 2637
 ---
 **`roadmap get-phase` no longer drops success criteria that wrap onto a second line** — the parser broke the criteria run at any indented continuation line, truncating the wrapped criterion (losing its trailing `[REQ-ID]` tag) and silently dropping every criterion below it. `verify-work` and `plan-phase` consumed the shortened list, so a phase could be planned and certified complete against a strict subset of its own success criteria with nothing reporting the gap. Continuation lines now fold into their criterion; blank-line-separated criteria still parse. (#2522)

--- a/.changeset/agile-elks-glide.md
+++ b/.changeset/agile-elks-glide.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`roadmap get-phase` no longer drops success criteria that wrap onto a second line** — the parser broke the criteria run at any indented continuation line, truncating the wrapped criterion (losing its trailing `[REQ-ID]` tag) and silently dropping every criterion below it. `verify-work` and `plan-phase` consumed the shortened list, so a phase could be planned and certified complete against a strict subset of its own success criteria with nothing reporting the gap. Continuation lines now fold into their criterion; blank-line-separated criteria still parse. (#2522)

--- a/src/roadmap.cts
+++ b/src/roadmap.cts
@@ -175,10 +175,17 @@ function searchPhaseInContent(content: string, escapedPhase: string, phaseNum: s
   const modeMatch = section.match(/\*\*Mode(?::\*\*|\*\*:)\s*([^\n]+)/i);
   const mode = modeMatch ? modeMatch[1].trim().toLowerCase() : null;
 
-  // Extract success criteria as structured array
-  const criteriaMatch = section.match(/\*\*Success Criteria\*\*[^\n]*:\s*\n((?:\s*\d+\.\s*[^\n]+\n?)+)/i);
+  // Extract success criteria as structured array. A criterion may wrap onto extra
+  // indented lines (no `N.` prefix); those continuations must fold INTO their
+  // criterion, not end the run (#2522 — the old `(?:\s*\d+\.\s*[^\n]+)+` broke on a
+  // wrapped line, truncating it and silently dropping every criterion below it).
+  // `\n*` before each numbered line keeps blank-line-separated criteria working.
+  const criteriaMatch = section.match(
+    /\*\*Success Criteria\*\*[^\n]*:\s*\n((?:\n*[ \t]*\d+\.[^\n]*\n?(?:[ \t]+(?!\d+\.)[^\n]*\n?)*)+)/i);
   const success_criteria = criteriaMatch
-    ? criteriaMatch[1].trim().split('\n').map(line => line.replace(/^\s*\d+\.\s*/, '').trim()).filter(Boolean)
+    ? criteriaMatch[1].trim().split(/\n+(?=[ \t]*\d+\.)/)
+        .map(entry => entry.replace(/^\s*\d+\.\s*/, '').replace(/\s*\n\s*/g, ' ').trim())
+        .filter(Boolean)
     : [];
 
   return {

--- a/tests/roadmap.test.cjs
+++ b/tests/roadmap.test.cjs
@@ -621,6 +621,73 @@ describe('roadmap get-phase success criteria', () => {
     assert.ok(output.success_criteria[2].includes('Third criterion'), 'third criterion matches');
   });
 
+  test('#2522: wrapped success-criteria lines fold into their criterion (not dropped/truncated)', () => {
+    // A criterion that wraps onto an indented continuation line must fold INTO its
+    // criterion (retaining its trailing [REQ-ID]), and every criterion below the wrap
+    // must still be parsed. The old regex broke the run at the wrap, truncating
+    // criterion 2 mid-sentence (losing [A-02]) and silently dropping criterion 3.
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      [
+        '# Roadmap',
+        '',
+        '### Phase 9: T',
+        '**Goal**: g',
+        '**Success Criteria** (what must be TRUE):',
+        '  1. alpha. [A-01]',
+        '  2. beta which is long and',
+        '     wraps onto a second line. [A-02]',
+        '  3. gamma. [A-03]',
+        '**Plans**: TBD',
+        '',
+      ].join('\n')
+    );
+
+    const result = runGsdTools('roadmap get-phase 9', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.found, true, 'phase should be found');
+    assert.strictEqual(output.success_criteria.length, 3, 'all 3 criteria must parse — wrapped continuations must not drop/truncate (#2522)');
+    assert.ok(output.success_criteria[1].includes('wraps onto a second line'), 'the wrapped continuation must fold into criterion 2');
+    assert.ok(output.success_criteria[1].includes('[A-02]'), 'the wrapped criterion must retain its trailing [REQ-ID] tag (#2522)');
+    assert.ok(output.success_criteria[2].includes('[A-03]'), 'criterion 3 (below the wrap) must not be dropped (#2522)');
+    // Boundary: the parse must not bleed past the Success Criteria block.
+    assert.ok(!output.success_criteria.some(c => c.includes('TBD')), 'parse must not consume the **Plans** line');
+  });
+
+  test('#2522: blank-line-separated success criteria still parse (the continuation fix must not regress blank lines)', () => {
+    // Guard against the naive-form trap the issue flags: narrowing the leading
+    // whitespace to [ \t]* and splitting on \n would trade wrapped-line truncation
+    // for blank-line truncation. Blank lines between criteria must keep working.
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      [
+        '# Roadmap',
+        '',
+        '### Phase 1: T',
+        '**Goal**: g',
+        '**Success Criteria** (what must be TRUE):',
+        '  1. alpha. [A-01]',
+        '',
+        '  2. beta. [A-02]',
+        '',
+        '  3. gamma. [A-03]',
+        '**Plans**: TBD',
+        '',
+      ].join('\n')
+    );
+
+    const result = runGsdTools('roadmap get-phase 1', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.success_criteria.length, 3, 'blank-line-separated criteria must all parse (#2522 guard)');
+    assert.ok(output.success_criteria[0].includes('[A-01]'));
+    assert.ok(output.success_criteria[1].includes('[A-02]'));
+    assert.ok(output.success_criteria[2].includes('[A-03]'));
+  });
+
   test('returns empty array when no success criteria present', () => {
     fs.writeFileSync(
       path.join(tmpDir, '.planning', 'ROADMAP.md'),


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #2522

> The linked issue carries the `confirmed-bug` label.

---

## What was broken

`getRoadmapPhase` (`src/roadmap.cts`) parsed success criteria with a regex that required every line to start with `N.` — so a criterion wrapping onto an indented continuation line (no `N.`) **broke the run**: the wrapped criterion was truncated mid-sentence (losing its trailing `[REQ-ID]` tag) and **every criterion below it was silently dropped**. Exit 0, `found:true`, nothing on stderr → `verify-work`/`plan-phase` consumed the shortened list, so a phase could be planned and certified complete against a strict subset of its own success criteria with no error anywhere.

## What this fix does

- Widened the capture regex so an indented continuation line (not starting with `N.`) folds INTO its criterion, and changed the mapper to split on the next numbered line (`\n+(?=[ \t]*\d+\.)`) and join continuations with a space — preserving the `string[]` shape and the trailing `[REQ-ID]` tag.
- The `\n*` prefix on each numbered criterion keeps **blank-line-separated** criteria working (guards the trap where a naive fix trades wrapped-truncation for blank-line-truncation — the issue explicitly flags this).
- Added 2 regression tests to `tests/roadmap.test.cjs`: the wrapped-criteria case (length 3, `[A-02]` retained, criterion 3 not dropped, no bleed into `**Plans**:`) and a blank-line-separated case.

## Root cause

The regex repetition `(?:\s*\d+\.\s*[^\n]+)+` required every line to begin with `N.`; a wrapped continuation has no `N.`, so the `+` stopped and everything after was dropped.

## Testing

### How I verified the fix

- Traced the new regex across flat / wrapped / blank-line / digit-continuation / `**Plans**`-boundary cases; flat-case output is byte-identical to the old parser (no backward-compat regression).
- The wrapped test fails on the old code (length 2, `[A-02]` lost, criterion 3 dropped) and passes on the fix; the blank-line test guards the naive-fix trap.
- `gsd-test` outcome:"passed" on this HEAD (both Linux lanes, 0 failures).

### Regression test added?

- [x] Yes — wrapped-criteria + blank-line-separated fixtures in `tests/roadmap.test.cjs`.

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux (gsd-test benches, Node 22 + 24)
- [ ] N/A

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (core parser, runtime-independent)

---

## Checklist

- [x] Issue linked above with `Fixes #2522`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug (`getRoadmapPhase` success-criteria parse only)
- [x] Regression test added
- [x] All existing tests pass (`gsd-test` outcome:"passed" on this HEAD)
- [x] `.changeset/` fragment added (`Fixed`)
- [x] No unnecessary dependencies added

## Review gates passed

- `/code-review` + `/security-review` (isolated subagent, combined): **APPROVE** — regex correct across all fixtures; boundary bleed safe (capture stops at `**Plans**:` / next heading); multi-fold mapper correct; blank-line trap guarded; old-code red genuine; flat-case backward-compat byte-identical; no ReDoS (linear on pathological input); no injection surface.
- Full `lint-tests` chain: clean.

## Breaking changes

None. Output is unchanged for the common flat / blank-line cases; the only behavior delta is the previously-broken wrapped case (now parsed correctly instead of silently truncated).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2637"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787545189&installation_model_id=22188&pr_number=2637&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2637&signature=e2fa4542338bf4818c0753f2e158d7a3629e1600ceb8b25d5619071263f87332"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->