### PR TITLE
fix(#2765): bump brace-expansion to patched 1.1.18/5.0.9 (high-severity devDep advisory)

### DIFF
--- a/.changeset/brave-orcas-rest.md
+++ b/.changeset/brave-orcas-rest.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**Dev-dependency `brace-expansion` bumped to patched versions (1.1.18 / 5.0.9), resolving the high-severity DoS/OOM advisories** — the lockfile now pins the 2026-07-30 patch backports reachable via eslint and stryker. A non-breaking in-range bump (no overrides, no major bumps); production `npm audit --omit=dev` is unaffected (devDependency only). (#2762... #2765)

--- a/.changeset/brave-orcas-rest.md
+++ b/.changeset/brave-orcas-rest.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 2888
 ---
 **Dev-dependency `brace-expansion` bumped to patched versions (1.1.18 / 5.0.9), resolving the high-severity DoS/OOM advisories** — the lockfile now pins the 2026-07-30 patch backports reachable via eslint and stryker. A non-breaking in-range bump (no overrides, no major bumps); production `npm audit --omit=dev` is unaffected (devDependency only). (#2765)

--- a/.changeset/brave-orcas-rest.md
+++ b/.changeset/brave-orcas-rest.md
@@ -2,4 +2,4 @@
 type: Fixed
 pr: 0
 ---
-**Dev-dependency `brace-expansion` bumped to patched versions (1.1.18 / 5.0.9), resolving the high-severity DoS/OOM advisories** — the lockfile now pins the 2026-07-30 patch backports reachable via eslint and stryker. A non-breaking in-range bump (no overrides, no major bumps); production `npm audit --omit=dev` is unaffected (devDependency only). (#2762... #2765)
+**Dev-dependency `brace-expansion` bumped to patched versions (1.1.18 / 5.0.9), resolving the high-severity DoS/OOM advisories** — the lockfile now pins the 2026-07-30 patch backports reachable via eslint and stryker. A non-breaking in-range bump (no overrides, no major bumps); production `npm audit --omit=dev` is unaffected (devDependency only). (#2765)

--- a/package-lock.json
+++ b/package-lock.json
@@ -815,9 +815,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -913,9 +913,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2198,16 +2198,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {
@@ -2887,9 +2887,9 @@
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/tests/issue-2765-brace-expansion-lockfile.test.cjs
+++ b/tests/issue-2765-brace-expansion-lockfile.test.cjs
@@ -37,10 +37,10 @@ test('all installed brace-expansion copies are patched (>=1.1.18 / >=5.0.9) — 
   const versions = npmLs('brace-expansion');
   assert.ok(versions.length > 0, 'brace-expansion must be installed (devDependency) to guard');
   for (const v of versions) {
-    const [maj, min] = v.split('.').map(Number);
-    const ok = (maj === 1 && (min > 1 || (min === 1 && v.split('.')[2] >= 18))) // 1.x >= 1.1.18
-      || (maj === 5 && (min > 0 || v.split('.')[2] >= 9))                       // 5.x >= 5.0.9
-      || (maj > 5);                                                             // >5.x
+    const [maj, min, pat] = v.split('.').map(Number);
+    const ok = (maj === 1 && (min > 1 || (min === 1 && pat >= 18))) // 1.x >= 1.1.18
+      || (maj === 5 && (min > 0 || pat >= 9))                       // 5.x >= 5.0.9
+      || (maj > 5);                                                 // >5.x
     assert.ok(ok,
       `brace-expansion@${v} is within the vulnerable range (<=5.0.7) — lockfile regressed the #2765 patch bump. ` +
       'Re-apply: npm audit fix (non-breaking) to bump to 1.1.18 / 5.0.9.');

--- a/tests/issue-2765-brace-expansion-lockfile.test.cjs
+++ b/tests/issue-2765-brace-expansion-lockfile.test.cjs
@@ -19,7 +19,7 @@ function npmLs(pkg) {
   // `npm ls <pkg> --json --all` lists every installed copy with its version. Collect
   // the version of every node whose key is `pkg` (not the parent packages).
   const out = execFileSync('npm', ['ls', pkg, '--json', '--all'], {
-    cwd: ROOT, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'],
+    cwd: ROOT, encoding: 'utf8', shell: true, stdio: ['ignore', 'pipe', 'ignore'],
   });
   const versions = [];
   const walk = (node) => {

--- a/tests/issue-2765-brace-expansion-lockfile.test.cjs
+++ b/tests/issue-2765-brace-expansion-lockfile.test.cjs
@@ -1,0 +1,48 @@
+// allow-test-rule: structural-implementation-guard (#2765)
+'use strict';
+
+// Regression guard for #2765: the lockfile must pin the patched brace-expansion
+// versions (>=1.1.18 for the 1.x line, >=5.0.9 for the 5.x line) published 2026-07-30
+// to resolve the high-severity DoS/OOM advisories (GHSA-3jxr-9vmj-r5cp /
+// GHSA-mh99-v99m-4gvg, range <=5.0.7). This is a lockfile-only devDependency bump
+// (eslint/stryker → minimatch → brace-expansion); production (npm audit --omit=dev) is
+// unaffected. The test pins the installed versions so the bump can't silently regress.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { execFileSync } = require('node:child_process');
+const path = require('node:path');
+
+const ROOT = path.join(__dirname, '..');
+
+function npmLs(pkg) {
+  // `npm ls <pkg> --json --all` lists every installed copy with its version. Collect
+  // the version of every node whose key is `pkg` (not the parent packages).
+  const out = execFileSync('npm', ['ls', pkg, '--json', '--all'], {
+    cwd: ROOT, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'],
+  });
+  const versions = [];
+  const walk = (node) => {
+    if (!node || !node.dependencies) return;
+    for (const [k, v] of Object.entries(node.dependencies)) {
+      if (k === pkg && v && v.version) versions.push(v.version);
+      walk(v);
+    }
+  };
+  walk(JSON.parse(out));
+  return versions;
+}
+
+test('all installed brace-expansion copies are patched (>=1.1.18 / >=5.0.9) — #2765', () => {
+  const versions = npmLs('brace-expansion');
+  assert.ok(versions.length > 0, 'brace-expansion must be installed (devDependency) to guard');
+  for (const v of versions) {
+    const [maj, min] = v.split('.').map(Number);
+    const ok = (maj === 1 && (min > 1 || (min === 1 && v.split('.')[2] >= 18))) // 1.x >= 1.1.18
+      || (maj === 5 && (min > 0 || v.split('.')[2] >= 9))                       // 5.x >= 5.0.9
+      || (maj > 5);                                                             // >5.x
+    assert.ok(ok,
+      `brace-expansion@${v} is within the vulnerable range (<=5.0.7) — lockfile regressed the #2765 patch bump. ` +
+      'Re-apply: npm audit fix (non-breaking) to bump to 1.1.18 / 5.0.9.');
+  }
+});


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #2765

---

## What was broken

`npm ci` reported a **high-severity** `brace-expansion` (≤5.0.7) advisory — DoS via exponential expansion (GHSA-3jxr-9vmj-r5cp) and OOM via unbounded length (GHSA-mh99-v99m-4gvg) — reachable via eslint (→ @eslint/config-array / @eslint/eslintrc / minimatch@3.1.5 → brace-expansion@1.1.15) and stryker (→ minimatch → brace-expansion@5.0.6). **devDependency-only** (`npm audit --omit=dev` = 0; the published package is unaffected).

## What this fix does

`npm audit fix` (non-breaking) bumps the lockfile to the patch backports published 2026-07-30:
- `brace-expansion 1.1.15 → 1.1.18` (eslint-nested; stays in 1.x, compatible with minimatch@3.x's `^1.1.7`)
- `brace-expansion 5.0.6 → 5.0.9` (stryker-nested)

No `overrides`, no major bumps, no `--force` — a pure in-range lockfile bump. `package.json` is untouched. A structural test pins the installed versions so the bump can't silently regress.

## Advisory-DB note

After the bump, `npm audit` still flags `GHSA-mh99` because the advisory DB's range (`<=5.0.7`) hasn't yet been updated to mark `1.1.18`/`5.0.9` as patched (npm still suggests eslint@10 as the "fix"). The advisory's `first_patched_version` is `5.0.8`, and `1.1.18`/`5.0.9` both sit above the vulnerable range — the residual flag is a flat-range DB-timing gap, not an unfixed vulnerability. `GHSA-3jxr` IS resolved. The installed versions are the maintainers' published patches (verified: registry integrity hashes match the lockfile).

## Testing

- `gsd-test` full matrix green.
- `npm audit --omit=dev` = 0 (production unaffected).
- `npm run lint:ci` exit 0; `npm run build:lib` exit 0.
- `tests/issue-2765-brace-expansion-lockfile.test.cjs` asserts every installed brace-expansion copy is ≥1.1.18 / ≥5.0.9 (parses all semver segments numerically so it can't false-pass a vulnerable single-digit patch).

### Platforms / Runtimes
- [x] Linux · [x] Windows (`shell: true` on the test's npm invocation, per the no-bare-npm-exec rule) · [x] N/A (dep bump, runtime-agnostic)

## Out of scope

The npm-suggested "full fix" (eslint@10) is a breaking major bump — separate concern.

## Breaking changes

None. A devDependency lockfile bump within existing semver ranges; no API or behavior change.

---

GSD_PR_GATES_OK=1

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2888"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788045796&installation_model_id=22188&pr_number=2888&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2888&signature=3fc71361cbc7a7e44f96edc37c6559f6ace8357f54a5528a6518f398f0424f98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->