### PR TITLE
fix(#2758): select the emitted differential wherever golden-parity runs

### DIFF
--- a/scripts/ci-test-scope.cjs
+++ b/scripts/ci-test-scope.cjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 'use strict';
 
-const path = require('node:path');
+const path = require('path');
 const { execFileSync } = require('child_process');
 const { existsSync, readdirSync, appendFileSync } = require('fs');
 
@@ -577,4 +577,4 @@ if (require.main === module) {
   runMain(main);
 }
 
-module.exports = { RULES, missingRuleTestFiles, classify, isInertCi };
+module.exports = { RULES, missingRuleTestFiles };

--- a/scripts/ci-test-scope.cjs
+++ b/scripts/ci-test-scope.cjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 'use strict';
 
+const path = require('node:path');
 const { execFileSync } = require('child_process');
 const { existsSync, readdirSync, appendFileSync } = require('fs');
 
@@ -105,9 +106,8 @@ const RULES = [
     fullMatrix: true,
     tests: [
       'tests/check-env.test.cjs',
-      'tests/npm-integrity-gate.test.cjs',
+      'tests/npm-integrity-gate.test.cjs', // #2758: absorbs the former tests/bug-3588-npm-audit-clean.test.cjs (folded into it by consolidation epic #1969 B6 #1975; the stale filename here was a silent coverage hole this rule never actually re-selected)
       'tests/package-manifest.test.cjs',
-      'tests/bug-3588-npm-audit-clean.test.cjs',
     ],
   },
   {
@@ -116,9 +116,10 @@ const RULES = [
     // still trigger the migrated module's tests (otherwise CI silently skips them).
     match: path => path.startsWith('src/') || path === 'tsconfig.build.json',
     tests: [
-      'tests/semver-compare.test.cjs',
-      'tests/bug-10-semver-policy-consolidation.test.cjs',
+      'tests/semver-compare.test.cjs', // #2758: absorbs the former tests/bug-10-semver-policy-consolidation.test.cjs (folded into it by consolidation epic #1969 B3 #1972; the stale filename here was a silent coverage hole this rule never actually re-selected)
       'tests/golden-install-parity.test.cjs', // any src/installer change can alter emitted install artifacts → re-verify golden install parity (drift guard)
+      'tests/emitted-provenance.test.cjs', // #2758: the differential travels with the golden — ADR-2719 dual-run
+      'tests/emitted-attribution.test.cjs',
     ],
   },
   {
@@ -143,6 +144,8 @@ const RULES = [
       // changed test file.
       'tests/runtime-artifact-layout.test.cjs',
       'tests/golden-install-parity.test.cjs', // any src/installer change can alter emitted install artifacts → re-verify golden install parity (drift guard)
+      'tests/emitted-provenance.test.cjs', // #2758: the differential travels with the golden — ADR-2719 dual-run
+      'tests/emitted-attribution.test.cjs',
     ],
   },
   {
@@ -155,6 +158,10 @@ const RULES = [
     // shipped to next undetected). Union semantics: this ADDS the parity guard on
     // top of each path's existing content-specific tests. Targeted lane only (the
     // golden test skips win32 by design), no fullMatrix.
+    // #2758: the Phase 2/3 emitted differential (ADR-2719) travels alongside the
+    // golden here too — a PR editing only shipped content is the archetypal
+    // emitted ripple, and until this fix no rule selected the differential at
+    // all. Both green, fixtures untouched, is the dual-run premise.
     // NOTE: intentionally NOT a blanket 'gsd-core/' prefix, for two reasons:
     // (1) gsd-core/bin/** is tsc-compiled runtime output — EXCLUDED_PREFIXES-
     //     excluded from both manifests, and already covered by the 'installer and
@@ -174,6 +181,8 @@ const RULES = [
     tests: [
       'tests/golden-install-parity.test.cjs',
       'tests/golden-install-tree.test.cjs',
+      'tests/emitted-provenance.test.cjs',
+      'tests/emitted-attribution.test.cjs',
     ],
   },
   {
@@ -236,7 +245,13 @@ const RULES = [
       'tests/workflow-size-budget.test.cjs',
       'tests/workflow-guard-registration.test.cjs',
       'tests/commands.test.cjs',
-      'tests/bug-3683-workflow-colon-namespace-leak.test.cjs',
+      // #2758: was 'tests/bug-3683-workflow-colon-namespace-leak.test.cjs', deleted by
+      // consolidation epic #1969 (B6 #1975) and folded into slash-command-namespace.test.cjs
+      // ("folded:bug-3683-workflow-colon-namespace-leak" describe block). The stale filename
+      // here was itself an instance of this issue's defect class — silently dropped by
+      // existingTests() below, so gsd-core/workflows/ changes stopped re-running this
+      // regression's coverage with nothing signaling it.
+      'tests/slash-command-namespace.test.cjs',
     ],
   },
   {
@@ -290,6 +305,41 @@ const RULES = [
     ],
   },
  ];
+
+/**
+ * Every RULES[].tests entry (deduped, across every rule) that does NOT exist on
+ * disk. #2758: a rule naming a test file that no longer exists is not merely
+ * inert — existingTests() below silently drops it out of targeted_tests, with
+ * nothing in the CI output signaling why. Phase 4 (#2724) deletes
+ * tests/golden-install-parity.test.cjs; without this check, any rule still
+ * naming it would stop selecting the guard entirely and CI would stay green
+ * throughout. Pure and independent of which rule / which file: it catches ANY
+ * phantom entry, not only the two names this issue is about.
+ * Paths resolve relative to the repo root (this file's parent directory), not
+ * the caller's cwd, so the check behaves identically whether invoked as the CLI
+ * (`node scripts/ci-test-scope.cjs ...`, cwd == repo root by convention) or
+ * required directly by a test.
+ */
+function missingRuleTestFiles(rules) {
+  const referenced = new Set();
+  for (const rule of rules) {
+    for (const f of rule.tests) referenced.add(f);
+  }
+  return [...referenced].filter(f => !existsSync(path.join(__dirname, '..', f))).sort();
+}
+
+// Fail loudly at module load, mirroring the PROTECTED_WORKFLOWS check above —
+// this fires on EVERY invocation of the CLI (including the real `changes` job
+// in .github/workflows/test.yml), not only when a test suite happens to run.
+{
+  const missing = missingRuleTestFiles(RULES);
+  if (missing.length > 0) {
+    throw new Error(
+      `ci-test-scope: RULES reference test file(s) that do not exist on disk ` +
+      `(silent coverage hole — see #2758):\n  ${missing.join('\n  ')}`,
+    );
+  }
+}
 
 function usage() {
   return [
@@ -523,4 +573,8 @@ function main() {
   }
 }
 
-runMain(main);
+if (require.main === module) {
+  runMain(main);
+}
+
+module.exports = { RULES, missingRuleTestFiles, classify, isInertCi };

--- a/tests/ci-test-scope.test.cjs
+++ b/tests/ci-test-scope.test.cjs
@@ -708,6 +708,115 @@ describe('shipped install content (golden-parity drift guard, #2267)', () => {
   });
 });
 
+describe('differential attribution gates travel with golden-parity (#2758)', () => {
+  // #2758: the golden-parity rules ran tests/golden-install-parity.test.cjs on a
+  // shipped-content-only PR — the archetypal emitted ripple — but selected neither
+  // tests/emitted-provenance.test.cjs nor tests/emitted-attribution.test.cjs. Fix:
+  // every rule that selects the golden also selects both emitted gates, so the
+  // differential travels with the golden everywhere the golden travels (the
+  // ADR-2719 dual-run premise: both green, fixtures untouched, until Phase 4).
+  const { RULES } = require('../scripts/ci-test-scope.cjs');
+  const GOLDEN = 'tests/golden-install-parity.test.cjs';
+  const GATES = ['tests/emitted-provenance.test.cjs', 'tests/emitted-attribution.test.cjs'];
+
+  test('every RULES entry selecting golden-install-parity also selects both emitted gates', () => {
+    const goldenRules = RULES.filter(r => r.tests.includes(GOLDEN));
+    // Guards the guard: if this count ever drops to 0, the assertion below is
+    // vacuously true and would silently stop meaning anything.
+    assert.ok(
+      goldenRules.length >= 3,
+      `expected at least 3 RULES entries selecting ${GOLDEN}, found ${goldenRules.length}: ` +
+      `${goldenRules.map(r => r.name).join(', ')}`,
+    );
+    const offenders = goldenRules.filter(r => !GATES.every(g => r.tests.includes(g)));
+    assert.deepStrictEqual(
+      offenders.map(r => r.name),
+      [],
+      `rule(s) select ${GOLDEN} without both emitted gates: ${offenders.map(r => r.name).join(', ')}`,
+    );
+  });
+
+  test('a pure shipped-content path selects both emitted gates alongside the golden', () => {
+    // #2758 AC: "a pure shipped-content path (e.g. gsd-core/workflows/plan-phase.md)
+    // selects the differential." The archetypal emitted ripple.
+    const result = scopeFor(['gsd-core/workflows/plan-phase.md']);
+    assert.strictEqual(result.code_changed, true);
+    assert.ok(result.targeted_tests.includes(GOLDEN));
+    for (const g of GATES) {
+      assert.ok(
+        result.targeted_tests.includes(g),
+        `expected ${g} in targeted_tests for a shipped-content-only change, got: ${JSON.stringify(result.targeted_tests)}`,
+      );
+    }
+  });
+
+  test('a src/*.cts-only change selects both emitted gates (TS runtime sources rule)', () => {
+    const result = scopeFor(['src/milestone.cts']);
+    for (const g of GATES) {
+      assert.ok(
+        result.targeted_tests.includes(g),
+        `expected ${g} in targeted_tests for src/ change, got: ${JSON.stringify(result.targeted_tests)}`,
+      );
+    }
+  });
+
+  test('bin/install.js selects both emitted gates (installer and package layout rule)', () => {
+    const result = scopeFor(['bin/install.js']);
+    for (const g of GATES) {
+      assert.ok(
+        result.targeted_tests.includes(g),
+        `expected ${g} in targeted_tests for bin/install.js, got: ${JSON.stringify(result.targeted_tests)}`,
+      );
+    }
+  });
+
+  test('docs-only change still does NOT select the emitted gates (negative case)', () => {
+    const result = scopeFor(['docs/usage.md']);
+    for (const g of GATES) {
+      assert.ok(!result.targeted_tests.includes(g), `docs-only must NOT select ${g}, got: ${JSON.stringify(result.targeted_tests)}`);
+    }
+  });
+});
+
+describe('RULES totality guard: no rule names a test file absent from disk (#2758)', () => {
+  // #2758: Phase 4 (#2724) deletes tests/golden-install-parity.test.cjs. Without an
+  // independent guard, a rule still naming it would produce no signal at all —
+  // existingTests() (scripts/ci-test-scope.cjs) silently filters missing files out
+  // of targeted_tests, so the gate simply stops being selected while CI stays
+  // green. This exists independently of the fix above: it catches ANY rule naming
+  // ANY absent file, not only the two gate filenames this issue is about.
+  const { RULES, missingRuleTestFiles } = require('../scripts/ci-test-scope.cjs');
+
+  test('no RULES entry today references a test file absent from disk', () => {
+    assert.deepStrictEqual(
+      missingRuleTestFiles(RULES), [],
+      'RULES reference test file(s) that do not exist — see missingRuleTestFiles() in scripts/ci-test-scope.cjs',
+    );
+  });
+
+  test('the guard mechanism itself catches a phantom entry (hostile input)', () => {
+    // Runs the REAL checker function used by the module-load assertion in
+    // scripts/ci-test-scope.cjs — not a hand-copied reimplementation of it — against
+    // a synthetic rule table, proving the mechanism would have caught exactly the
+    // Phase-4 shape: a rule naming a file that no longer exists on disk.
+    const phantomFile = 'tests/does-not-exist-2758.test.cjs';
+    assert.ok(
+      !fs.existsSync(path.join(ROOT, phantomFile)),
+      'precondition: the phantom file must genuinely not exist for this test to discriminate',
+    );
+    const synthetic = [
+      { name: 'real', tests: ['tests/commands.test.cjs'] },
+      { name: 'phantom', tests: [phantomFile, 'tests/commands.test.cjs'] },
+    ];
+    assert.deepStrictEqual(missingRuleTestFiles(synthetic), [phantomFile]);
+  });
+
+  test('an all-real synthetic table reports nothing missing (negative case)', () => {
+    const synthetic = [{ name: 'real', tests: ['tests/commands.test.cjs', 'tests/ci-test-scope.test.cjs'] }];
+    assert.deepStrictEqual(missingRuleTestFiles(synthetic), []);
+  });
+});
+
 describe('code_changed=false implies clean output invariant', () => {
   // Fix 1: when code_changed is false, full_matrix, targeted_tests, windows_tests
   // must ALL be empty/false — even if a docs path coincidentally


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #2758

---

## What was broken

`scripts/ci-test-scope.cjs` maps changed paths to a targeted CI test selection. The Phase 2/3 emitted gates were registered by **no rule at all**:

```
$ grep -c "emitted-attribution.test.cjs\|emitted-provenance.test.cjs" scripts/ci-test-scope.cjs
0
```

Three rules select `tests/golden-install-parity.test.cjs`; none selected the differential beside it. So a PR editing only shipped content — the archetypal emitted ripple, where one source edit rewrites the same hash across all 19 manifests — ran the golden check and **never ran the differential**.

Confirmed on PR #2566: `test (ubuntu-latest, 22)` ran a targeted selection of 38 files including `golden-install-parity` and excluding both emitted gates. The differential executed only because that PR *also* tripped a `fullMatrix: true` rule.

## Root cause

The same file already documents this defect from one generation ago:

> *"#2266: a `hooks/gsd-statusline.js` edit changed installed output but no rule selected golden-parity, so stale fixtures shipped to `next` undetected."*

Phase 2 and Phase 3 built the replacement gates and reproduced the identical shape — a gate that exists but that no rule selects.

## What this fix does

Adds `tests/emitted-provenance.test.cjs` and `tests/emitted-attribution.test.cjs` to **all three** rules that select `golden-install-parity`, so the differential travels with the golden — the premise of the ADR-2719 dual-run:

| Rule | Matches |
|---|---|
| `TS runtime sources (ADR-457 build-at-publish)` | `src/**`, `tsconfig.build.json` |
| `installer and package layout` | `bin/**`, `gsd-core/bin/**`, `*install*` |
| `shipped install content (golden-parity drift guard, #2267)` | `hooks/`, `commands/`, `agents/`, `skills/`, `gsd-core/{workflows,templates,references,contexts}/` |

It also adds an **independent existence guard**, `missingRuleTestFiles(RULES)`, wired at module load beside the existing `PROTECTED_WORKFLOWS` throw — so it fires on every CLI invocation including the real `changes` job, not only when a test happens to run. No rule may name a test file that is not on disk.

## The guard found three real phantom entries immediately

Before touching `golden-install-parity` at all, it caught the exact shape it was written for — three rules naming test files deleted months ago by consolidation epic #1969 and never removed from `RULES`:

- `tests/bug-3588-npm-audit-clean.test.cjs` — duplicate of an already-selected sibling; removed
- `tests/bug-10-semver-policy-consolidation.test.cjs` — same; removed
- `tests/bug-3683-workflow-colon-namespace-leak.test.cjs` — **a real coverage gap**; repointed to `tests/slash-command-namespace.test.cjs`

Those rules were silently selecting nothing. Fixed in the same change per the no-defer rule rather than filed separately.

## Why this blocks #2724

Phase 4 deletes `tests/golden-install-parity.test.cjs`. Without this guard, the shipped-content rule would name a **file that no longer exists**, with nothing replacing it on the targeted lane — the emitted gate unselected on precisely the PRs it exists to guard, while CI stays green because nothing fails when a gate simply isn't chosen. That is one of three blockers currently standing against the cutover.

## Testing

### How I verified the fix

Failing-first, proven by stashing the fix and driving the real CLI:

```
--- pre-fix ---
targeted_tests includes golden: true
tests/emitted-provenance.test.cjs  -> false
tests/emitted-attribution.test.cjs -> false
EXPECTED RED: MISSING tests/emitted-provenance.test.cjs
```

Verified structurally (`RULES.filter(r => r.tests.includes(golden))` → all 3 include both gates) and behaviorally through the CLI for a representative path from each rule (`gsd-core/workflows/plan-phase.md`, `src/milestone.cts`, `bin/install.js`).

Full matrix: **27362/27362 on `linux-node22` and `linux-node24`**, 0 unique failures.

### Regression test added?

- [x] Yes — 8 assertions in `tests/ci-test-scope.test.cjs` covering structural, behavioral, negative, totality and hostile input.

The adversarial case drives the **real** `missingRuleTestFiles` (not a reimplementation) with a synthetic table mixing a real and a phantom entry, and asserts only the phantom is flagged.

### Platforms tested

- [x] macOS
- [x] Windows (including backslash path handling)
- [x] Linux

### Runtimes tested

- [x] N/A (CI scope mapping, not runtime-specific)

---

## Known limit — stated plainly

The targeted lane's ability to actually **run** the differential (rather than `t.skip()`) rests on static evidence, not an observed live run:

- `.github/workflows/test.yml` checks out with `fetch-depth: 0`, which populates `origin/next` — the same precondition the repo's own pinned `#837` test already relies on for `ci-test-scope.cjs`'s three-dot merge-base to resolve.
- `GITHUB_BASE_REF` is a GitHub Actions built-in on `pull_request` runs.
- `resolveBase()`'s candidate order (`origin/<base>`, `<base>`, `origin/next`, `next`) resolves against either.

On the bench runner it **does** skip — `no base ref resolvable`, because that runner shallow-clones and merges, so no `origin/*` refs exist. That is pre-existing and documented in the test's own header, not introduced here. **This PR's own CI run is the first live proof**, and it should be checked before merge: if the targeted lane reports the differential as skipped, this needs a `fullMatrix` change or an explicit `GSD_EMITTED_BASE`, because a registered gate that always skips is worse than the honest gap it replaced.

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Fix is scoped to the reported bug
- [x] Regression test added
- [x] All existing tests pass — verified on this exact commit
- [x] `no-changelog` label applied (`changeset-lint: ok_no_user_facing_changes`)
- [x] No unnecessary dependencies added

## Breaking changes

None. The change only widens which tests a given path selects, and removes rule entries pointing at files that do not exist.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2759"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787839042&installation_model_id=22188&pr_number=2759&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2759&signature=660dc428e0a8480b7d7715a9da6e1c3592d26ce9c01a4ca61f6bda964d82a739"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->