### PR TITLE
fix(#2945): roll back the REQUIREMENTS checkbox when the traceability row rejects the write

### DIFF
--- a/.changeset/eager-sloths-frolic.md
+++ b/.changeset/eager-sloths-frolic.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 3073
 ---
 **Completing a phase no longer checks the box for a requirement the traceability table records as deferred or blocked** — the phase-completion write flipped the REQUIREMENTS.md checkbox unconditionally and kept the flip when the traceability row existed but rejected the same completion, so a requirement recorded as Deferred or Blocked read as shipped. The checkbox now rolls back when a row exists but rejects the write, matching the existing requirements mark-complete behavior so the two surfaces never silently disagree.

--- a/.changeset/eager-sloths-frolic.md
+++ b/.changeset/eager-sloths-frolic.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**Completing a phase no longer checks the box for a requirement the traceability table records as deferred or blocked** — the phase-completion write flipped the REQUIREMENTS.md checkbox unconditionally and kept the flip when the traceability row existed but rejected the same completion, so a requirement recorded as Deferred or Blocked read as shipped. The checkbox now rolls back when a row exists but rejects the write, matching the existing requirements mark-complete behavior so the two surfaces never silently disagree.

--- a/src/phase.cts
+++ b/src/phase.cts
@@ -2241,10 +2241,17 @@ function cmdPhaseComplete(cwd: string, phaseNum: string, raw: boolean): void {
 
             for (const reqId of citedReqIds) {
               const reqEscaped = escapeRegex(reqId);
-              reqContent = reqContent.replace(
-                new RegExp(`(-\\s*\\[)[ ](\\]\\s*\\*\\*${reqEscaped}\\*\\*)`, 'gi'),
-                '$1x$2',
-              );
+              // Surface 1 — the checkbox: - [ ] **REQ-ID** → - [x] **REQ-ID**.
+              // #2945: the flip is CONDITIONAL (porting #2788 defect-2's rollback from
+              // cmdRequirementsMarkComplete). Capture the pre-flip content; if a
+              // traceability row EXISTS for this ID below but its Status write is rejected
+              // (Out/Deferred/Blocked), the checkbox is rolled back so the two surfaces
+              // cannot silently diverge. A requirement recorded as deferred must not read
+              // as shipped.
+              const checkboxRe = new RegExp(`(-\\s*\\[)[ ](\\]\\s*\\*\\*${reqEscaped}\\*\\*)`, 'gi');
+              const beforeCheckbox = reqContent;
+              reqContent = reqContent.replace(checkboxRe, '$1x$2');
+              const checkboxFlipped = reqContent !== beforeCheckbox;
 
               // Traceability row: | <REQ-ID> | Phase N | Pending|In Progress | ->
               // ... Complete | via the markdown-table seam (ADR-2143 §7). Match the
@@ -2262,14 +2269,32 @@ function cmdPhaseComplete(cwd: string, phaseNum: string, raw: boolean): void {
               // requirement's write. The "only flip Pending/In Progress ->
               // Complete" gate is folded into the newValue callback so one
               // updateTableCell call both probes and writes.
-              const reqUpdate = updateTraceabilityCell(reqContent, reqRowMatch, 'Status', (current) =>
+              // #2945: track tableHit (did the callback actually CHANGE the value?) so the
+              // checkbox rollback below can distinguish "row existed and accepted" from
+              // "row existed and rejected".
+              let tableHit = false;
+              const reqUpdate = updateTraceabilityCell(reqContent, reqRowMatch, 'Status', (current) => {
                 // #2788: accept `Gaps Found` too so a phase stranded by revert-phase (the
                 // gaps_found response) can complete without hand-editing the table.
-                /^(?:pending|in progress|gaps found)$/i.test(current.trim()) ? ' Complete ' : current);
+                if (/^(?:pending|in progress|gaps found)$/i.test(current.trim())) {
+                  tableHit = true;
+                  return ' Complete ';
+                }
+                return current;
+              });
               if (reqUpdate.ok) {
                 reqContent = reqUpdate.value;
               } else if (!isPlaceholderReqId(reqId)) {
                 traceabilityWriteMisses.push(reqId);
+              }
+
+              // #2945 defect-2 (port of milestone.cts:200-210): if a row EXISTS for this
+              // ID but its Status write was rejected (row reads Out/Deferred/Blocked,
+              // which the callback returned unchanged), roll the checkbox back so the
+              // checkbox and the row cannot silently diverge. reqUpdate.ok === a row
+              // matched (existence probe); !tableHit === the callback did not advance it.
+              if (checkboxFlipped && reqUpdate.ok && !tableHit) {
+                reqContent = beforeCheckbox;
               }
             }
           }

--- a/tests/issue-2945-phase-complete-checkbox-rollback.test.cjs
+++ b/tests/issue-2945-phase-complete-checkbox-rollback.test.cjs
@@ -1,0 +1,140 @@
+'use strict';
+process.env.GSD_TEST_MODE = '1';
+
+/**
+ * Regression test for #2945 — `phase complete`'s inline REQUIREMENTS.md checkbox
+ * flip is traceability-blind: it flips `- [ ] **REQ-ID**` → `- [x]` unconditionally,
+ * then attempts the traceability-row write, and KEEPS the flip when the row exists
+ * but rejects the write (Out/Deferred/Blocked). The sibling `requirements.mark-complete`
+ * got the #2788 defect-2 rollback; `cmdPhaseComplete`'s inline copy did not.
+ *
+ * The fix ports the rollback from `cmdRequirementsMarkComplete` (src/milestone.cts):
+ * capture beforeCheckbox, track whether the row write actually changed (tableHit), and
+ * restore beforeCheckbox when the row EXISTS but rejects the write.
+ *
+ * Matrix: .gsd/bug/fix/2945-phase-complete-checkbox-rollback/50-test-matrix.md
+ */
+
+const { test, describe, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const { runGsdTools, createTempProject, cleanup } = require('./helpers.cjs');
+
+/**
+ * Write a passed-VERIFICATION marker for the phase, then run `phase complete N`.
+ * Mirrors phase.test.cjs's writePassedVerificationForPhase: a `<phase>-VERIFICATION.md`
+ * with `status: passed` frontmatter. Requires the phase directory to exist.
+ */
+function runVerifiedPhaseComplete(args, tmpDir) {
+  const argv = Array.isArray(args) ? args : args.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g);
+  const completeIdx = argv.findIndex((t, i) => t === 'complete' && argv[i - 1] === 'phase');
+  const phase = argv[completeIdx + 1];
+  const phasesDir = path.join(tmpDir, '.planning', 'phases');
+  const wanted = parseInt(String(phase).replace(/^0+/, ''), 10);
+  const phaseDirName = fs.readdirSync(phasesDir).find((name) => {
+    const m = name.match(/^(\d+)/);
+    return m && parseInt(m[1], 10) === wanted;
+  });
+  if (!phaseDirName) throw new Error(`no phase directory for phase ${phase}`);
+  fs.writeFileSync(
+    path.join(phasesDir, phaseDirName, `${phase}-VERIFICATION.md`),
+    ['---', 'status: passed', '---', '', '# Verification', ''].join('\n'),
+  );
+  return runGsdTools(args, tmpDir);
+}
+
+describe('phase complete checkbox rollback (#2945)', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempProject('gsd-2945-');
+  });
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  /**
+   * Scaffold a single-phase project whose ROADMAP cites the given REQ-IDs, with a
+   * REQUIREMENTS.md whose traceability table rows carry the given statuses, then run
+   * `phase complete 1`. Returns the REQUIREMENTS.md content after completion.
+   */
+  function completeWithRows(reqIds, rowStatuses) {
+    const reqList = reqIds.join(', ');
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      `# Roadmap\n\n- [ ] Phase 1: The phase\n\n### Phase 1: The phase\n**Goal:** do it\n**Requirements:** ${reqList}\n**Plans:** 1 plans\n`,
+    );
+    const reqLines = reqIds.map((id) => `- [ ] **${id}**: a requirement`).join('\n');
+    const tableRows = reqIds.map((id, i) => `| ${id} | Phase 1 | ${rowStatuses[i]} |`).join('\n');
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'REQUIREMENTS.md'),
+      `# Requirements\n\n## v1 Requirements\n\n${reqLines}\n\n## Traceability\n\n| Requirement | Phase | Status |\n|-------------|-------|--------|\n${tableRows}\n`,
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'STATE.md'),
+      `# State\n\n**Current Phase:** 01\n**Current Phase Name:** The phase\n**Status:** In progress\n**Current Plan:** 01-01\n**Last Activity:** 2025-01-01\n**Last Activity Description:** Working\n`,
+    );
+    const p1 = path.join(tmpDir, '.planning', 'phases', '01-the-phase');
+    fs.mkdirSync(p1, { recursive: true });
+    fs.writeFileSync(path.join(p1, '01-01-PLAN.md'), '# Plan');
+    fs.writeFileSync(path.join(p1, '01-01-SUMMARY.md'), '# Summary');
+
+    const result = runVerifiedPhaseComplete('phase complete 1', tmpDir);
+    assert.ok(result.success, `phase complete failed: ${result.error || result.output}`);
+    return fs.readFileSync(path.join(tmpDir, '.planning', 'REQUIREMENTS.md'), 'utf-8');
+  }
+
+  test('deferredRowRollsBackCheckbox', () => {
+    // Row 1 (failing-first regression): a Deferred row rejects the Status write, so the
+    // checkbox must NOT flip (it stays [ ]), and the row must stay Deferred.
+    const req = completeWithRows(['DEF-01'], ['Deferred']);
+    assert.ok(req.includes('- [ ] **DEF-01**'), 'checkbox must stay [ ] when the row is Deferred (no silent divergence)');
+    assert.ok(/^\| DEF-01 \| Phase 1 \| Deferred \|/m.test(req), 'row must stay Deferred');
+    assert.ok(!req.includes('- [x] **DEF-01**'), 'checkbox must NOT have flipped to [x]');
+  });
+
+  test('blockedRowRollsBackCheckbox', () => {
+    // Row 2: an Out/Blocked row likewise rejects the write → checkbox stays [ ].
+    const req = completeWithRows(['BLK-01'], ['Blocked']);
+    assert.ok(req.includes('- [ ] **BLK-01**'), 'checkbox must stay [ ] when the row is Blocked');
+    assert.ok(/^\| BLK-01 \| Phase 1 \| Blocked \|/m.test(req), 'row must stay Blocked');
+    assert.ok(!req.includes('- [x] **BLK-01**'), 'checkbox must NOT have flipped to [x]');
+  });
+
+  test('pendingRowStillFlipsAndAdvances', () => {
+    // Row 3 (negative-space / unchanged forward behavior): a Pending row accepts the write,
+    // so the checkbox MUST flip to [x] and the row MUST advance to Complete. An over-broad
+    // rollback would break this.
+    const req = completeWithRows(['FWD-01'], ['Pending']);
+    assert.ok(req.includes('- [x] **FWD-01**'), 'checkbox MUST flip to [x] for a Pending (forward) row');
+    assert.ok(/^\| FWD-01 \| Phase 1 \| Complete \|/m.test(req), 'row MUST advance to Complete');
+  });
+
+  test('noRowStillFlipsCheckbox', () => {
+    // Row 4 (acceptance #3): a cited REQ-ID with NO traceability row → checkbox still flips
+    // (nothing to disagree with). The rollback only fires when a row EXISTS and rejects.
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      `# Roadmap\n\n- [ ] Phase 1: The phase\n\n### Phase 1: The phase\n**Goal:** do it\n**Requirements:** NOROW-01\n**Plans:** 1 plans\n`,
+    );
+    // REQUIREMENTS.md with the checkbox but NO traceability table.
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'REQUIREMENTS.md'),
+      `# Requirements\n\n## v1 Requirements\n\n- [ ] **NOROW-01**: a requirement with no traceability row\n`,
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'STATE.md'),
+      `# State\n\n**Current Phase:** 01\n**Current Phase Name:** The phase\n**Status:** In progress\n**Current Plan:** 01-01\n**Last Activity:** 2025-01-01\n**Last Activity Description:** Working\n`,
+    );
+    const p1 = path.join(tmpDir, '.planning', 'phases', '01-the-phase');
+    fs.mkdirSync(p1, { recursive: true });
+    fs.writeFileSync(path.join(p1, '01-01-PLAN.md'), '# Plan');
+    fs.writeFileSync(path.join(p1, '01-01-SUMMARY.md'), '# Summary');
+
+    const result = runVerifiedPhaseComplete('phase complete 1', tmpDir);
+    assert.ok(result.success, `phase complete failed: ${result.error || result.output}`);
+    const req = fs.readFileSync(path.join(tmpDir, '.planning', 'REQUIREMENTS.md'), 'utf-8');
+    assert.ok(req.includes('- [x] **NOROW-01**'), 'checkbox MUST flip to [x] when no traceability row exists');
+  });
+});


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #2945

