### PR TITLE
fix(#2703): strip GSD-2 frontmatter with the canonical parser

### DIFF
--- a/.changeset/noble-jays-leap.md
+++ b/.changeset/noble-jays-leap.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 3027
 ---
 **GSD-2 import no longer duplicates frontmatter in the generated SUMMARY.md** — importing a GSD-2 project whose task summaries were authored with CRLF line endings emitted the original GSD-2 frontmatter a second time, as body text, below the new one. Stripping now goes through the canonical line-ending-tolerant parser. (#2703)

--- a/.changeset/noble-jays-leap.md
+++ b/.changeset/noble-jays-leap.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**GSD-2 import no longer duplicates frontmatter in the generated SUMMARY.md** — importing a GSD-2 project whose task summaries were authored with CRLF line endings emitted the original GSD-2 frontmatter a second time, as body text, below the new one. Stripping now goes through the canonical line-ending-tolerant parser. (#2703)

--- a/src/frontmatter.cts
+++ b/src/frontmatter.cts
@@ -642,22 +642,29 @@ const FRONTMATTER_SCHEMAS: Record<string, { required: string[]; requiredValues?:
 };
 
 /**
- * Strip ALL frontmatter blocks from the start of `content`.
+ * Strip frontmatter blocks from the start of `content`.
  *
- * Handles CRLF line endings and multiple stacked blocks (corruption
- * recovery): greedily strips consecutive `---...---` blocks separated by
- * optional whitespace, so a doubled/tripled frontmatter header (e.g. from a
- * botched merge) is fully removed, not just the first block.
+ * Handles CRLF line endings and, by default, multiple stacked blocks
+ * (corruption recovery): greedily strips consecutive `---...---` blocks
+ * separated by optional whitespace, so a doubled/tripled frontmatter header
+ * (e.g. from a botched merge) is fully removed, not just the first block.
+ *
+ * Pass `{ once: true }` to stop after the first block. Callers whose input is
+ * an arbitrary user-authored document — rather than a GSD artefact with a
+ * known doubling failure mode — need this: a body that opens with a
+ * thematic-break-delimited section is lexically indistinguishable from a
+ * second frontmatter block, and the greedy loop deletes it silently (#2703).
  *
  * Canonical home for this primitive (#2143 audit dedup): previously
  * duplicated byte-identically in both `state.cts` and `state-transition.cts`.
  */
-function stripFrontmatter(content: string): string {
+function stripFrontmatter(content: string, opts: { once?: boolean } = {}): string {
   let result = content;
   while (true) {
     const stripped = result.replace(/^\s*---\r?\n[\s\S]*?\r?\n---\s*/, '');
     if (stripped === result) break;
     result = stripped;
+    if (opts.once) break;
   }
   return result;
 }

--- a/src/gsd2-import.cts
+++ b/src/gsd2-import.cts
@@ -28,8 +28,11 @@ import { realClock } from './clock.cjs';
 import coreUtilsMod = require('./core-utils.cjs');
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import ioMod = require('./io.cjs');
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- frontmatter.cjs is an export= CommonJS module
+import frontmatterMod = require('./frontmatter.cjs');
 const { output } = ioMod;
 const { transliterateForSlug } = coreUtilsMod;
+const { stripFrontmatter } = frontmatterMod;
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -290,9 +293,12 @@ function buildPlanMd(task: TaskInfo, phasePrefix: string, planPrefix: string, ph
  */
 function buildSummaryMd(task: TaskInfo, phasePrefix: string, planPrefix: string): string {
   const raw = task.summary || '';
-  // Strip GSD-2 frontmatter block (--- ... ---) if present
-  const bodyMatch = raw.match(/^---[\s\S]*?---\n+([\s\S]*)$/);
-  const body = bodyMatch ? bodyMatch[1].trim() : raw.trim();
+  // Strip the GSD-2 frontmatter block via the canonical primitive (#2703). The
+  // previous local regex required a bare `\n` after the closing `---`, so a
+  // CRLF-authored summary never matched, fell through to the untouched-raw
+  // branch, and had its frontmatter emitted a second time inside the body of
+  // the document this function then wrapped in a fresh v1 block.
+  const body = stripFrontmatter(raw).trim();
 
   return [
     '---',

--- a/src/gsd2-import.cts
+++ b/src/gsd2-import.cts
@@ -298,7 +298,17 @@ function buildSummaryMd(task: TaskInfo, phasePrefix: string, planPrefix: string)
   // CRLF-authored summary never matched, fell through to the untouched-raw
   // branch, and had its frontmatter emitted a second time inside the body of
   // the document this function then wrapped in a fresh v1 block.
-  const body = stripFrontmatter(raw).trim();
+  //
+  // `extractFrontmatter` — which the issue names — returns only the parsed
+  // object and never the body, so it cannot serve this call site;
+  // `stripFrontmatter` is the same module's canonical body primitive.
+  //
+  // `once` is load-bearing. A GSD-2 summary is an arbitrary user-authored
+  // document, not a GSD artefact with a known frontmatter-doubling failure
+  // mode, so a body opening with a thematic-break-delimited section
+  // (`---` / heading / `---`) is far likelier than a corrupt second header —
+  // and the default greedy loop would delete it without a trace.
+  const body = stripFrontmatter(raw, { once: true }).trim();
 
   return [
     '---',

--- a/tests/frontmatter.unit.test.cjs
+++ b/tests/frontmatter.unit.test.cjs
@@ -21,6 +21,7 @@ const {
   extractFrontmatter,
   reconstructFrontmatter,
   spliceFrontmatter,
+  stripFrontmatter,
   noOpObjectListSetError,
   parseMustHavesBlock,
   FRONTMATTER_SCHEMAS,
@@ -1355,5 +1356,56 @@ describe('noOpObjectListSetError (#1660)', () => {
     assert.ok(msg.includes('had no effect'), msg);
     assert.ok(msg.includes('object-list'), msg);
     assert.ok(msg.includes('Edit the file directly'), msg);
+  });
+});
+
+// ─── stripFrontmatter ─────────────────────────────────────────────────────────
+
+describe('stripFrontmatter', () => {
+  const stacked = ['---', 'a: 1', '---', '---', 'b: 2', '---', '', 'Real body.'].join('\n');
+
+  test('strips a single block', () => {
+    assert.strictEqual(stripFrontmatter(['---', 'a: 1', '---', '', 'Body.'].join('\n')), 'Body.');
+  });
+
+  test('is CRLF-tolerant', () => {
+    const crlf = ['---', 'a: 1', '---', '', 'Body.'].join('\r\n');
+    assert.strictEqual(stripFrontmatter(crlf), 'Body.');
+  });
+
+  test('defaults to stripping every stacked block (corruption recovery)', () => {
+    assert.strictEqual(stripFrontmatter(stacked), 'Real body.');
+  });
+
+  test('an omitted options argument keeps the greedy default', () => {
+    // Back-compat: state.cts and state-transition.cts call this with one arg.
+    assert.strictEqual(stripFrontmatter(stacked, {}), 'Real body.');
+  });
+
+  test('once: true stops after the first block', () => {
+    assert.strictEqual(
+      stripFrontmatter(stacked, { once: true }),
+      ['---', 'b: 2', '---', '', 'Real body.'].join('\n'),
+    );
+  });
+
+  test('once: false is the greedy default', () => {
+    assert.strictEqual(stripFrontmatter(stacked, { once: false }), 'Real body.');
+  });
+
+  test('returns content unchanged when there is no frontmatter', () => {
+    const plain = ['Just prose.', '', 'More prose.'].join('\n');
+    assert.strictEqual(stripFrontmatter(plain), plain);
+    assert.strictEqual(stripFrontmatter(plain, { once: true }), plain);
+  });
+
+  test('leaves an unterminated block alone under both modes', () => {
+    const unterminated = ['---', 'a: 1', 'b: 2'].join('\n');
+    assert.strictEqual(stripFrontmatter(unterminated), unterminated);
+    assert.strictEqual(stripFrontmatter(unterminated, { once: true }), unterminated);
+  });
+
+  test('empty string round-trips', () => {
+    assert.strictEqual(stripFrontmatter(''), '');
   });
 });

--- a/tests/gsd2-import.test.cjs
+++ b/tests/gsd2-import.test.cjs
@@ -9,6 +9,7 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
 const { createTempDir, cleanup, runGsdTools } = require('./helpers.cjs');
+const fc = require('./helpers/fast-check-setup.cjs');
 
 const {
   parseSlicesFromRoadmap,
@@ -576,5 +577,133 @@ describe('gsd-tools from-gsd2 CLI', () => {
     assert.ok(fs.existsSync(path.join(tmpDir, '.planning', 'phases', '01-setup', '01-01-SUMMARY.md')));
     // S02/T01 is pending → no SUMMARY
     assert.ok(!fs.existsSync(path.join(tmpDir, '.planning', 'phases', '02-auth-system', '02-01-SUMMARY.md')));
+  });
+});
+
+// ─── SUMMARY.md frontmatter stripping (#2703) ──────────────────────────────
+
+/**
+ * The emitted artifact under test. `buildSummaryMd` is module-private;
+ * `buildPlanningArtifacts` is its only caller and is the shape `cmdFromGsd2`
+ * drives in production, so every row below asserts through that seam rather
+ * than against the private function.
+ */
+const SUMMARY_KEY = 'phases/01-setup/01-01-SUMMARY.md';
+
+function emitSummary(summary) {
+  return buildPlanningArtifacts({
+    projectContent: '# P\n',
+    requirements: null,
+    milestones: [{
+      id: 'M001',
+      title: 'Foundation',
+      slices: [{
+        done: true,
+        id: 'S01',
+        title: 'Setup',
+        tasks: [{ done: true, id: 'T01', title: 'Init', description: '', mustHaves: [], summary }],
+      }],
+    }],
+  }).get(SUMMARY_KEY);
+}
+
+/** Re-encode an LF document with CRLF line endings. */
+const crlf = (s) => s.replace(/\n/g, '\r\n');
+
+/** The whole document `buildSummaryMd` is expected to emit for a given body. */
+const expectedDoc = (body) => ['---', 'phase: "01"', 'plan: "01"', '---', '', body, ''].join('\n');
+
+describe('buildSummaryMd frontmatter stripping (#2703)', () => {
+  test('strips GSD-2 frontmatter identically under CRLF and LF (#2703)', () => {
+    const summary = ['---', 'task: T01', 'status: done', '---', '', 'The task body.'].join('\n');
+
+    // Parity is the invariant: the same logical document must emit the same
+    // artifact regardless of how its line endings were encoded. Before the fix
+    // the CRLF emission carries a second, unstripped frontmatter block.
+    assert.strictEqual(emitSummary(crlf(summary)), emitSummary(summary));
+    assert.strictEqual(emitSummary(crlf(summary)), expectedDoc('The task body.'));
+  });
+
+  test('strips a single LF frontmatter block', () => {
+    const summary = ['---', 'task: T01', '---', '', 'Body one.'].join('\n');
+    assert.strictEqual(emitSummary(summary), expectedDoc('Body one.'));
+  });
+
+  test('passes through an LF summary that has no frontmatter', () => {
+    const summary = ['Just prose.', '', 'No frontmatter here.'].join('\n');
+    assert.strictEqual(emitSummary(summary), expectedDoc(summary));
+  });
+
+  test('passes through a CRLF summary that has no frontmatter', () => {
+    const summary = ['Just prose.', '', 'No frontmatter here.'].join('\n');
+    // Body line endings are passed through untouched — stripping frontmatter
+    // must not silently re-encode the author's prose.
+    assert.strictEqual(emitSummary(crlf(summary)), expectedDoc(crlf(summary)));
+  });
+
+  test('emits no SUMMARY.md at all for an empty summary', () => {
+    // buildPlanningArtifacts guards on `task.done && task.summary`, so an empty
+    // summary produces no artifact rather than a default-bodied one.
+    assert.strictEqual(emitSummary(''), undefined);
+  });
+
+  test('falls back to the migration default for a whitespace-only summary', () => {
+    assert.strictEqual(emitSummary('   \n  \n'), expectedDoc('Task completed (migrated from GSD-2).'));
+  });
+
+  test('preserves a leading thematic break in the body', () => {
+    const summary = ['---', 'task: T01', '---', '', '---', '', 'Body after a rule.'].join('\n');
+    const body = ['---', '', 'Body after a rule.'].join('\n');
+    assert.strictEqual(emitSummary(summary), expectedDoc(body));
+    assert.strictEqual(emitSummary(crlf(summary)), expectedDoc(crlf(body)));
+  });
+
+  test('does not strip a --- that appears mid-body', () => {
+    const summary = ['Intro prose.', '', '---', '', 'More prose.'].join('\n');
+    assert.strictEqual(emitSummary(summary), expectedDoc(summary));
+  });
+
+  test('strips stacked frontmatter blocks left by a botched merge', () => {
+    const summary = ['---', 'a: 1', '---', '---', 'b: 2', '---', '', 'Real body.'].join('\n');
+    assert.strictEqual(emitSummary(summary), expectedDoc('Real body.'));
+    assert.strictEqual(emitSummary(crlf(summary)), expectedDoc('Real body.'));
+  });
+
+  test('leaves an unterminated frontmatter block as body text', () => {
+    const summary = ['---', 'task: T01', 'status: done'].join('\n');
+    assert.strictEqual(emitSummary(summary), expectedDoc(summary));
+  });
+
+  test('strips frontmatter behind a leading BOM', () => {
+    const summary = '﻿' + ['---', 'task: T01', '---', '', 'Body.'].join('\n');
+    assert.strictEqual(emitSummary(summary), expectedDoc('Body.'));
+    assert.strictEqual(emitSummary(crlf(summary)), expectedDoc('Body.'));
+  });
+
+  test('property: CRLF and LF summaries emit the same SUMMARY.md (#2703)', () => {
+    // Body lines are drawn from a charset with no `-`, so a generated body can
+    // never accidentally form a second frontmatter block.
+    const yamlKey = fc.stringMatching(/^[a-z][a-z0-9_]{0,10}$/);
+    const yamlValue = fc.stringMatching(/^[a-zA-Z0-9 ._]{1,20}$/);
+    const bodyLine = fc.stringMatching(/^[a-zA-Z0-9 ._]{1,30}$/);
+
+    fc.assert(
+      fc.property(
+        fc.array(fc.tuple(yamlKey, yamlValue), { minLength: 1, maxLength: 4 }),
+        fc.array(bodyLine, { minLength: 1, maxLength: 4 }),
+        (pairs, bodyLines) => {
+          const doc = [
+            '---',
+            ...pairs.map(([k, v]) => `${k}: ${v}`),
+            '---',
+            '',
+            ...bodyLines,
+          ].join('\n');
+          const fromLf = emitSummary(doc);
+          const fromCrlf = emitSummary(crlf(doc));
+          assert.strictEqual(fromCrlf.replace(/\r\n/g, '\n'), fromLf);
+        },
+      ),
+    );
   });
 });

--- a/tests/gsd2-import.test.cjs
+++ b/tests/gsd2-import.test.cjs
@@ -613,32 +613,34 @@ const crlf = (s) => s.replace(/\n/g, '\r\n');
 /** The whole document `buildSummaryMd` is expected to emit for a given body. */
 const expectedDoc = (body) => ['---', 'phase: "01"', 'plan: "01"', '---', '', body, ''].join('\n');
 
+/**
+ * Assert that `summary` — and its CRLF re-encoding — both emit the document
+ * built from `body`. CRLF/LF parity is the invariant this whole block exists
+ * to protect, so every row asserts it the same way rather than restating the
+ * pair by hand.
+ */
+function assertBothEncodings(summary, body) {
+  assert.strictEqual(emitSummary(summary), expectedDoc(body));
+  assert.strictEqual(emitSummary(crlf(summary)), expectedDoc(crlf(body)));
+}
+
 describe('buildSummaryMd frontmatter stripping (#2703)', () => {
   test('strips GSD-2 frontmatter identically under CRLF and LF (#2703)', () => {
     const summary = ['---', 'task: T01', 'status: done', '---', '', 'The task body.'].join('\n');
-
-    // Parity is the invariant: the same logical document must emit the same
-    // artifact regardless of how its line endings were encoded. Before the fix
-    // the CRLF emission carries a second, unstripped frontmatter block.
+    // The bug: the CRLF emission carried a second, unstripped frontmatter block.
     assert.strictEqual(emitSummary(crlf(summary)), emitSummary(summary));
-    assert.strictEqual(emitSummary(crlf(summary)), expectedDoc('The task body.'));
+    assertBothEncodings(summary, 'The task body.');
   });
 
-  test('strips a single LF frontmatter block', () => {
-    const summary = ['---', 'task: T01', '---', '', 'Body one.'].join('\n');
-    assert.strictEqual(emitSummary(summary), expectedDoc('Body one.'));
+  test('strips a single frontmatter block', () => {
+    assertBothEncodings(['---', 'task: T01', '---', '', 'Body one.'].join('\n'), 'Body one.');
   });
 
-  test('passes through an LF summary that has no frontmatter', () => {
-    const summary = ['Just prose.', '', 'No frontmatter here.'].join('\n');
-    assert.strictEqual(emitSummary(summary), expectedDoc(summary));
-  });
-
-  test('passes through a CRLF summary that has no frontmatter', () => {
-    const summary = ['Just prose.', '', 'No frontmatter here.'].join('\n');
+  test('passes through a summary that has no frontmatter', () => {
     // Body line endings are passed through untouched — stripping frontmatter
     // must not silently re-encode the author's prose.
-    assert.strictEqual(emitSummary(crlf(summary)), expectedDoc(crlf(summary)));
+    const summary = ['Just prose.', '', 'No frontmatter here.'].join('\n');
+    assertBothEncodings(summary, summary);
   });
 
   test('emits no SUMMARY.md at all for an empty summary', () => {
@@ -651,33 +653,43 @@ describe('buildSummaryMd frontmatter stripping (#2703)', () => {
     assert.strictEqual(emitSummary('   \n  \n'), expectedDoc('Task completed (migrated from GSD-2).'));
   });
 
-  test('preserves a leading thematic break in the body', () => {
+  test('preserves a lone thematic break that opens the body', () => {
     const summary = ['---', 'task: T01', '---', '', '---', '', 'Body after a rule.'].join('\n');
-    const body = ['---', '', 'Body after a rule.'].join('\n');
-    assert.strictEqual(emitSummary(summary), expectedDoc(body));
-    assert.strictEqual(emitSummary(crlf(summary)), expectedDoc(crlf(body)));
+    assertBothEncodings(summary, ['---', '', 'Body after a rule.'].join('\n'));
+  });
+
+  test('does not eat a thematic-break-delimited section that opens the body', () => {
+    // Regression guard. The canonical stripper's DEFAULT greedy loop deletes
+    // `Some Heading` outright, because `---` / text / `---` is lexically a
+    // second frontmatter block. buildSummaryMd therefore passes `once: true`.
+    // Caught by adversarial review of the first cut of this fix; the old
+    // pre-#2703 regex preserved this content, so eating it would have been a
+    // silent regression shipped alongside the CRLF fix.
+    const summary = ['---', 'task: T01', '---', '---', 'Some Heading', '---', '', 'Body content below.'].join('\n');
+    assertBothEncodings(summary, ['---', 'Some Heading', '---', '', 'Body content below.'].join('\n'));
+  });
+
+  test('strips only the first block when two frontmatter-shaped blocks lead', () => {
+    // Same `once` semantics stated for the YAML-shaped case: a GSD-2 summary is
+    // an arbitrary user document, so a second block is body content, not a
+    // corrupt duplicate header to be recovered from.
+    const summary = ['---', 'a: 1', '---', '---', 'b: 2', '---', '', 'Real body.'].join('\n');
+    assertBothEncodings(summary, ['---', 'b: 2', '---', '', 'Real body.'].join('\n'));
   });
 
   test('does not strip a --- that appears mid-body', () => {
     const summary = ['Intro prose.', '', '---', '', 'More prose.'].join('\n');
-    assert.strictEqual(emitSummary(summary), expectedDoc(summary));
-  });
-
-  test('strips stacked frontmatter blocks left by a botched merge', () => {
-    const summary = ['---', 'a: 1', '---', '---', 'b: 2', '---', '', 'Real body.'].join('\n');
-    assert.strictEqual(emitSummary(summary), expectedDoc('Real body.'));
-    assert.strictEqual(emitSummary(crlf(summary)), expectedDoc('Real body.'));
+    assertBothEncodings(summary, summary);
   });
 
   test('leaves an unterminated frontmatter block as body text', () => {
     const summary = ['---', 'task: T01', 'status: done'].join('\n');
-    assert.strictEqual(emitSummary(summary), expectedDoc(summary));
+    assertBothEncodings(summary, summary);
   });
 
   test('strips frontmatter behind a leading BOM', () => {
     const summary = '﻿' + ['---', 'task: T01', '---', '', 'Body.'].join('\n');
-    assert.strictEqual(emitSummary(summary), expectedDoc('Body.'));
-    assert.strictEqual(emitSummary(crlf(summary)), expectedDoc('Body.'));
+    assertBothEncodings(summary, 'Body.');
   });
 
   test('property: CRLF and LF summaries emit the same SUMMARY.md (#2703)', () => {


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #2703

---

## What was broken

Importing a GSD-2 project whose task summaries were authored with CRLF line endings emitted a `SUMMARY.md` containing **two** frontmatter blocks — the generated GSD v1 block, immediately followed by the original GSD-2 block sitting in the body. No error, no warning.

## What this fix does

`buildSummaryMd` no longer carries its own frontmatter-strip regex. It delegates to `stripFrontmatter` — the canonical, line-ending-tolerant primitive in `src/frontmatter.cts` — asking for a single block. CRLF input now produces exactly the result LF input has always produced.

## Root cause

`src/gsd2-import.cts` matched the closing delimiter with a hardcoded bare `\n`:

```ts
const bodyMatch = raw.match(/^---[\s\S]*?---\n+([\s\S]*)$/);
const body = bodyMatch ? bodyMatch[1].trim() : raw.trim();
```

Under CRLF the closing `---` is followed by `\r\n`, so `\n+` could not match, `bodyMatch` was `null`, and the fallback returned the summary **with its frontmatter intact**. The function then unconditionally prepended its own block. The failing branch is the same one a legitimately frontmatter-free summary takes, which is why nothing warned.

`get_timeline` shows the function carrying a single unchanged AST hash across every indexed version, so this predates the ADR-457 TypeScript migration and was carried across it verbatim — not a regression from any one commit.

### On the issue's suggested fix

The issue says to delegate to `extractFrontmatter`. That function returns only the parsed frontmatter *object* and never the body, so it cannot serve this call site. `stripFrontmatter`, exported from the same module and already the deduplicated home for this primitive (#2143), is the canonical *body* primitive and satisfies the criterion's stated intent — converge on the canonical parser, don't add a tenth hand-rolled variant. The reasoning is recorded in a comment at the call site so it isn't re-litigated.

### Why `{ once: true }`

The first cut of this fix used `stripFrontmatter`'s greedy default, which loops to strip stacked blocks. Adversarial review caught that this **silently deletes real body content**: a summary whose body opens with a thematic-break-delimited section (`---` / heading / `---`) had that section removed, where the old regex preserved it.

`stripFrontmatter` gains an explicit `{ once?: boolean }` option — default unchanged, all 19 existing call sites in `state.cjs` / `state-transition.cjs` pass a single argument and keep the greedy loop — and `buildSummaryMd` opts in. That is the correct semantic here: the loop exists for GSD-written artifacts with a known merge-doubling failure mode, whereas a GSD-2 summary is an arbitrary user document where a second `---…---` is far likelier to be prose.

## Testing

### How I verified the fix

Failing-first, on the remote runner. Tests were committed **without** the fix at `d6bd2c0945babc33906984b8707e61163680e94e` and verified RED:

```json
{"type":"verdict","outcome":"failed",
 "per_os":{"linux-node22":{"passed":29754,"failed":6,"total":29760,"outcome":"failed"},
           "linux-node24":{"passed":29754,"failed":6,"total":29760,"outcome":"failed"}},
 "unique_failures":6}
```

All 6 unique failures were in `tests/gsd2-import.test.cjs`, all inside the new `buildSummaryMd frontmatter stripping (#2703)` block. The full suite is green on the shipped commit.

Coverage added to `tests/gsd2-import.test.cjs` (the owning module's existing suite — no new `bug-*` file):

- CRLF/LF parity on the reported shape, plus a `fast-check` property test (seed 42, 200 runs) asserting parity holds for arbitrary frontmatter × body documents.
- Boundary coverage on leading block count: 0, 1, 2.
- Preservation guards for everything that must **not** change: no-frontmatter passthrough (body line endings included), empty and whitespace-only summaries, a lone leading thematic break, a paired `---`/text/`---` section, `---` appearing mid-body, and an unterminated block.
- A leading BOM before the opening `---` — which also defeated the old anchor.

`tests/frontmatter.unit.test.cjs` gains direct coverage of the new option: greedy with no argument, with `{}`, and with `{ once: false }`; single-block with `{ once: true }`; plus no-frontmatter, unterminated, and empty-string cases under both modes.

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

Linux node22 + node24 via the remote runner matrix; macOS locally. The change is pure string handling with no path or platform dependency, but it is line-ending-sensitive by nature, so both encodings are asserted explicitly rather than left to the checkout's `core.autocrlf`.

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass
- [x] `.changeset/` fragment added if this is a user-facing fix
- [x] No unnecessary dependencies added

## Breaking changes

None for callers of `stripFrontmatter`: the new parameter is optional and the default is byte-identical to today's behavior, verified by dedicated back-compat tests and by confirming every existing call site passes exactly one argument.

One deliberate behavior change in the emitted artifact, scoped to `from-gsd2`: a summary with a leading BOM, or authored with CRLF, is now stripped where it previously was not. That is the bug being fixed. LF summaries without a BOM emit byte-identical output to before.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/3027"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788374517&installation_model_id=22188&pr_number=3027&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F3027&signature=4b1e043b04f8e1ac728270d74493fd3697eaa3793f4024a34cf39d11054a427e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->