### PR TITLE
fix(#2764): extend no-path-literal-in-assert to membership/substring checks (catches the #2728 Windows CI shape)

### DIFF
--- a/.changeset/sturdy-deer-greet.md
+++ b/.changeset/sturdy-deer-greet.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 2879
 ---
 **The portability linter now catches Windows-path failures in membership and substring assertions** — `no-path-literal-in-assert` flags `.includes`/`.indexOf`/`.startsWith`/`.endsWith`/`.match` over a path-returning receiver (including through a `.map()` hop), not just equality assertions. Previously these passed lint and failed on Windows CI; the rule now surfaces them at lint time. (#2764)

--- a/.changeset/sturdy-deer-greet.md
+++ b/.changeset/sturdy-deer-greet.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**The portability linter now catches Windows-path failures in membership and substring assertions** — `no-path-literal-in-assert` flags `.includes`/`.indexOf`/`.startsWith`/`.endsWith`/`.match` over a path-returning receiver (including through a `.map()` hop), not just equality assertions. Previously these passed lint and failed on Windows CI; the rule now surfaces them at lint time. (#2764)

--- a/eslint-rules/no-path-literal-in-assert.cjs
+++ b/eslint-rules/no-path-literal-in-assert.cjs
@@ -44,6 +44,14 @@
  *     path really does contain forward-slashes even on Windows), wrapping with
  *     `String(<x>).replace(/\\\\/g, '/')` is the correct suppression; on POSIX
  *     systems where `\\` never appears, the replace is a no-op and has zero cost.
+ *
+ * (d) #2764 membership/substring shape — `.includes/.indexOf/.startsWith/.endsWith`
+ *     (string-literal arg) and `.match` (regex-literal arg) over a receiver that
+ *     traces to a path-returning call (directly or via `.map()` hops). For `.match`,
+ *     ANY regex literal whose source contains a `/` is treated as a POSIX-path
+ *     membership check; a non-path regex containing `/` on a path-returning receiver
+ *     (e.g. `.match(/https:\/\//)`) will also fire. The rule is scoped to the
+ *     `tests/` test-file glob, so every such call is a test assertion shape.
  */
 
 const {
@@ -103,7 +111,8 @@ const rule = {
 
     // True when `receiverNode` is (or traces to) a path-returning call, respecting
     // POSIX-normalizer suppression. Traces: String() cast → non-normalizer method
-    // chain peel → ONE .map(arrow-or-fn returning a path call) hop.
+    // chain peel → .map(callback-returning-a-path-call) hops (recursively — nested
+    // .map() is also traced, since each recursion descends into a smaller subtree).
     function receiverIsPathReturning(receiverNode) {
       if (!receiverNode) return false;
       // Suppressed if the receiver is already a valid POSIX normalizer.

--- a/eslint-rules/no-path-literal-in-assert.cjs
+++ b/eslint-rules/no-path-literal-in-assert.cjs
@@ -88,6 +88,76 @@ const rule = {
     /** expect(actual).<matcher>(expected) */
     const EXPECT_MATCHERS = new Set(['toBe', 'toEqual', 'toStrictEqual']);
 
+    // ── #2764 helpers: membership / substring checks over a path-returner ──────
+    // .includes / .indexOf / .startsWith / .endsWith / .match on a receiver that
+    // traces to a path-returning call (directly, or through ONE .map(f => path-…)
+    // hop). The receiver is unwrapped through String() and one non-normalizer
+    // method chain, and may itself be a .map(...) whose callback returns a path
+    // call — the exact #2728 shape (arr.map(f => path.relative(R, f)).includes(x)).
+    const MEMBERSHIP_METHODS = new Set([
+      'includes',
+      'indexOf',
+      'startsWith',
+      'endsWith',
+    ]);
+
+    // True when `receiverNode` is (or traces to) a path-returning call, respecting
+    // POSIX-normalizer suppression. Traces: String() cast → non-normalizer method
+    // chain peel → ONE .map(arrow-or-fn returning a path call) hop.
+    function receiverIsPathReturning(receiverNode) {
+      if (!receiverNode) return false;
+      // Suppressed if the receiver is already a valid POSIX normalizer.
+      if (isPosixNormalizerCall(receiverNode)) return false;
+
+      let probe = unwrapString(receiverNode);
+      if (isPathReturningCall(probe)) return true;
+
+      // Peel one non-normalizer method chain (.replace / .replaceAll / .split().join()).
+      const peeled = unwrapNonNormalizerMethodChain(receiverNode);
+      if (peeled != null) {
+        const inner = unwrapString(peeled);
+        if (isPathReturningCall(inner)) return true;
+      }
+
+      // ONE .map(callback) hop: arr.map(f => path.relative(...)) — the callback's
+      // return expression is the path-returner. Arrow with a body, or arrow with a
+      // single-expression concisereturn, or a `function` with a single return.
+      if (
+        receiverNode.type === 'CallExpression' &&
+        receiverNode.callee.type === 'MemberExpression' &&
+        !receiverNode.callee.computed &&
+        receiverNode.callee.property.type === 'Identifier' &&
+        receiverNode.callee.property.name === 'map' &&
+        receiverNode.arguments.length >= 1
+      ) {
+        const cb = receiverNode.arguments[0];
+        const retExpr = mapCallbackReturnExpression(cb);
+        if (retExpr && receiverIsPathReturning(retExpr)) return true;
+      }
+      return false;
+    }
+
+    // Extracts the returned expression from a .map() callback (arrow concise body,
+    // arrow block with one return, or function with one return). Null otherwise.
+    function mapCallbackReturnExpression(cb) {
+      if (!cb) return null;
+      if (cb.type === 'ArrowFunctionExpression') {
+        if (cb.body && cb.body.type !== 'BlockStatement') return cb.body; // concise
+        const stmts = cb.body && cb.body.body ? cb.body.body : [];
+        const ret = stmts.find((s) => s.type === 'ReturnStatement');
+        if (ret && stmts.filter((s) => s.type === 'ReturnStatement').length === 1) {
+          return ret.argument;
+        }
+      } else if (cb.type === 'FunctionExpression') {
+        const stmts = cb.body && cb.body.body ? cb.body.body : [];
+        const ret = stmts.find((s) => s.type === 'ReturnStatement');
+        if (ret && stmts.filter((s) => s.type === 'ReturnStatement').length === 1) {
+          return ret.argument;
+        }
+      }
+      return null;
+    }
+
     /**
      * Returns true when `pathNode` represents a path call and `literalNode` is
      * a POSIX slash literal, AND the path call is NOT already normalized.
@@ -179,6 +249,40 @@ const rule = {
 
           if (violated && !isWindowsExcludedNode(node, sourceCode)) {
             context.report({ node, messageId: 'pathLiteral' });
+          }
+          return;
+        }
+
+        // ── #2764: <path-returning-expr>.<membership-method>(<posix-literal>) ──
+        // .includes / .indexOf / .startsWith / .endsWith (and .match(/slashes/))
+        // over a receiver that traces to a path-returning call (directly or via
+        // one .map() hop). The rule runs on tests/**/*.test.cjs only, so every such
+        // call is a test assertion shape that fails on Windows.
+        if (
+          callee.type === 'MemberExpression' &&
+          !callee.computed &&
+          callee.property.type === 'Identifier' &&
+          (MEMBERSHIP_METHODS.has(callee.property.name) ||
+            callee.property.name === 'match')
+        ) {
+          const receiver = callee.object;
+          if (!receiverIsPathReturning(receiver)) return;
+          // The argument must be a POSIX-slash string literal (or, for .match, a
+          // regex literal whose pattern contains a slash).
+          const arg = node.arguments[0];
+          const argIsPosix =
+            arg && isPosixSlashStringLiteral(arg);
+          const argIsSlashRegex =
+            callee.property.name === 'match' &&
+            arg &&
+            arg.type === 'Literal' &&
+            arg.regex &&
+            typeof arg.regex.pattern === 'string' &&
+            arg.regex.pattern.includes('/');
+          if (argIsPosix || argIsSlashRegex) {
+            if (!isWindowsExcludedNode(node, sourceCode)) {
+              context.report({ node, messageId: 'pathLiteral' });
+            }
           }
           return;
         }

--- a/tests/no-path-literal-in-assert.rule.test.cjs
+++ b/tests/no-path-literal-in-assert.rule.test.cjs
@@ -247,6 +247,19 @@ describe('no-path-literal-in-assert invalid cases', () => {
       ],
     });
   });
+
+  test('invalid (#2764): path.resolve(...).match(/a\\/b/) — regex with a slash', () => {
+    ruleTester.run('no-path-literal-in-assert', noPathLiteralInAssert, {
+      valid: [],
+      invalid: [
+        {
+          code: `assert.ok(path.resolve(x).match(/a\\/b/));`,
+          filename: 'tests/foo.test.cjs',
+          errors: [{ messageId: 'pathLiteral' }],
+        },
+      ],
+    });
+  });
 });
 
 // ─── VALID cases (no violation expected) ─────────────────────────────────────
@@ -437,6 +450,30 @@ describe('no-path-literal-in-assert valid cases', () => {
       valid: [
         {
           code: `assert.ok(path.relative(ROOT, f).includes('foo'));`,
+          filename: 'tests/foo.test.cjs',
+        },
+      ],
+      invalid: [],
+    });
+  });
+
+  test('valid (#2764): path receiver .match(regex-with-no-slash)', () => {
+    ruleTester.run('no-path-literal-in-assert', noPathLiteralInAssert, {
+      valid: [
+        {
+          code: `assert.ok(path.resolve(x).match(/^home/));`,
+          filename: 'tests/foo.test.cjs',
+        },
+      ],
+      invalid: [],
+    });
+  });
+
+  test('valid (#2764): membership inside a Windows-excluded platform guard', () => {
+    ruleTester.run('no-path-literal-in-assert', noPathLiteralInAssert, {
+      valid: [
+        {
+          code: `if (process.platform !== 'win32') { assert.ok(path.relative(ROOT, f).includes('a/b')); }`,
           filename: 'tests/foo.test.cjs',
         },
       ],

--- a/tests/no-path-literal-in-assert.rule.test.cjs
+++ b/tests/no-path-literal-in-assert.rule.test.cjs
@@ -179,6 +179,74 @@ describe('no-path-literal-in-assert invalid cases', () => {
       ],
     });
   });
+
+  // ── #2764: membership / substring checks over a path-returning receiver ──
+  // The equality-only visitor missed these; they pass lint and fail on Windows.
+
+  test('invalid (#2764): assert.ok(path.relative(R,f).includes("a/b"))', () => {
+    ruleTester.run('no-path-literal-in-assert', noPathLiteralInAssert, {
+      valid: [],
+      invalid: [
+        {
+          code: `assert.ok(path.relative(ROOT, f).includes('a/b'));`,
+          filename: 'tests/foo.test.cjs',
+          errors: [{ messageId: 'pathLiteral' }],
+        },
+      ],
+    });
+  });
+
+  test('invalid (#2764): .map(f => path.relative(...)) hop then .includes (the #2728 shape)', () => {
+    ruleTester.run('no-path-literal-in-assert', noPathLiteralInAssert, {
+      valid: [],
+      invalid: [
+        {
+          code: `assert.ok(arr.map(f => path.relative(ROOT, f)).includes('a/b'));`,
+          filename: 'tests/foo.test.cjs',
+          errors: [{ messageId: 'pathLiteral' }],
+        },
+      ],
+    });
+  });
+
+  test('invalid (#2764): path.join(...).indexOf("a/b") !== -1', () => {
+    ruleTester.run('no-path-literal-in-assert', noPathLiteralInAssert, {
+      valid: [],
+      invalid: [
+        {
+          code: `assert.ok(path.join(a, b).indexOf('a/b') !== -1);`,
+          filename: 'tests/foo.test.cjs',
+          errors: [{ messageId: 'pathLiteral' }],
+        },
+      ],
+    });
+  });
+
+  test('invalid (#2764): path.resolve(...).startsWith("a/b")', () => {
+    ruleTester.run('no-path-literal-in-assert', noPathLiteralInAssert, {
+      valid: [],
+      invalid: [
+        {
+          code: `assert.ok(path.resolve(x).startsWith('a/b'));`,
+          filename: 'tests/foo.test.cjs',
+          errors: [{ messageId: 'pathLiteral' }],
+        },
+      ],
+    });
+  });
+
+  test('invalid (#2764): path.resolve(...).endsWith("a/b")', () => {
+    ruleTester.run('no-path-literal-in-assert', noPathLiteralInAssert, {
+      valid: [],
+      invalid: [
+        {
+          code: `assert.ok(path.resolve(x).endsWith('a/b'));`,
+          filename: 'tests/foo.test.cjs',
+          errors: [{ messageId: 'pathLiteral' }],
+        },
+      ],
+    });
+  });
 });
 
 // ─── VALID cases (no violation expected) ─────────────────────────────────────
