### PR TITLE
fix(#1883): distinguish a permission/IO error from genuine emptiness in dir scans

### DIFF
--- a/.changeset/1883-permission-error-not-empty.md
+++ b/.changeset/1883-permission-error-not-empty.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 2802
 ---
 **Permission errors on phase and milestone directories now surface instead of looking empty** — an unreadable phase directory used to be silently reported as "no CONTEXT.md" (so the discuss/plan gates wrongly skipped context) and an unreadable `milestones/` directory as "no archives" (so active-milestone resolution and archived-phase filtering misbehaved), because both scans treated a permission or I-O failure the same as a genuinely empty directory. (#1883)

--- a/.changeset/1883-permission-error-not-empty.md
+++ b/.changeset/1883-permission-error-not-empty.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**Permission errors on phase and milestone directories now surface instead of looking empty** — an unreadable phase directory used to be silently reported as "no CONTEXT.md" (so the discuss/plan gates wrongly skipped context) and an unreadable `milestones/` directory as "no archives" (so active-milestone resolution and archived-phase filtering misbehaved), because both scans treated a permission or I-O failure the same as a genuinely empty directory. (#1883)

--- a/src/planning-workspace.cts
+++ b/src/planning-workspace.cts
@@ -393,8 +393,14 @@ function findContextMdIn(absDirOrFiles: string | string[]): string | null {
       : fs.readdirSync(absDirOrFiles);
     if (files.includes('CONTEXT.md')) return 'CONTEXT.md';
     return files.find((f: string) => f.endsWith('-CONTEXT.md')) ?? null;
-  } catch {
-    return null;
+  } catch (err) {
+    // #1883: distinguish genuine absence from a permission/I-O failure. ENOENT
+    // ("nothing there") keeps the long-standing null contract the callers rely
+    // on; every other error (EACCES, EIO, …) is a real read failure that must
+    // propagate — otherwise an unreadable phase dir is silently reported as
+    // "no CONTEXT.md" and the discuss/plan gates wrongly skip context.
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw err;
   }
 }
 

--- a/src/verify.cts
+++ b/src/verify.cts
@@ -1250,8 +1250,15 @@ function listMilestoneArchiveDirs(planBase: string): string[] {
       .sort((a, b) =>
         path.basename(a).localeCompare(path.basename(b), undefined, { numeric: true }),
       );
-  } catch {
-    return [];
+  } catch (err) {
+    // #1883: distinguish genuine absence from a permission/I-O failure. ENOENT
+    // (no milestones/ dir yet) keeps the long-standing [] contract that
+    // collectPhaseRoots / forEachArchivedPhaseToken depend on for "no archives";
+    // every other error (EACCES, EIO, …) must propagate — otherwise an unreadable
+    // milestones/ dir is silently reported as "no archives" and active-milestone
+    // resolution / archived-phase filtering misbehaves.
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    throw err;
   }
 }
 
@@ -2632,4 +2639,9 @@ export = {
   cmdValidateAgents,
   cmdVerifySchemaDrift,
   cmdVerifyCodebaseDrift,
+  // Test seam (#1883): listMilestoneArchiveDirs is private and exercised through
+  // the validate command, which runs in a subprocess — an fs monkeypatch in the
+  // test process cannot reach it. Exposed under a leading underscore so the
+  // permission-error path can be unit-tested directly (no chmod 0o000).
+  _listMilestoneArchiveDirs: listMilestoneArchiveDirs,
 };

--- a/tests/emitted-drift-ack.json
+++ b/tests/emitted-drift-ack.json
@@ -1,8 +1,0 @@
-{
-  "version": 1,
-  "paths": {
-    "gsd-phase-researcher.md": {
-      "reason": "#1699 adds the in-repo value provenance rule to the claim-provenance section: an enum, schema/type-union, error code, status constant, or filesystem path earns [VERIFIED] only after a same-session Read, a path-and-line-range citation, and a verbatim quote in RESEARCH.md. Growth is inline prose in the agent body, deliberately NOT relocated into an eagerly @-imported reference, which ADR-1610 Decision 4 names as gaming the size proxy. 40866 -> 42020 bytes, LARGE tier, cap 49152."
-    }
-  }
-}

--- a/tests/planning-workspace.test.cjs
+++ b/tests/planning-workspace.test.cjs
@@ -594,42 +594,28 @@ describe('bug #1883 — findContextMdIn distinguishes a permission error from em
 
   // Helper: build a Node-style error with a `code`, matching what fs.readdirSync throws.
   function fsError(code) {
-    const err = new Error(`EACCES: permission denied, scandir '/denied'`);
+    const err = new Error(`${code}: operation failed, scandir '/denied'`);
     err.code = code;
     err.syscall = 'scandir';
     err.path = '/denied';
     return err;
   }
 
-  // Monkeypatch fs.readdirSync for the duration of one call, restored in finally —
-  // per repo rule: no chmod 0o000 (root bypasses mode bits → silent zero coverage).
-  function withReaddirThrowing(code, fn) {
-    const real = fs.readdirSync;
-    let restored = false;
-    fs.readdirSync = function mocked(...args) {
-      throw fsError(code);
-    };
-    try {
-      return fn();
-    } finally {
-      if (!restored) {
-        fs.readdirSync = real;
-        restored = true;
-      }
-    }
-  }
-
-  test('findContextMdIn re-throws a permission (EACCES) error instead of swallowing it as null', () => {
+  test('findContextMdIn re-throws a permission (EACCES) error instead of swallowing it as null', (t) => {
+    // No chmod 0o000 — root bypasses mode bits (silent zero coverage in root CI).
+    // t.mock auto-restores after the test.
+    t.mock.method(fs, 'readdirSync', () => { throw fsError('EACCES'); });
     assert.throws(
-      () => withReaddirThrowing('EACCES', () => findContextMdIn('/denied/phase-dir')),
+      () => findContextMdIn('/denied/phase-dir'),
       (err) => err.code === 'EACCES',
       'an unreadable dir must propagate EACCES, not return null as if empty',
     );
   });
 
-  test('findContextMdIn re-throws any non-ENOENT error (EIO)', () => {
+  test('findContextMdIn re-throws any non-ENOENT error (EIO)', (t) => {
+    t.mock.method(fs, 'readdirSync', () => { throw fsError('EIO'); });
     assert.throws(
-      () => withReaddirThrowing('EIO', () => findContextMdIn('/io-failure/phase-dir')),
+      () => findContextMdIn('/io-failure/phase-dir'),
       (err) => err.code === 'EIO',
       'every non-ENOENT error must propagate — the narrowed catch only keeps ENOENT',
     );
@@ -642,44 +628,29 @@ describe('bug #1883 — findContextMdIn distinguishes a permission error from em
       'an absent dir (ENOENT) must still return null — Hyrum: empty path unchanged');
   });
 
-  test('findContextMdIn finds bare CONTEXT.md', () => {
+  test('findContextMdIn finds bare CONTEXT.md', (t) => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-1883-bare-'));
-    try {
-      fs.writeFileSync(path.join(tmp, 'CONTEXT.md'), '# bare\n');
-      assert.strictEqual(findContextMdIn(tmp), 'CONTEXT.md');
-    } finally {
-      for (const f of fs.readdirSync(tmp)) fs.unlinkSync(path.join(tmp, f));
-      fs.rmdirSync(tmp);
-    }
+    t.after(() => { cleanup(tmp); });
+    fs.writeFileSync(path.join(tmp, 'CONTEXT.md'), '# bare\n');
+    assert.strictEqual(findContextMdIn(tmp), 'CONTEXT.md');
   });
 
-  test('findContextMdIn finds padded NN-CONTEXT.md', () => {
+  test('findContextMdIn finds padded NN-CONTEXT.md', (t) => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-1883-padded-'));
-    try {
-      fs.writeFileSync(path.join(tmp, '01-CONTEXT.md'), '# padded\n');
-      assert.strictEqual(findContextMdIn(tmp), '01-CONTEXT.md');
-    } finally {
-      for (const f of fs.readdirSync(tmp)) fs.unlinkSync(path.join(tmp, f));
-      fs.rmdirSync(tmp);
-    }
+    t.after(() => { cleanup(tmp); });
+    fs.writeFileSync(path.join(tmp, '01-CONTEXT.md'), '# padded\n');
+    assert.strictEqual(findContextMdIn(tmp), '01-CONTEXT.md');
   });
 
-  test('findContextMdIn matches against a pre-read files array without touching fs', () => {
+  test('findContextMdIn matches against a pre-read files array without touching fs', (t) => {
     // The array path never calls readdirSync — exercised by getPhaseFileStats,
     // countPhasePlansAndSummaries, runGapAnalysis. Must keep working untouched.
-    const orig = fs.readdirSync;
-    let called = false;
-    fs.readdirSync = function () { called = true; return []; };
-    try {
-      assert.strictEqual(findContextMdIn(['CONTEXT.md', 'PLAN.md']), 'CONTEXT.md',
-        'array path matches bare form');
-      assert.strictEqual(findContextMdIn(['02-CONTEXT.md']), '02-CONTEXT.md',
-        'array path matches padded form');
-      assert.strictEqual(findContextMdIn(['PLAN.md']), null,
-        'array path returns null when no match');
-      assert.strictEqual(called, false, 'array path must NOT call fs.readdirSync');
-    } finally {
-      fs.readdirSync = orig;
-    }
+    t.mock.method(fs, 'readdirSync', () => { throw new Error('array path must not call fs'); });
+    assert.strictEqual(findContextMdIn(['CONTEXT.md', 'PLAN.md']), 'CONTEXT.md',
+      'array path matches bare form');
+    assert.strictEqual(findContextMdIn(['02-CONTEXT.md']), '02-CONTEXT.md',
+      'array path matches padded form');
+    assert.strictEqual(findContextMdIn(['PLAN.md']), null,
+      'array path returns null when no match');
   });
 });

--- a/tests/planning-workspace.test.cjs
+++ b/tests/planning-workspace.test.cjs
@@ -582,3 +582,104 @@ describe('bug #3739 — gap-analysis padded-prefix CONTEXT.md', () => {
 });
   });
 }
+
+// ─── bug #1883: findContextMdIn must not swallow permission/I-O errors ───────
+// A catch-all `catch { return null }` conflated a genuine ENOENT ("nothing there")
+// with an EACCES/EIO failure ("can't read this"), so an unreadable phase dir was
+// silently reported as "no CONTEXT.md" — discuss/plan gates then wrongly believed
+// context had never been gathered. The narrowed catch re-throws every non-ENOENT
+// error and keeps returning null only for genuine absence.
+describe('bug #1883 — findContextMdIn distinguishes a permission error from emptiness', () => {
+  const { findContextMdIn } = require('../gsd-core/bin/lib/planning-workspace.cjs');
+
+  // Helper: build a Node-style error with a `code`, matching what fs.readdirSync throws.
+  function fsError(code) {
+    const err = new Error(`EACCES: permission denied, scandir '/denied'`);
+    err.code = code;
+    err.syscall = 'scandir';
+    err.path = '/denied';
+    return err;
+  }
+
+  // Monkeypatch fs.readdirSync for the duration of one call, restored in finally —
+  // per repo rule: no chmod 0o000 (root bypasses mode bits → silent zero coverage).
+  function withReaddirThrowing(code, fn) {
+    const real = fs.readdirSync;
+    let restored = false;
+    fs.readdirSync = function mocked(...args) {
+      throw fsError(code);
+    };
+    try {
+      return fn();
+    } finally {
+      if (!restored) {
+        fs.readdirSync = real;
+        restored = true;
+      }
+    }
+  }
+
+  test('findContextMdIn re-throws a permission (EACCES) error instead of swallowing it as null', () => {
+    assert.throws(
+      () => withReaddirThrowing('EACCES', () => findContextMdIn('/denied/phase-dir')),
+      (err) => err.code === 'EACCES',
+      'an unreadable dir must propagate EACCES, not return null as if empty',
+    );
+  });
+
+  test('findContextMdIn re-throws any non-ENOENT error (EIO)', () => {
+    assert.throws(
+      () => withReaddirThrowing('EIO', () => findContextMdIn('/io-failure/phase-dir')),
+      (err) => err.code === 'EIO',
+      'every non-ENOENT error must propagate — the narrowed catch only keeps ENOENT',
+    );
+  });
+
+  test('findContextMdIn returns null for an absent dir (ENOENT) — empty path unchanged', () => {
+    // A path that genuinely does not exist yields ENOENT from the real OS call.
+    const absent = path.join(os.tmpdir(), 'gsd-1883-does-not-exist-' + process.pid);
+    assert.strictEqual(findContextMdIn(absent), null,
+      'an absent dir (ENOENT) must still return null — Hyrum: empty path unchanged');
+  });
+
+  test('findContextMdIn finds bare CONTEXT.md', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-1883-bare-'));
+    try {
+      fs.writeFileSync(path.join(tmp, 'CONTEXT.md'), '# bare\n');
+      assert.strictEqual(findContextMdIn(tmp), 'CONTEXT.md');
+    } finally {
+      for (const f of fs.readdirSync(tmp)) fs.unlinkSync(path.join(tmp, f));
+      fs.rmdirSync(tmp);
+    }
+  });
+
+  test('findContextMdIn finds padded NN-CONTEXT.md', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-1883-padded-'));
+    try {
+      fs.writeFileSync(path.join(tmp, '01-CONTEXT.md'), '# padded\n');
+      assert.strictEqual(findContextMdIn(tmp), '01-CONTEXT.md');
+    } finally {
+      for (const f of fs.readdirSync(tmp)) fs.unlinkSync(path.join(tmp, f));
+      fs.rmdirSync(tmp);
+    }
+  });
+
+  test('findContextMdIn matches against a pre-read files array without touching fs', () => {
+    // The array path never calls readdirSync — exercised by getPhaseFileStats,
+    // countPhasePlansAndSummaries, runGapAnalysis. Must keep working untouched.
+    const orig = fs.readdirSync;
+    let called = false;
+    fs.readdirSync = function () { called = true; return []; };
+    try {
+      assert.strictEqual(findContextMdIn(['CONTEXT.md', 'PLAN.md']), 'CONTEXT.md',
+        'array path matches bare form');
+      assert.strictEqual(findContextMdIn(['02-CONTEXT.md']), '02-CONTEXT.md',
+        'array path matches padded form');
+      assert.strictEqual(findContextMdIn(['PLAN.md']), null,
+        'array path returns null when no match');
+      assert.strictEqual(called, false, 'array path must NOT call fs.readdirSync');
+    } finally {
+      fs.readdirSync = orig;
+    }
+  });
+});

--- a/tests/verify.test.cjs
+++ b/tests/verify.test.cjs
@@ -2909,38 +2909,33 @@ describe('bug #1883 — listMilestoneArchiveDirs distinguishes a permission erro
     return err;
   }
 
-  // Monkeypatch fs.readdirSync to throw for a specific path, restored in finally —
-  // per repo rule: no chmod 0o000 (root bypasses mode bits → silent zero coverage).
-  function withReaddirThrowing(code, targetPath, fn) {
-    const real = fs.readdirSync;
-    fs.readdirSync = function mocked(p, ...rest) {
+  // Inject a readdirSync fault scoped to the milestones/ path under test.
+  // t.mock auto-restores after each test — no chmod 0o000 (root bypasses mode bits).
+  function injectMilestonesFault(t, code, targetPath) {
+    const originalReaddirSync = fs.readdirSync;
+    t.mock.method(fs, 'readdirSync', function (p, ...rest) {
       if (typeof p === 'string' && p.endsWith(path.join('milestones'))) {
         throw fsError(code, targetPath);
       }
-      return real.call(this, p, ...rest);
-    };
-    try {
-      return fn();
-    } finally {
-      fs.readdirSync = real;
-    }
+      return originalReaddirSync.call(this, p, ...rest);
+    });
   }
 
-  test('listMilestoneArchiveDirs re-throws a permission (EACCES) error instead of returning []', () => {
+  test('listMilestoneArchiveDirs re-throws a permission (EACCES) error instead of returning []', (t) => {
     const planBase = path.join(os.tmpdir(), 'gsd-1883-eacces-' + process.pid);
+    injectMilestonesFault(t, 'EACCES', path.join(planBase, 'milestones'));
     assert.throws(
-      () => withReaddirThrowing('EACCES', path.join(planBase, 'milestones'),
-        () => listMilestoneArchiveDirs(planBase)),
+      () => listMilestoneArchiveDirs(planBase),
       (err) => err.code === 'EACCES',
       'an unreadable milestones/ dir must propagate EACCES, not return [] as if empty',
     );
   });
 
-  test('listMilestoneArchiveDirs re-throws any non-ENOENT error (EIO)', () => {
+  test('listMilestoneArchiveDirs re-throws any non-ENOENT error (EIO)', (t) => {
     const planBase = path.join(os.tmpdir(), 'gsd-1883-eio-' + process.pid);
+    injectMilestonesFault(t, 'EIO', path.join(planBase, 'milestones'));
     assert.throws(
-      () => withReaddirThrowing('EIO', path.join(planBase, 'milestones'),
-        () => listMilestoneArchiveDirs(planBase)),
+      () => listMilestoneArchiveDirs(planBase),
       (err) => err.code === 'EIO',
       'every non-ENOENT error must propagate',
     );

--- a/tests/verify.test.cjs
+++ b/tests/verify.test.cjs
@@ -2888,3 +2888,68 @@ describe('verifySummaryCore — reusable structured contract (#2572)', () => {
     );
   });
 });
+
+// ─── bug #1883: listMilestoneArchiveDirs must not swallow permission/I-O errors ──
+// The private helper catch-alled every readdirSync error into [], so an unreadable
+// milestones/ dir was silently reported as "no archives" (active-milestone
+// resolution / archived-phase filtering misbehaved). The narrowed catch re-throws
+// every non-ENOENT error and keeps [] only for genuine absence. Tested in-process
+// via the _listMilestoneArchiveDirs test seam (the validate command runs in a
+// subprocess, so an fs monkeypatch in the test process cannot reach it).
+describe('bug #1883 — listMilestoneArchiveDirs distinguishes a permission error from emptiness', () => {
+  const verifyLib = require('../gsd-core/bin/lib/verify.cjs');
+  const listMilestoneArchiveDirs = verifyLib._listMilestoneArchiveDirs;
+  const os = require('os');
+
+  function fsError(code, targetPath) {
+    const err = new Error(`${code}: operation failed, scandir '${targetPath}'`);
+    err.code = code;
+    err.syscall = 'scandir';
+    err.path = targetPath;
+    return err;
+  }
+
+  // Monkeypatch fs.readdirSync to throw for a specific path, restored in finally —
+  // per repo rule: no chmod 0o000 (root bypasses mode bits → silent zero coverage).
+  function withReaddirThrowing(code, targetPath, fn) {
+    const real = fs.readdirSync;
+    fs.readdirSync = function mocked(p, ...rest) {
+      if (typeof p === 'string' && p.endsWith(path.join('milestones'))) {
+        throw fsError(code, targetPath);
+      }
+      return real.call(this, p, ...rest);
+    };
+    try {
+      return fn();
+    } finally {
+      fs.readdirSync = real;
+    }
+  }
+
+  test('listMilestoneArchiveDirs re-throws a permission (EACCES) error instead of returning []', () => {
+    const planBase = path.join(os.tmpdir(), 'gsd-1883-eacces-' + process.pid);
+    assert.throws(
+      () => withReaddirThrowing('EACCES', path.join(planBase, 'milestones'),
+        () => listMilestoneArchiveDirs(planBase)),
+      (err) => err.code === 'EACCES',
+      'an unreadable milestones/ dir must propagate EACCES, not return [] as if empty',
+    );
+  });
+
+  test('listMilestoneArchiveDirs re-throws any non-ENOENT error (EIO)', () => {
+    const planBase = path.join(os.tmpdir(), 'gsd-1883-eio-' + process.pid);
+    assert.throws(
+      () => withReaddirThrowing('EIO', path.join(planBase, 'milestones'),
+        () => listMilestoneArchiveDirs(planBase)),
+      (err) => err.code === 'EIO',
+      'every non-ENOENT error must propagate',
+    );
+  });
+
+  test('listMilestoneArchiveDirs returns [] for an absent milestones/ dir (ENOENT) — empty path unchanged', () => {
+    const planBase = path.join(os.tmpdir(), 'gsd-1883-absent-' + process.pid);
+    // No milestones/ dir created → real OS readdirSync throws ENOENT.
+    assert.deepStrictEqual(listMilestoneArchiveDirs(planBase), [],
+      'an absent milestones/ dir (ENOENT) must still return [] — Hyrum: empty path unchanged');
+  });
+});


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #1883

## What was broken

Two directory scans treated a permission or I-O error the same as "nothing there": an unreadable phase directory was silently reported as "no CONTEXT.md" (so the discuss/plan gates wrongly skipped context), and an unreadable `milestones/` directory as "no archives" (so active-milestone resolution and archived-phase filtering misbehaved).

## What this fix does

Narrows each catch to `ENOENT` only — the long-standing `null` / `[]` contract for genuine absence is unchanged (Hyrum: empty path untouched), and every other error (`EACCES`, `EIO`, …) now re-throws so it propagates to the caller instead of being swallowed as empty.

## Root cause

`findContextMdIn` (`src/planning-workspace.cts`) and `listMilestoneArchiveDirs` (`src/verify.cts`) both used a catch-all `catch { return <empty-marker> }` around `fs.readdirSync`, conflating `ENOENT` (the genuine "nothing there" case the helpers are meant to handle) with `EACCES`/`EIO`/etc. (a real read failure the caller should see). Long-standing — the `findContextMdIn` body is unchanged since 2026-06-28.

All six `findContextMdIn` callers either pass a pre-read `string[]` (no readdir inside the helper, so the catch is unreachable) or sit inside a `try` block that already handles `readdirSync` failures, so the propagated error lands in an existing catch rather than crashing a new path. The two `listMilestoneArchiveDirs` callers are internal to the `validate` command path where errors reach the command error handler.

## Testing

### How I verified the fix

- Failing-first regression tests proven RED on the unfixed code at `1a7f9322f` (gsd-test verdict `failed`: the EACCES/EIO tests threw "expected error, got null/[]").
- Fix applied; gsd-test GREEN on the fixed HEAD (`27465/27465` passing across `linux-node22` + `linux-node24`, 0 failures).
- Tests cover: EACCES re-throw, EIO re-throw, ENOENT-returns-empty (unchanged Hyrum path), bare + padded `CONTEXT.md` forms, the pre-read-array fast-path, and `_listMilestoneArchiveDirs` via an in-process test seam.
- fs faults injected via `t.mock.method(fs, 'readdirSync', …)` (no `chmod 0o000` — root bypasses mode bits).

### Regression test added?

- [x] Yes — added tests that would have caught this bug (both helpers, EACCES + EIO + the unchanged ENOENT path).

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`gsd-test` 27465/27465 on both node lanes)
- [x] `.changeset/` fragment added (`.changeset/1883-permission-error-not-empty.md`)
- [x] No unnecessary dependencies added

## Breaking changes

None for the genuine-empty (`ENOENT`) path — `findContextMdIn` still returns `null`, `listMilestoneArchiveDirs` still returns `[]`. The only behavior change is that a previously-swallowed `EACCES`/`EIO` error now propagates to the caller's existing error handling instead of masquerading as "empty."

## Notes

- A `_listMilestoneArchiveDirs` test-probe export is added (leading-underscore, mirroring the existing `_setLockProbes`/`_resetLockProbes` seam in `planning-workspace.cts`) so the permission-error path can be unit-tested in-process — the `validate` command runs in a subprocess, so an fs monkeypatch in the test process cannot otherwise reach the private helper.
- This PR also deletes a stale `tests/emitted-drift-ack.json` (its single `gsd-phase-researcher.md` entry became obsolete when the #1699/#2768 provenance work landed on `next` at commit `6932fb16d`). That merge left every PR off `next` red on the emitted-attribution gate. The fix is the one the gate's own error message prescribes (delete the stale ack; an empty ack file signals nothing, so the file is removed). Folded inline in its own commit because it is a one-line, test-prescribed fix that unblocks the red base for all in-flight PRs and does not bury this fix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2802"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787878581&installation_model_id=22188&pr_number=2802&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2802&signature=eda09ae641f56d2c6634d5bb74532e2e0e480bbcc6807f4533608def82b532de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->