### PR TITLE
fix(#2956): scope Phase extraction to ## Current Position (3rd gen of #2444/#2567)

### DIFF
--- a/.changeset/curious-seals-zip.md
+++ b/.changeset/curious-seals-zip.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 2961
 ---
 **`current_phase` no longer rewinds to an archived phase when STATE.md carries a historical `Phase:` line** — a stale `Phase:` or `**Phase:**` line in an archive section of a long-lived STATE.md silently overwrote `current_phase` on every state write, and because `current_phase` drives `gsd-progress` and `--next` routing the rewind sent work to the wrong phase. Phase extraction is now scoped to the `## Current Position` section (mirroring the existing `## Session` scoping for Stopped At / Paused At). (#2956)

--- a/.changeset/curious-seals-zip.md
+++ b/.changeset/curious-seals-zip.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`current_phase` no longer rewinds to an archived phase when STATE.md carries a historical `Phase:` line** — a stale `Phase:` or `**Phase:**` line in an archive section of a long-lived STATE.md silently overwrote `current_phase` on every state write, and because `current_phase` drives `gsd-progress` and `--next` routing the rewind sent work to the wrong phase. Phase extraction is now scoped to the `## Current Position` section (mirroring the existing `## Session` scoping for Stopped At / Paused At). (#2956)

--- a/src/state.cts
+++ b/src/state.cts
@@ -1308,6 +1308,31 @@ function matchSessionSection(body: string): string | null {
 }
 
 /**
+ * Match the "Current Position" section body from a STATE.md body. #2956: this
+ * is the Phase analogue of matchSessionSection. `Phase` canonically lives under
+ * `## Current Position` (gsd-core/templates/state.md), so — like Stopped At /
+ * Paused At under `## Session` — it must be extracted from THAT section, not
+ * from the first `Phase:` / `**Phase:**` line anywhere in the body. Without the
+ * scope, a historical `Phase:` line in an archive section silently overwrites
+ * `current_phase` on every write, and because `current_phase` is routing input
+ * for gsd-progress / --next the rewind routes work to the wrong phase.
+ *
+ * Level-flexible: the canonical template uses an h2 `## Current Position`, the
+ * bootstrap template an h3 `### Current Position` (templates/state.md). Both
+ * must match — mirroring how matchSessionSection recognises `## Session` and
+ * `## Session Continuity`. Exact 'current position' text match (case-insensitive)
+ * excludes unrelated headings. Built on the same `collectSection` seam as
+ * matchSessionSection, so it inherits that seam's CRLF tolerance (#2444 fix).
+ * Returns the section body, or null (caller falls back to full-body search).
+ */
+function matchCurrentPositionSection(body: string): string | null {
+  const isCurrentPosition = (h: HeadingToken): boolean =>
+    (h.level === 2 || h.level === 3) && h.text.trim().toLowerCase() === 'current position';
+  const section = collectSection(body, isCurrentPosition, { levelBounded: true });
+  return section ? section.body : null;
+}
+
+/**
  * #2567: prevent a stale archive "Last activity:" line from overwriting a
  * newer frontmatter value. `stateExtractField` matches the first body
  * occurrence, which may be a historical line in an archive section. Unlike
@@ -1392,7 +1417,14 @@ function cmdStateSnapshot(cwd: string, raw: boolean): void {
   };
 
   // Extract basic fields — frontmatter keys take precedence over body
-  const prosePhase = parseProsePhaseField(stateExtractField(body, 'Phase'));
+  // #2956: scope `Phase` extraction to ## Current Position so a historical
+  // Phase: / **Phase:** line in an archive section cannot overwrite the current
+  // value. Phase canonically lives in ## Current Position (templates/state.md),
+  // so it is scopeable exactly like Stopped At under ## Session. Fall back to
+  // full-body search only when no ## Current Position section exists, so files
+  // with no section heading keep their current behaviour.
+  const currentPositionScope = matchCurrentPositionSection(body) ?? body;
+  const prosePhase = parseProsePhaseField(stateExtractField(currentPositionScope, 'Phase'));
   const currentPhase = fmScalar('current_phase') ?? stateExtractField(body, 'Current Phase') ?? prosePhase.phase;
   const currentPhaseName = fmScalar('current_phase_name') ?? stateExtractField(body, 'Current Phase Name') ?? prosePhase.name;
   const totalPhasesRaw = fmScalar('total_phases') ?? stateExtractField(body, 'Total Phases');
@@ -1404,7 +1436,12 @@ function cmdStateSnapshot(cwd: string, raw: boolean): void {
   const proseLastActivity = parseProseLastActivityField(rawLastActivity);
   const lastActivity = fmScalar('last_activity') ?? proseLastActivity.date ?? rawLastActivity;
   const lastActivityDesc = fmScalar('last_activity_desc') ?? stateExtractField(body, 'Last Activity Description') ?? proseLastActivity.description;
-  const pausedAt = fmScalar('paused_at') ?? stateExtractField(body, 'Paused At');
+  // #2956: Paused At canonically lives in ## Session (see the comment above
+  // preferNewerLastActivity and the write seam in buildStateFrontmatter). The
+  // write seam already scopes it to ## Session; this read seam must agree, so a
+  // stale "Paused At:" in a Session Continuity Archive cannot win here either.
+  const sessionScope = matchSessionSection(body) ?? body;
+  const pausedAt = fmScalar('paused_at') ?? stateExtractField(sessionScope, 'Paused At');
 
   // Parse numeric fields
   const totalPhases = totalPhasesRaw ? parseInt(totalPhasesRaw, 10) : null;
@@ -1552,7 +1589,14 @@ function extractRetiredPhaseNumbers(scope: string): Set<string> {
  * reliably via `state json` instead of fragile regex parsing.
  */
 function buildStateFrontmatter(bodyContent: string, cwd: string | undefined): Record<string, unknown> {
-  const prosePhase = parseProsePhaseField(stateExtractField(bodyContent, 'Phase'));
+  // #2956: scope `Phase` extraction to ## Current Position (mirrors the read
+  // path in cmdStateSnapshot and the Stopped At / Paused At ## Session scoping
+  // below). Phase canonically lives in ## Current Position (templates/state.md);
+  // without the scope, a historical Phase: / **Phase:** line in an archive
+  // section overwrites current_phase here, and the next read surfaces it. Fall
+  // back to full-body search when no ## Current Position section exists.
+  const currentPositionScope = matchCurrentPositionSection(bodyContent) ?? bodyContent;
+  const prosePhase = parseProsePhaseField(stateExtractField(currentPositionScope, 'Phase'));
   const currentPhase = stateExtractField(bodyContent, 'Current Phase') ?? prosePhase.phase;
   const currentPhaseName = stateExtractField(bodyContent, 'Current Phase Name') ?? prosePhase.name;
   const currentPlan = stateExtractField(bodyContent, 'Current Plan');

--- a/tests/state.test.cjs
+++ b/tests/state.test.cjs
@@ -764,12 +764,19 @@ describe('STATE.md frontmatter sync', () => {
     // must agree: a state write that re-syncs frontmatter must not pick up the
     // archive **Phase:** 19 line and write current_phase: 19, which the next
     // state-snapshot read would then surface. Round-trip must stay at 22.
+    //
+    // The fixture carries a **Status:** field so `state update Status` performs
+    // a real field update (updated:true) and forces the frontmatter resync
+    // through buildStateFrontmatter — without an existing Status field the
+    // update is a no-op (updated:false) and no write occurs.
     const stateContent = [
       '# Project State',
       '',
       '## Current Position',
       '',
       'Phase: 22 (Documentation hygiene)',
+      '',
+      '**Status:** Ready',
       '',
       '## Archive — earlier milestones',
       '',
@@ -782,6 +789,8 @@ describe('STATE.md frontmatter sync', () => {
     // state update forces a frontmatter sync through buildStateFrontmatter.
     const writeResult = runGsdTools('state update Status "Executing"', tmpDir);
     assert.ok(writeResult.success, `write failed: ${writeResult.error}`);
+    const writeOutput = JSON.parse(writeResult.output);
+    assert.strictEqual(writeOutput.updated, true, 'state update must perform a real field update to force the resync');
 
     // The persisted frontmatter must not have rewound to the archive phase.
     const written = fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf-8');

--- a/tests/state.test.cjs
+++ b/tests/state.test.cjs
@@ -162,6 +162,177 @@ describe('state-snapshot command', () => {
     assert.strictEqual(output.paused_at, 'Phase 3, Plan 1, Task 2 - mid-implementation', 'paused_at extracted');
   });
 
+  // ─── Regression: #2956 — Phase must be scoped to ## Current Position ──────
+  // Third generation of #2444 / #2567. Stopped At / Paused At were scoped to
+  // ## Session; Phase (which canonically lives in ## Current Position per
+  // gsd-core/templates/state.md) was left unscoped, so a historical Phase: /
+  // **Phase:** line in an archive section silently overwrote current_phase on
+  // every write. Because current_phase is routing input for gsd-progress / --next,
+  // the rewind routes work to the wrong phase — not merely a stale display.
+
+  test('#2956 scopes Phase to ## Current Position — bold archive line below the section (shape B)', () => {
+    // Bold **Phase:** 19 in an archive BELOW ## Current Position. The unscoped
+    // extractor's bold pattern wins outright (it is tried first, unanchored),
+    // so the read returns 19 instead of 22. Scoping to the section fixes it.
+    const stateContent = [
+      '# Project State',
+      '',
+      '## Current Position',
+      '',
+      'Phase: 22 (Documentation hygiene) — COMPLETE',
+      '',
+      '## Archive — earlier milestones',
+      '',
+ '**Phase:** 19 **complete — shipped v2.43.0**',
+      '',
+    ].join('\n');
+
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'STATE.md'), stateContent);
+
+    const result = runGsdTools('state-snapshot', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.current_phase, '22', 'current_phase must come from ## Current Position, not the bold archive line');
+  });
+
+  test('#2956 scopes Phase to ## Current Position — plain archive line above the section (shape C)', () => {
+    // Plain archive Phase: 19 ABOVE ## Current Position. Without scoping the
+    // plain pattern (^Phase:, /im) matches the first line-start occurrence in
+    // document order — the archive line — and returns 19 instead of 22.
+    const stateContent = [
+      '# Project State',
+      '',
+      '## Archive — earlier milestones',
+      '',
+      'Phase: 19 **complete — shipped v2.43.0**',
+      '',
+      '## Current Position',
+      '',
+      'Phase: 22 (Documentation hygiene) — COMPLETE',
+      '',
+    ].join('\n');
+
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'STATE.md'), stateContent);
+
+    const result = runGsdTools('state-snapshot', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.current_phase, '22', 'current_phase must come from ## Current Position, not the plain archive line above it');
+  });
+
+  test('#2956 scopes Phase to ### Current Position (bootstrap h3 variant)', () => {
+    // gsd-core/templates/state.md ships a bootstrap layout that uses a level-3
+    // ### Current Position heading. The section matcher must recognise BOTH h2
+    // and h3, mirroring how matchSessionSection recognises ## Session and
+    // ## Session Continuity — matching only h2 would silently drop the h3 shape.
+    const stateContent = [
+      '# Project State',
+      '',
+      '### Current Position',
+      '',
+      'Phase: 22 (Documentation hygiene)',
+      '',
+      '### Archive',
+      '',
+ '**Phase:** 19',
+      '',
+    ].join('\n');
+
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'STATE.md'), stateContent);
+
+    const result = runGsdTools('state-snapshot', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.current_phase, '22', 'current_phase must resolve from the h3 ### Current Position section');
+  });
+
+  test('#2956 scopes Phase to ## Current Position under CRLF', () => {
+    // The #2444 seam was CRLF-fixed by migrating onto collectSection (which
+    // strips the trailing \r before heading-text extraction). The Phase scope
+    // must inherit that CRLF tolerance — a hand-rolled [ \t]*\n boundary would
+    // silently fail to match a ## Current Position\r\n heading.
+    const stateContent = [
+      '# Project State',
+      '',
+      '## Current Position',
+      '',
+      'Phase: 22 (Documentation hygiene)',
+      '',
+      '## Archive — earlier milestones',
+      '',
+ '**Phase:** 19',
+      '',
+    ].join('\r\n');
+
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'STATE.md'), stateContent);
+
+    const result = runGsdTools('state-snapshot', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.current_phase, '22', 'current_phase must come from ## Current Position under CRLF');
+  });
+
+  test('#2956 ignores a Phase token in decisions prose outside ## Current Position', () => {
+    // A decisions-table row or prose mention of "Phase 19" elsewhere is NOT the
+    // current phase. Scoping it out is correct, not a regression — this is the
+    // over-broad-fix guard.
+    const stateContent = [
+      '# Project State',
+      '',
+      '## Current Position',
+      '',
+      'Phase: 22 (Documentation hygiene)',
+      '',
+      '### Decisions',
+      '',
+      '| Decided to defer Phase 19 to the next milestone | 2026-07-01 |',
+      '',
+    ].join('\n');
+
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'STATE.md'), stateContent);
+
+    const result = runGsdTools('state-snapshot', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.current_phase, '22', 'a Phase token in decisions prose must not leak into current_phase');
+  });
+
+  test('#2956 scopes Paused At to ## Session on the read path (parity with the write seam)', () => {
+    // The WRITE seam (buildStateFrontmatter src/state.cts ~1576) already scopes
+    // Paused At to ## Session. The READ seam (cmdStateSnapshot) read it
+    // unscoped — a parity gap. A stale "Paused At:" in a Session Continuity
+    // Archive below the real ## Session must not win on the read path.
+    const stateContent = [
+      '# Project State',
+      '',
+      '## Current Position',
+      '',
+      'Phase: 22 (Documentation hygiene)',
+      '',
+      '## Session',
+      '',
+      '**Paused At:** Phase 22, Plan 1, Task 2 - mid-implementation',
+      '',
+      '## Session Continuity Archive',
+      '',
+      '**Paused At:** Phase 19, Plan 3 (stale)',
+      '',
+    ].join('\n');
+
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'STATE.md'), stateContent);
+
+    const result = runGsdTools('state-snapshot', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.paused_at, 'Phase 22, Plan 1, Task 2 - mid-implementation', 'paused_at must come from ## Session, not the archive');
+  });
+
   describe('--cwd override', () => {
     let outsideDir;
 
@@ -586,6 +757,42 @@ describe('STATE.md frontmatter sync', () => {
     const delimiterCount = (content.match(/^---$/gm) || []).length;
     assert.strictEqual(delimiterCount, 2, 'should have exactly one frontmatter block (2 delimiters)');
     assert.ok(content.includes('status: paused'), 'frontmatter should reflect latest status');
+  });
+
+  test('#2956 write-then-read does not rewind current_phase past an archive Phase line', () => {
+    // The write seam (buildStateFrontmatter) and the read seam (cmdStateSnapshot)
+    // must agree: a state write that re-syncs frontmatter must not pick up the
+    // archive **Phase:** 19 line and write current_phase: 19, which the next
+    // state-snapshot read would then surface. Round-trip must stay at 22.
+    const stateContent = [
+      '# Project State',
+      '',
+      '## Current Position',
+      '',
+      'Phase: 22 (Documentation hygiene)',
+      '',
+      '## Archive — earlier milestones',
+      '',
+ '**Phase:** 19 **complete — shipped v2.43.0**',
+      '',
+    ].join('\n');
+
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'STATE.md'), stateContent);
+
+    // state update forces a frontmatter sync through buildStateFrontmatter.
+    const writeResult = runGsdTools('state update Status "Executing"', tmpDir);
+    assert.ok(writeResult.success, `write failed: ${writeResult.error}`);
+
+    // The persisted frontmatter must not have rewound to the archive phase.
+    const written = fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
+    assert.ok(/current_phase:\s*22\b/m.test(written), 'written frontmatter current_phase must be 22 (not the archive 19)');
+    assert.ok(!/^current_phase:\s*19\b/m.test(written), 'written frontmatter must NOT carry the archive phase 19');
+
+    // And a fresh read must agree.
+    const readResult = runGsdTools('state-snapshot', tmpDir);
+    assert.ok(readResult.success, `read failed: ${readResult.error}`);
+    const output = JSON.parse(readResult.output);
+    assert.strictEqual(output.current_phase, '22', 'read-after-write current_phase must stay 22 (round-trip agreement)');
   });
 
   test('preserves frontmatter status when body Status field is missing', () => {


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #2956

> The linked issue (#2956) carries the `confirmed-bug` label.

---

## What was broken

`Phase` was extracted **unscoped** from the STATE.md body in both `cmdStateSnapshot` (read path) and `buildStateFrontmatter` (write path), so a historical `Phase:` / `**Phase:**` line in an **archive section** of a long-lived STATE.md silently overwrote `current_phase` on every state write. Because `current_phase` is **routing input** for `gsd-progress` and the `--next` workflows, the rewind didn't just display a stale value — it routed work to the wrong phase. This is the **third generation** of the same defect class: #2444 scoped `Stopped At` to `## Session`, #2567 reported the sibling fields were still unscoped (`Last Activity` got a date-direction guard because it has no canonical section), and `Phase` got neither — even though, unlike `Last Activity`, it *does* live in a canonical section.

## What this fix does

Mirrors the proven #2444 `## Session` scoping seam for `Phase` under `## Current Position` (its canonical home per `gsd-core/templates/state.md`):
- New `matchCurrentPositionSection` helper (built on the same `collectSection` primitive as `matchSessionSection`, inheriting its CRLF tolerance; level-flexible for the bootstrap `### Current Position` h3 variant).
- Read path (`cmdStateSnapshot`) and write path (`buildStateFrontmatter`) now extract `Phase` from `matchCurrentPositionSection(body) ?? body` — falling back to full-body search only when no `## Current Position` section exists, so files without the heading keep their current behaviour.
- The read path's `Paused At` is also scoped to `matchSessionSection(body) ?? body`, so the read seam agrees with the write seam (which already scoped `Paused At` to `## Session`).

`stateExtractField` itself is untouched (its bold-before-plain precedence is load-bearing for other fields — the #3265 test depends on it), and `preferNewerLastActivity` is untouched (`Last Activity` has no canonical section; its date-direction guard is deliberate).

## Root cause

`Phase` extraction was simply never extended the scoping that `Stopped At` / `Paused At` got under `## Session`. The bug-report's triage pinned the mechanism: `stateExtractField` tries its bold pattern (unanchored) before the plain pattern, so a bold archive `**Phase:**` line *anywhere* wins outright, and only when no bold line exists does document order decide (a plain archive line above the current block still wins).

## Testing

### How I verified the fix

Reproduced at the extractor level first (all three document shapes returned the archive value `19` instead of `22`), then added failing-first regression tests in `tests/state.test.cjs` and confirmed RED under `gsd-test` (7 failures, all the new #2956 tests, 28754 baseline passing), then GREEN after the fix.

- **Shape B**: bold `**Phase:** 19` in an archive BELOW `## Current Position` → resolves `22`.
- **Shape C**: plain archive `Phase: 19` ABOVE `## Current Position` → resolves `22`.
- **Bootstrap h3** `### Current Position` variant → resolves `22`.
- **CRLF** variant → resolves `22`.
- **Decisions-prose guard**: a "Phase 19" mention in a decisions table row does not leak into `current_phase`.
- **Paused At read-path parity**: a stale `**Paused At:**` in a `## Session Continuity Archive` below the real `## Session` resolves to the Session value.
- **Write-then-read round trip**: `state update` then `state-snapshot` keeps `current_phase: 22` (read/write agreement; no rewind to 19).

### Regression test added?

- [x] Yes — added tests that would have caught this bug (shapes B/C, h3, CRLF, round-trip, Paused At parity)

### Platforms tested

- [x] macOS (local reproduction + build)
- [x] Linux (gsd-test matrix: linux-node22 + linux-node24)
- [x] Windows (CRLF variant covers the line-ending-sensitive case; full matrix lane runs in CI)

### Runtimes tested

- [x] N/A (not runtime-specific — pure state-parsing logic)

---

## Checklist

- [x] Issue linked above with `Fixes #2956`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — only `Phase` (read+write) and `Paused At` (read parity) extraction; `stateExtractField` and `preferNewerLastActivity` untouched
- [x] Regression test added
- [x] All existing tests pass (`gsd-test` full matrix)
- [x] `.changeset/` fragment added (`npm run changeset -- --type Fixed`)
- [x] No unnecessary dependencies added

## Breaking changes

None. Scoping only changes *where* in the body `Phase` is read; files without a `## Current Position` section fall back to identical full-body behaviour. No field semantics, output format, or API changed.

---

`GSD_PR_GATES_OK=1` — `/code-review` (Standards + Spec axes, both APPROVE) + `/security-review` (CLEAN) + isolated adversarial review (APPROVE) + graph-backed deterministic review (`find_cross_module_issues` / `find_code_review_issues`, 0 issues, graph ready) ran; `npm run lint:ci` clean; `gsd-test` full matrix green on the fix sha.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2961"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788148443&installation_model_id=22188&pr_number=2961&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2961&signature=b1490c17b4b4bc986c872acbf17416cb127bbdce36cd22ae54d611d7e6608447"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->