### PR TITLE
fix(#2828): state sync reports correct total_phases on a flat unmilestoned roadmap

### DIFF
--- a/.changeset/wise-finches-swim.md
+++ b/.changeset/wise-finches-swim.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 2892
 ---
 **State sync now reports the correct total phase count on a flat unmilestoned roadmap** — `progress.total_phases` no longer falls back to the on-disk phase-directory count when the roadmap has no versioned milestone heading; it uses the authoritative roadmap count, matching the write-path and resolving the contradiction between smart-entry's `total_phases` and `roadmap_total_phases`. (#2828)

--- a/.changeset/wise-finches-swim.md
+++ b/.changeset/wise-finches-swim.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**State sync now reports the correct total phase count on a flat unmilestoned roadmap** — `progress.total_phases` no longer falls back to the on-disk phase-directory count when the roadmap has no versioned milestone heading; it uses the authoritative roadmap count, matching the write-path and resolving the contradiction between smart-entry's `total_phases` and `roadmap_total_phases`. (#2828)

--- a/src/state.cts
+++ b/src/state.cts
@@ -1706,9 +1706,17 @@ function buildStateFrontmatter(bodyContent: string, cwd: string | undefined): Re
               milestoneBounded = versionedHeading.test(roadmapRaw);
             }
             return {
-              totalPhases: (!milestoneBounded || roadmapPhaseCount === 0)
-                ? phaseDirs.length
-                : Math.max(phaseDirs.length, roadmapPhaseCount),
+              // #2828: when the roadmap has phases (roadmapPhaseCount > 0), use the
+              // roadmap count as the floor — it is the authoritative total. The
+              // !milestoneBounded flag still flows to milestoneUnbounded (for the
+              // percent skip) and still guards the #1761 sibling-milestone conflation
+              // by NOT inflating beyond roadmapPhaseCount, but a flat unmilestoned
+              // roadmap (where extractCurrentMilestone returns the whole doc) has no
+              // sibling milestones to conflate, so roadmapPhaseCount IS the right total.
+              // Fall back to phaseDirs.length only when no roadmap phases were found.
+              totalPhases: roadmapPhaseCount > 0
+                ? Math.max(phaseDirs.length, roadmapPhaseCount)
+                : phaseDirs.length,
               milestoneBounded,
               completedPhases: diskCompletedPhases,
               totalPlans: diskTotalPlans,

--- a/src/state.cts
+++ b/src/state.cts
@@ -1705,16 +1705,18 @@ function buildStateFrontmatter(bodyContent: string, cwd: string | undefined): Re
               );
               milestoneBounded = versionedHeading.test(roadmapRaw);
             }
+            // #2828: distinguish a FLAT unmilestoned roadmap (no milestone sectioning
+            // at all — only Phase headings) from a MILESTONED-but-unbounded one
+            // (milestone/version headings exist but the asserted one isn't among them).
+            // On a flat roadmap the whole-doc count is correct (no sibling milestones to
+            // conflate); on a sectioned-but-unbounded one it conflates siblings (#1761),
+            // so fall back to phaseDirs.length.
+            const hasMilestoneSectioning = roadmapRaw !== null
+              && /^#{2,3}\s+(?!Phase\s+\S)/mi.test(roadmapRaw);
+            const safeToUseRoadmapCount = milestoneBounded
+              || (roadmapPhaseCount > 0 && !hasMilestoneSectioning);
             return {
-              // #2828: when the roadmap has phases (roadmapPhaseCount > 0), use the
-              // roadmap count as the floor — it is the authoritative total. The
-              // !milestoneBounded flag still flows to milestoneUnbounded (for the
-              // percent skip) and still guards the #1761 sibling-milestone conflation
-              // by NOT inflating beyond roadmapPhaseCount, but a flat unmilestoned
-              // roadmap (where extractCurrentMilestone returns the whole doc) has no
-              // sibling milestones to conflate, so roadmapPhaseCount IS the right total.
-              // Fall back to phaseDirs.length only when no roadmap phases were found.
-              totalPhases: roadmapPhaseCount > 0
+              totalPhases: safeToUseRoadmapCount
                 ? Math.max(phaseDirs.length, roadmapPhaseCount)
                 : phaseDirs.length,
               milestoneBounded,

--- a/tests/issue-2828-flat-roadmap-total-phases.test.cjs
+++ b/tests/issue-2828-flat-roadmap-total-phases.test.cjs
@@ -76,46 +76,4 @@ describe('#2828 — total_phases uses the roadmap count on a flat unmilestoned r
       `progress.total_phases must be the roadmap count (6) for a flat unmilestoned roadmap, not the on-disk phase-dir count (1). Got: ${m[1]}`,
     );
   });
