### PR TITLE
fix(#2753): scan every key occurrence when asserting a documented default

### DIFF
--- a/tests/gsd-settings-advanced.test.cjs
+++ b/tests/gsd-settings-advanced.test.cjs
@@ -28,6 +28,42 @@ const path = require('node:path');
 const { createTempProject, cleanup, runGsdTools } = require('./helpers.cjs');
 const { VALID_CONFIG_KEYS } = require('../gsd-core/bin/lib/config-schema.cjs');
 
+/** How far after a key mention the default may appear and still count as documenting it. */
+const DEFAULT_PROXIMITY_WINDOW = 400;
+
+/**
+ * Is `defaultToken` documented near ANY occurrence of `key` in `workflow`?
+ *
+ * Scans every occurrence, not just the first (#2753). The contract this enforces is "the
+ * workflow documents the default for this key". A first-occurrence search asserts something
+ * narrower and different — "the FIRST mention of this key is followed by the default" — which
+ * silently breaks the moment a workflow names a key in prose before its settings-table entry.
+ * That is a normal thing for a workflow to do, and #2558 does it: a shared language directive
+ * puts `response_language` at index 6 while the table documents `null` at 7185, so the check
+ * failed on a document that was correct.
+ *
+ * Deliberately still forgiving about WHERE the evidence sits (any occurrence) and strict about
+ * WHAT counts (the token inside a bounded window). Widening the window to the whole file would
+ * pass on any unrelated occurrence of the token and gut the check; parsing the settings table
+ * would couple this to table markup. Both rejected.
+ *
+ * @returns {{ok: boolean, occurrences: number, window: string}} `occurrences: 0` = key absent.
+ */
+function findDocumentedDefault(workflow, key, defaultToken, windowSize = DEFAULT_PROXIMITY_WINDOW) {
+  let occurrences = 0;
+  let lastWindow = '';
+  // Advance by one char, not by key length: a key that overlaps itself or sits inside the
+  // default token must still terminate.
+  for (let idx = workflow.indexOf(key); idx >= 0; idx = workflow.indexOf(key, idx + 1)) {
+    occurrences += 1;
+    lastWindow = workflow.slice(idx, idx + windowSize);
+    if (lastWindow.includes(defaultToken)) {
+      return { ok: true, occurrences, window: lastWindow };
+    }
+  }
+  return { ok: false, occurrences, window: lastWindow };
+}
+
 const ROOT = path.resolve(__dirname, '..');
 // #2790: settings-advanced.md was consolidated into config.md as the --advanced flag.
 const COMMAND_PATH = path.join(ROOT, 'commands', 'gsd', 'config.md');
@@ -151,14 +187,13 @@ describe('gsd-settings-advanced — workflow structure', () => {
       );
     });
     test(`workflow documents default for \`${field.key}\` (${field.default})`, () => {
-      // Search for the default token in proximity to the key. Keep this
-      // forgiving: same line, or within ~200 chars after the key.
-      const idx = workflow.indexOf(field.key);
-      assert.ok(idx >= 0, `key ${field.key} not found`);
-      const window = workflow.slice(idx, idx + 400);
+      // Proximity search across EVERY occurrence of the key, not just the first (#2753).
+      const found = findDocumentedDefault(workflow, field.key, field.default);
+      assert.ok(found.occurrences > 0, `key ${field.key} not found`);
       assert.ok(
-        window.includes(field.default),
-        `default "${field.default}" not found near key ${field.key}. Window:\n${window}`
+        found.ok,
+        `default "${field.default}" not found within ${DEFAULT_PROXIMITY_WINDOW} chars of any ` +
+        `of the ${found.occurrences} occurrence(s) of key ${field.key}. Last window:\n${found.window}`
       );
     });
   }
@@ -817,3 +852,88 @@ describe('issue #33: model_profile schema and settings.md UI are in sync', () =>
 });
   });
 }
