### PR TITLE
fix(#2855): scope the phase-locator archived-milestone fallback to the active workstream

### DIFF
--- a/.changeset/merry-geese-fly.md
+++ b/.changeset/merry-geese-fly.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**Phases no longer leak archived data from another workstream** — resolving a phase in one workstream whose own directory doesn't exist yet no longer falls back to an unrelated workstream's (or a flat-mode project's) same-numbered archived phase; it correctly resolves as pending. (#2855)

--- a/.changeset/merry-geese-fly.md
+++ b/.changeset/merry-geese-fly.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 3008
 ---
 **Phases no longer leak archived data from another workstream** — resolving a phase in one workstream whose own directory doesn't exist yet no longer falls back to an unrelated workstream's (or a flat-mode project's) same-numbered archived phase; it correctly resolves as pending. (#2855)

--- a/src/phase-locator.cts
+++ b/src/phase-locator.cts
@@ -136,7 +136,15 @@ function findPhaseInternal(cwd: string, phase: unknown): PhaseSearchResult | nul
   const current = searchPhaseInDir(phasesDir, relPhasesDir, normalized);
   if (current) return current;
 
-  const milestonesDir = path.join(cwd, '.planning', 'milestones');
+  // #2855: scope the archived-milestone fallback to the SAME workstream as the
+  // active-phase search above (planningDir(cwd) resolves GSD_WORKSTREAM/GSD_PROJECT
+  // the identical way both places), not the hardcoded project-root tree. Archived
+  // phases genuinely live under a workstream's own `.planning/workstreams/<ws>/
+  // milestones/` — that is where archivePhaseDirectories (milestone.cts) writes
+  // them via the same planningDir(cwd) resolution. Hardcoding root here let a
+  // pending workstream phase resolve to an unrelated workstream's (or a flat-mode
+  // project's) archived phase that merely shares a phase number.
+  const milestonesDir = path.join(planningDir(cwd), 'milestones');
   if (!fs.existsSync(milestonesDir)) return null;
 
   try {
@@ -151,7 +159,7 @@ function findPhaseInternal(cwd: string, phase: unknown): PhaseSearchResult | nul
       const versionMatch = archiveName.match(/^(v[\d.]+)-phases$/);
       const version = versionMatch![1];
       const archivePath = path.join(milestonesDir, archiveName);
-      const relBase = '.planning/milestones/' + archiveName;
+      const relBase = toPosixPath(path.relative(cwd, archivePath));
       const result = searchPhaseInDir(archivePath, relBase, normalized);
       if (result) {
         result.archived = version;
@@ -164,7 +172,10 @@ function findPhaseInternal(cwd: string, phase: unknown): PhaseSearchResult | nul
 }
 
 function getArchivedPhaseDirs(cwd: string): ArchivedPhaseDir[] {
-  const milestonesDir = path.join(cwd, '.planning', 'milestones');
+  // #2855: same workstream-scoped resolution as findPhaseInternal above — see
+  // that function's comment. `phase.list --include-archived` (the primary
+  // non-init consumer) must not leak a different workstream's archive either.
+  const milestonesDir = path.join(planningDir(cwd), 'milestones');
   const results: ArchivedPhaseDir[] = [];
 
   if (!fs.existsSync(milestonesDir)) return results;
@@ -187,7 +198,7 @@ function getArchivedPhaseDirs(cwd: string): ArchivedPhaseDir[] {
         results.push({
           name: dir,
           milestone: version,
-          basePath: path.join('.planning', 'milestones', archiveName),
+          basePath: path.relative(cwd, archivePath),
           fullPath: path.join(archivePath, dir),
         });
       }

--- a/src/phase-locator.cts
+++ b/src/phase-locator.cts
@@ -54,7 +54,44 @@ interface ArchivedPhaseDir {
   fullPath: string;
 }
 
+interface ArchiveVersionDir {
+  version: string;
+  archivePath: string;
+}
+
 // ─── Phase search helpers ─────────────────────────────────────────────────────
+
+/**
+ * #2855: single source of truth for resolving and enumerating a project's
+ * (or, when a workstream is active, that workstream's OWN) archived-milestone
+ * directories — `<planningDir(cwd)>/milestones/vX.Y-phases/`. Both
+ * `findPhaseInternal`'s archive fallback and `getArchivedPhaseDirs` used to
+ * carry independent copies of this resolve-then-enumerate logic, which is
+ * exactly the shape that let the original #2855 bug (hardcoded root path)
+ * exist in one copy and not the other. Sharing this seam means a future
+ * change to how the archive tree is located only needs to happen once.
+ * Most-recent-milestone-first order (reverse-sorted directory names).
+ * Never throws: an absent/unreadable milestones/ dir yields [].
+ */
+function listArchiveVersionDirs(cwd: string): ArchiveVersionDir[] {
+  const milestonesDir = path.join(planningDir(cwd), 'milestones');
+  if (!fs.existsSync(milestonesDir)) return [];
+
+  try {
+    const milestoneEntries = fs.readdirSync(milestonesDir, { withFileTypes: true });
+    return milestoneEntries
+      .filter(e => e.isDirectory() && /^v[\d.]+-phases$/.test(e.name))
+      .map(e => e.name)
+      .sort()
+      .reverse()
+      .map(archiveName => ({
+        version: archiveName.match(/^(v[\d.]+)-phases$/)![1],
+        archivePath: path.join(milestonesDir, archiveName),
+      }));
+  } catch {
+    return [];
+  }
+}
 
 function searchPhaseInDir(baseDir: string, relBase: string, normalized: string): PhaseSearchResult | null {
   try {
@@ -143,67 +180,39 @@ function findPhaseInternal(cwd: string, phase: unknown): PhaseSearchResult | nul
   // milestones/` — that is where archivePhaseDirectories (milestone.cts) writes
   // them via the same planningDir(cwd) resolution. Hardcoding root here let a
   // pending workstream phase resolve to an unrelated workstream's (or a flat-mode
-  // project's) archived phase that merely shares a phase number.
-  const milestonesDir = path.join(planningDir(cwd), 'milestones');
-  if (!fs.existsSync(milestonesDir)) return null;
-
-  try {
-    const milestoneEntries = fs.readdirSync(milestonesDir, { withFileTypes: true });
-    const archiveDirs = milestoneEntries
-      .filter(e => e.isDirectory() && /^v[\d.]+-phases$/.test(e.name))
-      .map(e => e.name)
-      .sort()
-      .reverse();
-
-    for (const archiveName of archiveDirs) {
-      const versionMatch = archiveName.match(/^(v[\d.]+)-phases$/);
-      const version = versionMatch![1];
-      const archivePath = path.join(milestonesDir, archiveName);
-      const relBase = toPosixPath(path.relative(cwd, archivePath));
-      const result = searchPhaseInDir(archivePath, relBase, normalized);
-      if (result) {
-        result.archived = version;
-        return result;
-      }
+  // project's) archived phase that merely shares a phase number. Shared with
+  // getArchivedPhaseDirs via listArchiveVersionDirs (see its doc comment).
+  for (const { version, archivePath } of listArchiveVersionDirs(cwd)) {
+    const relBase = toPosixPath(path.relative(cwd, archivePath));
+    const result = searchPhaseInDir(archivePath, relBase, normalized);
+    if (result) {
+      result.archived = version;
+      return result;
     }
-  } catch { /* intentionally empty */ }
+  }
 
   return null;
 }
 
 function getArchivedPhaseDirs(cwd: string): ArchivedPhaseDir[] {
-  // #2855: same workstream-scoped resolution as findPhaseInternal above — see
-  // that function's comment. `phase.list --include-archived` (the primary
-  // non-init consumer) must not leak a different workstream's archive either.
-  const milestonesDir = path.join(planningDir(cwd), 'milestones');
+  // #2855: same workstream-scoped resolution as findPhaseInternal above, via
+  // the shared listArchiveVersionDirs helper. `phase.list --include-archived`
+  // (the primary non-init consumer) must not leak a different workstream's
+  // archive either.
   const results: ArchivedPhaseDir[] = [];
 
-  if (!fs.existsSync(milestonesDir)) return results;
+  for (const { version, archivePath } of listArchiveVersionDirs(cwd)) {
+    const dirs = readSubdirectories(archivePath, true);
 
-  try {
-    const milestoneEntries = fs.readdirSync(milestonesDir, { withFileTypes: true });
-    const phaseDirs = milestoneEntries
-      .filter(e => e.isDirectory() && /^v[\d.]+-phases$/.test(e.name))
-      .map(e => e.name)
-      .sort()
-      .reverse();
-
-    for (const archiveName of phaseDirs) {
-      const versionMatch = archiveName.match(/^(v[\d.]+)-phases$/);
-      const version = versionMatch![1];
-      const archivePath = path.join(milestonesDir, archiveName);
-      const dirs = readSubdirectories(archivePath, true);
-
-      for (const dir of dirs) {
-        results.push({
-          name: dir,
-          milestone: version,
-          basePath: toPosixPath(path.relative(cwd, archivePath)),
-          fullPath: path.join(archivePath, dir),
-        });
-      }
+    for (const dir of dirs) {
+      results.push({
+        name: dir,
+        milestone: version,
+        basePath: toPosixPath(path.relative(cwd, archivePath)),
+        fullPath: path.join(archivePath, dir),
+      });
     }
-  } catch { /* intentionally empty */ }
+  }
 
   return results;
 }

--- a/src/phase-locator.cts
+++ b/src/phase-locator.cts
@@ -198,7 +198,7 @@ function getArchivedPhaseDirs(cwd: string): ArchivedPhaseDir[] {
         results.push({
           name: dir,
           milestone: version,
-          basePath: path.relative(cwd, archivePath),
+          basePath: toPosixPath(path.relative(cwd, archivePath)),
           fullPath: path.join(archivePath, dir),
         });
       }

--- a/tests/fix-2855-phase-locator-workstream-archive-scope.test.cjs
+++ b/tests/fix-2855-phase-locator-workstream-archive-scope.test.cjs
@@ -1,0 +1,216 @@
+/**
+ * Regression tests for #2855: the phase-locator's archived-milestone fallback
+ * hardcoded the project-root `.planning/milestones/` tree instead of routing
+ * through the workstream-aware `planningDir(cwd)` helper. A pending phase in
+ * workstream A, whose own `phases/` directory does not exist yet, would
+ * silently resolve to a same-numbered phase archived under the ROOT tree
+ * (an unrelated workstream's history, or a flat-mode project's archive) —
+ * complete with stale plan/summary counts and an "archived" status for a
+ * phase that is actually brand new.
+ *
+ * Root cause: src/phase-locator.cts:139 (`findPhaseInternal`) and
+ * src/phase-locator.cts:167 (`getArchivedPhaseDirs`) both used
+ * `path.join(cwd, '.planning', 'milestones')` instead of
+ * `path.join(planningDir(cwd), 'milestones')` — the same seam the
+ * active-phase search (line 132) and the archive-write path
+ * (`archivePhaseDirectories`, src/milestone.cts) already use.
+ *
+ * Ambient-env hermeticity: GSD_WORKSTREAM/GSD_PROJECT are read directly from
+ * process.env by planningDir() when omitted, so every test here explicitly
+ * saves and restores both (pattern from
+ * tests/fix-2297-resolve-model-ids-runtime-scoping.test.cjs) to avoid leaking
+ * state across tests or picking up a developer's ambient shell env.
+ */
+
+'use strict';
+
+const { test, describe, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const phaseLocator = require('../gsd-core/bin/lib/phase-locator.cjs');
+const { createTempProject, cleanup } = require('./helpers.cjs');
+
+let _origWorkstream;
+let _origProject;
+
+function isolateWorkstreamEnv() {
+  _origWorkstream = process.env.GSD_WORKSTREAM;
+  _origProject = process.env.GSD_PROJECT;
+  delete process.env.GSD_WORKSTREAM;
+  delete process.env.GSD_PROJECT;
+}
+
+function restoreWorkstreamEnv() {
+  if (_origWorkstream === undefined) delete process.env.GSD_WORKSTREAM;
+  else process.env.GSD_WORKSTREAM = _origWorkstream;
+  if (_origProject === undefined) delete process.env.GSD_PROJECT;
+  else process.env.GSD_PROJECT = _origProject;
+}
+
+describe('#2855: findPhaseInternal does not leak cross-workstream archived phases', () => {
+  let tmpDir;
+  beforeEach(() => { isolateWorkstreamEnv(); });
+  afterEach(() => {
+    restoreWorkstreamEnv();
+    if (tmpDir) { cleanup(tmpDir); tmpDir = null; }
+  });
+
+  test('does not leak root-tree archived phase into an unrelated workstream', () => {
+    tmpDir = createTempProject('gsd-2855-');
+    // Root archive holds phase 03 (unrelated workstream's / flat-mode history).
+    const rootArchive = path.join(tmpDir, '.planning', 'milestones', 'v1.0-phases', '03-legacy');
+    fs.mkdirSync(rootArchive, { recursive: true });
+    fs.writeFileSync(path.join(rootArchive, 'SOME-SUMMARY.md'), '# stale');
+
+    // Workstream "beta" exists with an empty phases/ dir — phase 03 is pending.
+    fs.mkdirSync(path.join(tmpDir, '.planning', 'workstreams', 'beta', 'phases'), { recursive: true });
+    process.env.GSD_WORKSTREAM = 'beta';
+
+    const result = phaseLocator.findPhaseInternal(tmpDir, '3');
+    assert.strictEqual(result, null, 'pending workstream phase must not resolve to the root archive');
+  });
+
+  test('does not leak root archive when workstream phases dir is entirely absent', () => {
+    tmpDir = createTempProject('gsd-2855-');
+    const rootArchive = path.join(tmpDir, '.planning', 'milestones', 'v2.0-phases', '01-legacy');
+    fs.mkdirSync(rootArchive, { recursive: true });
+
+    // Brand-new workstream: no .planning/workstreams/gamma/ directory at all yet.
+    process.env.GSD_WORKSTREAM = 'gamma';
+
+    const result = phaseLocator.findPhaseInternal(tmpDir, '1');
+    assert.strictEqual(result, null, 'a workstream with no directory yet must not resolve to the root archive');
+  });
+
+  test('still finds a phase genuinely archived under the active workstream\'s own tree', () => {
+    tmpDir = createTempProject('gsd-2855-');
+    const ownArchive = path.join(tmpDir, '.planning', 'workstreams', 'beta', 'milestones', 'v1.0-phases', '03-real');
+    fs.mkdirSync(ownArchive, { recursive: true });
+    process.env.GSD_WORKSTREAM = 'beta';
+
+    const result = phaseLocator.findPhaseInternal(tmpDir, '3');
+    assert.ok(result !== null, 'workstream\'s own archived phase must still resolve');
+    assert.strictEqual(result.found, true);
+    assert.strictEqual(result.archived, 'v1.0');
+    assert.strictEqual(
+      result.directory,
+      '.planning/workstreams/beta/milestones/v1.0-phases/03-real',
+    );
+  });
+
+  test('flat/non-workstream project archive resolution is unchanged', () => {
+    tmpDir = createTempProject('gsd-2855-');
+    const rootArchive = path.join(tmpDir, '.planning', 'milestones', 'v1.0-phases', '03-flat');
+    fs.mkdirSync(rootArchive, { recursive: true });
+    // No GSD_WORKSTREAM / GSD_PROJECT set — flat mode.
+
+    const result = phaseLocator.findPhaseInternal(tmpDir, '3');
+    assert.ok(result !== null, 'flat-mode archive lookup must be unaffected by the fix');
+    assert.strictEqual(result.found, true);
+    assert.strictEqual(result.archived, 'v1.0');
+    assert.strictEqual(result.directory, '.planning/milestones/v1.0-phases/03-flat');
+  });
+
+  test('two workstreams with same-numbered archived phases never cross-resolve', () => {
+    tmpDir = createTempProject('gsd-2855-');
+    const alphaArchive = path.join(tmpDir, '.planning', 'workstreams', 'alpha', 'milestones', 'v1.0-phases', '03-alpha-work');
+    const betaArchive = path.join(tmpDir, '.planning', 'workstreams', 'beta', 'milestones', 'v1.0-phases', '03-beta-work');
+    fs.mkdirSync(alphaArchive, { recursive: true });
+    fs.mkdirSync(betaArchive, { recursive: true });
+
+    process.env.GSD_WORKSTREAM = 'alpha';
+    const alphaResult = phaseLocator.findPhaseInternal(tmpDir, '3');
+    assert.ok(alphaResult !== null);
+    assert.strictEqual(alphaResult.phase_name, 'alpha-work');
+
+    process.env.GSD_WORKSTREAM = 'beta';
+    const betaResult = phaseLocator.findPhaseInternal(tmpDir, '3');
+    assert.ok(betaResult !== null);
+    assert.strictEqual(betaResult.phase_name, 'beta-work');
+  });
+
+  test('project+workstream combination scopes the archive fallback', () => {
+    tmpDir = createTempProject('gsd-2855-');
+    const rootArchive = path.join(tmpDir, '.planning', 'milestones', 'v1.0-phases', '05-root-legacy');
+    fs.mkdirSync(rootArchive, { recursive: true });
+
+    const scopedArchive = path.join(tmpDir, '.planning', 'proj-x', 'workstreams', 'beta', 'milestones', 'v1.0-phases', '05-scoped');
+    fs.mkdirSync(scopedArchive, { recursive: true });
+
+    process.env.GSD_PROJECT = 'proj-x';
+    process.env.GSD_WORKSTREAM = 'beta';
+
+    const result = phaseLocator.findPhaseInternal(tmpDir, '5');
+    assert.ok(result !== null, 'project+workstream scoped archive must resolve');
+    assert.strictEqual(result.phase_name, 'scoped');
+    assert.strictEqual(
+      result.directory,
+      '.planning/proj-x/workstreams/beta/milestones/v1.0-phases/05-scoped',
+    );
+  });
+
+  test('workstream-scoped archived directory is posix-style', () => {
+    tmpDir = createTempProject('gsd-2855-');
+    const ownArchive = path.join(tmpDir, '.planning', 'workstreams', 'beta', 'milestones', 'v1.0-phases', '07-posix');
+    fs.mkdirSync(ownArchive, { recursive: true });
+    process.env.GSD_WORKSTREAM = 'beta';
+
+    const result = phaseLocator.findPhaseInternal(tmpDir, '7');
+    assert.ok(result !== null);
+    assert.ok(!result.directory.includes('\\'), 'directory must use forward slashes on every platform');
+  });
+});
+
+describe('#2855: getArchivedPhaseDirs does not leak cross-workstream archived phases', () => {
+  let tmpDir;
+  beforeEach(() => { isolateWorkstreamEnv(); });
+  afterEach(() => {
+    restoreWorkstreamEnv();
+    if (tmpDir) { cleanup(tmpDir); tmpDir = null; }
+  });
+
+  test('does not leak root-tree archive entries under an active workstream', () => {
+    tmpDir = createTempProject('gsd-2855-');
+    const rootArchive = path.join(tmpDir, '.planning', 'milestones', 'v1.0-phases', '03-legacy');
+    fs.mkdirSync(rootArchive, { recursive: true });
+
+    fs.mkdirSync(path.join(tmpDir, '.planning', 'workstreams', 'beta', 'phases'), { recursive: true });
+    process.env.GSD_WORKSTREAM = 'beta';
+
+    const result = phaseLocator.getArchivedPhaseDirs(tmpDir);
+    assert.deepEqual(result, [], 'getArchivedPhaseDirs must not surface the root archive for a workstream');
+  });
+
+  test('still finds phases genuinely archived under the active workstream\'s own tree', () => {
+    tmpDir = createTempProject('gsd-2855-');
+    const ownArchive = path.join(tmpDir, '.planning', 'workstreams', 'beta', 'milestones', 'v2.0-phases', '04-own');
+    fs.mkdirSync(ownArchive, { recursive: true });
+    process.env.GSD_WORKSTREAM = 'beta';
+
+    const result = phaseLocator.getArchivedPhaseDirs(tmpDir);
+    assert.strictEqual(result.length, 1);
+    assert.strictEqual(result[0].name, '04-own');
+    assert.strictEqual(result[0].milestone, 'v2.0');
+    assert.strictEqual(
+      result[0].basePath,
+      path.join('.planning', 'workstreams', 'beta', 'milestones', 'v2.0-phases'),
+    );
+  });
+
+  test('flat/non-workstream project resolution is unchanged', () => {
+    tmpDir = createTempProject('gsd-2855-');
+    const archiveDir = path.join(tmpDir, '.planning', 'milestones', 'v2.1.0-phases');
+    fs.mkdirSync(path.join(archiveDir, '03-auth'), { recursive: true });
+    // No GSD_WORKSTREAM / GSD_PROJECT set — flat mode.
+
+    const result = phaseLocator.getArchivedPhaseDirs(tmpDir);
+    assert.strictEqual(result.length, 1);
+    const entry = result[0];
+    assert.strictEqual(entry.name, '03-auth');
+    assert.strictEqual(entry.milestone, 'v2.1.0');
+    assert.strictEqual(entry.basePath, path.join('.planning', 'milestones', 'v2.1.0-phases'));
+    assert.strictEqual(entry.fullPath, path.join(archiveDir, '03-auth'));
+  });
+});

--- a/tests/fix-2855-phase-locator-workstream-archive-scope.test.cjs
+++ b/tests/fix-2855-phase-locator-workstream-archive-scope.test.cjs
@@ -84,6 +84,32 @@ describe('#2855: findPhaseInternal does not leak cross-workstream archived phase
     assert.strictEqual(result, null, 'a workstream with no directory yet must not resolve to the root archive');
   });
 
+  // Issue #2855 AC1: "...regardless of whether workstream A's roadmap already
+  // lists the phase and when it doesn't yet." findPhaseInternal never reads
+  // ROADMAP.md (it is a pure filesystem lookup), so this dimension cannot
+  // change its behavior — demonstrated directly rather than left as an
+  // inference from reading the source.
+  for (const roadmapHasEntry of [true, false]) {
+    test(`does not leak root archive whether or not the workstream's ROADMAP.md already lists the phase (roadmapHasEntry=${roadmapHasEntry})`, () => {
+      tmpDir = createTempProject('gsd-2855-');
+      const rootArchive = path.join(tmpDir, '.planning', 'milestones', 'v1.0-phases', '03-legacy');
+      fs.mkdirSync(rootArchive, { recursive: true });
+
+      const wsDir = path.join(tmpDir, '.planning', 'workstreams', 'beta');
+      fs.mkdirSync(path.join(wsDir, 'phases'), { recursive: true });
+      if (roadmapHasEntry) {
+        fs.writeFileSync(
+          path.join(wsDir, 'ROADMAP.md'),
+          ['# Roadmap', '', '### Phase 03: Pending Work', ''].join('\n'),
+        );
+      }
+      process.env.GSD_WORKSTREAM = 'beta';
+
+      const result = phaseLocator.findPhaseInternal(tmpDir, '3');
+      assert.strictEqual(result, null, 'ROADMAP.md presence/absence must not affect the archive-leak guard');
+    });
+  }
+
   test('still finds a phase genuinely archived under the active workstream\'s own tree', () => {
     tmpDir = createTempProject('gsd-2855-');
     const ownArchive = path.join(tmpDir, '.planning', 'workstreams', 'beta', 'milestones', 'v1.0-phases', '03-real');

--- a/tests/fix-2855-phase-locator-workstream-archive-scope.test.cjs
+++ b/tests/fix-2855-phase-locator-workstream-archive-scope.test.cjs
@@ -193,9 +193,11 @@ describe('#2855: getArchivedPhaseDirs does not leak cross-workstream archived ph
     assert.strictEqual(result.length, 1);
     assert.strictEqual(result[0].name, '04-own');
     assert.strictEqual(result[0].milestone, 'v2.0');
+    // basePath is posix-normalized (toPosixPath) — a forward-slash literal is
+    // the correct cross-platform expectation, not path.join.
     assert.strictEqual(
       result[0].basePath,
-      path.join('.planning', 'workstreams', 'beta', 'milestones', 'v2.0-phases'),
+      '.planning/workstreams/beta/milestones/v2.0-phases',
     );
   });
 
@@ -210,7 +212,9 @@ describe('#2855: getArchivedPhaseDirs does not leak cross-workstream archived ph
     const entry = result[0];
     assert.strictEqual(entry.name, '03-auth');
     assert.strictEqual(entry.milestone, 'v2.1.0');
-    assert.strictEqual(entry.basePath, path.join('.planning', 'milestones', 'v2.1.0-phases'));
+    // basePath is posix-normalized (toPosixPath) — a forward-slash literal is
+    // the correct cross-platform expectation, not path.join.
+    assert.strictEqual(entry.basePath, '.planning/milestones/v2.1.0-phases');
     assert.strictEqual(entry.fullPath, path.join(archiveDir, '03-auth'));
   });
 });

--- a/tests/phase-locator.test.cjs
+++ b/tests/phase-locator.test.cjs
@@ -288,7 +288,11 @@ describe('getArchivedPhaseDirs', () => {
     const entry = result[0];
     assert.strictEqual(entry.name, '03-auth');
     assert.strictEqual(entry.milestone, 'v2.1.0');
-    assert.strictEqual(entry.basePath, path.join('.planning', 'milestones', 'v2.1.0-phases'));
+    // #2855: basePath is posix-normalized (toPosixPath), matching the sibling
+    // `directory` field's contract — a hardcoded forward-slash literal is the
+    // correct expectation on every platform, not path.join (which would emit
+    // backslashes on Windows and break this assertion there).
+    assert.strictEqual(entry.basePath, '.planning/milestones/v2.1.0-phases');
     assert.strictEqual(entry.fullPath, path.join(archiveDir, '03-auth'));
   });
 


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #2855

---

## What was broken

`init.plan-phase` resolved a *pending* workstream phase to the ROOT `.planning/milestones` archive whenever the workstream's own phase directory did not exist yet. A phase belonging to one workstream could therefore be answered with an archived phase from outside it — a silent cross-workstream leak.

## What this fix does

Scopes the archived-milestone lookup to the active workstream, so a workstream-scoped resolution fails closed instead of falling back to the root archive. Non-workstream (flat) mode is unchanged and still resolves to `.planning/milestones` exactly as before.

## Root cause

`findPhaseInternal` and `getArchivedPhaseDirs` each carried an **independent copy** of the resolve-milestones-dir-then-enumerate logic. One copy was workstream-aware and the other was not, which is precisely why the bug existed in one path and not the other. The fix extracts a shared `listArchiveVersionDirs(cwd)` seam so both callers resolve identically and the two cannot drift apart again.

Two further defects surfaced while fixing it, both folded in:

- `getArchivedPhaseDirs` built its `basePath` with bare `path.relative` while the sibling used `toPosixPath` — a Windows backslash leak that Linux CI would never surface.
- Acceptance criterion 1's "regardless of whether the workstream's roadmap already lists the phase" dimension had no direct test; it was only inferable from source.

## Testing

### How I verified the fix

Failing-first was proven on the remote runner, not asserted. The test-only commit `8f3d2e2ba` (a direct child of the base) returns `outcome:"failed"`; the fix tip `d8a1181a0` returns `outcome:"passed"` across linux-node22 and linux-node24.

Coverage spans all four acceptance criteria: the leak blocked both with and without a roadmap entry, the workstream's own archive still resolving, flat mode unchanged, and the non-init consumer `getArchivedPhaseDirs` exercised directly.

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

Verified on linux-node22 and linux-node24. The Windows path fix is covered by posix-literal assertions rather than a Windows run.

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — `roadmap.get-phase`, named out of scope in the issue, is untouched
- [x] Regression test added
- [x] All existing tests pass (verified on the remote runner; `npm test` is not run locally in this repo)
- [x] `.changeset/` fragment added
- [x] No unnecessary dependencies added

## Review

An independent reviewer that did not author the change returned **clean**, having verified the claims against the source rather than reading the diff:

- `planningDir(cwd)` resolves ws/project from env when omitted, so in flat mode the extracted helper computes **byte-identical** paths to the previous hardcode — non-workstream behavior is provably unchanged, not merely asserted.
- The extraction is behavior-preserving for both callers; multi-milestone reverse-sort ordering and active-beats-archived are covered by pre-existing, untouched tests that still pass against the shared helper.
- The `toPosixPath` fix is complete, and `fullPath` correctly remains OS-native, matching the sibling field's existing contract.
- `src/verify.cts` was independently re-confirmed **not** to be a second instance of the bug: `listMilestoneArchiveDirs`/`collectPhaseRoots` take `planBase` as a parameter and both call sites pass it explicitly.
- It additionally checked whether the helper's new dependency on `planningDir(cwd)` (which throws on malformed `GSD_WORKSTREAM`/`GSD_PROJECT`) introduces a new failure path for `cmdPhasesList`, `cmdHistoryDigest`, and `cmdAuditUat`. It does not — all three already call it earlier in the same function.

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/3008"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788303080&installation_model_id=22188&pr_number=3008&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F3008&signature=6837960713cff7f40f3fc3271d289c75cb4e5f05bc1bfe66b5e6a547be5f30e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->