### PR TITLE
docs(#2699): record the generalized subagent watchdog as out-of-scope

### DIFF
--- a/.out-of-scope/subagent-activity-watchdog.md
+++ b/.out-of-scope/subagent-activity-watchdog.md
@@ -1,0 +1,113 @@
+# Generalized subagent activity watchdog
+
+**Source:** [#2699](https://github.com/open-gsd/gsd-core/issues/2699)
+**Decision:** wontfix — No-go as filed; redirected to [#2650](https://github.com/open-gsd/gsd-core/issues/2650)
+**Date:** 2026-07-27
+
+## Proposal summary
+
+Reporter proposed a general, runtime-agnostic watchdog that would continuously classify
+every spawned role agent (planner, executor, reviewer, researcher) into one of five
+states — `ACTIVE`, `STALLED`, `COMPLETED_WITHOUT_MARKER`, `LOST_WITHOUT_ARTIFACT`,
+`FAILED` — and surface recovery checkpoints instead of an indefinite spinner.
+
+The proposed mechanism: a `SubagentWatchState` object per spawned agent, updated from
+tool-call start/end events, artifact creation and mtime changes, commits, and an optional
+30–60 second heartbeat emitted by the agent or its wrapper; plus per-unit
+`expectedArtifacts` declarations, a `watchdog.*` config block, and bounded chunk resume
+that preserves already-committed chunks. Explicitly not `ps aux`, explicitly no auto-kill.
+
+## Why GSD does not own this
+
+- **A narrower version already ships, and this proposal skips past it.**
+  `gsd-core/workflows/execute-phase.md` already implements artifact-aware stall detection
+  for the executor: a SUMMARY-existence plus `git log --since` spot-check (`:742-744`), a
+  periodic surveillance loop (`:755-762`) gated on `executor.stall_detect_interval_minutes`
+  and `executor.stall_threshold_minutes` (read at `:100-101`; both registered in
+  `SCHEMA_DEFAULTS` at `src/config.cts:89-90`, defaults 5 and 10), and a *continue waiting /
+  kill and retry / kill and switch to inline* recovery triad (`:759-762`) that never
+  auto-kills. The proposal's core insight is already the shipped design; what it adds is
+  generalization.
+  *(Line numbers are as of the commit that added this entry and will drift; the symbol and
+  config-key names are the durable anchors.)*
+
+- **The gap it is actually motivated by has a scoped fix already diagnosed.** #2650
+  carries a confirmed diagnosis and Agent Brief for the real gap — plan-phase's planner
+  and plan-checker have no equivalent mechanism — sized as mirroring the two executor
+  config keys into `planner.*` and reusing the existing checkpoint. That brief explicitly
+  scopes out generalizing beyond plan-phase and any `SubagentWatchState`-style
+  rearchitecture. Accepting #2699 would mean building the larger system on top of a
+  foundation that has not landed.
+
+- **The event-driven model assumes an orchestrator GSD does not have.** The proposal
+  assumes a resident process with an event loop that can subscribe to hook callbacks and
+  maintain an in-memory `lastActivityAt`. GSD's orchestrator is an LLM interpreting
+  workflow markdown one turn at a time. Host-fired hooks run out-of-band and do not
+  return control to the orchestrating prompt mid-spawn. The only mechanism that yields a
+  turn in which a check can run is a backgrounded dispatch that returns control between
+  polls. This is a categorical mismatch, not a per-runtime coverage gap — it does not
+  resolve by picking a different host.
+
+- **The heartbeat has no place to live.** Agents emitting JSON every 30–60 seconds
+  requires wrapper-level control over agent execution that no GSD-supported runtime
+  exposes. Absent a wrapper, the spawned agent would have to interleave heartbeat
+  emission with its actual work, competing for the same turn.
+
+- **The specification is incomplete by the project's own bar.** The issue was not filed
+  through `feature_request.yml` and omits its required fields — type of addition, user
+  stories, maintenance burden, alternatives considered, breaking changes. `CONTRIBUTING.md`
+  states that incomplete specs are closed rather than revised by maintainers.
+
+Note that the proposal's *premise* about runtime portability was sound and is not a
+ground for rejection: `hookBus: host` and `stateIO: filesystem` are documented for the
+large majority of supported runtimes in the host-integration capability matrix. The
+blocker is the dispatch model, not signal availability.
+
+## What this does NOT cover
+
+This entry denies a **generalized, event-driven, heartbeat-augmented watchdog layer**.
+Its keyword surface — watchdog, stall, timeout, heartbeat, hung agent, orphan, recovery —
+overlaps request types this decision deliberately does not deny. Do not apply this entry to:
+
+- **Extending the existing spot-check pattern to another spawn site.** Mirroring the
+  executor's config keys and checkpoint into plan-phase, code-review, or any other
+  workflow is the sanctioned incremental path. That is #2650's shape, and it is welcome.
+- **Fixing the shipped executor mechanism.** If the executor's stall detection does not
+  fire when it should — and there is open evidence it may not, on a single
+  non-backgrounded spawn — that is a defect report, not this proposal.
+- **Making a specific hang observable.** A report that one command hangs with no
+  diagnostic is a bug about that command.
+- **Config or documentation for the existing `executor.stall_*` keys.**
+- **A display-only progress or elapsed-time indicator.** Showing "waiting on planner,
+  last activity 4m ago" while a spawn is outstanding — with no state machine, no
+  classification, and no recovery action — is a UX improvement, not this proposal. It is
+  denied by nothing here.
+- **Orphaned OS processes, containers, or bench resources.** Leaked test-runner containers
+  and similar host-level cleanup share the words *orphan* and *recovery* with this entry
+  but are a different domain entirely — nothing about GSD subagent dispatch. This entry
+  says nothing about them.
+
+## Re-open criteria
+
+This may be revisited if:
+
+- **#2650's fix has shipped**, and the resubmission **names at least one specific residual
+  failure observed after it shipped** — a concrete case the shipped mechanism did not
+  catch — rather than arguing for the full five-state model in the abstract.
+- The **dispatch-turn dependency is resolved first**: a demonstrated mechanism by which
+  the orchestrator reliably receives an execution turn during a single, non-backgrounded
+  spawn. Until that exists, any watchdog generalization inherits the same unreliability
+  the executor mechanism is already suspected of.
+- The proposal is refiled through `feature_request.yml` with its required fields
+  completed.
+
+A generalization is accepted here once the narrow pattern it generalizes is **in use at two
+or more spawn sites** and a **named, reproduced failure** shows why per-site application is
+no longer sufficient — not before.
+
+## Related
+
+- `gsd-core/workflows/execute-phase.md` — the shipped executor stall-detection pattern
+- `src/config.cts` — `SCHEMA_DEFAULTS`, where `executor.stall_*` keys are registered
+- `docs/reference/host-integration-capability-matrix.md` — per-runtime `hookBus` / `stateIO` surfaces
+- [#2650](https://github.com/open-gsd/gsd-core/issues/2650) — the confirmed defect this was redirected to


### PR DESCRIPTION
<!-- pr-template-exempt: doc-only — adds one `.out-of-scope/` knowledge-base document. No code, no runtime-loaded text, no behavior change. None of the fix/enhancement/feature templates applies to a documentation record. -->

## What this does

Records the **No-go** disposition for #2699 in the rejected-capability knowledge base: `.out-of-scope/subagent-activity-watchdog.md`.

GSD does not take a generalized, event-driven, heartbeat-augmented subagent watchdog layer. The artifact-aware spot-check that proposal generalizes **already ships for the executor**, and the planner-side gap that actually motivated it has a scoped fix already diagnosed on #2650 — a brief that explicitly excludes this rearchitecture.

Doc-only: one new markdown file, no code, nothing the runtime loads.

## Why this entry exists

`.out-of-scope/` is consulted by `/triage-review` on every future triage run, so the reasoning has to live in the KB rather than in a closed-issue comment. A denial recorded only on the tracker is invisible to the next run's prior-denial check, and the same ask returns to be re-litigated from scratch.

Four grounds, each verified against the live tree during two independent review passes:

1. **A narrower version already ships.** `gsd-core/workflows/execute-phase.md` implements artifact-aware stall detection for the executor: a SUMMARY-existence plus `git log --since` spot-check (`:742-744`), a periodic surveillance loop (`:755-762`) gated on `executor.stall_detect_interval_minutes` / `executor.stall_threshold_minutes` (read at `:100-101`, registered at `src/config.cts:89-90` with defaults 5 and 10), and a *continue waiting / kill and retry / kill and switch to inline* triad (`:759-762`) that never auto-kills.
2. **The motivating gap has a scoped fix already diagnosed.** #2650 is OPEN, `bug` + `confirmed-bug`, and its Agent Brief scopes out *"generalizing to the other ~50+ `ORCHESTRATOR RULE` sites beyond plan-phase's planner/plan-checker."*
3. **The event-driven model assumes an orchestrator GSD does not have.** GSD's orchestrator is an LLM interpreting workflow markdown one turn at a time, not a resident process that can subscribe to hook callbacks. This is a categorical mismatch, not a per-runtime coverage gap.
4. **The spec is incomplete by the project's own bar.** Not filed through `feature_request.yml`; `CONTRIBUTING.md:70` states *"Incomplete specs are closed, not revised by maintainers."*

The entry also records what the proposal got **right** — its runtime-portability premise was sound (`hookBus: host` on 17 of 19 documented runtimes) — so the denial is not read as broader than it is.

## Scope guard

The entry carries an explicit **"What this does NOT cover"** section, because its keyword surface (*watchdog, stall, timeout, heartbeat, orphan, recovery*) overlaps request types this decision deliberately does **not** deny: extending the existing spot-check to another spawn site (that is #2650's shape, and it is welcome), fixing the shipped executor mechanism, making a specific hang observable, config/docs for the existing keys, a display-only progress indicator, and host-level orphaned processes or containers.

**Re-open criteria are stated as checkable tests**, not judgment calls: #2650 shipped *and* a named, reproduced residual failure; the dispatch-turn dependency demonstrated; refiled through the template.

## Verification

- `npm run lint:ci` — **exit 0** (run unpiped; the earlier piped run masked the real status).
- `GITHUB_BASE_REF=next node scripts/changeset/lint.cjs` — `ok_no_user_facing_changes` (no changeset required; a KB doc is not user-facing code).
- `GITHUB_BASE_REF=next node scripts/lint-docs-required.cjs` — `ok_no_triggering_fragments`.
  *Both lints were re-run with `GITHUB_BASE_REF` set explicitly — without it they resolve the wrong base ref and false-pass.*
- `gsd-test --base next --head <this sha>` — `outcome:"passed"`, 27044/27044 on `linux-node22` and `linux-node24`, 0 failures.
- **Two orthogonal review passes**, both in isolated reviewer contexts that did not author the change:
  - **Correctness** — independently verified all 8 factual claims against the live tree and tracker; all confirmed, no factual errors. Raised three documentation-quality findings, **all fixed here**: two scope-guard keyword gaps (a display-only progress indicator, and host-level orphaned processes/containers) that could have caused a future `/triage-review` to wrongly deny a legitimate adjacent request; two vague re-open clauses ("long enough", "limits are known from use") replaced with checkable tests; and missing line-number citations added to match sibling-entry rigor, with a drift caveat.
  - **Security** — clean, no blockers or majors. Checked prompt-injection and instruction smuggling (all reporter content is paraphrased into reported speech; none of the source issue's TS/JSON/YAML fenced blocks were carried over), tag/markup collision against the consuming command's container tags, secrets/PII (verified the source issues' project name and local paths did not leak), link safety, and untrusted-content provenance.

## Note for maintainers (not fixed here)

The correctness reviewer confirmed `execute-phase.md:755` labels its surveillance loop `#3212`. That number does not resolve in this repo but **does** resolve in the predecessor repository `gsd-build/get-shit-done` — as does `#3329`, the PR that added the mechanism. These are valid predecessor-repo references, not dangling ones. Untouched here; flagging so the decision is yours.

Closes #2699

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2706"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787757968&installation_model_id=22188&pr_number=2706&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2706&signature=32f1bce5db703dea5cb1a2aa63d99751b6584466b53cf725bdba0efa1b0dd868"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->