+
+// ─── findDocumentedDefault: the proximity scan itself (#2753) ────────────────
+//
+// The generated `workflow documents default for ...` tests above instantiate this helper
+// against the ONE real workflow, which documents every key — so they can only ever exercise
+// the passing path. The negative cases that stop this from degrading into "the token appears
+// somewhere in the file" are only reachable on synthetic documents, which is what these do.
+
+describe('findDocumentedDefault', () => {
+  const KEY = 'response_language';
+  const DEF = 'null';
+  const pad = (n) => 'x'.repeat(n);
+
+  test('documents default on a single occurrence', () => {
+    const r = findDocumentedDefault(`| ${KEY} | ${DEF} | prose`, KEY, DEF);
+    assert.equal(r.ok, true);
+    assert.equal(r.occurrences, 1);
+  });
+
+  test('documents default when a LATER occurrence carries it (#2558 shape)', () => {
+    // Prose directive names the key first; the settings table documents it much later.
+    const doc = `Apply ${KEY} to all user-facing prose.\n${pad(2000)}\n| ${KEY} | ${DEF} |`;
+    const r = findDocumentedDefault(doc, KEY, DEF);
+    assert.equal(r.ok, true, 'a later occurrence must satisfy the contract');
+    assert.equal(r.occurrences, 2);
+  });
+
+  test('documents default when the FIRST occurrence carries it (no regression)', () => {
+    const doc = `| ${KEY} | ${DEF} |\n${pad(2000)}\nlater prose about ${KEY}.`;
+    const r = findDocumentedDefault(doc, KEY, DEF);
+    assert.equal(r.ok, true);
+    assert.equal(r.occurrences, 2);
+  });
+
+  test('documents default on the LAST of many occurrences', () => {
+    const doc = [pad(500), KEY, pad(500), KEY, pad(500), KEY, pad(10), DEF].join('\n');
+    const r = findDocumentedDefault(doc, KEY, DEF);
+    assert.equal(r.ok, true);
+    assert.equal(r.occurrences, 3);
+  });
+
+  test('FAILS when no occurrence documents the default', () => {
+    // The load-bearing negative: scanning more occurrences must not turn a real miss into a pass.
+    const doc = [pad(500), KEY, pad(500), KEY, pad(500), KEY, pad(500)].join('\n');
+    const r = findDocumentedDefault(doc, KEY, DEF);
+    assert.equal(r.ok, false);
+    assert.equal(r.occurrences, 3, 'the count is what makes a genuine miss diagnosable');
+  });
+
+  test('reports zero occurrences when the key is absent', () => {
+    const r = findDocumentedDefault(`nothing relevant here ${DEF}`, KEY, DEF);
+    assert.equal(r.ok, false);
+    assert.equal(r.occurrences, 0);
+    assert.equal(r.window, '');
+  });
+
+  test('window boundary holds at limit-1 / limit / limit+1', () => {
+    // Offset measured from the start of the key, matching slice(idx, idx + windowSize).
+    const at = (gap) => `${KEY}${pad(gap)}${DEF}`;
+    const inside = DEFAULT_PROXIMITY_WINDOW - KEY.length - DEF.length - 1;
+    assert.equal(findDocumentedDefault(at(inside), KEY, DEF).ok, true, 'limit-1 must pass');
+    assert.equal(findDocumentedDefault(at(inside + 1), KEY, DEF).ok, true, 'limit must pass');
+    assert.equal(findDocumentedDefault(at(inside + 2), KEY, DEF).ok, false, 'limit+1 must fail');
+  });
+
+  test('fails cleanly on an empty document', () => {
+    const r = findDocumentedDefault('', KEY, DEF);
+    assert.deepEqual(r, { ok: false, occurrences: 0, window: '' });
+  });
+
+  test('terminates when the key overlaps itself', () => {
+    // Advance-by-one must not loop forever on a self-overlapping needle.
+    const r = findDocumentedDefault('aaaa', 'aa', 'zz');
+    assert.equal(r.ok, false);
+    assert.equal(r.occurrences, 3);
+  });
+
+  test('is newline-agnostic (CRLF reaches the same verdict as LF)', () => {
+    const lf = `prose ${KEY}\n${pad(2000)}\n| ${KEY} | ${DEF} |`;
+    assert.deepEqual(
+      findDocumentedDefault(lf.replace(/\n/g, '\r\n'), KEY, DEF).ok,
+      findDocumentedDefault(lf, KEY, DEF).ok
+    );
+  });
+});

