### PR TITLE
fix(#2783): address wedged PRs in ship note protocol

### DIFF
--- a/.changeset/2783-ship-note-wedged-pr.md
+++ b/.changeset/2783-ship-note-wedged-pr.md
@@ -3,3 +3,5 @@ type: Fixed
 pr: 2818
 ---
 **`/gsd-ship` now detects and recovers a PR wedged by the ship-note commit** — when the `[ci skip]` ship note leaves required checks unstarted, ship re-triggers CI instead of leaving the PR unmergeable. (#2783)
+
+*Note: This introduces a latency tradeoff. All `/gsd-ship` invocations now poll GitHub PR state for up to 15 seconds to ensure the commit was processed and check if recovery is needed, even for repositories without required checks.*

--- a/.changeset/2783-ship-note-wedged-pr.md
+++ b/.changeset/2783-ship-note-wedged-pr.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 2818
+---
+**`/gsd-ship` now detects and recovers a PR wedged by the ship-note commit** — when the `[ci skip]` ship note leaves required checks unstarted, ship re-triggers CI instead of leaving the PR unmergeable. (#2783)

--- a/gsd-core/workflows/ship.md
+++ b/gsd-core/workflows/ship.md
@@ -481,7 +481,7 @@ for i in {1..5}; do
   sleep 3
 done
 
-if [ "$STATUS" = "BLOCKED" ] && [ "$CHECKS" = "0" ] && [ "$REVIEW_DECISION" != "REVIEW_REQUIRED" ] && [ "$REVIEW_DECISION" != "CHANGES_REQUESTED" ]; then
+if [ "$STATUS" = "BLOCKED" ] && [ "$CHECKS" = "0" ] && [ "$REVIEW_DECISION" != "REVIEW_REQUIRED" ] && [ "$REVIEW_DECISION" != "CHANGES_REQUESTED" ] && git log -1 --format=%B "$SHIP_NOTE_SHA" | grep -q '\[ci skip\]'; then
   echo "⚠ PR is BLOCKED with zero checks. The [ci skip] trailer wedged the PR due to required checks."
   echo "Pushing an empty commit to trigger the required pipelines..."
   # gsd_run query commit requires a file list; use git directly for this intentionally empty commit.

--- a/gsd-core/workflows/ship.md
+++ b/gsd-core/workflows/ship.md
@@ -467,7 +467,7 @@ git push origin ${CURRENT_BRANCH} 2>&1 || echo "⚠ track_shipping: ship-note pu
 STATUS="UNKNOWN"
 CHECKS=0
 REVIEW_DECISION=""
-for i in 1 2 3 4 5; do
+for i in {1..5}; do
   PR_STATE=$(gh pr view ${PR_NUMBER} --json headRefOid,mergeStateStatus,statusCheckRollup,reviewDecision -q '{head: .headRefOid, status: .mergeStateStatus, checks: ((.statusCheckRollup // []) | length), review: (.reviewDecision // "")}' 2>/dev/null || echo '{"head":"","status":"UNKNOWN","checks":0,"review":""}')
   HEAD_OID=$(echo "$PR_STATE" | jq -r .head)
   if [ "$HEAD_OID" = "$SHIP_NOTE_SHA" ]; then

--- a/gsd-core/workflows/ship.md
+++ b/gsd-core/workflows/ship.md
@@ -457,7 +457,8 @@ would otherwise trigger (GitHub honors `[ci skip]` / `[skip ci]`):
 gsd_run query commit "docs(${padded_phase}): ship phase ${PHASE_NUMBER} — PR #${PR_NUMBER} [ci skip]" --files .planning/STATE.md
 git push origin ${CURRENT_BRANCH} 2>&1 || echo "⚠ track_shipping: ship-note push failed — it is local-only; rerun: git push origin ${CURRENT_BRANCH}"
 
-# If the push succeeds, check if the [ci skip] trailer wedged the PR due to required status checks (#2783).
+# Preserve the skip-token optimization for repositories without a required-check
+# wedge; only synthesize a second CI-triggering commit when GitHub reports one (#2783).
 # Poll mergeStateStatus with backoff to avoid racing GitHub's async state computation.
 # Note: Skip tokens recognized by GitHub Actions are [skip ci], [ci skip], [no ci], [skip actions], [actions skip], and skip-checks:true.
 # The recovery commit message MUST NOT contain any of these tokens.
@@ -475,12 +476,12 @@ done
 if [ "$STATUS" = "BLOCKED" ] && [ "$CHECKS" = "0" ]; then
   echo "⚠ PR is BLOCKED with zero checks. The [ci skip] trailer wedged the PR due to required checks."
   echo "Pushing an empty commit to trigger the required pipelines..."
+  # gsd_run query commit requires a file list; use git directly for this intentionally empty commit.
   git commit --allow-empty -m "chore: trigger CI (recover from ship-note skip-token)"
   git push origin ${CURRENT_BRANCH} 2>&1 || echo "⚠ track_shipping: recovery push failed — rerun: git push origin ${CURRENT_BRANCH}"
 elif [ "$STATUS" = "UNKNOWN" ]; then
   echo "⚠ track_shipping: PR mergeStateStatus is UNKNOWN after polling; PR may require manual check re-trigger."
 fi
-```
 ```
 </step>
 

--- a/gsd-core/workflows/ship.md
+++ b/gsd-core/workflows/ship.md
@@ -456,6 +456,31 @@ would otherwise trigger (GitHub honors `[ci skip]` / `[skip ci]`):
 ```bash
 gsd_run query commit "docs(${padded_phase}): ship phase ${PHASE_NUMBER} — PR #${PR_NUMBER} [ci skip]" --files .planning/STATE.md
 git push origin ${CURRENT_BRANCH} 2>&1 || echo "⚠ track_shipping: ship-note push failed — it is local-only; rerun: git push origin ${CURRENT_BRANCH}"
+
+# If the push succeeds, check if the [ci skip] trailer wedged the PR due to required status checks (#2783).
+# Poll mergeStateStatus with backoff to avoid racing GitHub's async state computation.
+# Note: Skip tokens recognized by GitHub Actions are [skip ci], [ci skip], [no ci], [skip actions], [actions skip], and skip-checks:true.
+# The recovery commit message MUST NOT contain any of these tokens.
+
+for i in 1 2 3 4 5; do
+  MERGE_STATE=$(gh pr view ${PR_NUMBER} --json mergeStateStatus,statusCheckRollup -q 'if .statusCheckRollup == null then {status: .mergeStateStatus, checks: 0} else {status: .mergeStateStatus, checks: (.statusCheckRollup | length)} end' 2>/dev/null || echo '{"status":"UNKNOWN","checks":0}')
+  STATUS=$(echo "$MERGE_STATE" | jq -r .status)
+  CHECKS=$(echo "$MERGE_STATE" | jq -r .checks)
+  if [ "$STATUS" != "UNKNOWN" ]; then
+    break
+  fi
+  sleep 3
+done
+
+if [ "$STATUS" = "BLOCKED" ] && [ "$CHECKS" = "0" ]; then
+  echo "⚠ PR is BLOCKED with zero checks. The [ci skip] trailer wedged the PR due to required checks."
+  echo "Pushing an empty commit to trigger the required pipelines..."
+  git commit --allow-empty -m "chore: trigger CI (recover from ship-note skip-token)"
+  git push origin ${CURRENT_BRANCH} 2>&1 || echo "⚠ track_shipping: recovery push failed — rerun: git push origin ${CURRENT_BRANCH}"
+elif [ "$STATUS" = "UNKNOWN" ]; then
+  echo "⚠ track_shipping: PR mergeStateStatus is UNKNOWN after polling; PR may require manual check re-trigger."
+fi
+```
 ```
 </step>
 

--- a/gsd-core/workflows/ship.md
+++ b/gsd-core/workflows/ship.md
@@ -455,6 +455,7 @@ would otherwise trigger (GitHub honors `[ci skip]` / `[skip ci]`):
 
 ```bash
 gsd_run query commit "docs(${padded_phase}): ship phase ${PHASE_NUMBER} — PR #${PR_NUMBER} [ci skip]" --files .planning/STATE.md
+SHIP_NOTE_SHA=$(git rev-parse HEAD)
 git push origin ${CURRENT_BRANCH} 2>&1 || echo "⚠ track_shipping: ship-note push failed — it is local-only; rerun: git push origin ${CURRENT_BRANCH}"
 
 # Preserve the skip-token optimization for repositories without a required-check
@@ -463,17 +464,24 @@ git push origin ${CURRENT_BRANCH} 2>&1 || echo "⚠ track_shipping: ship-note pu
 # Note: Skip tokens recognized by GitHub Actions are [skip ci], [ci skip], [no ci], [skip actions], [actions skip], and skip-checks:true.
 # The recovery commit message MUST NOT contain any of these tokens.
 
+STATUS="UNKNOWN"
+CHECKS=0
+REVIEW_DECISION=""
 for i in 1 2 3 4 5; do
-  MERGE_STATE=$(gh pr view ${PR_NUMBER} --json mergeStateStatus,statusCheckRollup -q 'if .statusCheckRollup == null then {status: .mergeStateStatus, checks: 0} else {status: .mergeStateStatus, checks: (.statusCheckRollup | length)} end' 2>/dev/null || echo '{"status":"UNKNOWN","checks":0}')
-  STATUS=$(echo "$MERGE_STATE" | jq -r .status)
-  CHECKS=$(echo "$MERGE_STATE" | jq -r .checks)
-  if [ "$STATUS" != "UNKNOWN" ]; then
+  PR_STATE=$(gh pr view ${PR_NUMBER} --json headRefOid,mergeStateStatus,statusCheckRollup,reviewDecision -q '{head: .headRefOid, status: .mergeStateStatus, checks: ((.statusCheckRollup // []) | length), review: (.reviewDecision // "")}' 2>/dev/null || echo '{"head":"","status":"UNKNOWN","checks":0,"review":""}')
+  HEAD_OID=$(echo "$PR_STATE" | jq -r .head)
+  if [ "$HEAD_OID" = "$SHIP_NOTE_SHA" ]; then
+    STATUS=$(echo "$PR_STATE" | jq -r .status)
+    CHECKS=$(echo "$PR_STATE" | jq -r .checks)
+    REVIEW_DECISION=$(echo "$PR_STATE" | jq -r .review)
+  fi
+  if [ "$HEAD_OID" = "$SHIP_NOTE_SHA" ] && [ "$STATUS" != "UNKNOWN" ]; then
     break
   fi
   sleep 3
 done
 
-if [ "$STATUS" = "BLOCKED" ] && [ "$CHECKS" = "0" ]; then
+if [ "$STATUS" = "BLOCKED" ] && [ "$CHECKS" = "0" ] && [ "$REVIEW_DECISION" != "REVIEW_REQUIRED" ] && [ "$REVIEW_DECISION" != "CHANGES_REQUESTED" ]; then
   echo "⚠ PR is BLOCKED with zero checks. The [ci skip] trailer wedged the PR due to required checks."
   echo "Pushing an empty commit to trigger the required pipelines..."
   # gsd_run query commit requires a file list; use git directly for this intentionally empty commit.

--- a/tests/emitted-drift-ack.json
+++ b/tests/emitted-drift-ack.json
@@ -1,0 +1,8 @@
+{
+  "version": 1,
+  "paths": {
+    "ship.md": {
+      "reason": "#2783: ship note protocol gains handling for wedged PRs — a PR that cannot merge must be reported rather than silently skipped. Growth is the added protocol branch and its example; no existing step changed shape."
+    }
+  }
+}

--- a/tests/emitted-drift-ack.json
+++ b/tests/emitted-drift-ack.json
@@ -1,8 +1,0 @@
-{
-  "version": 1,
-  "paths": {
-    "ship.md": {
-      "reason": "#2783: ship note protocol gains handling for wedged PRs — a PR that cannot merge must be reported rather than silently skipped. Growth is the added protocol branch and its example; no existing step changed shape."
-    }
-  }
-}

--- a/tests/emitted-drift-acks/2818-ship-note-wedged-pr.json
+++ b/tests/emitted-drift-acks/2818-ship-note-wedged-pr.json
@@ -1,0 +1,6 @@
+{
+  "version": 1,
+  "paths": {
+    "ship.md": "#2783: the ship-note protocol adds a bounded merge-state poll and an empty recovery commit when a skip token leaves a PR blocked with no checks."
+  }
+}

--- a/tests/fix-2138-ship-note-lost-on-merge.test.cjs
+++ b/tests/fix-2138-ship-note-lost-on-merge.test.cjs
@@ -46,6 +46,8 @@ describe('#2138 ship.md track_shipping pushes the ship-note onto the PR branch',
   });
 
   test('the ship-note commit carries a [ci skip] trailer to avoid a redundant pipeline', () => {
+    // GitHub honors `[ci skip]` / `[skip ci]`; the trailer suppresses the second
+    // pipeline the post-create_pr push would otherwise trigger.
     assert.ok(
       /\[ci skip\]|\[skip ci\]/.test(step),
       'track_shipping ship-note commit must include a [ci skip] trailer',

--- a/tests/fix-2138-ship-note-lost-on-merge.test.cjs
+++ b/tests/fix-2138-ship-note-lost-on-merge.test.cjs
@@ -46,11 +46,16 @@ describe('#2138 ship.md track_shipping pushes the ship-note onto the PR branch',
   });
 
   test('the ship-note commit carries a [ci skip] trailer to avoid a redundant pipeline', () => {
-    // GitHub honors `[ci skip]` / `[skip ci]`; the trailer suppresses the second
-    // pipeline the post-create_pr push would otherwise trigger.
     assert.ok(
       /\[ci skip\]|\[skip ci\]/.test(step),
       'track_shipping ship-note commit must include a [ci skip] trailer',
+    );
+  });
+
+  test('the ship-note step handles wedged PRs caused by skip-token or required status checks', () => {
+    assert.ok(
+      /mergeStateStatus|BLOCKED|trigger CI/.test(step),
+      'track_shipping must include self-healing or check handling for wedged PRs (#2783)',
     );
   });
 

--- a/tests/ship-notes-wedged-pr.test.cjs
+++ b/tests/ship-notes-wedged-pr.test.cjs
@@ -2,6 +2,7 @@ const { test, describe } = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
+const { stripFencedCode } = require('../gsd-core/bin/lib/markdown-sectionizer.cjs');
 
 const SHIP_MD = path.join(__dirname, '..', 'gsd-core', 'workflows', 'ship.md');
 
@@ -33,6 +34,17 @@ describe('#2783 ship.md track_shipping self-heals wedged PRs', () => {
     assert.ok(
       /trigger CI/.test(step) || /allow-empty/.test(step),
       'track_shipping must push a recovery commit to trigger CI when wedged (#2783)'
+    );
+  });
+
+  test('track_shipping and the following step remain outside balanced code fences', () => {
+    const content = fs.readFileSync(SHIP_MD, 'utf8');
+    const stripped = stripFencedCode(content);
+    assert.strictEqual(stripped.unterminatedFence, false, 'ship.md must not contain an unterminated code fence');
+    assert.match(
+      stripped.text,
+      /<step name="track_shipping">[\s\S]*?<\/step>\s*<step name="ship_post_capability_dispatch">/,
+      'the track_shipping boundary and following step must remain visible after stripping code fences',
     );
   });
 });

--- a/tests/ship-notes-wedged-pr.test.cjs
+++ b/tests/ship-notes-wedged-pr.test.cjs
@@ -1,0 +1,38 @@
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const SHIP_MD = path.join(__dirname, '..', 'gsd-core', 'workflows', 'ship.md');
+
+function extractStep(name) {
+  const content = fs.readFileSync(SHIP_MD, 'utf8');
+  const open = `<step name="${name}">`;
+  const start = content.indexOf(open);
+  assert.notEqual(start, -1, `ship.md must contain a ${name} step`);
+  const end = content.indexOf('</step>', start);
+  assert.notEqual(end, -1, `${name} step must close`);
+  return content.slice(start, end);
+}
+
+describe('#2783 ship.md track_shipping self-heals wedged PRs', () => {
+  const step = extractStep('track_shipping');
+
+  test('track_shipping inspects mergeStateStatus post-push', () => {
+    assert.ok(
+      /mergeStateStatus/.test(step),
+      'track_shipping must query mergeStateStatus to detect wedged PRs (#2783)'
+    );
+  });
+
+  test('track_shipping self-heals BLOCKED PRs by pushing a recovery commit without skip token', () => {
+    assert.ok(
+      /BLOCKED/.test(step),
+      'track_shipping must check for BLOCKED merge state (#2783)'
+    );
+    assert.ok(
+      /trigger CI/.test(step) || /allow-empty/.test(step),
+      'track_shipping must push a recovery commit to trigger CI when wedged (#2783)'
+    );
+  });
+});

--- a/tests/ship-notes-wedged-pr.test.cjs
+++ b/tests/ship-notes-wedged-pr.test.cjs
@@ -47,6 +47,8 @@ function runTrackShipping(responses) {
       'git() {',
       '  if [ "$1" = "rev-parse" ] && [ "$2" = "HEAD" ]; then',
       '    printf "%s\\n" "$EXPECTED_HEAD"',
+      '  elif [ "$1" = "log" ]; then',
+      '    printf "[ci skip]\\n"',
       '  elif [ "$1" = "commit" ]; then',
       '    printf "commit\\n" >> "$GIT_CALLS"',
       '  elif [ "$1" = "push" ]; then',
@@ -161,6 +163,54 @@ describe('#2783 ship-note recovery decisions use current GitHub state', { skip: 
       result.gitCalls.filter(call => call === 'commit').length,
       1,
       'a confirmed skip-token wedge must create exactly one recovery commit',
+    );
+  });
+
+  test('recovers successfully on the 4th polling attempt', () => {
+    const result = runTrackShipping([
+      { head: 'stale-head', status: 'BLOCKED', checks: 0, review: '' },
+      { head: 'current-head', status: 'UNKNOWN', checks: 0, review: '' },
+      { head: 'current-head', status: 'UNKNOWN', checks: 0, review: '' },
+      { head: 'current-head', status: 'BLOCKED', checks: 0, review: '' },
+    ]);
+    assert.strictEqual(result.ghCalls.length, 4, 'must poll exactly 4 times');
+    assert.strictEqual(
+      result.gitCalls.filter(call => call === 'commit').length,
+      1,
+      'must recover after resolving on the 4th attempt',
+    );
+  });
+
+  test('recovers successfully on the 5th (final) polling attempt', () => {
+    const result = runTrackShipping([
+      { head: 'stale-head', status: 'BLOCKED', checks: 0, review: '' },
+      { head: 'current-head', status: 'UNKNOWN', checks: 0, review: '' },
+      { head: 'current-head', status: 'UNKNOWN', checks: 0, review: '' },
+      { head: 'current-head', status: 'UNKNOWN', checks: 0, review: '' },
+      { head: 'current-head', status: 'BLOCKED', checks: 0, review: '' },
+    ]);
+    assert.strictEqual(result.ghCalls.length, 5, 'must poll exactly 5 times');
+    assert.strictEqual(
+      result.gitCalls.filter(call => call === 'commit').length,
+      1,
+      'must recover after resolving on the 5th attempt',
+    );
+  });
+
+  test('exhausts the polling bound after 5 attempts and warns without recovering (attempt 6)', () => {
+    const result = runTrackShipping([
+      { head: 'current-head', status: 'UNKNOWN', checks: 0, review: '' },
+      { head: 'current-head', status: 'UNKNOWN', checks: 0, review: '' },
+      { head: 'current-head', status: 'UNKNOWN', checks: 0, review: '' },
+      { head: 'current-head', status: 'UNKNOWN', checks: 0, review: '' },
+      { head: 'current-head', status: 'UNKNOWN', checks: 0, review: '' },
+      { head: 'current-head', status: 'BLOCKED', checks: 0, review: '' },
+    ]);
+    assert.strictEqual(result.ghCalls.length, 5, 'must exhaust after exactly 5 polling attempts');
+    assert.strictEqual(
+      result.gitCalls.filter(call => call === 'commit').length,
+      0,
+      'must not recover if the status is unresolved when polling exhausts',
     );
   });
 });

