### PR TITLE
fix(#2843): findProjectRoot stops at git-repo boundaries, not just MAX_DEPTH

### DIFF
--- a/.changeset/lucky-eagles-hop.md
+++ b/.changeset/lucky-eagles-hop.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`findProjectRoot` no longer silently resolves to a parent project across a git-repo boundary** — when invoked from a nested git repository that has no `.planning/` of its own, resolution stays within the caller's repo (or falls back to the start directory) instead of crossing into an ancestor GSD project. The existing plain-descendant and co-located `.git`+`.planning` cases are unchanged.

--- a/.changeset/lucky-eagles-hop.md
+++ b/.changeset/lucky-eagles-hop.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 2909
 ---
 **`findProjectRoot` no longer silently resolves to a parent project across a git-repo boundary** — when invoked from a nested git repository that has no `.planning/` of its own, resolution stays within the caller's repo (or falls back to the start directory) instead of crossing into an ancestor GSD project. The existing plain-descendant and co-located `.git`+`.planning` cases are unchanged.

--- a/src/project-root.cts
+++ b/src/project-root.cts
@@ -57,6 +57,30 @@ export function findProjectRoot(startDir: string): string {
     return false;
   }
 
+  // #2843: nearest ancestor (including `from` itself) that contains a `.git`,
+  // bounded by `upTo` (exclusive). Returns the git-repo root, or null if none
+  // exists before `upTo` / the filesystem root. Used to detect a NESTED child
+  // repo whose root is strictly below a candidate ancestor `.planning/` — in
+  // that case the caller's repo boundary sits between start and the ancestor,
+  // so trusting the ancestor's `.planning/` would silently cross into a
+  // different project. (No `git` subprocess — fs walk only, matching
+  // isInsideGitRepo's deliberate no-spawn contract.)
+  function nearestGitRoot(from: string, upTo: string): string | null {
+    let d = from;
+    while (d !== fsRoot) {
+      if (d === upTo) break;
+      try {
+        if (fs.existsSync(d + path.sep + '.git')) return d;
+      } catch {
+        // ignore
+      }
+      const next = path.dirname(d);
+      if (next === d) break;
+      d = next;
+    }
+    return null;
+  }
+
   let dir = resolvedStart;
   let depth = 0;
 
@@ -107,6 +131,18 @@ export function findProjectRoot(startDir: string): string {
       // claims our startDir — explicit sub_repos config takes precedence over the
       // implicit .git signal. (#1422)
       if (isInsideGitRepo(parent)) {
+        // #2843: do NOT cross a git-repo boundary. If the caller is inside its
+        // OWN nested repo whose root is strictly below `parent`, trusting
+        // `parent`'s .planning/ would silently resolve to a DIFFERENT project.
+        // isInsideGitRepo only proved SOME .git exists between start and parent;
+        // verify that .git is parent's own (or absent between), not a nested
+        // child repo. If nearestGitRoot finds a .git strictly below parent,
+        // the boundary is crossed — fall through (do not return parent).
+        if (nearestGitRoot(resolvedStart, parent) !== null) {
+          dir = parent;
+          depth += 1;
+          continue;
+        }
         // Lookahead: walk ancestors above `parent` to find a sub_repos claim.
         let ancestor = path.dirname(parent);
         let ancestorDepth = 0;
@@ -162,6 +198,15 @@ export function findProjectRoot(startDir: string): string {
     try {
       const candidatePlanning = parent2 + path.sep + '.planning';
       if (fs.existsSync(candidatePlanning) && fs.statSync(candidatePlanning).isDirectory()) {
+        // #2843: do not cross a git-repo boundary. If the caller is inside its
+        // own nested repo (a .git strictly below parent2), parent2's .planning/
+        // belongs to a DIFFERENT project — keep walking is wrong; stop and fall
+        // through to the startDir fallback instead of silently resolving to the
+        // ancestor project. (Reached only when no .git exists anywhere in the
+        // chain per the triage, but guard defensively.)
+        if (nearestGitRoot(resolvedStart, parent2) !== null) {
+          break;
+        }
         return parent2;
       }
     } catch {

--- a/tests/project-root.test.cjs
+++ b/tests/project-root.test.cjs
@@ -275,4 +275,44 @@ describe('findProjectRoot nearest-.planning resolution (#1414)', () => {
     assert.strictEqual(result, nested,
       'Should return startDir unchanged when no ancestor has .planning/ within the depth bound');
   });
+
+  // #2843: findProjectRoot must NOT cross a git-repo boundary. A nested child
+  // repo (own .git, no .planning of its own) under an ancestor GSD project must
+  // NOT resolve to the ancestor's root — that would silently return a different
+  // project's identity with exit 0. Pre-fix heuristic (3)'s isInsideGitRepo only
+  // checked "does SOME .git exist between start and the ancestor" — the child's
+  // own .git satisfied it, crossing the boundary.
+  test('#2843 does not resolve to an ancestor project across a nested child .git boundary', () => {
+    // tmpDir/                       (plain — not a git repo, not HOME)
+    //   parent-gsd/.planning/       ← ancestor GSD project
+    //   parent-gsd/child-app/.git   ← nested child repo, NO .planning of its own
+    //   parent-gsd/child-app/src/   ← startDir
+    const parentGsd = mkDeep(tmpDir, 'parent-gsd');
+    fs.mkdirSync(path.join(parentGsd, '.planning'), { recursive: true });
+    const childApp = mkDeep(parentGsd, 'child-app');
+    fs.mkdirSync(path.join(childApp, '.git'), { recursive: true });
+    const startDir = mkDeep(childApp, 'src');
+
+    const result = findProjectRoot(startDir);
+    assert.notStrictEqual(result, parentGsd,
+      'must NOT cross child-app\'s .git boundary to resolve to the ancestor parent-gsd project');
+    // The child repo has no .planning of its own, so resolution falls back to
+    // the startDir (or a path within child-app) — never the ancestor.
+    assert.ok(
+      result === startDir || result === childApp,
+      `expected to stay within the child repo (startDir or childApp fallback), got: ${result}`,
+    );
+  });
+
+  test('#2843 negative-space: a co-located .git + .planning (normal single-repo) still resolves to the project root', () => {
+    // The normal case: .git and .planning at the SAME level. The caller's .git
+    // IS the project's .git, so the boundary check passes (no nested child repo).
+    fs.mkdirSync(path.join(tmpDir, '.git'), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, '.planning'), { recursive: true });
+    const nested = mkDeep(tmpDir, 'src', 'lib');
+
+    const result = findProjectRoot(nested);
+    assert.strictEqual(result, tmpDir,
+      'a co-located .git + .planning (single-repo project) must still resolve to the project root');
+  });
 });


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #2843

---

## What was broken

`findProjectRoot` crossed git-repo boundaries. Its heuristic (3) used `isInsideGitRepo(parent)`,
which only checks "does SOME `.git` exist between the start directory and the candidate ancestor" —
it never verified that `.git` actually bounded the `.planning/` being trusted. So a nested child
repo (its own `.git`, no `.planning/`) sitting under an ancestor GSD project satisfied the check,
and resolution silently returned the **ancestor project's root** — the wrong identity, with exit 0
and no warning.

## What this fix does

Add `nearestGitRoot(from, upTo)` — an fs-walk (no `git` subprocess, matching the existing no-spawn
contract) returning the nearest ancestor at-or-above `from` that contains `.git`, bounded
exclusively by `upTo`. Use it in heuristics (3) and (4): if the caller is inside its **own** nested
repo whose root is strictly below the candidate ancestor, do not return that ancestor — the
boundary would be crossed into a different project.

The exclusive `upTo` bound is the key: a `.git` sitting exactly AT the candidate ancestor (the
normal single-repo case) is the candidate's OWN `.git`, not a nested child repo, so it is correctly
not detected as a boundary crossing.

## Root cause

Long-standing — `isInsideGitRepo` + heuristic (3) preserved byte-for-behavior through the ADR-457
CJS→TS migration; the gap predates it.

## Testing

### How I verified the fix

A regression test in `tests/project-root.test.cjs`: a nested child `.git` (no `.planning`) under an
ancestor GSD project no longer resolves to the ancestor (it stays within the child repo / falls
back to startDir). A negative-space test confirms a co-located `.git`+`.planning` single-repo
project still resolves to its root.

### Regression test added?

- [x] Yes — nested-child-`.git`-boundary regression (fails pre-fix) + co-located-single-repo
  negative-space test.

### Platforms tested

- [x] macOS
- [ ] Windows (path-logic only; the fix uses `path.sep` so it is portable)
- [x] Linux

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass (`gsd-test` on 2fc9815f)
- [x] `.changeset/` fragment added
- [x] No unnecessary dependencies added

## Breaking changes

None for legitimate projects. The only behavior change: a nested repo with no `.planning/` of its
own no longer silently resolves to an ancestor GSD project — it falls back to the start directory
(the documented "no project root found" behavior). Plain descendants, co-located single-repo
projects, and explicit `sub_repos`/`multiRepo` configs are unchanged.

---

GSD_PR_GATES_OK=1

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2909"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788070691&installation_model_id=22188&pr_number=2909&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2909&signature=8d74ec55558ac70f93ba5096591f66b44300c245f4457e9957b1f612019fda15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->