--- a/tests/gsd-settings-advanced.test.cjs
+++ b/tests/gsd-settings-advanced.test.cjs
@@ -48,7 +48,13 @@ const DEFAULT_PROXIMITY_WINDOW = 400;
  * pass on any unrelated occurrence of the token and gut the check; parsing the settings table
  * would couple this to table markup. Both rejected.
  *
- * @returns {{ok: boolean, occurrences: number, window: string}} `occurrences: 0` = key absent.
+ * @returns {{ok: boolean, occurrences: number, window: string}}
+ *   `occurrences` is how many key occurrences were EXAMINED before deciding — not how many
+ *   exist. The scan short-circuits on the first documenting window, so on success this is the
+ *   1-based position of the match, and on failure it is the document's full count. That
+ *   asymmetry is deliberate: the failure path is where the number has to be trustworthy, since
+ *   "examined N, none documented it" is what distinguishes a genuine miss from the
+ *   first-occurrence false negative this function exists to remove. `occurrences: 0` = key absent.
  */
 function findDocumentedDefault(workflow, key, defaultToken, windowSize = DEFAULT_PROXIMITY_WINDOW) {
   let occurrences = 0;
@@ -891,7 +897,10 @@ describe('findDocumentedDefault', () => {
     const doc = `| ${KEY} | ${DEF} |\n${pad(2000)}\nlater prose about ${KEY}.`;
     const r = findDocumentedDefault(doc, KEY, DEF);
     assert.equal(r.ok, true);
-    assert.equal(r.occurrences, 2);
+    // The document contains the key twice, but the scan short-circuits on the first
+    // documenting window, so exactly one occurrence is EXAMINED. Asserting 2 here would be
+    // asserting the document's contents rather than the function's behavior.
+    assert.equal(r.occurrences, 1, 'must short-circuit rather than scan the whole document');
   });
 
   test('documents default on the LAST of many occurrences', () => {

--- a/tests/gsd-settings-advanced.test.cjs
+++ b/tests/gsd-settings-advanced.test.cjs
@@ -27,6 +27,7 @@ const path = require('node:path');
 
 const { createTempProject, cleanup, runGsdTools } = require('./helpers.cjs');
 const { VALID_CONFIG_KEYS } = require('../gsd-core/bin/lib/config-schema.cjs');
+const fc = require('fast-check');
 
 /** How far after a key mention the default may appear and still count as documenting it. */
 const DEFAULT_PROXIMITY_WINDOW = 400;
@@ -52,6 +53,13 @@ const DEFAULT_PROXIMITY_WINDOW = 400;
 function findDocumentedDefault(workflow, key, defaultToken, windowSize = DEFAULT_PROXIMITY_WINDOW) {
   let occurrences = 0;
   let lastWindow = '';
+  // An empty needle would HANG this loop, not end it: String#indexOf('', pos) clamps to
+  // str.length instead of returning -1, so `idx` stabilizes at the end and never goes
+  // negative. Every SPEC_FIELDS key is non-empty today, which is exactly why this has to be
+  // guarded rather than assumed.
+  if (typeof key !== 'string' || key === '') {
+    return { ok: false, occurrences: 0, window: '' };
+  }
   // Advance by one char, not by key length: a key that overlaps itself or sits inside the
   // default token must still terminate.
   for (let idx = workflow.indexOf(key); idx >= 0; idx = workflow.indexOf(key, idx + 1)) {
@@ -931,9 +939,48 @@ describe('findDocumentedDefault', () => {
 
   test('is newline-agnostic (CRLF reaches the same verdict as LF)', () => {
     const lf = `prose ${KEY}\n${pad(2000)}\n| ${KEY} | ${DEF} |`;
+    const crlf = lf.replace(/\n/g, '\r\n');
+    // Asserting only that the two agree is vacuous — a stub returning a constant satisfies it.
+    // Pin the ABSOLUTE verdict on both, then that they agree.
+    assert.equal(findDocumentedDefault(lf, KEY, DEF).ok, true);
+    assert.equal(findDocumentedDefault(crlf, KEY, DEF).ok, true);
+    // And a document neither newline style can rescue must fail under both.
+    const missLf = [pad(500), KEY, pad(500), KEY, pad(500)].join('\n');
+    assert.equal(findDocumentedDefault(missLf, KEY, DEF).ok, false);
+    assert.equal(findDocumentedDefault(missLf.replace(/\n/g, '\r\n'), KEY, DEF).ok, false);
+  });
+
+  test('an empty key is refused rather than hanging the scan', () => {
+    // String#indexOf('', pos) clamps to str.length instead of returning -1, so an unguarded
+    // scan loops forever. Guarded above; this pins it. A timeout here means the guard is gone.
+    const r = findDocumentedDefault('some workflow text', '', DEF);
+    assert.deepEqual(r, { ok: false, occurrences: 0, window: '' });
     assert.deepEqual(
-      findDocumentedDefault(lf.replace(/\n/g, '\r\n'), KEY, DEF).ok,
-      findDocumentedDefault(lf, KEY, DEF).ok
+      findDocumentedDefault('', '', ''),
+      { ok: false, occurrences: 0, window: '' }
+    );
+  });
+
+  test('property: verdict is exactly "default fits inside the window from the key"', () => {
+    // windowSize is a budget limit, so it carries a property test (CLAUDE.md TEST RULES).
+    // Disjoint alphabets keep key/default/filler from colliding, so the expected verdict is
+    // pure arithmetic: the window starts AT the key and spans windowSize chars.
+    fc.assert(
+      fc.property(
+        fc.stringMatching(/^[a-f]{1,12}$/),
+        fc.stringMatching(/^[m-r]{1,8}$/),
+        fc.integer({ min: 0, max: 600 }),
+        fc.integer({ min: 20, max: 400 }),
+        (key, def, gap, windowSize) => {
+          const doc = `${key}${'z'.repeat(gap)}${def}`;
+          const expected = key.length + gap + def.length <= windowSize;
+          const r = findDocumentedDefault(doc, key, def, windowSize);
+          assert.equal(r.ok, expected);
+          assert.ok(r.occurrences >= 1, 'the key is present by construction');
+          return true;
+        }
+      ),
+      { numRuns: 300, seed: 2753 }
     );
   });
 });


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #2753

---

## What was broken

`tests/gsd-settings-advanced.test.cjs` asserted that each settings key's default is documented in `gsd-core/workflows/settings-advanced.md`, but located the key with a **first-occurrence** search:

```js
const idx = workflow.indexOf(field.key);
const window = workflow.slice(idx, idx + 400);
assert.ok(window.includes(field.default), ...);
```

Its stated contract is *"the workflow documents the default for this key."* What it actually asserted was *"the **first mention** of this key is followed by the default"* — an ordering assumption that was never part of the contract, and that breaks the moment a workflow names a key in prose before its settings-table entry.

## What this fix does

Extracts `findDocumentedDefault()`, which scans **every** occurrence and passes if any window documents the default, reporting how many occurrences it examined so a genuine miss stays distinguishable from this false negative.

## Root cause

Measured on `next` @ `0f6026604` and on the head of PR #2558:

| Tree | First `response_language` index | Default `null` inside the 400-char window |
|---|---|---|
| `next` | 7185 | ✅ true — the table happens to be the first mention |
| #2558 head | 6 | ❌ **false** — a prose directive is the first mention |

PR #2558 adds a shared response-language directive whose text contains the literal token `response_language`, landing it at index 6. The settings table still documents `null` correctly further down; the test simply never looked there. The failure message then displayed the *prose* window, which made a test bug read as a content bug.

This is **not** specific to #2558 — any workflow naming a settings key in prose ahead of its table entry trips it.

## Testing

### How I verified the fix

Reproduced the defect directly against both implementations before changing the assertion:

```
OLD (first occurrence only): FAIL   ← the reported defect
NEW (scan all, occurrences=2): PASS
NEW on never-documented (occurrences=3): FAIL (correct)  ← negative preserved
real next workflow: occurrences=1 PASS                   ← no regression
```

Then all 17 helper assertions plus 108 exhaustive `(key, default, gap, windowSize)` combinations were verified locally before the remote run.

Full matrix: **27352/27352 passing on `linux-node22` and `linux-node24`**.

### Regression test added?

- [x] Yes — 11 unit tests for `findDocumentedDefault`, including the #2558 shape

The generated `workflow documents default for ...` tests instantiate this helper against the one real workflow, which documents every key — so they can only ever exercise the passing path. The negative cases that stop this from degrading into *"the token appears somewhere in the file"* are only reachable on synthetic documents, which is what the new tests use. The load-bearing ones are **"FAILS when no occurrence documents the default"** and the `limit+1` boundary.

### Platforms tested

- [x] macOS
- [x] Windows (including backslash path handling)
- [x] Linux

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass — verified on this exact commit
- [x] `no-changelog` label applied (test-only; `changeset-lint` reports `ok_no_user_facing_changes`)
- [x] No unnecessary dependencies added

## Review

An isolated reviewer that did not author the change found **one major and two minors**, all fixed in-branch:

- **Major — the scan never terminated for an empty key.** `String#indexOf('', pos)` clamps to `str.length` rather than returning `-1`, so `idx` stabilized at the end of the document and the loop spun forever. Unreachable from `SPEC_FIELDS` today, but the docstring claimed termination while reasoning only about self-overlap — the claim was wrong, not merely incomplete. Guarded, with the clamping behavior named so the guard is not tidied away later.
- **Minor — the CRLF test was vacuous.** It asserted only that the two newline styles *agree*, which a constant stub satisfies. It now pins the absolute verdict on both, plus a document neither style can rescue.
- **Minor — no `fast-check` property**, despite `windowSize` being a budget-limit-shaped parameter (`CLAUDE.md` → TEST RULES). Added, seeded and bounded; it would have caught the empty-key hang on its own.

One finding was **not** accepted: that multi-occurrence scanning meaningfully weakens short defaults (`null`, `true`, `2`). That is the tradeoff #2753 requested, and the alternatives were weighed and rejected — widening the window to the whole file guts the check, and parsing the settings table couples the test to markup this repo prohibits. Recorded as a Known limit with the reviewer's concrete occurrence counts rather than dismissed.

The remote matrix then caught one more: an assertion that described the *fixture* (the document mentions the key twice) rather than the *function* (the scan short-circuits, so it examines one). Corrected, and the `occurrences` semantic is now documented explicitly.

## Known limits

- **Evidence quality.** The default token need only appear within 400 chars of *some* occurrence; it is not proven to be the table's documented value. This is the same looseness the original comment intentionally accepted ("Keep this forgiving"); scanning more occurrences widens it slightly. Tightening it means parsing the table, rejected above.
- **Substring keys.** `indexOf` still matches a key that is a prefix of a longer key. Pre-existing, unchanged, and not triggered by any current `SPEC_FIELDS` entry.

## Breaking changes

None. The assertion can only move fail→pass, never pass→fail: any document that satisfied the first-occurrence check still satisfies the scan, since the first occurrence is the first one examined.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2756"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787833938&installation_model_id=22188&pr_number=2756&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2756&signature=ce40264bc816464d165ce99d2446101edd43aa35785c8fdc5708c489dbbdb8ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->