### PR TITLE
fix(#2771): advisor mode spawns registered gsd-advisor-researcher subagent instead of general-purpose

### DIFF
--- a/.changeset/curious-pumas-wake.md
+++ b/.changeset/curious-pumas-wake.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**Discuss-phase advisor mode now spawns the registered `gsd-advisor-researcher` subagent instead of `general-purpose`** — resolving a contradiction with the universal-anti-patterns rule (injected into the same context) that forbids non-GSD agent types. The manual "read the agent def" prompt line is dropped (spawning by type auto-loads it). (#2771; the sibling assumptions-site needs a design decision — filed as #2883)

--- a/.changeset/curious-pumas-wake.md
+++ b/.changeset/curious-pumas-wake.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 2886
 ---
 **Discuss-phase advisor mode now spawns the registered `gsd-advisor-researcher` subagent instead of `general-purpose`** — resolving a contradiction with the universal-anti-patterns rule (injected into the same context) that forbids non-GSD agent types. The manual "read the agent def" prompt line is dropped (spawning by type auto-loads it). (#2771; the sibling assumptions-site needs a design decision — filed as #2883)

--- a/gsd-core/workflows/discuss-phase/modes/advisor.md
+++ b/gsd-core/workflows/discuss-phase/modes/advisor.md
@@ -92,16 +92,14 @@ research agents.
 
    ```
    Agent(
-     prompt="First, read @~/.claude/agents/gsd-advisor-researcher.md for your role and instructions.
-
-     <gray_area>{area_name}: {area_description from gray area identification}</gray_area>
+     prompt="<gray_area>{area_name}: {area_description from gray area identification}</gray_area>
      <phase_context>{phase_goal and description from ROADMAP.md}</phase_context>
      <project_context>{project name and brief description from PROJECT.md}</project_context>
      <calibration_tier>{resolved calibration tier: full_maturity | standard | minimal_decisive}</calibration_tier>
 
      Research this gray area and return a structured comparison table with rationale.
      ${AGENT_SKILLS_ADVISOR}",
-     subagent_type="general-purpose",
+     subagent_type="gsd-advisor-researcher",
      model="{ADVISOR_MODEL}",
      description="Research: {area_name}"
    )

--- a/tests/issue-2771-advisor-subagent-type.test.cjs
+++ b/tests/issue-2771-advisor-subagent-type.test.cjs
@@ -1,0 +1,41 @@
+// allow-test-rule: structural-implementation-guard (#2771)
+'use strict';
+
+// Regression guard for #2771: the discuss-phase advisor mode must spawn the REGISTERED
+// `gsd-advisor-researcher` subagent (auto-loads the agent def), not `general-purpose` —
+// which contradicts universal-anti-patterns rule 10 (injected into discuss-phase via
+// <required_reading>): "NEVER use non-GSD agent types — ALWAYS use gsd-{agent}".
+// Spawning general-purpose + a manual "read the agent def" prompt re-specifies what the
+// def already owns (a drift risk; the same shape assumptions's answer_validation hit).
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const ADVISOR_MD = path.join(
+  __dirname, '..', 'gsd-core', 'workflows', 'discuss-phase', 'modes', 'advisor.md'
+);
+
+test('advisor mode spawns the registered gsd-advisor-researcher subagent, not general-purpose (#2771)', () => {
+  const src = fs.readFileSync(ADVISOR_MD, 'utf8');
+
+  // Locate the Agent() block that researches gray areas.
+  const agentIdx = src.indexOf('subagent_type=');
+  assert.ok(agentIdx !== -1, 'advisor.md must contain an Agent() subagent_type declaration');
+
+  assert.ok(
+    src.includes('subagent_type="gsd-advisor-researcher"'),
+    'advisor mode must spawn subagent_type="gsd-advisor-researcher" (the registered agent def auto-loads) — not general-purpose (#2771, universal-anti-patterns rule 10)'
+  );
+  assert.ok(
+    !src.includes('subagent_type="general-purpose"'),
+    'advisor mode must NOT spawn subagent_type="general-purpose" (contradicts universal-anti-patterns rule 10, injected into the same context) (#2771)'
+  );
+  // The manual "First, read @.../gsd-advisor-researcher.md" prompt line must be gone —
+  // spawning by type auto-loads the def; re-specifying it is a drift risk.
+  assert.ok(
+    !/First, read @.*gsd-advisor-researcher\.md/.test(src),
+    'advisor mode must not manually instruct reading the agent def — spawning by type auto-loads it (#2771)'
+  );
+});

--- a/tests/issue-2771-advisor-subagent-type.test.cjs
+++ b/tests/issue-2771-advisor-subagent-type.test.cjs
@@ -32,10 +32,12 @@ test('advisor mode spawns the registered gsd-advisor-researcher subagent, not ge
     !src.includes('subagent_type="general-purpose"'),
     'advisor mode must NOT spawn subagent_type="general-purpose" (contradicts universal-anti-patterns rule 10, injected into the same context) (#2771)'
   );
-  // The manual "First, read @.../gsd-advisor-researcher.md" prompt line must be gone —
-  // spawning by type auto-loads the def; re-specifying it is a drift risk.
+  // The manual "read @.../gsd-advisor-researcher.md" prompt line must be gone —
+  // spawning by type auto-loads the def; re-specifying it is a drift risk. Deny the
+  // full class (any "read @" lead-in, case-insensitive) so a phrasing variant can't
+  // sneak the drift back in.
   assert.ok(
-    !/First, read @.*gsd-advisor-researcher\.md/.test(src),
+    !/read\s+@.*gsd-advisor-researcher\.md/i.test(src),
     'advisor mode must not manually instruct reading the agent def — spawning by type auto-loads it (#2771)'
   );
 });


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #2771

---

## What was broken

`discuss-phase/modes/advisor.md` spawned `subagent_type="general-purpose"` and manually told the agent to read the def — contradicting `references/universal-anti-patterns.md` rule 10 (injected into the same discuss-phase context via `<required_reading>`): *NEVER use non-GSD agent types — ALWAYS use `subagent_type: "gsd-{agent}"`*. A literal-instruction model received both orders at once.

## What this fix does

Swaps to `subagent_type="gsd-advisor-researcher"` (the registered agent — `agents/gsd-advisor-researcher.md` exists, so spawning by type auto-loads the def) and drops the redundant manual "First, read @…/gsd-advisor-researcher.md" prompt line (re-specifying the def is a drift risk — the same shape that bit `answer_validation`).

## Root cause

The advisor mode drifted from the universal-anti-patterns rule; spawning `general-purpose` + a manual def-read re-specifies what the def already owns.

## Testing

### How I verified the fix

- `gsd-test` full matrix green on the rule + original test.
- Structural test (`tests/issue-2771-advisor-subagent-type.test.cjs`) asserts the registered type is present, `general-purpose` is absent, and no manual def-read instruction remains (regex widened per review to deny phrasing variants).

### Regression test added?

- [x] Yes — `tests/issue-2771-advisor-subagent-type.test.cjs`.

### Platforms tested

- [ ] macOS · [ ] Windows · [x] Linux · [x] N/A (workflow text, not platform-specific)

### Runtimes tested

- [ ] Claude Code · [ ] Gemini CLI · [ ] OpenCode · [x] N/A (runtime-agnostic workflow text)

---

## Checklist

- [x] Issue linked with `Fixes #NNN`
- [x] Linked issue has `confirmed-bug`
- [x] Scoped to the reported bug — advisor.md + test + changeset only
- [x] Regression test added
- [x] All existing tests pass — `gsd-test` full matrix green
- [x] `.changeset/` fragment added (`Fixed`, pr backfilled)
- [x] No unnecessary dependencies

## Out of scope (filed, not deferred)

The issue also named `discuss-phase-assumptions.md`'s `external_research` step spawning `general-purpose` — but that site has **no registered GSD agent**, so it needs a design decision (register `gsd-external-researcher` vs carve a rule-10 exception). Filed as **#2883** rather than bundled here, per one-concern-per-PR.

## Breaking changes

None. The registered `gsd-advisor-researcher` agent already exists and is the intended type; the advisor-researcher model resolver and skills binding already target it.

---

GSD_PR_GATES_OK=1

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2884"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788037879&installation_model_id=22188&pr_number=2884&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2884&signature=d77d8fac5caa8a0888b6c8eebfdfe21f28c4ab8e551318d1a84a608eddca363a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->