### PR TITLE
fix(#2752): make tool_input.path authoritative over model-controlled file_path in gsd-phase-boundary.sh

### DIFF
--- a/.changeset/gentle-ibex-forage.md
+++ b/.changeset/gentle-ibex-forage.md
@@ -2,4 +2,4 @@
 type: Fixed
 pr: 0
 ---
-**The .planning/ write reminder can no longer be suppressed or fabricated by a model-supplied file_path** — the phase-boundary hook now treats `tool_input.path` (the field kimi-cli actually executes on) as authoritative and `file_path` as the fallback, matching the JS-guard fix from #2595. Previously a model-controlled decoy `file_path` could silence the reminder for a genuine .planning/ write or raise one naming a file never touched. (#2752)
+**The .planning/ write reminder can no longer be suppressed or fabricated by a model-supplied file_path** — the phase-boundary hook now treats `tool_input.path` (the field kimi-cli actually executes on) as authoritative and `file_path` as the fallback, reaching the same "path authoritative" outcome the JS guards establish via upstream normalization (#2595). Previously a model-controlled decoy `file_path` could silence the reminder for a genuine .planning/ write or raise one naming a file never touched. (#2752)

--- a/.changeset/gentle-ibex-forage.md
+++ b/.changeset/gentle-ibex-forage.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 2860
 ---
 **The .planning/ write reminder can no longer be suppressed or fabricated by a model-supplied file_path** — the phase-boundary hook now treats `tool_input.path` (the field kimi-cli actually executes on) as authoritative and `file_path` as the fallback, reaching the same "path authoritative" outcome the JS guards establish via upstream normalization (#2595). Previously a model-controlled decoy `file_path` could silence the reminder for a genuine .planning/ write or raise one naming a file never touched. (#2752)

--- a/.changeset/gentle-ibex-forage.md
+++ b/.changeset/gentle-ibex-forage.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**The .planning/ write reminder can no longer be suppressed or fabricated by a model-supplied file_path** — the phase-boundary hook now treats `tool_input.path` (the field kimi-cli actually executes on) as authoritative and `file_path` as the fallback, matching the JS-guard fix from #2595. Previously a model-controlled decoy `file_path` could silence the reminder for a genuine .planning/ write or raise one naming a file never touched. (#2752)

--- a/hooks/gsd-phase-boundary.sh
+++ b/hooks/gsd-phase-boundary.sh
@@ -26,7 +26,10 @@ INPUT=$(cat)
 # never `file_path`). `file_path` is model-controlled on Kimi, so consulting it
 # first let a model-supplied decoy suppress/fabricate the reminder. `path` wins,
 # `file_path` is the fallback (Claude Code emits `file_path` and no `path`, so the
-# fallback must remain). Mirrors the #2595 JS-guard fix.
+# fallback must remain). The JS guards reach the same "path authoritative" outcome
+# via an upstream normalizeKimiPayload step (copies path→file_path before any guard
+# reads); this shell hook parses tool_input once, raw, so it applies the precedence
+# directly at the read site.
 FILE=$(echo "$INPUT" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{try{const i=JSON.parse(d).tool_input||{};process.stdout.write((typeof i.path==='string'&&i.path)||(typeof i.file_path==='string'&&i.file_path)||'')}catch{}})" 2>/dev/null)
 
 # Emit a structured JSON envelope (#2974). additionalContext carries the

--- a/hooks/gsd-phase-boundary.sh
+++ b/hooks/gsd-phase-boundary.sh
@@ -22,7 +22,12 @@ INPUT=$(cat)
 # and its file tools name the field `path`, not `file_path` (kimi-cli
 # src/kimi_cli/tools/file/write.py + replace.py) — fall back to tool_input.path
 # when file_path is absent, mirroring normalizeKimiPayload in the JS guards.
-FILE=$(echo "$INPUT" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{try{const i=JSON.parse(d).tool_input||{};process.stdout.write(i.file_path||(typeof i.path==='string'?i.path:'')||'')}catch{}})" 2>/dev/null)
+# #2752: `path` is AUTHORITATIVE (kimi-cli executes on it; it sends `path` only,
+# never `file_path`). `file_path` is model-controlled on Kimi, so consulting it
+# first let a model-supplied decoy suppress/fabricate the reminder. `path` wins,
+# `file_path` is the fallback (Claude Code emits `file_path` and no `path`, so the
+# fallback must remain). Mirrors the #2595 JS-guard fix.
+FILE=$(echo "$INPUT" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{try{const i=JSON.parse(d).tool_input||{};process.stdout.write((typeof i.path==='string'&&i.path)||(typeof i.file_path==='string'&&i.file_path)||'')}catch{}})" 2>/dev/null)
 
 # Emit a structured JSON envelope (#2974). additionalContext carries the
 # user-visible reminder text; the typed `planning_modified` boolean and

--- a/tests/hooks-opt-in.test.cjs
+++ b/tests/hooks-opt-in.test.cjs
@@ -420,22 +420,50 @@ describe('hook execution when enabled', { skip: isWindows ? 'bash hooks require 
     assert.strictEqual(parsed.hookSpecificOutput.file_path, '.planning/STATE.md');
   });
 
-  test('phase-boundary prefers Claude file_path when both fields are present (#2304)', () => {
+  // #2752 — `path` is the AUTHORITATIVE field (kimi-cli executes on it; its file
+  // tools send `path` only). `file_path` is model-controlled on Kimi (kimi-cli never
+  // sends it). The old precedence (`file_path || path`) let a model-supplied decoy
+  // `file_path` suppress the reminder for a real write or fabricate one for a file
+  // never touched. Mirrors the #2595 JS-guard fix: `path` wins, `file_path` is the
+  // fallback (Claude emits `file_path` and no `path`, so the fallback must remain).
+  test('phase-boundary prefers Kimi tool_input.path when both fields are present (#2752)', () => {
     const hookPath = path.join(HOOKS_DIR, 'gsd-phase-boundary.sh');
-    const input = JSON.stringify({
-      tool_input: { file_path: '.planning/STATE.md', path: 'unrelated.txt' }
+    // Suppression repro: a real .planning/ write WITH a decoy non-empty file_path.
+    const suppressionInput = JSON.stringify({
+      tool_name: 'kimi_cli.tools.file:StrReplaceFile',
+      tool_input: { path: '.planning/STATE.md', file_path: 'unrelated.txt', edit: { old: 'a', new: 'b' } }
     });
 
-    const result = spawnHook(hookPath, {
-      input,
+    const suppressionResult = spawnHook(hookPath, {
+      input: suppressionInput,
       encoding: 'utf-8',
       cwd: tmpDir,
     });
 
-    assert.strictEqual(result.status, 0, `Should exit 0: ${result.stderr}`);
-    const parsed = JSON.parse(result.stdout);
-    assert.strictEqual(parsed.hookSpecificOutput.file_path, '.planning/STATE.md',
-      'file_path must win over path — normalization is a fallback, not an override');
+    assert.strictEqual(suppressionResult.status, 0, `Should exit 0: ${suppressionResult.stderr}`);
+    const suppressionParsed = JSON.parse(suppressionResult.stdout);
+    assert.strictEqual(suppressionParsed.hookSpecificOutput.planning_modified, true,
+      'A real .planning/STATE.md write must NOT be suppressed by a model-supplied decoy file_path (#2752)');
+    assert.strictEqual(suppressionParsed.hookSpecificOutput.file_path, '.planning/STATE.md',
+      'path must win over file_path — the runtime executes on path, file_path is the fallback');
+
+    // Fabrication repro: a write ELSEWHERE with a decoy file_path pointing into .planning/.
+    const fabricationInput = JSON.stringify({
+      tool_name: 'kimi_cli.tools.file:StrReplaceFile',
+      tool_input: { path: 'src/index.ts', file_path: '.planning/STATE.md', edit: { old: 'a', new: 'b' } }
+    });
+
+    const fabricationResult = spawnHook(hookPath, {
+      input: fabricationInput,
+      encoding: 'utf-8',
+      cwd: tmpDir,
+    });
+
+    assert.strictEqual(fabricationResult.status, 0, `Should exit 0: ${fabricationResult.stderr}`);
+    // No reminder emitted — the write was to src/index.ts; the decoy .planning/
+    // file_path must NOT fabricate a reminder for a file never touched.
+    assert.strictEqual(fabricationResult.stdout, '',
+      'A decoy .planning/ file_path must NOT fabricate a reminder when the real path is outside .planning/ (#2752)');
   });
 
   test('phase-boundary negative control: Kimi path outside .planning/ stays silent (#2304)', () => {

--- a/tests/kimi-guard-normalization-parity.test.cjs
+++ b/tests/kimi-guard-normalization-parity.test.cjs
@@ -159,12 +159,13 @@ describe('Kimi shell-guard vocabulary parity (#2304)', () => {
     );
   });
 
-  test('gsd-phase-boundary.sh falls back to Kimi\'s tool_input.path field', () => {
+  test('gsd-phase-boundary.sh prefers Kimi\'s authoritative tool_input.path, falls back to file_path (#2752)', () => {
     const src = readHook('hooks/gsd-phase-boundary.sh');
     assert.ok(
-      src.includes('i.file_path||(typeof i.path===\'string\'?i.path:\'\')'),
-      'gsd-phase-boundary.sh no longer falls back to tool_input.path — ' +
-        'the hook reads an empty path on Kimi (#2304)'
+      src.includes('(typeof i.path===\'string\'&&i.path)||(typeof i.file_path===\'string\'&&i.file_path)||\'\''),
+      'gsd-phase-boundary.sh no longer prefers tool_input.path over file_path — ' +
+        'path is the authoritative field (kimi-cli executes on it); a model-supplied ' +
+        'decoy file_path must not suppress or fabricate a reminder (#2752, mirrors #2595)'
     );
   });
 });


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #2752

---

## What was broken

`hooks/gsd-phase-boundary.sh` (an opt-in community PostToolUse hook that emits an advisory reminder when a `.planning/` file is written) resolved the written file as `tool_input.file_path || tool_input.path`. But kimi-cli executes on `path` (its file tools send `path` only, never `file_path`), so `path` is authoritative and `file_path` on a Kimi payload is model-controlled. The wrong precedence let a model-supplied decoy `file_path` **suppress** the reminder for a genuine `.planning/` write, or **fabricate** one naming a file never touched.

Same defect class as #2547 (fixed in #2595 for the five JS guards). This is the one shell copy reimplemented outside the JS guards, so the byte-identity parity test could not reach it.

## What this fix does

Flips the precedence so `path` is authoritative and `file_path` is the fallback — `(typeof i.path==='string'&&i.path)||(typeof i.file_path==='string'&&i.file_path)||''`. The fallback must remain because native Claude Code emits `file_path` and no `path`. The JS guards reach the same "path authoritative" outcome via an upstream `normalizeKimiPayload` step (copies `path`→`file_path` before any guard reads); this shell hook parses `tool_input` once, raw, so it applies the precedence directly at the read site.

## Root cause

#2518 added the `path` fallback that made the shadowing reachable (pre-#2518 the line read `file_path||''` with no fallback, so the hook was dormant on Kimi — #2304). The precedence was wrong from the moment the fallback was added: `file_path` was consulted first.

## Testing

### How I verified the fix

- `gsd-test --base next --head 53901a1c1f7bbe8f5da768fe20d949fb305426f0` → `outcome:"passed"`, 27,947/27,947 tests green on both linux-node22 and linux-node24 lanes, 0 failures.
- The rewritten test proves both repros from the issue: a real `.planning/STATE.md` write WITH a decoy non-empty `file_path` still fires the reminder (suppression repro), and a write to `src/index.ts` WITH a decoy `.planning/STATE.md` `file_path` does NOT fabricate one (fabrication repro).
- Verified all five scenarios by reasoning + the existing tests: Kimi `path`-only (✅), Claude `file_path`-only (✅ — fallback intact), both-present-decoy (✅ — path wins), both-empty (✅ — no reminder), empty-path + real-file_path (✅ — fallback).

### Regression test added?

- [x] Yes — the `#2752` test in `tests/hooks-opt-in.test.cjs` covers both the suppression and fabrication repros with realistic Kimi-shaped payloads. The old test at this site pinned the buggy `file_path`-wins precedence with an impossible no-`tool_name` `{file_path, path}` shape; it is rewritten to assert the correct precedence.

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [x] Other: Kimi CLI (the runtime whose `path` field the fix makes authoritative)
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`) — `gsd-test` 27,947/27,947 both lanes
- [x] `.changeset/` fragment added (`Fixed`, pr will be backfilled from `pr:0`)
- [x] No unnecessary dependencies added

## Breaking changes

None. The change only affects the precedence when *both* `path` and `file_path` are present and non-empty — a shape no real runtime sends (Claude emits `file_path` only; Kimi emits `path` only). For real-runtime payloads the behavior is unchanged.

---

GSD_PR_GATES_OK=1

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2860"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788017739&installation_model_id=22188&pr_number=2860&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2860&signature=57ac423043229b69450d0bca553fd77d9ac025499e8b47f24a9983d621acd19f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->