### PR TITLE
fix(#2893): preserve prose below the JSON ledger on windows append/waive/fixed

### DIFF
--- a/.changeset/clever-lemurs-snooze.md
+++ b/.changeset/clever-lemurs-snooze.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`windows append`/`waive`/`fixed` no longer destroy prose below the JSON ledger** — the writer reconstructed the file from the parsed JSON ledger only, silently dropping any human-authored prose sections below the closing fence. The writer now preserves trailing prose across all write operations. (#2893)

--- a/.changeset/clever-lemurs-snooze.md
+++ b/.changeset/clever-lemurs-snooze.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 2975
 ---
 **`windows append`/`waive`/`fixed` no longer destroy prose below the JSON ledger** — the writer reconstructed the file from the parsed JSON ledger only, silently dropping any human-authored prose sections below the closing fence. The writer now preserves trailing prose across all write operations. (#2893)

--- a/src/broken-windows.cts
+++ b/src/broken-windows.cts
@@ -721,7 +721,27 @@ function writeLedgerAtomic(cwd: string, ledger: Ledger): void {
   ensurePlanningDir(cwd);
   const p = ledgerPath(cwd);
   const tmp = `${p}.${process.pid}.tmp`;
-  fs.writeFileSync(tmp, renderLedger(ledger), 'utf8');
+
+  // #2893: preserve any prose below the JSON ledger block. renderLedger
+  // reconstructs frontmatter + header + table + JSON — it does not include
+  // trailing prose that users may have written below the closing fence.
+  // Without this, every append/waive/fixed silently destroys that prose.
+  let trailingProse = '';
+  try {
+    const existing = fs.readFileSync(p, 'utf8');
+    const fenceEnd = existing.indexOf(JSON_FENCE_CLOSE);
+    if (fenceEnd !== -1) {
+      const afterFence = existing.slice(fenceEnd + JSON_FENCE_CLOSE.length);
+      // Drop leading newlines/whitespace; keep the rest as prose.
+      trailingProse = afterFence.replace(/^\n+/, '');
+    }
+  } catch {
+    // File doesn't exist yet (first write) — no prose to preserve.
+  }
+
+  const rendered = renderLedger(ledger);
+  const content = trailingProse ? `${rendered}${trailingProse}` : rendered;
+  fs.writeFileSync(tmp, content, 'utf8');
   try {
     renameWithRetry(tmp, p);
   } catch (err) {

--- a/src/broken-windows.cts
+++ b/src/broken-windows.cts
@@ -729,11 +729,17 @@ function writeLedgerAtomic(cwd: string, ledger: Ledger): void {
   let trailingProse = '';
   try {
     const existing = fs.readFileSync(p, 'utf8');
-    const fenceEnd = existing.indexOf(JSON_FENCE_CLOSE);
-    if (fenceEnd !== -1) {
-      const afterFence = existing.slice(fenceEnd + JSON_FENCE_CLOSE.length);
-      // Drop leading newlines/whitespace; keep the rest as prose.
-      trailingProse = afterFence.replace(/^\n+/, '');
+    // #2893: search for the CLOSING fence starting AFTER the opening fence,
+    // mirroring parseJsonBlock — indexOf(JSON_FENCE_CLOSE) alone would match
+    // the opening fence ('````json' starts with '````').
+    const openIdx = existing.indexOf(JSON_FENCE_OPEN);
+    if (openIdx !== -1) {
+      const fenceEnd = existing.indexOf(JSON_FENCE_CLOSE, openIdx + JSON_FENCE_OPEN.length);
+      if (fenceEnd !== -1) {
+        const afterFence = existing.slice(fenceEnd + JSON_FENCE_CLOSE.length);
+        // Drop leading newlines; keep the rest as prose.
+        trailingProse = afterFence.replace(/^\n+/, '');
+      }
     }
   } catch {
     // File doesn't exist yet (first write) — no prose to preserve.

--- a/tests/broken-windows.test.cjs
+++ b/tests/broken-windows.test.cjs
@@ -610,12 +610,13 @@ describe('broken-windows CLI: windows append', () => {
     const tmp = createTempDir('bw-append-prose-');
     t.after(() => cleanup(tmp));
 
-    // Create a WINDOWS.md with prose below the JSON block.
+    // Create a WINDOWS.md with a NON-EMPTY ledger + prose below the JSON block.
     fs.mkdirSync(path.join(tmp, '.planning'), { recursive: true });
     const lp = path.join(tmp, '.planning', LEDGER_FILE_NAME);
     const initial = renderLedger({
-      schema_version: 1, open_count: 0, waived_count: 0, fixed_count: 0, total_count: 0,
-      last_updated: '2026-01-01T00:00:00Z', entries: [],
+      schema_version: 1, open_count: 1, waived_count: 0, fixed_count: 0, total_count: 1,
+      last_updated: '2026-01-01T00:00:00Z',
+      entries: [{ id: 1, phase: '1', kind: 'stub', file: '', line: null, description: 'pre-existing', status: 'open', reason: '', recorded_at: '2026-01-01T00:00:00Z', resolved_at: null }],
     });
     const prose = [
       '',
@@ -630,23 +631,37 @@ describe('broken-windows CLI: windows append', () => {
     ].join('\n');
     fs.writeFileSync(lp, initial + prose, 'utf8');
 
-    // Append a window entry.
+    // First append.
     const res = runGsdTools(
       ['windows', 'append', '--kind', 'stub', '--phase', '2', '--description', 'test entry'],
       tmp,
     );
     assert.equal(res.success, true, `stderr: ${res.error || ''}`);
-    const obj = JSON.parse(res.output);
-    assert.equal(obj.ok, true);
+    assert.equal(JSON.parse(res.output).ok, true);
 
-    // The prose must survive.
+    // Second append — idempotency: prose must appear exactly once, not duplicated.
+    const res2 = runGsdTools(
+      ['windows', 'append', '--kind', 'todo', '--phase', '3', '--description', 'second entry'],
+      tmp,
+    );
+    assert.equal(res2.success, true);
+
     const after = fs.readFileSync(lp, 'utf8');
-    assert.match(after, /Investigation Notes/, 'prose heading must survive the append');
-    assert.match(after, /thread-status\.test\.ts/, 'prose body must survive the append');
+    // Prose must survive.
+    assert.match(after, /Investigation Notes/, 'prose heading must survive');
+    assert.match(after, /thread-status\.test\.ts/, 'prose body must survive');
     assert.match(after, /ACPT-M03/, 'second prose heading must survive');
     assert.match(after, /PREDATED the diff/, 'second prose body must survive');
-    // The ledger must also be correct.
-    assert.match(after, /open_count: 1/);
+    // Prose must appear exactly once (not duplicated by the second write).
+    assert.equal((after.match(/Investigation Notes/g) || []).length, 1,
+      'prose heading must appear exactly once after two appends (idempotency)');
+    // The old JSON body must NOT be duplicated as prose (the indexOf(open-fence) bug).
+    // Count JSON fence opens — there must be exactly one.
+    assert.equal((after.match(/````json/g) || []).length, 1,
+      'exactly one JSON fence open must exist (no duplicated JSON body)');
+    // The file must re-parse cleanly with the correct entry count.
+    const reParsed = parseLedger(after);
+    assert.equal(reParsed.entries.length, 3, 'ledger must have 3 entries after two appends');
   });
 });
 

--- a/tests/broken-windows.test.cjs
+++ b/tests/broken-windows.test.cjs
@@ -603,6 +603,51 @@ describe('broken-windows CLI: windows append', () => {
     assert.equal(res.success, false);
     assert.match(res.error, /4-backtick|fence|invalid_text/i);
   });
+
+  // ─── #2893: append must not destroy prose below the JSON ledger ──────────
+
+  test('#2893 — append preserves prose below the JSON ledger block', (t) => {
+    const tmp = createTempDir('bw-append-prose-');
+    t.after(() => cleanup(tmp));
+
+    // Create a WINDOWS.md with prose below the JSON block.
+    fs.mkdirSync(path.join(tmp, '.planning'), { recursive: true });
+    const lp = path.join(tmp, '.planning', LEDGER_FILE_NAME);
+    const initial = renderLedger({
+      schema_version: 1, open_count: 0, waived_count: 0, fixed_count: 0, total_count: 0,
+      last_updated: '2026-01-01T00:00:00Z', entries: [],
+    });
+    const prose = [
+      '',
+      '## Investigation Notes',
+      '',
+      'This window was opened because the flaky test in thread-status.test.ts',
+      'turned out to be a real race condition against live data, not a pre-existing break.',
+      '',
+      '## ACPT-M03',
+      '',
+      'Went red on a green that PREDATED the diff — checkpoint refused, then fixed.',
+    ].join('\n');
+    fs.writeFileSync(lp, initial + prose, 'utf8');
+
+    // Append a window entry.
+    const res = runGsdTools(
+      ['windows', 'append', '--kind', 'stub', '--phase', '2', '--description', 'test entry'],
+      tmp,
+    );
+    assert.equal(res.success, true, `stderr: ${res.error || ''}`);
+    const obj = JSON.parse(res.output);
+    assert.equal(obj.ok, true);
+
+    // The prose must survive.
+    const after = fs.readFileSync(lp, 'utf8');
+    assert.match(after, /Investigation Notes/, 'prose heading must survive the append');
+    assert.match(after, /thread-status\.test\.ts/, 'prose body must survive the append');
+    assert.match(after, /ACPT-M03/, 'second prose heading must survive');
+    assert.match(after, /PREDATED the diff/, 'second prose body must survive');
+    // The ledger must also be correct.
+    assert.match(after, /open_count: 1/);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #2893

---

## What was broken

`writeLedgerAtomic` in `src/broken-windows.cts` overwrote the entire `WINDOWS.md` with `renderLedger(ledger)`, which only produces frontmatter + header + table + JSON block. Any prose a user wrote below the JSON closing fence was silently destroyed on every `append`/`waive`/`fixed` operation. The command reported `{"ok": true}` next to data loss.

## What this fix does

`writeLedgerAtomic` now reads the existing file before overwriting, extracts any content after the JSON closing fence (correctly skipping past the opening fence — ``````json`` starts with ``````), and appends it to the rendered ledger. First-write (no existing file) proceeds normally with no prose to preserve.

## Root cause

`renderLedger` reconstructs the structured portions only. It has no knowledge of prose. The writer called `renderLedger(ledger)` and wrote that as the entire file content.

## Testing

### How I verified the fix

RED proven at `30e8624eb` (2 failures both lanes — prose was destroyed). The regression test:
- Creates a WINDOWS.md with a **non-empty** ledger + prose below the JSON block
- Appends two entries (idempotency — prose appears exactly once after the second write)
- Asserts: prose headings/bodies survive, exactly one JSON fence open (no duplicated JSON body), `parseLedger` round-trip yields 3 entries

An isolated adversarial review caught a **BLOCKER** in the first iteration: `indexOf(JSON_FENCE_CLOSE)` matched the opening fence (`'````json'` starts with `'````'`), duplicating the entire JSON body on every write. Fixed by searching for the closing fence starting after the opening fence, mirroring `parseJsonBlock`.

### Regression test added?

- [x] Yes — hardened test in `tests/broken-windows.test.cjs`

### Platforms tested

- [x] Linux (gsd-test matrix)
- [ ] macOS / Windows (not platform-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #2893`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — `writeLedgerAtomic` only
- [x] Regression test added
- [x] All existing tests pass (`gsd-test`)
- [x] `.changeset/` fragment added
- [x] No unnecessary dependencies added

## Breaking changes

None. The fix is purely additive — prose that was previously destroyed is now preserved.

GSD_PR_GATES_OK=1

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2975"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788193924&installation_model_id=22188&pr_number=2975&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2975&signature=8ba61da0f12ec814c0e8857887ea9745c73d25d851c2fccf0aeef85c5eed658d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->