### PR TITLE
fix(#2949): exclude sentinel phase ids from stage-3 next-phase candidacy

### DIFF
--- a/.changeset/tidy-newts-roar.md
+++ b/.changeset/tidy-newts-roar.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 3070
 ---
 **Completing the last phase of a milestone no longer advances into a 0.x backlog sentinel row** — the phase-completion cascade's lowest-outstanding-phase override had no sentinel filter, so an unchecked backlog row like Phase 0.1 sorted below every real phase and was selected as the next phase, corrupting STATE.md and desyncing the current phase number from its name. The override now excludes sentinel-range phase ids via the existing isSentinelPhaseId predicate, so a real lower-numbered outstanding phase is still selected while backlog sentinels are skipped and the milestone completes cleanly.

--- a/.changeset/tidy-newts-roar.md
+++ b/.changeset/tidy-newts-roar.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**Completing the last phase of a milestone no longer advances into a 0.x backlog sentinel row** — the phase-completion cascade's lowest-outstanding-phase override had no sentinel filter, so an unchecked backlog row like Phase 0.1 sorted below every real phase and was selected as the next phase, corrupting STATE.md and desyncing the current phase number from its name. The override now excludes sentinel-range phase ids via the existing isSentinelPhaseId predicate, so a real lower-numbered outstanding phase is still selected while backlog sentinels are skipped and the milestone completes cleanly.

--- a/src/phase.cts
+++ b/src/phase.cts
@@ -35,6 +35,7 @@ const {
   phaseMarkdownRegexSource,
   comparePhaseNum,
   phaseTokenMatches,
+  isSentinelPhaseId,
   OPTIONAL_PROJECT_CODE_PREFIX_SOURCE,
   OPTIONAL_PHASE_TAG_SOURCE,
   PHASE_NUMBER_TOKEN_SOURCE,
@@ -2574,7 +2575,14 @@ function cmdPhaseComplete(cwd: string, phaseNum: string, raw: boolean): void {
           let lowestOutstanding: { num: string; name: string } | null = null;
           while ((cbm = cbPattern.exec(milestoneScope)) !== null) {
             const isChecked = cbm[1].toLowerCase() === 'x';
-            if (!isChecked && comparePhaseNum(cbm[2], phaseNum) < 0) {
+            // #2949: exclude sentinel-range phase ids (0.x backlog, 999.x) from candidacy.
+            // comparePhaseNum("0.1","12") === -12, so without this guard an unchecked 0.x
+            // backlog row sorts below every real phase and is wrongly selected as next_phase,
+            // corrupting STATE.md and desyncing current_phase from current_phase_name.
+            // isSentinelPhaseId covers both sentinel ranges (SENTINEL_RANGES = [0, 999]); a
+            // real lower-numbered outstanding phase (e.g. Phase 9) is NOT a sentinel and is
+            // still selected, preserving #2028's out-of-order-completion behavior.
+            if (!isChecked && !isSentinelPhaseId(cbm[2]) && comparePhaseNum(cbm[2], phaseNum) < 0) {
               if (lowestOutstanding === null || comparePhaseNum(cbm[2], lowestOutstanding.num) < 0) {
                 lowestOutstanding = {
                   num: cbm[2],

--- a/tests/issue-2949-phase-complete-stage3-sentinel.test.cjs
+++ b/tests/issue-2949-phase-complete-stage3-sentinel.test.cjs
@@ -138,8 +138,10 @@ describe('phase complete stage-3 sentinel filter (#2949)', () => {
     const output = JSON.parse(result.output);
 
     // A real lower phase (9) IS selected — the #2028 out-of-order behavior is preserved.
+    // next_phase may be padded ("09") or unpadded ("9"); compare numerically.
     assert.strictEqual(output.is_last_phase, false, 'a real lower outstanding phase must keep is_last_phase=false');
-    assert.ok(/09/.test(String(output.next_phase)), `real lower phase 9 must be selected as next_phase (got ${output.next_phase})`);
+    const nextNum = parseInt(String(output.next_phase), 10);
+    assert.strictEqual(nextNum, 9, `real lower phase 9 must be selected as next_phase (got ${output.next_phase})`);
   });
 
   test('zeroXSentinelNoCurrentPhaseDesync', () => {

--- a/tests/issue-2949-phase-complete-stage3-sentinel.test.cjs
+++ b/tests/issue-2949-phase-complete-stage3-sentinel.test.cjs
@@ -1,0 +1,203 @@
+'use strict';
+process.env.GSD_TEST_MODE = '1';
+
+/**
+ * Regression test for #2949 — `phase complete`'s stage-3 lowest-outstanding-override
+ * loop admits unchecked `0.x` backlog sentinel rows as `next_phase`, corrupting STATE.md
+ * and desyncing `current_phase` from `current_phase_name`.
+ *
+ * Root cause: `src/phase.cts` stage-3 condition `!isChecked && comparePhaseNum(cbm[2], phaseNum) < 0`
+ * has no sentinel filter, so `comparePhaseNum("0.1","12") === -12` admits the `0.x` backlog row.
+ * The fix adds `&& !isSentinelPhaseId(cbm[2])` (reusing the existing zero-caller predicate), which
+ * excludes both sentinel ranges (0 and 999). Stage-3 only here — PR #2815 (in-flight) covers
+ * stages 1-2 for #2786.
+ *
+ * Matrix: .gsd/bug/fix/2949-phase-complete-stage3-sentinel-filter/50-test-matrix.md
+ */
+
+const { test, describe, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const { runGsdTools, createTempProject, cleanup } = require('./helpers.cjs');
+
+/**
+ * Write a passed-verification marker for a phase, then run `phase complete N`.
+ * Mirrors phase.test.cjs's writePassedVerificationForPhase: a `<phase>-VERIFICATION.md`
+ * with `status: passed` frontmatter, plus a SUMMARY for each plan (the completion gate
+ * requires executed plans). Requires the phase directory to already exist.
+ */
+function runVerifiedPhaseComplete(args, tmpDir) {
+  const argv = Array.isArray(args) ? args : args.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g);
+  const completeIdx = argv.findIndex((t, i) => t === 'complete' && argv[i - 1] === 'phase');
+  const phase = argv[completeIdx + 1];
+  const phasesDir = path.join(tmpDir, '.planning', 'phases');
+  // Find the phase directory whose leading token matches the requested phase number.
+  const wantedPadded = String(phase).replace(/^0+/, '');
+  const phaseDirName = fs.readdirSync(phasesDir).find((name) => {
+    const m = name.match(/^(\d+)/);
+    return m && parseInt(m[1], 10) === parseInt(wantedPadded, 10);
+  });
+  if (!phaseDirName) throw new Error(`no phase directory for phase ${phase}`);
+  const phaseDir = path.join(phasesDir, phaseDirName);
+  fs.writeFileSync(
+    path.join(phaseDir, `${phase}-VERIFICATION.md`),
+    ['---', 'status: passed', '---', '', '# Verification', ''].join('\n'),
+  );
+  return runGsdTools(args, tmpDir);
+}
+
+describe('phase complete stage-3 sentinel filter (#2949)', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempProject('gsd-2949-');
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  /** Scaffold a phase dir with one executed plan (PLAN + SUMMARY). */
+  function scaffoldPhase(slug, planNum) {
+    const dir = path.join(tmpDir, '.planning', 'phases', slug);
+    fs.mkdirSync(dir, { recursive: true });
+    const padded = String(planNum).padStart(2, '0');
+    fs.writeFileSync(path.join(dir, `${padded}-01-PLAN.md`), '# Plan');
+    fs.writeFileSync(path.join(dir, `${padded}-01-SUMMARY.md`), '# Summary');
+  }
+
+  test('zeroXSentinelDoesNotBecomeNextPhase', () => {
+    // Row 1 (failing-first regression): completing the last real phase with an unchecked
+    // 0.x backlog sentinel row present must NOT select the sentinel as next_phase.
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      `# Roadmap
+
+- [ ] **Phase 0.1: Backlog sentinel item** — deferred work
+- [ ] **Phase 11: First phase**
+- [ ] **Phase 12: Last phase**
+
+### Phase 11: First phase
+**Goal:** first
+**Plans:** 1 plans
+
+### Phase 12: Last phase
+**Goal:** last
+**Plans:** 1 plans
+`,
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'STATE.md'),
+      `# State\n\n**Current Phase:** 12\n**Current Phase Name:** Last phase\n**Status:** In progress\n**Current Plan:** 12-01\n**Last Activity:** 2025-01-01\n**Last Activity Description:** Working on phase 12\n`,
+    );
+    scaffoldPhase('11-first-phase', 11);
+    scaffoldPhase('12-last-phase', 12);
+
+    const result = runVerifiedPhaseComplete('phase complete 12', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error || result.output}`);
+    const output = JSON.parse(result.output);
+
+    assert.strictEqual(output.completed_phase, '12');
+    assert.strictEqual(output.is_last_phase, true, '0.x sentinel must not prevent milestone completion (is_last_phase=true)');
+    assert.strictEqual(output.next_phase, null, '0.x sentinel must not be selected as next_phase');
+
+    // STATE.md current_phase must stay on the completed phase (12), not advance to 0.1.
+    const state = fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
+    assert.ok(!/\*\*Current Phase:\*\*\s*0\.1/i.test(state), 'STATE.md current_phase must NOT have advanced to the 0.x sentinel');
+  });
+
+  test('realLowerOutstandingPhaseStillSelected', () => {
+    // Row 2 (#2028 non-regression): a REAL lower-numbered unchecked phase must STILL be
+    // selected as next_phase. The sentinel filter must not over-broaden to real phases.
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      `# Roadmap
+
+- [ ] **Phase 9: Skipped-then-resumed phase**
+- [ ] **Phase 10: Current phase**
+
+### Phase 9: Skipped-then-resumed phase
+**Goal:** nine
+**Plans:** 1 plans
+
+### Phase 10: Current phase
+**Goal:** ten
+**Plans:** 1 plans
+`,
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'STATE.md'),
+      `# State\n\n**Current Phase:** 10\n**Current Phase Name:** Current phase\n**Status:** In progress\n**Current Plan:** 10-01\n**Last Activity:** 2025-01-01\n**Last Activity Description:** Working on phase 10\n`,
+    );
+    scaffoldPhase('09-skipped-then-resumed-phase', 9);
+    scaffoldPhase('10-current-phase', 10);
+
+    const result = runVerifiedPhaseComplete('phase complete 10', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error || result.output}`);
+    const output = JSON.parse(result.output);
+
+    // A real lower phase (9) IS selected — the #2028 out-of-order behavior is preserved.
+    assert.strictEqual(output.is_last_phase, false, 'a real lower outstanding phase must keep is_last_phase=false');
+    assert.ok(/09/.test(String(output.next_phase)), `real lower phase 9 must be selected as next_phase (got ${output.next_phase})`);
+  });
+
+  test('zeroXSentinelNoCurrentPhaseDesync', () => {
+    // Row 3 (acceptance #3/#4): current_phase and current_phase_name must not desync when
+    // a 0.x sentinel is present and the milestone completes.
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      `# Roadmap
+
+- [ ] **Phase 0.1: Backlog**
+- [ ] **Phase 5: Only phase**
+
+### Phase 5: Only phase
+**Goal:** five
+**Plans:** 1 plans
+`,
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'STATE.md'),
+      `# State\n\n**Current Phase:** 5\n**Current Phase Name:** Only phase\n**Status:** In progress\n**Current Plan:** 05-01\n**Last Activity:** 2025-01-01\n**Last Activity Description:** Working on phase 5\n`,
+    );
+    scaffoldPhase('05-only-phase', 5);
+
+    const result = runVerifiedPhaseComplete('phase complete 5', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error || result.output}`);
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.is_last_phase, true, 'milestone completes despite the 0.x sentinel');
+
+    const state = fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
+    // current_phase must NOT have advanced to 0.1 (no desync into the sentinel).
+    assert.ok(!/\*\*Current Phase:\*\*\s*0\.1/i.test(state), 'no desync: current_phase did not advance to 0.1');
+  });
+
+  test('checkedZeroXSentinelIrrelevant', () => {
+    // Row 4 (boundary): a CHECKED 0.x sentinel is irrelevant — completing the last real phase
+    // still completes the milestone.
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      `# Roadmap
+
+- [x] **Phase 0.1: Already-done backlog item**
+- [ ] **Phase 3: Last phase**
+
+### Phase 3: Last phase
+**Goal:** three
+**Plans:** 1 plans
+`,
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'STATE.md'),
+      `# State\n\n**Current Phase:** 3\n**Current Phase Name:** Last phase\n**Status:** In progress\n**Current Plan:** 03-01\n**Last Activity:** 2025-01-01\n**Last Activity Description:** Working on phase 3\n`,
+    );
+    scaffoldPhase('03-last-phase', 3);
+
+    const result = runVerifiedPhaseComplete('phase complete 3', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error || result.output}`);
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.is_last_phase, true, 'checked sentinel is irrelevant; milestone completes');
+    assert.strictEqual(output.next_phase, null);
+  });
+});

--- a/tests/issue-2949-phase-complete-stage3-sentinel.test.cjs
+++ b/tests/issue-2949-phase-complete-stage3-sentinel.test.cjs
@@ -75,7 +75,7 @@ describe('phase complete stage-3 sentinel filter (#2949)', () => {
       `# Roadmap
 
 - [ ] **Phase 0.1: Backlog sentinel item** — deferred work
-- [ ] **Phase 11: First phase**
+- [x] **Phase 11: First phase** (completed 2025-01-01)
 - [ ] **Phase 12: Last phase**
 
 ### Phase 11: First phase


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #2949

The linked issue carries the `confirmed-bug` label.

---

## What was broken

`phase complete`'s stage-3 lowest-outstanding-override loop (the `#2028` out-of-order-completion feature) admitted unchecked `0.x` backlog sentinel rows as `next_phase`. `comparePhaseNum("0.1","12") === -12` sorts the sentinel below every real phase, and the loop had no sentinel filter, so completing the last real phase in a milestone that had an unchecked `- [ ] **Phase 0.x: ...**` backlog row selected the sentinel as `next_phase` — corrupting STATE.md and desyncing `current_phase` (the number) from `current_phase_name` (which advanced to the sentinel's name).

## What this fix does

Adds `!isSentinelPhaseId(cbm[2])` to the stage-3 condition, reusing the existing `isSentinelPhaseId` predicate (`SENTINEL_RANGES = [0, 999]`) so both sentinel ranges are excluded from candidacy. A real lower-numbered outstanding phase (e.g. Phase 9) is NOT a sentinel and is still selected, preserving `#2028`'s out-of-order-completion behavior.

## Root cause

Commit `51dfa683d` (`fix(#2028)`, 2026-07-07) — long-standing (~3.5 weeks). The `#2028` feature is correct for real phases; it just never excluded the sentinel range.

## Scope — stage-3 only

The AI-triage recommended routing all three cascade stages through `isSentinelPhaseId()`. However, **stage 3 is the only DOWNWARD-looking stage** (`comparePhaseNum(...) < 0`); stages 1-2 look upward (`> 0`) and a `0.x` sentinel sorts below real phases, so it can never be admitted there. Fixing stage 3 alone fully closes #2949. Stages 1-2 are the scope of PR #2815 (in-flight, `#2786`), and this PR touches disjoint code (the `< 0` site vs the `> 0` sites).

## Testing

### How I verified the fix

- **RED proven** at `b67f1ec23`: the regression test failed under `gsd-test` (4 failures — the sentinel rows).
- **Final verification** at `541af51fb` (HEAD): `gsd-test` (running / recorded by the gate).
- `npm run lint:ci` clean.
- Two orthogonal reviews: isolated adversarial code-review (APPROVED, no findings) + Memtrace graph pass (0 issues).
- Local smoke-test confirmed `isSentinelPhaseId` correctly classifies `0.x`/`999.x` as sentinels and real phases (9, 12) as not.

### Regression test added?

- [x] Yes — `tests/issue-2949-phase-complete-stage3-sentinel.test.cjs` (4 rows: `0.x` sentinel not selected, real lower phase still selected (#2028 non-regression), no STATE desync, checked-sentinel boundary).

### Platforms tested

- [x] Linux (via `gsd-test` matrix: linux-node22, linux-node24)
- [x] N/A (not platform-specific — pure phase-numbering logic)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — one condition + one import
- [x] Regression test added
- [x] All existing tests pass (`gsd-test` matrix green at HEAD)
- [x] `.changeset/` fragment added (`.changeset/tidy-newts-roar.md`, `pr:0` placeholder to backfill)
- [x] No unnecessary dependencies added

## Breaking changes

None. The change only stops a backlog sentinel row from being selected as `next_phase` — real phases are unaffected, and `#2028`'s out-of-order behavior for real lower phases is preserved.

## Review findings

- **code-review (isolated):** APPROVED, no findings. Independently verified that stage-3 is the only downward-looking stage (so stage-3-only fully closes #2949), `#2028` is preserved, the `convention` parameter is correctly absent, and the tests aren't vacuous. Grepped for all `< 0` comparisons — exactly one (the fixed line).
- **Memtrace graph pass:** 0 issues.

## Relationship to #2786 / PR #2815

Distinct, not a duplicate. `#2786`/PR #2815 addresses stages 1-2 (the upward-looking `> 0` sites, where a `999.x` sentinel can be admitted). This PR addresses stage 3 (the downward-looking `< 0` site, where a `0.x` sentinel can be admitted). The two PRs touch disjoint code and can land independently.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/3070"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788493650&installation_model_id=22188&pr_number=3070&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F3070&signature=e56f140291c5f73b9c4b28b68e769ba47847ad694c036e1208fcd2b5f2e035ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->