@@ -331,6 +399,44 @@ describe('no-path-literal-in-assert valid cases', () => {
       valid: [
         {
           code: `assert.equal(toPosixPath(path.join(a, b)), '/x/y');`,
+          filename: 'tests/foo.test.cjs',
+        },
+      ],
+      invalid: [],
+    });
+  });
+
+  // ── #2764: membership checks that must NOT trigger ──
+
+  test('valid (#2764): normalized receiver .includes("a/b") — POSIX normalizer suppresses', () => {
+    ruleTester.run('no-path-literal-in-assert', noPathLiteralInAssert, {
+      valid: [
+        {
+          code: `assert.ok(path.relative(ROOT, f).replace(/\\\\/g, '/').includes('a/b'));`,
+          filename: 'tests/foo.test.cjs',
+        },
+      ],
+      invalid: [],
+    });
+  });
+
+  test('valid (#2764): non-path string receiver .includes("a/b")', () => {
+    ruleTester.run('no-path-literal-in-assert', noPathLiteralInAssert, {
+      valid: [
+        {
+          code: `assert.ok('plain string'.includes('a/b'));`,
+          filename: 'tests/foo.test.cjs',
+        },
+      ],
+      invalid: [],
+    });
+  });
+
+  test('valid (#2764): path receiver .includes(arg-with-no-slash)', () => {
+    ruleTester.run('no-path-literal-in-assert', noPathLiteralInAssert, {
+      valid: [
+        {
+          code: `assert.ok(path.relative(ROOT, f).includes('foo'));`,
           filename: 'tests/foo.test.cjs',
         },
       ],


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #2764

---

## What was broken

`eslint-rules/no-path-literal-in-assert.cjs` (scoped to `tests/**/*.test.cjs`) flagged path-returning calls compared to POSIX-slash literals in **equality** assertions only. A **membership/substring** check was invisible to it, so this passed lint and failed on Windows:

```js
const rel = dispatchSites.map(f => path.relative(REPO_ROOT, f));
assert.ok(rel.includes('gsd-core/workflows/quick.md'));   // backslashes on win32
```

That exact shape (PR #2728) cost a full Windows CI cycle to discover. The repo already had the convention (`.replace(/\\/g, '/')`) and the rule — the bug shipped anyway because the rule could not see the membership shape.

## What this fix does

Adds a third `CallExpression` shape to the rule: `.includes/.indexOf/.startsWith/.endsWith/.match` over a receiver that traces to a path-returning call — directly, or through `.map(f => path-…)` hops (the #2728 shape). It reuses the existing helpers (`isPathReturningCall`, `isPosixSlashStringLiteral`, `isPosixNormalizerCall`, `unwrapNonNormalizerMethodChain`) and preserves the POSIX-normalizer + Windows-excluded suppressions. For `.match(regex)`, any regex literal whose source contains a `/` is treated as a path-membership check.

## Root cause

Long-standing scope gap: the rule documented only the equality shape. The `.map()` hop was an additional limitation — a path-returning call wrapped one layer deep in an array was invisible.

## Testing

### How I verified the fix

- `gsd-test --base next --head <final sha>` → `outcome:"passed"`, full matrix green, 0 failures.
- ESLint probe on a temp test file confirmed: `.includes`/`.indexOf`/`.startsWith`/`.endsWith`/`.match` over a path-returning receiver (incl. the `.map()` hop) flagged; normalized receiver, non-path receiver, no-slash arg, `.match` no-slash, and Windows-guarded membership all NOT flagged.
- `npm run lint:ci` clean on the full tree — 0 false-positives across all existing tests.

### Regression test added?

- [x] Yes — `tests/no-path-literal-in-assert.rule.test.cjs` adds RuleTester invalid cases (includes, `.map()` hop, indexOf, startsWith, endsWith, `.match`-with-slash) and valid cases (POSIX-normalized receiver, non-path receiver, no-slash arg, `.match` no-slash, Windows-excluded membership).

### Platforms tested

- [ ] macOS
- [x] Windows (the rule's entire purpose is catching Windows path-separator failures at lint time)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (a lint rule, runtime-agnostic)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — only the new membership shape + helpers + tests + changeset; the equality/expect visitors are untouched
- [x] Regression test added (6 invalid + 5 valid RuleTester cases)
- [x] All existing tests pass — `gsd-test` full matrix green; `lint:ci` clean
- [x] `.changeset/` fragment added (`Fixed`, pr backfilled)
- [x] No unnecessary dependencies added

## Breaking changes

None. The change only ADDS lint detection for a previously-missed shape. No existing valid test code is newly flagged (verified: `lint:ci` clean on the full tree). Any test that legitimately compares a normalized path still passes (the normalizer suppression is preserved).

---

GSD_PR_GATES_OK=1

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2879"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788030692&installation_model_id=22188&pr_number=2879&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2879&signature=c8dbf8b584c01be3129b8971201799c19cee4d6f9122cd2425f2de1045257b88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->