### PR TITLE
fix(#2624): write the .gsd-source marker before staging reads it

### DIFF
--- a/.changeset/2624-install-source-root-stale-marker.md
+++ b/.changeset/2624-install-source-root-stale-marker.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**Upgrading a Claude-global GSD install now uses the new version's skill content instead of the previous version's** — the installer read a `.gsd-source` marker that still pointed at the prior install's source location before rewriting it, so on an upgrade every converted skill was generated from the old version's command definitions (while the file manifest faithfully recorded the stale content's hash as correct). The marker is now written before anything reads it. (#2624)

--- a/.changeset/2624-install-source-root-stale-marker.md
+++ b/.changeset/2624-install-source-root-stale-marker.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 2811
 ---
 **Upgrading a Claude-global GSD install now uses the new version's skill content instead of the previous version's** — the installer read a `.gsd-source` marker that still pointed at the prior install's source location before rewriting it, so on an upgrade every converted skill was generated from the old version's command definitions (while the file manifest faithfully recorded the stale content's hash as correct). The marker is now written before anything reads it. (#2624)

--- a/bin/install.js
+++ b/bin/install.js
@@ -10406,6 +10406,45 @@ function install(isGlobal, runtime = DEFAULT_RUNTIME, options = {}) {
     return Array.isArray(scopeLayout) && scopeLayout.length > 0;
   })();
 
+  // #2624: write the .gsd-source marker. Extracted from its former late position so it can be
+  // called BEFORE staging reads the marker (see the call site below). Scoped to the Claude-global
+  // layout (issue #1477) — the only install path that ships the skills layout without a
+  // commands/gsd source tree, so findInstallSourceRoot's walk-up has nothing to find and
+  // /gsd-surface (list/status) throws without it. Points at the package's own commands/gsd
+  // source. Guarded on source presence so a half-published package never writes a dangling
+  // marker. Write failure is non-fatal (install proceeds; warn so /gsd-surface breakage is
+  // diagnosable) — the same contract the late write had.
+  function _writeGsdSourceMarker(runtime, targetDir, src, isGlobal) {
+    if (_hostBehaviors(runtime).sourceMarkerFile && isGlobal) {
+      const gsdSourceCommands = path.join(src, 'commands', 'gsd');
+      if (fs.existsSync(gsdSourceCommands)) {
+        try {
+          // ADR-1239 Phase B write-confinement: the descriptor-sourced marker filename
+          // must resolve under targetDir (parity with the other descriptor-driven writes).
+          const _markerPath = assertDestWithinConfigHome(targetDir, _hostBehaviors(runtime).sourceMarkerFile);
+          fs.writeFileSync(_markerPath, gsdSourceCommands + '\n', 'utf8');
+        } catch (err) {
+          // Non-fatal: install proceeds. But on the Claude-global layout walk-up
+          // also fails (no commands/gsd source tree), so a silent write failure
+          // still leaves /gsd-surface broken at runtime — warn so it's diagnosable.
+          console.warn(`  ${yellow}!${reset} Could not write .gsd-source marker (${err.message}); /gsd-surface list/status may fail`);
+        }
+      }
+    }
+  }
+
+  // #2624: write the .gsd-source marker BEFORE any staging reads it. The marker write
+  // formerly lived AFTER staging; on an upgrade the marker still held the PREVIOUS
+  // install's source path (e.g. an npx per-version cache dir that still exists on disk),
+  // so findInstallSourceRoot(configDir) — called inside installRuntimeArtifacts below —
+  // returned the stale path and every converted skill was generated from the OLD version's
+  // commands/gsd, silently installing prior-version content with a self-consistent manifest
+  // hash. Writing first closes the read-before-write hole for every findInstallSourceRoot
+  // consumer (skills, commands, /gsd-surface, capability-state). Placed here (before the
+  // _isSkillsRuntime branch) so it runs for every Claude-global install, matching the
+  // original write's sourceMarkerFile && isGlobal guard exactly.
+  _writeGsdSourceMarker(runtime, targetDir, src, isGlobal);
+
   if (_isSkillsRuntime) {
     // Layout-driven install for skills-based runtimes (full and minimal modes)
     const scope = isGlobal ? 'global' : 'local';
@@ -10694,35 +10733,11 @@ function install(isGlobal, runtime = DEFAULT_RUNTIME, options = {}) {
     failures.push('gsd-core');
   }
 
-  // Write the .gsd-source marker so runtime source resolution succeeds at
-  // runtime (#1477). The Claude-global skills layout ships gsd-core/{bin,
-  // contexts,references,templates,workflows} but NOT the commands/gsd source
-  // tree, and _runLegacyUninstallCleanup actively removes any commands/gsd/
-  // for that scope — so findInstallSourceRoot's walk-up has nothing to find
-  // and /gsd-surface (list/status) throws. This is the writer half of the
-  // marker that runtime-artifact-layout.cjs's finders already read (the reader
-  // landed in #1476). It points at the package's own commands/gsd source.
-  // Scoped to the Claude-global layout (issue #1477) — the only install path
-  // that ships the skills layout without a commands/gsd source tree; every
-  // other runtime/scope deploys commands/gsd, so its walk-up already resolves
-  // and needs no marker. Guarded on source presence so a half-published
-  // package never writes a dangling marker.
-  if (_hostBehaviors(runtime).sourceMarkerFile && isGlobal) {
-    const gsdSourceCommands = path.join(src, 'commands', 'gsd');
-    if (fs.existsSync(gsdSourceCommands)) {
-      try {
-        // ADR-1239 Phase B write-confinement: the descriptor-sourced marker filename
-        // must resolve under targetDir (parity with the other descriptor-driven writes).
-        const _markerPath = assertDestWithinConfigHome(targetDir, _hostBehaviors(runtime).sourceMarkerFile);
-        fs.writeFileSync(_markerPath, gsdSourceCommands + '\n', 'utf8');
-      } catch (err) {
-        // Non-fatal: install proceeds. But on the Claude-global layout walk-up
-        // also fails (no commands/gsd source tree), so a silent write failure
-        // still leaves /gsd-surface broken at runtime — warn so it's diagnosable.
-        console.warn(`  ${yellow}!${reset} Could not write .gsd-source marker (${err.message}); /gsd-surface list/status may fail`);
-      }
-    }
-  }
+  // #2624: the .gsd-source marker is now written by _writeGsdSourceMarker()
+  // BEFORE staging reads it (see the early call above the _isSkillsRuntime
+  // block). The former write lived here — AFTER staging — which on an upgrade
+  // let staging read a stale prior-version marker and silently install
+  // old-version skill content. Moved up; this site intentionally left empty.
 
   // #1629 critical fix: Windsurf workflow wrappers (convertClaudeCommandToWindsurfWorkflow)
   // delegate to command bodies at <targetDir>/gsd-core/commands/gsd/${stem}.md via a

--- a/tests/runtime-artifact-layout.test.cjs
+++ b/tests/runtime-artifact-layout.test.cjs
@@ -936,3 +936,161 @@ describe('#1477 .gsd-source marker provisioning', () => {
     });
   });
 });
