### PR TITLE
test(#2877): property-test parsePhaseFromProse name precedence

### DIFF
--- a/tests/effort-surface-axis.test.cjs
+++ b/tests/effort-surface-axis.test.cjs
@@ -388,11 +388,6 @@ describe('#2481 — ADR-443 mechanism callers, as they actually exist', () => {
 });
 
 describe('#2481 review workflow resolves effort per reviewer', () => {
-  const reviewMd = fs.readFileSync(
-    path.join(REPO_ROOT, 'gsd-core', 'workflows', 'review.md'),
-    'utf8',
-  );
-
   test('shipped orchestration invokes resolve-execution — the grep ADR-443 said returned zero hits', () => {
     // Phase 5b (#2799) moved the call out of review.md's per-lane bash and into the review-lane
     // route, which resolves effort once per selected lane through the SAME surface. ADR-443's

--- a/tests/fix-2358-review-temp-path-scoping.test.cjs
+++ b/tests/fix-2358-review-temp-path-scoping.test.cjs
@@ -31,8 +31,6 @@ const path = require('node:path');
 const { cleanup } = require('./helpers.cjs');
 
 const REVIEW_MD = path.join(__dirname, '..', 'gsd-core', 'workflows', 'review.md');
-const SHIP_MD = path.join(__dirname, '..', 'gsd-core', 'workflows', 'ship.md');
-const REVIEWER_INSTANCES_MD = path.join(__dirname, '..', 'gsd-core', 'references', 'reviewer-instances.md');
 
 describe('#2358 review.md temp paths are run-scoped, not phase-only', () => {
   const content = fs.readFileSync(REVIEW_MD, 'utf-8');

--- a/tests/opencode-review-reconstruction.property.test.cjs
+++ b/tests/opencode-review-reconstruction.property.test.cjs
@@ -22,7 +22,6 @@
 'use strict';
 
 const { describe, test } = require('node:test');
-const assert = require('node:assert/strict');
 const fc = require('fast-check');
 
 const { handleOpencodeOutput } = require('../gsd-core/bin/lib/review-lane-runner.cjs');

--- a/tests/phase-id.test.cjs
+++ b/tests/phase-id.test.cjs
@@ -781,3 +781,197 @@ describe('#2232 continuation cap — properties', () => {
     );
   });
 });
+
+// ─── #2736 prose name-precedence property tests (fast-check) ─────────────────
+
+// #2821's only behavioral delta in parsePhaseFromProse is that a GENUINE
+// (non-status) em-dash name now takes precedence over a parenthetical name;
+// phase-token extraction and totality were unchanged by that commit.
+//
+// P1 and P9 are the delta guards: both fail against the pre-#2821 paren-first
+// parser (verified by the standalone mutation check against
+// parsePhaseFromProseOLD), because they each require the dash name to win
+// over a co-present parenthetical — P9 additionally exercises the
+// paren-stripped separator search, since the losing parenthetical itself
+// contains an em-dash.
+//
+// P2, P3, P4 are characterization tests: they pin currently-true precedence
+// contracts (status tails and em-dash-inside-parens both lose to a
+// parenthetical name) that the pre-#2821 parser ALSO satisfied, so they guard
+// against future regressions rather than proving the #2821 delta.
+//
+// P5-P8 pin totality and phase-token extraction, neither of which #2821
+// changed.
+
+const phaseToken = fc
+  .tuple(
+    digitRun(1, 3),
+    fc.option(fc.constantFrom(...'ABCDEFGHIJKLMNOPQRSTUVWXYZ'), { nil: '' }),
+    fc.array(digitRun(1, 2), { maxLength: 2 }),
+  )
+  .map(([lead, letter, decimals]) => `${lead}${letter}${decimals.map((d) => `.${d}`).join('')}`);
+
+const STATUSY =
+  /^(?:completed?|executing|not started|planning|planned|ready(?:\s+to\s+\S.{0,50})?|done|in progress|blocked|paused|verifying)$/i;
+
+const genuineName = fc
+  .string({
+    unit: fc.constantFrom(
+      'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
+      'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+      ' ', 'A', 'B', 'C',
+    ),
+    minLength: 1,
+    maxLength: 40,
+  })
+  .map((s) => s.trim())
+  .filter((s) => s.length > 0 && !STATUSY.test(s) && !/^milestone\s*:/i.test(s) && !/^[A-Z][A-Z0-9_-]*$/.test(s));
+
+const asideText = fc
+  .string({
+    unit: fc.constantFrom(...'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 -_'),
+    minLength: 1,
+    maxLength: 30,
+  })
+  .map((s) => s.trim())
+  .filter((s) => s.length > 0);
+
+const statusTail = fc.constantFrom(
+  'COMPLETE', 'COMPLETED', 'EXECUTING', 'READY', 'DONE', 'IN PROGRESS',
+  'BLOCKED', 'PAUSED', 'VERIFYING', 'PLANNING', 'PLANNED', 'NOT STARTED',
+);
+
+const capsToken = fc.string({
+  unit: fc.constantFrom(...'ABCDEFGHIJKLMNOPQRSTUVWXYZ'),
+  minLength: 2,
+  maxLength: 12,
+});
+
+describe('#2736 prose name precedence — properties', () => {
+  test('P1 dash name beats a trailing parenthetical aside', () => {
+    fc.assert(
+      fc.property(phaseToken, genuineName, asideText, (tok, name, aside) => {
+        const p = phaseId.parsePhaseFromProse(`${tok} — ${name} (${aside})`);
+        return p.phase === tok && p.name === name;
+      }),
+    );
+  });
+
+  test('P2 a status-keyword tail never displaces a parenthetical name', () => {
+    fc.assert(
+      fc.property(phaseToken, genuineName, statusTail, (tok, name, status) => {
+        const p = phaseId.parsePhaseFromProse(`${tok} (${name}) — ${status}`);
+        return p.phase === tok && p.name === name;
+      }),
+    );
+  });
+
+  test('P3 an em-dash inside parens is not mistaken for the separator', () => {
+    fc.assert(
+      fc.property(phaseToken, genuineName, genuineName, statusTail, (tok, a, b, status) => {
+        const p = phaseId.parsePhaseFromProse(`${tok} (${a} — ${b}) — ${status}`);
+        return p.phase === tok && p.name === `${a} — ${b}`;
+      }),
+    );
+  });
+
+  test('P4 a lone ALL-CAPS tail loses to a parenthetical name', () => {
+    fc.assert(
+      fc.property(phaseToken, genuineName, capsToken, (tok, name, caps) => {
+        const p = phaseId.parsePhaseFromProse(`${tok} (${name}) — ${caps}`);
+        return p.phase === tok && p.name === name;
+      }),
+    );
+  });
+
+  test('P5 parsePhaseFromProse is total over arbitrary input', () => {
+    fc.assert(
+      fc.property(fc.string({ maxLength: 300 }), (s) => {
+        const p = phaseId.parsePhaseFromProse(s);
+        return (
+          p !== null &&
+          typeof p === 'object' &&
+          (p.phase === null || typeof p.phase === 'string') &&
+          (p.name === null || typeof p.name === 'string')
+        );
+      }),
+    );
+  });
+
+  test('P6 pathological paren/em-dash runs stay total', () => {
+    fc.assert(
+      fc.property(fc.integer({ min: 1, max: 400 }), (n) => {
+        const p = phaseId.parsePhaseFromProse(`3 ${'('.repeat(n)}${'—'.repeat(n)}`);
+        return p.phase === '3' && (p.name === null || typeof p.name === 'string');
+      }),
+    );
+  });
+
+  test('P7 the phase token round-trips out of first-party prose shapes', () => {
+    fc.assert(
+      fc.property(phaseToken, genuineName, (tok, name) =>
+        phaseId.parsePhaseFromProse(`${tok} (${name})`).phase === tok &&
+        phaseId.parsePhaseFromProse(`Phase ${tok} — ${name}`).phase === tok &&
+        phaseId.parsePhaseFromProse(`${tok}`).phase === tok,
+      ),
+    );
+  });
+
+  test('P8 a milestone-prefixed token still yields the bare phase', () => {
+    fc.assert(
+      fc.property(
+        fc.string({ unit: fc.constantFrom(...'ABCDEFGHIJKLMNOPQRSTUVWXYZ'), minLength: 1, maxLength: 3 }),
+        phaseToken,
+        genuineName,
+        (ms, tok, name) => phaseId.parsePhaseFromProse(`${ms}1-${tok} (${name})`).phase === tok,
+      ),
+    );
+  });
+
+  test('P9 a genuine dash name wins over a paren containing an em-dash', () => {
+    fc.assert(
+      fc.property(phaseToken, genuineName, genuineName, genuineName, (tok, a, b, name) => {
+        const p = phaseId.parsePhaseFromProse(`${tok} (${a} — ${b}) — ${name}`);
+        return p.phase === tok && p.name === name;
+      }),
+    );
+  });
+
+  // The STATUSY regex above is a test-local mirror of the private, unexported
+  // STATUSY_TAIL_RE in src/phase-id.cts — it is not imported, only
+  // reimplemented. If a future edit to the implementation's status
+  // vocabulary drifts from this mirror, the properties above that rely on
+  // STATUSY (P2, genuineName's exclusion filter, etc.) would silently weaken
+  // rather than fail. This test pins the mirror to OBSERVABLE parser
+  // behavior instead of source text, so a divergence fails loudly here.
+  test('the test-local STATUSY mirror still agrees with the parser (divergence guard)', () => {
+    const statusVocab = [
+      'complete', 'completed', 'executing', 'not started', 'planning',
+      'planned', 'ready', 'done', 'in progress', 'blocked', 'paused',
+      'verifying',
+    ];
+
+    for (const w of statusVocab) {
+      assert.equal(
+        phaseId.parsePhaseFromProse(`3 (Real Name) — ${w}`).name,
+        'Real Name',
+        `expected status word "${w}" to lose to the parenthetical name`,
+      );
+      const upper = w.toUpperCase();
+      assert.equal(
+        phaseId.parsePhaseFromProse(`3 (Real Name) — ${upper}`).name,
+        'Real Name',
+        `expected status word "${upper}" to lose to the parenthetical name`,
+      );
+    }
+
+    const nonStatusNames = ['Foundation', 'Native Hotkey', 'setup work'];
+    for (const n of nonStatusNames) {
+      assert.equal(
+        phaseId.parsePhaseFromProse(`3 — ${n} (aside)`).name,
+        n,
+        `expected non-status name "${n}" to win as the dash name over the parenthetical aside`,
+      );
+    }
+  });
+});

--- a/tests/review-default-reviewers-workflow.test.cjs
+++ b/tests/review-default-reviewers-workflow.test.cjs
@@ -165,11 +165,6 @@ describe('review workflow source-grounding requirement in build_prompt (#1318)',
 
 const { describe, test } = require('node:test');
 const assert = require('node:assert/strict');
-const fs = require('node:fs');
-const path = require('node:path');
-
-const reviewPath = path.resolve(__dirname, '..', 'gsd-core', 'workflows', 'review.md');
-const read = () => fs.readFileSync(reviewPath, 'utf-8');
 
 describe('bug #687 → #2073: agy print mode is bounded, and its fallback chain fires', () => {
   // Phase 5b (#2799) moved the agy invocation out of review.md's bash into the declared lane plus
@@ -345,23 +340,6 @@ describe('#1698 regression: codex review is captured via --output-last-message, 
 
 const { describe, test } = require('node:test');
 const assert = require('node:assert/strict');
-const fs = require('node:fs');
-const path = require('node:path');
-
-const reviewPath = path.resolve(__dirname, '..', 'gsd-core', 'workflows', 'review.md');
-const read = () => fs.readFileSync(reviewPath, 'utf-8');
-
-// Isolate the base OpenCode reviewer block (heading -> next reviewer heading) so
-// assertions about its stderr handling don't accidentally match sibling reviewers
-// (gemini/claude/coderabbit/qwen legitimately use /dev/null).
-function openCodeBlock() {
-  const c = read();
-  const start = c.indexOf('**OpenCode (via GitHub Copilot):**');
-  assert.notStrictEqual(start, -1, 'review.md must contain the base OpenCode reviewer block');
-  const rest = c.slice(start + 1);
-  const nextHeading = rest.search(/\n\*\*[A-Z][^\n]*:\*\*/);
-  return nextHeading === -1 ? c.slice(start) : c.slice(start, start + 1 + nextHeading);
-}
 
 describe('bug #1936: OpenCode reviewer must not silently yield an empty review', () => {
   // The agent can end its turn with ZERO output tokens, and `--format default` then drops the


### PR DESCRIPTION
## Test-only: property coverage for `parsePhaseFromProse` name precedence

> Adapted from `fix.md`. Not using it verbatim because that template requires the linked issue to carry `confirmed-bug`; this is a `type: chore` test-quality task, and there is no `chore.md` PR template. Same structure as the precedent test-only PR #2436.

---

## Linked Issue

Fixes #2877

---

## What this adds that `next` does not have

#2821 (merged as `82ca13f5`) reworked `parsePhaseFromProse`'s **name precedence**: dash-vs-parenthetical choice, `STATUSY_TAIL_RE` status tails, `Milestone:` tails, a separator search performed on a paren-stripped copy, and a lone-ALL-CAPS-tail rule. All of it landed guarded only by hand-picked examples.

This adds nine fast-check properties plus a divergence guard.

**On the framing — worth stating plainly, because the first version of this finding was wrong.** This is *not* a case of "a parser with no property test." `parsePhaseFromProse` already had fast-check coverage from `bf25e0b43` (#2124) at `tests/phase-id.test.cjs:693-711`, so `RULESET.TESTS.property-based-testing` was already satisfied. Those two properties cover phase-token **anchoring** (the #2111 `Milestone vX.Y complete` invariant) and `"N of M"` phase extraction — neither touches name precedence. The gap is narrower than "missing property test," and naming it precisely is what determines which new properties are actually load-bearing.

### Which properties are load-bearing, and which are not

A mutation harness reconstructed the pre-#2821 paren-first parser (from `git show 82ca13f5a^:src/phase-id.cts`) and ran every candidate property against it:

| Property | vs. pre-#2821 parser | Role |
|---|---|---|
| **P1** — genuine dash name beats a trailing parenthetical aside | **FAILS** | delta guard |
| **P9** — genuine dash name beats a parenthetical that itself contains an em-dash | **FAILS** | delta guard (also exercises the paren-stripped separator search) |
| P2, P3, P4 | pass | characterization — both parser versions satisfy these |
| P5–P8 | pass | totality + phase-token extraction, which #2821 left alone |

Only P1 and P9 distinguish old from new, because #2821's **only** behavioral delta in this function is that precedence flip. The section comment in the test file says exactly this, so a future reader does not mistake the characterization tests for delta guards.

### Divergence guard

The generator's status-word exclusion filter is a test-local mirror of `STATUSY_TAIL_RE`, which is private and unexported. A new test pins that mirror to **observable parser behavior** — not source text, which `local/no-source-grep` forbids — so an implementation vocabulary change fails loudly instead of silently weakening every property that depends on the filter.

## Scope split

Also clears six pre-existing `no-unused-vars` ESLint warnings surfaced by the lint run for this change (dead bindings across four unrelated test files). Folded in rather than deferred, per the no-wave-off rule. Removing the never-called `openCodeBlock` helper cascaded to its now-unused `fs`/`path`/`reviewPath` consts in both fold scopes of `review-default-reviewers-workflow.test.cjs`.

An independent security pass confirmed the deletions cost no coverage — the security-relevant assertions in `fix-2358-review-temp-path-scoping.test.cjs` (`errPath` scoping, stderr-not-`/dev/null`, the `--format json` primary path) live in tests that remain, using `p.reviewPath` / `resolveLanePlan` / `handleOpencodeOutput`, not the removed helpers.

## Testing

### How I verified

- Remote dockerized runner on this exact commit (`5556f2e4`): **28119/28119 passed on Linux Node 22 and Node 24, 0 failures.**
- Mutation harness against the reconstructed pre-#2821 parser: P1 and P9 fail as designed; P2–P8 pass. This is the failing-first proof that the delta guards are non-vacuous.
- Independent isolated correctness review: all nine properties verified empirically true against the compiled module; `genuineName` filter rejection measured at **1.26%** over 5000 samples, so the properties genuinely reach the branches under test; `phaseToken` produces only tokens inside the parser's accepted grammar.
- Independent security review: clean. Confirmed the length-bounded quantifiers (≤200, no nested/overlapping) make the adversarial `(`×400 / `—`×400 property `O(n·200)` — no catastrophic backtracking, so it cannot hang CI.
- `npm run lint` with the ESLint cache cleared: **0 problems**.

### Regression test added?

- [x] Yes — P1 and P9 fail against the pre-#2821 implementation and pass against the merged one.
- [ ] No

### Platforms tested

- [x] macOS (lint, build, harnesses)
- [ ] Windows
- [x] Linux (remote runner, Node 22 + 24)
- [x] N/A — pure in-memory string parsing, no filesystem or path handling in the new tests

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue is `type: chore` — this is a test-quality task, not a bug fix, so `confirmed-bug` does not apply
- [x] Scoped to the linked issue, plus the six lint warnings the same lint run surfaced (folded in rather than deferred)
- [x] Regression test added
- [x] All existing tests pass — verified on the remote runner rather than locally, since local `node --test` / `npm test` is hard-blocked by `.claude/hooks/block-local-node-test.sh`
- [x] No `.changeset/` fragment — test-only, no user-facing behavior change (same basis as #2436). Apply `no-changelog` if the gate wants it explicit.
- [x] No dependencies added

## Breaking changes

None. Test-only; no `src/` file is touched.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2878"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788030385&installation_model_id=22188&pr_number=2878&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2878&signature=4bee8793f245a1a5e268d27f9476fd5187dd2e5e36835beb7ab974091eef7138"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->