### PR TITLE
fix(#2852): isolate wave-cleanup blocks to their own entry

### DIFF
--- a/.changeset/wise-sloths-frolic.md
+++ b/.changeset/wise-sloths-frolic.md
@@ -2,4 +2,4 @@
 type: Fixed
 pr: 0
 ---
-**`worktree cleanup-wave` no longer treats a safe deletion as an unconditional merge blocker, and no longer aborts the rest of the wave when one entry is blocked** — a deletion is now only blocked when another wave member's branch still depends on the deleted file, and every other independently-clean entry in the wave still merges and is removed even when one entry is blocked. (#2852)
+**`worktree cleanup-wave` no longer aborts the rest of a wave when one entry is blocked** — a blocked entry (mismatched branch/base, a deletion, a dirty worktree, or a failed merge/removal) now stays blocked with its existing reason code, while every other independently-clean entry in the wave still merges and is removed instead of being stranded unattempted. (#2852)

--- a/.changeset/wise-sloths-frolic.md
+++ b/.changeset/wise-sloths-frolic.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 3009
 ---
 **`worktree cleanup-wave` no longer aborts the rest of a wave when one entry is blocked** — a blocked entry (mismatched branch/base, a deletion, a dirty worktree, or a failed merge/removal) now stays blocked with its existing reason code, while every other independently-clean entry in the wave still merges and is removed instead of being stranded unattempted. (#2852)

--- a/.changeset/wise-sloths-frolic.md
+++ b/.changeset/wise-sloths-frolic.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`worktree cleanup-wave` no longer treats a safe deletion as an unconditional merge blocker, and no longer aborts the rest of the wave when one entry is blocked** — a deletion is now only blocked when another wave member's branch still depends on the deleted file, and every other independently-clean entry in the wave still merges and is removed even when one entry is blocked. (#2852)

--- a/src/worktree-safety.cts
+++ b/src/worktree-safety.cts
@@ -679,23 +679,30 @@ function executeWorktreeWaveCleanupPlan(plan: WaveCleanupPlan | null, deps: Work
   const pending: CleanupManifestEntry[] = [];
   let ok = true;
 
-  // #2852: memoized per-entry "what did this branch change overall" set, used only
-  // when ANOTHER entry in the wave has a deletion and we need to know whether this
-  // entry's branch still touches the deleted path. Computed lazily via `HEAD...branch`
-  // (same merge-base-relative form already used for the deletion check below) so a
-  // wave with no deletions never pays for the extra git call, and an already-merged
-  // sibling's diff stays stable even after its own merge has moved `repoRoot` HEAD —
-  // the merge-base between the (now-advanced) HEAD and an independent sibling branch
-  // is unaffected by that sibling's own merge commit.
+  // #2852: memoized per-entry "what did this branch change overall" set, used when
+  // ANOTHER entry in the wave has a deletion and we need to know whether this entry's
+  // branch still touches the deleted path.
+  //
+  // CORRECTNESS NOTE (caught in review): this cache must be populated for entry k
+  // no later than the START of k's own turn in the loop below (see `touchedFilesCache.set(i, …)`
+  // right after the per-entry diff call) — NOT lazily the first time some later entry
+  // asks for it. Once entry k has been merged, branch_k becomes an ancestor of `HEAD`
+  // and `git diff --name-only HEAD...branch_k` silently collapses to empty, which
+  // would make a genuinely-depended-on deletion look safe. Populating the cache
+  // during k's own turn captures its diff BEFORE k's own merge can move HEAD, so the
+  // cached value stays correct for every later entry's overlap check regardless of
+  // manifest order. An entry with a LARGER index than the current one has not had
+  // its turn yet (and therefore cannot have been merged), so computing its diff
+  // on-demand against the live `HEAD` at that point is still safe.
   const repoRoot = plan.repoRoot;
-  const changedFilesCache = new Map<number, Set<string> | null>();
+  const touchedFilesCache = new Map<number, Set<string> | null>();
   function getEntryChangedFiles(k: number): Set<string> | null {
-    if (changedFilesCache.has(k)) return changedFilesCache.get(k) as Set<string> | null;
+    if (touchedFilesCache.has(k)) return touchedFilesCache.get(k) as Set<string> | null;
     const diffResult = execGit(['diff', '--name-only', `HEAD...${entries[k].branch}`], { cwd: repoRoot });
     const value = gitResultOk(diffResult)
       ? new Set(diffResult.stdout.split('\n').map((l) => l.trim()).filter(Boolean))
       : null; // unknown — treated conservatively (fail-closed) by the caller
-    changedFilesCache.set(k, value);
+    touchedFilesCache.set(k, value);
     return value;
   }
 
@@ -815,6 +822,14 @@ function executeWorktreeWaveCleanupPlan(plan: WaveCleanupPlan | null, deps: Work
       ok = false;
       continue; // #2852: isolate
     }
+
+    // #2852: force-populate THIS entry's own touched-files cache now, immediately
+    // before the only step that can move `HEAD` (the merge below). Every entry that
+    // reaches this line is about to attempt a merge; capturing its diff here — not
+    // lazily, later, when some other entry's overlap check happens to ask for it —
+    // is what keeps that later lookup correct even after this entry has landed on
+    // `HEAD` (see the correctness note on `touchedFilesCache` above).
+    getEntryChangedFiles(i);
 
     const merge = execGit(['merge', entry.branch, '--no-ff', '--no-edit', '-m', `chore: merge executor worktree (${entry.branch})`], { cwd: plan.repoRoot });
     if (!gitResultOk(merge)) {

--- a/src/worktree-safety.cts
+++ b/src/worktree-safety.cts
@@ -679,6 +679,19 @@ function executeWorktreeWaveCleanupPlan(plan: WaveCleanupPlan | null, deps: Work
   const pending: CleanupManifestEntry[] = [];
   let ok = true;
 
+  // #2852: every per-entry failure site marks the SAME shape — status='blocked',
+  // a reason code, the captured stderr, push to results, flip the overall `ok`
+  // flag — and then either `continue` (isolate, the default) or, for the one
+  // repo-level-failure carve-out, `break`. Factored out so the 8 call sites below
+  // don't repeat the assembly; each site still owns its own control-flow decision.
+  function blockEntry(result: WaveCleanupEntryResult, reason: string, stderr: string): void {
+    result.status = 'blocked';
+    result.reason = reason;
+    result.stderr = stderr;
+    results.push(result);
+    ok = false;
+  }
+
   for (let i = 0; i < entries.length; i += 1) {
     const entry = entries[i];
     const result: WaveCleanupEntryResult = {
@@ -690,11 +703,7 @@ function executeWorktreeWaveCleanupPlan(plan: WaveCleanupPlan | null, deps: Work
 
     const branchCheck = execGit(['-C', entry.worktree_path, 'rev-parse', '--abbrev-ref', 'HEAD'], { cwd: plan.repoRoot });
     if (!gitResultOk(branchCheck) || branchCheck.stdout.trim() !== entry.branch) {
-      result.status = 'blocked';
-      result.reason = 'branch_mismatch';
-      result.stderr = branchCheck?.stderr || '';
-      results.push(result);
-      ok = false;
+      blockEntry(result, 'branch_mismatch', branchCheck?.stderr || '');
       // #2852: isolate — this entry's problem does not touch repoRoot's git state,
       // so every remaining entry is still independently evaluated.
       continue;
@@ -705,21 +714,13 @@ function executeWorktreeWaveCleanupPlan(plan: WaveCleanupPlan | null, deps: Work
       ? entry.allowed_bases
       : [entry.expected_base];
     if (!gitResultOk(mergeBase) || !allowedBases.includes(mergeBase.stdout.trim())) {
-      result.status = 'blocked';
-      result.reason = 'base_mismatch';
-      result.stderr = mergeBase?.stderr || '';
-      results.push(result);
-      ok = false;
+      blockEntry(result, 'base_mismatch', mergeBase?.stderr || '');
       continue; // #2852: isolate
     }
 
     const deletions = execGit(['diff', '--diff-filter=D', '--name-only', `HEAD...${entry.branch}`], { cwd: plan.repoRoot });
     if (!gitResultOk(deletions)) {
-      result.status = 'blocked';
-      result.reason = 'deletion_check_failed';
-      result.stderr = deletions?.stderr || '';
-      results.push(result);
-      ok = false;
+      blockEntry(result, 'deletion_check_failed', deletions?.stderr || '');
       continue; // #2852: isolate
     }
     if (deletions.stdout) {
@@ -728,11 +729,7 @@ function executeWorktreeWaveCleanupPlan(plan: WaveCleanupPlan | null, deps: Work
       // product decision (issue #2852's own triage scoped it out — tracked in #3003);
       // this fix only isolates the block to this one entry (#2852) instead of aborting
       // the rest of the wave, same as every other block reason below.
-      result.status = 'blocked';
-      result.reason = 'branch_contains_deletions';
-      result.stderr = deletions.stdout;
-      results.push(result);
-      ok = false;
+      blockEntry(result, 'branch_contains_deletions', deletions.stdout);
       continue; // #2852: isolate
     }
 
@@ -741,21 +738,13 @@ function executeWorktreeWaveCleanupPlan(plan: WaveCleanupPlan | null, deps: Work
     // orchestrator commits it.  Mirrors quick.md shell fallback (#2296, #2070, #2838, #3804).
     const { rescuedRelPaths, failures: rescueFailures } = rescueSummaryArtifacts(entry.worktree_path, plan.repoRoot, deps);
     if (rescueFailures.length > 0) {
-      result.status = 'blocked';
-      result.reason = 'summary_rescue_failed';
-      result.stderr = rescueFailures.map((f) => `${f.relPath}: ${f.error}`).join('; ');
-      results.push(result);
-      ok = false;
+      blockEntry(result, 'summary_rescue_failed', rescueFailures.map((f) => `${f.relPath}: ${f.error}`).join('; '));
       continue; // #2852: isolate
     }
 
     const worktreeStatus = execGit(['-C', entry.worktree_path, 'status', '--porcelain', '--untracked-files=all'], { cwd: plan.repoRoot });
     if (!gitResultOk(worktreeStatus)) {
-      result.status = 'blocked';
-      result.reason = 'worktree_dirty';
-      result.stderr = worktreeStatus?.stderr || '';
-      results.push(result);
-      ok = false;
+      blockEntry(result, 'worktree_dirty', worktreeStatus?.stderr || '');
       continue; // #2852: isolate
     }
     // Filter rescued SUMMARY paths out of the porcelain output before deciding dirty.
@@ -770,21 +759,13 @@ function executeWorktreeWaveCleanupPlan(plan: WaveCleanupPlan | null, deps: Work
         return !rescuedRelPaths.has(filePath);
       });
     if (dirtyLines.length > 0) {
-      result.status = 'blocked';
-      result.reason = 'worktree_dirty';
-      result.stderr = dirtyLines.join('\n');
-      results.push(result);
-      ok = false;
+      blockEntry(result, 'worktree_dirty', dirtyLines.join('\n'));
       continue; // #2852: isolate
     }
 
     const merge = execGit(['merge', entry.branch, '--no-ff', '--no-edit', '-m', `chore: merge executor worktree (${entry.branch})`], { cwd: plan.repoRoot });
     if (!gitResultOk(merge)) {
-      result.status = 'blocked';
-      result.reason = 'merge_failed';
-      result.stderr = merge?.stderr || merge?.stdout || '';
-      results.push(result);
-      ok = false;
+      blockEntry(result, 'merge_failed', merge?.stderr || merge?.stdout || '');
       // #2852: a failed --no-ff merge can leave repoRoot itself mid-merge (MERGE_HEAD
       // set, conflict markers in the tree) — unlike every other block reason above,
       // that state is NOT scoped to this one entry: a second `git merge` cannot even
@@ -809,11 +790,7 @@ function executeWorktreeWaveCleanupPlan(plan: WaveCleanupPlan | null, deps: Work
       remove = execGit(['worktree', 'remove', entry.worktree_path, '--force'], { cwd: plan.repoRoot });
     }
     if (!gitResultOk(remove)) {
-      result.status = 'blocked';
-      result.reason = 'worktree_remove_failed';
-      result.stderr = remove?.stderr || '';
-      results.push(result);
-      ok = false;
+      blockEntry(result, 'worktree_remove_failed', remove?.stderr || '');
       // #2852: isolate — the merge already landed on repoRoot; only this entry's
       // worktree/branch teardown is affected.
       continue;

--- a/src/worktree-safety.cts
+++ b/src/worktree-safety.cts
@@ -520,6 +520,17 @@ function gitResultOk(result: GitResult | null | undefined): boolean {
 }
 
 /**
+ * Parse `git diff --name-only` (or `--diff-filter=D --name-only`) stdout into a
+ * clean list of file paths: split on `\n`, trim each line (also strips a
+ * trailing `\r` from CRLF output on Windows git), drop blanks. Shared by both
+ * the per-entry deletion list and the cross-entry touched-files cache in
+ * `executeWorktreeWaveCleanupPlan` (#2852) so the two call sites can't drift.
+ */
+function parseGitNameOnlyLines(stdout: string): string[] {
+  return stdout.split('\n').map((l) => l.trim()).filter(Boolean);
+}
+
+/**
  * Walk <worktreePath>/.planning/ recursively and collect absolute paths of
  * all files whose names match *SUMMARY.md.  Returns [] when the directory
  * does not exist or cannot be read.
@@ -700,7 +711,7 @@ function executeWorktreeWaveCleanupPlan(plan: WaveCleanupPlan | null, deps: Work
     if (touchedFilesCache.has(k)) return touchedFilesCache.get(k) as Set<string> | null;
     const diffResult = execGit(['diff', '--name-only', `HEAD...${entries[k].branch}`], { cwd: repoRoot });
     const value = gitResultOk(diffResult)
-      ? new Set(diffResult.stdout.split('\n').map((l) => l.trim()).filter(Boolean))
+      ? new Set(parseGitNameOnlyLines(diffResult.stdout))
       : null; // unknown — treated conservatively (fail-closed) by the caller
     touchedFilesCache.set(k, value);
     return value;
@@ -756,7 +767,7 @@ function executeWorktreeWaveCleanupPlan(plan: WaveCleanupPlan | null, deps: Work
       // else in the wave depends on (the reported repro: folding a test file into a
       // sibling) is safe to let through. Unknown overlap (a sibling's diff could not
       // be determined) fails closed — block, matching the pre-fix conservative default.
-      const deletedFiles = deletions.stdout.split('\n').map((l) => l.trim()).filter(Boolean);
+      const deletedFiles = parseGitNameOnlyLines(deletions.stdout);
       let stillDependedOn = false;
       let overlapUnknown = false;
       for (let k = 0; k < entries.length; k += 1) {

--- a/src/worktree-safety.cts
+++ b/src/worktree-safety.cts
@@ -520,6 +520,36 @@ function gitResultOk(result: GitResult | null | undefined): boolean {
 }
 
 /**
+ * #2852: after a failed `git merge` + a `git merge --abort` attempt, determine
+ * whether `repoRoot` is STILL mid-merge — the only condition that genuinely
+ * invalidates the rest of a cleanup wave.
+ *
+ * `git merge --abort`'s own exit code is NOT a reliable signal here: git refuses
+ * many merges (e.g. "your local changes to the following files would be
+ * overwritten by merge") WITHOUT ever creating a `MERGE_HEAD`, in which case
+ * `repoRoot`'s tree was never touched and `git merge --abort` correctly fails
+ * with "fatal: There is no merge to abort (MERGE_HEAD missing)?" — a SAFE
+ * outcome, not a broken one. Trusting that exit code alone would misclassify an
+ * ordinary per-entry merge failure as a repo-level one and strand the rest of
+ * the wave (caught in review).
+ *
+ * Checked directly via `git rev-parse --verify -q MERGE_HEAD` against the git
+ * ref itself rather than the filesystem: exit 0 means a merge is genuinely still
+ * in progress (unrecoverable — halt); exit 1 (the ref simply doesn't exist) means
+ * repoRoot is clean, whether because no merge state was ever entered or because
+ * abort successfully cleared it (safe — isolate and continue). Anything else
+ * (a timeout, or an unexpected git error) is treated conservatively as "still
+ * mid-merge" — degrade to the safe/halting answer rather than throw or guess.
+ */
+function repoRootStillMidMerge(execGit: ExecGitFn, repoRoot: string): boolean {
+  const check = execGit(['rev-parse', '--verify', '-q', 'MERGE_HEAD'], { cwd: repoRoot });
+  if (check.timedOut) return true; // fail closed — cannot confirm safety
+  if (check.exitCode === 0) return true; // MERGE_HEAD exists — genuinely still mid-merge
+  if (check.exitCode === 1) return false; // ref not found — repoRoot is not mid-merge
+  return true; // any other exit code (e.g. a fatal git error) — fail closed
+}
+
+/**
  * Walk <worktreePath>/.planning/ recursively and collect absolute paths of
  * all files whose names match *SUMMARY.md.  Returns [] when the directory
  * does not exist or cannot be read.
@@ -766,19 +796,25 @@ function executeWorktreeWaveCleanupPlan(plan: WaveCleanupPlan | null, deps: Work
     const merge = execGit(['merge', entry.branch, '--no-ff', '--no-edit', '-m', `chore: merge executor worktree (${entry.branch})`], { cwd: plan.repoRoot });
     if (!gitResultOk(merge)) {
       blockEntry(result, 'merge_failed', merge?.stderr || merge?.stdout || '');
-      // #2852: a failed --no-ff merge can leave repoRoot itself mid-merge (MERGE_HEAD
-      // set, conflict markers in the tree) — unlike every other block reason above,
-      // that state is NOT scoped to this one entry: a second `git merge` cannot even
-      // start while one is in progress, so every remaining entry would be corrupted by
-      // it. Recover by aborting; only genuine recovery failure — repoRoot left in an
-      // unrecoverable state — legitimately halts the rest of the wave (the brief's
-      // "infrastructure-level failure affecting the repo itself" carve-out).
-      const abort = execGit(['merge', '--abort'], { cwd: plan.repoRoot });
-      if (!gitResultOk(abort)) {
+      // #2852: a failed --no-ff merge MIGHT leave repoRoot itself mid-merge
+      // (MERGE_HEAD set, conflict markers in the tree) — unlike every other block
+      // reason above, that specific state is NOT scoped to this one entry: a second
+      // `git merge` cannot even start while one is in progress, so every remaining
+      // entry would be corrupted by it. But git also refuses many merges WITHOUT ever
+      // entering a merge state (e.g. "your local changes would be overwritten by
+      // merge") — in that case repoRoot's tree was never touched and this failure is
+      // scoped to this entry, same as everything else. Attempt the abort as a
+      // best-effort cleanup, then check repoRoot's ACTUAL state directly — not
+      // `git merge --abort`'s own exit code, which fails "There is no merge to abort"
+      // in the safe case too and would misclassify it as unrecoverable (caught in
+      // review). Only a repo genuinely still mid-merge afterward legitimately halts
+      // the rest of the wave (the brief's "infrastructure-level failure" carve-out).
+      execGit(['merge', '--abort'], { cwd: plan.repoRoot });
+      if (repoRootStillMidMerge(execGit, plan.repoRoot)) {
         pending.push(...entries.slice(i + 1));
         break;
       }
-      continue; // #2852: isolate — repoRoot recovered, remaining entries unaffected
+      continue; // #2852: isolate — repoRoot is not (or no longer) mid-merge
     }
 
     let remove = execGit(['worktree', 'remove', entry.worktree_path, '--force'], { cwd: plan.repoRoot });

--- a/src/worktree-safety.cts
+++ b/src/worktree-safety.cts
@@ -520,17 +520,6 @@ function gitResultOk(result: GitResult | null | undefined): boolean {
 }
 
 /**
- * Parse `git diff --name-only` (or `--diff-filter=D --name-only`) stdout into a
- * clean list of file paths: split on `\n`, trim each line (also strips a
- * trailing `\r` from CRLF output on Windows git), drop blanks. Shared by both
- * the per-entry deletion list and the cross-entry touched-files cache in
- * `executeWorktreeWaveCleanupPlan` (#2852) so the two call sites can't drift.
- */
-function parseGitNameOnlyLines(stdout: string): string[] {
-  return stdout.split('\n').map((l) => l.trim()).filter(Boolean);
-}
-
-/**
  * Walk <worktreePath>/.planning/ recursively and collect absolute paths of
  * all files whose names match *SUMMARY.md.  Returns [] when the directory
  * does not exist or cannot be read.
@@ -690,33 +679,6 @@ function executeWorktreeWaveCleanupPlan(plan: WaveCleanupPlan | null, deps: Work
   const pending: CleanupManifestEntry[] = [];
   let ok = true;
 
-  // #2852: memoized per-entry "what did this branch change overall" set, used when
-  // ANOTHER entry in the wave has a deletion and we need to know whether this entry's
-  // branch still touches the deleted path.
-  //
-  // CORRECTNESS NOTE (caught in review): this cache must be populated for entry k
-  // no later than the START of k's own turn in the loop below (see `touchedFilesCache.set(i, …)`
-  // right after the per-entry diff call) — NOT lazily the first time some later entry
-  // asks for it. Once entry k has been merged, branch_k becomes an ancestor of `HEAD`
-  // and `git diff --name-only HEAD...branch_k` silently collapses to empty, which
-  // would make a genuinely-depended-on deletion look safe. Populating the cache
-  // during k's own turn captures its diff BEFORE k's own merge can move HEAD, so the
-  // cached value stays correct for every later entry's overlap check regardless of
-  // manifest order. An entry with a LARGER index than the current one has not had
-  // its turn yet (and therefore cannot have been merged), so computing its diff
-  // on-demand against the live `HEAD` at that point is still safe.
-  const repoRoot = plan.repoRoot;
-  const touchedFilesCache = new Map<number, Set<string> | null>();
-  function getEntryChangedFiles(k: number): Set<string> | null {
-    if (touchedFilesCache.has(k)) return touchedFilesCache.get(k) as Set<string> | null;
-    const diffResult = execGit(['diff', '--name-only', `HEAD...${entries[k].branch}`], { cwd: repoRoot });
-    const value = gitResultOk(diffResult)
-      ? new Set(parseGitNameOnlyLines(diffResult.stdout))
-      : null; // unknown — treated conservatively (fail-closed) by the caller
-    touchedFilesCache.set(k, value);
-    return value;
-  }
-
   for (let i = 0; i < entries.length; i += 1) {
     const entry = entries[i];
     const result: WaveCleanupEntryResult = {
@@ -761,35 +723,17 @@ function executeWorktreeWaveCleanupPlan(plan: WaveCleanupPlan | null, deps: Work
       continue; // #2852: isolate
     }
     if (deletions.stdout) {
-      // #2852: a deletion is only a genuine risk when ANOTHER entry in this same wave
-      // still touches the deleted path — merging it first could silently drop or
-      // conflict with that entry's changes once it is processed. A deletion nothing
-      // else in the wave depends on (the reported repro: folding a test file into a
-      // sibling) is safe to let through. Unknown overlap (a sibling's diff could not
-      // be determined) fails closed — block, matching the pre-fix conservative default.
-      const deletedFiles = parseGitNameOnlyLines(deletions.stdout);
-      let stillDependedOn = false;
-      let overlapUnknown = false;
-      for (let k = 0; k < entries.length; k += 1) {
-        if (k === i) continue;
-        const otherFiles = getEntryChangedFiles(k);
-        if (otherFiles === null) {
-          overlapUnknown = true;
-          continue;
-        }
-        if (deletedFiles.some((f) => otherFiles.has(f))) {
-          stillDependedOn = true;
-        }
-      }
-      if (stillDependedOn || overlapUnknown) {
-        result.status = 'blocked';
-        result.reason = 'branch_contains_deletions';
-        result.stderr = deletions.stdout;
-        results.push(result);
-        ok = false;
-        continue; // #2852: isolate
-      }
-      // else: no other wave member depends on the deleted path(s) — safe, fall through.
+      // Unconditional: any deletion in this entry's branch blocks THIS entry. Whether
+      // that guard should have an opt-in for intentional deletions is a deferred
+      // product decision (issue #2852's own triage scoped it out — tracked in #3003);
+      // this fix only isolates the block to this one entry (#2852) instead of aborting
+      // the rest of the wave, same as every other block reason below.
+      result.status = 'blocked';
+      result.reason = 'branch_contains_deletions';
+      result.stderr = deletions.stdout;
+      results.push(result);
+      ok = false;
+      continue; // #2852: isolate
     }
 
     // Safety net: rescue uncommitted SUMMARY.md artifacts before the dirty check.
@@ -833,14 +777,6 @@ function executeWorktreeWaveCleanupPlan(plan: WaveCleanupPlan | null, deps: Work
       ok = false;
       continue; // #2852: isolate
     }
-
-    // #2852: force-populate THIS entry's own touched-files cache now, immediately
-    // before the only step that can move `HEAD` (the merge below). Every entry that
-    // reaches this line is about to attempt a merge; capturing its diff here — not
-    // lazily, later, when some other entry's overlap check happens to ask for it —
-    // is what keeps that later lookup correct even after this entry has landed on
-    // `HEAD` (see the correctness note on `touchedFilesCache` above).
-    getEntryChangedFiles(i);
 
     const merge = execGit(['merge', entry.branch, '--no-ff', '--no-edit', '-m', `chore: merge executor worktree (${entry.branch})`], { cwd: plan.repoRoot });
     if (!gitResultOk(merge)) {

--- a/src/worktree-safety.cts
+++ b/src/worktree-safety.cts
@@ -679,6 +679,26 @@ function executeWorktreeWaveCleanupPlan(plan: WaveCleanupPlan | null, deps: Work
   const pending: CleanupManifestEntry[] = [];
   let ok = true;
 
+  // #2852: memoized per-entry "what did this branch change overall" set, used only
+  // when ANOTHER entry in the wave has a deletion and we need to know whether this
+  // entry's branch still touches the deleted path. Computed lazily via `HEAD...branch`
+  // (same merge-base-relative form already used for the deletion check below) so a
+  // wave with no deletions never pays for the extra git call, and an already-merged
+  // sibling's diff stays stable even after its own merge has moved `repoRoot` HEAD —
+  // the merge-base between the (now-advanced) HEAD and an independent sibling branch
+  // is unaffected by that sibling's own merge commit.
+  const repoRoot = plan.repoRoot;
+  const changedFilesCache = new Map<number, Set<string> | null>();
+  function getEntryChangedFiles(k: number): Set<string> | null {
+    if (changedFilesCache.has(k)) return changedFilesCache.get(k) as Set<string> | null;
+    const diffResult = execGit(['diff', '--name-only', `HEAD...${entries[k].branch}`], { cwd: repoRoot });
+    const value = gitResultOk(diffResult)
+      ? new Set(diffResult.stdout.split('\n').map((l) => l.trim()).filter(Boolean))
+      : null; // unknown — treated conservatively (fail-closed) by the caller
+    changedFilesCache.set(k, value);
+    return value;
+  }
+
   for (let i = 0; i < entries.length; i += 1) {
     const entry = entries[i];
     const result: WaveCleanupEntryResult = {
@@ -694,9 +714,10 @@ function executeWorktreeWaveCleanupPlan(plan: WaveCleanupPlan | null, deps: Work
       result.reason = 'branch_mismatch';
       result.stderr = branchCheck?.stderr || '';
       results.push(result);
-      pending.push(...entries.slice(i + 1));
       ok = false;
-      break;
+      // #2852: isolate — this entry's problem does not touch repoRoot's git state,
+      // so every remaining entry is still independently evaluated.
+      continue;
     }
 
     const mergeBase = execGit(['merge-base', 'HEAD', entry.branch], { cwd: plan.repoRoot });
@@ -708,9 +729,8 @@ function executeWorktreeWaveCleanupPlan(plan: WaveCleanupPlan | null, deps: Work
       result.reason = 'base_mismatch';
       result.stderr = mergeBase?.stderr || '';
       results.push(result);
-      pending.push(...entries.slice(i + 1));
       ok = false;
-      break;
+      continue; // #2852: isolate
     }
 
     const deletions = execGit(['diff', '--diff-filter=D', '--name-only', `HEAD...${entry.branch}`], { cwd: plan.repoRoot });
@@ -719,18 +739,39 @@ function executeWorktreeWaveCleanupPlan(plan: WaveCleanupPlan | null, deps: Work
       result.reason = 'deletion_check_failed';
       result.stderr = deletions?.stderr || '';
       results.push(result);
-      pending.push(...entries.slice(i + 1));
       ok = false;
-      break;
+      continue; // #2852: isolate
     }
     if (deletions.stdout) {
-      result.status = 'blocked';
-      result.reason = 'branch_contains_deletions';
-      result.stderr = deletions.stdout;
-      results.push(result);
-      pending.push(...entries.slice(i + 1));
-      ok = false;
-      break;
+      // #2852: a deletion is only a genuine risk when ANOTHER entry in this same wave
+      // still touches the deleted path — merging it first could silently drop or
+      // conflict with that entry's changes once it is processed. A deletion nothing
+      // else in the wave depends on (the reported repro: folding a test file into a
+      // sibling) is safe to let through. Unknown overlap (a sibling's diff could not
+      // be determined) fails closed — block, matching the pre-fix conservative default.
+      const deletedFiles = deletions.stdout.split('\n').map((l) => l.trim()).filter(Boolean);
+      let stillDependedOn = false;
+      let overlapUnknown = false;
+      for (let k = 0; k < entries.length; k += 1) {
+        if (k === i) continue;
+        const otherFiles = getEntryChangedFiles(k);
+        if (otherFiles === null) {
+          overlapUnknown = true;
+          continue;
+        }
+        if (deletedFiles.some((f) => otherFiles.has(f))) {
+          stillDependedOn = true;
+        }
+      }
+      if (stillDependedOn || overlapUnknown) {
+        result.status = 'blocked';
+        result.reason = 'branch_contains_deletions';
+        result.stderr = deletions.stdout;
+        results.push(result);
+        ok = false;
+        continue; // #2852: isolate
+      }
+      // else: no other wave member depends on the deleted path(s) — safe, fall through.
     }
 
     // Safety net: rescue uncommitted SUMMARY.md artifacts before the dirty check.
@@ -742,9 +783,8 @@ function executeWorktreeWaveCleanupPlan(plan: WaveCleanupPlan | null, deps: Work
       result.reason = 'summary_rescue_failed';
       result.stderr = rescueFailures.map((f) => `${f.relPath}: ${f.error}`).join('; ');
       results.push(result);
-      pending.push(...entries.slice(i + 1));
       ok = false;
-      break;
+      continue; // #2852: isolate
     }
 
     const worktreeStatus = execGit(['-C', entry.worktree_path, 'status', '--porcelain', '--untracked-files=all'], { cwd: plan.repoRoot });
@@ -753,9 +793,8 @@ function executeWorktreeWaveCleanupPlan(plan: WaveCleanupPlan | null, deps: Work
       result.reason = 'worktree_dirty';
       result.stderr = worktreeStatus?.stderr || '';
       results.push(result);
-      pending.push(...entries.slice(i + 1));
       ok = false;
-      break;
+      continue; // #2852: isolate
     }
     // Filter rescued SUMMARY paths out of the porcelain output before deciding dirty.
     // A line like "?? .planning/q1-SUMMARY.md" should not block when the SUMMARY
@@ -773,9 +812,8 @@ function executeWorktreeWaveCleanupPlan(plan: WaveCleanupPlan | null, deps: Work
       result.reason = 'worktree_dirty';
       result.stderr = dirtyLines.join('\n');
       results.push(result);
-      pending.push(...entries.slice(i + 1));
       ok = false;
-      break;
+      continue; // #2852: isolate
     }
 
     const merge = execGit(['merge', entry.branch, '--no-ff', '--no-edit', '-m', `chore: merge executor worktree (${entry.branch})`], { cwd: plan.repoRoot });
@@ -784,9 +822,20 @@ function executeWorktreeWaveCleanupPlan(plan: WaveCleanupPlan | null, deps: Work
       result.reason = 'merge_failed';
       result.stderr = merge?.stderr || merge?.stdout || '';
       results.push(result);
-      pending.push(...entries.slice(i + 1));
       ok = false;
-      break;
+      // #2852: a failed --no-ff merge can leave repoRoot itself mid-merge (MERGE_HEAD
+      // set, conflict markers in the tree) — unlike every other block reason above,
+      // that state is NOT scoped to this one entry: a second `git merge` cannot even
+      // start while one is in progress, so every remaining entry would be corrupted by
+      // it. Recover by aborting; only genuine recovery failure — repoRoot left in an
+      // unrecoverable state — legitimately halts the rest of the wave (the brief's
+      // "infrastructure-level failure affecting the repo itself" carve-out).
+      const abort = execGit(['merge', '--abort'], { cwd: plan.repoRoot });
+      if (!gitResultOk(abort)) {
+        pending.push(...entries.slice(i + 1));
+        break;
+      }
+      continue; // #2852: isolate — repoRoot recovered, remaining entries unaffected
     }
 
     let remove = execGit(['worktree', 'remove', entry.worktree_path, '--force'], { cwd: plan.repoRoot });
@@ -802,9 +851,10 @@ function executeWorktreeWaveCleanupPlan(plan: WaveCleanupPlan | null, deps: Work
       result.reason = 'worktree_remove_failed';
       result.stderr = remove?.stderr || '';
       results.push(result);
-      pending.push(...entries.slice(i + 1));
       ok = false;
-      break;
+      // #2852: isolate — the merge already landed on repoRoot; only this entry's
+      // worktree/branch teardown is affected.
+      continue;
     }
 
     const branchDelete = execGit(['branch', '-D', entry.branch], { cwd: plan.repoRoot });

--- a/tests/worktree-safety.test.cjs
+++ b/tests/worktree-safety.test.cjs
@@ -2023,6 +2023,135 @@ describe('executeWorktreeWaveCleanupPlan', () => {
     assert.deepEqual(result.pending.map((entry) => entry.branch), ['worktree-agent-a2']);
   });
 
+  test('#2852: an unverifiable repo state after merge_failed (rev-parse times out) fails closed and halts the wave', () => {
+    // Boundary coverage for repoRootStillMidMerge's fail-closed branches (caught in
+    // review as an untested mutation-survivor risk): when the post-abort
+    // `git rev-parse --verify -q MERGE_HEAD` check itself cannot be trusted — here, it
+    // times out — the module's existing degrade-not-throw contract applies: treat the
+    // repo state as unknown-therefore-unsafe (still mid-merge) rather than guessing
+    // it's clean. Entry 2 must NOT be evaluated.
+    const plan = {
+      ok: true,
+      repoRoot: '/repo/main',
+      action: 'cleanup_wave',
+      discovery: 'manifest',
+      entries: [
+        {
+          agent_id: 'a1',
+          worktree_path: '/repo/.claude/worktrees/agent-a1',
+          branch: 'worktree-agent-a1',
+          expected_base: 'abc123',
+        },
+        {
+          agent_id: 'a2',
+          worktree_path: '/repo/.claude/worktrees/agent-a2',
+          branch: 'worktree-agent-a2',
+          expected_base: 'abc123',
+        },
+      ],
+    };
+    const result = executeWorktreeWaveCleanupPlan(plan, {
+      execGit: (args) => {
+        const key = args.join(' ');
+        if (key === '-C /repo/.claude/worktrees/agent-a1 rev-parse --abbrev-ref HEAD') {
+          return { exitCode: 0, stdout: 'worktree-agent-a1', stderr: '' };
+        }
+        if (key === 'merge-base HEAD worktree-agent-a1') {
+          return { exitCode: 0, stdout: 'abc123', stderr: '' };
+        }
+        if (key === 'diff --diff-filter=D --name-only HEAD...worktree-agent-a1') {
+          return { exitCode: 0, stdout: '', stderr: '' };
+        }
+        if (key === '-C /repo/.claude/worktrees/agent-a1 status --porcelain --untracked-files=all') {
+          return { exitCode: 0, stdout: '', stderr: '' };
+        }
+        if (key.startsWith('merge worktree-agent-a1')) {
+          return { exitCode: 1, stdout: '', stderr: 'CONFLICT' };
+        }
+        if (key === 'merge --abort') {
+          return { exitCode: 0, stdout: '', stderr: '' };
+        }
+        if (key === 'rev-parse --verify -q MERGE_HEAD') {
+          // Cannot determine repo state — the check itself timed out.
+          return {
+            exitCode: null,
+            stdout: '',
+            stderr: '',
+            timedOut: true,
+            signal: 'SIGTERM',
+            error: Object.assign(new Error('spawnSync git ETIMEDOUT'), { code: 'ETIMEDOUT' }),
+          };
+        }
+        throw new Error(`unexpected git call — repo state is unverified, entry 2 must not be evaluated: ${key}`);
+      },
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.entries[0].status, 'blocked');
+    assert.equal(result.entries[0].reason, 'merge_failed');
+    assert.equal(result.entries.length, 1, 'entry 2 must not have been evaluated — state is unverified, fail closed');
+    assert.deepEqual(result.pending.map((entry) => entry.branch), ['worktree-agent-a2']);
+  });
+
+  test('#2852: an unverifiable repo state after merge_failed (rev-parse errors unexpectedly) fails closed and halts the wave', () => {
+    // Same boundary as the timeout case, but for a non-0/1 exit code (e.g. a fatal git
+    // error, code 128) from the post-abort MERGE_HEAD check — neither "found" (0) nor
+    // the well-known "not found" (1). Must also fail closed.
+    const plan = {
+      ok: true,
+      repoRoot: '/repo/main',
+      action: 'cleanup_wave',
+      discovery: 'manifest',
+      entries: [
+        {
+          agent_id: 'a1',
+          worktree_path: '/repo/.claude/worktrees/agent-a1',
+          branch: 'worktree-agent-a1',
+          expected_base: 'abc123',
+        },
+        {
+          agent_id: 'a2',
+          worktree_path: '/repo/.claude/worktrees/agent-a2',
+          branch: 'worktree-agent-a2',
+          expected_base: 'abc123',
+        },
+      ],
+    };
+    const result = executeWorktreeWaveCleanupPlan(plan, {
+      execGit: (args) => {
+        const key = args.join(' ');
+        if (key === '-C /repo/.claude/worktrees/agent-a1 rev-parse --abbrev-ref HEAD') {
+          return { exitCode: 0, stdout: 'worktree-agent-a1', stderr: '' };
+        }
+        if (key === 'merge-base HEAD worktree-agent-a1') {
+          return { exitCode: 0, stdout: 'abc123', stderr: '' };
+        }
+        if (key === 'diff --diff-filter=D --name-only HEAD...worktree-agent-a1') {
+          return { exitCode: 0, stdout: '', stderr: '' };
+        }
+        if (key === '-C /repo/.claude/worktrees/agent-a1 status --porcelain --untracked-files=all') {
+          return { exitCode: 0, stdout: '', stderr: '' };
+        }
+        if (key.startsWith('merge worktree-agent-a1')) {
+          return { exitCode: 1, stdout: '', stderr: 'CONFLICT' };
+        }
+        if (key === 'merge --abort') {
+          return { exitCode: 0, stdout: '', stderr: '' };
+        }
+        if (key === 'rev-parse --verify -q MERGE_HEAD') {
+          // A fatal git error (e.g. corrupted repo) — neither the "found" (0) nor the
+          // well-known "not found" (1) exit code.
+          return { exitCode: 128, stdout: '', stderr: 'fatal: not a git repository' };
+        }
+        throw new Error(`unexpected git call — repo state is unverified, entry 2 must not be evaluated: ${key}`);
+      },
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.entries[0].status, 'blocked');
+    assert.equal(result.entries[0].reason, 'merge_failed');
+    assert.equal(result.entries.length, 1, 'entry 2 must not have been evaluated — state is unverified, fail closed');
+    assert.deepEqual(result.pending.map((entry) => entry.branch), ['worktree-agent-a2']);
+  });
+
   test('#3804: rescues uncommitted SUMMARY.md from worktree .planning/ before dirty check', () => {
     // Fixture: the only dirty file is .planning/q1-SUMMARY.md (executor left it uncommitted
     // per documented contract — orchestrator commits it).  cleanup-wave MUST rescue it

--- a/tests/worktree-safety.test.cjs
+++ b/tests/worktree-safety.test.cjs
@@ -1824,11 +1824,6 @@ describe('executeWorktreeWaveCleanupPlan', () => {
         if (key === '-C /repo/.claude/worktrees/agent-a1 status --porcelain --untracked-files=all') {
           return { exitCode: 0, stdout: '', stderr: '' };
         }
-        // #2852: eager cache-population call, made right before this entry's own
-        // merge attempt (both a1's failed attempt and a2's successful one).
-        if (key === 'diff --name-only HEAD...worktree-agent-a1') {
-          return { exitCode: 0, stdout: '', stderr: '' };
-        }
         if (key.startsWith('merge worktree-agent-a1')) {
           return { exitCode: 1, stdout: '', stderr: 'CONFLICT' };
         }
@@ -1846,9 +1841,6 @@ describe('executeWorktreeWaveCleanupPlan', () => {
           return { exitCode: 0, stdout: '', stderr: '' };
         }
         if (key === '-C /repo/.claude/worktrees/agent-a2 status --porcelain --untracked-files=all') {
-          return { exitCode: 0, stdout: '', stderr: '' };
-        }
-        if (key === 'diff --name-only HEAD...worktree-agent-a2') {
           return { exitCode: 0, stdout: '', stderr: '' };
         }
         if (key.startsWith('merge worktree-agent-a2')) {
@@ -1905,10 +1897,6 @@ describe('executeWorktreeWaveCleanupPlan', () => {
           return { exitCode: 0, stdout: '', stderr: '' };
         }
         if (key === '-C /repo/.claude/worktrees/agent-a1 status --porcelain --untracked-files=all') {
-          return { exitCode: 0, stdout: '', stderr: '' };
-        }
-        // #2852: eager cache-population call, made right before entry 1's merge attempt.
-        if (key === 'diff --name-only HEAD...worktree-agent-a1') {
           return { exitCode: 0, stdout: '', stderr: '' };
         }
         if (key.startsWith('merge worktree-agent-a1')) {
@@ -2530,18 +2518,22 @@ describe('executeWorktreeWaveCleanupPlan', () => {
     assert.equal(calls.some((call) => call === 'branch -D worktree-agent-a1'), false);
   });
 
-  // ─── #2852: wave-abort isolation + deletion cross-entry overlap check ─────
+  // ─── #2852: wave-abort isolation ───────────────────────────────────────────
   //
-  // Two independent defects, both required by the linked issue:
-  //   (a) `branch_contains_deletions` blocked ANY deletion unconditionally — even
-  //       one nothing else in the wave depends on (the reported repro: folding a
-  //       test file into a sibling). Fixed by checking whether another entry's
-  //       branch still touches the deleted path.
-  //   (b) every per-entry block reason aborted the REST of the wave via
-  //       `pending.push(...entries.slice(i + 1)); break;`. Fixed by isolating each
-  //       block to its own entry (`continue`), except an unrecoverable
-  //       `merge_failed` (repoRoot itself left mid-merge), which legitimately
-  //       halts the remaining wave.
+  // Every per-entry block reason (branch_mismatch, base_mismatch,
+  // branch_contains_deletions, deletion_check_failed, summary_rescue_failed,
+  // worktree_dirty ×2, merge_failed, worktree_remove_failed) previously aborted
+  // the REST of the wave via `pending.push(...entries.slice(i + 1)); break;`.
+  // Fixed by isolating each block to its own entry (`continue`), except an
+  // unrecoverable `merge_failed` (repoRoot itself left mid-merge), which
+  // legitimately halts the remaining wave.
+  //
+  // Scope note: `branch_contains_deletions` itself STAYS unconditional — any
+  // deletion in an entry's branch blocks that entry, exactly as before this fix.
+  // Issue #2852's own triage explicitly scoped an opt-in for intentional
+  // deletions OUT of this fix as a separate, deferred product decision (see the
+  // tracked follow-up issue cited in the fix commit); only the wave-abort
+  // behavior is in scope here.
 
   function makeEntry(id, branch, base = 'abc123') {
     return {
@@ -2563,9 +2555,6 @@ describe('executeWorktreeWaveCleanupPlan', () => {
       return { exitCode: 0, stdout: 'abc123', stderr: '' };
     }
     if (key === `diff --diff-filter=D --name-only HEAD...${branch}`) {
-      return { exitCode: 0, stdout: '', stderr: '' };
-    }
-    if (key === `diff --name-only HEAD...${branch}`) {
       return { exitCode: 0, stdout: '', stderr: '' };
     }
     if (key === `-C ${worktreePath} status --porcelain --untracked-files=all`) {
@@ -2636,7 +2625,12 @@ describe('executeWorktreeWaveCleanupPlan', () => {
     assert.deepEqual(result.pending, []);
   });
 
-  test('#2852: a deletion no other wave member touches is not blocked', () => {
+  test('#2852: a branch_contains_deletions block on entry 1 does not abort entry 2', () => {
+    // Scope note: the deletions guard itself stays UNCONDITIONAL (any deletion in
+    // entry 1's branch blocks entry 1) — issue #2852's own triage scoped an opt-in
+    // for intentional deletions OUT of this fix as a separate product decision
+    // (tracked in #3003). This fix only isolates the block to entry 1 instead of
+    // aborting the rest of the wave, same as every other block reason.
     const e1 = makeEntry('a1', 'worktree-agent-a1');
     const e2 = makeEntry('a2', 'worktree-agent-a2');
     const plan = { ok: true, repoRoot: '/repo/main', action: 'cleanup_wave', discovery: 'manifest', entries: [e1, e2] };
@@ -2650,44 +2644,7 @@ describe('executeWorktreeWaveCleanupPlan', () => {
           return { exitCode: 0, stdout: 'abc123', stderr: '' };
         }
         if (key === 'diff --diff-filter=D --name-only HEAD...worktree-agent-a1') {
-          // entry 1 folds a sibling test file into another and deletes the original
           return { exitCode: 0, stdout: 'src/lib/payments/__tests__/payment-allocation.test.ts', stderr: '' };
-        }
-        // Cross-entry overlap check: entry 2's full diff does not touch the deleted path.
-        if (key === 'diff --name-only HEAD...worktree-agent-a2') {
-          return { exitCode: 0, stdout: 'src/other/file.ts', stderr: '' };
-        }
-        const clean1 = cleanEntryResponse(key, e1.branch, e1.worktree_path);
-        if (clean1) return clean1;
-        const clean2 = cleanEntryResponse(key, e2.branch, e2.worktree_path);
-        if (clean2) return clean2;
-        throw new Error(`unexpected git call: ${key}`);
-      },
-    });
-    assert.equal(result.ok, true, 'a deletion no one else depends on must not block the merge');
-    assert.equal(result.entries[0].status, 'merged_removed');
-    assert.equal(result.entries[1].status, 'merged_removed');
-  });
-
-  test('#2852: a deletion another wave member still depends on keeps blocking', () => {
-    const e1 = makeEntry('a1', 'worktree-agent-a1');
-    const e2 = makeEntry('a2', 'worktree-agent-a2');
-    const plan = { ok: true, repoRoot: '/repo/main', action: 'cleanup_wave', discovery: 'manifest', entries: [e1, e2] };
-    const result = executeWorktreeWaveCleanupPlan(plan, {
-      execGit: (args) => {
-        const key = args.join(' ');
-        if (key === '-C /repo/.claude/worktrees/agent-a1 rev-parse --abbrev-ref HEAD') {
-          return { exitCode: 0, stdout: 'worktree-agent-a1', stderr: '' };
-        }
-        if (key === 'merge-base HEAD worktree-agent-a1') {
-          return { exitCode: 0, stdout: 'abc123', stderr: '' };
-        }
-        if (key === 'diff --diff-filter=D --name-only HEAD...worktree-agent-a1') {
-          return { exitCode: 0, stdout: 'src/shared.js', stderr: '' };
-        }
-        if (key === 'diff --name-only HEAD...worktree-agent-a2') {
-          // entry 2's branch still touches the file entry 1 deletes — genuine risk (negative space)
-          return { exitCode: 0, stdout: 'src/shared.js\nsrc/other.js', stderr: '' };
         }
         const clean2 = cleanEntryResponse(key, e2.branch, e2.worktree_path);
         if (clean2) return clean2;
@@ -2697,33 +2654,8 @@ describe('executeWorktreeWaveCleanupPlan', () => {
     assert.equal(result.ok, false);
     assert.equal(result.entries[0].status, 'blocked');
     assert.equal(result.entries[0].reason, 'branch_contains_deletions');
-    assert.equal(result.entries[1].status, 'merged_removed', 'entry 2 (the dependent) is independently clean and still merges');
-    assert.equal(result.entries.length, 2);
+    assert.equal(result.entries[1].status, 'merged_removed', 'entry 2 must still merge — isolation, not wave-abort');
     assert.deepEqual(result.pending, []);
-  });
-
-  test('#2852: a single-entry wave with a deletion is not blocked (no other wave member can depend on it)', () => {
-    const e1 = makeEntry('a1', 'worktree-agent-a1');
-    const plan = { ok: true, repoRoot: '/repo/main', action: 'cleanup_wave', discovery: 'manifest', entries: [e1] };
-    const result = executeWorktreeWaveCleanupPlan(plan, {
-      execGit: (args) => {
-        const key = args.join(' ');
-        if (key === '-C /repo/.claude/worktrees/agent-a1 rev-parse --abbrev-ref HEAD') {
-          return { exitCode: 0, stdout: 'worktree-agent-a1', stderr: '' };
-        }
-        if (key === 'merge-base HEAD worktree-agent-a1') {
-          return { exitCode: 0, stdout: 'abc123', stderr: '' };
-        }
-        if (key === 'diff --diff-filter=D --name-only HEAD...worktree-agent-a1') {
-          return { exitCode: 0, stdout: 'old-file.js', stderr: '' };
-        }
-        const clean = cleanEntryResponse(key, e1.branch, e1.worktree_path);
-        if (clean) return clean;
-        throw new Error(`unexpected git call: ${key}`);
-      },
-    });
-    assert.equal(result.ok, true);
-    assert.equal(result.entries[0].status, 'merged_removed');
   });
 
   test('#2852: a worktree_remove_failed on entry 1 does not abort entry 2', () => {
@@ -2743,10 +2675,6 @@ describe('executeWorktreeWaveCleanupPlan', () => {
           return { exitCode: 0, stdout: '', stderr: '' };
         }
         if (key === '-C /repo/.claude/worktrees/agent-a1 status --porcelain --untracked-files=all') {
-          return { exitCode: 0, stdout: '', stderr: '' };
-        }
-        // #2852: eager cache-population call, made right before entry 1's (successful) merge.
-        if (key === 'diff --name-only HEAD...worktree-agent-a1') {
           return { exitCode: 0, stdout: '', stderr: '' };
         }
         if (key.startsWith('merge worktree-agent-a1')) {
@@ -2920,104 +2848,6 @@ describe('executeWorktreeWaveCleanupPlan', () => {
     assert.deepEqual(result.pending, []);
   });
 
-  test('#2852: CRLF line endings in diff output do not defeat the cross-entry overlap check', () => {
-    const e1 = makeEntry('a1', 'worktree-agent-a1');
-    const e2 = makeEntry('a2', 'worktree-agent-a2');
-    const plan = { ok: true, repoRoot: '/repo/main', action: 'cleanup_wave', discovery: 'manifest', entries: [e1, e2] };
-    const result = executeWorktreeWaveCleanupPlan(plan, {
-      execGit: (args) => {
-        const key = args.join(' ');
-        if (key === '-C /repo/.claude/worktrees/agent-a1 rev-parse --abbrev-ref HEAD') {
-          return { exitCode: 0, stdout: 'worktree-agent-a1', stderr: '' };
-        }
-        if (key === 'merge-base HEAD worktree-agent-a1') {
-          return { exitCode: 0, stdout: 'abc123', stderr: '' };
-        }
-        if (key === 'diff --diff-filter=D --name-only HEAD...worktree-agent-a1') {
-          // Windows git emits CRLF-terminated lines
-          return { exitCode: 0, stdout: 'src/shared.js\r\n', stderr: '' };
-        }
-        if (key === 'diff --name-only HEAD...worktree-agent-a2') {
-          return { exitCode: 0, stdout: 'src/shared.js\r\nsrc/other.js\r\n', stderr: '' };
-        }
-        const clean2 = cleanEntryResponse(key, e2.branch, e2.worktree_path);
-        if (clean2) return clean2;
-        throw new Error(`unexpected git call: ${key}`);
-      },
-    });
-    assert.equal(result.ok, false);
-    assert.equal(result.entries[0].status, 'blocked');
-    assert.equal(result.entries[0].reason, 'branch_contains_deletions');
-  });
-
-  test('#2852: a deletion still blocks when the dependent entry appears EARLIER and has already merged', () => {
-    // Regression for a real ordering bug caught in /code-review before this fix shipped:
-    // a NAIVE lazy "compute the other entry's diff only when someone asks" cache is WRONG
-    // here. If entry 1 (a1) modifies shared.js and merges FIRST, branch_a1 becomes an
-    // ancestor of HEAD by the time entry 2 (a2) deletes shared.js and needs to check
-    // whether anyone still depends on it — `git diff --name-only HEAD...worktree-agent-a1`
-    // at THAT point silently collapses to empty (a1 is now contained in HEAD), which would
-    // wrongly report "nobody depends on it" and let the deletion through. The fix caches
-    // each entry's touched-files set eagerly, during that entry's OWN turn, before its own
-    // merge can move HEAD — this test fails under the naive lazy design and passes under
-    // the eager one.
-    const e1 = makeEntry('a1', 'worktree-agent-a1');
-    const e2 = makeEntry('a2', 'worktree-agent-a2');
-    const plan = { ok: true, repoRoot: '/repo/main', action: 'cleanup_wave', discovery: 'manifest', entries: [e1, e2] };
-    let mergedA1 = false;
-    const result = executeWorktreeWaveCleanupPlan(plan, {
-      execGit: (args) => {
-        const key = args.join(' ');
-        // Entry 1: clean, touches shared.js, merges successfully (first).
-        if (key === '-C /repo/.claude/worktrees/agent-a1 rev-parse --abbrev-ref HEAD') {
-          return { exitCode: 0, stdout: 'worktree-agent-a1', stderr: '' };
-        }
-        if (key === 'merge-base HEAD worktree-agent-a1') {
-          return { exitCode: 0, stdout: 'abc123', stderr: '' };
-        }
-        if (key === 'diff --diff-filter=D --name-only HEAD...worktree-agent-a1') {
-          return { exitCode: 0, stdout: '', stderr: '' };
-        }
-        if (key === '-C /repo/.claude/worktrees/agent-a1 status --porcelain --untracked-files=all') {
-          return { exitCode: 0, stdout: '', stderr: '' };
-        }
-        if (key === 'diff --name-only HEAD...worktree-agent-a1') {
-          // Eager cache-population call for entry 1's own turn, made BEFORE its merge:
-          // must reflect its true diff (touches shared.js). If this were instead computed
-          // LAZILY after a1 has already merged, a real git call would return '' here —
-          // that is exactly the bug this test guards against.
-          return mergedA1
-            ? { exitCode: 0, stdout: '', stderr: '' }
-            : { exitCode: 0, stdout: 'src/shared.js', stderr: '' };
-        }
-        if (key.startsWith('merge worktree-agent-a1')) {
-          mergedA1 = true;
-          return { exitCode: 0, stdout: '', stderr: '' };
-        }
-        if (key === 'worktree remove /repo/.claude/worktrees/agent-a1 --force') {
-          return { exitCode: 0, stdout: '', stderr: '' };
-        }
-        if (key === 'branch -D worktree-agent-a1') {
-          return { exitCode: 0, stdout: '', stderr: '' };
-        }
-        // Entry 2: deletes shared.js — must be blocked because entry 1 (already merged)
-        // still depends on it.
-        if (key === '-C /repo/.claude/worktrees/agent-a2 rev-parse --abbrev-ref HEAD') {
-          return { exitCode: 0, stdout: 'worktree-agent-a2', stderr: '' };
-        }
-        if (key === 'merge-base HEAD worktree-agent-a2') {
-          return { exitCode: 0, stdout: 'abc123', stderr: '' };
-        }
-        if (key === 'diff --diff-filter=D --name-only HEAD...worktree-agent-a2') {
-          return { exitCode: 0, stdout: 'src/shared.js', stderr: '' };
-        }
-        throw new Error(`unexpected git call (means the overlap check live-diffed an already-merged sibling): ${key}`);
-      },
-    });
-    assert.equal(result.entries[0].status, 'merged_removed', 'entry 1 merges first, as set up');
-    assert.equal(result.entries[1].status, 'blocked', 'entry 2 must still be blocked — entry 1 depends on the deleted file');
-    assert.equal(result.entries[1].reason, 'branch_contains_deletions');
-  });
 });
 
 // ─── MOVE 2: resolveWorktreeRoot and pruneOrphanedWorktrees (#1268 T0) ────────

--- a/tests/worktree-safety.test.cjs
+++ b/tests/worktree-safety.test.cjs
@@ -1782,10 +1782,108 @@ describe('executeWorktreeWaveCleanupPlan', () => {
   // #2852: this test previously asserted the wave-abort BUG — that a merge conflict on
   // entry 1 left entry 2 stranded in `pending`, untouched. That is exactly the defect
   // reported in #2852 (part b): one blocked branch must not abort the rest of the wave.
-  // The corrected contract is exercised as two rows of the #2852 test matrix below:
-  // "recovered merge_failed isolates to entry 1" (this scenario, `git merge --abort`
-  // succeeds) and "unrecoverable merge_failed legitimately halts the wave" (abort itself
-  // fails — the one case that genuinely corrupts repoRoot for every remaining entry).
+  // The corrected contract is exercised as three rows of the #2852 test matrix below:
+  // "an ordinary merge_failed without entering a merge state" (no MERGE_HEAD was ever
+  // created — the common case, e.g. "your local changes would be overwritten" — isolate),
+  // "a recovered merge_failed" (a real conflict, `git merge --abort` clears MERGE_HEAD —
+  // isolate), and "an unrecoverable merge_failed" (MERGE_HEAD is STILL present after the
+  // abort attempt — the one case that genuinely corrupts repoRoot for every remaining
+  // entry — halt).
+  //
+  // CORRECTNESS NOTE (caught in review): `git merge --abort`'s own exit code is NOT the
+  // right signal for "unrecoverable". git legitimately fails abort with "There is no
+  // merge to abort (MERGE_HEAD missing)?" in the SAFE case too — whenever the original
+  // merge never entered a merge state in the first place (no conflict, just a refused
+  // merge). An earlier version of this fix trusted abort's exit code alone, which
+  // misclassified that common safe case as unrecoverable and stranded the rest of the
+  // wave — the exact bug #2852 exists to fix, reintroduced through the recovery path.
+  // The fix checks repoRoot's ACTUAL state via `git rev-parse --verify -q MERGE_HEAD`.
+
+  test('#2852: an ordinary merge_failed without entering a merge state does not abort the wave', () => {
+    // No MERGE_HEAD is ever created here — git refuses the merge outright (e.g. local
+    // changes would be overwritten). `git merge --abort` therefore legitimately fails
+    // with "There is no merge to abort", but repoRoot's tree was never touched, so this
+    // is an ORDINARY per-entry failure — entry 2 must still be evaluated and merge.
+    const plan = {
+      ok: true,
+      repoRoot: '/repo/main',
+      action: 'cleanup_wave',
+      discovery: 'manifest',
+      entries: [
+        {
+          agent_id: 'a1',
+          worktree_path: '/repo/.claude/worktrees/agent-a1',
+          branch: 'worktree-agent-a1',
+          expected_base: 'abc123',
+        },
+        {
+          agent_id: 'a2',
+          worktree_path: '/repo/.claude/worktrees/agent-a2',
+          branch: 'worktree-agent-a2',
+          expected_base: 'abc123',
+        },
+      ],
+    };
+    const result = executeWorktreeWaveCleanupPlan(plan, {
+      execGit: (args) => {
+        const key = args.join(' ');
+        if (key === '-C /repo/.claude/worktrees/agent-a1 rev-parse --abbrev-ref HEAD') {
+          return { exitCode: 0, stdout: 'worktree-agent-a1', stderr: '' };
+        }
+        if (key === 'merge-base HEAD worktree-agent-a1') {
+          return { exitCode: 0, stdout: 'abc123', stderr: '' };
+        }
+        if (key === 'diff --diff-filter=D --name-only HEAD...worktree-agent-a1') {
+          return { exitCode: 0, stdout: '', stderr: '' };
+        }
+        if (key === '-C /repo/.claude/worktrees/agent-a1 status --porcelain --untracked-files=all') {
+          return { exitCode: 0, stdout: '', stderr: '' };
+        }
+        if (key.startsWith('merge worktree-agent-a1')) {
+          // No conflict — git refuses the merge outright. No MERGE_HEAD is created.
+          return { exitCode: 1, stdout: '', stderr: 'error: Your local changes to the following files would be overwritten by merge' };
+        }
+        if (key === 'merge --abort') {
+          // Legitimately fails — there was never a merge to abort. NOT a signal of
+          // repo corruption; the wave-isolation decision must not trust this exit code.
+          return { exitCode: 1, stdout: '', stderr: 'fatal: There is no merge to abort (MERGE_HEAD missing)?' };
+        }
+        if (key === 'rev-parse --verify -q MERGE_HEAD') {
+          // repoRoot is NOT mid-merge — the ref simply doesn't exist.
+          return { exitCode: 1, stdout: '', stderr: '' };
+        }
+        // Entry 2 must still be evaluated independently.
+        if (key === '-C /repo/.claude/worktrees/agent-a2 rev-parse --abbrev-ref HEAD') {
+          return { exitCode: 0, stdout: 'worktree-agent-a2', stderr: '' };
+        }
+        if (key === 'merge-base HEAD worktree-agent-a2') {
+          return { exitCode: 0, stdout: 'abc123', stderr: '' };
+        }
+        if (key === 'diff --diff-filter=D --name-only HEAD...worktree-agent-a2') {
+          return { exitCode: 0, stdout: '', stderr: '' };
+        }
+        if (key === '-C /repo/.claude/worktrees/agent-a2 status --porcelain --untracked-files=all') {
+          return { exitCode: 0, stdout: '', stderr: '' };
+        }
+        if (key.startsWith('merge worktree-agent-a2')) {
+          return { exitCode: 0, stdout: '', stderr: '' };
+        }
+        if (key === 'worktree remove /repo/.claude/worktrees/agent-a2 --force') {
+          return { exitCode: 0, stdout: '', stderr: '' };
+        }
+        if (key === 'branch -D worktree-agent-a2') {
+          return { exitCode: 0, stdout: '', stderr: '' };
+        }
+        throw new Error(`unexpected git call: ${key}`);
+      },
+    });
+    assert.equal(result.ok, false, 'overall ok is false because entry 1 blocked');
+    assert.equal(result.entries[0].status, 'blocked');
+    assert.equal(result.entries[0].reason, 'merge_failed');
+    assert.equal(result.entries[1].status, 'merged_removed', 'entry 2 must still merge — no merge state was ever entered');
+    assert.deepEqual(result.pending, [], 'pending must be empty — every entry was evaluated');
+  });
+
   test('#2852: a recovered merge_failed isolates to entry 1, entry 2 still merges', () => {
     const calls = [];
     const plan = {
@@ -1825,10 +1923,15 @@ describe('executeWorktreeWaveCleanupPlan', () => {
           return { exitCode: 0, stdout: '', stderr: '' };
         }
         if (key.startsWith('merge worktree-agent-a1')) {
+          // A real conflict — MERGE_HEAD IS created.
           return { exitCode: 1, stdout: '', stderr: 'CONFLICT' };
         }
         if (key === 'merge --abort') {
           return { exitCode: 0, stdout: '', stderr: '' };
+        }
+        if (key === 'rev-parse --verify -q MERGE_HEAD') {
+          // abort succeeded — repoRoot is no longer mid-merge.
+          return { exitCode: 1, stdout: '', stderr: '' };
         }
         // Entry 2 must still be evaluated independently after recovery.
         if (key === '-C /repo/.claude/worktrees/agent-a2 rev-parse --abbrev-ref HEAD') {
@@ -1860,10 +1963,10 @@ describe('executeWorktreeWaveCleanupPlan', () => {
     assert.equal(result.entries[0].reason, 'merge_failed');
     assert.equal(result.entries[1].status, 'merged_removed', 'entry 2 must still merge — isolation, not wave-abort');
     assert.deepEqual(result.pending, [], 'pending must be empty — every entry was evaluated');
-    assert.ok(calls.includes('merge --abort'), 'a failed merge must be recovered with git merge --abort');
+    assert.ok(calls.includes('merge --abort'), 'a failed merge must attempt recovery with git merge --abort');
   });
 
-  test('#2852: an unrecoverable merge_failed (abort fails too) legitimately halts the remaining wave', () => {
+  test('#2852: an unrecoverable merge_failed (repoRoot STILL mid-merge after abort) legitimately halts the remaining wave', () => {
     const plan = {
       ok: true,
       repoRoot: '/repo/main',
@@ -1903,8 +2006,12 @@ describe('executeWorktreeWaveCleanupPlan', () => {
           return { exitCode: 1, stdout: '', stderr: 'CONFLICT' };
         }
         if (key === 'merge --abort') {
-          // repoRoot cannot be recovered — a genuine infrastructure-level failure.
-          return { exitCode: 1, stdout: '', stderr: 'fatal: There is no merge to abort (MERGE_HEAD missing)?' };
+          return { exitCode: 1, stdout: '', stderr: 'fatal: unable to abort' };
+        }
+        if (key === 'rev-parse --verify -q MERGE_HEAD') {
+          // repoRoot IS genuinely still mid-merge — the abort attempt did not clear it.
+          // This, not abort's own exit code, is what legitimately halts the wave.
+          return { exitCode: 0, stdout: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef', stderr: '' };
         }
         throw new Error(`unexpected git call — repoRoot is unrecoverable, entry 2 must not be evaluated: ${key}`);
       },

--- a/tests/worktree-safety.test.cjs
+++ b/tests/worktree-safety.test.cjs
@@ -1824,6 +1824,11 @@ describe('executeWorktreeWaveCleanupPlan', () => {
         if (key === '-C /repo/.claude/worktrees/agent-a1 status --porcelain --untracked-files=all') {
           return { exitCode: 0, stdout: '', stderr: '' };
         }
+        // #2852: eager cache-population call, made right before this entry's own
+        // merge attempt (both a1's failed attempt and a2's successful one).
+        if (key === 'diff --name-only HEAD...worktree-agent-a1') {
+          return { exitCode: 0, stdout: '', stderr: '' };
+        }
         if (key.startsWith('merge worktree-agent-a1')) {
           return { exitCode: 1, stdout: '', stderr: 'CONFLICT' };
         }
@@ -1841,6 +1846,9 @@ describe('executeWorktreeWaveCleanupPlan', () => {
           return { exitCode: 0, stdout: '', stderr: '' };
         }
         if (key === '-C /repo/.claude/worktrees/agent-a2 status --porcelain --untracked-files=all') {
+          return { exitCode: 0, stdout: '', stderr: '' };
+        }
+        if (key === 'diff --name-only HEAD...worktree-agent-a2') {
           return { exitCode: 0, stdout: '', stderr: '' };
         }
         if (key.startsWith('merge worktree-agent-a2')) {
@@ -1897,6 +1905,10 @@ describe('executeWorktreeWaveCleanupPlan', () => {
           return { exitCode: 0, stdout: '', stderr: '' };
         }
         if (key === '-C /repo/.claude/worktrees/agent-a1 status --porcelain --untracked-files=all') {
+          return { exitCode: 0, stdout: '', stderr: '' };
+        }
+        // #2852: eager cache-population call, made right before entry 1's merge attempt.
+        if (key === 'diff --name-only HEAD...worktree-agent-a1') {
           return { exitCode: 0, stdout: '', stderr: '' };
         }
         if (key.startsWith('merge worktree-agent-a1')) {
@@ -2733,6 +2745,10 @@ describe('executeWorktreeWaveCleanupPlan', () => {
         if (key === '-C /repo/.claude/worktrees/agent-a1 status --porcelain --untracked-files=all') {
           return { exitCode: 0, stdout: '', stderr: '' };
         }
+        // #2852: eager cache-population call, made right before entry 1's (successful) merge.
+        if (key === 'diff --name-only HEAD...worktree-agent-a1') {
+          return { exitCode: 0, stdout: '', stderr: '' };
+        }
         if (key.startsWith('merge worktree-agent-a1')) {
           return { exitCode: 0, stdout: '', stderr: '' };
         }
@@ -2932,6 +2948,75 @@ describe('executeWorktreeWaveCleanupPlan', () => {
     assert.equal(result.ok, false);
     assert.equal(result.entries[0].status, 'blocked');
     assert.equal(result.entries[0].reason, 'branch_contains_deletions');
+  });
+
+  test('#2852: a deletion still blocks when the dependent entry appears EARLIER and has already merged', () => {
+    // Regression for a real ordering bug caught in /code-review before this fix shipped:
+    // a NAIVE lazy "compute the other entry's diff only when someone asks" cache is WRONG
+    // here. If entry 1 (a1) modifies shared.js and merges FIRST, branch_a1 becomes an
+    // ancestor of HEAD by the time entry 2 (a2) deletes shared.js and needs to check
+    // whether anyone still depends on it — `git diff --name-only HEAD...worktree-agent-a1`
+    // at THAT point silently collapses to empty (a1 is now contained in HEAD), which would
+    // wrongly report "nobody depends on it" and let the deletion through. The fix caches
+    // each entry's touched-files set eagerly, during that entry's OWN turn, before its own
+    // merge can move HEAD — this test fails under the naive lazy design and passes under
+    // the eager one.
+    const e1 = makeEntry('a1', 'worktree-agent-a1');
+    const e2 = makeEntry('a2', 'worktree-agent-a2');
+    const plan = { ok: true, repoRoot: '/repo/main', action: 'cleanup_wave', discovery: 'manifest', entries: [e1, e2] };
+    let mergedA1 = false;
+    const result = executeWorktreeWaveCleanupPlan(plan, {
+      execGit: (args) => {
+        const key = args.join(' ');
+        // Entry 1: clean, touches shared.js, merges successfully (first).
+        if (key === '-C /repo/.claude/worktrees/agent-a1 rev-parse --abbrev-ref HEAD') {
+          return { exitCode: 0, stdout: 'worktree-agent-a1', stderr: '' };
+        }
+        if (key === 'merge-base HEAD worktree-agent-a1') {
+          return { exitCode: 0, stdout: 'abc123', stderr: '' };
+        }
+        if (key === 'diff --diff-filter=D --name-only HEAD...worktree-agent-a1') {
+          return { exitCode: 0, stdout: '', stderr: '' };
+        }
+        if (key === '-C /repo/.claude/worktrees/agent-a1 status --porcelain --untracked-files=all') {
+          return { exitCode: 0, stdout: '', stderr: '' };
+        }
+        if (key === 'diff --name-only HEAD...worktree-agent-a1') {
+          // Eager cache-population call for entry 1's own turn, made BEFORE its merge:
+          // must reflect its true diff (touches shared.js). If this were instead computed
+          // LAZILY after a1 has already merged, a real git call would return '' here —
+          // that is exactly the bug this test guards against.
+          return mergedA1
+            ? { exitCode: 0, stdout: '', stderr: '' }
+            : { exitCode: 0, stdout: 'src/shared.js', stderr: '' };
+        }
+        if (key.startsWith('merge worktree-agent-a1')) {
+          mergedA1 = true;
+          return { exitCode: 0, stdout: '', stderr: '' };
+        }
+        if (key === 'worktree remove /repo/.claude/worktrees/agent-a1 --force') {
+          return { exitCode: 0, stdout: '', stderr: '' };
+        }
+        if (key === 'branch -D worktree-agent-a1') {
+          return { exitCode: 0, stdout: '', stderr: '' };
+        }
+        // Entry 2: deletes shared.js — must be blocked because entry 1 (already merged)
+        // still depends on it.
+        if (key === '-C /repo/.claude/worktrees/agent-a2 rev-parse --abbrev-ref HEAD') {
+          return { exitCode: 0, stdout: 'worktree-agent-a2', stderr: '' };
+        }
+        if (key === 'merge-base HEAD worktree-agent-a2') {
+          return { exitCode: 0, stdout: 'abc123', stderr: '' };
+        }
+        if (key === 'diff --diff-filter=D --name-only HEAD...worktree-agent-a2') {
+          return { exitCode: 0, stdout: 'src/shared.js', stderr: '' };
+        }
+        throw new Error(`unexpected git call (means the overlap check live-diffed an already-merged sibling): ${key}`);
+      },
+    });
+    assert.equal(result.entries[0].status, 'merged_removed', 'entry 1 merges first, as set up');
+    assert.equal(result.entries[1].status, 'blocked', 'entry 2 must still be blocked — entry 1 depends on the deleted file');
+    assert.equal(result.entries[1].reason, 'branch_contains_deletions');
   });
 });
 

--- a/tests/worktree-safety.test.cjs
+++ b/tests/worktree-safety.test.cjs
@@ -1779,7 +1779,91 @@ describe('executeWorktreeWaveCleanupPlan', () => {
     assert.equal(calls.some((call) => call.args.join(' ') === 'branch -D worktree-agent-a1'), false);
   });
 
-  test('stops on merge conflict and records remaining manifest entries', () => {
+  // #2852: this test previously asserted the wave-abort BUG — that a merge conflict on
+  // entry 1 left entry 2 stranded in `pending`, untouched. That is exactly the defect
+  // reported in #2852 (part b): one blocked branch must not abort the rest of the wave.
+  // The corrected contract is exercised as two rows of the #2852 test matrix below:
+  // "recovered merge_failed isolates to entry 1" (this scenario, `git merge --abort`
+  // succeeds) and "unrecoverable merge_failed legitimately halts the wave" (abort itself
+  // fails — the one case that genuinely corrupts repoRoot for every remaining entry).
+  test('#2852: a recovered merge_failed isolates to entry 1, entry 2 still merges', () => {
+    const calls = [];
+    const plan = {
+      ok: true,
+      repoRoot: '/repo/main',
+      action: 'cleanup_wave',
+      discovery: 'manifest',
+      entries: [
+        {
+          agent_id: 'a1',
+          worktree_path: '/repo/.claude/worktrees/agent-a1',
+          branch: 'worktree-agent-a1',
+          expected_base: 'abc123',
+        },
+        {
+          agent_id: 'a2',
+          worktree_path: '/repo/.claude/worktrees/agent-a2',
+          branch: 'worktree-agent-a2',
+          expected_base: 'abc123',
+        },
+      ],
+    };
+    const result = executeWorktreeWaveCleanupPlan(plan, {
+      execGit: (args) => {
+        const key = args.join(' ');
+        calls.push(key);
+        if (key === '-C /repo/.claude/worktrees/agent-a1 rev-parse --abbrev-ref HEAD') {
+          return { exitCode: 0, stdout: 'worktree-agent-a1', stderr: '' };
+        }
+        if (key === 'merge-base HEAD worktree-agent-a1') {
+          return { exitCode: 0, stdout: 'abc123', stderr: '' };
+        }
+        if (key === 'diff --diff-filter=D --name-only HEAD...worktree-agent-a1') {
+          return { exitCode: 0, stdout: '', stderr: '' };
+        }
+        if (key === '-C /repo/.claude/worktrees/agent-a1 status --porcelain --untracked-files=all') {
+          return { exitCode: 0, stdout: '', stderr: '' };
+        }
+        if (key.startsWith('merge worktree-agent-a1')) {
+          return { exitCode: 1, stdout: '', stderr: 'CONFLICT' };
+        }
+        if (key === 'merge --abort') {
+          return { exitCode: 0, stdout: '', stderr: '' };
+        }
+        // Entry 2 must still be evaluated independently after recovery.
+        if (key === '-C /repo/.claude/worktrees/agent-a2 rev-parse --abbrev-ref HEAD') {
+          return { exitCode: 0, stdout: 'worktree-agent-a2', stderr: '' };
+        }
+        if (key === 'merge-base HEAD worktree-agent-a2') {
+          return { exitCode: 0, stdout: 'abc123', stderr: '' };
+        }
+        if (key === 'diff --diff-filter=D --name-only HEAD...worktree-agent-a2') {
+          return { exitCode: 0, stdout: '', stderr: '' };
+        }
+        if (key === '-C /repo/.claude/worktrees/agent-a2 status --porcelain --untracked-files=all') {
+          return { exitCode: 0, stdout: '', stderr: '' };
+        }
+        if (key.startsWith('merge worktree-agent-a2')) {
+          return { exitCode: 0, stdout: '', stderr: '' };
+        }
+        if (key === 'worktree remove /repo/.claude/worktrees/agent-a2 --force') {
+          return { exitCode: 0, stdout: '', stderr: '' };
+        }
+        if (key === 'branch -D worktree-agent-a2') {
+          return { exitCode: 0, stdout: '', stderr: '' };
+        }
+        throw new Error(`unexpected git call: ${key}`);
+      },
+    });
+    assert.equal(result.ok, false, 'overall ok is false because entry 1 blocked');
+    assert.equal(result.entries[0].status, 'blocked');
+    assert.equal(result.entries[0].reason, 'merge_failed');
+    assert.equal(result.entries[1].status, 'merged_removed', 'entry 2 must still merge — isolation, not wave-abort');
+    assert.deepEqual(result.pending, [], 'pending must be empty — every entry was evaluated');
+    assert.ok(calls.includes('merge --abort'), 'a failed merge must be recovered with git merge --abort');
+  });
+
+  test('#2852: an unrecoverable merge_failed (abort fails too) legitimately halts the remaining wave', () => {
     const plan = {
       ok: true,
       repoRoot: '/repo/main',
@@ -1818,12 +1902,17 @@ describe('executeWorktreeWaveCleanupPlan', () => {
         if (key.startsWith('merge worktree-agent-a1')) {
           return { exitCode: 1, stdout: '', stderr: 'CONFLICT' };
         }
-        throw new Error(`unexpected git call after conflict: ${key}`);
+        if (key === 'merge --abort') {
+          // repoRoot cannot be recovered — a genuine infrastructure-level failure.
+          return { exitCode: 1, stdout: '', stderr: 'fatal: There is no merge to abort (MERGE_HEAD missing)?' };
+        }
+        throw new Error(`unexpected git call — repoRoot is unrecoverable, entry 2 must not be evaluated: ${key}`);
       },
     });
     assert.equal(result.ok, false);
     assert.equal(result.entries[0].status, 'blocked');
     assert.equal(result.entries[0].reason, 'merge_failed');
+    assert.equal(result.entries.length, 1, 'entry 2 must not have been evaluated at all');
     assert.deepEqual(result.pending.map((entry) => entry.branch), ['worktree-agent-a2']);
   });
 
@@ -2427,6 +2516,422 @@ describe('executeWorktreeWaveCleanupPlan', () => {
     assert.equal(calls.some((call) => call.startsWith('merge worktree-agent-a1')), false);
     assert.equal(calls.some((call) => call === 'worktree remove /repo/.claude/worktrees/agent-a1 --force'), false);
     assert.equal(calls.some((call) => call === 'branch -D worktree-agent-a1'), false);
+  });
+
+  // ─── #2852: wave-abort isolation + deletion cross-entry overlap check ─────
+  //
+  // Two independent defects, both required by the linked issue:
+  //   (a) `branch_contains_deletions` blocked ANY deletion unconditionally — even
+  //       one nothing else in the wave depends on (the reported repro: folding a
+  //       test file into a sibling). Fixed by checking whether another entry's
+  //       branch still touches the deleted path.
+  //   (b) every per-entry block reason aborted the REST of the wave via
+  //       `pending.push(...entries.slice(i + 1)); break;`. Fixed by isolating each
+  //       block to its own entry (`continue`), except an unrecoverable
+  //       `merge_failed` (repoRoot itself left mid-merge), which legitimately
+  //       halts the remaining wave.
+
+  function makeEntry(id, branch, base = 'abc123') {
+    return {
+      agent_id: id,
+      worktree_path: `/repo/.claude/worktrees/agent-${id}`,
+      branch,
+      expected_base: base,
+    };
+  }
+
+  // Default git responses for an entry that should merge cleanly: no branch/base
+  // mismatch, no deletions, no dirty files. Returns undefined for an unmatched key
+  // so callers can layer entry-specific overrides in front of this fallback.
+  function cleanEntryResponse(key, branch, worktreePath) {
+    if (key === `-C ${worktreePath} rev-parse --abbrev-ref HEAD`) {
+      return { exitCode: 0, stdout: branch, stderr: '' };
+    }
+    if (key === `merge-base HEAD ${branch}`) {
+      return { exitCode: 0, stdout: 'abc123', stderr: '' };
+    }
+    if (key === `diff --diff-filter=D --name-only HEAD...${branch}`) {
+      return { exitCode: 0, stdout: '', stderr: '' };
+    }
+    if (key === `diff --name-only HEAD...${branch}`) {
+      return { exitCode: 0, stdout: '', stderr: '' };
+    }
+    if (key === `-C ${worktreePath} status --porcelain --untracked-files=all`) {
+      return { exitCode: 0, stdout: '', stderr: '' };
+    }
+    if (key === `merge ${branch} --no-ff --no-edit -m chore: merge executor worktree (${branch})`) {
+      return { exitCode: 0, stdout: '', stderr: '' };
+    }
+    if (key === `worktree remove ${worktreePath} --force`) {
+      return { exitCode: 0, stdout: '', stderr: '' };
+    }
+    if (key === `branch -D ${branch}`) {
+      return { exitCode: 0, stdout: '', stderr: '' };
+    }
+    return undefined;
+  }
+
+  test('#2852: a branch_mismatch block on entry 1 does not abort entries 2 and 3', () => {
+    const e1 = makeEntry('a1', 'worktree-agent-a1');
+    const e2 = makeEntry('a2', 'worktree-agent-a2');
+    const e3 = makeEntry('a3', 'worktree-agent-a3');
+    const plan = { ok: true, repoRoot: '/repo/main', action: 'cleanup_wave', discovery: 'manifest', entries: [e1, e2, e3] };
+    const result = executeWorktreeWaveCleanupPlan(plan, {
+      execGit: (args) => {
+        const key = args.join(' ');
+        if (key === '-C /repo/.claude/worktrees/agent-a1 rev-parse --abbrev-ref HEAD') {
+          // HEAD is on the wrong branch — branch_mismatch
+          return { exitCode: 0, stdout: 'some-other-branch', stderr: '' };
+        }
+        const clean2 = cleanEntryResponse(key, e2.branch, e2.worktree_path);
+        if (clean2) return clean2;
+        const clean3 = cleanEntryResponse(key, e3.branch, e3.worktree_path);
+        if (clean3) return clean3;
+        throw new Error(`unexpected git call: ${key}`);
+      },
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.entries.length, 3, 'all three entries must be evaluated');
+    assert.equal(result.entries[0].status, 'blocked');
+    assert.equal(result.entries[0].reason, 'branch_mismatch');
+    assert.equal(result.entries[1].status, 'merged_removed');
+    assert.equal(result.entries[2].status, 'merged_removed');
+    assert.deepEqual(result.pending, [], 'pending must be empty — every entry was evaluated');
+  });
+
+  test('#2852: a base_mismatch block on entry 1 does not abort entry 2', () => {
+    const e1 = makeEntry('a1', 'worktree-agent-a1');
+    const e2 = makeEntry('a2', 'worktree-agent-a2');
+    const plan = { ok: true, repoRoot: '/repo/main', action: 'cleanup_wave', discovery: 'manifest', entries: [e1, e2] };
+    const result = executeWorktreeWaveCleanupPlan(plan, {
+      execGit: (args) => {
+        const key = args.join(' ');
+        if (key === '-C /repo/.claude/worktrees/agent-a1 rev-parse --abbrev-ref HEAD') {
+          return { exitCode: 0, stdout: 'worktree-agent-a1', stderr: '' };
+        }
+        if (key === 'merge-base HEAD worktree-agent-a1') {
+          return { exitCode: 0, stdout: 'unrelatedbase', stderr: '' };
+        }
+        const clean2 = cleanEntryResponse(key, e2.branch, e2.worktree_path);
+        if (clean2) return clean2;
+        throw new Error(`unexpected git call: ${key}`);
+      },
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.entries[0].status, 'blocked');
+    assert.equal(result.entries[0].reason, 'base_mismatch');
+    assert.equal(result.entries[1].status, 'merged_removed');
+    assert.deepEqual(result.pending, []);
+  });
+
+  test('#2852: a deletion no other wave member touches is not blocked', () => {
+    const e1 = makeEntry('a1', 'worktree-agent-a1');
+    const e2 = makeEntry('a2', 'worktree-agent-a2');
+    const plan = { ok: true, repoRoot: '/repo/main', action: 'cleanup_wave', discovery: 'manifest', entries: [e1, e2] };
+    const result = executeWorktreeWaveCleanupPlan(plan, {
+      execGit: (args) => {
+        const key = args.join(' ');
+        if (key === '-C /repo/.claude/worktrees/agent-a1 rev-parse --abbrev-ref HEAD') {
+          return { exitCode: 0, stdout: 'worktree-agent-a1', stderr: '' };
+        }
+        if (key === 'merge-base HEAD worktree-agent-a1') {
+          return { exitCode: 0, stdout: 'abc123', stderr: '' };
+        }
+        if (key === 'diff --diff-filter=D --name-only HEAD...worktree-agent-a1') {
+          // entry 1 folds a sibling test file into another and deletes the original
+          return { exitCode: 0, stdout: 'src/lib/payments/__tests__/payment-allocation.test.ts', stderr: '' };
+        }
+        // Cross-entry overlap check: entry 2's full diff does not touch the deleted path.
+        if (key === 'diff --name-only HEAD...worktree-agent-a2') {
+          return { exitCode: 0, stdout: 'src/other/file.ts', stderr: '' };
+        }
+        const clean1 = cleanEntryResponse(key, e1.branch, e1.worktree_path);
+        if (clean1) return clean1;
+        const clean2 = cleanEntryResponse(key, e2.branch, e2.worktree_path);
+        if (clean2) return clean2;
+        throw new Error(`unexpected git call: ${key}`);
+      },
+    });
+    assert.equal(result.ok, true, 'a deletion no one else depends on must not block the merge');
+    assert.equal(result.entries[0].status, 'merged_removed');
+    assert.equal(result.entries[1].status, 'merged_removed');
+  });
+
+  test('#2852: a deletion another wave member still depends on keeps blocking', () => {
+    const e1 = makeEntry('a1', 'worktree-agent-a1');
+    const e2 = makeEntry('a2', 'worktree-agent-a2');
+    const plan = { ok: true, repoRoot: '/repo/main', action: 'cleanup_wave', discovery: 'manifest', entries: [e1, e2] };
+    const result = executeWorktreeWaveCleanupPlan(plan, {
+      execGit: (args) => {
+        const key = args.join(' ');
+        if (key === '-C /repo/.claude/worktrees/agent-a1 rev-parse --abbrev-ref HEAD') {
+          return { exitCode: 0, stdout: 'worktree-agent-a1', stderr: '' };
+        }
+        if (key === 'merge-base HEAD worktree-agent-a1') {
+          return { exitCode: 0, stdout: 'abc123', stderr: '' };
+        }
+        if (key === 'diff --diff-filter=D --name-only HEAD...worktree-agent-a1') {
+          return { exitCode: 0, stdout: 'src/shared.js', stderr: '' };
+        }
+        if (key === 'diff --name-only HEAD...worktree-agent-a2') {
+          // entry 2's branch still touches the file entry 1 deletes — genuine risk (negative space)
+          return { exitCode: 0, stdout: 'src/shared.js\nsrc/other.js', stderr: '' };
+        }
+        const clean2 = cleanEntryResponse(key, e2.branch, e2.worktree_path);
+        if (clean2) return clean2;
+        throw new Error(`unexpected git call: ${key}`);
+      },
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.entries[0].status, 'blocked');
+    assert.equal(result.entries[0].reason, 'branch_contains_deletions');
+    assert.equal(result.entries[1].status, 'merged_removed', 'entry 2 (the dependent) is independently clean and still merges');
+    assert.equal(result.entries.length, 2);
+    assert.deepEqual(result.pending, []);
+  });
+
+  test('#2852: a single-entry wave with a deletion is not blocked (no other wave member can depend on it)', () => {
+    const e1 = makeEntry('a1', 'worktree-agent-a1');
+    const plan = { ok: true, repoRoot: '/repo/main', action: 'cleanup_wave', discovery: 'manifest', entries: [e1] };
+    const result = executeWorktreeWaveCleanupPlan(plan, {
+      execGit: (args) => {
+        const key = args.join(' ');
+        if (key === '-C /repo/.claude/worktrees/agent-a1 rev-parse --abbrev-ref HEAD') {
+          return { exitCode: 0, stdout: 'worktree-agent-a1', stderr: '' };
+        }
+        if (key === 'merge-base HEAD worktree-agent-a1') {
+          return { exitCode: 0, stdout: 'abc123', stderr: '' };
+        }
+        if (key === 'diff --diff-filter=D --name-only HEAD...worktree-agent-a1') {
+          return { exitCode: 0, stdout: 'old-file.js', stderr: '' };
+        }
+        const clean = cleanEntryResponse(key, e1.branch, e1.worktree_path);
+        if (clean) return clean;
+        throw new Error(`unexpected git call: ${key}`);
+      },
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.entries[0].status, 'merged_removed');
+  });
+
+  test('#2852: a worktree_remove_failed on entry 1 does not abort entry 2', () => {
+    const e1 = makeEntry('a1', 'worktree-agent-a1');
+    const e2 = makeEntry('a2', 'worktree-agent-a2');
+    const plan = { ok: true, repoRoot: '/repo/main', action: 'cleanup_wave', discovery: 'manifest', entries: [e1, e2] };
+    const result = executeWorktreeWaveCleanupPlan(plan, {
+      execGit: (args) => {
+        const key = args.join(' ');
+        if (key === '-C /repo/.claude/worktrees/agent-a1 rev-parse --abbrev-ref HEAD') {
+          return { exitCode: 0, stdout: 'worktree-agent-a1', stderr: '' };
+        }
+        if (key === 'merge-base HEAD worktree-agent-a1') {
+          return { exitCode: 0, stdout: 'abc123', stderr: '' };
+        }
+        if (key === 'diff --diff-filter=D --name-only HEAD...worktree-agent-a1') {
+          return { exitCode: 0, stdout: '', stderr: '' };
+        }
+        if (key === '-C /repo/.claude/worktrees/agent-a1 status --porcelain --untracked-files=all') {
+          return { exitCode: 0, stdout: '', stderr: '' };
+        }
+        if (key.startsWith('merge worktree-agent-a1')) {
+          return { exitCode: 0, stdout: '', stderr: '' };
+        }
+        if (key === 'worktree unlock /repo/.claude/worktrees/agent-a1') {
+          return { exitCode: 1, stdout: '', stderr: 'not locked' };
+        }
+        if (key === 'worktree remove /repo/.claude/worktrees/agent-a1 --force') {
+          return { exitCode: 1, stdout: '', stderr: 'still locked' };
+        }
+        const clean2 = cleanEntryResponse(key, e2.branch, e2.worktree_path);
+        if (clean2) return clean2;
+        throw new Error(`unexpected git call: ${key}`);
+      },
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.entries[0].status, 'blocked');
+    assert.equal(result.entries[0].reason, 'worktree_remove_failed');
+    assert.equal(result.entries[1].status, 'merged_removed');
+    assert.deepEqual(result.pending, []);
+  });
+
+  test('#2852: a deletion_check_failed on entry 1 does not abort entry 2', () => {
+    const e1 = makeEntry('a1', 'worktree-agent-a1');
+    const e2 = makeEntry('a2', 'worktree-agent-a2');
+    const plan = { ok: true, repoRoot: '/repo/main', action: 'cleanup_wave', discovery: 'manifest', entries: [e1, e2] };
+    const result = executeWorktreeWaveCleanupPlan(plan, {
+      execGit: (args) => {
+        const key = args.join(' ');
+        if (key === '-C /repo/.claude/worktrees/agent-a1 rev-parse --abbrev-ref HEAD') {
+          return { exitCode: 0, stdout: 'worktree-agent-a1', stderr: '' };
+        }
+        if (key === 'merge-base HEAD worktree-agent-a1') {
+          return { exitCode: 0, stdout: 'abc123', stderr: '' };
+        }
+        if (key === 'diff --diff-filter=D --name-only HEAD...worktree-agent-a1') {
+          // simulate a timed-out / errored git diff for entry 1
+          return { exitCode: 1, stdout: '', stderr: 'fatal: unable to read tree', timedOut: true };
+        }
+        const clean2 = cleanEntryResponse(key, e2.branch, e2.worktree_path);
+        if (clean2) return clean2;
+        throw new Error(`unexpected git call: ${key}`);
+      },
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.entries[0].status, 'blocked');
+    assert.equal(result.entries[0].reason, 'deletion_check_failed');
+    assert.equal(result.entries[1].status, 'merged_removed');
+    assert.deepEqual(result.pending, []);
+  });
+
+  test('#2852: worktree_dirty (status query failed) on entry 1 does not abort entry 2', () => {
+    const e1 = makeEntry('a1', 'worktree-agent-a1');
+    const e2 = makeEntry('a2', 'worktree-agent-a2');
+    const plan = { ok: true, repoRoot: '/repo/main', action: 'cleanup_wave', discovery: 'manifest', entries: [e1, e2] };
+    const result = executeWorktreeWaveCleanupPlan(plan, {
+      execGit: (args) => {
+        const key = args.join(' ');
+        if (key === '-C /repo/.claude/worktrees/agent-a1 rev-parse --abbrev-ref HEAD') {
+          return { exitCode: 0, stdout: 'worktree-agent-a1', stderr: '' };
+        }
+        if (key === 'merge-base HEAD worktree-agent-a1') {
+          return { exitCode: 0, stdout: 'abc123', stderr: '' };
+        }
+        if (key === 'diff --diff-filter=D --name-only HEAD...worktree-agent-a1') {
+          return { exitCode: 0, stdout: '', stderr: '' };
+        }
+        if (key === '-C /repo/.claude/worktrees/agent-a1 status --porcelain --untracked-files=all') {
+          return { exitCode: 1, stdout: '', stderr: 'fatal: index corrupt' };
+        }
+        const clean2 = cleanEntryResponse(key, e2.branch, e2.worktree_path);
+        if (clean2) return clean2;
+        throw new Error(`unexpected git call: ${key}`);
+      },
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.entries[0].status, 'blocked');
+    assert.equal(result.entries[0].reason, 'worktree_dirty');
+    assert.equal(result.entries[1].status, 'merged_removed');
+  });
+
+  test('#2852: worktree_dirty (real dirty lines) on entry 1 does not abort entry 2', () => {
+    const e1 = makeEntry('a1', 'worktree-agent-a1');
+    const e2 = makeEntry('a2', 'worktree-agent-a2');
+    const plan = { ok: true, repoRoot: '/repo/main', action: 'cleanup_wave', discovery: 'manifest', entries: [e1, e2] };
+    const result = executeWorktreeWaveCleanupPlan(plan, {
+      execGit: (args) => {
+        const key = args.join(' ');
+        if (key === '-C /repo/.claude/worktrees/agent-a1 rev-parse --abbrev-ref HEAD') {
+          return { exitCode: 0, stdout: 'worktree-agent-a1', stderr: '' };
+        }
+        if (key === 'merge-base HEAD worktree-agent-a1') {
+          return { exitCode: 0, stdout: 'abc123', stderr: '' };
+        }
+        if (key === 'diff --diff-filter=D --name-only HEAD...worktree-agent-a1') {
+          return { exitCode: 0, stdout: '', stderr: '' };
+        }
+        if (key === '-C /repo/.claude/worktrees/agent-a1 status --porcelain --untracked-files=all') {
+          return { exitCode: 0, stdout: '?? scratch.txt', stderr: '' };
+        }
+        const clean2 = cleanEntryResponse(key, e2.branch, e2.worktree_path);
+        if (clean2) return clean2;
+        throw new Error(`unexpected git call: ${key}`);
+      },
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.entries[0].status, 'blocked');
+    assert.equal(result.entries[0].reason, 'worktree_dirty');
+    assert.equal(result.entries[1].status, 'merged_removed');
+  });
+
+  test('#2852: a summary_rescue_failed on entry 1 does not abort entry 2', () => {
+    const e1 = makeEntry('a1', 'worktree-agent-a1');
+    const e2 = makeEntry('a2', 'worktree-agent-a2');
+    const plan = { ok: true, repoRoot: '/repo/main', action: 'cleanup_wave', discovery: 'manifest', entries: [e1, e2] };
+    const result = executeWorktreeWaveCleanupPlan(plan, {
+      execGit: (args) => {
+        const key = args.join(' ');
+        if (key === '-C /repo/.claude/worktrees/agent-a1 rev-parse --abbrev-ref HEAD') {
+          return { exitCode: 0, stdout: 'worktree-agent-a1', stderr: '' };
+        }
+        if (key === 'merge-base HEAD worktree-agent-a1') {
+          return { exitCode: 0, stdout: 'abc123', stderr: '' };
+        }
+        if (key === 'diff --diff-filter=D --name-only HEAD...worktree-agent-a1') {
+          return { exitCode: 0, stdout: '', stderr: '' };
+        }
+        if (key === '-C /repo/.claude/worktrees/agent-a1 cat-file -e HEAD:.planning/q1-SUMMARY.md') {
+          return { exitCode: 128, stdout: '', stderr: "fatal: path '.planning/q1-SUMMARY.md' does not exist in 'HEAD'" };
+        }
+        const clean2 = cleanEntryResponse(key, e2.branch, e2.worktree_path);
+        if (clean2) return clean2;
+        throw new Error(`unexpected git call: ${key}`);
+      },
+      findSummaryFiles: (worktreePath) => {
+        if (worktreePath === '/repo/.claude/worktrees/agent-a1') {
+          return ['/repo/.claude/worktrees/agent-a1/.planning/q1-SUMMARY.md'];
+        }
+        return [];
+      },
+      readFileSync: () => 'summary content',
+      existsSync: () => false,
+      mkdirSync: () => {},
+      copyFileSync: () => { throw new Error('ENOSPC: no space left on device'); },
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.entries[0].status, 'blocked');
+    assert.equal(result.entries[0].reason, 'summary_rescue_failed');
+    assert.equal(result.entries[1].status, 'merged_removed');
+  });
+
+  test('#2852: an all-clean 3-entry wave still merges every entry (unchanged)', () => {
+    const e1 = makeEntry('a1', 'worktree-agent-a1');
+    const e2 = makeEntry('a2', 'worktree-agent-a2');
+    const e3 = makeEntry('a3', 'worktree-agent-a3');
+    const plan = { ok: true, repoRoot: '/repo/main', action: 'cleanup_wave', discovery: 'manifest', entries: [e1, e2, e3] };
+    const result = executeWorktreeWaveCleanupPlan(plan, {
+      execGit: (args) => {
+        const key = args.join(' ');
+        for (const e of [e1, e2, e3]) {
+          const clean = cleanEntryResponse(key, e.branch, e.worktree_path);
+          if (clean) return clean;
+        }
+        throw new Error(`unexpected git call: ${key}`);
+      },
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.entries.length, 3);
+    assert.ok(result.entries.every((e) => e.status === 'merged_removed'));
+    assert.deepEqual(result.pending, []);
+  });
+
+  test('#2852: CRLF line endings in diff output do not defeat the cross-entry overlap check', () => {
+    const e1 = makeEntry('a1', 'worktree-agent-a1');
+    const e2 = makeEntry('a2', 'worktree-agent-a2');
+    const plan = { ok: true, repoRoot: '/repo/main', action: 'cleanup_wave', discovery: 'manifest', entries: [e1, e2] };
+    const result = executeWorktreeWaveCleanupPlan(plan, {
+      execGit: (args) => {
+        const key = args.join(' ');
+        if (key === '-C /repo/.claude/worktrees/agent-a1 rev-parse --abbrev-ref HEAD') {
+          return { exitCode: 0, stdout: 'worktree-agent-a1', stderr: '' };
+        }
+        if (key === 'merge-base HEAD worktree-agent-a1') {
+          return { exitCode: 0, stdout: 'abc123', stderr: '' };
+        }
+        if (key === 'diff --diff-filter=D --name-only HEAD...worktree-agent-a1') {
+          // Windows git emits CRLF-terminated lines
+          return { exitCode: 0, stdout: 'src/shared.js\r\n', stderr: '' };
+        }
+        if (key === 'diff --name-only HEAD...worktree-agent-a2') {
+          return { exitCode: 0, stdout: 'src/shared.js\r\nsrc/other.js\r\n', stderr: '' };
+        }
+        const clean2 = cleanEntryResponse(key, e2.branch, e2.worktree_path);
+        if (clean2) return clean2;
+        throw new Error(`unexpected git call: ${key}`);
+      },
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.entries[0].status, 'blocked');
+    assert.equal(result.entries[0].reason, 'branch_contains_deletions');
   });
 });
 


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #2852

---

## What was broken

`worktree cleanup-wave` aborted the **entire remaining wave** whenever any single entry was blocked. Eight separate per-entry block sites all used the same `results.push(result); pending.push(...entries.slice(i + 1)); break;` pattern, so a problem specific to entry 1 stranded entries 2 and 3 as `pending` — untouched and never even git-checked — despite being independent worktrees on independent branches that would have merged cleanly.

## What this fix does

Scopes each per-entry block to its own entry: the entry is reported blocked with its existing reason code, and the wave continues to the next one. A genuinely repo-level failure may still halt the run, but that is now decided by inspecting actual repository state rather than by inferring it from an exit code.

## Root cause

Long-standing. `git log -S` on the `pending.push(...entries.slice(...))` pattern bottoms out at the ADR-457 `.cjs`→`.cts` migration, which was a byte-for-behavior mechanical port — so the wave-abort behavior predates that commit. The eight block sites were written as `break` from the start; nothing distinguished "this entry has a problem" from "this run cannot continue."

## Testing

### How I verified the fix

Failing-first was proven on the remote runner, not asserted: the test-only commit `a7a36201f` (a direct child of the base) returns `outcome:"failed"`; the fix tip `a79471bde` returns `outcome:"passed"`.

Coverage includes a multi-entry wave where entry 1 blocks for several different reasons and entries 2 and 3 must still reach `merged_removed`; the negative case where a deletion that genuinely should block still blocks; an ordinary `merge_failed` that never entered a merge state; and both fail-closed branches of the new state check.

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — see the scope note below
- [x] Regression test added
- [x] All existing tests pass (verified on the remote runner; `npm test` is not run locally in this repo)
- [x] `.changeset/` fragment added
- [x] No unnecessary dependencies added

**Scope note.** The issue's triage explicitly deferred the deletions-guard opt-in — *"What that opt-in should look like is a product decision, not something I'm resolving here"* — and listed it under **Out of scope**. An earlier revision of this branch implemented it anyway; that work has been **fully reverted** (commit `29253df35`, verified zero remaining occurrences of the heuristic), `branch_contains_deletions` fires unconditionally exactly as before, and the deferred product decision is tracked as **#3003**. The branch history retains the reverted commits plus an explicit `revert(#2852)` rather than being rewritten, so the reversal is auditable.

## Review

Three independent isolated passes ran, each finding what the previous could not:

1. **Over the original diff** — found the out-of-scope blocker above.
2. **After the revert** — confirmed scope was corrected, then found a second blocker: the `merge_failed` "unrecoverable" carve-out was scoped by whether `git merge --abort` **succeeded**. Abort legitimately fails with `fatal: There is no merge to abort (MERGE_HEAD missing)?` whenever no merge state was ever entered — an ordinary per-entry failure. That misclassification halted the wave, **reintroducing the exact bug this issue reports**. The branch's own test had encoded that git message as its canonical "unrecoverable" example, pinning the defect as correct behavior.
3. **Over the fix delta** — returned clean, having verified that `MERGE_HEAD` is the correct discriminator across pre-merge refusal, real conflict, and `--no-ff`, and that no unrecoverable state leaves `MERGE_HEAD` absent (it is git's definitional mid-merge marker). It confirmed the fail-closed direction on all three non-happy paths (timeout → halt, exit 0 → halt, exit 1 → continue, other → halt), that the boundary tests exercise those branches rather than asserting presence, and — decisively — that the rewritten regression test **would fail under the pre-fix logic**, making it a genuine regression test rather than pass-either-way.

## Breaking changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/3009"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788304381&installation_model_id=22188&pr_number=3009&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F3009&signature=66202c09014dd6ad26b927e37e23a903ae191a6ef1acdaf5d5c08810a7fffa83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->