### PR TITLE
fix(#2640): report truthful state_updated + keep progress frontmatter in sync after phase remove

### DIFF
--- a/.changeset/steady-seals-swim.md
+++ b/.changeset/steady-seals-swim.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 2974
 ---
 **`phase remove` now reports accurate state_updated and keeps STATE.md progress counters in sync** — the command reported `state_updated: true` based on file existence (always true) rather than actual content change, and the frontmatter `progress.total_phases`/`completed_phases`/`percent` counters went stale when the STATE.md body lacked a `Total Phases:` field (the no-op write guard skipped the frontmatter resync). (#2640)

--- a/.changeset/steady-seals-swim.md
+++ b/.changeset/steady-seals-swim.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`phase remove` now reports accurate state_updated and keeps STATE.md progress counters in sync** — the command reported `state_updated: true` based on file existence (always true) rather than actual content change, and the frontmatter `progress.total_phases`/`completed_phases`/`percent` counters went stale when the STATE.md body lacked a `Total Phases:` field (the no-op write guard skipped the frontmatter resync). (#2640)

--- a/src/phase.cts
+++ b/src/phase.cts
@@ -1598,24 +1598,54 @@ function cmdPhaseRemove(
   );
 
   const statePath = path.join(planningDir(cwd), 'STATE.md');
+  let stateUpdated = false;
   if (fs.existsSync(statePath)) {
-    readModifyWriteStateMd(
+    // #2640: report whether STATE.md content actually changed, not just file
+    // existence (fs.existsSync was trivially true). Also ensure the body
+    // transform produces a diff so readModifyWriteStateMd's no-op guard
+    // (#948) doesn't skip the frontmatter resync — without that, the
+    // progress.* frontmatter block stays stale when the body has no
+    // 'Total Phases:' or 'of N' phrase.
+    stateUpdated = readModifyWriteStateMd(
       statePath,
       (stateContent: string) => {
-        const totalRaw = stateExtractField(stateContent, 'Total Phases');
+        let modified = stateContent;
+        const totalRaw = stateExtractField(modified, 'Total Phases');
         if (totalRaw) {
-          stateContent =
-            stateReplaceField(stateContent, 'Total Phases', String(parseInt(totalRaw, 10) - 1)) ||
-            stateContent;
+          modified =
+            stateReplaceField(modified, 'Total Phases', String(parseInt(totalRaw, 10) - 1)) ||
+            modified;
         }
-        const ofMatch = stateContent.match(/(\bof\s+)(\d+)(\s*(?:\(|phases?))/i);
+        const ofMatch = modified.match(/(\bof\s+)(\d+)(\s*(?:\(|phases?))/i);
         if (ofMatch) {
-          stateContent = stateContent.replace(
+          modified = modified.replace(
             /(\bof\s+)(\d+)(\s*(?:\(|phases?))/i,
             `$1${parseInt(ofMatch[2], 10) - 1}$3`,
           );
         }
-        return stateContent;
+        // #2640: if neither body field was found, the transform is a no-op.
+        // readModifyWriteStateMd's no-op guard would then skip the frontmatter
+        // resync, leaving progress.* stale. Force a body diff by touching the
+        // 'Total Phases:' line — create it if absent so the guard passes and
+        // syncStateFrontmatter rebuilds the frontmatter from the post-deletion
+        // disk/ROADMAP state.
+        if (modified === stateContent) {
+          const remainingPhases = subdirs.filter(
+            (d) => phaseTokenMatches(d, normalized) === false,
+          ).length;
+          // Renumbering may have changed dir names; approximate with count - 1.
+          const approxTotal = Math.max(0, remainingPhases);
+          if (totalRaw) {
+            modified =
+              stateReplaceField(modified, 'Total Phases', String(approxTotal)) || modified;
+          } else {
+            // No 'Total Phases:' field in the body — append one so the no-op
+            // guard sees a diff. syncStateFrontmatter will then rebuild the
+            // frontmatter progress.* block from the real disk/ROADMAP count.
+            modified = `Total Phases: ${approxTotal}\n` + modified;
+          }
+        }
+        return modified;
       },
       cwd,
     );
@@ -1628,7 +1658,7 @@ function cmdPhaseRemove(
       renamed_directories: renamedDirs,
       renamed_files: renamedFiles,
       roadmap_updated: true,
-      state_updated: fs.existsSync(statePath),
+      state_updated: stateUpdated,
     },
     raw,
   );

--- a/src/phase.cts
+++ b/src/phase.cts
@@ -1624,25 +1624,27 @@ function cmdPhaseRemove(
           );
         }
         // #2640: if neither body field was found, the transform is a no-op.
-        // readModifyWriteStateMd's no-op guard would then skip the frontmatter
-        // resync, leaving progress.* stale. Force a body diff by touching the
-        // 'Total Phases:' line — create it if absent so the guard passes and
-        // syncStateFrontmatter rebuilds the frontmatter from the post-deletion
-        // disk/ROADMAP state.
-        if (modified === stateContent) {
+        // readModifyWriteStateMd's no-op guard (#948) would then skip the
+        // frontmatter resync, leaving progress.* stale. Force a body diff
+        // ONLY when a phase directory was actually removed (targetDir !== null)
+        // so the guard passes and syncStateFrontmatter rebuilds the frontmatter
+        // from the post-deletion disk/ROADMAP state. Without the targetDir gate,
+        // a no-op removal (ROADMAP-only phase, no directory) would inject a
+        // spurious 'Total Phases:' line into a body that intentionally lacked one.
+        if (targetDir && modified === stateContent) {
+          // subdirs was read before the deletion; excluding the removed target
+          // gives the remaining count. Renumbering changes names but not count.
           const remainingPhases = subdirs.filter(
             (d) => phaseTokenMatches(d, normalized) === false,
           ).length;
-          // Renumbering may have changed dir names; approximate with count - 1.
-          const approxTotal = Math.max(0, remainingPhases);
           if (totalRaw) {
             modified =
-              stateReplaceField(modified, 'Total Phases', String(approxTotal)) || modified;
+              stateReplaceField(modified, 'Total Phases', String(remainingPhases)) || modified;
           } else {
             // No 'Total Phases:' field in the body — append one so the no-op
             // guard sees a diff. syncStateFrontmatter will then rebuild the
             // frontmatter progress.* block from the real disk/ROADMAP count.
-            modified = `Total Phases: ${approxTotal}\n` + modified;
+            modified = `Total Phases: ${remainingPhases}\n` + modified;
           }
         }
         return modified;

--- a/src/state.cts
+++ b/src/state.cts
@@ -2213,7 +2213,7 @@ function writeStateMd(statePath: string, content: string, cwd?: string, clock?: 
  * @param clock
  *   Optional clock seam; defaults to realClock. Passed through to acquireStateLock.
  */
-function readModifyWriteStateMd(statePath: string, transformFn: (content: string) => string, cwd: string, options?: ReadModifyWriteOptions, clock?: StateLockClock): void {
+function readModifyWriteStateMd(statePath: string, transformFn: (content: string) => string, cwd: string, options?: ReadModifyWriteOptions, clock?: StateLockClock): boolean {
   const resync = !options || options.resync !== false;
   const lockPath = acquireStateLock(statePath, clock);
   try {
@@ -2261,7 +2261,7 @@ function readModifyWriteStateMd(statePath: string, transformFn: (content: string
     // content already returns the mutated string, and callers that detect a
     // no-op explicitly return the original content unchanged.
     if (modified === content) {
-      return;
+      return false;
     }
 
     let synced = syncStateFrontmatter(modified, cwd, options?.authoritativeFm);
@@ -2317,6 +2317,7 @@ function readModifyWriteStateMd(statePath: string, transformFn: (content: string
     }
 
     platformWriteSync(statePath, synced);
+    return true;
   } finally {
     releaseStateLock(lockPath);
   }

--- a/tests/phase.test.cjs
+++ b/tests/phase.test.cjs
@@ -2776,6 +2776,15 @@ Plans:
     assert.ok(result.success, `Command failed: ${result.error}`);
     const out = JSON.parse(result.output);
     assert.strictEqual(out.state_updated, true, 'state_updated must be true when STATE.md content changed');
+    // Body 'Total Phases:' must be decremented from 2 to 1.
+    const afterState = fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
+    const bodyMatch = afterState.match(/^Total Phases:\s*(\d+)/m);
+    assert.ok(bodyMatch, 'body must have Total Phases field after remove');
+    assert.strictEqual(bodyMatch[1], '1', `body 'Total Phases:' must be 1 after removing one of 2 phases; got ${bodyMatch[1]}`);
+    // Frontmatter progress.total_phases must agree.
+    const fmMatch = afterState.match(/total_phases:\s*(\d+)/);
+    assert.ok(fmMatch, 'frontmatter must have total_phases');
+    assert.strictEqual(fmMatch[1], '1', `frontmatter progress.total_phases must be 1; got ${fmMatch[1]}`);
   });
 
   test('#2640 — progress.total_phases resync\'d even when body lacks Total Phases', () => {
@@ -2802,8 +2811,10 @@ Plans:
     const afterState = fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
     const afterMatch = afterState.match(/total_phases:\s*(\d+)/);
     assert.ok(afterMatch, `STATE.md frontmatter must still have total_phases after remove; got:\n${afterState}`);
-    assert.notStrictEqual(afterMatch[1], '3',
-      `total_phases must change from 3 after removing a phase; got ${afterMatch[1]}`);
+    // Must be exactly 2 — 3 phases minus 1 removed. Asserting the exact value
+    // catches a wrong count (not just "not 3").
+    assert.strictEqual(afterMatch[1], '2',
+      `total_phases must be exactly 2 after removing one of 3 phases; got ${afterMatch[1]}`);
   });
 
   test('#2640 — state_updated is false when STATE.md does not exist', () => {

--- a/tests/phase.test.cjs
+++ b/tests/phase.test.cjs
@@ -2755,6 +2755,70 @@ Plans:
       "surviving row's Plans/Status/Completed cells stay byte-identical; only its leading ordinal renumbers 3->2",
     );
   });
+
+  // ─── #2640: state_updated must reflect actual content change, and progress
+  // frontmatter must be resync'd even when the body lacks 'Total Phases:'. ──
+
+  test('#2640 — state_updated reflects actual content change (not just file existence)', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      `# Roadmap\n\n### Phase 1: A\n**Goal:** x\n\n### Phase 2: B\n**Goal:** y\n`,
+    );
+    fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '01-a'), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '02-b'), { recursive: true });
+    // STATE.md with 'Total Phases:' body field + progress frontmatter
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'STATE.md'),
+      `---\ngsd_state_version: 1.0\ncurrent_phase: 1\nprogress:\n  total_phases: 2\n  completed_phases: 0\n  percent: 0\n---\n\n# State\n\nTotal Phases: 2\n`,
+    );
+
+    const result = runGsdTools('phase remove 2', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+    const out = JSON.parse(result.output);
+    assert.strictEqual(out.state_updated, true, 'state_updated must be true when STATE.md content changed');
+  });
+
+  test('#2640 — progress.total_phases resync\'d even when body lacks Total Phases', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      `# Roadmap\n\n### Phase 1: A\n**Goal:** x\n\n### Phase 2: B\n**Goal:** y\n\n### Phase 3: C\n**Goal:** z\n`,
+    );
+    fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '01-a'), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '02-b'), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '03-c'), { recursive: true });
+    // STATE.md with NO 'Total Phases:' body field, but with progress frontmatter
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'STATE.md'),
+      `---\ngsd_state_version: 1.0\ncurrent_phase: 1\nprogress:\n  total_phases: 3\n  completed_phases: 0\n  percent: 0\n---\n\n# State\n\nNo body phase count here.\n`,
+    );
+
+    const beforeState = fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
+    const beforeMatch = beforeState.match(/total_phases:\s*(\d+)/);
+    assert.ok(beforeMatch && beforeMatch[1] === '3', 'precondition: total_phases should be 3');
+
+    const result = runGsdTools('phase remove 2', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const afterState = fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
+    const afterMatch = afterState.match(/total_phases:\s*(\d+)/);
+    assert.ok(afterMatch, `STATE.md frontmatter must still have total_phases after remove; got:\n${afterState}`);
+    assert.notStrictEqual(afterMatch[1], '3',
+      `total_phases must change from 3 after removing a phase; got ${afterMatch[1]}`);
+  });
+
+  test('#2640 — state_updated is false when STATE.md does not exist', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      `# Roadmap\n\n### Phase 1: A\n**Goal:** x\n`,
+    );
+    fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '01-a'), { recursive: true });
+    // No STATE.md
+
+    const result = runGsdTools('phase remove 1', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+    const out = JSON.parse(result.output);
+    assert.strictEqual(out.state_updated, false, 'state_updated must be false when no STATE.md exists');
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #2640

---

## What was broken

`cmdPhaseRemove` had two defects:

1. **`state_updated` was a false positive** — it reported `fs.existsSync(statePath)`, which is trivially `true` since the file existed before and `readModifyWriteStateMd` never deletes it. It didn't reflect whether STATE.md's content actually changed.

2. **`progress.*` frontmatter stayed stale** — `readModifyWriteStateMd`'s no-op guard (#948) skipped `syncStateFrontmatter` when the body transform produced no change. This happened whenever STATE.md lacked the optional `Total Phases:` body field — the transform was a no-op, the guard fired, and the frontmatter `progress.total_phases`/`completed_phases`/`percent` were never rebuilt from the post-deletion disk/ROADMAP state.

## What this fix does

1. **`readModifyWriteStateMd` returns `boolean`** (`void` → `boolean`): `true` when content was written, `false` on no-op. Backward-compatible — all ~20 existing callers discard the return value as a bare statement.

2. **`cmdPhaseRemove` captures the boolean** for `state_updated` instead of `fs.existsSync`.

3. **Forces a body diff when a phase was actually removed** (`targetDir !== null`) and the body transform would otherwise be a no-op. This ensures the no-op guard passes and `syncStateFrontmatter` rebuilds the frontmatter `progress.*` from the post-deletion state.

## Root cause

- Defect 1: `fs.existsSync(statePath)` checks file existence, not content change. The function returned `void`, giving the caller no signal.
- Defect 2: The no-op guard (`if (modified === content) return;`) is intentional (#948), but it gated the frontmatter resync behind a body-text diff. When the body lacked `Total Phases:`, the resync never ran.

## Testing

### How I verified the fix

RED proven at `7fe7d762c` (2 failures both lanes — `progress.total_phases` was stale after remove). Three regression tests:
1. `state_updated` reflects actual content change + body `Total Phases:` and frontmatter `total_phases` both equal 1.
2. `progress.total_phases` resync'd to exactly 2 even when body lacks `Total Phases:` (the no-op guard case).
3. `state_updated: false` when no STATE.md exists.

### Regression test added?

- [x] Yes — three tests in `tests/phase.test.cjs`

### Platforms tested

- [x] Linux (gsd-test matrix)
- [ ] macOS / Windows (not platform-specific)

### Runtimes tested

- [x] N/A (core src fix — not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #2640`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — `readModifyWriteStateMd` return type + `cmdPhaseRemove`
- [x] Regression test added
- [x] All existing tests pass (`gsd-test`)
- [x] `.changeset/` fragment added
- [x] No unnecessary dependencies added

## Breaking changes

None. The `readModifyWriteStateMd` return-type change (`void` → `boolean`) is backward-compatible — TypeScript callers that ignore the return are unaffected. The `state_updated` output field changes from "always true when STATE.md exists" to "true when content actually changed," which is the correct behavior the issue requested.

GSD_PR_GATES_OK=1

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2974"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788191202&installation_model_id=22188&pr_number=2974&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2974&signature=aebbf4c24e5cf5cd0580733fa49c3ae67f3468a3a30b4b3ddbc41700347d605d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->