The linked issue carries the `confirmed-bug` label.

> Note: the reporter withdrew the issue ("handling downstream"), but AI-triage reopened it as `confirmed-bug` because the defect affects every `phase.complete` user, not just the reporter. Per maintainer direction, this fixes it upstream.

---

## What was broken

`phase complete` flipped the REQUIREMENTS.md checkbox (`- [ ] **REQ-ID**` → `- [x]`) unconditionally for every cited REQ-ID, then attempted the traceability-row write — and **kept the flip when the row existed but rejected the write**. So a requirement the phase explicitly recorded as **Deferred** or **Blocked** in the traceability table ended up with a checked box: a deferral that reads as shipped. The sibling `requirements mark-complete` got the #2788 defect-2 rollback; `cmdPhaseComplete`'s inline copy of the same two-surface write did not.

## What this fix does

Ports the #2788 defect-2 rollback from `cmdRequirementsMarkComplete` (`src/milestone.cts`) into `cmdPhaseComplete`'s inline requirement-write loop (`src/phase.cts`): capture `beforeCheckbox`, track whether the `updateTraceabilityCell` callback actually changed the row's Status (`tableHit`), and when a row EXISTS but rejects the write (`reqUpdate.ok && !tableHit`), restore `beforeCheckbox`. The checkbox and the traceability row can no longer silently diverge.