--- a/tests/ship-notes-wedged-pr.test.cjs
+++ b/tests/ship-notes-wedged-pr.test.cjs
@@ -1,19 +1,94 @@
 const { test, describe } = require('node:test');
 const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
 const fs = require('node:fs');
 const path = require('node:path');
 const { stripFencedCode } = require('../gsd-core/bin/lib/markdown-sectionizer.cjs');
+const { cleanup, createTempDir, readFileNormalized } = require('./helpers.cjs');
 
 const SHIP_MD = path.join(__dirname, '..', 'gsd-core', 'workflows', 'ship.md');
 
 function extractStep(name) {
-  const content = fs.readFileSync(SHIP_MD, 'utf8');
+  const content = readFileNormalized(SHIP_MD);
   const open = `<step name="${name}">`;
   const start = content.indexOf(open);
   assert.notEqual(start, -1, `ship.md must contain a ${name} step`);
   const end = content.indexOf('</step>', start);
   assert.notEqual(end, -1, `${name} step must close`);
   return content.slice(start, end);
+}
+
+function extractTrackShippingScript() {
+  const step = extractStep('track_shipping');
+  const blocks = [...step.matchAll(/```bash\r?\n([\s\S]*?)\r?\n```/g)];
+  const match = blocks.find(block => block[1].includes('mergeStateStatus'));
+  assert.ok(match, 'track_shipping must contain an executable merge-state bash block');
+  return match[1];
+}
+
+function runTrackShipping(responses) {
+  const tmpDir = createTempDir('gsd-ship-note-');
+  const responsesPath = path.join(tmpDir, 'responses.jsonl');
+  const ghCallsPath = path.join(tmpDir, 'gh-calls.log');
+  const gitCallsPath = path.join(tmpDir, 'git-calls.log');
+
+  try {
+    fs.writeFileSync(
+      responsesPath,
+      responses.map(response => JSON.stringify(response)).join('\n') + '\n',
+      'utf8',
+    );
+    fs.writeFileSync(ghCallsPath, '', 'utf8');
+    fs.writeFileSync(gitCallsPath, '', 'utf8');
+
+    const preamble = [
+      'gsd_run() { :; }',
+      'sleep() { :; }',
+      'git() {',
+      '  if [ "$1" = "rev-parse" ] && [ "$2" = "HEAD" ]; then',
+      '    printf "%s\\n" "$EXPECTED_HEAD"',
+      '  elif [ "$1" = "commit" ]; then',
+      '    printf "commit\\n" >> "$GIT_CALLS"',
+      '  elif [ "$1" = "push" ]; then',
+      '    printf "push\\n" >> "$GIT_CALLS"',
+      '  fi',
+      '}',
+      'gh() {',
+      '  _call=$(wc -l < "$GH_CALLS")',
+      '  _call=$((_call + 1))',
+      '  printf "call\\n" >> "$GH_CALLS"',
+      '  sed -n "${_call}p" "$GH_RESPONSES"',
+      '}',
+      'jq() {',
+      '  "$NODE_BIN" -e "let d=\'\';process.stdin.on(\'data\',c=>d+=c);process.stdin.on(\'end\',()=>{const o=JSON.parse(d);process.stdout.write(String(o[process.argv[1].slice(1)] ?? \'\'));});" "$2"',
+      '}',
+    ].join('\n');
+
+    const result = spawnSync('bash', ['-c', `${preamble}\n${extractTrackShippingScript()}`], {
+      cwd: tmpDir,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        CURRENT_BRANCH: 'fix/ship-note',
+        EXPECTED_HEAD: 'current-head',
+        GH_CALLS: ghCallsPath,
+        GH_RESPONSES: responsesPath,
+        GIT_CALLS: gitCallsPath,
+        NODE_BIN: process.execPath,
+        PHASE_NUMBER: '1',
+        PR_NUMBER: '123',
+        padded_phase: '01',
+      },
+    });
+
+    assert.strictEqual(result.status, 0, `track_shipping failed: ${result.stderr}`);
+    return {
+      ghCalls: fs.readFileSync(ghCallsPath, 'utf8').trim().split(/\r?\n/).filter(Boolean),
+      gitCalls: fs.readFileSync(gitCallsPath, 'utf8').trim().split(/\r?\n/).filter(Boolean),
+    };
+  } finally {
+    cleanup(tmpDir);
+  }
 }
 
 describe('#2783 ship.md track_shipping self-heals wedged PRs', () => {
@@ -45,6 +120,47 @@ describe('#2783 ship.md track_shipping self-heals wedged PRs', () => {
       stripped.text,
       /<step name="track_shipping">[\s\S]*?<\/step>\s*<step name="ship_post_capability_dispatch">/,
       'the track_shipping boundary and following step must remain visible after stripping code fences',
+    );
+  });
+});
+
+describe('#2783 ship-note recovery decisions use current GitHub state', { skip: process.platform === 'win32' }, () => {
+  test('ignores a stale BLOCKED response until headRefOid matches the pushed commit', () => {
+    const result = runTrackShipping([
+      { head: 'stale-head', status: 'BLOCKED', checks: 0, review: '' },
+      { head: 'current-head', status: 'CLEAN', checks: 0, review: '' },
+    ]);
+
+    assert.strictEqual(result.ghCalls.length, 2, 'must poll through the stale PR response');
+    assert.strictEqual(
+      result.gitCalls.filter(call => call === 'commit').length,
+      0,
+      'must not recover from merge state attached to an older head',
+    );
+  });
+
+  test('does not recover when review requirements are the BLOCKED reason', () => {
+    for (const review of ['REVIEW_REQUIRED', 'CHANGES_REQUESTED']) {
+      const result = runTrackShipping([
+        { head: 'current-head', status: 'BLOCKED', checks: 0, review },
+      ]);
+      assert.strictEqual(
+        result.gitCalls.filter(call => call === 'commit').length,
+        0,
+        `${review} must not create an empty CI-recovery commit`,
+      );
+    }
+  });
+
+  test('still recovers a current BLOCKED head with zero checks and no review gate', () => {
+    const result = runTrackShipping([
+      { head: 'current-head', status: 'BLOCKED', checks: 0, review: 'APPROVED' },
+    ]);
+
+    assert.strictEqual(
+      result.gitCalls.filter(call => call === 'commit').length,
+      1,
+      'a confirmed skip-token wedge must create exactly one recovery commit',
     );
   });
 });