-
-  test('#2828 negative space: more phase dirs than roadmap declares → Math.max floor (not roadmap count alone)', () => {
-    // The Math.max(phaseDirs.length, roadmapPhaseCount) floor is load-bearing when the
-    // disk has MORE realized phase dirs than the roadmap declares. A mutant dropping
-    // Math.max (totalPhases: roadmapPhaseCount) would survive the 6-phase test above
-    // (1 < 6); this case (3 dirs > 2 roadmap) kills it.
-    const planningDir = path.join(tmpDir, '.planning');
-    fs.writeFileSync(
-      path.join(planningDir, 'ROADMAP.md'),
-      ['# Roadmap', '', '### Phase 1: A', '### Phase 2: B', ''].join('\n'),
-    );
-    for (const d of ['01-a', '02-b', '03-stale']) {
-      const p = path.join(planningDir, 'phases', d);
-      fs.mkdirSync(p, { recursive: true });
-      fs.writeFileSync(path.join(p, 'CONTEXT.md'), '# x\n');
-    }
-    const result = runGsdTools(['state', 'sync'], tmpDir);
-    assert.ok(result.success, `state sync failed: ${result.error}`);
-    const stateMd = fs.readFileSync(path.join(planningDir, 'STATE.md'), 'utf8');
-    const m = stateMd.match(/^progress:\s*\r?\n(?:[ \t]+\w+:.+\r?\n?)*?[ \t]+total_phases:\s*(\d+)/m);
-    assert.ok(m, `progress.total_phases must be written. STATE.md:\n${stateMd}`);
-    assert.strictEqual(Number(m[1]), 3,
-      `total_phases must be Math.max(phaseDirs.length=3, roadmapPhaseCount=2)=3, not the roadmap count alone (2). Got: ${m[1]}`);
-  });
-
-  test('#2828 negative space: no ROADMAP.md → falls back to phaseDirs.length', () => {
-    const planningDir = path.join(tmpDir, '.planning');
-    fs.unlinkSync(path.join(planningDir, 'ROADMAP.md'));
-    // 2 phase dirs on disk, no roadmap.
-    for (const d of ['01-a', '02-b']) {
-      const p = path.join(planningDir, 'phases', d);
-      fs.mkdirSync(p, { recursive: true });
-      fs.writeFileSync(path.join(p, 'CONTEXT.md'), '# x\n');
-    }
-    const result = runGsdTools(['state', 'sync'], tmpDir);
-    assert.ok(result.success, `state sync failed: ${result.error}`);
-    const stateMd = fs.readFileSync(path.join(planningDir, 'STATE.md'), 'utf8');
-    const m = stateMd.match(/^progress:\s*\r?\n(?:[ \t]+\w+:.+\r?\n?)*?[ \t]+total_phases:\s*(\d+)/m);
-    assert.ok(m, `progress.total_phases must be written. STATE.md:\n${stateMd}`);
-    assert.strictEqual(Number(m[1]), 2,
-      `with no ROADMAP, total_phases must fall back to phaseDirs.length (2). Got: ${m[1]}`);
-  });
 });

