### PR TITLE
fix(#2943): rename get-library-docs -> query-docs; correct the ctx7 fallback rationale

### DIFF
--- a/.changeset/vivid-ibex-hop.md
+++ b/.changeset/vivid-ibex-hop.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**Research agents no longer call a context7 tool that doesn't exist** — four shipped docs instructed agents to call `mcp__context7__get-library-docs`, a tool the context7 MCP server does not register (it exposes only `resolve-library-id` and `query-docs`). Every research workflow that loaded the canonical doc-lookup reference either errored, fell back to the `ctx7` CLI, or fabricated a result. All sites now name `query-docs` with the registered `libraryId`/`query` params, the CLI-fallback rationale now describes the real project-scoped `.mcp.json` mechanism, and a parity guard fails the build if the banned name returns. (#2943)

--- a/.changeset/vivid-ibex-hop.md
+++ b/.changeset/vivid-ibex-hop.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 2963
 ---
 **Research agents no longer call a context7 tool that doesn't exist** — four shipped docs instructed agents to call `mcp__context7__get-library-docs`, a tool the context7 MCP server does not register (it exposes only `resolve-library-id` and `query-docs`). Every research workflow that loaded the canonical doc-lookup reference either errored, fell back to the `ctx7` CLI, or fabricated a result. All sites now name `query-docs` with the registered `libraryId`/`query` params, the CLI-fallback rationale now describes the real project-scoped `.mcp.json` mechanism, and a parity guard fails the build if the banned name returns. (#2943)

--- a/agents/gsd-executor.md
+++ b/agents/gsd-executor.md
@@ -26,10 +26,12 @@ When you need library or framework documentation, check in this order:
 
 1. If Context7 MCP tools (`mcp__context7__*, mcp__plugin_context7_context7__*`) are available in your environment, use them:
    - Resolve library ID: `mcp__context7__resolve-library-id` with `libraryName`
-   - Fetch docs: `mcp__context7__get-library-docs` with `context7CompatibleLibraryId` and `topic`
+   - Fetch docs: `mcp__context7__query-docs` with `libraryId` (the ID from step 1) and `query`
 
-2. If Context7 MCP is not available (upstream bug anthropics/claude-code#13898 strips MCP
-   tools from agents with a `tools:` frontmatter restriction), use the CLI fallback via Bash:
+2. If Context7 MCP is not available (custom subagents cannot see project-scoped
+   `.mcp.json` servers — they only inherit user-scoped `~/.claude/mcp.json`, so a
+   context7 server configured at the project scope is invisible to spawned
+   agents), use the CLI fallback via Bash:
 
    Step 1 — Resolve library ID:
    ```bash

--- a/gsd-core/references/research-documentation-lookup.md
+++ b/gsd-core/references/research-documentation-lookup.md
@@ -2,10 +2,12 @@ When you need library or framework documentation, check in this order:
 
 1. If Context7 MCP tools (`mcp__context7__*`) are available in your environment, use them:
    - Resolve library ID: `mcp__context7__resolve-library-id` with `libraryName`
-   - Fetch docs: `mcp__context7__get-library-docs` with `context7CompatibleLibraryId` and `topic`
+   - Fetch docs: `mcp__context7__query-docs` with `libraryId` (the ID from step 1) and `query`
 
-2. If Context7 MCP is not available (upstream bug anthropics/claude-code#13898 strips MCP
-   tools from agents with a `tools:` frontmatter restriction), use the CLI fallback via Bash:
+2. If Context7 MCP is not available (custom subagents cannot see project-scoped
+   `.mcp.json` servers — they only inherit user-scoped `~/.claude/mcp.json`, so a
+   context7 server configured at the project scope is invisible to spawned
+   agents), use the CLI fallback via Bash:
 
    Step 1 — Resolve library ID:
    ```bash

--- a/gsd-core/workflows/discovery-phase.md
+++ b/gsd-core/workflows/discovery-phase.md
@@ -65,9 +65,9 @@ For: Single known library, confirming syntax/version still correct.
 2. Fetch relevant docs:
 
    ```
-   mcp__context7__get-library-docs with:
-   - context7CompatibleLibraryID: [from step 1]
-   - topic: [specific concern]
+   mcp__context7__query-docs with:
+   - libraryId: [from step 1]
+   - query: [specific concern]
    ```
 
 3. Verify:
@@ -101,7 +101,7 @@ For: Choosing between options, new external integration.
    ```
    For each library/framework:
    - mcp__context7__resolve-library-id
-   - mcp__context7__get-library-docs (mode: "code" for API, "info" for concepts)
+   - mcp__context7__query-docs (frame the `query` for API usage vs concepts)
    ```
 
 3. **Official docs** for anything Context7 lacks.

--- a/tests/context7-tool-name-parity.test.cjs
+++ b/tests/context7-tool-name-parity.test.cjs
@@ -1,0 +1,103 @@
+'use strict';
+
+// Regression guard for #2943 — the context7 MCP server registers exactly two
+// tools (`resolve-library-id` and `query-docs`); it does NOT register
+// `get-library-docs`. That stale name survived in shipped prose (copied from
+// upstream's own stale README), so agents were instructed to call a tool the
+// server does not register — they errored, fell through to the ctx7 CLI
+// fallback, or fabricated a result.
+//
+// This is the SECOND context7 naming drift after #2017 (which guarded the
+// plugin-marketplace PREFIX). #2017's guard (context7-plugin-grant-parity) only
+// checks `tools:` frontmatter lines; it does not scan prose bodies, which is
+// where the broken tool NAME lived. This guard scans the shipped prose surface
+// and fails if any artifact tells an agent to call the nonexistent tool.
+//
+// Allowed (registered upstream): mcp__context7__resolve-library-id,
+// mcp__context7__query-docs, and the mcp__context7__* / plugin-marketplace
+// grants. Banned: mcp__context7__get-library-docs.
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const REPO_ROOT = path.join(__dirname, '..');
+
+// Shipped prose directories an agent can be instructed by. Tests/, CHANGELOG,
+// RELEASE-NOTES-LEGACY (historical record), and node_modules are deliberately
+// excluded — a test fixture may use the banned name as a negative input, and
+// history must not be rewritten.
+const SCAN_DIRS = [
+  'agents',
+  'gsd-core/references',
+  'gsd-core/workflows',
+  'commands/gsd',
+  'skills',
+];
+
+const BANNED = 'mcp__context7__get-library-docs';
+
+function listMarkdown(dir) {
+  const abs = path.join(REPO_ROOT, dir);
+  if (!fs.existsSync(abs)) return [];
+  const out = [];
+  for (const entry of fs.readdirSync(abs, { withFileTypes: true })) {
+    const full = path.join(abs, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...listMarkdown(path.join(dir, entry.name)));
+    } else if (entry.isFile() && entry.name.endsWith('.md')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe('#2943 — no shipped artifact references the nonexistent get-library-docs tool', () => {
+  const files = SCAN_DIRS.flatMap(listMarkdown);
+  assert.ok(files.length > 50, `scan surface sanity check (found ${files.length} markdown files)`);
+
+  const offenders = [];
+  for (const file of files) {
+    const content = fs.readFileSync(file, 'utf8');
+    if (content.includes(BANNED)) {
+      // Report every offending line for actionable failures.
+      const rel = path.relative(REPO_ROOT, file);
+      for (const [i, line] of content.split(/\r?\n/).entries()) {
+        if (line.includes(BANNED)) offenders.push(`${rel}:${i + 1}`);
+      }
+    }
+  }
+
+  test(`no shipped prose references ${BANNED}`, () => {
+    assert.deepEqual(offenders, [],
+      `Shipped artifacts must not instruct agents to call ${BANNED} — the ` +
+      `context7 MCP server does not register it (only resolve-library-id and ` +
+      `query-docs exist). Offending sites:\n${offenders.join('\n')}`);
+  });
+
+  test('the canonical reference names the registered query-docs tool', () => {
+    const ref = path.join(REPO_ROOT, 'gsd-core', 'references', 'research-documentation-lookup.md');
+    const content = fs.readFileSync(ref, 'utf8');
+    assert.ok(content.includes('mcp__context7__query-docs'),
+      'research-documentation-lookup.md must name mcp__context7__query-docs');
+    // The canonical param names (upstream query-docs: libraryId + query). The
+    // alias context7CompatibleLibraryID is tolerated upstream but the canonical
+    // spelling removes the drift source.
+    assert.ok(/query-docs` with `libraryId`/.test(content) || /libraryId` and `query`/.test(content),
+      'query-docs must be documented with the libraryId / query params');
+  });
+
+  test('resolve-library-id tool name is preserved (still registered upstream)', () => {
+    // Negative-space guard: this fix renames get-library-docs only.
+    // resolve-library-id is a different, still-valid tool and must survive.
+    let any = false;
+    for (const file of files) {
+      if (fs.readFileSync(file, 'utf8').includes('mcp__context7__resolve-library-id')) {
+        any = true;
+        break;
+      }
+    }
+    assert.ok(any, 'mcp__context7__resolve-library-id must still appear in shipped artifacts');
+  });
+});

--- a/tests/context7-tool-name-parity.test.cjs
+++ b/tests/context7-tool-name-parity.test.cjs
@@ -34,7 +34,16 @@ const SCAN_DIRS = [
   'gsd-core/workflows',
   'commands/gsd',
   'skills',
+  'docs',
 ];
+
+// Files that are historical record (must not be rewritten to satisfy this
+// guard) or generated changelog. RELEASE-NOTES-LEGACY.md carries the old #13898
+// attribution as shipped history; it is out of scope.
+const EXCLUDED_FILES = new Set([
+  path.join(REPO_ROOT, 'docs', 'RELEASE-NOTES-LEGACY.md'),
+  path.join(REPO_ROOT, 'CHANGELOG.md'),
+]);
 
 const BANNED = 'mcp__context7__get-library-docs';
 
@@ -54,7 +63,8 @@ function listMarkdown(dir) {
 }
 
 describe('#2943 — no shipped artifact references the nonexistent get-library-docs tool', () => {
-  const files = SCAN_DIRS.flatMap(listMarkdown);
+  const files = SCAN_DIRS.flatMap(listMarkdown)
+    .filter((f) => !EXCLUDED_FILES.has(f));
   assert.ok(files.length > 50, `scan surface sanity check (found ${files.length} markdown files)`);
 
   const offenders = [];

--- a/tests/emitted-drift-acks/2943-context7-tool-name.json
+++ b/tests/emitted-drift-acks/2943-context7-tool-name.json
@@ -1,0 +1,6 @@
+{
+  "version": 1,
+  "paths": {
+    "gsd-executor.md": "#2943: the context7 doc-lookup block's ctx7 CLI-fallback rationale was rewritten to describe the real mechanism (custom subagents cannot see project-scoped .mcp.json; they inherit only user-scoped ~/.claude/mcp.json), replacing the wrong anthropics/claude-code#13898 'tools: frontmatter restriction' attribution. The tool name was also corrected (get-library-docs -> query-docs) and the params renamed (context7CompatibleLibraryId/topic -> libraryId/query). The +95 bytes is the longer-but-accurate mechanism description; it is the literal fix for the mis-attribution, not incidental prose growth, and the rationale must be correct because agents read it to decide when to fall back to the CLI."
+  }
+}

--- a/tests/no-bare-gsd-tools-command-position.test.cjs
+++ b/tests/no-bare-gsd-tools-command-position.test.cjs
@@ -82,7 +82,7 @@ const BARE_COMMAND_RE = new RegExp(
 // Each entry MUST carry a one-line reason; the test prints the allowlist on
 // failure so a reviewer can see exactly what is sanctioned.
 const PROSE_ALLOWLIST = [
-  { file: 'agents/gsd-executor.md', line: 791, reason: 'describes the SDK return envelope of `gsd-tools query commit`; not an instruction to run the bare word' },
+  { file: 'agents/gsd-executor.md', line: 793, reason: 'describes the SDK return envelope of `gsd-tools query commit`; not an instruction to run the bare word' },
   { file: 'agents/gsd-phase-researcher.md', line: 33, reason: 'package-legitimacy provenance rule names the command as the source of an OK verdict; descriptive' },
   { file: 'agents/gsd-roadmapper.md', line: 624, reason: 'parenthetical "e.g." naming SDK queries a user *could* run; not an agent instruction' },
   { file: 'agents/gsd-intel-updater.md', line: 40, reason: 'cross-platform note names the `gsd-tools intel <subcommand>` CLI surface descriptively ("CLI invocations go through..."); not an agent instruction' },


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #2943

> The linked issue (#2943) carries the `confirmed-bug` label.

---

## What was broken

Four shipped prose artifacts instructed agents to call `mcp__context7__get-library-docs` — a tool the context7 MCP server **does not register**. Upstream (`upstash/context7`, `packages/mcp/src/index.ts`) exposes only `resolve-library-id` and `query-docs`; `get-library-docs` is a stale name copied from upstream's own README. Every research workflow that loaded the canonical doc-lookup reference (`research-documentation-lookup.md`, `@`-referenced by six researcher agents) either errored, fell through to the `ctx7` CLI fallback, or fabricated a result.

A second defect in the same block: the `ctx7` CLI fallback's rationale cited `anthropics/claude-code#13898` as "strips MCP tools from agents with a `tools:` frontmatter restriction". That was wrong on two counts — #13898 is **closed**, and it was about project-scoped `.mcp.json` being invisible to custom subagents, not about `tools:` frontmatter.

This is the **second** context7 naming drift after #2017 (which guarded the plugin-marketplace *prefix* — a different field).

## What this fix does

- **Rename** `get-library-docs` → `query-docs` at all four sites (`research-documentation-lookup.md:5`, `discovery-phase.md:68` & `:104`, `gsd-executor.md:29`), with the registered params `libraryId` + `query` (the old `context7CompatibleLibraryId`/`topic`/`mode` were the dropped `get-library-docs` API). Verified against upstream truth.
- **Correct the CLI-fallback rationale** in `research-documentation-lookup.md` and `gsd-executor.md` to describe the real mechanism (custom subagents cannot see project-scoped `.mcp.json`; they inherit only user-scoped `~/.claude/mcp.json`). The fallback itself is kept.
- **Add a parity guard** (`tests/context7-tool-name-parity.test.cjs`) that fails the build if any shipped artifact (`agents/`, `gsd-core/references|workflows/`, `commands/gsd/`, `skills/`, `docs/`) tells an agent to call the nonexistent tool — the durable fix that makes a third drift fail CI. Tests/ and historical record (CHANGELOG, RELEASE-NOTES-LEGACY) are excluded.

## Root cause

A stale copy of the tool name from upstream's README that was never updated when upstream renamed the tool. The canonical `query-docs` name already existed in 15 sites — the 4 broken sites were stragglers. Nothing asserted the two spellings agreed, so they diverged (Generative Fix Divergence).

## Testing

### How I verified the fix

- **Verified upstream truth independently**: `gh api repos/upstash/context7/contents/packages/mcp/src/index.ts` → registers `resolve-library-id` (L135) + `query-docs` (L222, params `libraryId`+`query`); no `get-library-docs`.
- **Failing-first**: the new parity guard fails today on `1e7b3ca9` (4 offenders) and passes after the rename.
- `gsd-test` full matrix green on the fix sha.

### Regression test added?

- [x] Yes — `tests/context7-tool-name-parity.test.cjs` (parity guard; would have caught this and prevents the next drift)

### Platforms tested

- [x] macOS (local verify + build)
- [x] Linux (gsd-test matrix)
- [x] N/A Windows (pure markdown/docs + a read-only fs-scan test; not platform-specific)

### Runtimes tested

- [x] Claude Code (the runtime that surfaces the broken tool calls)
- [x] N/A otherwise (docs change)

---

## Checklist

- [x] Issue linked above with `Fixes #2943`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — only the context7 tool-name/params + the wrong #13898 citation; `resolve-library-id` untouched
- [x] Regression test added
- [x] All existing tests pass (`gsd-test` full matrix)
- [x] `.changeset/` fragment added
- [x] No unnecessary dependencies added

## Breaking changes

None. Agents are now told to call a tool that actually exists; the `ctx7` CLI fallback is unchanged. `resolve-library-id` is untouched.

---

`GSD_PR_GATES_OK=1` — isolated adversarial review (APPROVE, 1 minor fixed inline: widened the parity-guard scan surface to `docs/`) + security review (CLEAN — `npx --yes` guard intact, read-only test) + graph deterministic review (0 issues, ready) ran; `npm run lint:ci` clean; `gsd-test` full matrix green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2963"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788153730&installation_model_id=22188&pr_number=2963&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2963&signature=6bdc58db43d87cde6c4cb0a445bafc14e76df0e2f442a4a4037c2cfb25955208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->