### PR TITLE
fix(#2523): normalize --files to repo-relative; reject out-of-repo; gate push on git-add exit

### DIFF
--- a/.changeset/lively-finches-leap.md
+++ b/.changeset/lively-finches-leap.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 2638
 ---
 **`query commit --files` now accepts absolute paths** — `cmdCommit` used `path.join(cwd, file)`, which concatenates instead of resetting on an absolute path, so absolute `--files` entries (e.g. the absolute `phase_dir` emitted by `init phase-op` since #2428) were joined to `cwd+absPath` (non-existent) and silently dropped as `nothing_to_commit` — and a mixed relative/absolute list committed the relative entries while reporting `committed:true`. Absolute paths are now normalized to repo-relative before staging/branch-detection, so they commit correctly and the phase-branch detection no longer matches digit-hyphen runs in the absolute prefix. (#2523)

--- a/.changeset/lively-finches-leap.md
+++ b/.changeset/lively-finches-leap.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`query commit --files` now accepts absolute paths** — `cmdCommit` used `path.join(cwd, file)`, which concatenates instead of resetting on an absolute path, so absolute `--files` entries (e.g. the absolute `phase_dir` emitted by `init phase-op` since #2428) were joined to `cwd+absPath` (non-existent) and silently dropped as `nothing_to_commit` — and a mixed relative/absolute list committed the relative entries while reporting `committed:true`. Absolute paths are now normalized to repo-relative before staging/branch-detection, so they commit correctly and the phase-branch detection no longer matches digit-hyphen runs in the absolute prefix. (#2523)

--- a/src/commands.cts
+++ b/src/commands.cts
@@ -769,6 +769,28 @@ function cmdCommit(cwd: string, message: string | undefined, files: string[] | u
     return;
   }
 
+  // Normalize --files to repo-relative paths (#2523). path.join(cwd, absPath)
+  // concatenates instead of resetting (path.resolve does), so absolute phase_dir
+  // paths emitted by init phase-op (#2428) were joined to cwd+absPath (non-existent)
+  // and silently dropped by the existence check — and a mixed relative/absolute list
+  // then committed the relative entries while reporting committed:true. Relative-izing
+  // also keeps the phase-branch detection below from matching digit-hyphen runs in the
+  // absolute prefix (e.g. /proj-7-decoy2/ → wrong phase branch).
+  const filesRel = files && files.length > 0
+    ? files.map(f => toPosixPath(path.relative(cwd, path.resolve(cwd, f))))
+    : [];
+  // Reject --files entries resolving OUTSIDE the project root: fail loudly rather
+  // than silently skip or reach `git add` (which rejects them and would pollute the
+  // index via an unconditional stagedPaths.push) (#2523). `toPosixPath` only flips
+  // backslashes, so a `..` escape is still detectable.
+  for (const rel of filesRel) {
+    if (rel.startsWith('..') || path.isAbsolute(rel)) {
+      const result = { committed: false, hash: null, reason: 'path_outside_repo', path: rel };
+      output(result, raw, 'failed');
+      return;
+    }
+  }
+
   // Ensure branching strategy branch exists before first commit (#1278).
   // Pre-execution workflows (discuss, plan, research) commit artifacts but the branch
   // was previously only created during execute-phase — too late.
@@ -777,7 +799,7 @@ function cmdCommit(cwd: string, message: string | undefined, files: string[] | u
     let branchName: string | null = null;
     if (branchingStrategy === 'phase') {
       // Determine which phase we're committing for from the file paths
-      const phaseMatch = (files || []).join(' ').match(/(\d+(?:\.\d+)*)-/);
+      const phaseMatch = (filesRel || []).join(' ').match(/(\d+(?:\.\d+)*)-/);
       if (phaseMatch) {
         const phaseNum = phaseMatch[1];
         const phaseInfo = findPhaseInternal(cwd, phaseNum) as Record<string, unknown> | null;
@@ -809,7 +831,7 @@ function cmdCommit(cwd: string, message: string | undefined, files: string[] | u
 
   // Stage files
   const explicitFiles = files && files.length > 0;
-  const filesToStage = explicitFiles ? files : ['.planning/'];
+  const filesToStage = explicitFiles ? filesRel : ['.planning/'];
   const stagedPaths: string[] = [];
   for (const file of filesToStage) {
     const fullPath = path.join(cwd, file);
@@ -824,8 +846,13 @@ function cmdCommit(cwd: string, message: string | undefined, files: string[] | u
       // removed planning files are not left dangling in the index.
       execGit(['rm', '--cached', '--ignore-unmatch', file], { cwd });
     } else {
-      execGit(['add', file], { cwd });
-      stagedPaths.push(file);
+      const addResult = execGit(['add', file], { cwd });
+      // Only record paths that actually staged — a failed `git add` (permissions,
+      // out-of-repo edge) must not enter the commit pathspec (#2523). Mirrors
+      // cmdCommitToSubrepo's exitCode-gated push.
+      if (addResult.exitCode === 0) {
+        stagedPaths.push(file);
+      }
     }
   }
 

--- a/tests/commit-files-pathspec.test.cjs
+++ b/tests/commit-files-pathspec.test.cjs
@@ -173,4 +173,66 @@ describe('commit --files: pathspec honors declared scope (#2112)', () => {
       'extra.txt should remain staged, not absorbed into a commit',
     );
   });
+
+  test('#2523: absolute --files path inside the repo is committed, not silently dropped', () => {
+    // init phase-op emits phase_dir as an ABSOLUTE path (#2428); cmdCommit must
+    // accept it. The bug was path.join(cwd, absPath) → cwd+absPath (non-existent)
+    // → silently skipped as nothing_to_commit (#2523).
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'A.md'), 'a\n');
+    const absPath = path.join(tmpDir, '.planning', 'A.md');
+    const res = runGsdTools(['commit', 'docs: abs path', '--files', absPath], tmpDir);
+    const parsed = JSON.parse(res.output);
+    assert.strictEqual(parsed.committed, true, `absolute path must commit, not nothing_to_commit: ${res.output}`);
+
+    // The absolute path must land in the commit, normalized to repo-relative.
+    const diff = execSync('git diff HEAD~1 HEAD --name-only', { cwd: tmpDir, encoding: 'utf-8' }).trim();
+    assert.strictEqual(diff, '.planning/A.md', `absolute --files path must be committed (normalized to relative); got: ${diff}`);
+  });
+
+  test('#2523: mixed relative+absolute --files list commits BOTH (no silent partial commit)', () => {
+    // The sharpest symptom: a mixed list committed the relative entry, dropped the
+    // absolute one, and reported committed:true (#2523). Both must land.
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'REL.md'), 'r\n');
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'ABS.md'), 'a\n');
+    const absPath = path.join(tmpDir, '.planning', 'ABS.md');
+    const res = runGsdTools(
+      ['commit', 'docs: mixed', '--files', '.planning/REL.md', absPath],
+      tmpDir,
+    );
+    const parsed = JSON.parse(res.output);
+    assert.strictEqual(parsed.committed, true, `mixed list must commit: ${res.output}`);
+
+    const diff = execSync('git diff HEAD~1 HEAD --name-only', { cwd: tmpDir, encoding: 'utf-8' })
+      .trim().split('\n').sort();
+    assert.deepStrictEqual(
+      diff,
+      ['.planning/ABS.md', '.planning/REL.md'],
+      `mixed relative+absolute list must commit BOTH entries (the bug dropped the absolute one); got: ${diff.join(',')}`,
+    );
+  });
+
+  test('#2523: out-of-repo --files path is rejected loudly (path_outside_repo), no index pollution', (t) => {
+    // An absolute path resolving OUTSIDE the project root must fail loudly, not
+    // silently skip and not pollute the index via a failed git add (#2523).
+    const outsideDir = path.join(tmpDir, '..', `gsd-2523-outside-${process.pid}-${Date.now()}`);
+    fs.mkdirSync(outsideDir, { recursive: true });
+    t.after(() => cleanup(outsideDir));
+    const outsideFile = path.join(outsideDir, 'secret.md');
+    fs.writeFileSync(outsideFile, 's\n');
+
+    const res = runGsdTools(
+      ['commit', 'docs: outside', '--files', path.resolve(outsideFile)],
+      tmpDir,
+    );
+    const parsed = JSON.parse(res.output);
+    assert.strictEqual(parsed.committed, false, 'out-of-repo path must not commit');
+    assert.strictEqual(parsed.reason, 'path_outside_repo', `out-of-repo path must fail loudly: ${res.output}`);
+
+    // No new commit created (still at the single initial commit).
+    const logCount = execSync('git rev-list --count HEAD', { cwd: tmpDir, encoding: 'utf-8' }).trim();
+    assert.strictEqual(logCount, '1', 'no new commit must be created for an out-of-repo path');
+    // Index stays clean (no pollution from a failed git add).
+    const status = execSync('git status --porcelain', { cwd: tmpDir, encoding: 'utf-8' }).trim();
+    assert.strictEqual(status, '', `index must be clean (no pollution): ${status}`);
+  });
 });


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #2523

