### PR TITLE
docs(#3037): record OMP first-class runtime support as out-of-scope

### DIFF
--- a/.out-of-scope/omp-runtime-in-core.md
+++ b/.out-of-scope/omp-runtime-in-core.md
@@ -1,0 +1,69 @@
+# OMP (Oh My Pi) as a first-class runtime in gsd-core
+
+gsd-core does not add `omp` (Oh My Pi) as a first-class runtime: no
+`capabilities/omp/capability.json`, no `omp` entry in the runtime registry, no
+`omp` alias canonicalization, and no installer runtime selection for it.
+
+This is a **scope** decision, not a judgement about OMP or about the quality of
+the proposals that have asked for it.
+
+## Why this is out of scope
+
+- **GSD is not expanding its supported-runtime set.** The long-term direction is
+  to *reduce* the number of supported runtimes, not grow it, absent funded
+  development. Each first-class runtime is a permanent maintenance obligation
+  across the registry, installer, artifact conversion, agent discovery, model
+  routing, dispatch isolation, golden install-parity fixtures, and localized
+  capability matrices — carried indefinitely by the project, for a host it does
+  not control.
+- **Host integration is the supported direction, and it is already available.**
+  The Embeddable Orchestration System (ADR-1239) exists precisely so a host can
+  embed GSD and declare its own capabilities, instead of GSD resolving the host
+  from an in-tree registry. An out-of-tree host plugin needs no runtime
+  descriptor. `GSD_AGENTS_DIR` is a documented Priority-1 override honored for
+  *any* runtime name (`src/agent-install-check.cts`, `getAgentsDir`), so a plugin
+  can own its filesystem layout without core knowing the runtime exists.
+- **The ask as filed also carried a defect.** #3037 proposed canonicalizing
+  `pi`, `oh-my-pi` and `pi-coding-agent` to `omp`. OMP is a *fork* of pi
+  (pi.dev), and gsd-core already ships a distinct `pi` runtime
+  ([`capabilities/pi/capability.json`](../capabilities/pi/capability.json), home
+  `~/.pi/agent`, tier 2). That alias list would relocate an existing shipped
+  runtime's config home rather than add a new one. This is recorded so a future
+  revision does not repeat it — it is a correction, not an additional ground for
+  the decision.
+
+## What this does NOT cover
+
+This entry denies **in-tree, first-class runtime registration for OMP**. It does
+not deny, and should never be cited against:
+
+- **Shipping an out-of-tree host plugin for OMP, or for any other host.** This
+  is welcome and supported. `gsd-omp` is already listed in
+  [`docs/registries/eos.json`](../docs/registries/eos.json) and remains listed;
+  registry inclusion is explicitly non-endorsement and is unaffected by this
+  decision.
+- **Feature capabilities** (`role: "feature"`) published out-of-tree under
+  ADR-1244. That is a different axis — *what loop behavior you add*, not *which
+  runtime you are*.
+- **Fixing defects that happen to surface through a non-registered runtime**, or
+  improving the documented override contracts a host plugin depends on.
+- **Any other runtime's support tier.** This entry is about OMP specifically and
+  says nothing about existing runtimes, including `pi`.
+
+**Revisit if** third-party `role: "runtime"` descriptors become loadable from
+outside the repo — ADR-857 D8 defers this to a purely additive external loader
+that has not been delivered — or if funded development changes the maintenance
+calculus that makes an additional first-class runtime unaffordable.
+
+## Prior requests
+
+- #874 — "feat: Native OMP (Oh My Pi) Runtime Support" (closed not planned,
+  2026-06-08)
+- #1948 — "Add Oh My Pi / OMP as a supported runtime" (closed as duplicate of
+  #874)
+- #1947 — implementation PR for #874 (closed unmerged)
+- #3037 — "feat: complete first-class OMP runtime descriptor and registry
+  integration" (closed not planned; the decision this entry records)
+
+*The first denial was never written down here, so the same request returned
+twice more. That is the reason this file exists.*


### PR DESCRIPTION
<!-- pr-template-exempt: doc-only — adds one `.out-of-scope/` knowledge-base document. No code, no runtime-loaded text, no behavior change. -->

Records the maintainer's decision that gsd-core will not add OMP (Oh My Pi) as a first-class
runtime, so the decision is discoverable by the `.out-of-scope/` prior-denial check instead of
living only in a closed issue.

Closes #3037

## Why this exists

The request has now been raised three times — #874 (closed not planned, 2026-06-08), #1948
(closed as its duplicate), and #3037 — because the original denial was recorded only in a closed
issue comment. `/triage-review`'s prior-denial step greps `.out-of-scope/`, so it never saw the
earlier decision and the ask was re-litigated from scratch each time. This entry closes that gap.

## What the entry records

Two grounds, kept distinct:

1. **The standing scope decision** — GSD is not expanding its supported-runtime set, and the
   direction is to reduce it absent funded development. Each first-class runtime is a permanent
   obligation across registry, installer, artifact conversion, agent discovery, model routing,
   dispatch isolation, golden fixtures and localized matrices.
2. **A correction to the ask as filed** — #3037 proposed canonicalizing `pi`, `oh-my-pi` and
   `pi-coding-agent` to `omp`. OMP is a *fork* of pi (pi.dev), and gsd-core already ships a
   distinct `pi` runtime (`capabilities/pi/capability.json`, home `~/.pi/agent`, tier 2), so that
   alias list would relocate a shipped runtime's config home rather than add a new one. Recorded
   as a correction, explicitly **not** as an additional ground for the denial.

The entry carries a **What this does NOT cover** section, because this KB's sharpest failure mode
is a future keyword match ("omp", "runtime", "plugin") applying an entry too broadly. It states
that out-of-tree host plugins remain welcome, that `gsd-omp`'s existing `docs/registries/eos.json`
listing is unaffected, and that ADR-1244 feature capabilities are a different axis.

**Revisit-if** is a checkable condition, not a judgement call: third-party `role: "runtime"`
descriptors becoming loadable from outside the repo — ADR-857 D8 defers this to an external
loader that has not been delivered — or funded development changing the maintenance calculus.

## Gates

| Gate | Result |
|---|---|
| `npm run lint:ci` | exit 0 |
| `GITHUB_BASE_REF=next node scripts/changeset/lint.cjs` | `ok_no_user_facing_changes` |
| `GITHUB_BASE_REF=next node scripts/lint-docs-required.cjs` | `ok_no_triggering_fragments` |
| Remote suite | pass recorded for `68d07cec382359eda39ca350e727e9f14c1a452d` |

`lint:ci` initially reported red on a stale `docs/INVENTORY-MANIFEST.json`. The error's suggested
remedy (`gen-inventory-manifest.cjs --write`) would have deleted 13 real modules from the
manifest. Root cause was a stale `tsconfig.build.tsbuildinfo` leaving incremental `tsc` reporting
success while emitting nothing, so `gsd-core/bin/lib` held 169 of 176 modules. Clearing it and
rebuilding restored the count and greened the gate — local build state, not a defect on `next`.

Orthogonal code/security review was not run: `CLAUDE.md` scopes that requirement to bug-fix and
feature changes, and this is a knowledge-base document. The entry's factual claims (ADR-1239,
ADR-857 D8, ADR-1244, the `getAgentsDir` Priority-1 override contract, the `pi` capability
descriptor, the `eos.json` listing, and the four referenced issue states) were each verified
against the repo and the tracker while drafting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/3048"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788457295&installation_model_id=22188&pr_number=3048&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F3048&signature=44acbb192bb71271c24e61f8088436fb85f6a94616dc89c1e7e3f709af35d760"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->