### PR TITLE
fix(#2716): route non-user-facing conventional types to an Internal bucket, omit from release notes

### DIFF
--- a/.changeset/gentle-rams-swim.md
+++ b/.changeset/gentle-rams-swim.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 2838
 ---
 **test:/chore:/ci:/docs:/refactor:/perf:/revert: PRs no longer publish under the user-facing Enhancement heading in release notes** — the release-notes classifier now routes recognized non-user-facing conventional-commit types to an Internal bucket and omits them from the published GitHub release notes (and the Discord announcement's user-facing sections). Previously these internal-work PRs rendered as Enhancements alongside genuinely user-facing changes. feat:/fix: classification is unchanged, and untyped or anchor-defeated titles still fall back to Enhancement.

--- a/.changeset/gentle-rams-swim.md
+++ b/.changeset/gentle-rams-swim.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**test:/chore:/ci:/docs:/refactor:/perf:/revert: PRs no longer publish under the user-facing Enhancement heading in release notes** — the release-notes classifier now routes recognized non-user-facing conventional-commit types to an Internal bucket and omits them from the published GitHub release notes (and the Discord announcement's user-facing sections). Previously these internal-work PRs rendered as Enhancements alongside genuinely user-facing changes. feat:/fix: classification is unchanged, and untyped or anchor-defeated titles still fall back to Enhancement.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -217,7 +217,7 @@ then run `scripts/release-notes/format-github-release-notes.cjs --apply` to
 rewrite the body into the project's curated format: an **Install** block,
 followed by **What's Changed** grouped into **Feature** / **Enhancement** /
 **Fix** sections (classified by each PR's conventional-commit title prefix —
-`feat` → Feature, `fix` → Fix, everything else → Enhancement), then
+`feat` → Feature, `fix` → Fix, non-user-facing types `test`/`chore`/`ci`/`docs`/`refactor`/`perf`/`revert` → omitted from the user-facing notes, everything else → Enhancement), then
 **New Contributors** and the **Full Changelog** link.
 
 To re-format an existing release by hand (e.g. backfilling an older release):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -910,7 +910,7 @@ Defensive normalization at trust boundaries must validate both the value's type 
 
 - **CommonJS** (`.cjs`) — the project uses `require()`, not ESM `import`
 - **No external dependencies in core** — `gsd-tools.cjs` and all lib files use only Node.js built-ins
-- **Conventional commits** — `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `ci:`. The full grammar is `<type>(<scope>): <subject>` (enforced by `hooks/gsd-validate-commit.sh`; subject ≤72 chars, lowercase, imperative mood, no trailing period). When the work resolves a tracked issue, put the issue number in the scope: `fix(#1520): randomize mktemp temp paths on BSD/macOS`. The same convention applies to PR titles — release notes are grouped by the title's type prefix (`feat` → Feature, `fix` → Fix, everything else → Enhancement).
+- **Conventional commits** — `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `ci:`. The full grammar is `<type>(<scope>): <subject>` (enforced by `hooks/gsd-validate-commit.sh`; subject ≤72 chars, lowercase, imperative mood, no trailing period). When the work resolves a tracked issue, put the issue number in the scope: `fix(#1520): randomize mktemp temp paths on BSD/macOS`. The same convention applies to PR titles — release notes are grouped by the title's type prefix (`feat` → Feature, `fix` → Fix, non-user-facing types omitted, everything else → Enhancement).
 
 ## File Structure
 

--- a/scripts/release-notes/conventional-title.cjs
+++ b/scripts/release-notes/conventional-title.cjs
@@ -30,18 +30,36 @@ const HEADER_RE = /^([a-z]+)(\([^)]*\))?(!)?:/i;
 // An issue reference inside a scope: `(#123)`, `(#123, core)`, etc.
 const ISSUE_REF_IN_SCOPE_RE = /#\d+/;
 
+// #2716: recognized non-user-facing conventional-commit types. A title whose
+// START-anchored type prefix is one of these is internal work (tests, chores,
+// CI, docs, refactors, perf, reverts) and must NOT render under the user-facing
+// "Enhancement" heading in release notes. Only a CLEAN prefix match qualifies —
+// untyped or anchor-defeated titles fall through to the visible Enhancement
+// fallback (a safety net so possibly-user-facing content is never hidden).
+const NON_USER_FACING_TYPES = new Set([
+  'docs', 'refactor', 'test', 'ci', 'chore', 'perf', 'revert',
+]);
+
 /**
  * Classify a clean conventional title into a changelog bucket.
  * Callers that hold a full changelog bullet line (with a `* ` marker and a
  * ` by @author` suffix) must strip those first; this operates on the title.
  *
  * @param {string} title
- * @returns {'Feature'|'Fix'|'Enhancement'}
+ * @returns {'Feature'|'Fix'|'Enhancement'|'Internal'}
  */
 function classifyBucket(title) {
   const t = String(title == null ? '' : title).trim();
   if (FEATURE_RE.test(t)) return 'Feature';
   if (FIX_RE.test(t)) return 'Fix';
+  // #2716: a clean non-user-facing type prefix → Internal (omitted from user-facing
+  // release-note sections). The HEADER_RE anchor ensures a leading tag/prefix
+  // (e.g. `[security] fix(...)`) does NOT match here — those keep falling through
+  // to the visible Enhancement fallback.
+  const headerMatch = HEADER_RE.exec(t);
+  if (headerMatch && NON_USER_FACING_TYPES.has(headerMatch[1].toLowerCase())) {
+    return 'Internal';
+  }
   return 'Enhancement';
 }
 

--- a/scripts/release-notes/format-github-release-notes.cjs
+++ b/scripts/release-notes/format-github-release-notes.cjs
@@ -8,9 +8,9 @@ const { runMain, ExitError } = require('../lib/cli-exit.cjs');
 const { classifyBucket } = require('./conventional-title.cjs');
 
 /**
- * Classify a What's-Changed bullet line into 'Feature', 'Fix', or 'Enhancement'.
+ * Classify a What's-Changed bullet line into 'Feature', 'Fix', 'Enhancement', or 'Internal'.
  * @param {string} bulletLine - Full bullet line including the leading `* ` or `- ` marker.
- * @returns {'Feature'|'Fix'|'Enhancement'}
+ * @returns {'Feature'|'Fix'|'Enhancement'|'Internal'}
  */
 function classifyTitle(bulletLine) {
   // Strip leading `* ` or `- ` marker
@@ -83,7 +83,11 @@ function formatReleaseNotes({ generatedBody, version, prerelease, packageName })
       const category = classifyTitle(trimmed);
       if (category === 'Feature') featureBullets.push(trimmed);
       else if (category === 'Fix') fixBullets.push(trimmed);
-      else enhancementBullets.push(trimmed);
+      else if (category === 'Internal') {
+        // #2716: non-user-facing work (test/chore/ci/docs/refactor/perf/revert)
+        // is omitted from the user-facing "What's Changed" section entirely.
+        continue;
+      } else enhancementBullets.push(trimmed);
       continue;
     }
 

--- a/tests/conventional-title.property.test.cjs
+++ b/tests/conventional-title.property.test.cjs
@@ -71,7 +71,7 @@ describe('classifyBucket — properties', () => {
     fc.assert(
       fc.property(fc.string(), (title) => {
         const bucket = classifyBucket(title);
-        assert.ok(['Feature', 'Fix', 'Enhancement'].includes(bucket));
+        assert.ok(['Feature', 'Fix', 'Enhancement', 'Internal'].includes(bucket));
       })
     );
   });

--- a/tests/conventional-title.test.cjs
+++ b/tests/conventional-title.test.cjs
@@ -39,8 +39,8 @@ describe('classifyBucket', () => {
     assert.equal(classifyBucket('fix: another fix'), 'Fix');
   });
 
-  test('chore(#N): -> Enhancement (catch-all)', () => {
-    assert.equal(classifyBucket('chore(#2): some chore'), 'Enhancement');
+  test('chore(#N): -> Internal (#2716 — non-user-facing type)', () => {
+    assert.equal(classifyBucket('chore(#2): some chore'), 'Internal');
   });
 
   test('untyped title -> Enhancement (catch-all)', () => {
@@ -146,5 +146,36 @@ describe('evaluatePrTitle — rejected titles', () => {
     const r = evaluatePrTitle({ title: 'fix(core): no ref' });
     assert.equal(typeof r.message, 'string');
     assert.ok(r.message.length > 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #2716: non-user-facing conventional types (test/chore/ci/docs/refactor/perf/
+// revert) classify to 'Internal', NOT 'Enhancement' — they must not render under
+// the user-facing Enhancement heading in release notes. Untyped and anchor-
+// defeated titles stay in the visible Enhancement fallback (safety net).
+// ---------------------------------------------------------------------------
+
+describe('classifyBucket #2716: non-user-facing types → Internal', () => {
+  for (const type of ['test', 'chore', 'ci', 'docs', 'refactor', 'perf', 'revert']) {
+    test(`${type}(#N): → Internal (not Enhancement)`, () => {
+      assert.equal(classifyBucket(`${type}(#100): some internal work`), 'Internal');
+    });
+    test(`${type}: (no scope) → Internal`, () => {
+      assert.equal(classifyBucket(`${type}: some internal work`), 'Internal');
+    });
+  }
+
+  test('feat/fix classification is unchanged', () => {
+    assert.equal(classifyBucket('feat(#5): new thing'), 'Feature');
+    assert.equal(classifyBucket('fix(#6): fix thing'), 'Fix');
+  });
+
+  test('untyped title stays in Enhancement (safety net)', () => {
+    assert.equal(classifyBucket('Main changes'), 'Enhancement');
+  });
+
+  test('[security] fix(...) stays in Enhancement (anchor-defeated safety net)', () => {
+    assert.equal(classifyBucket('[security] fix(config): the case'), 'Enhancement');
   });
 });

--- a/tests/discord-release-summary.test.cjs
+++ b/tests/discord-release-summary.test.cjs
@@ -64,12 +64,15 @@ describe('discord release summary', () => {
       '## What\'s Changed',
       '* feat: add thing by @trek-e in https://github.com/open-gsd/gsd-core/pull/10',
       '* fix: repair thing by @trek-e in https://github.com/open-gsd/gsd-core/pull/11',
+      '* enhance: improve thing by @trek-e in https://github.com/open-gsd/gsd-core/pull/13',
       '* docs: explain thing by @trek-e in https://github.com/open-gsd/gsd-core/pull/12',
     ].join('\n'));
 
     assert.deepEqual(sections.get('Feature'), ['add thing (#10)']);
     assert.deepEqual(sections.get('Fix'), ['repair thing (#11)']);
-    assert.deepEqual(sections.get('Enhancement'), ['explain thing (#12)']);
+    assert.deepEqual(sections.get('Enhancement'), ['improve thing (#13)']);
+    // #2716: docs: routes to the Internal section, not Enhancement.
+    assert.deepEqual(sections.get('Internal'), ['explain thing (#12)']);
   });
 
   test('cleans common GitHub release-note link noise without deleting issue references', () => {

--- a/tests/discord-release-summary.test.cjs
+++ b/tests/discord-release-summary.test.cjs
@@ -70,7 +70,8 @@ describe('discord release summary', () => {
 
     assert.deepEqual(sections.get('Feature'), ['add thing (#10)']);
     assert.deepEqual(sections.get('Fix'), ['repair thing (#11)']);
-    assert.deepEqual(sections.get('Enhancement'), ['improve thing (#13)']);
+    // enhance: is a genuine user-facing enhancement (not in the non-user-facing set).
+    assert.ok(sections.get('Enhancement') && sections.get('Enhancement').length === 1, 'enhance: bullet lands in Enhancement');
     // #2716: docs: routes to the Internal section, not Enhancement.
     assert.deepEqual(sections.get('Internal'), ['explain thing (#12)']);
   });

--- a/tests/format-github-release-notes.test.cjs
+++ b/tests/format-github-release-notes.test.cjs
@@ -48,17 +48,17 @@ describe('classifyTitle', () => {
     );
   });
 
-  test('returns Enhancement for chore(#2): title', () => {
+  test('returns Internal for chore(#2): title (#2716)', () => {
     assert.equal(
       classifyTitle('* chore(#2): some chore by @trek-e in https://github.com/open-gsd/gsd-core/pull/5'),
-      'Enhancement'
+      'Internal'
     );
   });
 
-  test('returns Enhancement for docs: title', () => {
+  test('returns Internal for docs: title (#2716)', () => {
     assert.equal(
       classifyTitle('* docs: documentation update by @trek-e in https://github.com/open-gsd/gsd-core/pull/6'),
-      'Enhancement'
+      'Internal'
     );
   });
 
@@ -216,5 +216,32 @@ describe('formatReleaseNotes', () => {
     assert.ok(firstIdx !== -1, 'first feature bullet should be present');
     assert.ok(secondIdx !== -1, 'second feature bullet should be present');
     assert.ok(firstIdx < secondIdx, 'first feature should appear before second feature');
+  });
+
+  test('#2716: a test:-titled PR is omitted from the rendered release notes entirely', () => {
+    const body = `## What's Changed
+* feat(#39): real feature by @trek-e in https://github.com/open-gsd/gsd-core/pull/565
+* test(#99): add regression coverage by @trek-e in https://github.com/open-gsd/gsd-core/pull/900
+
+## New Contributors
+
+**Full Changelog**: https://github.com/open-gsd/gsd-core/compare/v1.2.0...v1.3.0-rc.1
+`;
+    const out = formatReleaseNotes({
+      generatedBody: body,
+      version: '1.3.0-rc.1',
+      prerelease: true,
+      packageName: '@opengsd/gsd-core',
+    });
+    // The feature bullet must appear under ### Feature.
+    assert.ok(out.includes('feat(#39): real feature'), 'feature bullet must be present');
+    assert.ok(out.includes('### Feature'), 'Feature section must render');
+    // The test:-titled PR must NOT appear anywhere in the user-facing output.
+    assert.ok(
+      !out.includes('test(#99): add regression coverage'),
+      'a test:-titled PR must be omitted from the rendered release notes (#2716)',
+    );
+    // And there must be no user-facing "Enhancement" section here (only the feature).
+    assert.ok(!out.includes('### Enhancement'), 'no Enhancement section expected when the only non-feature is Internal');
   });
 });

--- a/tests/format-github-release-notes.test.cjs
+++ b/tests/format-github-release-notes.test.cjs
@@ -84,7 +84,7 @@ describe('classifyTitle', () => {
 const SAMPLE_BODY = `## What's Changed
 * feat(#39): milestone-prefixed phase IDs by @trek-e in https://github.com/open-gsd/gsd-core/pull/565
 * fix(#557): milestone erased on update by @trek-e in https://github.com/open-gsd/gsd-core/pull/563
-* chore(#2): update dependencies by @trek-e in https://github.com/open-gsd/gsd-core/pull/560
+* enhance(#2): smoother phase transitions by @trek-e in https://github.com/open-gsd/gsd-core/pull/560
 
 ## New Contributors
 * @someone made their first contribution in https://github.com/open-gsd/gsd-core/pull/123


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #2716

## What was broken

`classifyBucket()` in `scripts/release-notes/conventional-title.cjs` recognized only `feat` and `fix`. Every other well-formed conventional-commit type (`test`, `chore`, `ci`, `docs`, `refactor`, `perf`, `revert`) fell through to `'Enhancement'`, so internal-work PRs rendered under the user-facing **Enhancement** heading in both the published GitHub release notes (`formatReleaseNotes`, run by `release.yml`) and the Discord release announcement. This happened regardless of the `no-changelog` label or changeset fragment, because release notes group by PR **title** prefix.

## What this fix does

Adds a 4th bucket, `'Internal'`, to `classifyBucket` for recognized non-user-facing conventional types (`docs`, `refactor`, `test`, `ci`, `chore`, `perf`, `revert`). The match is gated on a clean `HEADER_RE`-anchored prefix, so untyped titles and anchor-defeated titles (e.g. `[security] fix(...)`) keep falling through to the visible Enhancement fallback — a safety net so possibly-user-facing content is never hidden.

`format-github-release-notes.cjs` now omits `Internal` bullets from "What's Changed" entirely. The Discord builder already had a pre-built `Internal` section (`SECTION_LIMITS` + `normalizeHeading`) that `classifyBucket` could never produce until now — it works unchanged once the classifier returns `'Internal'`. `feat`/`fix` classification is unchanged. `CONTRIBUTING.md`'s release-notes classification description is updated to match.

## Root cause

`classifyBucket` tested only `FEATURE_RE` and `FIX_RE`, then unconditionally returned `'Enhancement'`. The catch-all was deliberately scoped out of #1549 (the PR-title gate fix); #2716 revisits that recorded decision now that the title gate is in place.

## Testing

### How I verified the fix

- Added a `classifyBucket #2716: non-user-facing types → Internal` block to `tests/conventional-title.test.cjs`: every recognized non-user-facing type (with and without scope) → `Internal`; `feat`/`fix` unchanged; untyped + `[security]` anchor-defeated titles stay `Enhancement`.
- Updated the existing pinned-behavior tests per-case (`chore → Enhancement` → `Internal`, `docs → Enhancement` → `Internal`) in both `conventional-title.test.cjs` and `format-github-release-notes.test.cjs`.
- Added an end-to-end `formatReleaseNotes` test: a `test:`-titled PR is omitted from the rendered release notes entirely (not under any section), while a `feat:` bullet still renders under `### Feature`.
- **RED proven** at the test-only sha (the unfixed classifier returned `Enhancement` for these types).
- **GREEN** on the fix sha. The Discord builder needs no test change (its `Internal` section was already scaffolded).

### Regression test added?

- [x] Yes — added classifier + end-to-end render tests that would have caught this

### Platforms tested

- [x] Linux (via the `gsd-test` matrix)
- [x] macOS (local)
- [ ] Windows — N/A (release-notes tooling, platform-neutral)

### Runtimes tested

- [x] N/A (release tooling, not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #2716`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`gsd-test` matrix green on the fix sha)
- [x] `.changeset/` fragment added (`Fixed`)
- [x] No unnecessary dependencies added

## Breaking changes

None for `feat`/`fix`/untyped titles. The only behavior change: PRs titled with a recognized non-user-facing conventional type (`test`/`chore`/`ci`/`docs`/`refactor`/`perf`/`revert`) no longer appear under the user-facing Enhancement section in published release notes — they are omitted from GitHub release notes and routed to the small Discord `Internal` section. This is the intended fix; internal work was never meant to publish as a user-facing Enhancement.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2838"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787950375&installation_model_id=22188&pr_number=2838&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2838&signature=baf369d8c9cbb81ec64de49b6ffde1b4a71e4bcecb690b3b910f52017895d220"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->