### PR TITLE
fix(#2754): make parseStateMd CRLF-safe — frontmatter no longer drops on Windows-authored STATE.md

### DIFF
--- a/.changeset/eager-dogs-jump.md
+++ b/.changeset/eager-dogs-jump.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**The statusline now renders GSD state correctly on Windows-authored (CRLF) STATE.md** — `parseStateMd` no longer drops the entire frontmatter block on CRLF input. The fence regex and downstream splits now accept CRLF line endings, matching the canonical `extractFrontmatter` parser. Previously a CRLF STATE.md silently produced an empty GSD-state segment (no status, phase, or milestone) with no error. (#2754)

--- a/.changeset/eager-dogs-jump.md
+++ b/.changeset/eager-dogs-jump.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 2865
 ---
 **The statusline now renders GSD state correctly on Windows-authored (CRLF) STATE.md** — `parseStateMd` no longer drops the entire frontmatter block on CRLF input. The fence regex and downstream splits now accept CRLF line endings, matching the canonical `extractFrontmatter` parser. Previously a CRLF STATE.md silently produced an empty GSD-state segment (no status, phase, or milestone) with no error. (#2754)

--- a/hooks/gsd-statusline.js
+++ b/hooks/gsd-statusline.js
@@ -143,12 +143,15 @@ function readGsdState(dir) {
 function parseStateMd(content) {
   const state = {};
 
-  // YAML frontmatter between --- markers (anchored at file start)
-  const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
+  // YAML frontmatter between --- markers (anchored at file start).
+  // #2754: \r?\n (not literal \n) so a CRLF STATE.md (Windows-authored) parses
+  // identically to LF — pre-fix the literal-\n fence dropped the ENTIRE block.
+  // Mirrors the CRLF-safe extractFrontmatter in src/frontmatter.cts.
+  const fmMatch = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
   if (fmMatch) {
     const fm = fmMatch[1];
     // Top-level scalar key: value
-    for (const line of fm.split('\n')) {
+    for (const line of fm.split(/\r?\n/)) {
       const m = line.match(/^(\w+):\s*(.+)/);
       if (!m) continue;
       const [, key, val] = m;
@@ -169,10 +172,10 @@ function parseStateMd(content) {
       const items = npFlowMatch[1].split(',').map(s => s.trim().replace(/^["']|["']$/g, '')).filter(Boolean);
       state.nextPhases = items.length > 0 ? items : null;
     } else {
-      const npBlockMatch = fm.match(/^next_phases:\s*\n((?:[ \t]*-[ \t]*[^\n]+\n?)*)/m);
+      const npBlockMatch = fm.match(/^next_phases:\s*\r?\n((?:[ \t]*-[ \t]*[^\r\n]+\r?\n?)*)/m);
       if (npBlockMatch) {
         const items = npBlockMatch[1]
-          .split('\n')
+          .split(/\r?\n/)
           .map(line => line.match(/^[ \t]*-[ \t]*(.+)$/))
           .filter(Boolean)
           .map(m => m[1].trim().replace(/^["']|["']$/g, ''))
@@ -181,7 +184,7 @@ function parseStateMd(content) {
       }
     }
     // progress nested block: completed_phases / total_phases / percent (2-space indent)
-    const progMatch = fm.match(/^progress:\s*\n((?:[ \t]+\w+:.+\n?)+)/m);
+    const progMatch = fm.match(/^progress:\s*\r?\n((?:[ \t]+\w+:.+\r?\n?)+)/m);
     if (progMatch) {
       const cp = progMatch[1].match(/^[ \t]+completed_phases:\s*(\d+)/m);
       const tp = progMatch[1].match(/^[ \t]+total_phases:\s*(\d+)/m);

--- a/tests/gsd-statusline.test.cjs
+++ b/tests/gsd-statusline.test.cjs
@@ -237,6 +237,40 @@ describe('parseStateMd', () => {
     assert.equal(parseStateMd(crlf(lf)).status, null);
     assert.equal(parseStateMd(crlf(lf)).milestone, null);
   });
+
+  // #2754 (Generative-Fix Divergence guard, CLAUDE.md "parallel surfaces sharing a
+  // parser"): parseStateMd and the canonical extractFrontmatter both derive GSD
+  // state from the same STATE.md frontmatter, and they diverged once already (this
+  // very CRLF bug). Pin the overlap so a future divergence on a scalar shape or
+  // line ending is caught here, not in a live Windows report.
+  const { extractFrontmatter } = require('../gsd-core/bin/lib/frontmatter.cjs');
+
+  test('parseStateMd frontmatter-derived fields agree with extractFrontmatter (LF + CRLF, #2754)', () => {
+    const lf = [
+      '---',
+      'status: executing',
+      'milestone: v1.9',
+      'milestone_name: Code Quality',
+      'active_phase: 4',
+      'next_action: execute',
+      '---',
+      '',
+      '# State',
+      'Phase: 1 of 5 (fix-graphiti-deployment)',
+    ].join('\n');
+
+    for (const [label, content] of [['LF', lf], ['CRLF', crlf(lf)]]) {
+      const fm = extractFrontmatter(content);
+      const st = parseStateMd(content);
+      // extractFrontmatter yields the raw frontmatter object; parseStateMd projects
+      // a subset onto its own keys. Assert the projection matches the raw values.
+      assert.equal(st.status, fm.status, `status mismatch (${label})`);
+      assert.equal(st.milestone, fm.milestone, `milestone mismatch (${label})`);
+      assert.equal(st.milestoneName, fm.milestone_name, `milestone_name mismatch (${label})`);
+      assert.equal(st.activePhase, String(fm.active_phase), `active_phase mismatch (${label})`);
+      assert.equal(st.nextAction, fm.next_action, `next_action mismatch (${label})`);
+    }
+  });
 });
 
 // ─── formatGsdState ─────────────────────────────────────────────────────────

--- a/tests/gsd-statusline.test.cjs
+++ b/tests/gsd-statusline.test.cjs
@@ -146,6 +146,97 @@ describe('parseStateMd', () => {
     assert.equal(s.nextAction, 'execute');
     assert.deepEqual(s.nextPhases, ['4.5', '4.6']);
   });
+
+  // #2754 — the frontmatter fence regex and downstream splits used literal \n,
+  // so a CRLF STATE.md dropped the ENTIRE frontmatter block (every field absent).
+  // The invariant is CRLF/LF parity — parseStateMd must yield the same state for
+  // the same content regardless of line endings, matching the canonical
+  // extractFrontmatter parser (src/frontmatter.cts), which is CRLF-safe.
+  const crlf = (lfContent) => lfContent.replace(/\n/g, '\r\n');
+
+  test('parses full YAML frontmatter identically under CRLF (#2754)', () => {
+    const lf = [
+      '---',
+      'status: executing',
+      'milestone: v1.9',
+      'milestone_name: Code Quality',
+      'active_phase: 4',
+      'next_action: execute',
+      '---',
+      '',
+      '# State',
+      'Phase: 1 of 5 (fix-graphiti-deployment)',
+    ].join('\n');
+
+    const lfState = parseStateMd(lf);
+    const crlfState = parseStateMd(crlf(lf));
+    assert.deepStrictEqual(crlfState, lfState,
+      'CRLF STATE.md must parse identically to LF — pre-fix the entire frontmatter block was dropped (#2754)');
+    // pin the specific fields the issue names so a vacuous deepEqual({},{}) can't pass:
+    assert.equal(crlfState.status, 'executing');
+    assert.equal(crlfState.milestone, 'v1.9');
+    assert.equal(crlfState.milestoneName, 'Code Quality');
+    assert.equal(crlfState.activePhase, '4');
+    assert.equal(crlfState.nextAction, 'execute');
+    assert.equal(crlfState.phaseNum, '1');
+    assert.equal(crlfState.phaseTotal, '5');
+  });
+
+  test('parses next_phases flow-array form identically under CRLF (#2754)', () => {
+    const lf = [
+      '---',
+      'next_phases: [4.5, 4.6]',
+      '---',
+    ].join('\n');
+
+    assert.deepStrictEqual(parseStateMd(crlf(lf)), parseStateMd(lf));
+    assert.deepEqual(parseStateMd(crlf(lf)).nextPhases, ['4.5', '4.6']);
+  });
+
+  test('parses next_phases block-list form identically under CRLF (#2754)', () => {
+    const lf = [
+      '---',
+      'next_phases:',
+      '  - 4.5',
+      '  - 4.6',
+      '---',
+    ].join('\n');
+
+    assert.deepStrictEqual(parseStateMd(crlf(lf)).nextPhases, parseStateMd(lf).nextPhases,
+      'block-list regex used a literal \\n — CRLF must still parse the list');
+    assert.deepEqual(parseStateMd(crlf(lf)).nextPhases, ['4.5', '4.6']);
+  });
+
+  test('parses the progress nested block identically under CRLF (#2754)', () => {
+    const lf = [
+      '---',
+      'progress:',
+      '  completed_phases: 3',
+      '  total_phases: 5',
+      '  percent: 60',
+      '---',
+    ].join('\n');
+
+    assert.deepStrictEqual(parseStateMd(crlf(lf)), parseStateMd(lf),
+      'progress block regex used a literal \\n — CRLF must still parse completed/total/percent');
+    assert.equal(parseStateMd(crlf(lf)).completedPhases, '3');
+    assert.equal(parseStateMd(crlf(lf)).totalPhases, '5');
+    assert.equal(parseStateMd(crlf(lf)).percent, '60');
+  });
+
+  test('treats literal "null" values as null identically under CRLF (#2754)', () => {
+    const lf = [
+      '---',
+      'status: null',
+      'milestone: null',
+      'milestone_name: null',
+      '---',
+    ].join('\n');
+
+    assert.deepStrictEqual(parseStateMd(crlf(lf)), parseStateMd(lf));
+    assert.equal(parseStateMd(crlf(lf)).status, null);
+    assert.equal(parseStateMd(crlf(lf)).milestone, null);
+  });
 });
 
 // ─── formatGsdState ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #2754

---

## What was broken

`parseStateMd` in `hooks/gsd-statusline.js` parsed STATE.md YAML frontmatter with a hardcoded literal `\n` fence regex (`/^---\n([\s\S]*?)\n---/`) and literal-`\n` splits. On a CRLF (Windows-authored) STATE.md the opening fence is `---\r\n`, so the pattern never matched and **the entire frontmatter block failed to parse** — not one field. Every statusline value (status, phase, milestone, next_phases, progress) was silently absent. The production parser `extractFrontmatter` (`src/frontmatter.cts`) was already CRLF-safe, so the two derivation paths for the same STATE.md fields diverged on CRLF.

Same literal-`\n` CRLF class as #1658, #1668, #2206, #2449, #2450, #2694.

## What this fix does

Makes each CRLF-sensitive point in `parseStateMd` use `\r?\n` / `/\r?\n/` splits, mirroring the canonical `extractFrontmatter`: the fence regex, the scalar-line split, the `next_phases` block-list regex, and the `progress` nested-block regex. LF behavior is unchanged (`\r?\n` is a superset of `\n`).

## Root cause

Long-standing literal-`\n` assumption. The body-fallback `Phase:`/`Status:` parses were already CRLF-safe (they use the `/m` flag), but the frontmatter fence and block-list/progress regexes were not.

## Testing

### How I verified the fix

- `gsd-test --base next --head fa89152097d5fce3248ba51a5620b270e47e9c6b` → `outcome:"passed"`, full matrix green, 0 failures.
- Local repro confirmed: `parseStateMd` of the LF and CRLF forms of a full STATE.md now yield byte-identical state (status, milestone, milestoneName, activePhase, nextAction, nextPhases flow + block, progress completed/total/percent, phaseNum/Total/Name).

### Regression test added?

- [x] Yes — `tests/gsd-statusline.test.cjs` adds CRLF/LF parity tests for full frontmatter, `next_phases` flow + block forms, the `progress` block, and null handling. The invariant is `assert.deepStrictEqual(parseStateMd(crlf), parseStateMd(lf))` with per-field pins so a vacuous `{}`==`{}` can't pass. Also adds a **cross-parser parity test** pinning `parseStateMd`'s frontmatter-derived fields against the canonical `extractFrontmatter` (LF + CRLF) — the structural guard against the divergence that caused this bug (CLAUDE.md parallel-surfaces rule).

### Platforms tested

- [ ] macOS
- [x] Windows (the fix targets Windows-authored CRLF STATE.md; CRLF/LF parity asserted)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (the statusline is runtime-agnostic; the bug is line-ending-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes
- [x] Regression test added (CRLF/LF parity + cross-parser parity)
- [x] All existing tests pass — `gsd-test` full matrix green
- [x] `.changeset/` fragment added (`Fixed`, pr backfilled)
- [x] No unnecessary dependencies added

## Breaking changes

None. `\r?\n` matches `\n`, so LF STATE.md parses identically to before. CRLF STATE.md now parses correctly instead of producing an empty state.

---

GSD_PR_GATES_OK=1

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2865"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788022873&installation_model_id=22188&pr_number=2865&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2865&signature=c647db3fd6e73f32e1f286198c23f9d3447a93c374c8f91458b95a697dbf67e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->