### PR TITLE
fix(#2840): exclude runtime from defaults.json spread into project config

### DIFF
--- a/.changeset/quick-sloths-tumble.md
+++ b/.changeset/quick-sloths-tumble.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**Project configs no longer inherit `runtime` from the machine-wide `~/.gsd/defaults.json`** — on machines with 2+ runtimes installed (e.g. Codex + Claude Code), the last installer's `runtime` value poisoned every new project, resolving agents to wrong model IDs. The key is now excluded from the defaults spread. (#2840)

--- a/.changeset/quick-sloths-tumble.md
+++ b/.changeset/quick-sloths-tumble.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 2985
 ---
 **Project configs no longer inherit `runtime` from the machine-wide `~/.gsd/defaults.json`** — on machines with 2+ runtimes installed (e.g. Codex + Claude Code), the last installer's `runtime` value poisoned every new project, resolving agents to wrong model IDs. The key is now excluded from the defaults spread. (#2840)

--- a/scripts/lint-test-file-count.allowlist.json
+++ b/scripts/lint-test-file-count.allowlist.json
@@ -3,6 +3,7 @@
   "modules": {
     "config": {
       "files": [
+        "config-defaults-runtime-exclusion.test.cjs",
         "config-field-docs.test.cjs",
         "config-get-default.test.cjs",
         "config-schema.property.test.cjs",

--- a/src/config.cts
+++ b/src/config.cts
@@ -329,10 +329,20 @@ function buildNewProjectConfig(userChoices: Record<string, unknown>): Record<str
   const ch = choices as Record<string, Record<string, unknown>>;
   const hd = hardcoded as Record<string, Record<string, unknown>>;
 
+  // #2840: `runtime` is host-specific (written by the installer for whichever
+  // runtime's install ran last). On a machine with 2+ runtimes, it poisons every
+  // new project config — e.g. a Codex install's `runtime:"codex"` leaks into
+  // Claude Code projects, resolving agents to wrong model IDs. `resolve_model_ids`
+  // already has a per-install guard (#2297); `runtime` gets the same treatment
+  // by excluding it from the defaults spread. Projects detect the runtime from
+  // the install path / .gsd-runtime marker, not from a copied config key.
+  const safeDefaults = { ...userDefaults };
+  delete safeDefaults['runtime'];
+
   // Three-level deep merge: hardcoded <- userDefaults <- choices
   const config: Record<string, unknown> = {
     ...hardcoded,
-    ...userDefaults,
+    ...safeDefaults,
     ...choices,
     git: {
       ...hd['git'],

--- a/tests/config-defaults-runtime-exclusion.test.cjs
+++ b/tests/config-defaults-runtime-exclusion.test.cjs
@@ -1,0 +1,75 @@
+// allow-test-rule: source-text-is-the-product (see #2840)
+// ~/.gsd/defaults.json is machine-wide. The `runtime` key is host-specific
+// (written by whichever installer ran last). It must NOT be copied into project
+// configs — on a machine with 2+ runtimes, it poisons every new project.
+
+'use strict';
+
+const { describe, test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { runGsdTools, createTempDir, cleanup } = require('./helpers.cjs');
+
+describe('#2840 — runtime from defaults.json must not poison project config', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempDir('cfg-runtime-');
+    fs.mkdirSync(path.join(tmpDir, '.planning'), { recursive: true });
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('runtime key in defaults.json is NOT copied into the new project config', () => {
+    // Create ~/.gsd/defaults.json with a runtime key + a legitimate key
+    fs.mkdirSync(path.join(tmpDir, '.gsd'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, '.gsd', 'defaults.json'),
+      JSON.stringify({ runtime: 'codex', model_profile: 'opus' }),
+    );
+
+    const result = runGsdTools('config-ensure-section', tmpDir, {
+      HOME: tmpDir,
+      USERPROFILE: tmpDir,
+    });
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const config = JSON.parse(
+      fs.readFileSync(path.join(tmpDir, '.planning', 'config.json'), 'utf8'),
+    );
+    // runtime must NOT be in the project config — it's host-specific.
+    assert.ok(
+      !('runtime' in config),
+      `runtime must not be copied from defaults.json into the project config; got: ${JSON.stringify({ runtime: config.runtime })}`,
+    );
+    // Other defaults must still be copied.
+    assert.strictEqual(
+      config.model_profile,
+      'opus',
+      'legitimate defaults (model_profile) must still be copied from defaults.json',
+    );
+  });
+
+  test('defaults.json without a runtime key works normally', () => {
+    fs.mkdirSync(path.join(tmpDir, '.gsd'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, '.gsd', 'defaults.json'),
+      JSON.stringify({ model_profile: 'haiku' }),
+    );
+
+    const result = runGsdTools('config-ensure-section', tmpDir, {
+      HOME: tmpDir,
+      USERPROFILE: tmpDir,
+    });
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const config = JSON.parse(
+      fs.readFileSync(path.join(tmpDir, '.planning', 'config.json'), 'utf8'),
+    );
+    assert.strictEqual(config.model_profile, 'haiku');
+    assert.ok(!('runtime' in config), 'runtime should not appear when defaults.json lacks it');
+  });
+});


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #2840

---

## What was broken

`~/.gsd/defaults.json` is machine-wide, but the installer writes the host-specific `runtime` key into it. On a machine with 2+ runtimes (Codex + Claude Code), the Codex install's `runtime: "codex"` was copied into every new `.planning/config.json` — including Claude Code projects, which then resolved agents to `gpt-5.6-*` model IDs that Claude Code can't spawn.

## What this fix does

Excludes `runtime` from the `userDefaults` spread in `buildNewProjectConfig` (`src/config.cts`). The key is host-specific, not project-specific — projects detect the runtime from the install path / `.gsd-runtime` marker, not from a copied config key. This mirrors the existing `resolve_model_ids` guard (#2297).

## Root cause

`buildNewProjectConfig` spread `...userDefaults` unconditionally. The `runtime` key has no business in a project config — it's a per-install identity, not a project preference.

## Testing

### How I verified the fix

Two regression tests:
1. `runtime` in `defaults.json` is NOT copied into the new project config (while `model_profile` IS).
2. `defaults.json` without `runtime` works normally.

### Regression test added?

- [x] Yes — `tests/config-defaults-runtime-exclusion.test.cjs`

### Platforms tested

- [x] Linux (gsd-test matrix)
- [ ] macOS / Windows (not platform-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #2840`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — one key exclusion in buildNewProjectConfig
- [x] Regression test added
- [x] All existing tests pass (`gsd-test`)
- [x] `.changeset/` fragment added
- [x] No unnecessary dependencies added

## Breaking changes

None. Projects that explicitly set `runtime` in their own config (via `config-set`) are unaffected — the exclusion only applies to the `defaults.json` spread.

GSD_PR_GATES_OK=1

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/2985"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788207203&installation_model_id=22188&pr_number=2985&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F2985&signature=c4ff07faec3d6826b4e89bedfc44b0d2a7fea67855df78ce9ddd81585fca8898"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->