### PR TITLE
fix(#2697): skip the context-monitor spawn in-process when context_warnings disabled

### DIFF
--- a/.changeset/eager-moles-tumble.md
+++ b/.changeset/eager-moles-tumble.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**OpenCode/Kilo no longer spawn the context-monitor subprocess on every tool call when context warnings are disabled** — the adapter now reads the existing `hooks.context_warnings` toggle in-process and skips the child-process spawn entirely when it is set to `false`, instead of paying a Node boot per tool call only to read the flag and exit inside the child. Behavior is unchanged when the toggle is absent or enabled (the default).

--- a/.changeset/eager-moles-tumble.md
+++ b/.changeset/eager-moles-tumble.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 2824
 ---
 **OpenCode/Kilo no longer spawn the context-monitor subprocess on every tool call when context warnings are disabled** — the adapter now reads the existing `hooks.context_warnings` toggle in-process and skips the child-process spawn entirely when it is set to `false`, instead of paying a Node boot per tool call only to read the flag and exit inside the child. Behavior is unchanged when the toggle is absent or enabled (the default).

--- a/.kilo/plugins/gsd-core.js
+++ b/.kilo/plugins/gsd-core.js
@@ -239,6 +239,32 @@ function runHook(hookFile, payload, opts = {}) {
   return { stdout, exitCode, timedOut: result.signal === "SIGTERM" };
 }
 
+/**
+ * In-process check for whether context-usage warnings are disabled in project
+ * config. Mirrors the exact semantics of the same check inside
+ * hooks/gsd-context-monitor.js (introduced by #1073): an explicit
+ * `config.hooks.context_warnings === false` disables them; a missing or
+ * unparseable .planning/config.json keeps them enabled (the default).
+ *
+ * #2697: hoisting this check in-process lets the adapter SKIP the context-monitor
+ * spawn entirely when the user has opted out, instead of paying a full Node boot
+ * inside the child only to read the boolean and exit. Missing/unparseable config
+ * MUST behave identically to the hook (enabled) so the default path is unchanged.
+ *
+ * @param {string} cwd  project working directory (the plugin's currentCwd)
+ * @returns {boolean} true when context warnings are explicitly disabled
+ */
+function contextWarningsDisabled(cwd) {
+  try {
+    const configPath = path.join(cwd, '.planning', 'config.json');
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    return config.hooks?.context_warnings === false;
+  } catch {
+    // Missing or unparseable config → proceed with defaults (context warnings enabled).
+    return false;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Hook output translation → OpenCode semantics
 // ---------------------------------------------------------------------------
@@ -587,7 +613,11 @@ const GsdCorePlugin = async ({ directory } = {}) => {
 
       // gsd-context-monitor.js — context usage warnings (Bash/Edit/Write/Task/...)
       // Only meaningful when a session_id is tracked (writes metrics sentinel).
-      if (currentSessionId) {
+      // #2697: skip the subprocess spawn entirely when context warnings are
+      // explicitly disabled in project config — the hook would exit early anyway,
+      // so hoisting the check in-process avoids paying a Node boot per tool call.
+      // Missing/unparseable config = enabled (default), so the spawn still runs.
+      if (currentSessionId && !contextWarningsDisabled(cwd)) {
         const payload = {
           hook_event_name: "PostToolUse",
           tool_name: claudeTool,

--- a/.opencode/plugins/gsd-core.js
+++ b/.opencode/plugins/gsd-core.js
@@ -239,6 +239,32 @@ function runHook(hookFile, payload, opts = {}) {
   return { stdout, exitCode, timedOut: result.signal === "SIGTERM" };
 }
 
+/**
+ * In-process check for whether context-usage warnings are disabled in project
+ * config. Mirrors the exact semantics of the same check inside
+ * hooks/gsd-context-monitor.js (introduced by #1073): an explicit
+ * `config.hooks.context_warnings === false` disables them; a missing or
+ * unparseable .planning/config.json keeps them enabled (the default).
+ *
+ * #2697: hoisting this check in-process lets the adapter SKIP the context-monitor
+ * spawn entirely when the user has opted out, instead of paying a full Node boot
+ * inside the child only to read the boolean and exit. Missing/unparseable config
+ * MUST behave identically to the hook (enabled) so the default path is unchanged.
+ *
+ * @param {string} cwd  project working directory (the plugin's currentCwd)
+ * @returns {boolean} true when context warnings are explicitly disabled
+ */
+function contextWarningsDisabled(cwd) {
+  try {
+    const configPath = path.join(cwd, '.planning', 'config.json');
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    return config.hooks?.context_warnings === false;
+  } catch {
+    // Missing or unparseable config → proceed with defaults (context warnings enabled).
+    return false;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Hook output translation → OpenCode semantics
 // ---------------------------------------------------------------------------
@@ -587,7 +613,11 @@ const GsdCorePlugin = async ({ directory } = {}) => {
 
       // gsd-context-monitor.js — context usage warnings (Bash/Edit/Write/Task/...)
       // Only meaningful when a session_id is tracked (writes metrics sentinel).
-      if (currentSessionId) {
+      // #2697: skip the subprocess spawn entirely when context warnings are
+      // explicitly disabled in project config — the hook would exit early anyway,
+      // so hoisting the check in-process avoids paying a Node boot per tool call.
+      // Missing/unparseable config = enabled (default), so the spawn still runs.
+      if (currentSessionId && !contextWarningsDisabled(cwd)) {
         const payload = {
           hook_event_name: "PostToolUse",
           tool_name: claudeTool,

--- a/tests/opencode-plugin-adapter.test.cjs
+++ b/tests/opencode-plugin-adapter.test.cjs
@@ -416,3 +416,126 @@ test('installer copies plugin as .js, records it in the manifest, and removes it
   assert.ok(!fs.existsSync(pluginPath), 'plugin must be removed on uninstall');
   assert.ok(!fs.existsSync(path.join(cfg, 'plugins')), 'empty plugins/ dir must be pruned');
 });
+
+// ---------------------------------------------------------------------------
+// #2697: context-monitor subprocess is skipped in-process when context_warnings
+// is disabled, instead of paying a full Node boot inside the child only to exit.
+// The plugin destructures spawnSync at require-time, so we intercept by
+// monkeypatching require('child_process').spawnSync BEFORE loading the copied
+// plugin, recording every spawn's argv. Restore in t.after.
+// ---------------------------------------------------------------------------
+
+/**
+ * Build an installed layout, intercept spawnSync, and return { handlers, spawns, projectDir }.
+ * `planningConfig` (object|null) is written to <projectDir>/.planning/config.json; null = absent.
+ */
+async function buildLayoutWithSpawnTrace(t, { stubHooks, planningConfig }) {
+  const cp = require('node:child_process');
+  const { mod } = buildInstalledLayout(t, stubHooks || {});
+
+  // Project dir is the cwd the plugin reads config from (currentCwd).
+  const projectDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-oc-proj-')));
+  t.after(() => cleanup(projectDir));
+  if (planningConfig !== null) {
+    fs.mkdirSync(path.join(projectDir, '.planning'), { recursive: true });
+    fs.writeFileSync(
+      path.join(projectDir, '.planning', 'config.json'),
+      JSON.stringify(planningConfig),
+    );
+  }
+
+  const spawns = [];
+  const realSpawnSync = cp.spawnSync;
+  cp.spawnSync = (...args) => {
+    spawns.push(args);
+    // Return an allow/no-op result so the adapter's handleHookResult path completes.
+    return { stdout: '', status: 0, signal: null };
+  };
+  t.after(() => { cp.spawnSync = realSpawnSync; });
+
+  const handlers = await mod.server({ directory: projectDir });
+  return { handlers, spawns, projectDir };
+}
+
+function spawnTargetedMonitor(spawns) {
+  return spawns.some((a) => {
+    const argv = a[1];
+    return Array.isArray(argv) && argv.some((s) => String(s).includes('gsd-context-monitor.js'));
+  });
+}
+
+test('#2697: context-monitor subprocess is skipped when context_warnings is disabled', async (t) => {
+  const { handlers, spawns } = await buildLayoutWithSpawnTrace(t, {
+    stubHooks: { 'gsd-context-monitor.js': stubHook('') },
+    planningConfig: { hooks: { context_warnings: false } },
+  });
+  // Bash is a non-Read tool → reaches the context-monitor dispatch.
+  await handlers['tool.execute.after']({ tool: 'bash', args: { command: 'echo hi' } }, {});
+  assert.ok(
+    !spawnTargetedMonitor(spawns),
+    `context-monitor spawn must be skipped when context_warnings:false; spawn argvs: ${JSON.stringify(spawns)}`,
+  );
+});
+
+test('#2697: context-monitor subprocess still runs when config is absent (default enabled)', async (t) => {
+  const { handlers, spawns } = await buildLayoutWithSpawnTrace(t, {
+    stubHooks: { 'gsd-context-monitor.js': stubHook('') },
+    planningConfig: null,
+  });
+  await handlers['tool.execute.after']({ tool: 'bash', args: { command: 'echo hi' } }, {});
+  assert.ok(
+    spawnTargetedMonitor(spawns),
+    'context-monitor spawn must still occur when the config toggle is absent (default = enabled)',
+  );
+});
+
+test('#2697: context-monitor subprocess runs when context_warnings explicitly true', async (t) => {
+  const { handlers, spawns } = await buildLayoutWithSpawnTrace(t, {
+    stubHooks: { 'gsd-context-monitor.js': stubHook('') },
+    planningConfig: { hooks: { context_warnings: true } },
+  });
+  await handlers['tool.execute.after']({ tool: 'bash', args: { command: 'echo hi' } }, {});
+  assert.ok(
+    spawnTargetedMonitor(spawns),
+    'context-monitor spawn must occur when context_warnings is explicitly true',
+  );
+});
+
+test('#2697: context-monitor subprocess runs when config.json is unparseable (defaults enabled)', async (t) => {
+  const { mod } = buildInstalledLayout(t, { 'gsd-context-monitor.js': stubHook('') });
+  const projectDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-oc-proj-')));
+  t.after(() => cleanup(projectDir));
+  fs.mkdirSync(path.join(projectDir, '.planning'), { recursive: true });
+  // Malformed JSON → the in-process check must treat it as "enabled" (Postel: conservative).
+  fs.writeFileSync(path.join(projectDir, '.planning', 'config.json'), '{ not valid json');
+
+  const cp = require('node:child_process');
+  const spawns = [];
+  const realSpawnSync = cp.spawnSync;
+  cp.spawnSync = (...args) => { spawns.push(args); return { stdout: '', status: 0, signal: null }; };
+  t.after(() => { cp.spawnSync = realSpawnSync; });
+
+  const handlers = await mod.server({ directory: projectDir });
+  await handlers['tool.execute.after']({ tool: 'bash', args: { command: 'echo hi' } }, {});
+  assert.ok(
+    spawnTargetedMonitor(spawns),
+    'context-monitor spawn must occur when config.json is unparseable (defaults = enabled)',
+  );
+});
+
+test('#2697: context-monitor skipped for Write when context_warnings disabled (not Bash-specific)', async (t) => {
+  const { handlers, spawns } = await buildLayoutWithSpawnTrace(t, {
+    stubHooks: { 'gsd-context-monitor.js': stubHook('') },
+    planningConfig: { hooks: { context_warnings: false } },
+  });
+  // Write reaches context-monitor dispatch (non-Read); the guard hooks run before it
+  // via tool.execute.before, not here, so the after-handler only hits the monitor.
+  await handlers['tool.execute.after'](
+    { tool: 'write', args: { filePath: '/proj/a.md', content: 'x' } },
+    {},
+  );
+  assert.ok(
+    !spawnTargetedMonitor(spawns),
+    `context-monitor spawn must be skipped for Write when context_warnings:false; spawn argvs: ${JSON.stringify(spawns)}`,
+  );
+});

--- a/tests/opencode-plugin-adapter.test.cjs
+++ b/tests/opencode-plugin-adapter.test.cjs
@@ -458,6 +458,13 @@ async function buildLayoutWithSpawnTrace(t, { stubHooks, planningConfig }) {
   }
 
   const handlers = await mod.server({ directory: projectDir });
+  // Establish an active session — the context-monitor dispatch is gated on
+  // currentSessionId, which session.created populates. Without this the gate
+  // short-circuits on the first operand (null) and the toggle is never reached,
+  // making the "disabled" assertions pass vacuously and the "enabled" ones fail.
+  await handlers.event({
+    event: { type: 'session.created', properties: { info: { id: 's1', directory: projectDir } } },
+  });
   return { handlers, spawns, projectDir };
 }
 
@@ -521,6 +528,10 @@ test('#2697: context-monitor subprocess runs when config.json is unparseable (de
   fs.writeFileSync(path.join(projectDir, '.planning', 'config.json'), '{ not valid json');
 
   const handlers = await mod.server({ directory: projectDir });
+  // Establish an active session (the dispatch is gated on currentSessionId).
+  await handlers.event({
+    event: { type: 'session.created', properties: { info: { id: 's1', directory: projectDir } } },
+  });
   await handlers['tool.execute.after']({ tool: 'bash', args: { command: 'echo hi' } }, {});
   assert.ok(
     spawnTargetedMonitor(spawns),

--- a/tests/opencode-plugin-adapter.test.cjs
+++ b/tests/opencode-plugin-adapter.test.cjs
@@ -431,6 +431,19 @@ test('installer copies plugin as .js, records it in the manifest, and removes it
  */
 async function buildLayoutWithSpawnTrace(t, { stubHooks, planningConfig }) {
   const cp = require('node:child_process');
+  const spawns = [];
+  const realSpawnSync = cp.spawnSync;
+  // IMPORTANT: the plugin destructures spawnSync at require-time
+  // (`const { spawnSync } = require("child_process")`), so the patch MUST be in
+  // place BEFORE buildInstalledLayout requires the copied plugin, or the plugin
+  // captures the original spawnSync and our trace records nothing.
+  cp.spawnSync = (...args) => {
+    spawns.push(args);
+    // Return an allow/no-op result so the adapter's handleHookResult path completes.
+    return { stdout: '', status: 0, signal: null };
+  };
+  t.after(() => { cp.spawnSync = realSpawnSync; });
+
   const { mod } = buildInstalledLayout(t, stubHooks || {});
 
   // Project dir is the cwd the plugin reads config from (currentCwd).
@@ -443,15 +456,6 @@ async function buildLayoutWithSpawnTrace(t, { stubHooks, planningConfig }) {
       JSON.stringify(planningConfig),
     );
   }
-
-  const spawns = [];
-  const realSpawnSync = cp.spawnSync;
-  cp.spawnSync = (...args) => {
-    spawns.push(args);
-    // Return an allow/no-op result so the adapter's handleHookResult path completes.
-    return { stdout: '', status: 0, signal: null };
-  };
-  t.after(() => { cp.spawnSync = realSpawnSync; });
 
   const handlers = await mod.server({ directory: projectDir });
   return { handlers, spawns, projectDir };
@@ -502,18 +506,19 @@ test('#2697: context-monitor subprocess runs when context_warnings explicitly tr
 });
 
 test('#2697: context-monitor subprocess runs when config.json is unparseable (defaults enabled)', async (t) => {
+  const cp = require('node:child_process');
+  const spawns = [];
+  const realSpawnSync = cp.spawnSync;
+  // Patch BEFORE requiring the plugin (it destructures spawnSync at require-time).
+  cp.spawnSync = (...args) => { spawns.push(args); return { stdout: '', status: 0, signal: null }; };
+  t.after(() => { cp.spawnSync = realSpawnSync; });
+
   const { mod } = buildInstalledLayout(t, { 'gsd-context-monitor.js': stubHook('') });
   const projectDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-oc-proj-')));
   t.after(() => cleanup(projectDir));
   fs.mkdirSync(path.join(projectDir, '.planning'), { recursive: true });
   // Malformed JSON → the in-process check must treat it as "enabled" (Postel: conservative).
   fs.writeFileSync(path.join(projectDir, '.planning', 'config.json'), '{ not valid json');
-
-  const cp = require('node:child_process');
-  const spawns = [];
-  const realSpawnSync = cp.spawnSync;
-  cp.spawnSync = (...args) => { spawns.push(args); return { stdout: '', status: 0, signal: null }; };
-  t.after(() => { cp.spawnSync = realSpawnSync; });
 
   const handlers = await mod.server({ directory: projectDir });
   await handlers['tool.execute.after']({ tool: 'bash', args: { command: 'echo hi' } }, {});


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #2697

## What was broken

The OpenCode/Kilo plugin adapter (`.opencode/plugins/gsd-core.js`, byte-identical copy at `.kilo/plugins/gsd-core.js`) spawned `gsd-context-monitor.js` as a Node subprocess on every non-Read tool call, even when the user had explicitly disabled context-usage warnings via `hooks.context_warnings: false` in `.planning/config.json`. The disable check existed, but only ran *inside the already-spawned child process* — so disabling the feature silenced the warning output but did not avoid the spawn cost it was meant to eliminate.

## What this fix does

Hoists the existing config check in-process via a new `contextWarningsDisabled(cwd)` helper that mirrors the exact semantics of `hooks/gsd-context-monitor.js:56-68`. The context-monitor dispatch is now gated: `if (currentSessionId && !contextWarningsDisabled(cwd))`. When context warnings are explicitly disabled, the adapter skips the subprocess spawn entirely instead of paying a Node boot per tool call only to read a boolean and exit. Behavior is unchanged when the toggle is absent or enabled (the default): missing/unparseable config keeps warnings enabled, so the spawn still runs exactly as today. The identical change lands in both byte-identical plugin files (the `kilo-upgrades` parity test enforces byte-identity).

## Root cause

The adapter's `tool.execute.after` handler (`.opencode/plugins/gsd-core.js`, the `#2697`-tagged guard) gated the context-monitor dispatch on `currentSessionId` only and unconditionally called `runHook("gsd-context-monitor.js", ...)`. The config toggle (`hooks.context_warnings`, added to the hook by #1073) was never hoisted up to the adapter's call site — so the adapter always spawned the child, which then re-read the same config and exited early when disabled. Present since the adapter's first commit (#1914, "SUBPROCESS REUSE" architecture) — not a regression.

## Testing

### How I verified the fix

- Added 5 behavioral tests to `tests/opencode-plugin-adapter.test.cjs` that drive the real adapter's `tool.execute.after` handler with a `spawnSync` trace (monkeypatched before require, since the plugin destructures `spawnSync` at load time) and an established session. They assert directly on whether the context-monitor spawn occurs: (1) skipped when `context_warnings:false`; (2) runs when config absent; (3) runs when explicitly `true`; (4) runs when `config.json` is unparseable (Postel: defaults = enabled); (5) skipped for the `Write` tool when disabled (not Bash-specific).
- **RED proven** at `c26e783` (the new suite fails). An isolated code review then caught a test-construction defect (the harness did not establish a session, so `currentSessionId` was null and the disabled-path assertions passed vacuously) — fixed at `d880bc1`; the broken-test intermediate sha `3ec959f` was independently confirmed to fail with 3 enabled-path failures, exactly as the review predicted.
- **GREEN** on the corrected sha (new suite passing, full matrix).

### Regression test added?

- [x] Yes — added tests that would have caught this bug (and a review caught that the first cut was vacuous, now fixed)

### Platforms tested

- [x] Linux (via the `gsd-test` matrix)
- [x] macOS (local dev host)
- [ ] Windows — the plugin logic is platform-neutral; the config read uses `path.join` and a `try/catch`. CI matrix covers it.

### Runtimes tested

- [x] Other: OpenCode/Kilo plugin adapter (the subject of the fix)

---

## Checklist

- [x] Issue linked above with `Fixes #2697`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`gsd-test` matrix green on the fix sha)
- [x] `.changeset/` fragment added (`Fixed`)
- [x] No unnecessary dependencies added

## Breaking changes

None. The fix only changes behavior in the case the user has *already* opted out of (context warnings disabled) — in that case it now avoids the spawn instead of paying for it silently. The default (warnings enabled) path is byte-for-byte identical in observable behavior.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2824"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787927845&installation_model_id=22188&pr_number=2824&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2824&signature=3002d74486f6f34c2cd38f74ebe03772f1f75a58bcc2d01aee606452bb24ab2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->