> The linked issue carries the `confirmed-bug` label.

---

## What was broken

`cmdCommit` (`src/commands.cts`) used `path.join(cwd, file)` for the `--files` existence check. `path.join` concatenates rather than resetting on an absolute path, so an absolute `--files` entry (e.g. the absolute `phase_dir` emitted by `init phase-op` since #2428) became `cwd+absPath` (non-existent) → **silently skipped as `nothing_to_commit`**. Worse, a mixed relative/absolute list committed the relative entries and **dropped the absolute ones while reporting `committed:true`** — the exact shape of the phase-completion commit, which therefore landed ROADMAP/STATE/REQUIREMENTS and silently omitted `*-VERIFICATION.md`. A third failure mode: the phase-branch detection regex scans the joined `--files` string, so an absolute prefix with a digit-hyphen (e.g. `/proj-7-decoy2/`) selected the wrong phase branch.

## What this fix does

- Normalize each `--files` entry to a **repo-relative** path (`path.relative(cwd, path.resolve(cwd, f))`, wrapped in `toPosixPath`) up front. The normalized array feeds both the phase-branch detection (now sees only repo-relative paths → no external digit-hyphen) and the staging loop.
- **Reject out-of-repo paths loudly** (`reason: 'path_outside_repo'`, fail fast) — a `--files` entry resolving outside the project root errors rather than silently skipping or polluting the index.
- **Gate `stagedPaths.push` on the `git add` exit code** (mirrors `cmdCommitToSubrepo`) so a failed `add` can't put a bad path into the commit pathspec.
- 3 regression tests in `tests/commit-files-pathspec.test.cjs`: absolute-path-committed, mixed-list-commits-both, out-of-repo-rejected-loudly (no index pollution).

## Root cause

`path.join` vs `path.resolve`: join concatenates, resolve resets on an absolute argument. `cmdCommit` needed resolve (or pre-normalization) to accept the absolute paths its own `init phase-op` emits.

## Testing

### How I verified the fix

- The 3 tests reproduce all failure modes (absolute dropped, mixed partial-commit, out-of-repo) and assert the fixed behavior; they fail on the old `path.join` code.
- `gsd-test` outcome:"passed" on this HEAD (both Linux lanes, 0 failures).

### Regression test added?

- [x] Yes — absolute / mixed / out-of-repo `--files` cases in `tests/commit-files-pathspec.test.cjs`.

### Platforms tested

- [x] macOS
- [ ] Windows (backslash path handling — `toPosixPath` wrap added per codebase convention; gsd-test matrix includes Windows)
- [x] Linux (gsd-test benches, Node 22 + 24)
- [ ] N/A

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (core commit logic, runtime-independent)

---

## Checklist

- [x] Issue linked above with `Fixes #2523`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug (`cmdCommit` --files path handling; the general unanchored phase-detection regex is tracked separately as #2539)
- [x] Regression test added
- [x] All existing tests pass (`gsd-test` outcome:"passed" on this HEAD)
- [x] `.changeset/` fragment added (`Fixed`)
- [x] No unnecessary dependencies added

## Review gates passed

- `/code-review` + `/security-review` (isolated subagent, combined): initially REQUEST CHANGES — caught that `stagedPaths.push` ran unconditionally (an out-of-repo path would pollute the index + fail the commit), a missing `toPosixPath` convention wrap, and missing out-of-repo coverage. **All findings addressed**: out-of-repo guard (fail-loud `path_outside_repo`), gated push on `git add` exitCode, `toPosixPath` wrap, out-of-repo regression test. Re-verified via gsd-test (0 failures).
- Full `lint-tests` chain: clean.

## Breaking changes

None for in-repo paths (relative or absolute) — output is byte-identical for the common case. The only behavior delta: (a) absolute in-repo paths now commit correctly (the bug), and (b) out-of-repo paths now error loudly (`path_outside_repo`) instead of silently skipping — the "fail loudly" the issue asks for.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2638"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787548966&installation_model_id=22188&pr_number=2638&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2638&signature=873733dc51f9f076df8afdb248d0ad4ddc552f05e02290435976763d066bd519"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->