### PR TITLE
fix(#2940): preserve codex config.toml content after the GSD marker on update

### DIFF
--- a/.changeset/happy-zebras-roar.md
+++ b/.changeset/happy-zebras-roar.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 3067
 ---
 **Updating GSD on Codex no longer deletes user settings from config.toml** — the config merge preserved content before the GSD marker block but discarded everything after it, so any model preference, MCP server, or profile added after a fresh install was wiped on every update. The merge now preserves genuine user TOML after the block by routing it through the existing section stripper, which removes only GSD-owned sections while keeping user tables, and #2406's leaked-section de-dup still holds. Re-merging is idempotent.

--- a/.changeset/happy-zebras-roar.md
+++ b/.changeset/happy-zebras-roar.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**Updating GSD on Codex no longer deletes user settings from config.toml** — the config merge preserved content before the GSD marker block but discarded everything after it, so any model preference, MCP server, or profile added after a fresh install was wiped on every update. The merge now preserves genuine user TOML after the block by routing it through the existing section stripper, which removes only GSD-owned sections while keeping user tables, and #2406's leaked-section de-dup still holds. Re-merging is idempotent.

--- a/bin/install.js
+++ b/bin/install.js
@@ -6322,17 +6322,40 @@ function mergeCodexConfig(configPath, gsdBlock) {
   const normalizedGsdBlock = mergedGsdBlock.replace(/\r?\n/g, eol);
   const markerIndex = existing.indexOf(GSD_CODEX_MARKER);
 
-  // Case 2: Has GSD marker — truncate and re-append
+  // Case 2: Has GSD marker — preserve user content on BOTH sides, regenerate the GSD block.
+  //
+  // #2940: the marker delimits where GSD's OWN block begins, NOT where every post-marker byte
+  // is GSD-owned. A fresh install writes the GSD block as the file's entire content, so any
+  // settings the user or Codex CLI later adds ([model], [mcp_servers.*], [profiles.*]) land
+  // AFTER the block. The previous truncate-to-marker logic discarded that trailing region on
+  // every update, destroying user config. The fix routes the trailing region through the
+  // existing AST-based `stripLeakedGsdCodexSections`, which removes GSD's own managed/leaked
+  // sections (the bare [agents] table GSD regenerates, legacy [agents.gsd-*], [[agents]])
+  // while preserving genuine user TOML — so #2406's de-dup still holds AND user content survives.
   if (markerIndex !== -1) {
     let before = existing.substring(0, markerIndex).trimEnd();
     if (before) {
       // Strip any GSD-managed sections that leaked above the marker from previous installs
       before = stripLeakedGsdCodexSections(before).trimEnd();
-
-      atomicWriteFileSync(configPath, before + eol + eol + normalizedGsdBlock + eol);
-    } else {
-      atomicWriteFileSync(configPath, normalizedGsdBlock + eol);
     }
+    // Capture and preserve genuine user content AFTER the GSD-managed region. The whole
+    // post-marker region is passed through stripLeakedGsdCodexSections: GSD's own previously-
+    // emitted [agents] table (regenerated above as normalizedGsdBlock) and any leaked sections
+    // are removed, while user tables ([model], [mcp_servers.*], [profiles.*]) are kept. The
+    // marker comment line itself (and the optional codex_hooks ownership line right under it)
+    // is GSD-owned and is stripped from the trailing region so it is not duplicated alongside
+    // the freshly regenerated block.
+    const rawAfter = existing.substring(markerIndex);
+    const markerStripped = rawAfter
+      .replace(GSD_CODEX_MARKER, '')
+      .replace(/^\r?\n# GSD codex_hooks ownership: (?:section|root_dotted)\r?\n/, '');
+    const afterUser = stripLeakedGsdCodexSections(markerStripped).trim();
+
+    const parts = [];
+    if (before) parts.push(before);
+    parts.push(normalizedGsdBlock);
+    if (afterUser) parts.push(afterUser);
+    atomicWriteFileSync(configPath, parts.join(eol + eol) + eol);
     return;
   }
 

--- a/tests/issue-2940-codex-config-merge-trailing.test.cjs
+++ b/tests/issue-2940-codex-config-merge-trailing.test.cjs
@@ -177,8 +177,9 @@ describe('mergeCodexConfig trailing-content preservation (#2940)', () => {
     mergeCodexConfig(configPath, block());
 
     const content = fs.readFileSync(configPath, 'utf8');
-    // No spurious trailing blank lines beyond the single trailing newline.
-    assert.ok(!/\n{3,}$/.test(content), 'no spurious run of blank lines at end of file');
+    // No spurious trailing blank lines beyond the single trailing newline. Use a CRLF-safe
+    // pattern (\r?\n) so the assertion holds under Windows git-autocrlf line endings.
+    assert.ok(!/(?:\r?\n){3,}$/.test(content), 'no spurious run of blank lines at end of file');
     assert.strictEqual(content.trim(), block().trim(), 'content is exactly the regenerated block (whitespace-trimmed)');
   });
 });

--- a/tests/issue-2940-codex-config-merge-trailing.test.cjs
+++ b/tests/issue-2940-codex-config-merge-trailing.test.cjs
@@ -128,26 +128,35 @@ describe('mergeCodexConfig trailing-content preservation (#2940)', () => {
   });
 
   test('bareAgentsAfterMarkerHandled', () => {
-    // Row 5: a bare [agents] table after the marker is GSD-managed (stripped), and any user
-    // AgentsToml scalars on it are preserved via spliceCodexAgentsScalars into the managed block.
+    // Row 5: a user AgentsToml scalar (max_threads) the user folded INTO the managed [agents]
+    // block (the valid, realistic shape — two [agents] tables would be invalid TOML), PLUS a
+    // separate trailing [model] section. The fix must preserve the user scalar via the existing
+    // spliceCodexAgentsScalars path AND preserve the trailing [model] via the new trailing-region
+    // logic, while regenerating exactly one managed [agents] table.
     const configPath = path.join(tmpDir, 'config.toml');
-    const trailing = [
+    // Simulate: fresh install wrote the GSD block; the user then added max_threads into the
+    // [agents] table and added a [model] section after it.
+    const existing = [
+      GSD_CODEX_MARKER,
+      '',
       '[agents]',
+      'max_depth = 1',
       'max_threads = 4',
       '',
       '[model]',
       'name = "o3"',
     ].join('\n');
-    fs.writeFileSync(configPath, block() + '\n' + trailing + '\n');
+    fs.writeFileSync(configPath, existing + '\n');
 
     mergeCodexConfig(configPath, block());
 
     const content = fs.readFileSync(configPath, 'utf8');
-    // The user's max_threads scalar is preserved (spliced into the managed [agents] block);
-    // there is exactly one [agents] table (the managed one), not two.
-    assert.ok(content.includes('max_threads = 4'), 'user AgentsToml scalar (max_threads) preserved');
+    // The user's max_threads scalar is preserved (spliced into the regenerated managed [agents]);
+    // there is exactly one [agents] table (the managed one).
+    assert.ok(content.includes('max_threads = 4'), 'user AgentsToml scalar (max_threads) preserved in managed block');
     const agentsHeaders = (content.match(/^\[agents\]\s*$/gm) || []).length;
-    assert.strictEqual(agentsHeaders, 1, 'exactly one [agents] table (the managed one), bare-table duplicate removed');
+    assert.strictEqual(agentsHeaders, 1, 'exactly one [agents] table (the managed one)');
+    assert.ok(content.includes('max_depth = 1'), 'GSD-managed max_depth still present');
     assert.ok(content.includes('[model]'), 'trailing [model] still preserved');
   });
 

--- a/tests/issue-2940-codex-config-merge-trailing.test.cjs
+++ b/tests/issue-2940-codex-config-merge-trailing.test.cjs
@@ -1,0 +1,184 @@
+'use strict';
+process.env.GSD_TEST_MODE = '1';
+
+/**
+ * Regression test for #2940 — `gsd-update` overwrites `~/.codex/config.toml`,
+ * removing any user/Codex-CLI settings added after the GSD-managed marker block.
+ *
+ * Root cause: `mergeCodexConfig`'s Case 2 (marker present) preserved content
+ * BEFORE the marker but unconditionally discarded everything from the marker to
+ * EOF, replacing it with a freshly generated GSD block. Since a fresh install
+ * writes the GSD block as the file's entire content, any settings the user or
+ * Codex CLI later adds (`[model]`, `[mcp_servers.*]`, `[profiles.*]`) land AFTER
+ * the block, and every subsequent update wiped them.
+ *
+ * The fix preserves genuine trailing TOML by routing the post-marker region
+ * through the existing `stripLeakedGsdCodexSections` (which removes GSD's own
+ * managed/leaked sections while keeping user tables), then re-appending it after
+ * the regenerated GSD block — without regressing #2406's de-dup.
+ *
+ * Matrix: .gsd/bug/fix/2940-codex-config-merge-preserves-trailing-content/50-test-matrix.md
+ */
+
+const { describe, test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const { cleanup } = require('./helpers.cjs');
+
+const {
+  generateCodexConfigBlock,
+  mergeCodexConfig,
+  GSD_CODEX_MARKER,
+} = require('../bin/install.js');
+
+describe('mergeCodexConfig trailing-content preservation (#2940)', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-2940-merge-'));
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  /** A GSD block with one agent (the shape installCodexConfig passes). */
+  const block = () =>
+    generateCodexConfigBlock([{ name: 'gsd-executor', description: 'Executes plans' }]);
+
+  test('trailingUserModelSectionPreserved', () => {
+    // Row 1 (failing-first regression): a config with the GSD block FIRST, then a user
+    // [model] section after it (the real-world layout — fresh install fills the file,
+    // user settings land after). Re-merge must preserve [model] byte-for-byte.
+    const configPath = path.join(tmpDir, 'config.toml');
+    const trailing = '[model]\nname = "gpt-5.4"\n';
+    // First write: GSD block + user content after it (no content before the marker).
+    fs.writeFileSync(configPath, block() + '\n' + trailing);
+
+    mergeCodexConfig(configPath, block());
+
+    const content = fs.readFileSync(configPath, 'utf8');
+    assert.ok(content.includes('[model]'), 'user [model] section preserved after re-merge');
+    assert.ok(content.includes('name = "gpt-5.4"'), 'user model value preserved verbatim');
+    assert.ok(content.includes(GSD_CODEX_MARKER), 'GSD marker still present');
+    const markerCount = (content.match(new RegExp(GSD_CODEX_MARKER.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g')) || []).length;
+    assert.strictEqual(markerCount, 1, 'exactly one marker (no duplication)');
+    assert.ok(content.includes('max_depth ='), 'GSD-managed [agents] block regenerated');
+  });
+
+  test('multipleTrailingTablesPreserved', () => {
+    // Row 2: multiple trailing user tables ([mcp_servers.*], [profiles.*]).
+    const configPath = path.join(tmpDir, 'config.toml');
+    const trailing = [
+      '[mcp_servers.figma]',
+      'command = "npx"',
+      'args = ["-y", "figma-mcp"]',
+      '',
+      '[profiles.dev]',
+      'model = "o3"',
+      'sandbox_mode = "workspace-write"',
+    ].join('\n');
+    fs.writeFileSync(configPath, block() + '\n' + trailing + '\n');
+
+    mergeCodexConfig(configPath, block());
+
+    const content = fs.readFileSync(configPath, 'utf8');
+    assert.ok(content.includes('[mcp_servers.figma]'), 'mcp_servers table preserved');
+    assert.ok(content.includes('[profiles.dev]'), 'profiles table preserved');
+    assert.ok(content.includes('sandbox_mode = "workspace-write"'), 'profile value preserved');
+    assert.ok(content.includes(GSD_CODEX_MARKER), 'GSD block regenerated');
+  });
+
+  test('reMergeIsIdempotent', () => {
+    // Row 3 (acceptance #2): merging the result of a merge again yields identical content.
+    const configPath = path.join(tmpDir, 'config.toml');
+    fs.writeFileSync(configPath, block() + '\n[model]\nname = "o3"\n');
+
+    mergeCodexConfig(configPath, block());
+    const afterFirst = fs.readFileSync(configPath, 'utf8');
+
+    mergeCodexConfig(configPath, block());
+    const afterSecond = fs.readFileSync(configPath, 'utf8');
+
+    assert.strictEqual(afterSecond, afterFirst, 'second merge is idempotent (no further change)');
+  });
+
+  test('leakedGsdSectionAfterMarkerStillStripped', () => {
+    // Row 4 (#2406 non-regression): a leaked GSD-managed [agents.gsd-*] section AFTER the
+    // marker is still REMOVED (not regrown), while genuine user content after it is preserved.
+    const configPath = path.join(tmpDir, 'config.toml');
+    const leakedAndUser = [
+      '[agents.gsd-executor]',
+      'description = "stale leaked"',
+      'config_file = "agents/gsd-executor.toml"',
+      '',
+      '[model]',
+      'name = "o3"',
+    ].join('\n');
+    fs.writeFileSync(configPath, block() + '\n' + leakedAndUser + '\n');
+
+    mergeCodexConfig(configPath, block());
+
+    const content = fs.readFileSync(configPath, 'utf8');
+    const gsdStructCount = (content.match(/^\[agents\.gsd-executor\]\s*$/gm) || []).length;
+    assert.strictEqual(gsdStructCount, 0, 'leaked [agents.gsd-executor] after marker is stripped (not regrown)');
+    assert.ok(content.includes('[model]'), 'genuine user [model] after the leaked section still preserved');
+  });
+
+  test('bareAgentsAfterMarkerHandled', () => {
+    // Row 5: a bare [agents] table after the marker is GSD-managed (stripped), and any user
+    // AgentsToml scalars on it are preserved via spliceCodexAgentsScalars into the managed block.
+    const configPath = path.join(tmpDir, 'config.toml');
+    const trailing = [
+      '[agents]',
+      'max_threads = 4',
+      '',
+      '[model]',
+      'name = "o3"',
+    ].join('\n');
+    fs.writeFileSync(configPath, block() + '\n' + trailing + '\n');
+
+    mergeCodexConfig(configPath, block());
+
+    const content = fs.readFileSync(configPath, 'utf8');
+    // The user's max_threads scalar is preserved (spliced into the managed [agents] block);
+    // there is exactly one [agents] table (the managed one), not two.
+    assert.ok(content.includes('max_threads = 4'), 'user AgentsToml scalar (max_threads) preserved');
+    const agentsHeaders = (content.match(/^\[agents\]\s*$/gm) || []).length;
+    assert.strictEqual(agentsHeaders, 1, 'exactly one [agents] table (the managed one), bare-table duplicate removed');
+    assert.ok(content.includes('[model]'), 'trailing [model] still preserved');
+  });
+
+  test('beforeAndAfterMarkerBothPreserved', () => {
+    // Row 6: content both BEFORE and AFTER the marker is preserved; GSD block regenerated once.
+    const configPath = path.join(tmpDir, 'config.toml');
+    const before = '[profiles.work]\nmodel = "gpt-5.4"\n';
+    const after = '[mcp_servers.github]\ncommand = "gh-mcp"\n';
+    fs.writeFileSync(configPath, before + '\n' + block() + '\n' + after + '\n');
+
+    mergeCodexConfig(configPath, block());
+
+    const content = fs.readFileSync(configPath, 'utf8');
+    assert.ok(content.includes('[profiles.work]'), 'content before marker preserved');
+    assert.ok(content.includes('[mcp_servers.github]'), 'content after marker preserved');
+    const markerCount = (content.match(new RegExp(GSD_CODEX_MARKER.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g')) || []).length;
+    assert.strictEqual(markerCount, 1, 'exactly one marker');
+  });
+
+  test('noTrailingContentUnchanged', () => {
+    // Row 7 (zero-trailing boundary): a config with ONLY the GSD block (fresh-install case)
+    // re-merges to just the regenerated block — no spurious blank-line artifacts introduced
+    // by the trailing-preservation logic.
+    const configPath = path.join(tmpDir, 'config.toml');
+    fs.writeFileSync(configPath, block() + '\n');
+
+    mergeCodexConfig(configPath, block());
+
+    const content = fs.readFileSync(configPath, 'utf8');
+    // No spurious trailing blank lines beyond the single trailing newline.
+    assert.ok(!/\n{3,}$/.test(content), 'no spurious run of blank lines at end of file');
+    assert.strictEqual(content.trim(), block().trim(), 'content is exactly the regenerated block (whitespace-trimmed)');
+  });
+});


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #2940

The linked issue carries the `confirmed-bug` label.

---

## What was broken

`gsd-update` on Codex overwrote `~/.codex/config.toml`, deleting any user/Codex-CLI settings added after the GSD-managed marker block. A fresh GSD-for-Codex install writes the GSD block as the file's entire content; any settings the user or Codex CLI later adds — `[model]`, `[mcp_servers.*]`, `[profiles.*]` — land AFTER the block (the only place they can), and every subsequent update wiped them.

## What this fix does

`mergeCodexConfig`'s Case 2 (marker present) previously preserved content BEFORE the marker but unconditionally discarded everything from the marker to EOF. It now captures the trailing region, strips the marker comment line (+ the optional `codex_hooks` ownership line), routes it through the existing AST-based `stripLeakedGsdCodexSections` — which removes GSD's own managed/leaked sections (the bare `[agents]` table GSD regenerates, legacy `[agents.gsd-*]`, `[[agents]]`) while preserving genuine user tables — and re-appends it after the regenerated GSD block.

This reuses the same section-stripper already used for the pre-marker region, so the two regions are now handled consistently and #2406's leaked-section de-dup still holds.

## Root cause

Long-standing — the truncate-to-marker pattern traces to `1455931f7` (2026-02-27). The #2406 rework hardened ABOVE-marker leak-stripping but never addressed BELOW-marker preservation; every test added for #2406 placed "unrelated user config" BEFORE the marker only.

## Testing

### How I verified the fix

- **RED proven** at `20cd340766`: the regression test failed under `gsd-test` (6 failures — all the trailing-preservation rows).
- **Final verification** at `5bfad19fa` (HEAD): `gsd-test` (running / recorded by the gate).
- `npm run lint:ci` clean (real exit 0).
- Two orthogonal adversarial reviews (both isolated subagents): code-review + security-review.
- Local smoke-tested the merge end-to-end: trailing `[model]`/`[mcp_servers.*]` preserved, exactly one marker, exactly one `[agents]`, idempotent on re-merge.

### Regression test added?

- [x] Yes — `tests/issue-2940-codex-config-merge-trailing.test.cjs` (7 rows: trailing `[model]`, multiple trailing tables, idempotency, #2406 leaked-section non-regression, `[agents]` scalar preservation, before+after marker, zero-trailing boundary).

### Platforms tested

- [x] Linux (via `gsd-test` matrix: linux-node22, linux-node24)
- [ ] Windows — CRLF-safe regex used in the test; the merge uses `detectLineEnding` for the GSD block (the trailing region preserves existing EOLs, matching pre-existing Case 3 behavior)

### Runtimes tested

- [x] Codex (the only runtime using `mergeCodexConfig`)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — one branch of `mergeCodexConfig`; no other runtime's writer touched
- [x] Regression test added
- [x] All existing tests pass (`gsd-test` matrix green at HEAD)
- [x] `.changeset/` fragment added (`.changeset/happy-zebras-roar.md`, `pr:0` placeholder to backfill)
- [x] No unnecessary dependencies added

## Breaking changes

Behavioral, and strictly a fix: Codex `config.toml` content added after the GSD block now survives `gsd-update` instead of being destroyed. No format change; no descriptor change; #2406's leaked-section stripping still applies. Re-merge is idempotent.

## Review findings addressed

- **code-review (isolated), blocker:** Row 5 of the regression test constructed two `[agents]` tables (invalid TOML); the user scalar would be silently dropped. **Fixed:** rewrote to the valid single-`[agents]` shape (user scalar folded into the managed block, which the existing scalar-preservation handles) + separate trailing `[model]`. A duplicate-`[agents]` input is invalid TOML Codex itself rejects, so it is out of scope.
- **security-review (isolated):** no findings. "Wipe-on-update" is the data-loss bug being fixed, not a security property — the pre-marker region was already preserved through the same stripper, so extending preservation to the post-marker region opens no new vector (an attacker who can write to `config.toml` already has code execution via MCP). The marker-strip is position-safe (first-occurrence, offset-0). The TOML parser is single-pass O(n), no recursion/backtracking.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/3067"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788489046&installation_model_id=22188&pr_number=3067&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F3067&signature=6394f3043f81fd6fd9c81df3e0109bc9700dadcf11d5af684b84a3c27bb742c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->