### PR TITLE
ci(#2952): budget CI job timeouts by headroom over measured cost

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,7 +116,19 @@ jobs:
     needs: changes
     if: needs.changes.outputs.product_changed == 'true'
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
+    # #2952: the `ubuntu-latest / 24` entry is the only `scope: full` lane — it
+    # runs the WHOLE unit suite under c8 coverage, then the scripts/ coverage
+    # floor, integration, security, install and slow, all serially on one runner.
+    # On next@5a0a9f097 that job ran 15m16s against a 15-minute cap, so GitHub
+    # axed it 23s into `npm run test:slow` and reported it `cancelled` — which
+    # reddened `Required tests` and `next` with it. Projected to a completed
+    # slow step (27s on the last green run) the lane costs ~15m20s, and it had
+    # been riding the ceiling for hours (14m25s, 14m51s) before it crossed.
+    #
+    # 25 is ~1.5x that measured cost. tests/ci-test-job-timeout-budget.test.cjs
+    # holds every lane in this file to the same headroom rule, so a budget can
+    # not be lowered back beneath what its lane is known to need.
+    timeout-minutes: 25
     env:
       GSD_PLUGIN_ROOT: .ci-gsd-plugin-root-disabled
       # #2854: pin the emitted gate's baseline to the SAME commit the tree was merged
@@ -353,7 +365,13 @@ jobs:
     # and a NESTED `leg.os` key is not resolvable by the H1 shell-policy linter
     # in scripts/workflow-policy.cjs, which reads `matrix.os`/`matrix.shell`
     # directly. Explicit rows keep both the cross-product and the linter happy.)
-    timeout-minutes: 20
+    # #2952: `full test (windows-latest, 22, shard 3/3)` reached 18m59s (94% of
+    # a 20-minute cap) on 05b170e44 and 18m14s (91%) on 81eeb8a53. The Windows
+    # shards are slow for platform reasons — process spawn and filesystem cost,
+    # not extra work — and this lane has already blown its cap twice before
+    # (#1051, #1212). 30 is ~1.5x the worst observed shard, restoring the
+    # headroom that #1212's sharding bought and this suite has since eaten.
+    timeout-minutes: 30
     env:
       GSD_PLUGIN_ROOT: .ci-gsd-plugin-root-disabled
       # #2854: pin the emitted gate's baseline to the SAME commit the tree was merged

--- a/tests/ci-test-job-timeout-budget.test.cjs
+++ b/tests/ci-test-job-timeout-budget.test.cjs
@@ -1,0 +1,150 @@
+'use strict';
+
+/**
+ * CI job timeout budgets — .github/workflows/test.yml (#2952).
+ *
+ * A GitHub Actions job that exceeds its `timeout-minutes` is reported
+ * `cancelled`, not `failed`. That conclusion propagates into `Required tests`
+ * and reddens the branch, while reading like someone hit the cancel button —
+ * which is what makes this failure mode expensive to diagnose and worth a gate.
+ *
+ * It has now happened three times in this repo: #1051 and #1212 on the Windows
+ * full-test lane, and #2952 on the unsharded `test` lane, whose
+ * `ubuntu-latest / 24` entry is the only `scope: full` matrix entry — it runs
+ * the whole unit suite under c8 coverage, then the scripts/ coverage floor,
+ * integration, security, install and slow, serially on one runner. Every one of
+ * those was the same root cause: a budget sized to what the lane cost that
+ * week, with no headroom for the suite to grow into.
+ *
+ * So the rule enforced here is not a fixed number per lane — it is a HEADROOM
+ * FACTOR over each lane's measured cost. A lane may be slow; what it may not be
+ * is budgeted to finish with seconds to spare.
+ *
+ * This is a budget assertion, not a duration assertion. No unit test can prove
+ * a lane still FITS its budget — only a real CI run measures that. What this
+ * file guarantees is that a budget cannot be quietly lowered back beneath what
+ * its lane is already known to need.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const yaml = require('js-yaml');
+
+const WORKFLOWS_DIR = path.join(__dirname, '..', '.github', 'workflows');
+
+function loadWorkflow(name) {
+  return yaml.load(fs.readFileSync(path.join(WORKFLOWS_DIR, name), 'utf8'));
+}
+
+/**
+ * Multiplier applied to a lane's measured cost to get its required budget.
+ * 1.5x is enough slack for ordinary suite growth across a release cycle without
+ * letting a genuinely runaway lane hide behind a large number.
+ */
+const HEADROOM_FACTOR = 1.5;
+
+/**
+ * Measured wall-clock cost per lane, in whole minutes rounded UP, each from a
+ * named run. Raise an entry only alongside a fresh measurement — never to make
+ * a red gate green. Raising a measurement raises the required budget with it,
+ * which is the point: a lane that got slower must be re-budgeted, not excused.
+ */
+const LANE_COSTS = [
+  {
+    job: 'test',
+    measuredMinutes: 16,
+    // run 30660240241 job 91254510104, next@5a0a9f097: the job ran 15m16s
+    // before GitHub axed it 23s into `npm run test:slow`. The unit suite under
+    // c8 alone was 769s of that. Projected to a completed slow step (27s on the
+    // last green run, 81eeb8a53) the lane costs ~15m20s.
+    evidence: 'run 30660240241 — 15m20s projected',
+  },
+  {
+    job: 'test-full',
+    measuredMinutes: 19,
+    // Worst observed shard is `full test (windows-latest, 22, shard 3/3)`:
+    // 18m59s on 05b170e44 and 18m14s on 81eeb8a53. The Windows shards are slow
+    // for platform reasons, not extra work.
+    evidence: 'run 30650559192 — 18m59s, windows-22 shard 3/3',
+  },
+  {
+    job: 'test-inert',
+    measuredMinutes: 2,
+    // Runs only the targeted-test step when no product code changed; observed
+    // around a minute. Listed so its budget cannot be dropped to nothing.
+    evidence: 'targeted-only lane, ~1m observed',
+  },
+];
+
+function requiredBudgetMinutes(measuredMinutes, headroomFactor = HEADROOM_FACTOR) {
+  return Math.ceil(measuredMinutes * headroomFactor);
+}
+
+function hasSufficientBudget(budgetMinutes, measuredMinutes, headroomFactor = HEADROOM_FACTOR) {
+  return Number.isInteger(budgetMinutes)
+    && budgetMinutes >= requiredBudgetMinutes(measuredMinutes, headroomFactor);
+}
+
+test('CI job timeout budgets carry headroom over measured cost (#2952)', async (t) => {
+  const workflow = loadWorkflow('test.yml');
+
+  for (const lane of LANE_COSTS) {
+    await t.test(`${lane.job} is budgeted above its measured cost`, () => {
+      assert.ok(
+        workflow.jobs && Object.prototype.hasOwnProperty.call(workflow.jobs, lane.job),
+        `.github/workflows/test.yml declares no job \`${lane.job}\`. If it was `
+        + 'renamed or removed, update LANE_COSTS in this file to match — do not '
+        + 'delete the entry to make this pass.',
+      );
+
+      const budget = workflow.jobs[lane.job]['timeout-minutes'];
+      const required = requiredBudgetMinutes(lane.measuredMinutes);
+
+      assert.equal(
+        typeof budget, 'number',
+        `.github/workflows/test.yml jobs.${lane.job} must declare timeout-minutes`,
+      );
+      assert.ok(
+        hasSufficientBudget(budget, lane.measuredMinutes),
+        `jobs.${lane.job}.timeout-minutes is ${budget}, but the lane measured `
+        + `${lane.measuredMinutes}m (${lane.evidence}) and needs at least `
+        + `${required} — ${HEADROOM_FACTOR}x — so suite growth does not breach `
+        + 'the cap. A job that exceeds timeout-minutes is reported `cancelled` '
+        + 'and reddens `Required tests`.',
+      );
+    });
+  }
+
+  // Boundary coverage on the predicate that decides every lane above:
+  // required-1 must be rejected, required and required+1 accepted.
+  await t.test('budget sufficiency is exact at the boundary', () => {
+    for (const lane of LANE_COSTS) {
+      const required = requiredBudgetMinutes(lane.measuredMinutes);
+
+      assert.equal(hasSufficientBudget(required - 1, lane.measuredMinutes), false,
+        `${lane.job}: a budget one minute under the requirement must be rejected`);
+      assert.equal(hasSufficientBudget(required, lane.measuredMinutes), true,
+        `${lane.job}: a budget exactly at the requirement must be accepted`);
+      assert.equal(hasSufficientBudget(required + 1, lane.measuredMinutes), true,
+        `${lane.job}: a budget over the requirement must be accepted`);
+    }
+  });
+
+  await t.test('a non-integer budget is not a sufficient budget', () => {
+    // `timeout-minutes: 24.5` is not something GitHub accepts; treating it as
+    // sufficient would let a malformed workflow through this gate.
+    assert.equal(hasSufficientBudget(24.5, 16), false);
+    assert.equal(hasSufficientBudget(Number.NaN, 16), false);
+    assert.equal(hasSufficientBudget(undefined, 16), false);
+  });
+
+  await t.test('requiredBudgetMinutes rounds up rather than truncating', () => {
+    // 15 * 1.5 = 22.5 — truncation would hand back 22 and under-budget the lane.
+    assert.equal(requiredBudgetMinutes(15, 1.5), 23);
+    assert.equal(requiredBudgetMinutes(16, 1.5), 24);
+    assert.equal(requiredBudgetMinutes(19, 1.5), 29);
+    assert.equal(requiredBudgetMinutes(10, 1.5), 15);
+  });
+});


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #2952

---

## What was broken

`origin/next` was red. The only failing check was `Required tests`, and its sole cause was `test (ubuntu-latest, 24)` reported `cancelled` — which is GitHub's conclusion for a job that exceeds its `timeout-minutes`, not a button press. That job ran 15m16s against a 15-minute cap and was axed 23s into `npm run test:slow`.

## What this fix does

Budgets every lane in `.github/workflows/test.yml` by a **headroom factor over its own measured cost** rather than a hand-picked number: `test` 15 → 25, `test-full` 20 → 30, `test-inert` unchanged at 15. `tests/ci-test-job-timeout-budget.test.cjs` locks that rule so a budget cannot be lowered back beneath what its lane is known to need.

## Root cause

The `test` job's `ubuntu-latest / 24` entry is the only `scope: full` matrix entry. It runs the whole unit suite under c8 coverage, then the scripts/ coverage floor, integration, security, install and slow — serially, on one runner:

| step | duration |
| --- | --- |
| checkout + node + `npm ci` + integrity gate | 30s |
| **unit suite under c8 coverage** | **769s** |
| coverage floor — `scripts/` | 22s |
| upload coverage artifact | 1s |
| integration | 17s |
| security | 5s |
| install | 46s |
| slow | killed at 23s (27s on the last green run) |
| **total (projected)** | **~15m20s** |

**The budget, not the suite.** The lane had been riding the ceiling all day — 12m03s, 11m34s, 11m50s, 14m25s, 14m51s — and crossed on three of the last four full-lane runs (`d2d2f7c08`, `07603df8f`, `5a0a9f097`). Re-running could not have helped: the work is larger than the budget.

Ruled out as causes:

- **A pathological or hung test.** The unit run is cost-first bin-packed into 12 chunks. Chunk 1 (196s) is gated by `tests/run-tests-harness.test.cjs` at 169s, which is expensive *by design* — it spawns real harness subprocesses, one of which deliberately exercises the per-chunk timeout. The remaining chunks are 32–94s. 769s is the honest cost of 689 files under c8.
- **`docs/CONTEXT-INDEX.json` drift.** The earlier `failure` at `05b170e44` was a genuine `gen-context-index.cjs --check` staleness — the ADR-2928 drift guard landing alongside a concurrent `CONTEXT.md` edit. `07603df8f` re-synced it and `lint-tests` is green at HEAD. `07603df8f`'s own run then hit *this* timeout, which is why it never reported green either.

### Adjacent defect fixed here rather than deferred

Review of the first cut surfaced the same failure one runner away: `full test (windows-latest, 22, shard 3/3)` reached **18m59s against its own 20-minute cap** on `05b170e44` (94%) and **18m14s** on `81eeb8a53` (91%). That lane has already blown its cap twice — #1051 and #1212. Raised to 30 in this PR.

### Invariant corrected during review

The first cut asserted `test >= test-full`, reasoning that the unsharded lane does more work than a shard. That is **unsound**: the two budgets are dominated by different platforms (`test-full`'s cost is the Windows shards, slow for process-spawn and filesystem reasons, not extra work), so their ordering carries no meaning. Replaced with the invariant that generalises — each lane is held to a headroom factor over its *own* measured cost.

---

## Testing

### How I verified the fix

- **Reproduced from CI, not asserted.** Pulled run [30660240241](https://github.com/open-gsd/gsd-core/actions/runs/30660240241) job `91254510104` and confirmed the job ran 15m16s (`19:44:35Z` → `19:59:51Z`) against `timeout-minutes: 15`, ending in `##[error]The operation was canceled.` and `Terminate orphan process: pid (60098) (npm run test:slow)`.
- **Trended the duration across 9 runs** to establish this is a consistent overrun, not a one-off.
- **Failing-first:** with the workflow at `15`, both budget assertions fail (`15 >= 24` false). After the change all three lanes pass (`test` 25 ≥ 24, `test-full` 30 ≥ 29, `test-inert` 15 ≥ 3).
- `npm run lint` and `npm run lint:ci` green on the final tree.
- Full remote suite green on the exact shipped sha (see gate below).

### Regression test added?

- [x] Yes — added a test that would have caught this bug

`tests/ci-test-job-timeout-budget.test.cjs`. Honest scope: this is a **budget** assertion, not a duration assertion. No unit test can prove a lane still *fits* its budget — only a real CI run measures that. What it does guarantee is that a budget cannot be quietly lowered back beneath its lane's known cost, and that a lane which gets slower must be re-measured rather than excused.

### Platforms tested

- [x] macOS
- [x] Windows (including backslash path handling)
- [x] Linux

Full `(OS × Node)` matrix via the remote runner on `bdeff1fb4`.

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — the `test-full` bump is the *same* defect surfaced by review, folded in per the no-defer rule rather than filed away
- [x] Regression test added
- [x] All existing tests pass
- [x] `no-changelog` label applied — `scripts/changeset/lint.cjs` `USER_FACING_PREFIXES` does not cover `.github/**` or `tests/**`, so no fragment is required
- [x] No unnecessary dependencies added (`js-yaml` already a devDependency, already used this way by `tests/release-backmerge-invariants.test.cjs`)

## Breaking changes

None. CI-only; no user-facing behavior, output, file format or config changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2959"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788130213&installation_model_id=22188&pr_number=2959&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2959&signature=2674d29fa5fd4fab44719747117c88b4c20350aed42d5a535128a29423058c39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->