### PR TITLE
fix(#2770): decision-coverage gate fails closed on empty arg + workflow recomputes CONTEXT_PATH in-block

### DIFF
--- a/.changeset/bold-geese-wander.md
+++ b/.changeset/bold-geese-wander.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**The plan-phase decision-coverage gate can no longer silently pass when its context-path argument is missing** — the handler now fails closed on an empty/missing argument (a caller error), and the plan-phase workflow recomputes the CONTEXT.md path in the same Bash block that runs the gate (the variable set in the init block did not survive into the gate block). A genuinely-absent CONTEXT.md still produces the legitimate green skip. Previously the gate reported `passed` without ever checking coverage. (#2770)

--- a/.changeset/bold-geese-wander.md
+++ b/.changeset/bold-geese-wander.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 2881
 ---
 **The plan-phase decision-coverage gate can no longer silently pass when its context-path argument is missing** — the handler now fails closed on an empty/missing argument (a caller error), and the plan-phase workflow recomputes the CONTEXT.md path in the same Bash block that runs the gate (the variable set in the init block did not survive into the gate block). A genuinely-absent CONTEXT.md still produces the legitimate green skip. Previously the gate reported `passed` without ever checking coverage. (#2770)

--- a/gsd-core/workflows/plan-phase.md
+++ b/gsd-core/workflows/plan-phase.md
@@ -1400,28 +1400,20 @@ If `TEXT_MODE` is true, present as a plain-text numbered list (options already s
 
 ## 13a. Decision Coverage Gate
 
-After the requirements coverage gate passes, verify that every trackable
-decision captured by discuss-phase in CONTEXT.md `<decisions>` is referenced
-by at least one plan. This is the **translation gate** from issue #2492 —
-its job is to refuse to mark a phase planned when a discuss-phase decision
-silently dropped on the way into the plans.
+Verify every trackable decision in CONTEXT.md `<decisions>` is referenced by at
+least one plan. This **translation gate** (#2492) refuses to mark a phase planned
+when a discuss-phase decision silently dropped.
 
-**Skip if** `workflow.context_coverage_gate` is explicitly set to `false`
-(absent key = enabled). Also skip if no CONTEXT.md exists for this phase
-(nothing to translate) or if its `<decisions>` block is empty.
+**Skip if** `workflow.context_coverage_gate` is `false` (absent = enabled), or
+no CONTEXT.md exists for this phase, or its `<decisions>` block is empty.
 
 ```bash
 GATE_CFG=$(gsd_run query config-get workflow.context_coverage_gate 2>/dev/null || echo "true")
 if [ "$GATE_CFG" != "false" ]; then
-  # #2770: recompute CONTEXT_PATH HERE — the variable set in the step-1 init block
-  # does not survive into this separately-spawned Bash block, so consuming it above
-  # passed an empty arg and the gate silently green-skipped. Derive it from the phase
-  # dir (the canonical <phase>-CONTEXT.md convention).
+  # #2770: CONTEXT_PATH from step-1 init doesn't survive into this Bash block;
+  # recompute it. Only run when a CONTEXT.md exists (handler fails closed on an
+  # empty arg, so an unguarded empty glob would halt a context-less phase).
   CONTEXT_PATH=$(ls "${PHASE_DIR}"/*-CONTEXT.md 2>/dev/null | head -1)
-  # Only run the gate when a CONTEXT.md actually exists for this phase. A genuinely
-  # CONTEXT.md-less phase (e.g. the §4 "Continue without context" path) is the
-  # legitimate skip — do NOT invoke the gate with an empty path, which the handler
-  # now fails closed on (a caller error, not "no context").
   if [ -n "$CONTEXT_PATH" ]; then
     GATE_RESULT=$(gsd_run query check.decision-coverage-plan "${PHASE_DIR}" "${CONTEXT_PATH}")
     # BLOCKING: refuse to mark phase planned when a trackable decision is uncovered.
@@ -1438,20 +1430,13 @@ fi
 
 The handler returns JSON:
 ```json
-{
-  "passed": true,
-  "skipped": false,
-  "total":  2,
-  "covered": 2,
-  "uncovered": [ { "id": "D-01", "text": "...", "category": "..." } ],
-  "message": "..."
-}
+{ "passed": true, "skipped": false, "total": 2, "covered": 2,
+  "uncovered": [{ "id": "D-01", "text": "...", "category": "..." }], "message": "..." }
 ```
 
 **If `passed` is true (or `skipped` is true):** Display
-`✓ Decision coverage: {M}/{N} CONTEXT.md decisions covered by plans` (or
-`(skipped — gate disabled)` / `(skipped — no decisions)`) and proceed to
-step 13b.
+`✓ Decision coverage: {M}/{N} decisions covered` (or `(skipped)`) and proceed
+to step 13b.
 
 **If `passed` is false:** Display the handler's `message` block. It already
 names each uncovered decision (`D-NN | category | text`) and tells the user

--- a/gsd-core/workflows/plan-phase.md
+++ b/gsd-core/workflows/plan-phase.md
@@ -1413,6 +1413,11 @@ silently dropped on the way into the plans.
 ```bash
 GATE_CFG=$(gsd_run query config-get workflow.context_coverage_gate 2>/dev/null || echo "true")
 if [ "$GATE_CFG" != "false" ]; then
+  # #2770: recompute CONTEXT_PATH HERE — the variable set in the step-1 init block
+  # does not survive into this separately-spawned Bash block, so consuming it above
+  # passed an empty arg and the gate silently green-skipped. Derive it from the phase
+  # dir (the canonical <phase>-CONTEXT.md convention).
+  CONTEXT_PATH=$(ls "${PHASE_DIR}"/*-CONTEXT.md 2>/dev/null | head -1)
   GATE_RESULT=$(gsd_run query check.decision-coverage-plan "${PHASE_DIR}" "${CONTEXT_PATH}")
   # BLOCKING: refuse to mark phase planned when a trackable decision is uncovered.
   # `passed: true` covers both real-pass and skipped cases (gate disabled / no CONTEXT.md /

--- a/gsd-core/workflows/plan-phase.md
+++ b/gsd-core/workflows/plan-phase.md
@@ -1418,15 +1418,21 @@ if [ "$GATE_CFG" != "false" ]; then
   # passed an empty arg and the gate silently green-skipped. Derive it from the phase
   # dir (the canonical <phase>-CONTEXT.md convention).
   CONTEXT_PATH=$(ls "${PHASE_DIR}"/*-CONTEXT.md 2>/dev/null | head -1)
-  GATE_RESULT=$(gsd_run query check.decision-coverage-plan "${PHASE_DIR}" "${CONTEXT_PATH}")
-  # BLOCKING: refuse to mark phase planned when a trackable decision is uncovered.
-  # `passed: true` covers both real-pass and skipped cases (gate disabled / no CONTEXT.md /
-  # no trackable decisions). Verify-phase counterpart deliberately omits this exit-1 — that
-  # gate is non-blocking by design (review finding F15).
-  echo "$GATE_RESULT" | jq -e '(.passed // .data.passed) == true' >/dev/null || {
-    echo "$GATE_RESULT" | jq -r '(.message // .data.message // "Decision coverage gate failed.")'
-    exit 1
-  }
+  # Only run the gate when a CONTEXT.md actually exists for this phase. A genuinely
+  # CONTEXT.md-less phase (e.g. the §4 "Continue without context" path) is the
+  # legitimate skip — do NOT invoke the gate with an empty path, which the handler
+  # now fails closed on (a caller error, not "no context").
+  if [ -n "$CONTEXT_PATH" ]; then
+    GATE_RESULT=$(gsd_run query check.decision-coverage-plan "${PHASE_DIR}" "${CONTEXT_PATH}")
+    # BLOCKING: refuse to mark phase planned when a trackable decision is uncovered.
+    # `passed: true` covers both real-pass and skipped cases (gate disabled / no CONTEXT.md /
+    # no trackable decisions). Verify-phase counterpart deliberately omits this exit-1 — that
+    # gate is non-blocking by design (review finding F15).
+    echo "$GATE_RESULT" | jq -e '(.passed // .data.passed) == true' >/dev/null || {
+      echo "$GATE_RESULT" | jq -r '(.message // .data.message // "Decision coverage gate failed.")'
+      exit 1
+    }
+  fi
 fi
 ```
 

--- a/src/check-command-router.cts
+++ b/src/check-command-router.cts
@@ -276,13 +276,23 @@ function loadDecisionExtraction(contextPath: string): { trackable: Decision[]; o
 
 function cmdDecisionCoveragePlan(projectDir: string, args: string[], raw: boolean): void {
   const phaseDir = args[2] ? resolvePath(args[2], projectDir) : '';
-  const contextPath = args[3] ? resolvePath(args[3], projectDir) : '';
+  const contextArg = args[3];
+  const contextPath = contextArg ? resolvePath(contextArg, projectDir) : '';
 
   if (!gateEnabled(projectDir)) {
     output({ passed: true, skipped: true, reason: 'workflow.context_coverage_gate is false', total: 0, covered: 0, uncovered: [], message: 'Decision coverage gate disabled by config.' }, raw, undefined);
     return;
   }
-  if (!contextPath || !fs.existsSync(contextPath)) {
+  // #2770: an EMPTY/MISSING contextPath argument is a CALLER ERROR (the workflow
+  // forgot to pass the path — e.g. a shell variable lost between Bash blocks), not
+  // evidence the phase has no CONTEXT.md. Fail closed (mirrors #1365 fail-loud) so a
+  // blocking gate cannot silently certify success on a caller mistake.
+  if (!contextArg || contextArg === '') {
+    output({ passed: false, skipped: false, reason: 'missing context path argument', total: 0, covered: 0, uncovered: [], message: 'Decision coverage gate called without a context path argument — the caller (e.g. the plan-phase workflow) must pass the CONTEXT.md path. An empty argument is a caller error, not evidence there is nothing to check (#2770).' }, raw, undefined);
+    return;
+  }
+  // A REAL path whose file genuinely does not exist is the LEGITIMATE green skip.
+  if (!fs.existsSync(contextPath)) {
     output({ passed: true, skipped: true, reason: 'CONTEXT.md missing', total: 0, covered: 0, uncovered: [], message: 'No CONTEXT.md - nothing to check.' }, raw, undefined);
     return;
   }

--- a/tests/decisions.test.cjs
+++ b/tests/decisions.test.cjs
@@ -1124,3 +1124,59 @@ describe('check.decision-coverage-plan — planner-canonical tag scanning (#2372
     assert.strictEqual(parsed.passed, true);
   });
 });
+
+// ─── #2770: empty contextPath argument must fail closed, not green-skip ──────
+// The handler conflated "empty argument" (a CALLER ERROR — the workflow forgot to
+// pass the path) with "file missing" (a LEGITIMATE green skip). An empty arg
+// returned passed:true/skipped/reason:"CONTEXT.md missing", silently certifying a
+// blocking gate. Must fail closed (mirrors #1365 fail-loud).
+
+describe('check.decision-coverage-plan — empty contextPath argument fails closed (#2770)', () => {
+  let tmpDir;
+  let planningDir;
+  let phaseDir;
+
+  beforeEach(() => {
+    tmpDir = createTempProject('gsd-2770-');
+    planningDir = path.join(tmpDir, '.planning');
+    phaseDir = path.join(planningDir, 'phases', '01-init');
+    fs.mkdirSync(phaseDir, { recursive: true });
+  });
+
+  afterEach(() => cleanup(tmpDir));
+
+  test('empty contextPath argument → passed:false (caller error, fail closed)', () => {
+    const result = runDecisionCoveragePlan(phaseDir, '', tmpDir);
+    const parsed = JSON.parse(result.output || '{}');
+    assert.strictEqual(parsed.passed, false,
+      `Empty contextPath argument must fail closed (caller error), not green-skip. Got: ${JSON.stringify(parsed)}`);
+    const reason = (parsed.reason || '').toLowerCase();
+    assert.ok(
+      reason.includes('missing') && reason.includes('argument'),
+      `Reason must identify the missing argument. Got: "${parsed.reason}"`
+    );
+  });
+
+  test('real path to a genuinely-absent CONTEXT.md → legitimate green skip preserved (#2770)', () => {
+    // Negative space: a REAL path whose file does not exist is the legitimate skip.
+    const absentPath = path.join(phaseDir, 'CONTEXT.md'); // never written
+    const result = runDecisionCoveragePlan(phaseDir, absentPath, tmpDir);
+    const parsed = JSON.parse(result.output || '{}');
+    assert.strictEqual(parsed.passed, true,
+      `A real path to a genuinely-absent CONTEXT.md is a legitimate green skip. Got: ${JSON.stringify(parsed)}`);
+    assert.strictEqual(parsed.skipped, true);
+    assert.ok(
+      (parsed.reason || '').toLowerCase().includes('context.md missing'),
+      `Reason must be the legitimate CONTEXT.md-missing skip. Got: "${parsed.reason}"`
+    );
+  });
+
+  test('undefined-ish argument omitted entirely → passed:false (fail closed)', () => {
+    // The CLI invocation drops a trailing empty arg in some shells; the handler must
+    // still fail closed when args[3] is absent (not just empty string).
+    const result = runGsdTools(['query', 'check.decision-coverage-plan', phaseDir], tmpDir);
+    const parsed = JSON.parse(result.output || '{}');
+    assert.strictEqual(parsed.passed, false,
+      `Missing contextPath argument must fail closed. Got: ${JSON.stringify(parsed)}`);
+  });
+});

--- a/tests/emitted-drift-ack.json
+++ b/tests/emitted-drift-ack.json
@@ -1,0 +1,8 @@
+{
+  "version": 1,
+  "paths": {
+    "plan-phase.md": {
+      "reason": "#2770: decision-coverage gate recomputes CONTEXT_PATH in-block + guards the empty-glob case (handler now fails closed on empty arg). Net growth kept under the ADR-857 size cap by condensing adjacent §13a prose/JSON; the residual +89 bytes are the irreducible glob+guard logic."
+    }
+  }
+}

--- a/tests/plan-phase-drift-guard.test.cjs
+++ b/tests/plan-phase-drift-guard.test.cjs
@@ -1614,7 +1614,9 @@ describe('plan-phase decision-coverage gate (#2492)', () => {
     const gateIdx = md.indexOf('check.decision-coverage-plan');
     assert.ok(gateIdx !== -1, 'check.decision-coverage-plan invocation must exist');
 
-    const snippet = md.slice(Math.max(0, gateIdx - 400), gateIdx + 400);
+    // The gate invocation is now nested inside the empty-glob guard, so slice a wide
+    // window around it to capture both the recompute and the guard.
+    const snippet = md.slice(Math.max(0, gateIdx - 600), gateIdx + 400);
     assert.ok(
       snippet.includes('CONTEXT_PATH=$(ls "${PHASE_DIR}"/*-CONTEXT.md'),
       'Gate must recompute CONTEXT_PATH in-block from the phase-dir glob (not rely on the init-block variable) (#2770)',

--- a/tests/plan-phase-drift-guard.test.cjs
+++ b/tests/plan-phase-drift-guard.test.cjs
@@ -1604,25 +1604,24 @@ describe('plan-phase decision-coverage gate (#2492)', () => {
     assert.ok(decIdx < commitIdx, 'Decision gate must run before commit so failures block the commit');
   });
 
-  test('plan-phase Decision Coverage Gate uses CONTEXT_PATH variable defined in INIT extraction (review F1)', () => {
-    // The CONTEXT_PATH bash variable is defined at Step 4 (`CONTEXT_PATH=$(_gsd_field "$INIT" context_path)`).
-    // The plan-phase gate snippet must reference the same casing — `${CONTEXT_PATH}` — not `${context_path}`,
-    // otherwise the BLOCKING gate is invoked with an empty path and silently skips.
-    const defIdx = md.indexOf('CONTEXT_PATH=$(_gsd_field "$INIT" context_path)');
-    assert.ok(defIdx !== -1, 'CONTEXT_PATH must be defined from INIT JSON');
-
+  test('plan-phase Decision Coverage Gate recomputes CONTEXT_PATH in-block and guards the empty-glob case (#2770)', () => {
+    // #2770: the CONTEXT_PATH set in the step-1 init Bash block does NOT survive into
+    // the separately-spawned gate block, so the gate used to run with an empty arg and
+    // silently green-skip. The gate must now (a) recompute CONTEXT_PATH locally from the
+    // phase dir, and (b) guard the empty case so a genuinely CONTEXT.md-less phase still
+    // skips (the handler now fails closed on an empty arg, so an unguarded empty path
+    // would hard-halt the legitimate "Continue without context" flow).
     const gateIdx = md.indexOf('check.decision-coverage-plan');
     assert.ok(gateIdx !== -1, 'check.decision-coverage-plan invocation must exist');
 
-    // Slice the surrounding gate snippet (~600 chars) and verify variable casing matches the definition.
-    const snippet = md.slice(Math.max(0, gateIdx - 200), gateIdx + 400);
+    const snippet = md.slice(Math.max(0, gateIdx - 400), gateIdx + 400);
     assert.ok(
-      snippet.includes('${CONTEXT_PATH}'),
-      'Gate snippet must reference ${CONTEXT_PATH} (uppercase) to match the variable defined in Step 4',
+      snippet.includes('CONTEXT_PATH=$(ls "${PHASE_DIR}"/*-CONTEXT.md'),
+      'Gate must recompute CONTEXT_PATH in-block from the phase-dir glob (not rely on the init-block variable) (#2770)',
     );
     assert.ok(
-      !snippet.includes('${context_path}'),
-      'Gate snippet must NOT reference ${context_path} (lowercase) — that name is undefined in shell scope',
+      snippet.includes('if [ -n "$CONTEXT_PATH" ]'),
+      'Gate must guard the empty-glob case so a CONTEXT.md-less phase still skips (handler now fails closed on empty arg) (#2770)',
     );
   });
 


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #2770

---

## What was broken

The blocking plan-phase decision-coverage gate (`check.decision-coverage-plan`) could report `passed:true` **without ever checking coverage**. Two defects composed:

1. **Workflow (`plan-phase.md`):** `CONTEXT_PATH` was set in the step-1 init Bash block but consumed in a *different* Bash block. Shell variables don't survive between separately-spawned Bash blocks, so the gate ran with an empty argument.
2. **Handler (`check-command-router.cts`):** `if (!contextPath || !fs.existsSync(contextPath))` conflated "empty argument" (a caller error) with "file missing" (a legitimate green skip), returning `passed:true/skipped` on an empty arg.

Net: a phase's decision-coverage gate silently green-skipped, and uncovered decisions reached execution (the issue documents a real phase whose gate "passed" this way; re-running with the correct path named an uncovered decision that later stalled execution).

## What this fix does

- **Handler:** split the guard. An empty/missing `contextPath` argument is a caller error → `passed:false` (fail closed, mirrors the #1365 fail-loud convention). A *real* path whose file genuinely does not exist keeps the legitimate green skip (`reason:"CONTEXT.md missing"`).
- **Workflow:** recompute `CONTEXT_PATH` inside the consuming Bash block (it was lost between blocks), and guard the empty-glob case so a genuinely CONTEXT.md-less phase still skips (the handler now fails closed on empty arg, so an unguarded empty path would otherwise hard-halt the legitimate "Continue without context" flow).

## Root cause

Long-standing: the handler's empty-arg handling predates the gate wiring; the workflow's cross-block variable loss has existed since the gate was added (#2492).

## Testing

### How I verified the fix

- `gsd-test --base next --head <final sha>` → `outcome:"passed"`, full matrix green, 0 failures.
- Local repro confirmed: empty arg now → `passed:false, reason:"missing context path argument"` (was `passed:true`); a real path to an absent file → `passed:true, skipped:true, reason:"CONTEXT.md missing"` (legitimate skip preserved).

### Regression test added?

- [x] Yes — `tests/decisions.test.cjs` adds: empty arg → `passed:false`; real-path-to-absent-file → legitimate green skip; omitted arg → fail closed. Plus an updated `plan-phase-drift-guard.test.cjs` test asserting the workflow recomputes `CONTEXT_PATH` in-block AND guards the empty-glob case (the old test gave false coverage).

### Platforms tested

- [ ] macOS
- [ ] Windows
- [x] Linux
- [x] N/A (workflow/handler logic, not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (a planning gate, runtime-agnostic)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — handler guard split + workflow recompute/guard + tests + changeset
- [x] Regression test added (handler-level + workflow drift-guard)
- [x] All existing tests pass — `gsd-test` full matrix green
- [x] `.changeset/` fragment added (`Fixed`, pr backfilled)
- [x] No unnecessary dependencies added

## Breaking changes

None for correct callers. A caller that invokes `check.decision-coverage-plan` with an empty/missing context path now gets `passed:false` instead of a silent green skip — this is the fix (a blocking gate must not certify success on a caller error). The workflow was updated to always pass a real path. The legitimate "no CONTEXT.md" skip is preserved at both layers.

---

GSD_PR_GATES_OK=1

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2881"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788034558&installation_model_id=22188&pr_number=2881&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2881&signature=0833e4020ddc6f5eb3767db3d6aea346b819f449e54c947c328b99a21616c7a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->