### PR TITLE
fix(#2703): strip CRLF gsd2 summary frontmatter

### DIFF
--- a/.changeset/sturdy-elks-howl.md
+++ b/.changeset/sturdy-elks-howl.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 2708
+---
+**GSD-2 imports now strip CRLF task-summary frontmatter** — migrated SUMMARY.md files no longer embed a second GSD-2 frontmatter block when source summaries use Windows line endings.

--- a/src/gsd2-import.cts
+++ b/src/gsd2-import.cts
@@ -25,6 +25,9 @@ import { platformWriteSync } from './shell-command-projection.cjs';
 import { formatGsdSlash, resolveRuntime } from './runtime-slash.cjs';
 import { realClock } from './clock.cjs';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
+import frontmatterMod = require('./frontmatter.cjs');
+const frontmatter = frontmatterMod as { stripFrontmatter(content: string): string };
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 import ioMod = require('./io.cjs');
 const { output } = ioMod;
 
@@ -283,9 +286,7 @@ function buildPlanMd(task: TaskInfo, phasePrefix: string, planPrefix: string, ph
  */
 function buildSummaryMd(task: TaskInfo, phasePrefix: string, planPrefix: string): string {
   const raw = task.summary || '';
-  // Strip GSD-2 frontmatter block (--- ... ---) if present
-  const bodyMatch = raw.match(/^---[\s\S]*?---\n+([\s\S]*)$/);
-  const body = bodyMatch ? bodyMatch[1].trim() : raw.trim();
+  const body = frontmatter.stripFrontmatter(raw).replace(/\r\n?/g, '\n').trim();
 
   return [
     '---',

--- a/tests/gsd2-import.test.cjs
+++ b/tests/gsd2-import.test.cjs
@@ -410,6 +410,37 @@ describe('buildPlanningArtifacts', () => {
     assert.ok(summary.includes('Init Project'));
   });
 
+  test('SUMMARY.md strips CRLF GSD-2 frontmatter the same as LF frontmatter', () => {
+    const gsdDir = makeGsd2Project(tmpDir);
+    const data = parseGsd2(gsdDir);
+    const task = data.milestones[0].slices[0].tasks[0];
+    const lfSummary = task.summary;
+
+    const lfArtifacts = buildPlanningArtifacts(data);
+    const lfOutput = lfArtifacts.get('phases/01-setup/01-01-SUMMARY.md');
+
+    task.summary = lfSummary.replace(/\n/g, '\r\n');
+    const crlfArtifacts = buildPlanningArtifacts(data);
+    const crlfOutput = crlfArtifacts.get('phases/01-setup/01-01-SUMMARY.md');
+
+    assert.strictEqual(crlfOutput, lfOutput);
+    assert.strictEqual((crlfOutput.match(/^---$/gm) || []).length, 2);
+    assert.ok(!crlfOutput.includes('completed_at:'));
+    assert.ok(crlfOutput.includes('Init Project'));
+  });
+
+  test('SUMMARY.md preserves summaries with no GSD-2 frontmatter', () => {
+    const gsdDir = makeGsd2Project(tmpDir);
+    const data = parseGsd2(gsdDir);
+    data.milestones[0].slices[0].tasks[0].summary = '# Plain summary\n\nNo frontmatter here.\n';
+
+    const artifacts = buildPlanningArtifacts(data);
+    const summary = artifacts.get('phases/01-setup/01-01-SUMMARY.md');
+
+    assert.ok(summary.includes('# Plain summary'));
+    assert.ok(summary.includes('No frontmatter here.'));
+  });
+
   test('config.json is valid JSON', () => {
     const gsdDir = makeGsd2Project(tmpDir);
     const data = parseGsd2(gsdDir);


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #2703

---

## What was broken

`buildSummaryMd` stripped GSD-2 task-summary frontmatter with a local regex that only matched LF after the closing delimiter. CRLF source summaries fell through to `raw.trim()`, so the generated v1 `SUMMARY.md` could contain both the new v1 frontmatter and the original GSD-2 frontmatter in the body.

## What this fix does

Delegates stripping to the shared frontmatter helper, then normalizes the imported body line endings to LF so CRLF and LF source summaries produce byte-identical v1 summaries. Adds regression coverage for CRLF frontmatter and the no-frontmatter fallback case.

## Root cause

The importer re-derived frontmatter stripping with `---\n` semantics instead of using the repository’s CRLF-tolerant frontmatter module, making the null-match path indistinguishable from a legitimate summary without frontmatter.

## Testing

### How I verified the fix

- `npm run build:lib`
- `node --test tests/gsd2-import.test.cjs`
- `npm run lint`
- `git diff --check`
- `npm test` was attempted, but exceeded the 600s local command timeout after reaching passing test output through suite 58; focused tests and lint passed locally.

### Regression test added?
- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why: 

### Platforms tested
- [ ] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested
- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [ ] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2708"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787759473&installation_model_id=22188&pr_number=2708&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2708&signature=0e656b33c44c39762b880e8324e1293892b24ed9553112f1e8096d3e3019ae0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->