### PR TITLE
fix(#2641): treat absent capture_artifacts as enabled (schema default)

### DIFF
--- a/.changeset/tidy-lynx-run.md
+++ b/.changeset/tidy-lynx-run.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 2982
 ---
 **MemPalace capture no longer silently disables itself when `capture_artifacts` is unset** — the skill gate used `!== true` (treating absent as disabled), but the capability schema defaults to enabled. Fixed to `=== false` (disabled only on explicit false). (#2641)

--- a/.changeset/tidy-lynx-run.md
+++ b/.changeset/tidy-lynx-run.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**MemPalace capture no longer silently disables itself when `capture_artifacts` is unset** — the skill gate used `!== true` (treating absent as disabled), but the capability schema defaults to enabled. Fixed to `=== false` (disabled only on explicit false). (#2641)

--- a/commands/gsd/mempalace-capture.md
+++ b/commands/gsd/mempalace-capture.md
@@ -25,7 +25,7 @@ Then proceed to Step 1.
 Check whether the MemPalace capability is enabled by reading `.planning/config.json` directly with the Read tool.
 
 1. Read `.planning/config.json` with the Read tool.
-2. If the file does not exist, or `config.mempalace` is absent, or `config.mempalace.enabled !== true`, or `config.mempalace.capture_artifacts !== true`: display the disabled message and **STOP**.
+2. If the file does not exist, or `config.mempalace` is absent, or `config.mempalace.enabled !== true`, or `config.mempalace.capture_artifacts === false`: display the disabled message and **STOP**.
 3. Otherwise proceed to Step 2.
 
 **Disabled message:**

--- a/skills/gsd-mempalace-capture/SKILL.md
+++ b/skills/gsd-mempalace-capture/SKILL.md
@@ -25,7 +25,7 @@ Then proceed to Step 1.
 Check whether the MemPalace capability is enabled by reading `.planning/config.json` directly with the Read tool.
 
 1. Read `.planning/config.json` with the Read tool.
-2. If the file does not exist, or `config.mempalace` is absent, or `config.mempalace.enabled !== true`, or `config.mempalace.capture_artifacts !== true`: display the disabled message and **STOP**.
+2. If the file does not exist, or `config.mempalace` is absent, or `config.mempalace.enabled !== true`, or `config.mempalace.capture_artifacts === false`: display the disabled message and **STOP**.
 3. Otherwise proceed to Step 2.
 
 **Disabled message:**

--- a/tests/mempalace-capture-gate-default.test.cjs
+++ b/tests/mempalace-capture-gate-default.test.cjs
@@ -1,0 +1,42 @@
+// allow-test-rule: source-text-is-the-product (see #2641)
+// The mempalace-capture skill gates on config.mempalace.capture_artifacts.
+// The capability registry declares this key with default: true, so an absent
+// key must be treated as enabled. The skill previously used `!== true` which
+// treated absent (undefined) as disabled — inverted from the schema default.
+// The fix changes it to `=== false` (disabled only on explicit false).
+
+'use strict';
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const SKILL = path.join(__dirname, '..', 'skills', 'gsd-mempalace-capture', 'SKILL.md');
+const COMMAND = path.join(__dirname, '..', 'commands', 'gsd', 'mempalace-capture.md');
+
+describe('#2641 — mempalace-capture gate treats absent capture_artifacts as enabled', () => {
+  test('SKILL.md uses === false (disabled only on explicit false), not !== true', () => {
+    const text = fs.readFileSync(SKILL, 'utf8');
+    assert.ok(
+      text.includes('capture_artifacts === false'),
+      'SKILL.md must use capture_artifacts === false (defaults to enabled when absent, matching the schema) — not !== true (#2641)',
+    );
+    assert.ok(
+      !text.includes('capture_artifacts !== true'),
+      'SKILL.md must NOT use the inverted capture_artifacts !== true check (#2641)',
+    );
+  });
+
+  test('commands/gsd/mempalace-capture.md uses === false, not !== true', () => {
+    const text = fs.readFileSync(COMMAND, 'utf8');
+    assert.ok(
+      text.includes('capture_artifacts === false'),
+      'commands/gsd/mempalace-capture.md must use capture_artifacts === false (#2641)',
+    );
+    assert.ok(
+      !text.includes('capture_artifacts !== true'),
+      'commands/gsd/mempalace-capture.md must NOT use the inverted check (#2641)',
+    );
+  });
+});


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #2641

---

## What was broken

`gsd-mempalace-capture`'s Step 1 gate checked `config.mempalace.capture_artifacts !== true`. The capability registry declares this key with `"default": true`, so an absent key should be treated as enabled. But `undefined !== true` evaluates to `true`, silently disabling capture for any project that sets `mempalace.enabled: true` without redundantly restating `capture_artifacts: true`.

## What this fix does

Changed the condition from `!== true` to `=== false` — disabled only on an explicit `false`, matching the schema default and the sibling `gsd-mempalace-recall` skill's correct `!== false` pattern.

Fixed in both copies: `skills/gsd-mempalace-capture/SKILL.md` and `commands/gsd/mempalace-capture.md`.

## Root cause

Same bug class as closed #2256 (two independent config-default resolvers disagreeing), but at a structurally distinct site — a hand-rolled `Read` + literal-boolean-check in skill prose that bypasses the registry-aware resolver.

## Testing

### How I verified the fix

Source-text assertion test verifies both files use `=== false` and NOT `!== true`.

### Regression test added?

- [x] Yes — `tests/mempalace-capture-gate-default.test.cjs`

### Platforms tested

- [x] Linux (gsd-test matrix)
- [ ] macOS / Windows (skill prose — not platform-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #2641`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — one condition flip in two files
- [x] Regression test added
- [x] All existing tests pass (`gsd-test`)
- [x] `.changeset/` fragment added
- [x] No unnecessary dependencies added

## Breaking changes

None. Projects that explicitly set `capture_artifacts: false` are still disabled. Projects that omit the key now correctly default to enabled.

GSD_PR_GATES_OK=1

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2982"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788203658&installation_model_id=22188&pr_number=2982&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2982&signature=7cf9f0c499c8132e1d37e2f5d0daeaa694b7ed41fee4abf4df0a8befd9a40673"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->