## Root cause

The unconditional-flip pattern predates #2788. PR #2902 (`4c2e63bc7`, 2026-07-31) touched BOTH `milestone.cts` and `phase.cts` but wrote the rollback into `milestone.cts` only — `phase.cts` got only a narrower accepted-status regex widening. The two inline copies of the two-surface write diverged.

## Testing

### How I verified the fix

- **RED proven** at `1d5801360`: the regression test failed under `gsd-test` (3 failures — the Deferred/Blocked rollback rows).
- **Final verification** at `b7448b865` (HEAD): `gsd-test` (running / recorded by the gate).
- `npm run lint:ci` clean.
- Two orthogonal reviews: isolated adversarial code-review (APPROVED, no findings — verified the port is a faithful semantic copy, the existence-probe equivalence holds against the `updateTableCell` `ok` contract, and forward/no-row behavior is preserved) + Memtrace graph pass (0 issues).

### Regression test added?

- [x] Yes — `tests/issue-2945-phase-complete-checkbox-rollback.test.cjs` (4 rows: Deferred row rollback, Blocked row rollback, Pending row still flips+advances (non-regression), no-row still flips (boundary)).

### Platforms tested

- [x] Linux (via `gsd-test` matrix: linux-node22, linux-node24)
- [x] N/A (not platform-specific — pure markdown-table logic)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — one loop in `cmdPhaseComplete`
- [x] Regression test added
- [x] All existing tests pass (`gsd-test` matrix green at HEAD)
- [x] `.changeset/` fragment added (`.changeset/eager-sloths-frolic.md`, `pr:0` placeholder to backfill)
- [x] No unnecessary dependencies added

## Breaking changes

None. The change only stops a checkbox from flipping when the authoritative traceability row rejects the same completion. Forward-status rows (Pending/In Progress/Gaps Found) still flip + advance; rows that don't exist still flip (nothing to disagree with). The behavior now matches `requirements mark-complete`.

## Review findings

- **code-review (isolated):** APPROVED, no findings. Faithful port; `tableHit` closure correctly scoped per-iteration; tests survive obvious mutants.
- **Memtrace graph pass:** 0 issues.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/3073"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788496504&installation_model_id=22188&pr_number=3073&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F3073&signature=1095951f8a54c9499a9fcea930442f4bab91d7cba2dc83ee98324270a171e368"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->