### PR TITLE
fix(#2539): anchor commit phase-token detection; drop silent wrong-branch switch

### DIFF
--- a/.changeset/2539-commit-phase-detection-anchored.md
+++ b/.changeset/2539-commit-phase-detection-anchored.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`query commit --files` no longer silently checks out the wrong phase branch mid-commit** — the phase-token extraction is now anchored to the directory segment under `.planning/phases/` and reuses the project-code-aware `extractPhaseToken` helper instead of an unanchored regex, so a `project_code` ending in a digit (e.g. `PROJECT_V2`) no longer makes `…/PROJECT_V2-07-name/…` match the `2-` inside `V2-` and resolve to the wrong phase. The commit-path branch auto-switch also no longer silently force-switches an already-checked-out working branch onto a different existing phase branch (it creates-if-absent only, per the original `#1278` intent); the only prior trace of the silent switch was a `git reflog` entry. (#2539)

--- a/.changeset/2539-commit-phase-detection-anchored.md
+++ b/.changeset/2539-commit-phase-detection-anchored.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 2669
 ---
 **`query commit --files` no longer silently checks out the wrong phase branch mid-commit** — the phase-token extraction is now anchored to the directory segment under `.planning/phases/` and reuses the project-code-aware `extractPhaseToken` helper instead of an unanchored regex, so a `project_code` ending in a digit (e.g. `PROJECT_V2`) no longer makes `…/PROJECT_V2-07-name/…` match the `2-` inside `V2-` and resolve to the wrong phase. The commit-path branch auto-switch also no longer silently force-switches an already-checked-out working branch onto a different existing phase branch (it creates-if-absent only, per the original `#1278` intent); the only prior trace of the silent switch was a `git reflog` entry. (#2539)

--- a/src/commands.cts
+++ b/src/commands.cts
@@ -768,8 +768,14 @@ function detectPhaseNumberFromFiles(files: string[] | undefined): string | null 
         if (!phaseDir) continue;
         const token = extractPhaseToken(phaseDir);
         // extractPhaseToken falls back to returning dirName unchanged when no
-        // numeric token is found — only accept a real numeric phase token.
-        if (token && token !== phaseDir && /\d/.test(token)) {
+        // numeric token is found. normalizePhaseName is the canonical arbiter
+        // of "is this a real phase token": it strips the project-code prefix
+        // and returns a zero-padded numeric form for a genuine phase token, or
+        // the input unchanged otherwise. Accept the token only when it
+        // normalizes to a numeric phase form (the single-owner rule shared by
+        // every other phase-token reader — see #2528).
+        const normalized = normalizePhaseName(token);
+        if (token !== phaseDir && /^\d+[A-Z]?(?:\.\d+)*$/i.test(normalized)) {
           return token;
         }
       }
@@ -858,10 +864,19 @@ function cmdCommit(cwd: string, message: string | undefined, files: string[] | u
         // the whole working tree onto an existing unrelated branch in the same
         // call that then committed (the only trace was a reflog entry). So:
         // create-if-absent only. If the resolved branch already exists and the
-        // tree is on some other branch, do NOT switch — the operator is on the
-        // branch they intend to be on. `git checkout -b` fails (non-zero) when
-        // the branch already exists; that is the signal to leave the tree alone.
-        execGit(['checkout', '-b', branchName], { cwd });
+        // tree is on some other branch, do NOT switch — but never silently: log
+        // the resolution so the operator sees that the phase branch was
+        // resolved and deliberately not switched to (#2539 AC2: an auto-
+        // checkout mid-commit must never happen silently).
+        const create = execGit(['checkout', '-b', branchName], { cwd });
+        if (create.exitCode !== 0) {
+          // `git checkout -b` fails (non-zero) when the branch already exists.
+          // The operator is on the branch they intend to be on; commit there.
+          process.stderr.write(
+            `Warning: resolved ${branchingStrategy} branch "${branchName}" already exists; ` +
+            `committing on the current branch "${currentBranch.stdout.trim()}" instead of switching.\n`
+          );
+        }
       }
     }
   }

--- a/src/commands.cts
+++ b/src/commands.cts
@@ -21,7 +21,7 @@ import coreUtilsMod = require('./core-utils.cjs');
 const { toPosixPath, generateSlugInternal, extractOneLinerFromBody } = coreUtilsMod;
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import phaseIdMod = require('./phase-id.cjs');
-const { normalizePhaseName, comparePhaseNum, extractPhaseToken } = phaseIdMod;
+const { normalizePhaseName, comparePhaseNum, extractPhaseToken, PHASE_NUMBER_TOKEN_SOURCE } = phaseIdMod;
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import phaseLocatorMod = require('./phase-locator.cjs');
 const { getArchivedPhaseDirs, findPhaseInternal } = phaseLocatorMod;
@@ -775,7 +775,11 @@ function detectPhaseNumberFromFiles(files: string[] | undefined): string | null 
         // normalizes to a numeric phase form (the single-owner rule shared by
         // every other phase-token reader — see #2528).
         const normalized = normalizePhaseName(token);
-        if (token !== phaseDir && /^\d+[A-Z]?(?:\.\d+)*$/i.test(normalized)) {
+        // Built from the single-owner PHASE_NUMBER_TOKEN_SOURCE (the canonical
+        // phase-number grammar — #2128 anti-divergence guard) so this read-side
+        // acceptance check cannot drift from every other phase-token reader.
+        const phaseTokenShape = new RegExp(`^${PHASE_NUMBER_TOKEN_SOURCE}$`, 'i');
+        if (token !== phaseDir && phaseTokenShape.test(normalized)) {
           return token;
         }
       }

--- a/src/commands.cts
+++ b/src/commands.cts
@@ -736,6 +736,48 @@ function cmdEffortSync(cwd: string, raw: boolean, opts?: { dryRun?: boolean; con
   output({ synced, skipped, changes, dry_run: dryRun, agents_dir: agentsDir }, raw, synced > 0 ? 'changed' : 'ok');
 }
 
+/**
+ * Detect the phase number for a commit from its `--files` path list.
+ *
+ * #2539: the extraction is anchored to the directory segment immediately under
+ * `.planning/phases/` or `.planning/milestones/<version>-phases/`, then run
+ * through the project-code-aware `extractPhaseToken` helper. The prior
+ * unanchored `match(/(\d+(?:\.\d+)*)-/)` returned the leftmost digit-run-then-
+ * hyphen anywhere in the joined path, so a project_code ending in a digit
+ * (e.g. PROJECT_V2) made `…/PROJECT_V2-07-name/…` match the `2-` inside `V2-`
+ * before the real `07-` phase token — resolving phase "2" instead of "7".
+ *
+ * Returns the phase number string (e.g. '07', '45.14'), or null when no phase
+ * directory segment is present in any of the file paths (e.g. a commit of
+ * `.planning/ROADMAP.md` has no phase segment, so no branch is resolved —
+ * matching the prior regex-no-match behaviour).
+ */
+function detectPhaseNumberFromFiles(files: string[] | undefined): string | null {
+  if (!files || files.length === 0) return null;
+  // A phase directory lives one segment below a `phases` parent segment:
+  //   .planning/phases/<phase-dir>/…
+  //   .planning/milestones/v1.0-phases/<phase-dir>/…
+  // The segment immediately after the `…phases` segment is the phase directory
+  // name. extractPhaseToken owns the project-code-aware token read.
+  for (const file of files) {
+    const norm = String(file).replace(/\\/g, '/').replace(/^\.\//, '');
+    const segments = norm.split('/');
+    for (let i = 0; i < segments.length - 1; i++) {
+      if (segments[i] === 'phases' || segments[i].endsWith('-phases')) {
+        const phaseDir = segments[i + 1];
+        if (!phaseDir) continue;
+        const token = extractPhaseToken(phaseDir);
+        // extractPhaseToken falls back to returning dirName unchanged when no
+        // numeric token is found — only accept a real numeric phase token.
+        if (token && token !== phaseDir && /\d/.test(token)) {
+          return token;
+        }
+      }
+    }
+  }
+  return null;
+}
+
 function cmdCommit(cwd: string, message: string | undefined, files: string[] | undefined, raw: boolean, amend: boolean, noVerify: boolean): void {
   if (!message && !amend) {
     error('commit message required');
@@ -776,10 +818,21 @@ function cmdCommit(cwd: string, message: string | undefined, files: string[] | u
   if (branchingStrategy && branchingStrategy !== 'none') {
     let branchName: string | null = null;
     if (branchingStrategy === 'phase') {
-      // Determine which phase we're committing for from the file paths
-      const phaseMatch = (files || []).join(' ').match(/(\d+(?:\.\d+)*)-/);
-      if (phaseMatch) {
-        const phaseNum = phaseMatch[1];
+      // Determine which phase we're committing for from the file paths.
+      // #2539: the extraction is anchored to the directory SEGMENT immediately
+      // under `.planning/phases/` (or `.planning/milestones/<v>-phases/`) and
+      // runs through the project-code-aware extractPhaseToken helper, NOT a
+      // free unanchored regex. The prior `match(/(\d+(?:\.\d+)*)-/)` returned
+      // the leftmost digit-run-then-hyphen anywhere in the joined path, so a
+      // project_code ending in a digit (PROJECT_V2) made `.../PROJECT_V2-07-…`
+      // match the `2-` inside `V2-` before the real `07-` phase token —
+      // resolving phase "2" instead of phase "7" and silently checking out the
+      // wrong branch. extractPhaseToken already owns project-code-aware phase-
+      // token parsing (it is the single owner shared by the other 6 call sites
+      // — see #2528 for the parallel drift problem in phase-locator/phase),
+      // so this is the canonical path-segment-bound read, not a fourth copy.
+      const phaseNum = detectPhaseNumberFromFiles(files);
+      if (phaseNum) {
         const phaseInfo = findPhaseInternal(cwd, phaseNum) as Record<string, unknown> | null;
         if (phaseInfo) {
           branchName = (config['phase_branch_template'] as string)
@@ -798,11 +851,17 @@ function cmdCommit(cwd: string, message: string | undefined, files: string[] | u
     if (branchName) {
       const currentBranch = execGit(['rev-parse', '--abbrev-ref', 'HEAD'], { cwd });
       if (currentBranch.exitCode === 0 && currentBranch.stdout.trim() !== branchName) {
-        // Create branch if it doesn't exist, or switch to it if it does
-        const create = execGit(['checkout', '-b', branchName], { cwd });
-        if (create.exitCode !== 0) {
-          execGit(['checkout', branchName], { cwd });
-        }
+        // #2539: the #1278 intent is to CREATE the phase/milestone branch
+        // before the FIRST commit on it — not to force-switch an already-
+        // checked-out working branch onto a DIFFERENT existing branch. The
+        // prior fallback to a bare `git checkout <branch>` silently switched
+        // the whole working tree onto an existing unrelated branch in the same
+        // call that then committed (the only trace was a reflog entry). So:
+        // create-if-absent only. If the resolved branch already exists and the
+        // tree is on some other branch, do NOT switch — the operator is on the
+        // branch they intend to be on. `git checkout -b` fails (non-zero) when
+        // the branch already exists; that is the signal to leave the tree alone.
+        execGit(['checkout', '-b', branchName], { cwd });
       }
     }
   }

--- a/tests/commands.test.cjs
+++ b/tests/commands.test.cjs
@@ -1303,7 +1303,7 @@ describe('resolve-model command', () => {
 
 describe('commit command', () => {
   const { createTempGitProject } = require('./helpers.cjs');
-  const { execSync } = require('child_process');
+  const { execSync, execFileSync } = require('child_process');
   let tmpDir;
 
   beforeEach(() => {
@@ -1503,7 +1503,6 @@ describe('commit command', () => {
   // whole working tree onto the wrong branch in the same call that then
   // committed. This fixture reproduces both preconditions.
   test('#2539: digit-suffixed project_code does not collide with the phase number', () => {
-    const { execFileSync } = require('child_process');
     // Configure phase branching strategy with a project_code ending in a digit.
     fs.writeFileSync(
       path.join(tmpDir, '.planning', 'config.json'),
@@ -1573,7 +1572,6 @@ describe('commit command', () => {
   // tree is on some other branch, switching to it silently is the dangerous
   // drift; the fix keeps create-if-absent but drops the silent switch-to-existing.
   test('#2539: does not silently switch onto an existing unrelated phase branch', () => {
-    const { execFileSync } = require('child_process');
     fs.writeFileSync(
       path.join(tmpDir, '.planning', 'config.json'),
       JSON.stringify({
@@ -1604,13 +1602,22 @@ describe('commit command', () => {
       cwd: tmpDir, encoding: 'utf-8',
     }).trim();
 
-    const result = runGsdTools(
-      'commit "docs(01): add context" --files .planning/phases/01-first-phase/01-CONTEXT.md',
-      tmpDir
-    );
-    assert.ok(result.success, `Command failed: ${result.error}`);
+    // Invoke gsd-tools via spawnSync so stderr is observable on the success
+    // path — the warning that proves the no-switch path is not silent (#2539
+    // AC2) is written to stderr, which execFileSync discards on success.
+    const { TOOLS_PATH } = require('./helpers.cjs');
+    const { spawnSync } = require('child_process');
+    const proc = spawnSync(process.execPath, [
+      TOOLS_PATH, 'commit', 'docs(01): add context',
+      '--files', '.planning/phases/01-first-phase/01-CONTEXT.md',
+    ], { cwd: tmpDir, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] });
+    const stdout = proc.stdout || '';
+    const stderr = proc.stderr || '';
+    if (proc.status !== 0) {
+      throw new Error(`gsd-tools commit exited ${proc.status}: stdout=${stdout} stderr=${stderr}`);
+    }
 
-    const output = JSON.parse(result.output);
+    const output = JSON.parse(stdout.trim());
     assert.strictEqual(output.committed, true, 'should have committed');
 
     // The command must NOT have silently switched the working tree onto the
@@ -1622,6 +1629,13 @@ describe('commit command', () => {
       afterBranch,
       beforeBranch,
       `must not silently switch onto an existing phase branch mid-commit (was ${beforeBranch}, now ${afterBranch})`
+    );
+
+    // #2539 AC2: the no-switch path must not be silent either. The warning
+    // surfaces the resolved branch and the branch the commit actually lands on.
+    assert.ok(
+      /Warning: resolved phase branch .* already exists/.test(stderr),
+      `expected a non-silent warning on stderr when the resolved branch already exists; got stderr=${stderr}`
     );
   });
 });

--- a/tests/commands.test.cjs
+++ b/tests/commands.test.cjs
@@ -1490,6 +1490,140 @@ describe('commit command', () => {
     const branch = execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: tmpDir, encoding: 'utf-8' }).trim();
     assert.strictEqual(branch, 'gsd/phase-45.14-golden-capture', 'should be on decimal phase branch, not integer-only');
   });
+
+  // #2539: the phase-token extraction must be anchored to the path segment under
+  // .planning/phases/ and reuse the project-code-aware extractPhaseToken helper.
+  // The prior unanchored `match(/(\d+(?:\.\d+)*)-/)` matched the leftmost
+  // digit-run-then-hyphen anywhere in the joined file path, so a project_code
+  // ending in a digit (e.g. PROJECT_V2) made `.../PROJECT_V2-07-name/...` match
+  // the `2-` inside `V2-` BEFORE reaching the real `07-` phase token —
+  // resolving phase "2" instead of phase "7". findPhaseInternal also searches
+  // archived milestones, so an existing archived phase 2 produced a real branch
+  // name, and the silent `git checkout <existing-branch>` fallback switched the
+  // whole working tree onto the wrong branch in the same call that then
+  // committed. This fixture reproduces both preconditions.
+  test('#2539: digit-suffixed project_code does not collide with the phase number', () => {
+    const { execFileSync } = require('child_process');
+    // Configure phase branching strategy with a project_code ending in a digit.
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({
+        commit_docs: true,
+        project_code: 'PROJECT_V2',
+        branching_strategy: 'phase',
+        phase_branch_template: 'gsd/phase-{phase}-{slug}',
+      })
+    );
+
+    // Archived phase 02 under a shipped milestone — the collision target that
+    // findPhaseInternal reaches via the .planning/milestones/<v>-phases/ search.
+    fs.mkdirSync(
+      path.join(tmpDir, '.planning', 'milestones', 'v1.0-phases', 'PROJECT_V2-02-archived-phase'),
+      { recursive: true }
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'milestones', 'v1.0-phases', 'PROJECT_V2-02-archived-phase', '02-CONTEXT.md'),
+      '# Archived\n'
+    );
+
+    // Active phase 07 — the phase actually being committed.
+    fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', 'PROJECT_V2-07-active-phase'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      '# Roadmap\n\n## Phase 7: Active Phase\nGoal: ship it\n'
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'phases', 'PROJECT_V2-07-active-phase', '07-CONTEXT.md'),
+      '# Context\n'
+    );
+
+    const result = runGsdTools(
+      'commit "docs(07): add context" --files .planning/phases/PROJECT_V2-07-active-phase/07-CONTEXT.md',
+      tmpDir
+    );
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.committed, true, 'should have committed');
+
+    // The commit must land on the phase-07 branch. Pre-fix this resolved the
+    // `2-` in `PROJECT_V2-` and silently switched onto the archived phase-02
+    // branch instead.
+    const branch = execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: tmpDir, encoding: 'utf-8' }).trim();
+    assert.strictEqual(
+      branch,
+      'gsd/phase-07-active-phase',
+      `should be on the active phase-07 branch, not the archived phase-02 branch (got ${branch})`
+    );
+
+    // The committed file must exist on the phase-07 branch's HEAD, proving the
+    // commit did not silently land on the wrong branch.
+    const committedFile = execFileSync(
+      'git',
+      ['show', 'HEAD:.planning/phases/PROJECT_V2-07-active-phase/07-CONTEXT.md'],
+      { cwd: tmpDir, encoding: 'utf-8' }
+    );
+    assert.ok(committedFile.includes('# Context'), 'phase-07 file must be in the commit');
+  });
+
+  // #2539 second defect: an auto-checkout mid-commit must never be silent. The
+  // #1278 intent was to CREATE the phase branch before the FIRST commit on it —
+  // not to force-switch an already-checked-out working branch onto a different
+  // existing branch. If the resolved phase branch already exists and the working
+  // tree is on some other branch, switching to it silently is the dangerous
+  // drift; the fix keeps create-if-absent but drops the silent switch-to-existing.
+  test('#2539: does not silently switch onto an existing unrelated phase branch', () => {
+    const { execFileSync } = require('child_process');
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({
+        commit_docs: true,
+        branching_strategy: 'phase',
+        phase_branch_template: 'gsd/phase-{phase}-{slug}',
+      })
+    );
+    // Active phase 01.
+    fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '01-first-phase'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      '# Roadmap\n\n## Phase 1: First Phase\nGoal: start\n'
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'phases', '01-first-phase', '01-CONTEXT.md'),
+      '# Context\n'
+    );
+
+    // Pre-create the phase-01 branch and check it out, then return to the
+    // default branch so the working tree is NOT on the phase branch when commit
+    // runs. The resolved branch already exists; the pre-fix code silently
+    // switched onto it.
+    execFileSync('git', ['branch', 'gsd/phase-01-first-phase'], { cwd: tmpDir, stdio: 'pipe' });
+    // Ensure the file is staged only by the commit command itself (it must run
+    // from the current/default branch and must not be force-switched).
+    const beforeBranch = execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
+      cwd: tmpDir, encoding: 'utf-8',
+    }).trim();
+
+    const result = runGsdTools(
+      'commit "docs(01): add context" --files .planning/phases/01-first-phase/01-CONTEXT.md',
+      tmpDir
+    );
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.committed, true, 'should have committed');
+
+    // The command must NOT have silently switched the working tree onto the
+    // pre-existing phase branch. The commit lands on the branch we were on.
+    const afterBranch = execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
+      cwd: tmpDir, encoding: 'utf-8',
+    }).trim();
+    assert.strictEqual(
+      afterBranch,
+      beforeBranch,
+      `must not silently switch onto an existing phase branch mid-commit (was ${beforeBranch}, now ${afterBranch})`
+    );
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #2539

> The linked issue carries the `confirmed-bug` label.

---

## What was broken

`query commit --files …` auto-detected which phase a commit belongs to from the file paths with an **unanchored** regex (`match(/(\d+(?:\.\d+)*)-/)`), which returns the leftmost digit-run-then-hyphen anywhere in the joined path. For a `project_code` ending in a digit (e.g. `PROJECT_V2`), the path `.planning/phases/PROJECT_V2-07-name/file.md` matched the `2-` inside `V2-` *before* the real `07-` phase token — resolving phase **2** instead of phase **7**. `findPhaseInternal` also searches archived milestones, so an existing archived phase 2 produced a real branch name, and the silent `git checkout <existing-branch>` fallback switched the entire working tree onto the wrong branch in the same call that then committed. The only trace was a `git reflog` entry; `gsd-tools` printed nothing.

## What this fix does

1. **Anchored extraction.** A new `detectPhaseNumberFromFiles` helper anchors phase-token detection to the directory segment immediately under `.planning/phases/` (or `.planning/milestones/<v>-phases/`) and runs it through the existing project-code-aware `extractPhaseToken` + `normalizePhaseName` helpers — the single-owner surface shared by every other phase-token reader — instead of a fourth independent regex copy. A digit-suffixed `project_code` no longer collides with the phase number.
2. **No more silent switch.** The `#1278` intent was to *create* the phase branch before the first commit on it — not to force-switch an already-checked-out working branch onto a different *existing* branch. The fix keeps create-if-absent and drops the silent switch-to-existing; when the resolved branch already exists and the tree is elsewhere, it now emits a `Warning: resolved phase branch "…" already exists; committing on the current branch "…" instead of switching.` line to stderr rather than silently drifting.

## Root cause

Two compounding defects in `cmdCommit`'s branching-strategy block (`src/commands.cts`):
- The phase-token regex was unanchored and scanned the whole joined path string freely, so any digit-then-hyphen earlier in the path (a project-code suffix) won over the real phase segment.
- The branch-resolution fallback silently `git checkout`-ed an existing unrelated branch, so a wrong resolution became a silent wrong-branch commit with no log line.

No recorded Cortex decision explains the silent force-checkout (`recall_decision` returned only weak statistical matches → treated as `CannotProve`); the `#1278` comment documents only the create-before-first-commit intent.

## Testing

### How I verified the fix

Two regression tests in `tests/commands.test.cjs` (commit command block), both failing-first on the pre-fix code:

- `#2539: digit-suffixed project_code does not collide with the phase number` — sets `project_code: 'PROJECT_V2'`, an archived `PROJECT_V2-02-archived-phase` under `.planning/milestones/v1.0-phases/`, and an active `PROJECT_V2-07-active-phase`; commits a phase-07 file and asserts the commit lands on `gsd/phase-07-active-phase` (pre-fix: silently landed on the archived `gsd/phase-02-archived-phase`).
- `#2539: does not silently switch onto an existing unrelated phase branch` — pre-creates the phase-01 branch, commits from the default branch, and asserts (a) the working tree is NOT silently switched onto the pre-existing phase branch, and (b) a non-silent `Warning:` is emitted on stderr.

Full suite via `gsd-test --base next --head <sha>`: **26,764 passed / 0 failed** on linux-node22 and linux-node24.

### Regression test added?

- [x] Yes — added two tests that would have caught this bug

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux — gsd-test matrix (linux-node22, linux-node24)
- [ ] N/A (not platform-specific)

The path normalization (`replace(/\\/g, '/')`) handles Windows backslash paths; gsd-test did not exercise a Windows bench in this run.

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific — pure `gsd-tools` command behavior)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — `Fixes #2539`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (two tests)
- [x] All existing tests pass — `gsd-test` 26,764/26,764 passed (linux-node22 + linux-node24)
- [x] `.changeset/` fragment added (`.changeset/2539-commit-phase-detection-anchored.md`, type `Fixed`) — PR number backfilled after `gh pr create`
- [x] No unnecessary dependencies added (reuses existing `extractPhaseToken` / `normalizePhaseName` / `PHASE_NUMBER_TOKEN_SOURCE` exports; no new deps)

## Reviews

- `/code-review` (standards + spec, orthogonal sub-agents): findings addressed — hoisted `execFileSync`/`spawnSync` requires; tightened the token-acceptance guard to use `normalizePhaseName`; added the non-silent warning.
- `/security-review` (isolated context): **clean** — no injection/traversal/unsafe-argv; removing the silent switch is a security improvement, not a regression.
- Graph-backed deterministic review (`find_code_review_issues`, strict): **0 issues** — no cross-module drift, no removed-symbol references, no signature drift.

## Breaking changes

None. The only behavioral change for an operator is: when `branching_strategy: 'phase'` resolves a branch that already exists and the working tree is on a different branch, the commit now stays on the current branch (with a stderr warning) instead of silently switching. The create-before-first-commit behavior is unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2669"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787680689&installation_model_id=22188&pr_number=2669&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2669&signature=07f46907e1d6a31117dd0f5580a78c73e3a254d01c033e41210549c788b8577b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->