### PR TITLE
enhance(#2586): stop installing inert Codex context monitor

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -117,26 +117,6 @@ const CODEX_AGENTS_TOML_SCALAR_KEYS = new Set([
 // (ADR-1239 upgrade 2 / #2088). Per the negotiated capability, GSD-hosted Codex
 // dispatch is single-level (maxDepth === 1 \u2192 `degradationFor` flattens waves).
 const GSD_CODEX_AGENTS_MAX_DEPTH = 1;
-// Codex hooks.json lifecycle events GSD registers beyond SessionStart (which has
-// its own dedicated path). This is Codex's OWN hook-event vocabulary (per
-// developers.openai.com/codex/config-reference), distinct from the cross-runtime
-// settings.json `extendedHookEvents` descriptor field (a claude/gemini-family
-// allowlist consumed only by hooksSurface==='settings-json' runtimes — Codex is
-// codex-hooks-json). All route through gsd-context-monitor.js. #772 wired the
-// first three; #2088 adds the remaining six documented events so GSD's monitor
-// fires at the same lifecycle points as in Claude Code. Install and uninstall
-// share this list so the registered set and the removed set never diverge.
-const CODEX_EXTENDED_HOOK_EVENTS = [
-  'SubagentStart',
-  'Stop',
-  'PostToolUse',
-  'PreToolUse',
-  'PermissionRequest',
-  'PreCompact',
-  'PostCompact',
-  'SubagentStop',
-  'UserPromptSubmit',
-];
 // Codex's hook-enabling feature flag (issue #3566). Codex itself marks
 // `codex_hooks` as a `legacy_key` in codex-rs/features/src/legacy.rs; the
 // canonical current key under [features] is `hooks`. The installer always
@@ -548,8 +528,11 @@ function _runtimeAdapter(runtime) {
   }
 }
 const {
+  acquireInstallMigrationLock,
   applyInstallerMigrationPlan,
+  classifyArtifact,
   discoverInstallerMigrations,
+  readInstallManifest,
   runInstallerMigrations,
 } = require(path.join(_gsdLibDir, 'installer-migrations.cjs'));
 const {
@@ -1019,10 +1002,6 @@ function rewriteLegacyCodexHookBlock(content, absoluteRunner, opts) {
  *   timeout: optional timeout in seconds.
  * @returns {{ changed: boolean, wrote: boolean, path: string }}
  */
-function reconcileCodexHooksJsonEvent(targetDir, eventName, opts = {}) {
-  return hooksSurface.reconcileCodexHooksJsonEvent(targetDir, eventName, opts);
-}
-
 /**
  * Reconcile the GSD-managed SessionStart hook entry in hooks.json.
  * Delegates to the generic reconcileCodexHooksJsonEvent helper.
@@ -1096,48 +1075,143 @@ function buildCodexHookWindowsShimIR(scriptAbsPath, absoluteRunnerToken) {
  * @returns {{ changed: boolean, wrote: boolean, path: string }}
  */
 function ensureCodexHooksJsonSessionStart(targetDir, opts = {}) {
-  return hooksSurface.ensureCodexHooksJsonSessionStart(targetDir, opts);
+  return withCodexHooksJsonLock(targetDir, 'SessionStart registration', () =>
+    hooksSurface.ensureCodexHooksJsonSessionStart(targetDir, opts));
 }
 
-/**
- * Ensure hooks.json contains exactly one managed GSD hook entry for the given
- * Codex event, wired to gsd-context-monitor.js. Preserves user-owned entries.
- *
- * Used for the new Codex events added in #772:
- *   SubagentStart — inject context / GSD_AGENT_NAME awareness at subagent open
- *   Stop          — post-session context headroom tracking
- *   PostToolUse   — mirror the Claude Code PostToolUse context monitor
- *
- * All three events are routed through gsd-context-monitor.js — the same hook
- * used for PostToolUse in the Claude Code baseline — so context-headroom
- * warnings surface at these key Codex session lifecycle moments.
- *
- * On Windows (#3426): writes a gsd-context-monitor.cmd shim alongside the .js
- * file and uses the .cmd path as the hook command — exactly the same fix as
- * SessionStart uses for gsd-check-update — to avoid the bash.exe POSIX-exec
- * failure when Codex's hook dispatcher tries to run node.exe through Git Bash.
- *
- * @param {string} targetDir
- * @param {string} eventName - One of 'SubagentStart', 'Stop', 'PostToolUse'.
- * @param {{ absoluteRunner: string|null, platform?: NodeJS.Platform }} opts
- * @returns {{ changed: boolean, wrote: boolean, path: string }}
- */
-function ensureCodexHooksJsonEvent(targetDir, eventName, opts = {}) {
-  return hooksSurface.ensureCodexHooksJsonEvent(targetDir, eventName, opts);
+function withCodexHooksJsonLock(targetDir, operation, action) {
+  const hooksJsonPath = path.join(targetDir, 'hooks.json');
+  let releaseLock;
+  let primaryError = null;
+  try {
+    releaseLock = acquireInstallMigrationLock(targetDir);
+  } catch {
+    throw new Error(`Codex ${operation} failed to acquire lock for ${hooksJsonPath}`);
+  }
+
+  try {
+    return action();
+  } catch (error) {
+    primaryError = error;
+    throw error;
+  } finally {
+    try {
+      releaseLock();
+    } catch {
+      const releaseError = new Error(
+        `Codex ${operation} failed to release lock for ${hooksJsonPath}`,
+      );
+      if (primaryError) {
+        primaryError.suppressed = [...(primaryError.suppressed || []), releaseError];
+      } else {
+        throw releaseError;
+      }
+    }
+  }
 }
 
-/**
- * Remove a GSD-managed event entry from hooks.json. Called during uninstall.
- *
- * @param {string} targetDir
- * @param {string} eventName
- */
-function removeCodexHooksJsonEvent(targetDir, eventName) {
-  return hooksSurface.removeCodexHooksJsonEvent(targetDir, eventName);
+function cleanupCodexContextMonitor(targetDir) {
+  return withCodexHooksJsonLock(targetDir, 'context-monitor cleanup', () => {
+    // Recompute both the configuration rewrite and manifest-owned artifact
+    // actions from durable state while holding the existing installer lock.
+    // The rewrite is applied first so a later orphan-removal failure can never
+    // reintroduce the unsupported registration.
+    const cleanupPlan = hooksSurface.planCodexContextMonitorCleanup(targetDir);
+    const result = hooksSurface.applyCodexContextMonitorCleanup(cleanupPlan);
+    const manifest = readInstallManifest(targetDir);
+    const artifactActions = [];
+    const artifactInspectionFailures = [];
+    if (cleanupPlan.removed > 0 && !cleanupPlan.monitorArtifactsReferenced) {
+      const resolvedTargetDir = path.resolve(targetDir);
+      for (const relPath of [
+        'hooks/gsd-context-monitor.js',
+        'hooks/gsd-context-monitor.cmd',
+      ]) {
+        const artifactPath = path.resolve(targetDir, relPath);
+        if (hasExistingSymlinkBetween(resolvedTargetDir, artifactPath)) continue;
+        let stat;
+        try {
+          stat = fs.lstatSync(artifactPath, { throwIfNoEntry: false });
+        } catch (error) {
+          if (error && error.code !== 'ENOENT') {
+            artifactInspectionFailures.push(artifactPath);
+          }
+          continue;
+        }
+        if (!stat || !stat.isFile() || stat.isSymbolicLink()) continue;
+
+        let classification;
+        try {
+          classification = classifyArtifact(targetDir, relPath, manifest);
+        } catch {
+          throw new Error(`Codex context-monitor cleanup failed to inspect ${artifactPath}`);
+        }
+        if (
+          classification.classification !== 'managed-pristine'
+          && classification.classification !== 'managed-modified'
+        ) {
+          continue;
+        }
+        artifactActions.push({
+          migrationId: '2026-07-24-codex-context-monitor-artifact',
+          migrationChecksum: `sha256:${crypto.createHash('sha256')
+            .update('2026-07-24-codex-context-monitor-artifact')
+            .digest('hex')}`,
+          type: classification.classification === 'managed-modified'
+            ? 'backup-and-remove'
+            : 'remove-managed',
+          relPath,
+          reason: 'obsolete Codex context-monitor artifact is no longer referenced',
+          classification: classification.classification,
+          originalHash: classification.originalHash,
+          currentHash: classification.currentHash,
+        });
+      }
+    }
+
+    if (result.removed > 0) {
+      console.log(
+        `  ${green}✓${reset} Removed obsolete Codex context-monitor registration; `
+        + 'agent-facing context warnings remain unavailable.',
+      );
+    }
+
+    for (const artifactPath of artifactInspectionFailures) {
+      console.warn(
+        `  ${yellow}Warning:${reset} failed to inspect obsolete Codex `
+        + `context-monitor artifact at ${artifactPath}; `
+        + 'the registration remains removed.',
+      );
+    }
+
+    if (artifactActions.length > 0) {
+      try {
+        applyInstallerMigrationPlan({
+          configDir: targetDir,
+          plan: {
+            actions: artifactActions,
+            blocked: [],
+            checksumDrift: [],
+          },
+        });
+      } catch {
+        for (const action of artifactActions) {
+          console.warn(
+            `  ${yellow}Warning:${reset} failed to remove obsolete Codex `
+            + `context-monitor artifact at ${path.join(targetDir, action.relPath)}; `
+            + 'the registration remains removed.',
+          );
+        }
+      }
+    }
+
+    return result;
+  });
 }
 
 function removeCodexHooksJsonSessionStart(targetDir) {
-  return hooksSurface.removeCodexHooksJsonSessionStart(targetDir);
+  return withCodexHooksJsonLock(targetDir, 'SessionStart removal', () =>
+    hooksSurface.removeCodexHooksJsonSessionStart(targetDir));
 }
 
 /**
@@ -7980,7 +8054,8 @@ function uninstall(isGlobal, runtime = DEFAULT_RUNTIME) {
   // #2099: isCopilot dropped — both Copilot side-effect branches below are now
   // gated on resolveInstallPlan(runtime).installSurface === 'copilot-instructions'.
   // #2100: isWindsurf dropped — unused in this function.
-  const { isOpencode, isCodex, isCursor, isAugment, isQwen, isHermes, isCline } = runtimeFlags(runtime);
+  const { isOpencode, isCursor, isAugment, isQwen, isHermes, isCline } = runtimeFlags(runtime);
+  const plan = resolveInstallPlan(runtime);
   const dirName = getDirName(runtime);
 
   // Get the target directory based on runtime and install type. Cline local
@@ -8015,7 +8090,7 @@ function uninstall(isGlobal, runtime = DEFAULT_RUNTIME) {
   // which writes this same repo-root AGENTS.md only for local ('!isGlobal')
   // installs — 'copilot-instructions' is unique to copilot's descriptor, so
   // this is byte-parity.
-  if (resolveInstallPlan(runtime).installSurface === 'copilot-instructions' && !isGlobal) {
+  if (plan.installSurface === 'copilot-instructions' && !isGlobal) {
     const agentsMdPath = path.join(process.cwd(), 'AGENTS.md');
     if (fs.existsSync(agentsMdPath)) {
       const content = fs.readFileSync(agentsMdPath, 'utf8');
@@ -8038,6 +8113,14 @@ function uninstall(isGlobal, runtime = DEFAULT_RUNTIME) {
   }
 
   let removedCount = 0;
+  if (plan.installSurface === 'codex-toml') {
+    cleanupCodexContextMonitor(targetDir);
+    const hooksJsonCleanup = removeCodexHooksJsonSessionStart(targetDir);
+    if (hooksJsonCleanup.changed) {
+      removedCount++;
+      console.log(`  ${green}✓${reset} Removed managed Codex SessionStart hook from hooks.json`);
+    }
+  }
 
   // Remove profile marker so a clean reinstall defaults to full surface.
   try {
@@ -8107,22 +8190,6 @@ function uninstall(isGlobal, runtime = DEFAULT_RUNTIME) {
       }
     }
 
-    const hooksJsonCleanup = removeCodexHooksJsonSessionStart(targetDir);
-    if (hooksJsonCleanup.changed) {
-      removedCount++;
-      console.log(`  ${green}✓${reset} Removed managed Codex SessionStart hook from hooks.json`);
-    }
-
-    // #772/#2088: remove every managed Codex extended hook-event registration.
-    // Shares CODEX_EXTENDED_HOOK_EVENTS with the install loop — removal set ==
-    // registration set, so no managed event is ever orphaned.
-    for (const eventName of CODEX_EXTENDED_HOOK_EVENTS) {
-      const eventCleanup = removeCodexHooksJsonEvent(targetDir, eventName);
-      if (eventCleanup.changed) {
-        removedCount++;
-        console.log(`  ${green}✓${reset} Removed managed Codex ${eventName} hook from hooks.json`);
-      }
-    }
   }
 
   // 1a-kimi. Non-layout Kimi side-effect (#2095 EoS/kimi Upgrade 1): kimi's
@@ -8130,7 +8197,7 @@ function uninstall(isGlobal, runtime = DEFAULT_RUNTIME) {
   // resolves ~/.kimi, a sibling of targetDir's ~/.config/agents), so its
   // cleanup can't be driven by anything under targetDir the way every other
   // hook surface above is.
-  if (resolveInstallPlan(runtime).hooksSurface === 'kimi-hooks-toml') {
+  if (plan.hooksSurface === 'kimi-hooks-toml') {
     const kimiHooksRoot = resolveKimiHooksTomlDir();
     const kimiHooksTomlPath = path.join(kimiHooksRoot, 'config.toml');
     const kimiHooksCleanup = removeKimiHooksToml(kimiHooksTomlPath);
@@ -8202,7 +8269,7 @@ function uninstall(isGlobal, runtime = DEFAULT_RUNTIME) {
   // #2099: descriptor-driven via resolveInstallPlan(runtime).installSurface ===
   // 'copilot-instructions' (was hardcoded `isCopilot`), mirroring the same
   // gate used at the install-time 'copilot-instructions' branch.
-  if (resolveInstallPlan(runtime).installSurface === 'copilot-instructions') {
+  if (plan.installSurface === 'copilot-instructions') {
     const instructionsPath = path.join(targetDir, 'copilot-instructions.md');
     if (fs.existsSync(instructionsPath)) {
       const content = fs.readFileSync(instructionsPath, 'utf8');
@@ -10012,6 +10079,10 @@ function install(isGlobal, runtime = DEFAULT_RUNTIME, options = {}) {
     ? targetDir.replace(os.homedir(), '~')
     : targetDir.replace(process.cwd(), '.');
 
+  if (plan.installSurface === 'codex-toml') {
+    cleanupCodexContextMonitor(targetDir);
+  }
+
   // Path prefix for file references in markdown content (e.g. gsd-tools.cjs).
   // Replaces $HOME/.claude/ or ~/.claude/ so the result is <pathPrefix>gsd-core/bin/...
   // For global installs: use $HOME/ so paths expand correctly inside double-quoted
@@ -11437,7 +11508,10 @@ function install(isGlobal, runtime = DEFAULT_RUNTIME, options = {}) {
       // If installer migrations touched hooks.json, rollbackInstallerMigrations()
       // already restored the pre-migration file. Don't overwrite that state with
       // a post-migration snapshot.
-      if (!migrationTouchesHooksJson) {
+      if (
+        !migrationTouchesHooksJson
+        && !hasExistingSymlinkBetween(path.resolve(targetDir), codexHooksJsonPathPreInstall)
+      ) {
         if (codexHooksJsonPreInstallSnapshot !== null) {
           try { fs.writeFileSync(codexHooksJsonPathPreInstall, codexHooksJsonPreInstallSnapshot); }
           catch (_) { /* best-effort restore — surface the original error */ }
@@ -11570,10 +11644,9 @@ function install(isGlobal, runtime = DEFAULT_RUNTIME, options = {}) {
     }
 
     // Copy only the hook files that Codex actually registers via its hook configuration (#2153).
-    // #772: added gsd-context-monitor.js for the new SubagentStart/Stop/PostToolUse events.
     // We deliberately do *not* copy gsd-graphify-update.sh or hooks/lib/ for Codex
     // in this change (graphify auto-update support for Codex is out of scope for #3579).
-    const CODEX_HOOKS_TO_COPY = ['gsd-check-update.js', 'gsd-context-monitor.js'];
+    const CODEX_HOOKS_TO_COPY = ['gsd-check-update.js'];
     const codexHooksSrc = path.join(src, 'hooks', 'dist');
     if (fs.existsSync(codexHooksSrc)) {
       const codexHooksDest = path.join(targetDir, 'hooks');
@@ -11703,38 +11776,6 @@ function install(isGlobal, runtime = DEFAULT_RUNTIME, options = {}) {
             console.log(`  ${green}✓${reset} Verified Codex hooks (SessionStart via hooks.json)`);
           }
         }
-
-        // ── Codex extended hook events (#772, #2088) ─────────────────────────
-        // Codex CLI stabilised a full hook-event set in rust-v0.137.0. GSD
-        // registers CODEX_EXTENDED_HOOK_EVENTS (#2088 adds the 6 documented
-        // events beyond the original #772 three) — all routed through
-        // gsd-context-monitor.js so context-headroom warnings surface at each
-        // lifecycle point: SubagentStart/SubagentStop (subagent open/close),
-        // Stop (final-response), PreToolUse/PostToolUse (tool boundaries),
-        // PermissionRequest (approval prompts), Pre/PostCompact (context
-        // compaction), and UserPromptSubmit (per-turn context injection). The
-        // context-monitor script decides per-payload what to do; unregistered
-        // events simply never fire.
-        //
-        // Guard: only register when the context-monitor file exists and the node
-        // runner is available — same guards as the SessionStart path above.
-        const contextMonitorFile = path.join(targetDir, 'hooks', 'gsd-context-monitor.js');
-        if (codexNodeRunner && fs.existsSync(contextMonitorFile)) {
-          for (const codexEvent of CODEX_EXTENDED_HOOK_EVENTS) {
-            const eventWrite = ensureCodexHooksJsonEvent(targetDir, codexEvent, {
-              absoluteRunner: codexNodeRunner,
-              platform: process.platform,
-            });
-            if (eventWrite.wrote) {
-              console.log(`  ${green}✓${reset} Configured Codex hooks (${codexEvent} via hooks.json)`);
-            } else if (eventWrite.changed) {
-              console.log(`  ${green}✓${reset} Verified Codex hooks (${codexEvent} via hooks.json)`);
-            }
-          }
-        } else if (!codexNodeRunner) {
-          console.warn(`  ${yellow}⚠${reset}  Skipped Codex extended hook-event registration — Node runner unavailable.`);
-        }
-        // ── end Codex extended hook events ────────────────────────────────────
       }
     } catch (e) {
       // #2760 — schema-validation and write failures must be loud and fatal
@@ -11762,6 +11803,10 @@ function install(isGlobal, runtime = DEFAULT_RUNTIME, options = {}) {
       throw wrapped;
     }
 
+    console.log(
+      `  ${yellow}Notice:${reset} Agent-facing context warnings and GSD phase/lifecycle display `
+      + 'are unsupported on Codex.',
+    );
     persistActiveProfileMarker();
     return { settingsPath: null, settings: null, statuslineCommand: null, updateBannerCommand: null, runtime, configDir: targetDir };
   }
@@ -13247,7 +13292,6 @@ module.exports = {
     codexBareAgentsHasOnlyKnownScalars,
     extractCodexUserAgentsScalars,
     spliceCodexAgentsScalars,
-    CODEX_EXTENDED_HOOK_EVENTS,
     generateCodexConfigBlock,
     stripGsdFromCodexConfig,
     migrateCodexHooksMapFormat,
@@ -13406,9 +13450,7 @@ module.exports = {
     rewriteLegacyCodexHookBlock,
     buildCodexHookWindowsShimIR,
     ensureCodexHooksJsonSessionStart,
-    ensureCodexHooksJsonEvent,
-    removeCodexHooksJsonEvent,
-    reconcileCodexHooksJsonEvent,
+    cleanupCodexContextMonitor,
     readGsdCommandNames,
     installRuntimeArtifacts,
     installOpencodeFamilySkills,

--- a/capabilities/codex/capability.json
+++ b/capabilities/codex/capability.json
@@ -51,11 +51,7 @@
     "installSurface": "codex-toml",
     "writesSharedSettings": false,
     "permissionWriter": null,
-    "extendedHookEvents": [
-      "SubagentStop",
-      "Stop",
-      "PreCompact"
-    ],
+    "extendedHookEvents": [],
     "hostIntegration": {
       "embeddingMode": "declarative",
       "commandSurface": "slash-file",
@@ -87,7 +83,9 @@
       "cleanupSkillSidecars": true,
       "agentTomlFiles": true,
       "frontmatterDialect": "codex",
-      "reviewerCli": true
+      "reviewerCli": true,
+      "agentFacingContextWarnings": false,
+      "gsdPhaseLifecycleDisplay": false
     }
   }
 }

--- a/gsd-core/bin/lib/capability-registry.cjs
+++ b/gsd-core/bin/lib/capability-registry.cjs
@@ -927,11 +927,7 @@ const capabilities = {
       "installSurface": "codex-toml",
       "writesSharedSettings": false,
       "permissionWriter": null,
-      "extendedHookEvents": [
-        "SubagentStop",
-        "Stop",
-        "PreCompact"
-      ],
+      "extendedHookEvents": [],
       "hostIntegration": {
         "embeddingMode": "declarative",
         "commandSurface": "slash-file",
@@ -965,7 +961,9 @@ const capabilities = {
         "cleanupSkillSidecars": true,
         "agentTomlFiles": true,
         "frontmatterDialect": "codex",
-        "reviewerCli": true
+        "reviewerCli": true,
+        "agentFacingContextWarnings": false,
+        "gsdPhaseLifecycleDisplay": false
       }
     }
   },
@@ -4683,11 +4681,7 @@ const runtimes = {
       "installSurface": "codex-toml",
       "writesSharedSettings": false,
       "permissionWriter": null,
-      "extendedHookEvents": [
-        "SubagentStop",
-        "Stop",
-        "PreCompact"
-      ],
+      "extendedHookEvents": [],
       "hostIntegration": {
         "embeddingMode": "declarative",
         "commandSurface": "slash-file",
@@ -4721,7 +4715,9 @@ const runtimes = {
         "cleanupSkillSidecars": true,
         "agentTomlFiles": true,
         "frontmatterDialect": "codex",
-        "reviewerCli": true
+        "reviewerCli": true,
+        "agentFacingContextWarnings": false,
+        "gsdPhaseLifecycleDisplay": false
       }
     }
   },

--- a/src/installer-migrations/002-codex-legacy-hooks-json.cts
+++ b/src/installer-migrations/002-codex-legacy-hooks-json.cts
@@ -7,7 +7,10 @@
  * the prior hand-written .cjs; only types are added.
  */
 
-import { isManagedHookCommand } from '../shell-command-projection.cjs';
+import {
+  isManagedHookCommand,
+  isRecognizedCodexContextMonitorCommand,
+} from '../shell-command-projection.cjs';
 
 type JsonValue =
   | string
@@ -64,6 +67,15 @@ function isStructurallyEmpty(value: JsonValue): boolean {
 }
 
 function isManagedCodexHookCommand(command: unknown, configDir: string): boolean {
+  if (
+    typeof command === 'string'
+    && (
+      command.includes('gsd-context-monitor.js')
+      || command.includes('gsd-context-monitor.cmd')
+    )
+  ) {
+    return isRecognizedCodexContextMonitorCommand(command, configDir);
+  }
   return isManagedHookCommand(command, {
     surface: 'codex-hooks-json',
     includeLegacyAliases: true,
@@ -92,7 +104,7 @@ function pruneLegacyCodexHooksJsonValue(value: JsonValue, configDir: string): Pr
     }
 
     let changed = false;
-    const next: { [key: string]: JsonValue } = {};
+    const next = Object.create(null) as { [key: string]: JsonValue };
     for (const [key, child] of Object.entries(valueObj)) {
       const pruned = pruneLegacyCodexHooksJsonValue(child, configDir);
       if (pruned.changed) changed = true;
@@ -129,7 +141,7 @@ const migration: InstallerMigration = {
         value: pruned.value,
         deleteIfEmpty: true,
         reason: 'legacy Codex hooks.json GSD registration retired by installer migration',
-        ownershipEvidence: 'pruned command matches generated GSD hook command under the install hooks directory',
+        ownershipEvidence: 'pruned command is an exact retired monitor or target-confined update hook registration',
       },
     ];
   },

--- a/src/runtime-hooks-surface.cts
+++ b/src/runtime-hooks-surface.cts
@@ -10,9 +10,9 @@
  *   Cursor:  buildCursorHookEntry, isManagedCursorHookEntry,
  *            reconcileCursorHooksJson, writeCursorHooksJson, removeCursorHooksJson
  *   Copilot: buildCopilotHookConfig, writeCopilotHookConfig
- *   Codex hooks.json: ensureCodexHooksJsonSessionStart, ensureCodexHooksJsonEvent,
+ *   Codex hooks.json: ensureCodexHooksJsonSessionStart,
  *            reconcileCodexHooksJsonEvent, reconcileCodexHooksJsonSessionStart,
- *            removeCodexHooksJsonEvent, removeCodexHooksJsonSessionStart,
+ *            removeCodexHooksJsonSessionStart,
  *            buildCodexHookWindowsShimIR, buildCodexHookBlock, rewriteLegacyCodexHookBlock
  *   Shared:  buildHookCommand, rewriteLegacyManagedNodeHookCommands
  *
@@ -36,9 +36,12 @@ import {
 } from './host-integration-adapters/imperative-hook-bus.cjs';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import shellCmdProjection = require('./shell-command-projection.cjs');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import installEngine = require('./install-engine.cjs');
 const {
   isManagedHookBasename,
   isManagedHookCommand,
+  isRecognizedCodexContextMonitorCommand,
   projectLegacySettingsHookCommand,
   projectManagedHookCommand,
   projectPortableHookBaseDir,
@@ -48,12 +51,16 @@ const {
 } = shellCmdProjection as {
   isManagedHookBasename: (scriptPath: string, opts?: { surface?: string }) => boolean;
   isManagedHookCommand: (cmd: string | null | undefined, opts?: { surface?: string; includeLegacyAliases?: boolean; configDir?: string }) => boolean;
+  isRecognizedCodexContextMonitorCommand: (cmd: unknown, configDir: string) => boolean;
   projectLegacySettingsHookCommand: (opts: { absoluteRunner: string; scriptPath: string; scriptToken: string; runtime: string; platform: string }) => string | null;
   projectManagedHookCommand: (opts: { absoluteRunner: string; scriptPath: string; runtime: string; platform: string; hookShell?: string }) => string | null;
   projectPortableHookBaseDir: (opts: { configDir: string; homeDir: string }) => string;
   projectCodexHookTomlCommand: (opts: { absoluteRunner: string; scriptPath: string; platform: string }) => string;
   shellHookOmitsBashRunner: (opts: { platform: string; runtime: string; isShellHook: boolean }) => boolean;
   escapeTomlDoubleQuotedString: (value: unknown) => string;
+};
+const { hasExistingSymlinkBetween } = installEngine as {
+  hasExistingSymlinkBetween: (root: string, fullPath: string) => boolean;
 };
 
 // ---------------------------------------------------------------------------
@@ -183,12 +190,18 @@ let __atomicWriteCounter = 0;
 // Set<string> — absolute paths of .tmp-<pid>-<n> files this process created.
 const __atomicWrittenTmps: Set<string> = new Set();
 
-function atomicWriteFileSync(target: string, data: string, options: fs.WriteFileOptions): void {
+function atomicWriteFileSync(
+  target: string,
+  data: string,
+  options: fs.WriteFileOptions,
+  beforeRename?: () => void,
+): void {
   __atomicWriteCounter += 1;
   const tmp = `${target}.tmp-${process.pid}-${__atomicWriteCounter}`;
   __atomicWrittenTmps.add(tmp);
   try {
     fs.writeFileSync(tmp, data, options);
+    beforeRename?.();
     shellCmdProjection.retryRenameSync(tmp, target);
     // Successful rename: the tmp path no longer exists, but leave it in the
     // Set so _cleanTmpFiles can recognise it as installer-owned if it somehow
@@ -580,47 +593,329 @@ interface ReconcileResult {
   path: string;
 }
 
+interface CodexMonitorCleanupResult extends ReconcileResult {
+  removed: number;
+}
+
+interface CodexMonitorCleanupPlan extends CodexMonitorCleanupResult {
+  currentContent: string | null;
+  currentIdentity: CodexHooksJsonIdentity | null;
+  nextContent: string | null;
+  monitorArtifactsReferenced: boolean;
+}
+
+const REMOVE_CODEX_MONITOR_ENTRY = Symbol('remove-codex-monitor-entry');
+
+interface CodexHooksJsonIdentity {
+  dev: number;
+  ino: number;
+}
+
+interface CodexHooksJsonSnapshot {
+  content: string | null;
+  identity: CodexHooksJsonIdentity | null;
+}
+
+function sameCodexHooksJsonIdentity(
+  left: CodexHooksJsonIdentity | null,
+  right: CodexHooksJsonIdentity | null,
+): boolean {
+  return left === null
+    ? right === null
+    : right !== null && left.dev === right.dev && left.ino === right.ino;
+}
+
+function inspectCodexHooksJson(
+  hooksJsonPath: string,
+  failureMessage: string,
+): CodexHooksJsonSnapshot {
+  if (hasExistingSymlinkBetween(path.dirname(hooksJsonPath), hooksJsonPath)) {
+    throw new Error(`${failureMessage} ${hooksJsonPath}`);
+  }
+
+  let before: fs.Stats | undefined;
+  try {
+    before = fs.lstatSync(hooksJsonPath, { throwIfNoEntry: false });
+  } catch {
+    throw new Error(`${failureMessage} ${hooksJsonPath}`);
+  }
+  if (!before) return { content: null, identity: null };
+  if (!before.isFile() || before.isSymbolicLink()) {
+    throw new Error(`${failureMessage} ${hooksJsonPath}`);
+  }
+
+  let content: string;
+  let after: fs.Stats | undefined;
+  try {
+    content = fs.readFileSync(hooksJsonPath, 'utf8');
+    after = fs.lstatSync(hooksJsonPath, { throwIfNoEntry: false });
+  } catch {
+    throw new Error(`${failureMessage} ${hooksJsonPath}`);
+  }
+  const beforeIdentity = { dev: before.dev, ino: before.ino };
+  const afterIdentity = after ? { dev: after.dev, ino: after.ino } : null;
+  if (
+    !after
+    || !after.isFile()
+    || after.isSymbolicLink()
+    || !sameCodexHooksJsonIdentity(beforeIdentity, afterIdentity)
+  ) {
+    throw new Error(`${failureMessage} ${hooksJsonPath}`);
+  }
+  return { content, identity: afterIdentity };
+}
+
+function assertCodexHooksJsonUnchanged(
+  hooksJsonPath: string,
+  expected: CodexHooksJsonSnapshot,
+  failureMessage: string,
+): void {
+  const current = inspectCodexHooksJson(hooksJsonPath, failureMessage);
+  if (
+    current.content !== expected.content
+    || !sameCodexHooksJsonIdentity(current.identity, expected.identity)
+  ) {
+    throw new Error(`${failureMessage} ${hooksJsonPath}`);
+  }
+}
+
+function defineCodexHookEvent(
+  hookTable: Record<string, unknown>,
+  eventName: string,
+  value: unknown[],
+): void {
+  Object.defineProperty(hookTable, eventName, {
+    configurable: true,
+    enumerable: true,
+    value,
+    writable: true,
+  });
+}
+
+function normalizeCodexHooksJson(
+  parsed: Record<string, unknown>,
+  hooksJsonPath: string,
+  failureMessage: string,
+): Record<string, unknown> {
+  const nestedHooks = parsed['hooks'];
+  if (
+    nestedHooks !== undefined
+    && (!nestedHooks || typeof nestedHooks !== 'object' || Array.isArray(nestedHooks))
+  ) {
+    throw new Error(`${failureMessage} ${hooksJsonPath}`);
+  }
+
+  const hookTable: Record<string, unknown> = Object.create(null) as Record<string, unknown>;
+  if (nestedHooks) {
+    for (const [eventName, value] of Object.entries(nestedHooks as Record<string, unknown>)) {
+      if (!Array.isArray(value)) {
+        throw new Error(`${failureMessage} ${hooksJsonPath}`);
+      }
+      defineCodexHookEvent(hookTable, eventName, value);
+    }
+  }
+
+  for (const key of Object.keys(parsed)) {
+    if (key === 'hooks' || !Array.isArray(parsed[key])) continue;
+    const existing = Object.hasOwn(hookTable, key) ? hookTable[key] as unknown[] : [];
+    defineCodexHookEvent(hookTable, key, [...parsed[key] as unknown[], ...existing]);
+    delete parsed[key];
+  }
+  parsed['hooks'] = hookTable;
+  return hookTable;
+}
+
+function containsCodexMonitorArtifactReference(value: unknown): boolean {
+  if (typeof value === 'string') {
+    const normalized = shellCmdProjection.posixNormalize(value).toLowerCase();
+    return normalized.includes('gsd-context-monitor.js')
+      || normalized.includes('gsd-context-monitor.cmd');
+  }
+  if (Array.isArray(value)) {
+    return value.some(containsCodexMonitorArtifactReference);
+  }
+  if (value && typeof value === 'object') {
+    return Object.values(value as Record<string, unknown>)
+      .some(containsCodexMonitorArtifactReference);
+  }
+  return false;
+}
+
+function pruneCodexMonitorEntry(
+  entry: unknown,
+  targetDir: string,
+): { value: unknown; removed: number } {
+  if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+    return { value: entry, removed: 0 };
+  }
+
+  const entryObject = entry as Record<string, unknown>;
+  if (isRecognizedCodexContextMonitorCommand(entryObject['command'], targetDir)) {
+    return { value: REMOVE_CODEX_MONITOR_ENTRY, removed: 1 };
+  }
+  if (!Array.isArray(entryObject['hooks'])) {
+    return { value: entry, removed: 0 };
+  }
+
+  let removed = 0;
+  const hooks: unknown[] = [];
+  for (const hook of entryObject['hooks']) {
+    const pruned = pruneCodexMonitorEntry(hook, targetDir);
+    removed += pruned.removed;
+    if (pruned.value !== REMOVE_CODEX_MONITOR_ENTRY) hooks.push(pruned.value);
+  }
+  if (hooks.length === 0 && removed > 0) {
+    return { value: REMOVE_CODEX_MONITOR_ENTRY, removed };
+  }
+  return {
+    value: removed > 0 ? { ...entryObject, hooks } : entry,
+    removed,
+  };
+}
+
+function planCodexContextMonitorCleanup(targetDir: string): CodexMonitorCleanupPlan {
+  const hooksJsonPath = path.join(targetDir, 'hooks.json');
+  if (hasExistingSymlinkBetween(path.resolve(targetDir), hooksJsonPath)) {
+    throw new Error(`Codex context-monitor cleanup failed to inspect ${hooksJsonPath}`);
+  }
+  if (!fs.existsSync(hooksJsonPath)) {
+    return {
+      changed: false,
+      wrote: false,
+      path: hooksJsonPath,
+      removed: 0,
+      currentContent: null,
+      currentIdentity: null,
+      nextContent: null,
+      monitorArtifactsReferenced: false,
+    };
+  }
+
+  const snapshot = inspectCodexHooksJson(
+    hooksJsonPath,
+    'Codex context-monitor cleanup failed to inspect',
+  );
+  const currentContent = snapshot.content as string;
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = currentContent.trim()
+      ? JSON.parse(currentContent) as Record<string, unknown>
+      : {};
+  } catch {
+    throw new Error(`Codex context-monitor cleanup failed to parse ${hooksJsonPath}`);
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(`Codex context-monitor cleanup failed to validate ${hooksJsonPath}`);
+  }
+
+  const hookTable = normalizeCodexHooksJson(
+    parsed,
+    hooksJsonPath,
+    'Codex context-monitor cleanup failed to validate',
+  );
+
+  let removed = 0;
+  for (const [eventName, value] of Object.entries(hookTable)) {
+    if (!Array.isArray(value)) {
+      throw new Error(`Codex context-monitor cleanup failed to validate ${hooksJsonPath}`);
+    }
+    const entries: unknown[] = [];
+    for (const entry of value) {
+      const pruned = pruneCodexMonitorEntry(entry, targetDir);
+      removed += pruned.removed;
+      if (pruned.value !== REMOVE_CODEX_MONITOR_ENTRY) entries.push(pruned.value);
+    }
+    if (entries.length > 0) hookTable[eventName] = entries;
+    else delete hookTable[eventName];
+  }
+
+  const monitorArtifactsReferenced = containsCodexMonitorArtifactReference(hookTable);
+  if (removed === 0) {
+    return {
+      changed: false,
+      wrote: false,
+      path: hooksJsonPath,
+      removed,
+      currentContent,
+      currentIdentity: snapshot.identity,
+      nextContent: currentContent,
+      monitorArtifactsReferenced,
+    };
+  }
+
+  if (Object.keys(hookTable).length === 0) delete parsed['hooks'];
+  const nextContent = `${JSON.stringify(parsed, null, 2)}\n`;
+  const changed = currentContent !== nextContent;
+  return {
+    changed,
+    wrote: false,
+    path: hooksJsonPath,
+    removed,
+    currentContent,
+    currentIdentity: snapshot.identity,
+    nextContent,
+    monitorArtifactsReferenced,
+  };
+}
+
+function applyCodexContextMonitorCleanup(plan: CodexMonitorCleanupPlan): CodexMonitorCleanupResult {
+  if (!plan.changed || plan.nextContent === null) {
+    return { changed: false, wrote: false, path: plan.path, removed: plan.removed };
+  }
+  if (hasExistingSymlinkBetween(path.dirname(plan.path), plan.path)) {
+    throw new Error(`Codex context-monitor cleanup failed to rewrite ${plan.path}`);
+  }
+  try {
+    atomicWriteFileSync(plan.path, plan.nextContent, 'utf8', () => {
+      assertCodexHooksJsonUnchanged(
+        plan.path,
+        { content: plan.currentContent, identity: plan.currentIdentity },
+        'Codex context-monitor cleanup failed to rewrite',
+      );
+    });
+  } catch {
+    throw new Error(`Codex context-monitor cleanup failed to rewrite ${plan.path}`);
+  }
+  return { changed: true, wrote: true, path: plan.path, removed: plan.removed };
+}
+
+function cleanupCodexContextMonitor(targetDir: string): CodexMonitorCleanupResult {
+  return applyCodexContextMonitorCleanup(planCodexContextMonitorCleanup(targetDir));
+}
+
 function reconcileCodexHooksJsonEvent(targetDir: string, eventName: string, opts: ReconcileCodexOpts = {}): ReconcileResult {
   const hooksJsonPath = path.join(targetDir, 'hooks.json');
   const managedCommand = typeof opts.managedCommand === 'string' ? opts.managedCommand : null;
   const commandWindows = typeof opts.commandWindows === 'string' ? opts.commandWindows : null;
   const matcher = typeof opts.matcher === 'string' ? opts.matcher : undefined;
   const timeout = typeof opts.timeout === 'number' ? opts.timeout : undefined;
+  const snapshot = inspectCodexHooksJson(
+    hooksJsonPath,
+    'Codex hooks.json reconciliation failed to inspect',
+  );
+  const currentContent = snapshot.content;
   let parsed: Record<string, unknown> = {};
-  let currentContent: string | null = null;
-  if (fs.existsSync(hooksJsonPath)) {
-    const raw = fs.readFileSync(hooksJsonPath, 'utf8');
-    currentContent = raw;
-    if (raw.trim()) {
-      try {
-        parsed = JSON.parse(raw) as Record<string, unknown>;
-      } catch (err) {
-        throw new Error(`hooks.json parse failed: ${err && (err as Error).message ? (err as Error).message : String(err)}`);
-      }
+  if (currentContent?.trim()) {
+    try {
+      parsed = JSON.parse(currentContent) as Record<string, unknown>;
+    } catch (err) {
+      throw new Error(`hooks.json parse failed: ${err && (err as Error).message ? (err as Error).message : String(err)}`);
     }
   }
-  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) parsed = {};
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(`Codex hooks.json reconciliation failed to validate ${hooksJsonPath}`);
+  }
 
-  const usesNestedHooksObject =
-    parsed['hooks'] && typeof parsed['hooks'] === 'object' && !Array.isArray(parsed['hooks']);
   // #1348: canonicalize every write to the nested { hooks: { <Event>: [...] } }
   // shape. Lift ANY top-level event array (legacy, empty, OR mixed nested+top-level)
   // into the nested table — merging when the same event exists in both — so
   // user/legacy entries are preserved under `hooks` and no stray top-level event
   // key survives (Codex deny_unknown_fields rejects them). Mirrors reconcileCursorHooksJson.
-  const hookTable: Record<string, unknown> = usesNestedHooksObject
-    ? (parsed['hooks'] as Record<string, unknown>)
-    : {};
-  for (const key of Object.keys(parsed)) {
-    if (key === 'hooks') continue;
-    if (Array.isArray(parsed[key])) {
-      const lifted = parsed[key] as unknown[];
-      const existing = Array.isArray(hookTable[key]) ? (hookTable[key] as unknown[]) : [];
-      hookTable[key] = [...lifted, ...existing];
-      delete parsed[key];
-    }
-  }
-  parsed['hooks'] = hookTable;
+  const hookTable = normalizeCodexHooksJson(
+    parsed,
+    hooksJsonPath,
+    'Codex hooks.json reconciliation failed to validate',
+  );
   const eventEntries = Array.isArray(hookTable[eventName]) ? (hookTable[eventName] as unknown[]) : [];
 
   let removedLegacy = false;
@@ -635,11 +930,18 @@ function reconcileCodexHooksJsonEvent(targetDir: string, eventName: string, opts
     }
     const keptHooks = originalHooks.filter((hook) => {
       const cmd = hook && typeof hook === 'object' ? (hook as Record<string, unknown>)['command'] : null;
-      const managed = isManagedHookCommand(cmd as string | null | undefined, {
-        surface: 'codex-hooks-json',
-        includeLegacyAliases: true,
-        configDir: targetDir,
-      });
+      const monitorCandidate = typeof cmd === 'string'
+        && (
+          cmd.includes('gsd-context-monitor.js')
+          || cmd.includes('gsd-context-monitor.cmd')
+        );
+      const managed = monitorCandidate
+        ? isRecognizedCodexContextMonitorCommand(cmd, targetDir)
+        : isManagedHookCommand(cmd as string | null | undefined, {
+          surface: 'codex-hooks-json',
+          includeLegacyAliases: true,
+          configDir: targetDir,
+        });
       if (managed) removedLegacy = true;
       return !managed;
     });
@@ -672,7 +974,13 @@ function reconcileCodexHooksJsonEvent(targetDir: string, eventName: string, opts
   const changed = currentContent !== nextContent;
   const shouldWrite = changed && (currentContent !== null || Object.keys(parsed).length > 0);
   if (shouldWrite) {
-    atomicWriteFileSync(hooksJsonPath, nextContent, 'utf8');
+    atomicWriteFileSync(hooksJsonPath, nextContent, 'utf8', () => {
+      assertCodexHooksJsonUnchanged(
+        hooksJsonPath,
+        snapshot,
+        'Codex hooks.json reconciliation failed to rewrite',
+      );
+    });
   }
 
   return { changed: changed || removedLegacy, wrote: shouldWrite, path: hooksJsonPath };
@@ -782,57 +1090,8 @@ function ensureCodexHooksJsonSessionStart(targetDir: string, opts: EnsureCodexSe
 }
 
 // ---------------------------------------------------------------------------
-// ensureCodexHooksJsonEvent
+// removeCodexHooksJsonSessionStart
 // ---------------------------------------------------------------------------
-
-interface EnsureCodexEventOpts {
-  absoluteRunner?: string | null;
-  platform?: NodeJS.Platform;
-}
-
-function ensureCodexHooksJsonEvent(targetDir: string, eventName: string, opts: EnsureCodexEventOpts = {}): ReconcileResult {
-  const platform = opts.platform || process.platform;
-  const absoluteRunner = opts.absoluteRunner || null;
-  const hooksJsonPath = path.join(targetDir, 'hooks.json');
-  if (!absoluteRunner) return { changed: false, wrote: false, path: hooksJsonPath };
-
-  const scriptPath = shellCmdProjection.posixNormalize(path.resolve(targetDir, 'hooks', 'gsd-context-monitor.js'));
-
-  let managedCommand: string | undefined;
-  if (platform === 'win32') {
-    const shimIR = buildCodexHookWindowsShimIR(scriptPath, absoluteRunner);
-    if (!shimIR) return { changed: false, wrote: false, path: hooksJsonPath };
-    try {
-      atomicWriteFileSync(shimIR.cmdPath, shimIR.render.cmd(), 'utf8');
-    } catch (shimWriteErr) {
-      const reason = shimWriteErr && (shimWriteErr as Error).message ? (shimWriteErr as Error).message : String(shimWriteErr);
-      console.warn(
-        `  ${yellow}⚠${reset}  Codex Windows hook NOT installed — .cmd shim write failed for ${eventName}: ${reason}. ` +
-          `Fix the write error (permissions? disk full?) and re-run the installer.`,
-      );
-      return { changed: false, wrote: false, path: hooksJsonPath };
-    }
-    managedCommand = shimIR.hookCommand;
-  } else {
-    managedCommand = projectManagedHookCommand({
-      absoluteRunner,
-      scriptPath,
-      runtime: 'codex',
-      platform,
-    }) ?? undefined;
-  }
-
-  if (!managedCommand) return { changed: false, wrote: false, path: hooksJsonPath };
-  return reconcileCodexHooksJsonEvent(targetDir, eventName, { managedCommand, timeout: 10 });
-}
-
-// ---------------------------------------------------------------------------
-// removeCodexHooksJsonEvent / removeCodexHooksJsonSessionStart
-// ---------------------------------------------------------------------------
-
-function removeCodexHooksJsonEvent(targetDir: string, eventName: string): ReconcileResult {
-  return reconcileCodexHooksJsonEvent(targetDir, eventName, { managedCommand: null });
-}
 
 function removeCodexHooksJsonSessionStart(targetDir: string): ReconcileResult {
   return reconcileCodexHooksJsonSessionStart(targetDir, { managedCommand: null });
@@ -2362,9 +2621,10 @@ export = {
   // Codex hooks.json
   reconcileCodexHooksJsonEvent,
   reconcileCodexHooksJsonSessionStart,
+  planCodexContextMonitorCleanup,
+  applyCodexContextMonitorCleanup,
+  cleanupCodexContextMonitor,
   ensureCodexHooksJsonSessionStart,
-  ensureCodexHooksJsonEvent,
-  removeCodexHooksJsonEvent,
   removeCodexHooksJsonSessionStart,
   buildCodexHookWindowsShimIR,
 

--- a/src/shell-command-projection.cts
+++ b/src/shell-command-projection.cts
@@ -234,9 +234,9 @@ const MANAGED_HOOK_COMMAND_BASENAMES_BY_SURFACE: Record<string, Set<string>> = {
     // reconcileCodexHooksJsonSessionStart can replace stale node-runner commands
     // with the .cmd shim on reinstall (and vice-versa on cross-platform moves).
     'gsd-check-update.cmd',
-    // #772: context-monitor is now registered for Codex SubagentStart/Stop/PostToolUse.
+    // Cleanup-only legacy basename retained for exact retired monitor recognition.
     'gsd-context-monitor.js',
-    // #772: Windows .cmd shim for gsd-context-monitor — same #3426 pattern.
+    // Windows .cmd legacy counterpart; cleanup-only for exact recognition.
     'gsd-context-monitor.cmd',
   ]),
 };
@@ -300,6 +300,41 @@ export function isManagedHookCommand(commandText: unknown, opts: { surface?: str
     const escapedBasename = basename.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     const pattern = new RegExp(`(^|[\\\\/\\s"'` + '`' + `])${escapedBasename}(?=$|[\\s"'` + '`' + `])`);
     if (pattern.test(normalizedCommand)) return true;
+  }
+  return false;
+}
+
+export function isRecognizedCodexContextMonitorCommand(commandText: unknown, configDir: string): boolean {
+  if (typeof commandText !== 'string' || typeof configDir !== 'string' || configDir.length === 0) {
+    return false;
+  }
+
+  const normalizedHooksDir = posixNormalize(path.resolve(configDir, 'hooks'));
+  const monitorScript = `${normalizedHooksDir}/gsd-context-monitor.js`;
+  const monitorShim = `${normalizedHooksDir}/gsd-context-monitor.cmd`;
+  const jsonString = '"(?:\\\\.|[^"\\\\])*"';
+
+  const shimMatch = commandText.match(new RegExp(`^(${jsonString})$`));
+  if (shimMatch) {
+    try {
+      return posixNormalize(JSON.parse(shimMatch[1]) as string) === monitorShim;
+    } catch {
+      return false;
+    }
+  }
+
+  const nodeMatch = commandText.match(new RegExp(`^(${jsonString}) (${jsonString})$`));
+  if (nodeMatch) {
+    try {
+      const runner = JSON.parse(nodeMatch[1]) as string;
+      const script = JSON.parse(nodeMatch[2]) as string;
+      const runnerBasename = posixNormalize(runner).split('/').pop()?.toLowerCase();
+      return (path.isAbsolute(runner) || path.win32.isAbsolute(runner))
+        && (runnerBasename === 'node' || runnerBasename === 'node.exe')
+        && posixNormalize(script) === monitorScript;
+    } catch {
+      return false;
+    }
   }
   return false;
 }

--- a/tests/codex-config.test.cjs
+++ b/tests/codex-config.test.cjs
@@ -18,10 +18,12 @@ const assert = require('node:assert/strict');
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
-const { execFileSync } = require('child_process');
-const { cleanup } = require('./helpers.cjs');
+const nodeCrypto = require('node:crypto');
+const { execFileSync, spawn } = require('child_process');
+const { cleanup, captureConsole, waitFor } = require('./helpers.cjs');
 const fc = require('fast-check');
 const { CLAUDE_AGENT_ALIASES } = require('../gsd-core/bin/lib/model-resolver.cjs');
+const { runtimes } = require('../gsd-core/bin/lib/capability-registry.cjs');
 
 // #2153 follow-up: ensure hooks/dist/ exists before any install integration
 // test runs. The Codex install path copies hook files from hooks/dist/, which
@@ -47,11 +49,14 @@ const {
   convertClaudeCommandToCodexSkill,
   generateCodexAgentToml,
   cleanupCodexSkillMetadataSidecars,
+  cleanupCodexContextMonitor,
+  ensureCodexHooksJsonSessionStart,
   generateCodexConfigBlock,
   stripGsdFromCodexConfig,
   migrateCodexHooksMapFormat,
   mergeCodexConfig,
   install,
+  uninstall,
   GSD_CODEX_MARKER,
   CODEX_AGENT_SANDBOX,
   parseTomlToObject,
@@ -60,6 +65,13 @@ const {
 } = require('../bin/install.js');
 
 const { resolveInstallPlan } = require('../gsd-core/bin/lib/runtime-config-adapter-registry.cjs');
+const {
+  isRecognizedCodexContextMonitorCommand,
+} = require('../gsd-core/bin/lib/shell-command-projection.cjs');
+const {
+  applyCodexContextMonitorCleanup,
+  planCodexContextMonitorCleanup,
+} = require('../gsd-core/bin/lib/runtime-hooks-surface.cjs');
 
 function runCodexInstall(codexHome, cwd = path.join(__dirname, '..')) {
   const previousCodeHome = process.env.CODEX_HOME;
@@ -77,6 +89,29 @@ function runCodexInstall(codexHome, cwd = path.join(__dirname, '..')) {
   try {
     process.chdir(cwd);
     return install(true, 'codex');
+  } finally {
+    process.chdir(previousCwd);
+    if (previousCodeHome === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = previousCodeHome;
+    if (previousHome === undefined) delete process.env.HOME;
+    else process.env.HOME = previousHome;
+    if (previousUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = previousUserProfile;
+  }
+}
+
+function runCodexUninstall(codexHome, cwd = path.join(__dirname, '..')) {
+  const previousCodeHome = process.env.CODEX_HOME;
+  const previousHome = process.env.HOME;
+  const previousUserProfile = process.env.USERPROFILE;
+  const previousCwd = process.cwd();
+  process.env.CODEX_HOME = codexHome;
+  process.env.HOME = codexHome;
+  process.env.USERPROFILE = codexHome;
+
+  try {
+    process.chdir(cwd);
+    return uninstall(true, 'codex');
   } finally {
     process.chdir(previousCwd);
     if (previousCodeHome === undefined) delete process.env.CODEX_HOME;
@@ -119,6 +154,24 @@ function readHooksSessionStartCommands(codexHome) {
   ]);
 }
 
+function readAllHooksCommands(codexHome) {
+  const hooksPath = path.join(codexHome, 'hooks.json');
+  if (!fs.existsSync(hooksPath)) return [];
+  const parsed = JSON.parse(fs.readFileSync(hooksPath, 'utf8'));
+  const table = (parsed.hooks && typeof parsed.hooks === 'object' && !Array.isArray(parsed.hooks))
+    ? parsed.hooks
+    : parsed;
+  return Object.values(table).flatMap((entries) => (
+    Array.isArray(entries)
+      ? entries.flatMap((entry) => (
+        Array.isArray(entry?.hooks)
+          ? entry.hooks.map((hook) => hook?.command).filter((command) => typeof command === 'string')
+          : []
+      ))
+      : []
+  ));
+}
+
 function countMatches(content, pattern) {
   return (content.match(pattern) || []).length;
 }
@@ -153,6 +206,15 @@ function assertNoCodexBareGsdToolsInvocation(content, label) {
     );
   }
 }
+
+describe('Codex public capability metadata', () => {
+  test('reports agent-facing warnings and GSD phase display as unsupported', () => {
+    const hostBehaviors = runtimes.codex.runtime.hostBehaviors;
+
+    assert.strictEqual(hostBehaviors.agentFacingContextWarnings, false);
+    assert.strictEqual(hostBehaviors.gsdPhaseLifecycleDisplay, false);
+  });
+});
 
 // ─── getCodexSkillAdapterHeader ─────────────────────────────────────────────────
 
@@ -1922,6 +1984,86 @@ describe('Codex install hook configuration (e2e)', () => {
     );
   });
 
+  test('fresh and repeated installs expose only the supported update hook', () => {
+    runCodexInstall(codexHome);
+    runCodexInstall(codexHome);
+
+    const commands = readAllHooksCommands(codexHome);
+    assert.strictEqual(
+      commands.filter((command) => command.includes('gsd-check-update')).length,
+      1,
+      'reinstall leaves exactly one update handler',
+    );
+    assert.ok(
+      commands.every((command) => !command.includes('gsd-context-monitor')),
+      'no hooks.json event references the unsupported context monitor',
+    );
+    assert.ok(
+      !fs.existsSync(path.join(codexHome, 'hooks', 'gsd-context-monitor.js')),
+      'does not install the context monitor',
+    );
+    assert.ok(
+      !fs.existsSync(path.join(codexHome, 'hooks', 'gsd-context-monitor.cmd')),
+      'does not install a context-monitor Windows shim',
+    );
+  });
+
+  test('fresh and repeated installs state the unsupported Codex capability boundary once per run', () => {
+    const noticePattern = /Agent-facing context warnings and GSD phase\/lifecycle display are unsupported on Codex\./g;
+
+    const freshOutput = captureConsole(() => runCodexInstall(codexHome)).stdout;
+    const repeatOutput = captureConsole(() => runCodexInstall(codexHome)).stdout;
+
+    assert.strictEqual((freshOutput.match(noticePattern) || []).length, 1);
+    assert.strictEqual((repeatOutput.match(noticePattern) || []).length, 1);
+    assert.doesNotMatch(freshOutput, /Removed obsolete Codex context-monitor registration/);
+    assert.doesNotMatch(repeatOutput, /Removed obsolete Codex context-monitor registration/);
+  });
+
+  test('monitor cleanup on an absent hooks.json is a no-op', () => {
+    assert.strictEqual(typeof cleanupCodexContextMonitor, 'function');
+
+    const result = cleanupCodexContextMonitor(codexHome);
+
+    assert.deepStrictEqual(result, {
+      changed: false,
+      wrote: false,
+      path: path.join(codexHome, 'hooks.json'),
+      removed: 0,
+    });
+    assert.ok(!fs.existsSync(path.join(codexHome, 'hooks.json')));
+  });
+
+  test('monitor recognition is exact and confined to the target hooks directory', () => {
+    assert.strictEqual(typeof isRecognizedCodexContextMonitorCommand, 'function');
+
+    const hooksDir = path.join(codexHome, 'hooks').replace(/\\/g, '/');
+    const exactNodeCommand = `"/usr/bin/node" "${hooksDir}/gsd-context-monitor.js"`;
+    const exactNodeExeCommand = `"C:/Program Files/nodejs/node.exe" "${hooksDir}/gsd-context-monitor.js"`;
+    const exactCmdCommand = `"${hooksDir}/gsd-context-monitor.cmd"`;
+    for (const command of [exactNodeCommand, exactNodeExeCommand, exactCmdCommand]) {
+      assert.strictEqual(isRecognizedCodexContextMonitorCommand(command, codexHome), true, command);
+    }
+
+    const externalMonitor = path.join(tmpDir, 'external', 'gsd-context-monitor.js').replace(/\\/g, '/');
+    for (const command of [
+      `${exactNodeCommand} --custom-threshold 25`,
+      `${exactNodeCommand}; echo custom`,
+      `sh -c '${exactNodeCommand}'`,
+      ` ${exactNodeCommand}`,
+      `${exactNodeCommand} `,
+      `node "${hooksDir}/gsd-context-monitor.js"`,
+      `"/usr/bin/bun" "${hooksDir}/gsd-context-monitor.js"`,
+      `"/usr/bin/node" "$CODEX_HOME/hooks/gsd-context-monitor.js"`,
+      `"/usr/bin/node" "${hooksDir}/gsd-context-monitor.js.backup"`,
+      `"/usr/bin/node" "${hooksDir}/custom-gsd-context-monitor.js"`,
+      `"/usr/bin/node" "${hooksDir}/gsd-check-update.js"`,
+      `"/usr/bin/node" "${externalMonitor}"`,
+    ]) {
+      assert.strictEqual(isRecognizedCodexContextMonitorCommand(command, codexHome), false, command);
+    }
+  });
+
   test('fresh CODEX_HOME enables codex_hooks without draft root defaults', () => {
     runCodexInstall(codexHome);
 
@@ -2616,6 +2758,876 @@ describe('Codex install hook configuration (e2e)', () => {
     assert.ok(content.includes('[model]\r\nname = "o3"'), 'preserves the existing CRLF model lines');
     assert.strictEqual(countMatches(content, /^hooks = true$/gm), 1, 'remains idempotent on repeated installs');
     assertNoDraftRootKeys(content);
+  });
+});
+
+describe('Codex legacy context-monitor cleanup hardening', { concurrency: false }, () => {
+  let tmpDir;
+  let codexHome;
+  let originalRenameSync;
+  let originalRmSync;
+  let originalLstatSync;
+  let originalOpenSync;
+  let originalWriteFileSync;
+  let originalConsoleWarn;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-codex-monitor-cleanup-'));
+    codexHome = path.join(tmpDir, 'codex-home');
+    fs.mkdirSync(codexHome, { recursive: true });
+    originalRenameSync = fs.renameSync;
+    originalRmSync = fs.rmSync;
+    originalLstatSync = fs.lstatSync;
+    originalOpenSync = fs.openSync;
+    originalWriteFileSync = fs.writeFileSync;
+    originalConsoleWarn = console.warn;
+  });
+
+  afterEach(() => {
+    fs.renameSync = originalRenameSync;
+    fs.rmSync = originalRmSync;
+    fs.lstatSync = originalLstatSync;
+    fs.openSync = originalOpenSync;
+    fs.writeFileSync = originalWriteFileSync;
+    console.warn = originalConsoleWarn;
+    cleanup(tmpDir);
+  });
+
+  function monitorCommand(file = 'gsd-context-monitor.js') {
+    const monitorPath = path.join(codexHome, 'hooks', file).replace(/\\/g, '/');
+    return file.endsWith('.cmd')
+      ? `"${monitorPath}"`
+      : `"/usr/bin/node" "${monitorPath}"`;
+  }
+
+  function writeHooks(value) {
+    const hooksPath = path.join(codexHome, 'hooks.json');
+    fs.writeFileSync(hooksPath, JSON.stringify(value, null, 2) + '\n');
+    return hooksPath;
+  }
+
+  function writeManifestOwnedArtifacts(contentsByRelPath) {
+    const files = {};
+    const paths = {};
+    for (const [relPath, content] of Object.entries(contentsByRelPath)) {
+      const artifactPath = path.join(codexHome, relPath);
+      fs.mkdirSync(path.dirname(artifactPath), { recursive: true });
+      fs.writeFileSync(artifactPath, content);
+      files[relPath] = nodeCrypto.createHash('sha256').update(content).digest('hex');
+      paths[relPath] = artifactPath;
+    }
+    fs.writeFileSync(path.join(codexHome, 'gsd-file-manifest.json'), JSON.stringify({
+      version: 'legacy',
+      files,
+    }, null, 2) + '\n');
+    return paths;
+  }
+
+  function writeManifestOwnedMonitor(content) {
+    return writeManifestOwnedArtifacts({
+      'hooks/gsd-context-monitor.js': content,
+    })['hooks/gsd-context-monitor.js'];
+  }
+
+  test('removes exact monitor handlers from mixed flat and nested events and converges byte-for-byte', () => {
+    const externalMonitor = path.join(tmpDir, 'external', 'gsd-context-monitor.js').replace(/\\/g, '/');
+    const updateHook = path.join(codexHome, 'hooks', 'gsd-check-update.js').replace(/\\/g, '/');
+    const hooksPath = writeHooks({
+      Stop: [{
+        matcher: 'stop',
+        hooks: [
+          { type: 'command', command: monitorCommand() },
+          { type: 'command', command: 'custom-stop-handler' },
+        ],
+      }],
+      hooks: {
+        SessionStart: [{
+          hooks: [
+            { type: 'command', command: monitorCommand('gsd-context-monitor.cmd') },
+            { type: 'command', command: `"/usr/bin/node" "${updateHook}"` },
+          ],
+        }],
+        PostToolUse: [{
+          hooks: [
+            { type: 'command', command: `"/usr/bin/node" "${externalMonitor}"` },
+            { type: 'command', command: 'unknown-handler --context-monitor' },
+          ],
+        }],
+      },
+    });
+
+    const first = cleanupCodexContextMonitor(codexHome);
+    const firstBytes = fs.readFileSync(hooksPath, 'utf8');
+    const second = cleanupCodexContextMonitor(codexHome);
+
+    assert.strictEqual(first.removed, 2);
+    assert.strictEqual(first.changed, true);
+    assert.strictEqual(second.changed, false);
+    assert.strictEqual(second.removed, 0);
+    assert.strictEqual(fs.readFileSync(hooksPath, 'utf8'), firstBytes);
+
+    const parsed = JSON.parse(firstBytes);
+    assert.deepStrictEqual(Object.keys(parsed), ['hooks']);
+    assert.deepStrictEqual(Object.keys(parsed.hooks).sort(), ['PostToolUse', 'SessionStart', 'Stop']);
+    const commands = readAllHooksCommands(codexHome);
+    assert.ok(commands.includes('custom-stop-handler'));
+    assert.ok(commands.some((command) => command.includes('gsd-check-update.js')));
+    assert.ok(commands.some((command) => command.includes(externalMonitor)));
+    assert.ok(commands.includes('unknown-handler --context-monitor'));
+    assert.ok(commands.every((command) => !isRecognizedCodexContextMonitorCommand(command, codexHome)));
+  });
+
+  test('preserves customized monitor commands while removing only exact retired registrations', () => {
+    const exactCommand = monitorCommand();
+    const customCommands = [
+      `${exactCommand} --custom-threshold 25`,
+      `${exactCommand}; echo custom`,
+      `sh -c '${exactCommand}'`,
+      `node "${path.join(codexHome, 'hooks', 'gsd-context-monitor.js').replace(/\\/g, '/')}"`,
+      `"/usr/bin/bun" "${path.join(codexHome, 'hooks', 'gsd-context-monitor.js').replace(/\\/g, '/')}"`,
+      '"/usr/bin/node" "$CODEX_HOME/hooks/gsd-context-monitor.js"',
+    ];
+    const hooksPath = writeHooks({
+      hooks: {
+        Stop: [{
+          hooks: [
+            { type: 'command', command: exactCommand },
+            ...customCommands.map((command) => ({ type: 'command', command })),
+          ],
+        }],
+      },
+    });
+
+    const result = cleanupCodexContextMonitor(codexHome);
+    const remainingCommands = readAllHooksCommands(codexHome);
+
+    assert.strictEqual(result.removed, 1);
+    assert.deepStrictEqual(remainingCommands, customCommands);
+    assert.doesNotThrow(() => JSON.parse(fs.readFileSync(hooksPath, 'utf8')));
+  });
+
+  test('retains both managed monitor artifacts when any surviving field still references one', () => {
+    const hooksPath = writeHooks({
+      hooks: {
+        Stop: [{
+          hooks: [
+            { type: 'command', command: monitorCommand() },
+            {
+              type: 'command',
+              command: 'node "$CODEX_HOME/hooks/gsd-context-monitor.js" --custom',
+              commandWindows: '"%CODEX_HOME%/hooks/gsd-context-monitor.cmd"',
+              args: ['$CODEX_HOME/hooks/gsd-context-monitor.js'],
+              customHandler: {
+                fallback: 'hooks/gsd-context-monitor.cmd',
+              },
+            },
+          ],
+        }],
+      },
+    });
+    const artifactPaths = writeManifestOwnedArtifacts({
+      'hooks/gsd-context-monitor.js': 'managed js monitor\n',
+      'hooks/gsd-context-monitor.cmd': 'managed cmd monitor\n',
+    });
+
+    const result = cleanupCodexContextMonitor(codexHome);
+
+    assert.strictEqual(result.removed, 1);
+    assert.doesNotThrow(() => JSON.parse(fs.readFileSync(hooksPath, 'utf8')));
+    for (const artifactPath of Object.values(artifactPaths)) {
+      assert.strictEqual(fs.existsSync(artifactPath), true, artifactPath);
+    }
+  });
+
+  test('monitor-free flat and nested hooks remain byte-identical and retain managed artifacts', () => {
+    const hooksPath = path.join(codexHome, 'hooks.json');
+    const cases = [
+      '{"Stop":[{"hooks":[{"type":"command","command":"custom-flat"}]}]}\n',
+      '{"customTopLevel":true,"hooks":{"Stop":[{"custom":"keep","hooks":[{"type":"command","command":"custom-nested"}]}]}}\n',
+    ];
+
+    for (const originalBytes of cases) {
+      fs.writeFileSync(hooksPath, originalBytes);
+      const artifactPaths = writeManifestOwnedArtifacts({
+        'hooks/gsd-context-monitor.js': 'managed js monitor\n',
+        'hooks/gsd-context-monitor.cmd': 'managed cmd monitor\n',
+      });
+
+      const result = cleanupCodexContextMonitor(codexHome);
+
+      assert.deepStrictEqual(result, {
+        changed: false,
+        wrote: false,
+        path: hooksPath,
+        removed: 0,
+      });
+      assert.strictEqual(fs.readFileSync(hooksPath, 'utf8'), originalBytes);
+      for (const artifactPath of Object.values(artifactPaths)) {
+        assert.strictEqual(fs.existsSync(artifactPath), true, artifactPath);
+      }
+    }
+  });
+
+  test('symlinked hooks directory cannot remove or back up an external monitor artifact', () => {
+    const externalHooksDir = path.join(tmpDir, 'external-hooks');
+    fs.mkdirSync(externalHooksDir, { recursive: true });
+    const hooksLink = path.join(codexHome, 'hooks');
+    fs.symlinkSync(externalHooksDir, hooksLink, 'dir');
+    const hooksPath = writeHooks({
+      hooks: {
+        Stop: [{
+          hooks: [
+            { type: 'command', command: monitorCommand() },
+            { type: 'command', command: monitorCommand('gsd-context-monitor.cmd') },
+          ],
+        }],
+      },
+    });
+    const artifactPaths = writeManifestOwnedArtifacts({
+      'hooks/gsd-context-monitor.js': 'managed pristine monitor\n',
+      'hooks/gsd-context-monitor.cmd': 'manifest baseline monitor\n',
+    });
+    fs.writeFileSync(
+      artifactPaths['hooks/gsd-context-monitor.cmd'],
+      'managed modified monitor\n',
+    );
+    const expectedBytes = Object.fromEntries(
+      Object.entries(artifactPaths)
+        .map(([relPath, artifactPath]) => [relPath, fs.readFileSync(artifactPath)]),
+    );
+
+    const previousSymlinkOptIn = process.env.GSD_ALLOW_SYMLINKED_DEST;
+    process.env.GSD_ALLOW_SYMLINKED_DEST = '1';
+    let result;
+    try {
+      result = cleanupCodexContextMonitor(codexHome);
+    } finally {
+      if (previousSymlinkOptIn === undefined) delete process.env.GSD_ALLOW_SYMLINKED_DEST;
+      else process.env.GSD_ALLOW_SYMLINKED_DEST = previousSymlinkOptIn;
+    }
+
+    assert.strictEqual(result.removed, 2);
+    assert.strictEqual(fs.lstatSync(hooksLink).isSymbolicLink(), true);
+    for (const [relPath, artifactPath] of Object.entries(artifactPaths)) {
+      assert.strictEqual(fs.existsSync(artifactPath), true, relPath);
+      assert.deepStrictEqual(fs.readFileSync(artifactPath), expectedBytes[relPath], relPath);
+    }
+    assert.strictEqual(
+      fs.existsSync(path.join(codexHome, 'gsd-migration-journal')),
+      false,
+      'unsafe external referents do not create migration backups',
+    );
+    assert.ok(!fs.readFileSync(hooksPath, 'utf8').includes('gsd-context-monitor'));
+  });
+
+  test('rejects symlinked hooks.json before install or uninstall mutation', () => {
+    const previousSymlinkOptIn = process.env.GSD_ALLOW_SYMLINKED_DEST;
+    try {
+      for (const allowSymlinkFollow of [false, true]) {
+        for (const operation of ['install', 'uninstall']) {
+          const caseDir = path.join(
+            tmpDir,
+            `${operation}-${allowSymlinkFollow ? 'follow-enabled' : 'follow-disabled'}`,
+          );
+          const caseHome = path.join(caseDir, 'codex-home');
+          const externalHooksPath = path.join(caseDir, 'external-hooks.json');
+          fs.mkdirSync(caseHome, { recursive: true });
+          const privateSentinel = `PRIVATE_${operation.toUpperCase()}_HOOK_VALUE`;
+          const externalBytes = `${JSON.stringify({
+            hooks: {
+              Stop: [{
+                hooks: [{
+                  type: 'command',
+                  command: `"/usr/bin/node" "${path.join(caseHome, 'hooks', 'gsd-context-monitor.js')}"`,
+                  marker: privateSentinel,
+                }],
+              }],
+            },
+          }, null, 2)}\n`;
+          fs.writeFileSync(externalHooksPath, externalBytes);
+          const hooksPath = path.join(caseHome, 'hooks.json');
+          fs.symlinkSync(externalHooksPath, hooksPath);
+          const configPath = path.join(caseHome, 'config.toml');
+          const configBytes = '# PRIVATE_USER_CONFIG\n';
+          fs.writeFileSync(configPath, configBytes);
+          fs.writeFileSync(path.join(caseHome, '.gsd-profile'), 'full\n');
+          const beforeInventory = fs.readdirSync(caseHome).sort();
+          const beforeLink = fs.lstatSync(hooksPath);
+
+          if (allowSymlinkFollow) process.env.GSD_ALLOW_SYMLINKED_DEST = '1';
+          else delete process.env.GSD_ALLOW_SYMLINKED_DEST;
+
+          assert.throws(
+            () => {
+              if (operation === 'install') runCodexInstall(caseHome);
+              else {
+                const previousCodeHome = process.env.CODEX_HOME;
+                const previousHome = process.env.HOME;
+                const previousUserProfile = process.env.USERPROFILE;
+                process.env.CODEX_HOME = caseHome;
+                process.env.HOME = caseHome;
+                process.env.USERPROFILE = caseHome;
+                try {
+                  uninstall(true, 'codex');
+                } finally {
+                  if (previousCodeHome === undefined) delete process.env.CODEX_HOME;
+                  else process.env.CODEX_HOME = previousCodeHome;
+                  if (previousHome === undefined) delete process.env.HOME;
+                  else process.env.HOME = previousHome;
+                  if (previousUserProfile === undefined) delete process.env.USERPROFILE;
+                  else process.env.USERPROFILE = previousUserProfile;
+                }
+              }
+            },
+            (error) => {
+              assert.match(error.message, /Codex context-monitor cleanup failed to (inspect|rewrite)/);
+              assert.ok(error.message.includes(hooksPath));
+              assert.ok(!error.message.includes(privateSentinel));
+              assert.ok(!error.message.includes('PRIVATE_USER_CONFIG'));
+              return true;
+            },
+          );
+
+          assert.strictEqual(fs.lstatSync(hooksPath).isSymbolicLink(), true);
+          assert.strictEqual(fs.lstatSync(hooksPath).ino, beforeLink.ino);
+          assert.strictEqual(fs.readlinkSync(hooksPath), externalHooksPath);
+          assert.strictEqual(fs.readFileSync(externalHooksPath, 'utf8'), externalBytes);
+          assert.strictEqual(fs.readFileSync(configPath, 'utf8'), configBytes);
+          assert.deepStrictEqual(fs.readdirSync(caseHome).sort(), beforeInventory);
+        }
+      }
+    } finally {
+      if (previousSymlinkOptIn === undefined) delete process.env.GSD_ALLOW_SYMLINKED_DEST;
+      else process.env.GSD_ALLOW_SYMLINKED_DEST = previousSymlinkOptIn;
+    }
+  });
+
+  test('install preserves a symlink introduced after preflight and does not touch its referent', () => {
+    const hooksPath = writeHooks({
+      hooks: {
+        Stop: [{ hooks: [{ type: 'command', command: 'original-user-handler' }] }],
+      },
+    });
+    const externalHooksPath = path.join(tmpDir, 'external-hooks.json');
+    const externalBytes = '{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"external-user-handler"}]}]}}\n';
+    fs.writeFileSync(externalHooksPath, externalBytes);
+    const configPath = path.join(codexHome, 'config.toml');
+    const configBytes = '# PRIVATE_USER_CONFIG\n';
+    fs.writeFileSync(configPath, configBytes);
+    let swapped = false;
+    fs.writeFileSync = (target, ...args) => {
+      const result = originalWriteFileSync(target, ...args);
+      if (
+        !swapped
+        && path.resolve(String(target)) === path.resolve(codexHome, 'hooks', 'gsd-check-update.js')
+      ) {
+        swapped = true;
+        fs.unlinkSync(hooksPath);
+        fs.symlinkSync(externalHooksPath, hooksPath);
+      }
+      return result;
+    };
+
+    assert.throws(
+      () => runCodexInstall(codexHome),
+      /Codex hooks.json reconciliation failed to inspect/,
+    );
+
+    assert.strictEqual(swapped, true);
+    assert.strictEqual(fs.lstatSync(hooksPath).isSymbolicLink(), true);
+    assert.strictEqual(fs.readlinkSync(hooksPath), externalHooksPath);
+    assert.strictEqual(fs.readFileSync(externalHooksPath, 'utf8'), externalBytes);
+    assert.strictEqual(fs.readFileSync(configPath, 'utf8'), configBytes);
+  });
+
+  test('uninstall preserves a symlink introduced between preflight and SessionStart removal', () => {
+    runCodexInstall(codexHome);
+    const hooksPath = path.join(codexHome, 'hooks.json');
+    const externalHooksPath = path.join(tmpDir, 'external-uninstall-hooks.json');
+    const externalBytes = '{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"external-user-handler"}]}]}}\n';
+    fs.writeFileSync(externalHooksPath, externalBytes);
+    const configPath = path.join(codexHome, 'config.toml');
+    const configBytes = fs.readFileSync(configPath, 'utf8');
+    const lockPath = path.join(codexHome, 'gsd-install-migration.lock');
+    let lockAcquisitions = 0;
+    fs.openSync = (target, ...args) => {
+      if (path.resolve(String(target)) === path.resolve(lockPath)) {
+        lockAcquisitions++;
+        if (lockAcquisitions === 2) {
+          fs.unlinkSync(hooksPath);
+          fs.symlinkSync(externalHooksPath, hooksPath);
+        }
+      }
+      return originalOpenSync(target, ...args);
+    };
+
+    assert.throws(
+      () => runCodexUninstall(codexHome),
+      /Codex hooks.json reconciliation failed to inspect/,
+    );
+
+    assert.strictEqual(lockAcquisitions, 2);
+    assert.strictEqual(fs.lstatSync(hooksPath).isSymbolicLink(), true);
+    assert.strictEqual(fs.readlinkSync(hooksPath), externalHooksPath);
+    assert.strictEqual(fs.readFileSync(externalHooksPath, 'utf8'), externalBytes);
+    assert.strictEqual(fs.readFileSync(configPath, 'utf8'), configBytes);
+  });
+
+  test('rejects incompatible flat and nested hook events without data loss', () => {
+    const hooksPath = path.join(codexHome, 'hooks.json');
+    const originalBytes = `${JSON.stringify({
+      Stop: [{
+        hooks: [{ type: 'command', command: monitorCommand() }],
+      }],
+      hooks: {
+        Stop: {
+          privateUserValue: 'PRIVATE_COLLISION_VALUE',
+        },
+      },
+    }, null, 2)}\n`;
+    fs.writeFileSync(hooksPath, originalBytes);
+    const configPath = path.join(codexHome, 'config.toml');
+    fs.writeFileSync(configPath, '# PRIVATE_USER_CONFIG\n');
+    const beforeInventory = fs.readdirSync(codexHome).sort();
+
+    assert.throws(
+      () => runCodexInstall(codexHome),
+      (error) => {
+        assert.match(error.message, /Codex context-monitor cleanup failed to validate/);
+        assert.ok(error.message.includes(hooksPath));
+        assert.ok(!error.message.includes('PRIVATE_COLLISION_VALUE'));
+        assert.ok(!error.message.includes('PRIVATE_USER_CONFIG'));
+        return true;
+      },
+    );
+
+    assert.strictEqual(fs.readFileSync(hooksPath, 'utf8'), originalBytes);
+    assert.strictEqual(fs.readFileSync(configPath, 'utf8'), '# PRIVATE_USER_CONFIG\n');
+    assert.deepStrictEqual(fs.readdirSync(codexHome).sort(), beforeInventory);
+  });
+
+  test('preserves __proto__ as an own hook event key', () => {
+    const hooksPath = path.join(codexHome, 'hooks.json');
+    const originalBytes = [
+      '{',
+      '  "__proto__": [{ "hooks": [{ "type": "command", "command": "custom-special-handler" }] }],',
+      `  "Stop": [{ "hooks": [{ "type": "command", "command": ${JSON.stringify(monitorCommand())} }] }],`,
+      '  "hooks": {',
+      '    "SessionStart": [{ "hooks": [{ "type": "command", "command": "custom-session-handler" }] }]',
+      '  }',
+      '}',
+      '',
+    ].join('\n');
+    fs.writeFileSync(hooksPath, originalBytes);
+
+    const result = cleanupCodexContextMonitor(codexHome);
+    const parsed = JSON.parse(fs.readFileSync(hooksPath, 'utf8'));
+
+    assert.strictEqual(result.removed, 1);
+    assert.ok(Object.hasOwn(parsed.hooks, '__proto__'));
+    assert.deepStrictEqual(
+      parsed.hooks.__proto__,
+      [{ hooks: [{ type: 'command', command: 'custom-special-handler' }] }],
+    );
+    assert.deepStrictEqual(
+      parsed.hooks.SessionStart,
+      [{ hooks: [{ type: 'command', command: 'custom-session-handler' }] }],
+    );
+    assert.strictEqual(Object.hasOwn(Object.prototype, 'hooks'), false);
+  });
+
+  test('install preserves a nested own __proto__ event while pruning a legacy update hook', () => {
+    const hooksPath = path.join(codexHome, 'hooks.json');
+    const legacyCommand = `node "${path.join(codexHome, 'hooks', 'gsd-check-update.js')}"`;
+    fs.writeFileSync(hooksPath, [
+      '{',
+      '  "hooks": {',
+      '    "__proto__": [{ "hooks": [{ "type": "command", "command": "custom-special-handler" }] }],',
+      `    "SessionStart": [{ "hooks": [{ "type": "command", "command": ${JSON.stringify(legacyCommand)} }] }],`,
+      '    "Stop": [{ "hooks": [{ "type": "command", "command": "custom-stop-handler" }] }]',
+      '  }',
+      '}',
+      '',
+    ].join('\n'));
+
+    runCodexInstall(codexHome);
+
+    const parsed = JSON.parse(fs.readFileSync(hooksPath, 'utf8'));
+    assert.ok(Object.hasOwn(parsed.hooks, '__proto__'));
+    assert.deepStrictEqual(
+      parsed.hooks.__proto__,
+      [{ hooks: [{ type: 'command', command: 'custom-special-handler' }] }],
+    );
+    assert.ok(readAllHooksCommands(codexHome).includes('custom-stop-handler'));
+    assert.equal(
+      readAllHooksCommands(codexHome)
+        .filter((command) => command.includes('gsd-check-update')).length,
+      1,
+    );
+    assert.strictEqual(Object.hasOwn(Object.prototype, 'hooks'), false);
+  });
+
+  test('uninstall preserves a monitor-free top-level __proto__ hook event', () => {
+    const hooksPath = path.join(codexHome, 'hooks.json');
+    runCodexInstall(codexHome);
+    const installed = JSON.parse(fs.readFileSync(hooksPath, 'utf8'));
+    fs.writeFileSync(hooksPath, [
+      '{',
+      '  "__proto__": [{ "hooks": [{ "type": "command", "command": "custom-special-handler" }] }],',
+      `  "hooks": { "SessionStart": ${JSON.stringify(installed.hooks.SessionStart)} }`,
+      '}',
+      '',
+    ].join('\n'));
+
+    runCodexUninstall(codexHome);
+
+    const parsed = JSON.parse(fs.readFileSync(hooksPath, 'utf8'));
+    assert.ok(Object.hasOwn(parsed.hooks, '__proto__'));
+    assert.deepStrictEqual(
+      parsed.hooks.__proto__,
+      [{ hooks: [{ type: 'command', command: 'custom-special-handler' }] }],
+    );
+    assert.ok(readAllHooksCommands(codexHome)
+      .every((command) => !command.includes('gsd-check-update')));
+    assert.strictEqual(Object.hasOwn(Object.prototype, 'hooks'), false);
+  });
+
+  test('a stale cleanup plan cannot overwrite newer hooks.json bytes', () => {
+    const hooksPath = writeHooks({
+      hooks: {
+        Stop: [{ hooks: [{ type: 'command', command: monitorCommand() }] }],
+      },
+    });
+    const plan = planCodexContextMonitorCleanup(codexHome);
+    const newerBytes = `${JSON.stringify({
+      hooks: {
+        Stop: [{ hooks: [{ type: 'command', command: 'concurrent-user-handler' }] }],
+      },
+    }, null, 2)}\n`;
+    fs.writeFileSync(hooksPath, newerBytes);
+
+    assert.throws(
+      () => applyCodexContextMonitorCleanup(plan),
+      /Codex context-monitor cleanup failed to rewrite/,
+    );
+    assert.strictEqual(fs.readFileSync(hooksPath, 'utf8'), newerBytes);
+  });
+
+  test('SessionStart publication rejects a concurrent hooks.json content change', () => {
+    const hooksPath = writeHooks({
+      hooks: {
+        Stop: [{ hooks: [{ type: 'command', command: 'original-user-handler' }] }],
+      },
+    });
+    fs.mkdirSync(path.join(codexHome, 'hooks'), { recursive: true });
+    fs.writeFileSync(path.join(codexHome, 'hooks', 'gsd-check-update.js'), '// update hook\n');
+    const newerBytes = `${JSON.stringify({
+      hooks: {
+        Stop: [{ hooks: [{ type: 'command', command: 'concurrent-user-handler' }] }],
+      },
+    }, null, 2)}\n`;
+    let injected = false;
+    fs.writeFileSync = (target, ...args) => {
+      const result = originalWriteFileSync(target, ...args);
+      if (!injected && String(target).startsWith(`${hooksPath}.tmp-`)) {
+        injected = true;
+        originalWriteFileSync(hooksPath, newerBytes);
+      }
+      return result;
+    };
+
+    assert.throws(
+      () => ensureCodexHooksJsonSessionStart(codexHome, {
+        absoluteRunner: '"/usr/bin/node"',
+        platform: 'linux',
+      }),
+      /Codex hooks.json reconciliation failed to rewrite/,
+    );
+    assert.strictEqual(injected, true);
+    assert.strictEqual(fs.readFileSync(hooksPath, 'utf8'), newerBytes);
+    assert.strictEqual(
+      fs.existsSync(path.join(codexHome, 'gsd-install-migration.lock')),
+      false,
+    );
+  });
+
+  test('barrier-synchronized cleanup processes converge on complete monitor-free JSON', async () => {
+    const hooksPath = writeHooks({
+      hooks: {
+        Stop: [{
+          hooks: [
+            { type: 'command', command: monitorCommand() },
+            { type: 'command', command: 'custom-stop-handler' },
+          ],
+        }],
+      },
+    });
+    const barrierPath = path.join(tmpDir, 'cleanup-barrier');
+    const readyPaths = [
+      path.join(tmpDir, 'cleanup-ready-a'),
+      path.join(tmpDir, 'cleanup-ready-b'),
+    ];
+    const wrapperPath = path.join(tmpDir, 'cleanup-wrapper.cjs');
+    fs.writeFileSync(barrierPath, 'hold');
+    fs.writeFileSync(wrapperPath, [
+      "'use strict';",
+      "const fs = require('node:fs');",
+      "process.env.GSD_TEST_MODE = '1';",
+      "const { cleanupCodexContextMonitor } = require(process.env.INSTALL_PATH);",
+      'fs.writeFileSync(process.env.READY_PATH, String(process.pid));',
+      'const signal = new Int32Array(new SharedArrayBuffer(4));',
+      'const deadline = Date.now() + 10000;',
+      'while (fs.existsSync(process.env.BARRIER_PATH)) {',
+      '  if (Date.now() > deadline) throw new Error("cleanup barrier timeout");',
+      '  Atomics.wait(signal, 0, 0, 10);',
+      '}',
+      'cleanupCodexContextMonitor(process.env.CODEX_HOME);',
+    ].join('\n'));
+
+    const children = [];
+    const runCleanup = (readyPath) => new Promise((resolve, reject) => {
+      const child = spawn(process.execPath, [wrapperPath], {
+        env: {
+          ...process.env,
+          BARRIER_PATH: barrierPath,
+          CODEX_HOME: codexHome,
+          INSTALL_PATH: path.resolve(__dirname, '..', 'bin', 'install.js'),
+          READY_PATH: readyPath,
+        },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      children.push(child);
+      let stderr = '';
+      child.stderr.on('data', (chunk) => { stderr += chunk.toString(); });
+      child.on('error', reject);
+      child.on('close', (code) => {
+        if (code === 0) resolve();
+        else reject(new Error(`cleanup child exited ${code}: ${stderr}`));
+      });
+    });
+    const runs = readyPaths.map(runCleanup);
+
+    try {
+      await waitFor(
+        () => readyPaths.every((readyPath) => fs.existsSync(readyPath)),
+        { message: 'cleanup subprocesses did not reach the barrier' },
+      );
+      fs.unlinkSync(barrierPath);
+      await Promise.all(runs);
+    } finally {
+      for (const child of children) {
+        try { child.kill(); } catch { /* already exited */ }
+      }
+    }
+
+    const parsed = JSON.parse(fs.readFileSync(hooksPath, 'utf8'));
+    const commands = readAllHooksCommands(codexHome);
+    assert.ok(parsed && typeof parsed === 'object');
+    assert.ok(commands.includes('custom-stop-handler'));
+    assert.ok(commands.every((command) => !isRecognizedCodexContextMonitorCommand(command, codexHome)));
+  });
+
+  test('malformed hooks.json aborts install before any other Codex mutation without disclosing content', () => {
+    const hooksPath = path.join(codexHome, 'hooks.json');
+    const malformed = '{"hooks":{"Stop":[SECRET_MONITOR_PAYLOAD';
+    fs.writeFileSync(hooksPath, malformed);
+    fs.writeFileSync(path.join(codexHome, 'config.toml'), '# user config\n');
+    const before = fs.readdirSync(codexHome).sort();
+
+    assert.throws(
+      () => runCodexInstall(codexHome),
+      (error) => {
+        assert.match(error.message, /Codex context-monitor cleanup failed to parse/);
+        assert.ok(error.message.includes(hooksPath));
+        assert.ok(!error.message.includes('SECRET_MONITOR_PAYLOAD'));
+        return true;
+      },
+    );
+
+    assert.strictEqual(fs.readFileSync(hooksPath, 'utf8'), malformed);
+    assert.strictEqual(fs.readFileSync(path.join(codexHome, 'config.toml'), 'utf8'), '# user config\n');
+    assert.deepStrictEqual(fs.readdirSync(codexHome).sort(), before);
+  });
+
+  test('atomic rewrite failure preserves original state and aborts before other Codex mutation', () => {
+    const hooksPath = writeHooks({
+      hooks: {
+        Stop: [{ hooks: [{ type: 'command', command: monitorCommand(), marker: 'PRIVATE_HOOK_VALUE' }] }],
+      },
+    });
+    const originalBytes = fs.readFileSync(hooksPath, 'utf8');
+    const before = fs.readdirSync(codexHome).sort();
+    fs.renameSync = (source, destination) => {
+      if (path.resolve(String(destination)) === path.resolve(hooksPath)) {
+        assert.ok(
+          fs.existsSync(path.join(codexHome, 'gsd-install-migration.lock')),
+          'atomic hooks replacement runs while the installer lock is held',
+        );
+        throw new Error('injected pre-rename failure PRIVATE_HOOK_VALUE');
+      }
+      return originalRenameSync(source, destination);
+    };
+
+    assert.throws(
+      () => runCodexInstall(codexHome),
+      (error) => {
+        assert.match(error.message, /Codex context-monitor cleanup failed to rewrite/);
+        assert.ok(error.message.includes(hooksPath));
+        assert.ok(!error.message.includes('PRIVATE_HOOK_VALUE'));
+        return true;
+      },
+    );
+
+    assert.strictEqual(fs.readFileSync(hooksPath, 'utf8'), originalBytes);
+    assert.doesNotThrow(() => JSON.parse(fs.readFileSync(hooksPath, 'utf8')));
+    assert.deepStrictEqual(fs.readdirSync(codexHome).sort(), before);
+
+    fs.renameSync = originalRenameSync;
+    const successfulRetry = cleanupCodexContextMonitor(codexHome);
+    const successfulBytes = fs.readFileSync(hooksPath, 'utf8');
+    const convergedRetry = cleanupCodexContextMonitor(codexHome);
+    assert.strictEqual(successfulRetry.removed, 1);
+    assert.strictEqual(convergedRetry.changed, false);
+    assert.strictEqual(fs.readFileSync(hooksPath, 'utf8'), successfulBytes);
+  });
+
+  test('durable deregistration removes an unreferenced manifest-owned monitor artifact', () => {
+    const hooksPath = writeHooks({
+      hooks: {
+        Stop: [{ hooks: [{ type: 'command', command: monitorCommand() }] }],
+      },
+    });
+    const artifactPath = writeManifestOwnedMonitor('legacy managed monitor\n');
+
+    const captured = captureConsole(() => cleanupCodexContextMonitor(codexHome));
+
+    assert.match(
+      captured.stdout,
+      /Removed obsolete Codex context-monitor registration; agent-facing context warnings remain unavailable\./,
+    );
+    assert.strictEqual(fs.existsSync(artifactPath), false);
+    assert.ok(!fs.readFileSync(hooksPath, 'utf8').includes('gsd-context-monitor'));
+  });
+
+  test('modified manifest-owned monitor artifact is backed up before removal', () => {
+    writeHooks({
+      hooks: {
+        Stop: [{ hooks: [{ type: 'command', command: monitorCommand() }] }],
+      },
+    });
+    const artifactPath = writeManifestOwnedMonitor('manifest baseline monitor\n');
+    const modifiedContents = 'user-modified legacy monitor\n';
+    fs.writeFileSync(artifactPath, modifiedContents);
+
+    cleanupCodexContextMonitor(codexHome);
+
+    assert.strictEqual(fs.existsSync(artifactPath), false);
+    const journalRoot = path.join(codexHome, 'gsd-migration-journal');
+    const backupDir = fs.readdirSync(journalRoot)
+      .find((entry) => entry.endsWith('-backups'));
+    assert.ok(backupDir, 'managed-modified removal creates a user-facing backup');
+    assert.strictEqual(
+      fs.readFileSync(path.join(journalRoot, backupDir, 'hooks', 'gsd-context-monitor.js'), 'utf8'),
+      modifiedContents,
+    );
+  });
+
+  test('unowned monitor artifact survives after its obsolete registration is removed', () => {
+    const hooksPath = writeHooks({
+      hooks: {
+        Stop: [{ hooks: [{ type: 'command', command: monitorCommand() }] }],
+      },
+    });
+    const artifactPath = path.join(codexHome, 'hooks', 'gsd-context-monitor.js');
+    fs.mkdirSync(path.dirname(artifactPath), { recursive: true });
+    fs.writeFileSync(artifactPath, 'unowned monitor\n');
+
+    cleanupCodexContextMonitor(codexHome);
+
+    assert.strictEqual(fs.readFileSync(artifactPath, 'utf8'), 'unowned monitor\n');
+    assert.ok(!fs.readFileSync(hooksPath, 'utf8').includes('gsd-context-monitor'));
+  });
+
+  test('artifact inspection failure keeps deregistration durable and warns safely', () => {
+    writeHooks({
+      hooks: {
+        Stop: [{
+          hooks: [{
+            type: 'command',
+            command: monitorCommand(),
+            marker: 'PRIVATE_HOOKS_CONFIG_CONTENT',
+          }],
+        }],
+      },
+    });
+    const artifactContents = 'PRIVATE_RETAINED_ARTIFACT\n';
+    const artifactPath = writeManifestOwnedMonitor(artifactContents);
+    const warnings = [];
+    console.warn = (...args) => { warnings.push(args.join(' ')); };
+    fs.lstatSync = (target, options) => {
+      if (
+        path.resolve(String(target)) === path.resolve(artifactPath)
+        && options?.throwIfNoEntry === false
+      ) {
+        const error = new Error('PRIVATE_INSPECTION_FAILURE');
+        error.code = 'EACCES';
+        throw error;
+      }
+      return originalLstatSync(target, options);
+    };
+
+    runCodexInstall(codexHome);
+
+    assert.ok(fs.existsSync(path.join(codexHome, 'config.toml')), 'install completes');
+    assert.strictEqual(fs.readFileSync(artifactPath, 'utf8'), artifactContents);
+    assert.ok(readAllHooksCommands(codexHome)
+      .every((command) => !isRecognizedCodexContextMonitorCommand(command, codexHome)));
+    assert.strictEqual(cleanupCodexContextMonitor(codexHome).changed, false);
+    const matchingWarnings = warnings.filter((line) => line.includes(artifactPath));
+    assert.strictEqual(matchingWarnings.length, 1);
+    assert.match(matchingWarnings[0], /inspect obsolete Codex context-monitor artifact/);
+    assert.match(matchingWarnings[0], /registration remains removed/);
+    assert.ok(!matchingWarnings[0].includes('PRIVATE_RETAINED_ARTIFACT'));
+    assert.ok(!matchingWarnings[0].includes('PRIVATE_INSPECTION_FAILURE'));
+    assert.ok(!matchingWarnings[0].includes('PRIVATE_HOOKS_CONFIG_CONTENT'));
+  });
+
+  test('artifact deletion failure keeps deregistration durable, warns safely, and lets install finish', () => {
+    const hooksPath = writeHooks({
+      hooks: {
+        Stop: [{ hooks: [{ type: 'command', command: monitorCommand() }] }],
+      },
+    });
+    const artifactContents = 'PRIVATE_ORPHAN_CONTENT\n';
+    const artifactPath = writeManifestOwnedMonitor(artifactContents);
+    const warnings = [];
+    console.warn = (...args) => { warnings.push(args.join(' ')); };
+    fs.rmSync = (target, options) => {
+      if (path.resolve(String(target)) === path.resolve(artifactPath)) {
+        assert.ok(
+          fs.existsSync(path.join(codexHome, 'gsd-install-migration.lock')),
+          'artifact removal runs while the installer lock is held',
+        );
+        throw new Error('injected deletion failure PRIVATE_ORPHAN_CONTENT');
+      }
+      return originalRmSync(target, options);
+    };
+
+    runCodexInstall(codexHome);
+
+    assert.ok(fs.existsSync(path.join(codexHome, 'config.toml')), 'install completes');
+    assert.strictEqual(fs.readFileSync(artifactPath, 'utf8'), artifactContents);
+    const hooksDocument = JSON.parse(fs.readFileSync(hooksPath, 'utf8'));
+    assert.ok(hooksDocument && typeof hooksDocument === 'object');
+    assert.ok(readAllHooksCommands(codexHome)
+      .every((command) => !isRecognizedCodexContextMonitorCommand(command, codexHome)));
+    assert.strictEqual(cleanupCodexContextMonitor(codexHome).changed, false);
+    const warning = warnings.find((line) => line.includes(artifactPath));
+    assert.ok(warning, 'warning identifies the retained artifact path');
+    assert.match(warning, /remove obsolete Codex context-monitor artifact/);
+    assert.match(warning, /registration remains removed/);
+    assert.doesNotMatch(warning, /monitor remains registered/);
+    assert.ok(!warning.includes('PRIVATE_ORPHAN_CONTENT'));
   });
 });
 
@@ -8236,37 +9248,8 @@ describe('bug #851: Codex adapter documents multi_agent_v1 schema limitation and
 process.env.GSD_TEST_MODE = '1';
 
 /**
- * Enhancement #772: Adopt new stable Codex hook events + commandWindows for
- * Windows parity.
- *
- * Codex CLI (rust-v0.137.0) stabilised the full hook-event set. This suite
- * asserts that a Codex install:
- *
- * (a) Registers the 3 new high-value hook events in hooks.json:
- *   - SubagentStart — inject context / GSD_AGENT_NAME awareness at subagent open
- *   - Stop          — post-session context headroom tracking
- *   - PostToolUse   — mirror the Claude Code PostToolUse context monitor
- *
- * (b) Emits `commandWindows` in the SessionStart hooks.json entry so that
- *   Windows users get the .cmd shim path and non-Windows users get the POSIX
- *   node runner command. Both fields are present in the same entry; Codex picks
- *   the right one per its HookHandlerConfig schema
- *   (codex-rs/config/src/hook_config.rs: commandWindows / command_windows alias).
- *
- * Note: UserPromptSubmit is NOT wired (same rationale as Qwen #788 — the
- * gsd-prompt-guard handler exits unless tool_name is Write|Edit, so it would be
- * a silent no-op for the UserPromptSubmit payload shape).
- *
- * Test strategy:
- *   - Test new event registration via ensureCodexHooksJsonEvent() directly
- *     (mirrors the #3426 pattern of testing ensureCodexHooksJsonSessionStart
- *     directly with a stub hook file — avoids full install() migration dance).
- *   - Test commandWindows via ensureCodexHooksJsonSessionStart() directly.
- *   - IR-first discipline: assert on the structured result, not rendered text.
- *
- * Verified hook event schema:
- *   https://github.com/openai/codex/blob/main/codex-rs/protocol/src/protocol.rs
- *   https://github.com/openai/codex/blob/main/codex/codex-rs/config/src/hook_config.rs
+ * Retained #772 coverage for the supported SessionStart update hook's Windows
+ * command projection. Context-monitor event registration was retired by WARN-01.
  */
 
 const { test, describe, beforeEach, afterEach } = require('node:test');
@@ -8274,13 +9257,7 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
 
-const INSTALL = require('../bin/install.js');
-const {
-  ensureCodexHooksJsonSessionStart,
-  ensureCodexHooksJsonEvent,
-  removeCodexHooksJsonEvent,
-  reconcileCodexHooksJsonEvent,
-} = INSTALL;
+const { ensureCodexHooksJsonSessionStart } = require('../bin/install.js');
 const { createTempDir, cleanup } = require('./helpers.cjs');
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -8316,118 +9293,6 @@ function stubHookFile(targetDir, hookName) {
     try { fs.chmodSync(dest, 0o755); } catch { /* Windows */ }
   }
 }
-
-// ─── Suite 1: ensureCodexHooksJsonEvent export surface ───────────────────────
-
-describe('enh-772: export surface — new functions are exported', () => {
-  test('ensureCodexHooksJsonEvent is a function', () => {
-    assert.strictEqual(typeof ensureCodexHooksJsonEvent, 'function',
-      'ensureCodexHooksJsonEvent must be exported from bin/install.js');
-  });
-
-  test('removeCodexHooksJsonEvent is a function', () => {
-    assert.strictEqual(typeof removeCodexHooksJsonEvent, 'function',
-      'removeCodexHooksJsonEvent must be exported from bin/install.js');
-  });
-
-  test('reconcileCodexHooksJsonEvent is a function', () => {
-    assert.strictEqual(typeof reconcileCodexHooksJsonEvent, 'function',
-      'reconcileCodexHooksJsonEvent must be exported from bin/install.js');
-  });
-});
-
-// ─── Suite 2: ensureCodexHooksJsonEvent registers new events ─────────────────
-
-describe('enh-772: ensureCodexHooksJsonEvent registers SubagentStart, Stop, PostToolUse', () => {
-  let tmpDir;
-
-  beforeEach(() => {
-    tmpDir = createTempDir('gsd-772-events-');
-    stubHookFile(tmpDir, 'gsd-context-monitor.js');
-  });
-
-  afterEach(() => {
-    cleanup(tmpDir);
-  });
-
-  for (const eventName of ['SubagentStart', 'Stop', 'PostToolUse']) {
-    test(`${eventName}: ensureCodexHooksJsonEvent writes hooks.json`, () => {
-      const fakeRunner = '"/usr/local/bin/node"';
-      const result = ensureCodexHooksJsonEvent(tmpDir, eventName, {
-        absoluteRunner: fakeRunner,
-        platform: 'linux',
-      });
-      assert.ok(result && result.path, `result must have path for ${eventName}`);
-      assert.ok(result.wrote || result.changed,
-        `ensureCodexHooksJsonEvent must write or change hooks.json for ${eventName}`);
-      assert.ok(fs.existsSync(path.join(tmpDir, 'hooks.json')),
-        `hooks.json must exist after registering ${eventName}`);
-    });
-
-    test(`${eventName}: hooks.json contains the event entry`, () => {
-      const fakeRunner = '"/usr/local/bin/node"';
-      ensureCodexHooksJsonEvent(tmpDir, eventName, {
-        absoluteRunner: fakeRunner,
-        platform: 'linux',
-      });
-      const hooksJson = readHooksJson(tmpDir);
-      const handlers = hooksJsonHandlersForEvent(hooksJson, eventName);
-      assert.ok(handlers.length > 0,
-        `Expected ${eventName} entry in hooks.json; got: ${JSON.stringify(hooksJson)}`);
-    });
-
-    test(`${eventName}: hook entry uses gsd-context-monitor`, () => {
-      const fakeRunner = '"/usr/local/bin/node"';
-      ensureCodexHooksJsonEvent(tmpDir, eventName, {
-        absoluteRunner: fakeRunner,
-        platform: 'linux',
-      });
-      const hooksJson = readHooksJson(tmpDir);
-      const handlers = hooksJsonHandlersForEvent(hooksJson, eventName);
-      assert.ok(
-        handlers.some(h => h.command && h.command.includes('gsd-context-monitor')),
-        `${eventName} hook must use gsd-context-monitor; got: ${JSON.stringify(handlers)}`
-      );
-    });
-
-    test(`${eventName}: hook entry has type: 'command'`, () => {
-      const fakeRunner = '"/usr/local/bin/node"';
-      ensureCodexHooksJsonEvent(tmpDir, eventName, {
-        absoluteRunner: fakeRunner,
-        platform: 'linux',
-      });
-      const hooksJson = readHooksJson(tmpDir);
-      const handlers = hooksJsonHandlersForEvent(hooksJson, eventName);
-      const entry = handlers.find(h => h.command && h.command.includes('gsd-context-monitor'));
-      assert.strictEqual(entry && entry.type, 'command',
-        `${eventName} hook entry must have type 'command'`);
-    });
-
-    test(`${eventName}: hook entry has timeout: 10`, () => {
-      const fakeRunner = '"/usr/local/bin/node"';
-      ensureCodexHooksJsonEvent(tmpDir, eventName, {
-        absoluteRunner: fakeRunner,
-        platform: 'linux',
-      });
-      const hooksJson = readHooksJson(tmpDir);
-      const handlers = hooksJsonHandlersForEvent(hooksJson, eventName);
-      const entry = handlers.find(h => h.command && h.command.includes('gsd-context-monitor'));
-      assert.strictEqual(entry && entry.timeout, 10,
-        `${eventName} hook entry must have timeout 10`);
-    });
-  }
-
-  test('null absoluteRunner returns unchanged result without writing', () => {
-    const result = ensureCodexHooksJsonEvent(tmpDir, 'SubagentStart', {
-      absoluteRunner: null,
-      platform: 'linux',
-    });
-    assert.strictEqual(result.changed, false,
-      'null runner must return changed: false');
-    assert.ok(!fs.existsSync(path.join(tmpDir, 'hooks.json')),
-      'hooks.json must NOT be written when runner is null');
-  });
-});
 
 // ─── Suite 3: commandWindows parity in SessionStart ──────────────────────────
 
@@ -8530,118 +9395,6 @@ describe('enh-772: commandWindows parity — ensureCodexHooksJsonSessionStart em
   });
 });
 
-// ─── Suite 4: idempotency ────────────────────────────────────────────────────
-
-describe('enh-772: ensureCodexHooksJsonEvent is idempotent', () => {
-  let tmpDir;
-
-  beforeEach(() => {
-    tmpDir = createTempDir('gsd-772-idem-');
-    stubHookFile(tmpDir, 'gsd-context-monitor.js');
-  });
-
-  afterEach(() => {
-    cleanup(tmpDir);
-  });
-
-  for (const eventName of ['SubagentStart', 'Stop', 'PostToolUse']) {
-    test(`${eventName}: calling twice does not duplicate hook entries`, () => {
-      const fakeRunner = '"/usr/local/bin/node"';
-      const opts = { absoluteRunner: fakeRunner, platform: 'linux' };
-
-      ensureCodexHooksJsonEvent(tmpDir, eventName, opts);
-      ensureCodexHooksJsonEvent(tmpDir, eventName, opts);
-
-      const hooksJson = readHooksJson(tmpDir);
-      const handlers = hooksJsonHandlersForEvent(hooksJson, eventName);
-      assert.strictEqual(handlers.length, 1,
-        `${eventName} should have exactly 1 hook handler after idempotent re-register; got ${handlers.length}: ${JSON.stringify(handlers)}`);
-    });
-  }
-});
-
-// ─── Suite 5: removeCodexHooksJsonEvent ──────────────────────────────────────
-
-describe('enh-772: removeCodexHooksJsonEvent removes managed entries', () => {
-  let tmpDir;
-
-  beforeEach(() => {
-    tmpDir = createTempDir('gsd-772-remove-');
-    stubHookFile(tmpDir, 'gsd-context-monitor.js');
-  });
-
-  afterEach(() => {
-    cleanup(tmpDir);
-  });
-
-  for (const eventName of ['SubagentStart', 'Stop', 'PostToolUse']) {
-    test(`${eventName}: removeCodexHooksJsonEvent removes the managed entry`, () => {
-      const fakeRunner = '"/usr/local/bin/node"';
-      ensureCodexHooksJsonEvent(tmpDir, eventName, {
-        absoluteRunner: fakeRunner,
-        platform: 'linux',
-      });
-
-      // Verify it was registered
-      let hooksJson = readHooksJson(tmpDir);
-      let handlers = hooksJsonHandlersForEvent(hooksJson, eventName);
-      assert.ok(handlers.length > 0, `${eventName} must be registered before removal`);
-
-      // Remove
-      const result = removeCodexHooksJsonEvent(tmpDir, eventName);
-      assert.ok(result.changed || result.wrote,
-        `removeCodexHooksJsonEvent must change hooks.json for ${eventName}`);
-
-      hooksJson = readHooksJson(tmpDir);
-      if (hooksJson) {
-        handlers = hooksJsonHandlersForEvent(hooksJson, eventName);
-        assert.strictEqual(handlers.length, 0,
-          `After removal, ${eventName} should have 0 handlers; got: ${JSON.stringify(handlers)}`);
-      }
-    });
-  }
-});
-
-// ─── Suite 6: reconcileCodexHooksJsonEvent preserves user entries ─────────────
-
-describe('enh-772: reconcileCodexHooksJsonEvent preserves user-owned entries', () => {
-  let tmpDir;
-
-  beforeEach(() => {
-    tmpDir = createTempDir('gsd-772-preserve-');
-  });
-
-  afterEach(() => {
-    cleanup(tmpDir);
-  });
-
-  test('user-owned SubagentStart entry is preserved when GSD entry is registered', () => {
-    const hooksJsonPath = path.join(tmpDir, 'hooks.json');
-    const userEntry = {
-      hooks: [{ type: 'command', command: 'my-custom-hook.sh' }]
-    };
-    fs.writeFileSync(hooksJsonPath, JSON.stringify({
-      SubagentStart: [userEntry]
-    }, null, 2) + '\n');
-
-    reconcileCodexHooksJsonEvent(tmpDir, 'SubagentStart', {
-      managedCommand: '"/usr/local/bin/node" "/home/me/.codex/hooks/gsd-context-monitor.js"',
-    });
-
-    const hooksJson = JSON.parse(fs.readFileSync(hooksJsonPath, 'utf8'));
-    const table = hooksJson.hooks || hooksJson;
-    const entries = Array.isArray(table.SubagentStart) ? table.SubagentStart : [];
-    // Should have 2 entries: user entry + GSD entry
-    assert.ok(entries.length >= 2,
-      `User entry must be preserved; got entries: ${JSON.stringify(entries)}`);
-    // User entry must still be present
-    const userEntryStillPresent = entries.some(e =>
-      Array.isArray(e.hooks) && e.hooks.some(h => h.command === 'my-custom-hook.sh')
-    );
-    assert.ok(userEntryStillPresent,
-      `User entry must survive GSD registration; entries: ${JSON.stringify(entries)}`);
-  });
-});
   });
 }
 

--- a/tests/codex-declarative-reference.test.cjs
+++ b/tests/codex-declarative-reference.test.cjs
@@ -9,7 +9,7 @@
  * correctly (including the documented `maxDepth === 1 → flat` dispatch
  * degradation), that negotiation fails CLOSED on a corrupted descriptor, that
  * the three Context7-verified UPGRADES land on the user-reachable surface
- * (skill-root → $HOME/.agents/skills, the 6 new hooks.json lifecycle events, and
+ * (skill-root → $HOME/.agents/skills, the supported SessionStart update hook, and
  * explicit `[agents] max_depth` dispatch tuning), and that the migration retired
  * the hardcoded `runtime === 'codex'` / positive-`isCodex` projection (folded
  * into descriptor-driven `runtime.hostBehaviors`).
@@ -20,6 +20,8 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
+const espree = require('espree');
+const tsParser = require('@typescript-eslint/parser');
 
 process.env.GSD_TEST_MODE = '1';
 
@@ -34,6 +36,7 @@ const {
 } = require('../gsd-core/bin/lib/host-integration.cjs');
 
 const install = require('../bin/install.js');
+const { resolveInstallPlan } = require('../gsd-core/bin/lib/runtime-config-adapter-registry.cjs');
 const { cleanup } = require('./helpers.cjs');
 
 const CODEX_CAP = JSON.parse(
@@ -129,27 +132,56 @@ test('codex descriptor declares runtime.hostBehaviors (the folded-in behaviors)'
 });
 
 test('no `runtime === "codex"` string-equality and no positive `isCodex` gate remain in the install source (AC2)', () => {
-  const strip = (src) => src
-    .replace(/\/\*[\s\S]*?\*\//g, '')
-    .replace(/\/\/[^\r\n]*/g, '')
-    .replace(/`[^`]*`/g, '');
   for (const rel of ['bin/install.js', 'src/install-engine.cts', 'src/runtime-artifact-conversion.cts']) {
     const raw = fs.readFileSync(path.join(__dirname, '..', rel), 'utf8');
-    const src = strip(raw);
-
-    const stringEq = src.match(/runtime\s*[!=]==\s*'codex'/g) || [];
-    assert.deepEqual(stringEq, [], `AC2: no hardcoded runtime==='codex' branch may remain in ${rel}; found: ${stringEq.join(', ')}`);
-
-    // Every `isCodex` reference must be either a runtimeFlags(...) destructure
-    // line or a NEGATED occurrence inside a shared multi-runtime roster
-    // (`!isCodex && !isCopilot && ...`). A positive `isCodex` gate is forbidden.
-    for (const line of src.split(/\r?\n/)) {
-      if (!/\bisCodex\b/.test(line)) continue;
-      if (/runtimeFlags\s*\(/.test(line)) continue; // destructure declaration
-      const positive = line.replace(/!\s*isCodex\b/g, '').match(/\bisCodex\b/);
-      assert.equal(positive, null, `AC2: positive isCodex gate forbidden in ${rel}: ${line.trim()}`);
+    const source = raw.startsWith('#!') ? `//${raw.slice(2)}` : raw;
+    const ast = rel.endsWith('.cts')
+      ? tsParser.parse(source, { loc: true, range: true })
+      : espree.parse(source, {
+        ecmaVersion: 2022,
+        loc: true,
+        range: true,
+        sourceType: 'script',
+      });
+    const violations = [];
+    function walk(node, parent = null, grandparent = null) {
+      if (!node || typeof node !== 'object') return;
+      if (
+        node.type === 'BinaryExpression'
+        && ['===', '!=='].includes(node.operator)
+        && (
+          (node.left?.type === 'Identifier' && node.left.name === 'runtime'
+            && node.right?.type === 'Literal' && node.right.value === 'codex')
+          || (node.right?.type === 'Identifier' && node.right.name === 'runtime'
+            && node.left?.type === 'Literal' && node.left.value === 'codex')
+        )
+      ) {
+        violations.push(`runtime/codex comparison at line ${node.loc.start.line}`);
+      }
+      if (node.type === 'Identifier' && node.name === 'isCodex') {
+        const destructured = parent?.type === 'Property' && grandparent?.type === 'ObjectPattern';
+        const negated = parent?.type === 'UnaryExpression' && parent.operator === '!';
+        if (!destructured && !negated) {
+          violations.push(`positive isCodex reference at line ${node.loc.start.line}`);
+        }
+      }
+      for (const value of Object.values(node)) {
+        if (Array.isArray(value)) {
+          for (const child of value) walk(child, node, parent);
+        } else if (value && typeof value === 'object' && typeof value.type === 'string') {
+          walk(value, node, parent);
+        }
+      }
     }
+    walk(ast);
+    assert.deepEqual(violations, [], `AC2 descriptor dispatch violations in ${rel}: ${violations.join(', ')}`);
   }
+});
+
+test('unsupported Codex context-monitor event registration is not publicly exported', () => {
+  assert.equal(install.ensureCodexHooksJsonEvent, undefined);
+  assert.equal(install.removeCodexHooksJsonEvent, undefined);
+  assert.equal(install.reconcileCodexHooksJsonEvent, undefined);
 });
 
 // -- AC4 upgrade 3: skill root is the canonical $HOME/.agents/skills ---------
@@ -185,39 +217,31 @@ test('upgrade 3 — the pre-move location is migrated (stale ~/.codex/skills/gsd
   }
 });
 
-// -- AC4 upgrade 1: the 6 new hooks.json lifecycle events are registered ------
+// -- AC4 upgrade 1: Codex keeps only the supported update hook ----------------
 
-test('upgrade 1 — codex registers all documented hooks.json lifecycle events, incl. the 6 new in #2088', () => {
-  const expected = [
-    'SubagentStart', 'Stop', 'PostToolUse',       // #772
-    'PreToolUse', 'PermissionRequest', 'PreCompact', 'PostCompact', 'SubagentStop', 'UserPromptSubmit', // #2088
-  ];
-  assert.deepEqual(install.CODEX_EXTENDED_HOOK_EVENTS, expected,
-    'the shared install/uninstall event list must contain the 3 original + 6 new events');
-
+test('upgrade 1 — codex registers only the supported SessionStart update hook', () => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-hooks-'));
   try {
     fs.mkdirSync(path.join(tmp, 'hooks'), { recursive: true });
-    fs.writeFileSync(path.join(tmp, 'hooks', 'gsd-context-monitor.js'), '// stub');
     fs.writeFileSync(path.join(tmp, 'hooks', 'gsd-check-update.js'), '// stub');
-    for (const ev of install.CODEX_EXTENDED_HOOK_EVENTS) {
-      install.ensureCodexHooksJsonEvent(tmp, ev, { absoluteRunner: '/usr/bin/node', platform: 'linux' });
-    }
     install.ensureCodexHooksJsonSessionStart(tmp, { absoluteRunner: '/usr/bin/node', platform: 'linux' });
     const hooksJson = JSON.parse(fs.readFileSync(path.join(tmp, 'hooks.json'), 'utf8'));
-    const registered = Object.keys(hooksJson.hooks || hooksJson || {});
-    for (const ev of ['PreToolUse', 'PermissionRequest', 'PreCompact', 'PostCompact', 'SubagentStop', 'UserPromptSubmit']) {
-      assert.ok(registered.includes(ev), `#2088 must register the ${ev} hook in hooks.json`);
-    }
-    assert.ok(registered.includes('SessionStart'), 'the SessionStart baseline stays registered');
+    const hooks = hooksJson.hooks || hooksJson || {};
+    assert.deepEqual(Object.keys(hooks), ['SessionStart'],
+      'Codex must not register unsupported context-monitor lifecycle events');
+    const serialized = JSON.stringify(hooks);
+    assert.match(serialized, /gsd-check-update(?:\.js|\.cmd)/,
+      'the supported SessionStart registration must run the update hook');
+    assert.doesNotMatch(serialized, /gsd-context-monitor(?:\.js|\.cmd)/,
+      'no Codex registration may reference the unsupported context monitor');
   } finally {
     cleanup(tmp);
   }
 });
 
-test('upgrade 1 — extendedHookEvents descriptor reconciled to the schema-valid wired subset (no longer [])', () => {
-  assert.deepEqual(CODEX_CAP.runtime.extendedHookEvents, ['SubagentStop', 'Stop', 'PreCompact'],
-    'reconciled from [] to the wired extended-lifecycle events expressible in the cross-runtime vocabulary');
+test('upgrade 1 — codex install plan advertises no unsupported extended lifecycle hooks', () => {
+  assert.deepEqual(resolveInstallPlan('codex').extendedHookEvents, [],
+    'SessionStart is the only supported Codex lifecycle registration');
 });
 
 // -- AC4 upgrade 2: explicit [agents] max_depth dispatch tuning ---------------

--- a/tests/fixtures/golden-install-parity/codex.json
+++ b/tests/fixtures/golden-install-parity/codex.json
@@ -434,7 +434,6 @@
   "gsd-core/workflows/verify-phase.md": "ce508f9c2242b91f",
   "gsd-core/workflows/verify-work.md": "618068315b712d29",
   "hooks/gsd-check-update.js": "ef48957eb6ac6a10",
-  "hooks/gsd-context-monitor.js": "ec76b23f45d29b02",
   "scripts/changeset/README.md": "86ff89331dfd94b2",
   "scripts/changeset/cli.cjs": "68f92a344b199271",
   "scripts/changeset/github-release-notes.cjs": "795677f0c009b132",

--- a/tests/fixtures/install-tree/codex.json
+++ b/tests/fixtures/install-tree/codex.json
@@ -434,7 +434,6 @@
   "gsd-core/workflows/verify-phase.md",
   "gsd-core/workflows/verify-work.md",
   "hooks/gsd-check-update.js",
-  "hooks/gsd-context-monitor.js",
   "scripts/changeset/README.md",
   "scripts/changeset/cli.cjs",
   "scripts/changeset/github-release-notes.cjs",

--- a/tests/installer-migrations.test.cjs
+++ b/tests/installer-migrations.test.cjs
@@ -1561,6 +1561,42 @@ test('runs a Codex legacy hooks.json cleanup migration without removing user hoo
   }
 });
 
+test('Codex legacy hooks.json cleanup plan preserves an own __proto__ event', () => {
+  const configDir = createTempInstall();
+  try {
+    writeFile(configDir, 'hooks.json', [
+      '{',
+      '  "hooks": {',
+      '    "__proto__": [{ "hooks": [{ "type": "command", "command": "custom-special-handler" }] }],',
+      `    "SessionStart": ${JSON.stringify([legacyCodexHook(configDir)])}`,
+      '  }',
+      '}',
+    ].join('\n'));
+    writeManifest(configDir, {});
+
+    const plan = planInstallerMigrations({
+      configDir,
+      migrations: discoverInstallerMigrations({
+        migrationsDir: path.join(__dirname, '..', 'gsd-core', 'bin', 'lib', 'installer-migrations'),
+      }),
+      runtime: 'codex',
+      scope: 'global',
+      now: () => '2026-05-11T00:00:06.000Z',
+    });
+    const action = plan.actions.find((item) =>
+      item.migrationId === '2026-05-11-codex-legacy-hooks-json'
+      && item.relPath === 'hooks.json'
+    );
+
+    assert.ok(action);
+    assert.ok(Object.hasOwn(action.value.hooks, '__proto__'));
+    assert.equal(action.value.hooks.__proto__[0].hooks[0].command, 'custom-special-handler');
+    assert.equal(action.value.hooks.SessionStart, undefined);
+  } finally {
+    cleanup(configDir);
+  }
+});
+
 test('preserves unrelated empty hooks.json structure while pruning legacy Codex hooks', () => {
   const configDir = createTempInstall();
   try {
@@ -1650,8 +1686,10 @@ test('shipped installer-migration checksums are locked to a committed baseline (
       'sha256:4ec58d35b30dbf39cc56e3972146086d8d31861ecd800cf0b37a7aa94fe74c2a',
     '2026-05-11-legacy-orphan-files':
       'sha256:e492698748a2436a12a55f0940f539b9bf651d8ffcac6f60cd856a6dabd6788c',
+    // Intentional issue #670 exception: align the shipped Codex cleanup with
+    // exact monitor ownership so upgrades stop deleting customized commands.
     '2026-05-11-codex-legacy-hooks-json':
-      'sha256:5ce55294aa02f25758f604a569c899a6d2d060299189f5f447f68d8033157058',
+      'sha256:78a2b83b770774fdd0e51d4919c41d4ad5630c1887b4292f1cebb32b687ad87f',
     '2026-06-02-rename-get-shit-done-to-gsd-core':
       'sha256:3a9f1d97f64097fb313203d19c6d93a187a38df61dd299afa5eef73e16124e95',
     // Migration 004: prune stale gsd-pristine/get-shit-done/ snapshots (#934) // gsd-allow-legacy-name
@@ -1816,7 +1854,14 @@ const { execFileSync } = require('node:child_process');
 
 const installModule = require('../bin/install.js');
 const { readInstallState } = require('../gsd-core/bin/lib/installer-migrations.cjs');
-const { install, parseTomlToObject, reconcileCodexHooksJsonEvent } = installModule;
+const {
+  install,
+  parseTomlToObject,
+  resolveNodeRunner,
+} = installModule;
+const {
+  reconcileCodexHooksJsonEvent,
+} = require('../gsd-core/bin/lib/runtime-hooks-surface.cjs');
 const { createTempDir, cleanup } = require('./helpers.cjs');
 const HOOKS_DIST = path.join(__dirname, '..', 'hooks', 'dist');
 const BUILD_HOOKS_SCRIPT = path.join(__dirname, '..', 'scripts', 'build-hooks.js');
@@ -1853,13 +1898,22 @@ function legacyGsdHook(codexHome) {
   };
 }
 
-function userHook() {
+function userHook(command = 'node "/Users/example/bin/user-hook.js"') {
   return {
     hooks: [{
       type: 'command',
-      command: 'node "/Users/example/bin/user-hook.js"',
+      command,
     }],
   };
+}
+
+function hooksJsonCommands(codexHome) {
+  const parsed = JSON.parse(fs.readFileSync(path.join(codexHome, 'hooks.json'), 'utf8'));
+  return Object.values(parsed.hooks ?? parsed)
+    .flatMap((entries) => Array.isArray(entries) ? entries : [])
+    .flatMap((entry) => Array.isArray(entry.hooks) ? entry.hooks : [])
+    .map((hook) => hook.command)
+    .filter((command) => typeof command === 'string');
 }
 
 function tomlGsdHookCount(codexHome) {
@@ -1945,9 +1999,64 @@ describe('#3357 — Codex install removes legacy GSD hooks.json entries', { conc
     assert.equal(tomlGsdHookCount(codexHome), 0);
   });
 
-  test('restores migrated hooks.json and install state when later Codex validation fails', () => {
-    const before = JSON.stringify({ SessionStart: [legacyGsdHook(codexHome)] }, null, 2);
-    fs.writeFileSync(path.join(codexHome, 'hooks.json'), before);
+  test('preserves user-owned monitor commands through full Codex install', () => {
+    const absoluteNodeRunner = resolveNodeRunner();
+    assert.ok(absoluteNodeRunner, 'test requires the installer Node runner');
+
+    const targetMonitorPath = path.normalize(path.resolve(
+      codexHome,
+      'hooks',
+      'gsd-context-monitor.js',
+    ));
+    const exactMonitorCommand = `${absoluteNodeRunner} ${JSON.stringify(targetMonitorPath)}`;
+    const preservedCommands = [
+      `${exactMonitorCommand} --custom-threshold 25`,
+      `${exactMonitorCommand} && echo custom`,
+      `"/usr/bin/bun" ${JSON.stringify(targetMonitorPath)}`,
+      `node ${JSON.stringify(targetMonitorPath)}`,
+      `${absoluteNodeRunner} ${JSON.stringify(path.join(tmpRoot, 'external', 'gsd-context-monitor.js'))}`,
+      'node "/Users/example/bin/user-hook.js"',
+    ];
+    fs.writeFileSync(
+      path.join(codexHome, 'hooks.json'),
+      JSON.stringify({
+        SessionStart: [
+          legacyGsdHook(codexHome),
+          userHook(exactMonitorCommand),
+          ...preservedCommands.map((command) => userHook(command)),
+        ],
+      }, null, 2),
+    );
+
+    withCodexHome(codexHome, () => install(true, 'codex'));
+
+    const commands = hooksJsonCommands(codexHome);
+    assert.equal(commands.includes(exactMonitorCommand), false);
+    for (const command of preservedCommands) {
+      assert.equal(commands.includes(command), true, `preserves user-owned command: ${command}`);
+    }
+    assert.equal(
+      commands.filter((command) => /gsd-check-update\.(?:js|cmd)/.test(command)).length,
+      1,
+      'legacy update hook converges to one supported SessionStart command',
+    );
+  });
+
+  test('keeps preflight monitor cleanup durable while restoring later migration state on validation failure', () => {
+    const absoluteNodeRunner = resolveNodeRunner();
+    assert.ok(absoluteNodeRunner, 'test requires the installer Node runner');
+    const monitorCommand = `${absoluteNodeRunner} ${JSON.stringify(path.normalize(path.resolve(
+      codexHome,
+      'hooks',
+      'gsd-context-monitor.js',
+    )))}`;
+    fs.writeFileSync(
+      path.join(codexHome, 'hooks.json'),
+      JSON.stringify({
+        SessionStart: [legacyGsdHook(codexHome)],
+        Stop: [{ hooks: [{ type: 'command', command: monitorCommand }] }],
+      }, null, 2),
+    );
 
     installModule.__codexSchemaValidator = () => ({
       ok: false,
@@ -1959,7 +2068,22 @@ describe('#3357 — Codex install removes legacy GSD hooks.json entries', { conc
       /forced migration rollback test/
     );
 
-    assert.equal(fs.readFileSync(path.join(codexHome, 'hooks.json'), 'utf8'), before);
+    const hooksJson = JSON.parse(fs.readFileSync(path.join(codexHome, 'hooks.json'), 'utf8'));
+    assert.deepEqual(Object.keys(hooksJson), ['hooks']);
+    assert.equal(hooksJson.hooks.Stop, undefined, 'obsolete monitor-only event stays removed');
+    assert.equal(
+      JSON.stringify(hooksJson).includes('gsd-context-monitor'),
+      false,
+      'later validation rollback cannot reintroduce the unsupported monitor registration',
+    );
+    assert.equal(
+      hooksJson.hooks.SessionStart
+        .flatMap((entry) => entry.hooks)
+        .filter((hook) => hook.command.includes('gsd-check-update'))
+        .length,
+      1,
+      'the supported update hook survives preflight cleanup',
+    );
     assert.equal(
       readInstallState(codexHome).appliedMigrations.some((entry) => entry.id === '2026-05-11-codex-legacy-hooks-json'),
       false


### PR DESCRIPTION
## Enhancement PR

> **Using the wrong template?**
> — Bug fix: use [fix.md](?template=fix.md)
> — New feature: use [feature.md](?template=feature.md)

---

## Linked Issue

> **Required.** This PR will be auto-closed if no valid issue link is found.
> The linked issue **must** have the `approved-enhancement` label. If it does not, this PR will be closed without review.

Closes #2586

> ⛔ **No `approved-enhancement` label on the issue = immediate close.**
> Do not open this PR if a maintainer has not yet approved the enhancement proposal.

---

## What this enhancement improves

Codex installation and reinstall now accurately reflect the runtime's supported hook surface instead of installing an inert context monitor.

## Before / After

**Before:**
Fresh Codex installs copied and registered `gsd-context-monitor.js` even though Codex does not expose the remaining-context metric required for its warning and phase-status behavior.

**After:**
Fresh installs register only the supported `SessionStart` update check. Reinstalls remove exact GSD-owned current or recognized legacy monitor registrations and artifacts while preserving customized or unknown handlers and failing closed when cleanup cannot be proven safe.

## How it was implemented

The Codex hook projection now omits the unsupported monitor, shared cleanup recognizes only GSD-owned monitor command shapes (including Windows shims), and capability metadata reports context warnings and GSD phase/lifecycle display as unsupported. Tests cover fresh install, safe legacy cleanup, preserved customization, unsafe rewrites, and generated install parity.

## Testing

### How I verified the enhancement works

- 492 focused and golden-install tests passed.
- `npm run build:lib` passed.
- `npm run gen:capability-registry` passed.
- `npm run lint:generated-sync` passed.
- Changed source/test ESLint checks passed.
- `npm run lint:docs` passed.
- `GITHUB_BASE_REF=next node scripts/changeset/lint.cjs` passed.

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [x] Other: Codex
- [ ] N/A (not runtime-specific)

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue — no additions or removals
- [ ] If scope changed during implementation, I updated the issue and got re-approval before continuing

Native Codex footer/statusline configuration and #2602 agent-discovery work are intentionally excluded.

---

## Documentation

- [x] Updated the relevant file(s) under `docs/` to reflect this change
- [x] All `docs/` content added in this PR is written in English
- [ ] If genuinely no user-facing docs impact (infrastructure / internal refactor / test-only), apply the `no-docs` label or add a `docs-exempt` marker

## Checklist

- [x] Issue linked above with `Closes #NNN`
- [x] Linked issue has the `approved-enhancement` label
- [x] Changes are scoped to the approved enhancement — nothing extra included
- [ ] All existing tests pass (`npm test`)
- [x] New or updated tests cover the enhanced behavior
- [x] `.changeset/` fragment added
- [x] No unnecessary dependencies added

## Breaking changes

A Codex reinstall removes only recognized GSD-owned inert context-monitor registrations and unreferenced artifacts. Customized or unknown hook handlers are preserved.
