### PR TITLE
fix(#2666): code-review scopes root-level + extensionless build files, cross-checks against git diff

### DIFF
--- a/.changeset/witty-pumas-wave.md
+++ b/.changeset/witty-pumas-wave.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**Code-review now scopes repository-root and extensionless build files (Dockerfile, Makefile, .gitlab-ci.yml, renovate.json, AGENTS.md)** — the SUMMARY.md file extractor no longer silently drops every root-level path and every extensionless build file, and a partial SUMMARY scope is now cross-checked against `git diff` with a warning naming any changed files it missed. (#2666)

--- a/.changeset/witty-pumas-wave.md
+++ b/.changeset/witty-pumas-wave.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 2895
 ---
 **Code-review now scopes repository-root and extensionless build files (Dockerfile, Makefile, .gitlab-ci.yml, renovate.json, AGENTS.md)** — the SUMMARY.md file extractor no longer silently drops every root-level path and every extensionless build file, and a partial SUMMARY scope is now cross-checked against `git diff` with a warning naming any changed files it missed. (#2666)

--- a/gsd-core/workflows/code-review.md
+++ b/gsd-core/workflows/code-review.md
@@ -185,7 +185,21 @@ if [ -z "$FILES_OVERRIDE" ]; then
             raw = raw.replace(/^['"]|['"]$/g, '');
             raw = raw.replace(/\s+\([^)]*\)\s*$/, '');
             raw = raw.split(/\s+—\s/)[0].trim();
-            if (/\//.test(raw) && /\.[A-Za-z0-9]+$/.test(raw)) {
+            // #2666: accept root-level paths (no `/`) and known extensionless build
+            // files, not only nested paths with a trailing extension. The pre-fix
+            // predicate `/\//.test(raw) && /\.[A-Za-z0-9]+$/.test(raw)` silently
+            // dropped every repository-root file (Dockerfile, renovate.json,
+            // AGENTS.md, package.json, .gitlab-ci.yml, …) and every extensionless
+            // build file anywhere in the tree (**/Dockerfile, **/Makefile).
+            // Prose bullets are rejected by the known-filename / has-extension
+            // distinction, with the post-processing existence check (`[ -f ]`) as a
+            // backstop — a prose string is never a real file on disk.
+            const KNOWN_EXTENSIONLESS_BUILD_FILES = new Set([
+              'dockerfile', 'containerfile', 'makefile', 'justfile', 'procfile',
+            ]);
+            const hasExtension = /\.[A-Za-z0-9]+$/.test(raw);
+            const basename = raw.split('/').pop().toLowerCase();
+            if (hasExtension || KNOWN_EXTENSIONLESS_BUILD_FILES.has(basename)) {
               files.push(raw);
             }
           }
@@ -210,38 +224,74 @@ if [ -z "$FILES_OVERRIDE" ]; then
 fi
 ```
 
-**Tier 3 — Git diff fallback (per D-02):**
+**Tier 3 — Git diff fallback (per D-02) and SUMMARY/diff cross-check (per #2666):**
 
-If no SUMMARY.md files found OR no files extracted from them:
+If no SUMMARY.md files found OR no files extracted from them, fall back to the git diff.
+Additionally, whenever a reliable diff base is available, cross-check the SUMMARY scope
+against the diff and warn about (then add) any changed files the SUMMARY extractor did not
+surface — so a partial SUMMARY result can no longer silently mask the rest of the phase.
 ```bash
+# Compute diff base from phase commits — fail closed if no reliable base found
+PHASE_COMMITS=$(git log --oneline --all --grep="${PADDED_PHASE}" --format="%H" 2>/dev/null)
+DIFF_BASE=""
+if [ -n "$PHASE_COMMITS" ]; then
+  DIFF_BASE=$(echo "$PHASE_COMMITS" | tail -1)^
+  # Verify the parent commit exists (first commit in repo has no parent)
+  if ! git rev-parse "${DIFF_BASE}" >/dev/null 2>&1; then
+    DIFF_BASE=$(echo "$PHASE_COMMITS" | tail -1)
+  fi
+fi
+
 if [ ${#REVIEW_FILES[@]} -eq 0 ]; then
-  # Compute diff base from phase commits — fail closed if no reliable base found
-  PHASE_COMMITS=$(git log --oneline --all --grep="${PADDED_PHASE}" --format="%H" 2>/dev/null)
-  
-  if [ -n "$PHASE_COMMITS" ]; then
-    DIFF_BASE=$(echo "$PHASE_COMMITS" | tail -1)^
-    
-    # Verify the parent commit exists (first commit in repo has no parent)
-    if ! git rev-parse "${DIFF_BASE}" >/dev/null 2>&1; then
-      DIFF_BASE=$(echo "$PHASE_COMMITS" | tail -1)
-    fi
-    
+  # Full git-diff fallback (per D-02): SUMMARY scoping yielded nothing.
+  if [ -n "$DIFF_BASE" ]; then
     # Run git diff with specific exclusions (per D-03)
     DIFF_FILES=$(git diff --name-only "${DIFF_BASE}..HEAD" -- . \
       ':!.planning/' ':!ROADMAP.md' ':!STATE.md' \
       ':!*-SUMMARY.md' ':!*-VERIFICATION.md' ':!*-PLAN.md' \
       ':!package-lock.json' ':!yarn.lock' ':!Gemfile.lock' ':!poetry.lock' 2>/dev/null)
-    
+
     while IFS= read -r file; do
       [ -n "$file" ] && REVIEW_FILES+=("$file")
     done <<< "$DIFF_FILES"
-    
+
     echo "File scope: ${#REVIEW_FILES[@]} files from git diff (base: ${DIFF_BASE})"
   else
     # Fail closed — no reliable diff base found. Do not use arbitrary HEAD~N.
     echo "Warning: No phase commits found for '${PADDED_PHASE}'. Cannot determine reliable diff scope."
     echo "Use --files flag to specify files explicitly: /gsd:code-review ${PHASE_ARG} --files=file1,file2,..."
   fi
+elif [ -n "$DIFF_BASE" ]; then
+  # #2666 cross-check: SUMMARY yielded a non-empty (possibly partial) scope.
+  # Warn about — and add — any changed files the SUMMARY extractor did not surface,
+  # so a partial result can no longer silently ship an incomplete review scope.
+  DIFF_FILES=$(git diff --name-only "${DIFF_BASE}..HEAD" -- . \
+    ':!.planning/' ':!ROADMAP.md' ':!STATE.md' \
+    ':!*-SUMMARY.md' ':!*-VERIFICATION.md' ':!*-PLAN.md' \
+    ':!package-lock.json' ':!yarn.lock' ':!Gemfile.lock' ':!poetry.lock' 2>/dev/null)
+
+  # Build a newline-delimited list of already-scoped files for membership testing
+  # (portable — bash 3.2 on macOS has no associative arrays)
+  IN_SCOPE=$(
+    printf '%s\n' "${REVIEW_FILES[@]}"
+    printf '\n'
+  )
+
+  MISSING_FROM_SUMMARY=()
+  while IFS= read -r file; do
+    [ -z "$file" ] && continue
+    # Membership test against the newline-delimited scope (portable pattern match)
+    case "$IN_SCOPE" in
+      *"$file"$'\n'*) ;;  # already scoped
+      *) MISSING_FROM_SUMMARY+=("$file"); REVIEW_FILES+=("$file") ;;
+    esac
+  done <<< "$DIFF_FILES"
+
+  if [ ${#MISSING_FROM_SUMMARY[@]} -gt 0 ]; then
+    echo "Warning: SUMMARY scope was missing ${#MISSING_FROM_SUMMARY[@]} changed file(s) the git diff surfaced; adding them to the review scope:"
+    printf '  - %s\n' "${MISSING_FROM_SUMMARY[@]}"
+  fi
+  unset IN_SCOPE
 fi
 ```
 

--- a/gsd-core/workflows/code-review.md
+++ b/gsd-core/workflows/code-review.md
@@ -187,10 +187,10 @@ if [ -z "$FILES_OVERRIDE" ]; then
             raw = raw.split(/\s+—\s/)[0].trim();
             // #2666: accept root-level paths (no `/`) and known extensionless build
             // files, not only nested paths with a trailing extension. The pre-fix
-            // predicate `/\//.test(raw) && /\.[A-Za-z0-9]+$/.test(raw)` silently
-            // dropped every repository-root file (Dockerfile, renovate.json,
-            // AGENTS.md, package.json, .gitlab-ci.yml, …) and every extensionless
-            // build file anywhere in the tree (**/Dockerfile, **/Makefile).
+            // guard required BOTH a directory separator AND a trailing dot-extension,
+            // which silently dropped every repository-root file (Dockerfile,
+            // renovate.json, AGENTS.md, package.json, .gitlab-ci.yml, …) and every
+            // extensionless build file anywhere in the tree (**/Dockerfile, **/Makefile).
             // Prose bullets are rejected by the known-filename / has-extension
             // distinction, with the post-processing existence check (`[ -f ]`) as a
             // backstop — a prose string is never a real file on disk.

--- a/gsd-core/workflows/code-review.md
+++ b/gsd-core/workflows/code-review.md
@@ -270,28 +270,27 @@ elif [ -n "$DIFF_BASE" ]; then
     ':!*-SUMMARY.md' ':!*-VERIFICATION.md' ':!*-PLAN.md' \
     ':!package-lock.json' ':!yarn.lock' ':!Gemfile.lock' ':!poetry.lock' 2>/dev/null)
 
-  # Build a newline-delimited list of already-scoped files for membership testing
-  # (portable — bash 3.2 on macOS has no associative arrays)
-  IN_SCOPE=$(
-    printf '%s\n' "${REVIEW_FILES[@]}"
-    printf '\n'
-  )
+  # Build a newline-delimited list of already-scoped files for exact membership
+  # testing (portable — bash 3.2 on macOS has no associative arrays). grep -Fxq
+  # matches the WHOLE line exactly, so a short basename (e.g. root `Dockerfile`)
+  # does NOT substring-match a longer scoped path (e.g. `docker/Dockerfile`).
+  IN_SCOPE=$(printf '%s\n' "${REVIEW_FILES[@]}")
 
   MISSING_FROM_SUMMARY=()
   while IFS= read -r file; do
     [ -z "$file" ] && continue
-    # Membership test against the newline-delimited scope (portable pattern match)
-    case "$IN_SCOPE" in
-      *"$file"$'\n'*) ;;  # already scoped
-      *) MISSING_FROM_SUMMARY+=("$file"); REVIEW_FILES+=("$file") ;;
-    esac
+    # Exact whole-line match; grep nonzero-exit => not in scope.
+    if printf '%s\n' "${REVIEW_FILES[@]}" | grep -Fxq -- "$file" 2>/dev/null; then
+      : # already scoped
+    else
+      MISSING_FROM_SUMMARY+=("$file"); REVIEW_FILES+=("$file")
+    fi
   done <<< "$DIFF_FILES"
 
   if [ ${#MISSING_FROM_SUMMARY[@]} -gt 0 ]; then
     echo "Warning: SUMMARY scope was missing ${#MISSING_FROM_SUMMARY[@]} changed file(s) the git diff surfaced; adding them to the review scope:"
     printf '  - %s\n' "${MISSING_FROM_SUMMARY[@]}"
   fi
-  unset IN_SCOPE
 fi
 ```
 

--- a/tests/code-review-pipeline-regression.test.cjs
+++ b/tests/code-review-pipeline-regression.test.cjs
@@ -38,7 +38,24 @@ const REVIEWER_PATH = path.join(ROOT, 'agents', 'gsd-code-reviewer.md');
 // This mirrors the logic in code-review.md lines 172-184 exactly.
 // If those lines change, this function must be updated in tandem (and the
 // docs-parity assertions below will catch a mismatch at the regex level).
-// ---------------------------------------------------------------------------
+//
+// #2666: the acceptance predicate accepts root-level paths (no `/`) and known
+// extensionless build files (Dockerfile/Makefile/etc.), not only nested paths
+// with a trailing extension. Prose bullets are rejected by the known-filename /
+// has-extension distinction (plus the post-processing existence check backstop
+// in the shipped workflow).
+const KNOWN_EXTENSIONLESS_BUILD_FILES = new Set([
+  'dockerfile', 'containerfile', 'makefile', 'justfile', 'procfile',
+]);
+function isAcceptablePath(raw) {
+  // A trailing `.`+alphanumerics extension qualifies (root-level OR nested):
+  // package.json, renovate.json, .gitlab-ci.yml, AGENTS.md, app/foo.tsx
+  if (/\.[A-Za-z0-9]+$/.test(raw)) return true;
+  // Known extensionless build filename (basename, case-insensitive): Dockerfile, Makefile, …
+  const base = raw.split('/').pop();
+  if (KNOWN_EXTENSIONLESS_BUILD_FILES.has(base.toLowerCase())) return true;
+  return false;
+}
 function parseKeyFiles(yaml) {
   const files = [];
   let inSection = null;
@@ -53,7 +70,7 @@ function parseKeyFiles(yaml) {
       // Order matters: parens BEFORE em-dash because em-dashes can appear inside parens
       raw = raw.replace(/\s+\([^)]*\)\s*$/, '');
       raw = raw.split(/\s+—\s/)[0].trim();
-      if (/\//.test(raw) && /\.[A-Za-z0-9]+$/.test(raw)) {
+      if (isAcceptablePath(raw)) {
         files.push(raw);
       }
     }
@@ -160,6 +177,107 @@ describe('Bug 1 — compute_file_scope SUMMARY parser', () => {
     assert.deepStrictEqual(files, ['app/page.tsx']);
   });
 
+  // #2666 — the Tier-2 extractor must NOT drop repository-root files (no `/`)
+  // or known extensionless build files. Pre-fix the buggy predicate
+  // `/\//.test(raw) && /\.[A-Za-z0-9]+$/.test(raw)` dropped every root-level
+  // path and every extensionless build file anywhere in the tree.
+  test('#2666 RED: root-level files with extensions are accepted (package.json, renovate.json, .gitlab-ci.yml, AGENTS.md)', () => {
+    const yaml = [
+      'key-files:',
+      '  modified:',
+      '    - package.json',
+      '    - renovate.json',
+      '    - .gitlab-ci.yml',
+      '    - AGENTS.md',
+      '    - CLAUDE.md',
+    ].join('\n');
+    const files = parseKeyFiles(yaml);
+    assert.deepStrictEqual(
+      files.sort(),
+      ['.gitlab-ci.yml', 'AGENTS.md', 'CLAUDE.md', 'package.json', 'renovate.json'],
+      'root-level files with extensions must not be dropped for lacking a directory separator',
+    );
+  });
+
+  test('#2666: nested extensionless build files are accepted (docker/Dockerfile, web/Makefile)', () => {
+    const yaml = [
+      'key-files:',
+      '  modified:',
+      '    - docker/Dockerfile',
+      '    - web/Makefile',
+    ].join('\n');
+    const files = parseKeyFiles(yaml);
+    assert.deepStrictEqual(files.sort(), ['docker/Dockerfile', 'web/Makefile']);
+  });
+
+  test('#2666: root-level extensionless build files are accepted (Dockerfile, Makefile, Justfile, Containerfile, Procfile)', () => {
+    const yaml = [
+      'key-files:',
+      '  created:',
+      '    - Dockerfile',
+      '    - Makefile',
+      '    - Justfile',
+      '    - Containerfile',
+      '    - Procfile',
+    ].join('\n');
+    const files = parseKeyFiles(yaml);
+    assert.deepStrictEqual(
+      files.sort(),
+      ['Containerfile', 'Dockerfile', 'Justfile', 'Makefile', 'Procfile'],
+    );
+  });
+
+  test('#2666 acceptance #1: the reporter 10-file Docker+CI phase yields all 10 paths', () => {
+    const yaml = [
+      'key-files:',
+      '  created:',
+      '    - Dockerfile',
+      '    - .gitlab-ci.yml',
+      '    - renovate.json',
+      '    - AGENTS.md',
+      '    - CLAUDE.md',
+      '    - docs/DEVELOPMENT.md',
+      '    - scripts/version-consistency-gate.mjs',
+      '    - web/package.json',
+      '    - web/version_management.md',
+      '    - web/update-version.cjs',
+    ].join('\n');
+    const files = parseKeyFiles(yaml);
+    assert.deepStrictEqual(
+      files.sort(),
+      [
+        '.gitlab-ci.yml', 'AGENTS.md', 'CLAUDE.md', 'Dockerfile',
+        'docs/DEVELOPMENT.md', 'renovate.json', 'scripts/version-consistency-gate.mjs',
+        'web/package.json', 'web/update-version.cjs', 'web/version_management.md',
+      ],
+      'the full reporter phase must scope all 10 files, including Dockerfile + root files',
+    );
+  });
+
+  test('#2666 negative-space: a path-like prose bullet with no extension and unknown basename is rejected', () => {
+    // `topic/mode/date filters` has a `/` but no extension and an unknown basename —
+    // the pre-fix predicate dropped it (good), the relaxed predicate must STILL drop it.
+    const yaml = [
+      'key-decisions:',
+      '  - topic/mode/date filters',
+      'key-files:',
+      '  created:',
+      '    - app/page.tsx',
+    ].join('\n');
+    const files = parseKeyFiles(yaml);
+    assert.deepStrictEqual(files, ['app/page.tsx']);
+  });
+
+  test('#2666 negative-space: em-dash/parenthetical stripping still works on an accepted root file', () => {
+    const yaml = [
+      'key-files:',
+      '  modified:',
+      '    - Dockerfile — multi-stage build',
+    ].join('\n');
+    const files = parseKeyFiles(yaml);
+    assert.deepStrictEqual(files, ['Dockerfile']);
+  });
+
   // Docs-parity: the workflow .md must contain the hyphen-aware boundary regex
   // so what we tested above is actually what is deployed.
   test('code-review.md contains hyphen-aware boundary regex [\\w-]+', () => {
@@ -190,6 +308,53 @@ describe('Bug 1 — compute_file_scope SUMMARY parser', () => {
     assert.ok(
       scriptSection.includes('split(/\\s+—\\s'),
       'Script must split on em-dash to strip narrative'
+    );
+  });
+
+  // #2666 docs-parity: the shipped workflow must NOT still carry the buggy
+  // AND-joined predicate that required BOTH a `/` and a trailing extension —
+  // that predicate dropped every root-level file and every extensionless build
+  // file. Catches a revert of the #2666 fix.
+  test('#2666 docs-parity: compute_file_scope does not contain the buggy /\//.test && extension predicate', () => {
+    const src = fs.readFileSync(WORKFLOW_PATH, 'utf8');
+    const scriptStart = src.indexOf('const files = [];');
+    const scriptEnd = src.indexOf('if (files.length)', scriptStart);
+    const scriptSection = src.slice(scriptStart, scriptEnd);
+    assert.ok(
+      !scriptSection.includes('/\\//.test(raw) && /\\.[A-Za-z0-9]+$/.test(raw)'),
+      'compute_file_scope must not use the buggy AND-joined /\\//.test(raw) && /\\.[A-Za-z0-9]+$/.test(raw) ' +
+        'predicate (#2666) — it drops every root-level and extensionless build file. Found section:\n' +
+        scriptSection
+    );
+  });
+
+  // #2666 docs-parity: the shipped workflow must reference the known
+  // extensionless build filenames so Dockerfile/Makefile/etc. are accepted.
+  test('#2666 docs-parity: compute_file_scope accepts known extensionless build files (Dockerfile)', () => {
+    const src = fs.readFileSync(WORKFLOW_PATH, 'utf8');
+    const scriptStart = src.indexOf('const files = [];');
+    const scriptEnd = src.indexOf('if (files.length)', scriptStart);
+    const scriptSection = src.slice(scriptStart, scriptEnd);
+    assert.ok(
+      /dockerfile/i.test(scriptSection),
+      'compute_file_scope must reference known extensionless build filenames (e.g. Dockerfile) ' +
+        'so they are not dropped (#2666). Found section:\n' + scriptSection
+    );
+  });
+
+  // #2666 docs-parity: the Tier-3 git-diff fallback must intersect with the
+  // SUMMARY scope and warn on dropped files (not only fire on zero Tier-2 hits).
+  test('#2666 docs-parity: Tier-3 intersects/warns against git diff --name-only', () => {
+    const src = fs.readFileSync(WORKFLOW_PATH, 'utf8');
+    // The shipped workflow must compute git diff --name-only AND emit a warning
+    // when the diff contains files the SUMMARY extractor did not surface.
+    assert.ok(
+      src.includes('git diff --name-only'),
+      'code-review.md must run `git diff --name-only` to cross-check the SUMMARY scope (#2666)'
+    );
+    assert.ok(
+      /warn|missing|not surfaced|did not|not in/i.test(src),
+      'code-review.md must warn when git diff contains files the SUMMARY extractor dropped (#2666)'
     );
   });
 });

--- a/tests/code-review-pipeline-regression.test.cjs
+++ b/tests/code-review-pipeline-regression.test.cjs
@@ -315,7 +315,7 @@ describe('Bug 1 — compute_file_scope SUMMARY parser', () => {
   // AND-joined predicate that required BOTH a `/` and a trailing extension —
   // that predicate dropped every root-level file and every extensionless build
   // file. Catches a revert of the #2666 fix.
-  test('#2666 docs-parity: compute_file_scope does not contain the buggy /\//.test && extension predicate', () => {
+  test('#2666 docs-parity: compute_file_scope does not contain the buggy slash-and-extension predicate', () => {
     const src = fs.readFileSync(WORKFLOW_PATH, 'utf8');
     const scriptStart = src.indexOf('const files = [];');
     const scriptEnd = src.indexOf('if (files.length)', scriptStart);
@@ -355,6 +355,29 @@ describe('Bug 1 — compute_file_scope SUMMARY parser', () => {
     assert.ok(
       /warn|missing|not surfaced|did not|not in/i.test(src),
       'code-review.md must warn when git diff contains files the SUMMARY extractor dropped (#2666)'
+    );
+  });
+
+  // #2666 docs-parity: the membership test must be EXACT whole-line matching
+  // (grep -Fxq), not an unanchored `case` substring match — otherwise a short
+  // basename in the diff (root `Dockerfile`) substring-matches a longer scoped
+  // path (`docker/Dockerfile`) and is silently skipped, reintroducing the bug.
+  test('#2666 docs-parity: Tier-3 cross-check uses exact whole-line matching (grep -Fxq), not substring case', () => {
+    const src = fs.readFileSync(WORKFLOW_PATH, 'utf8');
+    assert.ok(
+      src.includes('grep -Fxq'),
+      'code-review.md Tier-3 cross-check must use grep -Fxq (exact whole-line match) for membership ' +
+        'testing, not an unanchored `case` substring match that would skip a root `Dockerfile` ' +
+        'whose name appears as a suffix of an already-scoped `docker/Dockerfile` (#2666)'
+    );
+    // The unanchored substring `case "$IN_SCOPE" in` membership test must NOT be
+    // present — it would false-match a basename suffix. Plain substring check (no
+    // regex, so no CRLF-fragility): the grep -Fxq positive guard above proves the
+    // correct mechanism; this negative guard catches a revert to the `case` form.
+    assert.ok(
+      !src.includes('case "$IN_SCOPE"'),
+      'code-review.md Tier-3 must not use the unanchored `case "$IN_SCOPE"` substring membership ' +
+        'test (#2666) — use grep -Fxq for exact whole-line matching'
     );
   });
 });

--- a/tests/emitted-drift-ack.json
+++ b/tests/emitted-drift-ack.json
@@ -12,6 +12,9 @@
     },
     "next.md": {
       "reason": "#2800 — same derived-flag-loop change as autonomous.md. next.md needed no relocation (its launcher preamble already precedes the loop), so the growth here is only the loop plus the comment recording that --all and --text stay literal because they are convergence controls, not reviewer lanes."
+    },
+    "code-review.md": {
+      "reason": "#2666: the Tier-2 SUMMARY extractor predicate is relaxed to accept root-level and extensionless build files (Dockerfile/Makefile/etc.), and the Tier-3 git-diff fallback is converted from an eq-zero gate into an intersect-and-warn that cross-checks the SUMMARY scope against `git diff --name-only` with exact whole-line matching (grep -Fxq) and warns about + adds any changed files the extractor missed. Growth is the relaxed predicate + the portable cross-check branch + their explanatory comments."
     }
   }
 }


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #2666

---

## What was broken

`/gsd-code-review`'s Tier-2 SUMMARY.md file extractor silently dropped **every repository-root
file** (`Dockerfile`, `.gitlab-ci.yml`, `renovate.json`, `AGENTS.md`, `CLAUDE.md`, `package.json`)
and **every extensionless build file anywhere in the tree** (`**/Dockerfile`, `**/Makefile`) via
an AND-joined predicate that required BOTH a directory separator AND a trailing dot-extension.
The omission was silent: a partial-but-nonempty Tier-2 result masked the Tier-3 git-diff fallback,
so the reviewer received an incomplete diff and reported success.

## What this fix does

Two coordinated edits to `gsd-core/workflows/code-review.md` `compute_file_scope`:

1. **Tier-2 predicate relaxed** — a path is now accepted if it has a trailing dot-extension (root
   or nested: `package.json`, `renovate.json`, `.gitlab-ci.yml`, `AGENTS.md`, `app/foo.tsx`) OR a
   known extensionless build basename (`Dockerfile`, `Containerfile`, `Makefile`, `Justfile`,
   `Procfile`). Prose bullets are still rejected by the known-filename/has-extension distinction,
   with the post-processing existence check (`[ -f ]`) as a backstop.

2. **Tier-3 converted to intersect-and-warn** — whenever a reliable diff base is available, the
   SUMMARY scope is cross-checked against `git diff --name-only` using exact whole-line matching
   (`grep -Fxq`), and any changed files the extractor missed are warned about and added. This
   converts the silent scope hole into a loud one, independent of whatever the regex misses next.
   Portable (bash 3.2, no associative arrays).

## Root cause

Commit `ac5186462` (PR #3274, 2026-05-08, "harden code-review SUMMARY parser") added the
AND-joined predicate as a defensive guard to stop prose bullets being captured as paths — the
guard over-matched. The same commit added the Tier-3 eq-zero gate, so a partial non-zero Tier-2
result silently suppressed the fallback.

## Testing

### How I verified the fix

Added behavioral regression tests + docs-parity structural guards in
`tests/code-review-pipeline-regression.test.cjs` (the harness that already mirrors the parser as a
pure function `parseKeyFiles`). The full reporter 10-file Docker+CI phase now scopes all 10 paths.

### Regression test added?

- [x] Yes — added tests covering root-level files, nested/root extensionless build files, the full
  reporter phase, prose-rejection negative-space, and a docs-parity guard binding the shipped `.md`
  to the fix. Adversarial review also caught a membership-test substring-match defect, fixed via
  `grep -Fxq` with its own docs-parity guard.

### Platforms tested

- [x] macOS
- [x] Windows (the bug is platform-independent, but the cross-check was verified bash-3.2-portable)
- [x] Linux

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`gsd-test` on bbf44b18)
- [x] `.changeset/` fragment added
- [x] No unnecessary dependencies added

## Breaking changes

None — the code-review file scope is strictly wider (it now includes files it previously dropped)
and the new cross-check is additive (warn + augment, never removes). `--files` override behavior is
unchanged.

---

GSD_PR_GATES_OK=1

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2895"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788055862&installation_model_id=22188&pr_number=2895&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2895&signature=9aa8e5e96e14e3650a3e176e3a9bb53fc3f07282d29a8bbf1c89f0f043c7a293"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->