### PR TITLE
fix(#2654): bump js-yaml past the merge-key DoS advisory

### DIFF
--- a/.changeset/lively-finches-forage.md
+++ b/.changeset/lively-finches-forage.md
@@ -1,5 +1,5 @@
 ---
 type: Security
-pr: 0
+pr: 2655
 ---
 **Dev-tooling `js-yaml` bumped past the merge-key DoS advisory** — `js-yaml` was pinned `^4.2.0`, inside the vulnerable `4.0.0 - 4.2.0` range of GHSA-52cp-r559-cp3m (quadratic CPU on YAML merge-key chains). It is a devDependency with no shipped-runtime reachability, but `scripts/workflow-policy.cjs` parses workflow frontmatter in CI, which is attacker-controlled on a fork PR. Now `^4.2.1`. (#2654)

--- a/.changeset/lively-finches-forage.md
+++ b/.changeset/lively-finches-forage.md
@@ -1,0 +1,5 @@
+---
+type: Security
+pr: 0
+---
+**Dev-tooling `js-yaml` bumped past the merge-key DoS advisory** — `js-yaml` was pinned `^4.2.0`, inside the vulnerable `4.0.0 - 4.2.0` range of GHSA-52cp-r559-cp3m (quadratic CPU on YAML merge-key chains). It is a devDependency with no shipped-runtime reachability, but `scripts/workflow-policy.cjs` parses workflow frontmatter in CI, which is attacker-controlled on a fork PR. Now `^4.2.1`. (#2654)

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "eslint-plugin-no-only-tests": "^3.4.0",
         "fast-check": "^4.8.0",
         "globals": "^16.5.0",
-        "js-yaml": "^4.2.0",
+        "js-yaml": "^4.2.1",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.60.0"
       },
@@ -3842,9 +3842,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "eslint-plugin-no-only-tests": "^3.4.0",
     "fast-check": "^4.8.0",
     "globals": "^16.5.0",
-    "js-yaml": "^4.2.0",
+    "js-yaml": "^4.2.1",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.60.0"
   },


### PR DESCRIPTION
## Linked Issue

Fixes #2654

## What was broken

`js-yaml` was pinned `^4.2.0`, which sits inside the vulnerable `4.0.0 - 4.2.0` range of [GHSA-52cp-r559-cp3m](https://github.com/advisories/GHSA-52cp-r559-cp3m) — YAML merge-key chains force quadratic CPU consumption (CVSS 7.5). `npm ci` reported it as one of two high-severity advisories.

## What this fix does

Bumps the devDependency to `^4.2.1`; the lockfile resolves `4.3.0`.

```
before: 2 high severity vulnerabilities
after:  1 high severity vulnerability
```

## Root cause

The pin was written as `^4.2.0` before the advisory was published, and `^4.2.0` happily resolves to the last vulnerable release.

## Exposure — bounded, but real

`js-yaml` is a **devDependency with no reachability from shipped runtime code** under `gsd-core/bin/` or `src/`. Every in-repo consumer is dev tooling or a test:

- `scripts/workflow-policy.cjs`
- `tests/ci-test-scope.test.cjs`
- `tests/frontmatter.property.test.cjs`
- `tests/frontmatter.unit.test.cjs`
- `tests/mempalace-capture-headless-invocation.test.cjs`
- `tests/release-backmerge-invariants.test.cjs`

So there is no end-user exposure. The path worth closing is CI: `scripts/workflow-policy.cjs` parses workflow `.md` frontmatter during the `Tests` workflow, and **on a fork PR that frontmatter is attacker-controlled** — a crafted merge-key chain could burn CI CPU on a quadratic parse.

## Scope: js-yaml only, deliberately

The second advisory (`brace-expansion`, `<=5.0.7`) is **not** fixed here, and that is on purpose. I tested `npm audit fix --package-lock-only` and backed it out because it makes things worse:

| | before | after `audit fix` |
|---|---|---|
| high advisories | 1 | **5** |
| `node_modules/brace-expansion` | 5.0.6 | 5.0.8 |
| nested under `@eslint/config-array`, `@eslint/eslintrc`, `eslint` | 1.1.15 | 1.1.16 |

The top-level copy does move past `5.0.7`, but the three copies nested under eslint land on `1.1.16`, which still compares inside the advisory's `<=5.0.7` semver range — so npm reports each separately and the count goes **up**. Closing it needs an eslint major bump (`npm audit fix --force`) or an `overrides` entry, which deserves its own issue rather than riding along on a one-line devDependency fix. Noted on #2654.

## Testing

- `gsd-test --base next --head c8ce13d92` → **`outcome: "passed"`**, 26683/26683 on linux-node22 and linux-node24, 0 failures. The container installs from this lockfile, so the suite genuinely ran against `js-yaml 4.3.0` — including all six consumers above.
- `npx eslint .` (cache cleared first, since the local cache can false-green) → clean.
- `npm run lint:changeset` → `ok_fragment_present`.
- `npm audit` → 2 high → 1 high, with only `brace-expansion` remaining.

No source changes; the API surface used here (`load`, `dump`) is unchanged across the bump.

## Platforms tested

- [x] Linux (node 22 + node 24, via gsd-test)
- [ ] macOS
- [ ] Windows

## Breaking changes

None. Dev-only dependency, same major, same API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2655"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787617008&installation_model_id=22188&pr_number=2655&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2655&signature=718329a6192592b1a822f72651e00c891b8815c49a1ab274e61341e78c86240a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->