### PR TITLE
fix(#2941): hint at global: prefix when bare skill name matches a global skill

### DIFF
--- a/.changeset/wise-rams-glide.md
+++ b/.changeset/wise-rams-glide.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**Agent-skills warnings now suggest the `global:` prefix when a bare name matches a global skill** — configuring a skill by bare name (e.g. `patch-coverage-check`) that exists as a global skill was silently skipped with no hint that the fix is `global:patch-coverage-check`. The skip warning now appends a hint when the bare name matches an existing global skill. (#2941)

--- a/.changeset/wise-rams-glide.md
+++ b/.changeset/wise-rams-glide.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 2973
 ---
 **Agent-skills warnings now suggest the `global:` prefix when a bare name matches a global skill** — configuring a skill by bare name (e.g. `patch-coverage-check`) that exists as a global skill was silently skipped with no hint that the fix is `global:patch-coverage-check`. The skip warning now appends a hint when the bare name matches an existing global skill. (#2941)

--- a/src/init.cts
+++ b/src/init.cts
@@ -2201,8 +2201,21 @@ function buildAgentSkillsBlock(
 
     const skillMdPath = path.join(projectRoot, skillPath, 'SKILL.md');
     if (!fs.existsSync(skillMdPath)) {
+      // #2941: if the bare name matches a global skill, hint at the global: prefix.
+      // The bare name resolves as project-relative (which doesn't exist), but the
+      // user likely meant to reference a global skill. getGlobalSkillDir is already
+      // imported for the global: branch above; guard on globalSkillsBase being non-null
+      // since runtimes without a skills directory don't support the prefix.
+      let hint = '';
+      if (globalSkillsBase !== null) {
+        const baseName = path.basename(skillPath);
+        const globalDir = getGlobalSkillDir(runtime, baseName) as string;
+        if (globalDir && fs.existsSync(path.join(globalDir, 'SKILL.md'))) {
+          hint = ` — a global skill named "${baseName}" exists; use "global:${baseName}" to reference it`;
+        }
+      }
       warn(
-        `[agent-skills] WARNING: Skill not found at "${skillPath}/SKILL.md" — skipping\n`,
+        `[agent-skills] WARNING: Skill not found at "${skillPath}/SKILL.md"${hint} — skipping\n`,
       );
       continue;
     }

--- a/tests/agent-skills.test.cjs
+++ b/tests/agent-skills.test.cjs
@@ -558,6 +558,49 @@ describe('agent-skills global: prefix', () => {
     assert.strictEqual(r.ir.block, '', 'block must be empty when skill is missing');
   });
 
+  // ─── #2941: bare skill name matching a global skill must hint at global: prefix ──
+
+  test('#2941 — bare name matching a global skill hints at the global: prefix', () => {
+    // Create a global skill so it exists on disk under ~/.claude/skills/
+    createGlobalSkill('patch-coverage-check');
+    // Reference it by BARE name (no global: prefix) — this resolves as
+    // project-relative, which doesn't exist, so it's skipped. The warning
+    // must hint that the name matches a global skill.
+    writeConfig(tmpDir, {
+      agent_skills: { 'gsd-executor': ['patch-coverage-check'] },
+    });
+
+    const r = runAgentSkillsJson(
+      ['agent-skills', 'gsd-executor'], tmpDir, { HOME: fakeHome, USERPROFILE: fakeHome }
+    );
+    assert.ok(r.success, `Command failed: ${r.error}`);
+    assert.strictEqual(r.ir.block, '', 'block must be empty — bare name does not resolve as project-relative');
+    assert.ok(Array.isArray(r.ir.warnings), 'IR must include warnings');
+    const hintWarning = r.ir.warnings.find((w) => /patch-coverage-check/.test(w) && /global:/.test(w));
+    assert.ok(hintWarning,
+      `warning must hint at the global: prefix when a bare name matches a global skill, got: ${JSON.stringify(r.ir.warnings)}`);
+  });
+
+  test('#2941 — bare name with NO global match keeps the original warning (no false hint)', () => {
+    // No global skill of this name exists. The warning must be the original
+    // "Skill not found" message without a global: hint.
+    writeConfig(tmpDir, {
+      agent_skills: { 'gsd-executor': ['totally-nonexistent-skill'] },
+    });
+
+    const r = runAgentSkillsJson(
+      ['agent-skills', 'gsd-executor'], tmpDir, { HOME: fakeHome, USERPROFILE: fakeHome }
+    );
+    assert.ok(r.success, `Command failed: ${r.error}`);
+    assert.strictEqual(r.ir.block, '', 'block must be empty');
+    assert.ok(Array.isArray(r.ir.warnings), 'IR must include warnings');
+    const notFoundWarning = r.ir.warnings.find((w) => /Skill not found/.test(w) && /totally-nonexistent-skill/.test(w));
+    assert.ok(notFoundWarning, `must have the standard "not found" warning, got: ${JSON.stringify(r.ir.warnings)}`);
+    // Must NOT contain a global: hint — there is no global skill of this name.
+    assert.ok(!notFoundWarning.includes('global:'),
+      `warning must not hint at global: when no global skill matches, got: ${notFoundWarning}`);
+  });
+
   test('mix of global: and project-relative paths both resolve correctly', () => {
     createGlobalSkill('shadcn');
 


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #2941

---

## What was broken

When a user configured `agent_skills` with a bare skill name (e.g. `"gsd-executor": "patch-coverage-check"`) and that skill existed as a global skill (`~/.claude/skills/patch-coverage-check/SKILL.md`), the skill was silently skipped. The warning said "Skill not found at patch-coverage-check/SKILL.md — skipping" but didn't hint that the name matched a global skill and the fix was to use `global:patch-coverage-check`.

## What this fix does

In `buildAgentSkillsBlock`'s missing-skill warning path, before emitting the warning, the code now checks if the bare name matches an existing global skill. If it does, the warning appends: `— a global skill named "X" exists; use "global:X" to reference it`. When no global skill matches, the warning is unchanged.

## Root cause

Bare skill names resolve as project-relative paths. A bare name like `patch-coverage-check` resolves to `<projectRoot>/patch-coverage-check/SKILL.md`, which doesn't exist. The warning path didn't check whether the name matched a global skill — the `getGlobalSkillDir` function (already imported for the `global:` branch) was never called on the bare-name path.

## Testing

### How I verified the fix

RED proven at `6d2bdd976` (2 failures both lanes — the hint assertion failed because no hint was emitted). Two regression tests:
1. Bare name matching a global skill → warning includes the `global:` hint.
2. Bare name with no global match → original "Skill not found" warning unchanged, no false hint.

### Regression test added?

- [x] Yes — two tests in `tests/agent-skills.test.cjs`

### Platforms tested

- [x] Linux (gsd-test matrix)
- [ ] macOS / Windows (not platform-specific)

### Runtimes tested

- [x] Claude Code (the global skills base is `~/.claude/skills/`)

---

## Checklist

- [x] Issue linked above with `Fixes #2941`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — one warning path, additive hint
- [x] Regression test added
- [x] All existing tests pass (`gsd-test`)
- [x] `.changeset/` fragment added
- [x] No unnecessary dependencies added

## Breaking changes

None. The warning message gains an optional hint suffix only when a global skill of the exact name exists. No behavior change — the skill is still correctly skipped when referenced by bare name without `global:`.

GSD_PR_GATES_OK=1

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2973"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788187657&installation_model_id=22188&pr_number=2973&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2973&signature=3da070709a4e0976fda87e958758784cab6c9173f293340b235d66eff0512093"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->