### PR TITLE
docs(#2585): single lockfile-driven bootstrap path in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,29 +7,25 @@
 git clone https://github.com/open-gsd/gsd-core.git
 cd gsd-core
 
-# Install dependencies
-npm install
+# Activate the pinned Node version from .nvmrc
+nvm use
+
+# Validate your environment
+npm run check:env
+
+# Install dependencies (reproducible, lockfile-driven)
+npm ci
 
 # Run tests
 npm test
 ```
 
----
+`npm ci` is required over `npm install`. It installs exactly what `package-lock.json`
+specifies and fails fast if the lockfile is out of sync — this is intentional.
 
-## Bootstrap your environment
-
-For a step-by-step setup guide covering Node version managers, `npm ci`, the environment
-validator, daily commands, and troubleshooting, see:
-
-**[docs/contributing/bootstrap.md](docs/contributing/bootstrap.md)**
-
-Quick start:
-
-```bash
-nvm use           # activate the pinned Node version from .nvmrc
-npm run check:env # validate your environment
-npm ci            # install from lockfile
-```
+**[docs/contributing/bootstrap.md](docs/contributing/bootstrap.md)** is the source of truth
+for setup. See it for Node version managers other than nvm (fnm, asdf, mise), the
+environment validator, daily commands, and troubleshooting.
 
 ---
 


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #2585

---

## What was broken

`CONTRIBUTING.md`'s **Getting Started** — the first copyable block a new contributor sees — told them to run `npm install`. That contradicted the `npm ci` quick start fifteen lines below it in the same file, and `docs/contributing/bootstrap.md`, which states `npm ci` is *required* so installs are reproducible, lockfile-driven, and fail fast when `package-lock.json` is out of sync. A contributor taking the shortest path got the wrong bootstrap contract.

## What this fix does

Leaves `CONTRIBUTING.md` with exactly **one** fresh-checkout path, in the canonical order from `bootstrap.md`.

## Root cause

Three competing bootstrap variants existed (`CONTRIBUTING.md` Getting Started, `CONTRIBUTING.md` Bootstrap-your-environment, `bootstrap.md` One-time setup). Correcting `npm install` → `npm ci` in place would have fixed the wrong command but left two near-identical blocks in one file — still a drift source. So the duplicate quick-start section is folded into Getting Started, and `bootstrap.md` is named the source of truth for everything else (fnm/asdf/mise, the environment validator, daily commands, troubleshooting). Three variants become one pointer plus one sequence, which is what the issue asked for: *"keep `docs/contributing/bootstrap.md` as the source of truth rather than introducing another variant."*

## Testing

### How I verified the fix

Acceptance criterion, verbatim: *"Done when every fresh-checkout bootstrap path in `CONTRIBUTING.md` consistently directs contributors to the lockfile-driven `npm ci` flow."*

An isolated reviewer verified this repo-wide, not just in the changed file:

- Every remaining `npm install` in the repo is a legitimate non-bootstrap use — installing the **published package** (`VERSIONING.md`, `bug_report.yml`, `install-smoke.yml`), `bootstrap.md`'s own scoped troubleshooting steps, or guidance for GSD-generated *downstream* projects. None is a contributor bootstrap path.
- The removed `## Bootstrap your environment` heading has **no** inbound anchors anywhere (`*.md`, `*.yml`, `*.json`), and `CONTRIBUTING.md` has no table of contents — so no dangling references.
- The retained sequence matches `bootstrap.md`'s One-time setup steps 2–4 verbatim in command and order.
- `npm test` is correct: `package.json` maps it to `node scripts/run-tests.cjs`, matching both CONTRIBUTING.md's own Testing Standards section and bootstrap.md's Daily Commands table.

`npm run lint:ci` and `npm run lint:docs` both clean.

### Regression test added?

- [ ] Yes
- [x] No — explain why: the change is prose in a contributor guide, not a runtime contract. A `readFileSync` + `includes()` assertion over `CONTRIBUTING.md` is precisely the source-grep test `scripts/lint-no-source-grep.cjs` rejects, and the `allow-test-rule` exemption is scoped to config/state documents where the runtime contract *is* the product. There is no behavior to assert.

### Platforms tested

- [ ] macOS
- [ ] Windows
- [ ] Linux
- [x] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes
- [x] Regression test added (or explained why not)
- [x] All existing tests pass — documentation-only change; no executable code ships, so this is doc-only per the repo's own exemption (`.claude/hooks/pre-pr-gate.sh` `DOC_ONLY_RE`, root-level `*.md`)
- [x] `.changeset/` fragment — not required: contributor-guide prose, not a user-facing code change (`lint:docs` passes clean)
- [x] No unnecessary dependencies added

## Breaking changes

None. Documentation only — no code, config, or command behavior changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2675"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787693746&installation_model_id=22188&pr_number=2675&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2675&signature=c7ff81ea9e330a0d703edad867b510adcf8109026f5b65f375cbea80b4e80d80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->