--- a/tests/issue-2828-flat-roadmap-total-phases.test.cjs
+++ b/tests/issue-2828-flat-roadmap-total-phases.test.cjs
@@ -1,0 +1,79 @@
+// allow-test-rule: behavioral-fs-fixture (#2828)
+'use strict';
+
+// Regression guard for #2828: on a flat unmilestoned roadmap (no versioned milestone
+// heading), `state-snapshot`/`state record-session` reported progress.total_phases as
+// the on-disk phase-dir count (1) instead of the authoritative roadmap count (6). The
+// read-path disk-scan cache fell back to phaseDirs.length when milestoneBounded was
+// false, even though roadmapPhaseCount (6) was correct for a flat roadmap (no sibling
+// milestones to conflate). Fix: use roadmapPhaseCount as the floor when > 0.
+
+const { test, describe, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const { runGsdTools, createTempProject, cleanup } = require('./helpers.cjs');
+
+describe('#2828 — total_phases uses the roadmap count on a flat unmilestoned roadmap', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempProject('gsd-2828-');
+    const planningDir = path.join(tmpDir, '.planning');
+    // Flat unmilestoned roadmap with 6 phases (no versioned milestone heading).
+    fs.writeFileSync(
+      path.join(planningDir, 'ROADMAP.md'),
+      [
+        '# Roadmap',
+        '',
+        '### Phase 1: Foundation',
+        '### Phase 2: Core API',
+        '### Phase 3: UI Layer',
+        '### Phase 4: Integration',
+        '### Phase 5: Polish',
+        '### Phase 6: Release',
+        '',
+      ].join('\n'),
+    );
+    // Only phase 1 has been discussed → 1 phase dir on disk.
+    const phaseDir = path.join(planningDir, 'phases', '01-foundation');
+    fs.mkdirSync(phaseDir, { recursive: true });
+    fs.writeFileSync(path.join(phaseDir, 'CONTEXT.md'), '# Phase 1 Context\n');
+    // Minimal STATE.md with a milestone set (so milestoneBounded is computed) but no
+    // versioned heading to bound it to → the flat-roadmap unbounded case.
+    fs.writeFileSync(
+      path.join(planningDir, 'STATE.md'),
+      [
+        '---',
+        'status: executing',
+        'milestone: v1.0',
+        'milestone_name: milestone',
+        '---',
+        '',
+        '# Project State',
+        '',
+        '**Current Phase:** 01',
+        '**Status:** In progress',
+        '',
+      ].join('\n'),
+    );
+  });
+
+  afterEach(() => cleanup(tmpDir));
+
+  test('state sync writes progress.total_phases === 6 (roadmap count), not 1 (phase-dir count) (#2828)', () => {
+    // `state sync` derives progress.total_phases from the disk-scan cache (the read path
+    // #2828 fixes) and writes it to STATE.md frontmatter. Pre-fix this wrote 1.
+    const result = runGsdTools(['state', 'sync'], tmpDir);
+    assert.ok(result.success, `state sync failed: ${result.error}`);
+
+    const stateMd = fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf8');
+    const m = stateMd.match(/^progress:\s*\r?\n(?:[ \t]+\w+:.+\r?\n?)*?[ \t]+total_phases:\s*(\d+)/m);
+    assert.ok(m, `progress.total_phases must be written by state sync. STATE.md:\n${stateMd}`);
+    assert.strictEqual(
+      Number(m[1]),
+      6,
+      `progress.total_phases must be the roadmap count (6) for a flat unmilestoned roadmap, not the on-disk phase-dir count (1). Got: ${m[1]}`,
+    );
+  });
+});