+
+// ─── #2624: stale .gsd-source marker read before rewrite on upgrade ──────────
+//
+// Regression for #2624: a Claude-global upgrade silently installed skill content
+// from the PREVIOUS version. findInstallSourceRoot prefers <configDir>/.gsd-source,
+// and install() used to REWRITE that marker AFTER staging had already read it — so
+// on an upgrade the marker still pointed at the prior version's source (an npx
+// cache dir that still exists on disk) and every converted skill was generated from
+// the OLD commands/gsd. Fix: write the marker BEFORE staging reads it.
+//
+// These exercise the real install(true, 'claude') with HOME redirected to a tmp dir,
+// pre-seeding a STALE marker that points at a different (still-existing) source —
+// the exact upgrade condition. No live npx / network.
+describe('#2624 .gsd-source marker is rewritten before staging reads it', () => {
+  let tmpRoot;
+  let savedHome;
+  let savedUserProfile;
+  let savedExplicitConfigDir;
+  let savedTestMode;
+
+  function silenceConsole(fn) {
+    const orig = { log: console.log, warn: console.warn, error: console.error };
+    console.log = () => {};
+    console.warn = () => {};
+    console.error = () => {};
+    try {
+      return fn();
+    } finally {
+      console.log = orig.log;
+      console.warn = orig.warn;
+      console.error = orig.error;
+    }
+  }
+
+  function runInstall(isGlobal, runtime) {
+    const origExit = process.exit;
+    let exitCalled = false;
+    process.exit = (code) => {
+      exitCalled = true;
+      throw new Error(`process.exit(${code}) during install — should not happen`);
+    };
+    try {
+      return silenceConsole(() => install(isGlobal, runtime));
+    } catch (e) {
+      if (exitCalled) assert.fail(`install() called process.exit — unexpected: ${e.message}`);
+      throw e;
+    } finally {
+      process.exit = origExit;
+    }
+  }
+
+  beforeEach(() => {
+    tmpRoot = createTempDir('gsd-2624-');
+    savedHome = process.env.HOME;
+    savedUserProfile = process.env.USERPROFILE;
+    process.env.HOME = tmpRoot;
+    process.env.USERPROFILE = tmpRoot;
+    savedExplicitConfigDir = process.env.GSD_EXPLICIT_CONFIG_DIR;
+    delete process.env.GSD_EXPLICIT_CONFIG_DIR;
+    savedTestMode = process.env.GSD_TEST_MODE;
+    process.env.GSD_TEST_MODE = '1';
+  });
+
+  afterEach(() => {
+    if (savedHome === undefined) delete process.env.HOME;
+    else process.env.HOME = savedHome;
+    if (savedUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = savedUserProfile;
+    if (savedExplicitConfigDir === undefined) delete process.env.GSD_EXPLICIT_CONFIG_DIR;
+    else process.env.GSD_EXPLICIT_CONFIG_DIR = savedExplicitConfigDir;
+    if (savedTestMode === undefined) delete process.env.GSD_TEST_MODE;
+    else process.env.GSD_TEST_MODE = savedTestMode;
+    cleanup(tmpRoot);
+  });
+
+  // The current package's commands/gsd — what the marker MUST point at after install.
+  const CURRENT_SOURCE = path.join(REPO_ROOT, 'commands', 'gsd');
+
+  test('claude-global install overwrites a stale .gsd-source marker before staging reads it', (t) => {
+    const claudeDir = path.join(tmpRoot, '.claude');
+    fs.mkdirSync(claudeDir, { recursive: true });
+
+    // Simulate the PREVIOUS install's marker: a different source dir that STILL EXISTS
+    // on disk (mirroring a coexisting npx per-version cache dir). findInstallSourceRoot
+    // returns this immediately if it is read before the marker is rewritten.
+    const staleSource = path.join(tmpRoot, 'old-npx-cache', 'commands', 'gsd');
+    fs.mkdirSync(staleSource, { recursive: true });
+    fs.writeFileSync(path.join(claudeDir, '.gsd-source'), staleSource + '\n', 'utf8');
+
+    // Spy on findInstallSourceRoot to capture WHICH source staging actually resolves.
+    // The marker ends up correct either way (the late write corrected it on the old code),
+    // so the marker content alone cannot prove the ordering — the resolved-source captures
+    // can. Before the fix, staging resolves the stale path; after, the current path.
+    // install-engine.cjs calls runtimeArtifactLayout.findInstallSourceRoot via the module
+    // object (not a captured ref), so mocking the property on the shared module instance
+    // intercepts the staging call. Same pattern as tests/phase.test.cjs (capture original,
+    // delegate).
+    const runtimeArtifactLayout = require('../gsd-core/bin/lib/runtime-artifact-layout.cjs');
+    const realFindInstallSourceRoot = runtimeArtifactLayout.findInstallSourceRoot;
+    const resolvedSources = [];
+    t.mock.method(runtimeArtifactLayout, 'findInstallSourceRoot', function (configDir) {
+      const result = realFindInstallSourceRoot.call(this, configDir);
+      resolvedSources.push(path.resolve(result));
+      return result;
+    });
+
+    runInstall(true /* isGlobal */, 'claude');
+
+    const markerPath = path.join(claudeDir, '.gsd-source');
+    assert.ok(fs.existsSync(markerPath), 'marker must exist after install');
+    const finalMarker = path.resolve(fs.readFileSync(markerPath, 'utf8').trim());
+    assert.equal(finalMarker, path.resolve(CURRENT_SOURCE),
+      `final marker must point at the current package source, not ${finalMarker}`);
+
+    // The decisive assertion: staging must NEVER have resolved the stale source. Before the
+    // fix, at least one staging resolution returned the stale path (read before rewrite).
+    const resolvedStale = resolvedSources.filter((p) => p === path.resolve(staleSource));
+    assert.equal(resolvedStale.length, 0,
+      `staging must not resolve the stale source during install, but did ${resolvedStale.length} time(s). ` +
+      `Resolved: ${JSON.stringify(resolvedSources)}`);
+  });
+
+  test('fresh claude-global install (no prior marker) still writes the correct marker', () => {
+    const claudeDir = path.join(tmpRoot, '.claude');
+    fs.mkdirSync(claudeDir, { recursive: true });
+    // No pre-existing marker — fresh install (negative space, must stay correct).
+    runInstall(true /* isGlobal */, 'claude');
+
+    const markerPath = path.join(claudeDir, '.gsd-source');
+    assert.ok(fs.existsSync(markerPath), 'fresh claude-global install must write the marker');
+    const resolved = fs.readFileSync(markerPath, 'utf8').trim();
+    assert.equal(
+      path.resolve(resolved),
+      path.resolve(CURRENT_SOURCE),
+      'fresh install marker must point at the current package source',
+    );
+  });
+
+  test('claude-global install rewrites a marker pointing at a deleted (ghost) source', () => {
+    const claudeDir = path.join(tmpRoot, '.claude');
+    fs.mkdirSync(claudeDir, { recursive: true });
+    // A ghost path that does NOT exist on disk — findInstallSourceRoot ignores it and
+    // falls through to walk-up, then install() rewrites the marker to the current source.
+    const ghost = path.join(tmpRoot, 'gone', 'commands', 'gsd');
+    fs.writeFileSync(path.join(claudeDir, '.gsd-source'), ghost + '\n', 'utf8');
+
+    runInstall(true /* isGlobal */, 'claude');
+
+    const markerPath = path.join(claudeDir, '.gsd-source');
+    assert.ok(fs.existsSync(markerPath), 'marker must exist after install');
+    const resolved = fs.readFileSync(markerPath, 'utf8').trim();
+    assert.equal(
+      path.resolve(resolved),
+      path.resolve(CURRENT_SOURCE),
+      'ghost marker must be rewritten to the current package source',
+    );
+  });
+});

--- a/tests/runtime-artifact-layout.test.cjs
+++ b/tests/runtime-artifact-layout.test.cjs
@@ -956,35 +956,17 @@ describe('#2624 .gsd-source marker is rewritten before staging reads it', () => 
   let savedExplicitConfigDir;
   let savedTestMode;
 
-  function silenceConsole(fn) {
-    const orig = { log: console.log, warn: console.warn, error: console.error };
-    console.log = () => {};
-    console.warn = () => {};
-    console.error = () => {};
-    try {
-      return fn();
-    } finally {
-      console.log = orig.log;
-      console.warn = orig.warn;
-      console.error = orig.error;
-    }
-  }
-
-  function runInstall(isGlobal, runtime) {
-    const origExit = process.exit;
-    let exitCalled = false;
-    process.exit = (code) => {
-      exitCalled = true;
+  // Run install() with process.exit and console output mocked via t.mock (auto-restored),
+  // per CONTRIBUTING.md test rules (no manual monkeypatch / try-finally in test bodies).
+  // process.exit during install is a hard failure — surface it, don't let it kill the runner.
+  function runInstall(t, isGlobal, runtime) {
+    t.mock.method(process, 'exit', (code) => {
       throw new Error(`process.exit(${code}) during install — should not happen`);
-    };
-    try {
-      return silenceConsole(() => install(isGlobal, runtime));
-    } catch (e) {
-      if (exitCalled) assert.fail(`install() called process.exit — unexpected: ${e.message}`);
-      throw e;
-    } finally {
-      process.exit = origExit;
-    }
+    });
+    t.mock.method(console, 'log', () => {});
+    t.mock.method(console, 'warn', () => {});
+    t.mock.method(console, 'error', () => {});
+    return install(isGlobal, runtime);
   }
 
   beforeEach(() => {
@@ -1042,7 +1024,7 @@ describe('#2624 .gsd-source marker is rewritten before staging reads it', () => 
       return result;
     });
 
-    runInstall(true /* isGlobal */, 'claude');
+    runInstall(t, true /* isGlobal */, 'claude');
 
     const markerPath = path.join(claudeDir, '.gsd-source');
     assert.ok(fs.existsSync(markerPath), 'marker must exist after install');
@@ -1058,11 +1040,11 @@ describe('#2624 .gsd-source marker is rewritten before staging reads it', () => 
       `Resolved: ${JSON.stringify(resolvedSources)}`);
   });
 
-  test('fresh claude-global install (no prior marker) still writes the correct marker', () => {
+  test('fresh claude-global install (no prior marker) still writes the correct marker', (t) => {
     const claudeDir = path.join(tmpRoot, '.claude');
     fs.mkdirSync(claudeDir, { recursive: true });
     // No pre-existing marker — fresh install (negative space, must stay correct).
-    runInstall(true /* isGlobal */, 'claude');
+    runInstall(t, true /* isGlobal */, 'claude');
 
     const markerPath = path.join(claudeDir, '.gsd-source');
     assert.ok(fs.existsSync(markerPath), 'fresh claude-global install must write the marker');
@@ -1074,7 +1056,7 @@ describe('#2624 .gsd-source marker is rewritten before staging reads it', () => 
     );
   });
 
-  test('claude-global install rewrites a marker pointing at a deleted (ghost) source', () => {
+  test('claude-global install rewrites a marker pointing at a deleted (ghost) source', (t) => {
     const claudeDir = path.join(tmpRoot, '.claude');
     fs.mkdirSync(claudeDir, { recursive: true });
     // A ghost path that does NOT exist on disk — findInstallSourceRoot ignores it and
@@ -1082,7 +1064,7 @@ describe('#2624 .gsd-source marker is rewritten before staging reads it', () => 
     const ghost = path.join(tmpRoot, 'gone', 'commands', 'gsd');
     fs.writeFileSync(path.join(claudeDir, '.gsd-source'), ghost + '\n', 'utf8');
 
-    runInstall(true /* isGlobal */, 'claude');
+    runInstall(t, true /* isGlobal */, 'claude');
 
     const markerPath = path.join(claudeDir, '.gsd-source');
     assert.ok(fs.existsSync(markerPath), 'marker must exist after install');


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #2624

## What was broken

Upgrading a Claude-global GSD install (e.g. `npx @opengsd/gsd-core@1.8.0 --claude --global` over an existing 1.7.0) silently installed skill content from the **previous** version. Every skill whose `SKILL.md` changed upstream kept the old content; skills whose content didn't change looked correct only because the old and new bytes happened to match. `gsd-file-manifest.json` recorded the stale content's hash as correct, so the tree looked self-consistent until the next bump flagged the files as "local patches."

## What this fix does

Writes the `.gsd-source` marker **before** the staging pass reads it. The marker write is extracted into a `_writeGsdSourceMarker(...)` helper and moved from its former position (after staging) to before the `_isSkillsRuntime` branch, preserving the original `sourceMarkerFile && isGlobal` guard, the half-published-package `existsSync` guard, and the non-fatal write-failure warning.

## Root cause

A read-before-write ordering bug. `findInstallSourceRoot` (`src/runtime-artifact-layout.cts`) resolves the command source by preferring `<configDir>/.gsd-source` when the path it records still exists on disk. On an upgrade the marker still holds the **previous** install's source path (e.g. an npx per-version cache dir that npx does not clean up). `install()` in `bin/install.js` staged skills (which call `findInstallSourceRoot` internally) **before** it rewrote the marker to the current package's `commands/gsd` — so staging read the stale marker and converted skills from the old version's command definitions. The marker eventually got corrected, but the old-version content was already on disk.

`generateManifest()` then hashed whatever landed on disk, so the manifest faithfully — and misleadingly — recorded the stale content. The shipped tarball is correct; the installer cannot produce 1.7.0 bytes from 1.8.0 package bytes — it read them from the stale source path.

Long-standing (the marker write was added in `ee6f3b70c` / #1477, already in v1.7.0); triggers on any Claude-global upgrade where skill content changed and the prior source path still exists (the common npx-persistent-cache case). The fix closes the hole for **every** `findInstallSourceRoot` consumer — skills, commands, `/gsd-surface` (list/status), and capability-state — not just skill staging.

## Testing

### How I verified the fix

- Failing-first regression proven RED on the unfixed code at `d6184e9ff` (gsd-test verdict `failed`: the row-1 test asserted staging must never resolve the stale source — it did, 1+ times).
- Fix applied; gsd-test GREEN on the fixed HEAD (`27469/27469` across `linux-node22` + `linux-node24`, 0 failures).
- The regression test exercises the real `install(true, 'claude')` with `HOME` redirected to a tmp dir, pre-seeds a STALE marker pointing at a still-existing fake source (mirroring a coexisting npx cache dir), and spies on `findInstallSourceRoot` to capture which source staging resolves — asserting staging never resolves the stale path. Also covers fresh-install (no prior marker) and ghost-marker (deleted source) negative space.
- No live npx / network; no `chmod 0o000`.

### Regression test added?

- [x] Yes — `tests/runtime-artifact-layout.test.cjs` `#2624 .gsd-source marker is rewritten before staging reads it` (stale-marker, fresh-install, ghost-marker).

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [ ] N/A (not runtime-specific)

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass (`gsd-test` 27469/27469 on both node lanes)
- [x] `.changeset/` fragment added (`.changeset/2624-install-source-root-stale-marker.md`)
- [x] No unnecessary dependencies added

## Breaking changes

None. The marker mechanism (#1477) is unchanged; only its placement in the install sequence moved (write before read instead of after). Fresh installs, non-Claude/global installs, and `/gsd-surface`/capability-state resolution are unaffected — the marker still points at a valid `commands/gsd`, now consistently the current package's.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2811"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787885313&installation_model_id=22188&pr_number=2811&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2811&signature=2a64c127651e2564d6c50273168c044b0580af2930419377edbd43f00c6d9ac8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->