--- a/tests/ship-notes-wedged-pr.test.cjs
+++ b/tests/ship-notes-wedged-pr.test.cjs
@@ -69,6 +69,7 @@ function runTrackShipping(responses) {
     const result = spawnSync('bash', ['-c', `${preamble}\n${extractTrackShippingScript()}`], {
       cwd: tmpDir,
       encoding: 'utf8',
+      timeout: 10000,
       env: {
         ...process.env,
         CURRENT_BRANCH: 'fix/ship-note',

--- a/tests/ship-notes-wedged-pr.test.cjs
+++ b/tests/ship-notes-wedged-pr.test.cjs
@@ -190,7 +190,7 @@ describe('#2783 ship-note recovery decisions use current GitHub state', { skip: 
       { head: 'current-head', status: 'UNKNOWN', checks: 0, review: '' },
       { head: 'current-head', status: 'BLOCKED', checks: 0, review: '' },
     ]);
-    assert.strictEqual(result.ghCalls.length, 5, 'must poll exactly 5 times');
+    assert.strictEqual(result.ghCalls.length, 6, 'must poll up to 6 total calls (1 initial + 5 retries)');
     assert.strictEqual(
       result.gitCalls.filter(call => call === 'commit').length,
       1,
@@ -207,7 +207,7 @@ describe('#2783 ship-note recovery decisions use current GitHub state', { skip: 
       { head: 'current-head', status: 'UNKNOWN', checks: 0, review: '' },
       { head: 'current-head', status: 'BLOCKED', checks: 0, review: '' },
     ]);
-    assert.strictEqual(result.ghCalls.length, 5, 'must exhaust after exactly 5 polling attempts');
+    assert.strictEqual(result.ghCalls.length, 6, 'must exhaust after 6 total calls (1 initial + 5 retries)');
     assert.strictEqual(
       result.gitCalls.filter(call => call === 'commit').length,
       0,

--- a/tests/ship-notes-wedged-pr.test.cjs
+++ b/tests/ship-notes-wedged-pr.test.cjs
@@ -190,7 +190,7 @@ describe('#2783 ship-note recovery decisions use current GitHub state', { skip: 
       { head: 'current-head', status: 'UNKNOWN', checks: 0, review: '' },
       { head: 'current-head', status: 'BLOCKED', checks: 0, review: '' },
     ]);
-    assert.strictEqual(result.ghCalls.length, 6, 'must poll up to 6 total calls (1 initial + 5 retries)');
+    assert.strictEqual(result.ghCalls.length, 5, 'must poll exactly 5 times');
     assert.strictEqual(
       result.gitCalls.filter(call => call === 'commit').length,
       1,
@@ -207,7 +207,7 @@ describe('#2783 ship-note recovery decisions use current GitHub state', { skip: 
       { head: 'current-head', status: 'UNKNOWN', checks: 0, review: '' },
       { head: 'current-head', status: 'BLOCKED', checks: 0, review: '' },
     ]);
-    assert.strictEqual(result.ghCalls.length, 6, 'must exhaust after 6 total calls (1 initial + 5 retries)');
+    assert.strictEqual(result.ghCalls.length, 5, 'must exhaust after exactly 5 polling attempts');
     assert.strictEqual(
       result.gitCalls.filter(call => call === 'commit').length,
       0,


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

Fixes #2783

> The linked issue must have the `confirmed-bug` label. If it doesn't, ask a maintainer to confirm the bug before continuing.

---

## What was broken

During `/gsd-ship`, the `track_shipping` step pushed a ship-note commit containing `[ci skip]` onto open PR branches. On repositories with required status checks, GitHub Actions suppressed checks for that head SHA, leaving the PR wedged in a `BLOCKED` state with 0 status checks.

## What this fix does

Updates `gsd-core/workflows/ship.md` to check `mergeStateStatus` and `statusCheckRollup` post-push. If the PR is `BLOCKED` with zero status checks, it self-heals by pushing an empty commit without the `[ci skip]` token to trigger required pipelines.

## Root cause

The ship-note commit pushed a `[ci skip]` trailer onto the open PR branch head. GitHub Actions honors `[ci skip]` on PR head commits, preventing required status check workflows from evaluating.

## Testing

### How I verified the fix

Added a behavioral test in `tests/ship-notes-wedged-pr.test.cjs` and updated `tests/fix-2138-ship-note-lost-on-merge.test.cjs` to assert `mergeStateStatus` inspection and self-healing recovery.

- **Without fix (on `next`):** PRs with required status checks wedged on `[ci skip]` head commit without recovery logic.
- **With fix:** `node --test tests/ship-notes-wedged-pr.test.cjs tests/fix-2138-ship-note-lost-on-merge.test.cjs` passes cleanly.

### Regression test added?

- [x] Yes — added `tests/ship-notes-wedged-pr.test.cjs` and updated `tests/fix-2138-ship-note-lost-on-merge.test.cjs`

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #2783` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2818"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787910146&installation_model_id=22188&pr_number=2818&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2818&signature=47e8847120c7fcbe5c4f8c6c77d3ca264c90ae524da42475f71cc333089dfde3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->