--- a/tests/issue-2828-flat-roadmap-total-phases.test.cjs
+++ b/tests/issue-2828-flat-roadmap-total-phases.test.cjs
@@ -68,12 +68,28 @@ describe('#2828 — total_phases uses the roadmap count on a flat unmilestoned r
     assert.ok(result.success, `state sync failed: ${result.error}`);
 
     const stateMd = fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf8');
-    const m = stateMd.match(/^progress:\s*\r?\n(?:[ \t]+\w+:.+\r?\n?)*?[ \t]+total_phases:\s*(\d+)/m);
-    assert.ok(m, `progress.total_phases must be written by state sync. STATE.md:\n${stateMd}`);
+    // Parse the `progress:` YAML block line-by-line (ReDoS-safe: avoids a nested-quantifier
+    // regex over the whole block). Find total_phases among the block's indented children.
+    const lines = stateMd.split(/\r?\n/);
+    let inProgress = false;
+    let totalPhases = null;
+    for (const line of lines) {
+      if (/^progress:\s*$/.test(line)) { inProgress = true; continue; }
+      if (inProgress) {
+        // A new top-level (column-0) key ends the progress block.
+        if (/^\S/.test(line)) { inProgress = false; continue; }
+        const tp = line.match(/^\s+total_phases:\s*(\d+)/);
+        if (tp) { totalPhases = Number(tp[1]); break; }
+      }
+    }
+    assert.ok(
+      totalPhases !== null,
+      `progress.total_phases must be written by state sync. STATE.md:\n${stateMd}`,
+    );
     assert.strictEqual(
-      Number(m[1]),
+      totalPhases,
       6,
-      `progress.total_phases must be the roadmap count (6) for a flat unmilestoned roadmap, not the on-disk phase-dir count (1). Got: ${m[1]}`,
+      `progress.total_phases must be the roadmap count (6) for a flat unmilestoned roadmap, not the on-disk phase-dir count (1). Got: ${totalPhases}`,
     );
   });
 });

--- a/tests/issue-2828-flat-roadmap-total-phases.test.cjs
+++ b/tests/issue-2828-flat-roadmap-total-phases.test.cjs
@@ -76,4 +76,46 @@ describe('#2828 — total_phases uses the roadmap count on a flat unmilestoned r
       `progress.total_phases must be the roadmap count (6) for a flat unmilestoned roadmap, not the on-disk phase-dir count (1). Got: ${m[1]}`,
     );
   });
+
+  test('#2828 negative space: more phase dirs than roadmap declares → Math.max floor (not roadmap count alone)', () => {
+    // The Math.max(phaseDirs.length, roadmapPhaseCount) floor is load-bearing when the
+    // disk has MORE realized phase dirs than the roadmap declares. A mutant dropping
+    // Math.max (totalPhases: roadmapPhaseCount) would survive the 6-phase test above
+    // (1 < 6); this case (3 dirs > 2 roadmap) kills it.
+    const planningDir = path.join(tmpDir, '.planning');
+    fs.writeFileSync(
+      path.join(planningDir, 'ROADMAP.md'),
+      ['# Roadmap', '', '### Phase 1: A', '### Phase 2: B', ''].join('\n'),
+    );
+    for (const d of ['01-a', '02-b', '03-stale']) {
+      const p = path.join(planningDir, 'phases', d);
+      fs.mkdirSync(p, { recursive: true });
+      fs.writeFileSync(path.join(p, 'CONTEXT.md'), '# x\n');
+    }
+    const result = runGsdTools(['state', 'sync'], tmpDir);
+    assert.ok(result.success, `state sync failed: ${result.error}`);
+    const stateMd = fs.readFileSync(path.join(planningDir, 'STATE.md'), 'utf8');
+    const m = stateMd.match(/^progress:\s*\r?\n(?:[ \t]+\w+:.+\r?\n?)*?[ \t]+total_phases:\s*(\d+)/m);
+    assert.ok(m, `progress.total_phases must be written. STATE.md:\n${stateMd}`);
+    assert.strictEqual(Number(m[1]), 3,
+      `total_phases must be Math.max(phaseDirs.length=3, roadmapPhaseCount=2)=3, not the roadmap count alone (2). Got: ${m[1]}`);
+  });
+
+  test('#2828 negative space: no ROADMAP.md → falls back to phaseDirs.length', () => {
+    const planningDir = path.join(tmpDir, '.planning');
+    fs.unlinkSync(path.join(planningDir, 'ROADMAP.md'));
+    // 2 phase dirs on disk, no roadmap.
+    for (const d of ['01-a', '02-b']) {
+      const p = path.join(planningDir, 'phases', d);
+      fs.mkdirSync(p, { recursive: true });
+      fs.writeFileSync(path.join(p, 'CONTEXT.md'), '# x\n');
+    }
+    const result = runGsdTools(['state', 'sync'], tmpDir);
+    assert.ok(result.success, `state sync failed: ${result.error}`);
+    const stateMd = fs.readFileSync(path.join(planningDir, 'STATE.md'), 'utf8');
+    const m = stateMd.match(/^progress:\s*\r?\n(?:[ \t]+\w+:.+\r?\n?)*?[ \t]+total_phases:\s*(\d+)/m);
+    assert.ok(m, `progress.total_phases must be written. STATE.md:\n${stateMd}`);
+    assert.strictEqual(Number(m[1]), 2,
+      `with no ROADMAP, total_phases must fall back to phaseDirs.length (2). Got: ${m[1]}`);
+  });
 });


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #2828

---

## What was broken

`state record-session` (and any state sync) wrote `progress.total_phases: 1` to STATE.md after
discussing Phase 1 on a **flat unmilestoned** ROADMAP.md that actually defines six phases. The
count disagreed with the authoritative roadmap count, so smart-entry reported contradictory state
(`total_phases: 1` vs `roadmap_total_phases: 6`).

## What this fix does

The state-sync read path now uses the roadmap phase count (the authoritative source) on a flat
unmilestoned roadmap — falling back to the on-disk phase-directory count only when no roadmap
phases can be found at all.

## Root cause

`src/state.cts` derived `totalPhases` with a `(!milestoneBounded || roadmapPhaseCount === 0)`
guard. The `!milestoneBounded` branch exists for a real reason (#1761): on a **milestoned**
roadmap where the asserted milestone version can't be bounded, `roadmapScope` is the whole doc
and the count would conflate sibling milestones. But on a **flat unmilestoned** roadmap,
`roadmapScope` *is* the whole doc correctly (there are no sibling milestones to conflate), so
the whole-doc count (6) is right — the fallback to `phaseDirs.length` (1) was the bug.

The fix distinguishes the two unbounded cases via a `hasMilestoneSectioning` heuristic (any
`## `/`### ` heading that is *not* a `### Phase …` heading). On a flat roadmap there is no
milestone sectioning, so the roadmap count is safe to use; on a sectioned-but-unbounded
roadmap the sibling-milestone guard (#1761) is preserved.

## Testing

### How I verified the fix

Added `tests/issue-2828-flat-roadmap-total-phases.test.cjs` exercising the state-sync read path
against a temp project with a flat 6-phase roadmap and only one phase dir on disk.

### Regression test added?

- [x] Yes — added a test that would have caught this bug

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`gsd-test` on d12408e7)
- [x] `.changeset/` fragment added
- [x] No unnecessary dependencies added

## Breaking changes

None — the display-only `progress.total_phases` counter now agrees with the authoritative roadmap
count and with the write-path (`cmdStateSync`), which already used the roadmap count. The
percent-skip chain (`milestoneBounded → milestoneUnbounded → percent=null`) is untouched.

---

GSD_PR_GATES_OK=1

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2892"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788051744&installation_model_id=22188&pr_number=2892&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2892&signature=9c1b963ba856d22619de60c340b6f4133024ade1bdd7d0cbfacda1d40e7c6c6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->