### PR TITLE
docs(#3074): correct ADR-1671's MCP deferral citation and stale runtime counts

### DIFF
--- a/docs/adr/1671-dynamic-context-management-platform.md
+++ b/docs/adr/1671-dynamic-context-management-platform.md
@@ -3,7 +3,7 @@
 - **Status:** Proposed
 - **Date:** 2026-06-24
 - **Extends:** ADR-0002 (Command Contract Validation Module), ADR-457 (build-at-publish generation model for `bin/lib/*.cjs`)
-- **Relates:** ADR-857 §7 (Connected-Capability / MCP contract — kept deferred by this ADR)
+- **Relates:** [ADR-1239](1239-gsd-embeddable-orchestration-engine.md) (owns GSD's MCP surface — the companion `gsd-mcp-server`; this ADR defers only the served *content* catalog), ADR-857 (capability system — its Phase-6 completion property bounds workflow size, see Open questions)
 
 ## Context
 
@@ -11,7 +11,7 @@ GSD ships command and workflow content as large, hand-edited Markdown files. Two
 
 1. **Authoring is monolithic.** A single workflow body carries every branch inline. `gsd-core/workflows/plan-phase.md` is 93,973 bytes / 1,770 lines; `execute-phase.md` is 93,426 bytes. Mutually-exclusive paths (`--prd`, `--ingest`, `--mvp`, `--reviews`) all live in the same file, so a runtime loads guidance for branches a given invocation will never take.
 
-2. **One payload ships to every runtime.** Install copies the whole `gsd-core/` tree (3.4 MB, 89 workflows, 1.7 MB) **byte-identical to all 15 runtimes** via `copyWithPathReplacement` (`bin/install.js`). The only per-runtime work is string rewrites and description truncation. There is **no per-runtime trimming or splitting**.
+2. **One payload ships to every runtime.** Install copies the whole `gsd-core/` tree (3.4 MB, 89 workflows, 1.7 MB) **byte-identical to all 19 runtimes** (the capability descriptors carrying `role: runtime`, of 44 descriptors total) via `copyWithPathReplacement` (`bin/install.js`). The only per-runtime work is string rewrites and description truncation. There is **no per-runtime trimming or splitting**.
 
 The result is constant pressure against size caps, enforced today only against *source* files (not emitted output) by a two-part guard (issue #1074): a per-file baseline ratchet plus per-tier hard caps (workflows XL 96 KiB / LARGE 60 KiB / DEFAULT 40 KiB; agents XL 56 KiB / LARGE 48 KiB / DEFAULT 24 KiB). Several files have almost no headroom — `agents/gsd-verifier.md` has **293 bytes**. The one true emission-time cap, Windsurf's 12,000-byte limit (`src/runtime-artifact-conversion.cts`), is a hard `throw` with no graceful fallback. Adding one rule to a tight file forces an extract-to-`references/` refactor (`DEFECT.AGENT-FILE-SIZE-CAP-BREACH`), turning a one-line edit into a multi-file change that ripples across stub frontmatter, the workflow body, reference fragments, and `docs/` — each guarded by a different lint.
 
@@ -30,7 +30,7 @@ Research into the codebase found that most JIT primitives are already present an
 
 ### External practice
 
-The closest external analogs are Anthropic Agent Skills' three-tier progressive disclosure (metadata → `SKILL.md` → bundled references), MCP resources/prompts/deferred-tools (list-then-fetch JIT), and priority/token-budget prompt renderers (Priompt, VS Code `@vscode/prompt-tsx`) that include the highest-priority fragments that fit a budget via a binary-search cutoff, with `flexReserve` floors for load-bearing content and `<isolate>` for a stable cacheable prefix. The portability catch is real and load-bearing: only the Skills *format* (directory + `SKILL.md` + frontmatter) is an open standard; native lazy loading is Claude-specific, and GSD's 15 runtimes do not all support skills or MCP (cf. surface-mismatch bugs #1614 antigravity, #1615 windsurf).
+The closest external analogs are Anthropic Agent Skills' three-tier progressive disclosure (metadata → `SKILL.md` → bundled references), MCP resources/prompts/deferred-tools (list-then-fetch JIT), and priority/token-budget prompt renderers (Priompt, VS Code `@vscode/prompt-tsx`) that include the highest-priority fragments that fit a budget via a binary-search cutoff, with `flexReserve` floors for load-bearing content and `<isolate>` for a stable cacheable prefix. The portability catch is real and load-bearing: only the Skills *format* (directory + `SKILL.md` + frontmatter) is an open standard; native lazy loading is Claude-specific, and GSD's 19 runtimes do not all support skills or MCP (cf. surface-mismatch bugs #1614 antigravity, #1615 windsurf).
 
 ## Decision
 
@@ -46,7 +46,13 @@ Adopt a **dynamic context management platform** built on a hybrid of build-time 
 
 5. **Formalize the `CONTEXT.md` predicate fact-store → JIT selector.** Give the predicate grammar a parser (on `markdown-sectionizer`), an ID-uniqueness validator, a `--check`/`--write` drift-guard, and a `task → relevant predicate set` selector. This converts hand-assembled briefs into JIT-generated context and attacks the maintainer-side "edit a 200 KB file by hand" pain directly. **This is sequenced first** (see Prototype) because it is the smallest, lowest-risk piece that proves the whole pattern.
 
-6. **Defer MCP (Connected-Capability).** Per ADR-857 §7 / #956, a served MCP catalog (resources/prompts/deferred-tools) remains an additive future enhancement for MCP-capable runtimes — never a replacement for the file-copy floor. Not in scope here.
+6. **Defer the MCP served catalog.** A served MCP catalog remains an additive future enhancement for MCP-capable runtimes — never a replacement for the file-copy floor. Not in scope here.
+
+   *The grounds are this ADR's own, not a borrowed citation.* MCP is runtime-partial (see **External practice** above, option D below, and the paragraph closing this section), so only build-time emission relieves caps on every runtime. Earlier revisions of this ADR attributed the deferral to "ADR-857 §7 / #956"; neither source supports it, and the deferral never needed either. `docs/adr/857-capability-system.md` contains no MCP content at all — its Decision 7 is third-party **code-loading** and its Decision 8 is Runtime/CLI-as-Capability — and #956 is the (closed) *first-party MemPalace plugin capability* pre-proposal, which [ADR-1239](1239-gsd-embeddable-orchestration-engine.md) explicitly disclaims in its own header ("Distinct from: #956"). Corrected by #3074.
+
+   *This defers a content catalog, not MCP itself.* A companion MCP server shipped 2026-06-28 under [ADR-1239](1239-gsd-embeddable-orchestration-engine.md) (#1681 / PR #1809) — `package.json` bin `gsd-mcp-server` → `bin/gsd-mcp-server.js`, module `src/mcp-server.cts` — exposing three **tools**: `gsd_invoke_command`, `gsd_read_state`, `gsd_write_state`. ADR-1239 owns that surface; this ADR defers a different one over the same protocol. What is genuinely unbuilt is the served **resources** and **prompts** catalog, tracked in #3072.
+
+   *"deferred-tools" is not deferred; it is unbuildable.* The **External practice** section above names "resources/prompts/deferred-tools" as the external list-then-fetch analog, and that phrase propagated into this decision. MCP defines exactly three server primitives — resources, prompts, and tools — and the tools surface is `tools/list` (cursor-paginated) plus `tools/call`. There is no server-side deferred-tools primitive; deferring tool *schemas* is host behavior, not a server capability. The list-then-fetch property this ADR wants is delivered by resources and prompts. Recorded in #3075 rather than carried here as a deliverable.
 
 ### Options considered
 
@@ -55,7 +61,7 @@ Adopt a **dynamic context management platform** built on a hybrid of build-time 
 | A. Progressive-disclosure authoring | Metadata-first files + one-level references; lean on host lazy-load | Partial; needs host lazy-load | Authoring universal; native JIT Claude-first | Adopt as a layer |
 | B. Build-time composer + per-runtime budget emission | Composer trims fragments to each runtime cap, emits right-sized files | Yes — measured before write | Universal floor | **Adopt as core** |
 | C. Run-time selection via init seam | Init bundle names which slices this invocation needs | Reduces per-invocation context | Broad (the `gsd_run` shim is universal) | Adopt after B |
-| D. MCP served catalog | Serve content as resources/prompts/deferred-tools | For MCP hosts only | Partial; needs 2nd channel | Defer (ADR-857 §7) |
+| D. MCP served catalog | Serve content as resources/prompts | For MCP hosts only | Partial; needs 2nd channel | Defer — runtime-partial (see Decision 6) |
 | E. Predicate fact-store → JIT selector | Parse/validate/select `CONTEXT.md` predicates | Maintainer-side big-file pain | N/A (build + orchestrator) | **Adopt first** |
 
 Pure Agent Skills (A alone) and pure MCP (D alone) were rejected as the foundation because both are runtime-partial; only build-time emission (B) relieves caps on every runtime.
@@ -273,7 +279,7 @@ Sequenced to de-risk — prove the pattern on the smallest surface first, scale 
    roughly nineteen, which is how a gate becomes something contributors route around.
 6. **Wire the init bundle (C)** to emit a per-invocation sections manifest; workflows consume it.
 7. **Roll out across LARGE/XL tiers**; update INVENTORY families + parity tests.
-8. **(Deferred)** MCP served catalog (ADR-857 §7 / #956).
+8. **(Deferred)** MCP served catalog — resources + prompts, served through the same composition seam as the file floor so the two channels cannot drift (#3072). Additive for MCP-capable hosts only; the file-copy floor stays the default (Decision 6).
 
 **Ordering landmine:** any generator consuming compiled output must run *after* `build:lib` (tsc), like `gen-plugin-skills` / `gen-capability-registry`; regenerating before `build:lib` silently drops unbuilt modules (`gsd-inventory-manifest-regen-needs-build`).
 
@@ -352,4 +358,5 @@ Prototype scope notes: the parser is intentionally self-contained for the exampl
 
 - ADR-0002 — Command Contract Validation Module (the stub `<execution_context>` @-ref contract this platform's emission must keep satisfying).
 - ADR-457 — build-at-publish generation model (the codegen + drift-guard precedent the composer extends).
-- ADR-857 §7 — Connected-Capability / MCP contract (the deferred served-catalog channel).
+- [ADR-1239](1239-gsd-embeddable-orchestration-engine.md) — the ADR that owns GSD's MCP surface. It shipped the companion `gsd-mcp-server` (three tools) on 2026-06-28; the catalog this ADR defers (resources + prompts) is a different surface over the same protocol.
+- ADR-857 — capability system. It carries **no** MCP content; earlier revisions of this ADR wrongly cited its §7 as the authority for the MCP deferral (corrected by #3074). Its genuine bearing here is the Phase-6 completion property that bounds workflow size, which constrained Phase 3's pilot (see Open questions).


### PR DESCRIPTION
Closes #3074

Item 0 of #3072, split out because it is docs-only and lands independently of the served catalog. Part of epic #1671.

ADR-1671 grounded its MCP deferral in a citation that does not support it. This corrects the record. **No code, no behavior, no test surface** — one file, +14/−7.

## The citation was wrong

ADR-1671 attributed the deferral to **"ADR-857 §7 / #956"** at five sites (`Relates:` header, Decision item 6, the options table, migration step 8, and Related). Neither source supports it:

- **`docs/adr/857-capability-system.md` contains zero occurrences of `MCP`** (case-insensitive). Its Decision 7 is *"Code — declarative + first-party, third-party deferred"* — third-party **code-loading**, which its own text scopes as *"a trust/load/build/security surface that deserves its own ADR"*. Decision 8 is Runtime/CLI-as-Capability. Neither is an MCP contract.
- **#956** is *"Pre-Proposal: first-party MemPalace plugin capability"* (CLOSED). ADR-1239's header reads *"Distinct from: #956"* — so ADR-1671 cited, as its authority, the very issue the governing ADR disclaims.

The deferral itself was never in doubt. ADR-1671's own reasoning — MCP is runtime-partial, so only build-time emission relieves caps on every runtime — is sufficient, and is what the decision now rests on.

## What changed

| Site | Before | After |
|---|---|---|
| `Relates:` | `ADR-857 §7 (Connected-Capability / MCP contract)` | ADR-1239 (owns GSD's MCP surface) + ADR-857 for the relation it genuinely has |
| Decision 6 | `Per ADR-857 §7 / #956, …` | Grounded in this ADR's own runtime-partial reasoning; records that the three-tool companion server shipped 2026-06-28; narrows the deferral to resources + prompts |
| Options table, D | `Defer (ADR-857 §7)` | `Defer — runtime-partial (see Decision 6)` |
| Migration step 8 | `(Deferred) MCP served catalog (ADR-857 §7 / #956).` | Names the real tracking issue (#3072) and the two surfaces deferred |
| Related | `ADR-857 §7 — Connected-Capability / MCP contract` | ADR-1239 entry + an honest ADR-857 entry |
| Context `:14`, External practice `:33` | "15 runtimes" | 19 runtimes (of 44 capability descriptors), with the basis stated so the next drift is cheap to spot |

**A companion MCP server has existed since 2026-06-28** (ADR-1239, #1681 / PR #1809) exposing `gsd_invoke_command`, `gsd_read_state`, `gsd_write_state`. ADR-1671 deferred a *content catalog*, ADR-1239 shipped a *tool server* — the two statements never actually conflicted, but nothing said so. Now it does.

## One scope call worth your eye

#3074/#3072 ask to narrow the deferral to "resources, prompts, deferred-tools". **I narrowed it to resources and prompts**, and recorded why the third is not a surface anyone can build:

> MCP defines exactly three server primitives — resources, prompts, and tools — and the tools surface is `tools/list` (cursor-paginated) plus `tools/call`. There is no server-side deferred-tools primitive; deferring tool *schemas* is host behavior.

Leaving it in would have kept this ADR asserting a buildable surface that does not exist, in the very PR whose purpose is making the record true. Tracked in **#3075**. Revert that one paragraph if you would rather it live only in the issue.

## What this PR deliberately does **not** do

- **It does not lift the deferral.** The served catalog is still unbuilt; ADR-1671 must keep reading that way until #3072 lands and amends it. Writing "shipped" here would make the ADR false for the whole window between the two PRs.
- **It does not touch `Status: Proposed`**, despite Phases 0–7 having shipped. Separate decision; also switches on `validate`'s reciprocity rule, which currently short-circuits for non-Accepted ADRs.

## Verification

**The negative space was the real risk here.** ADR-1671 carries a *legitimate* ADR-857 reference in Open questions — the Phase-6 completion property (`PRE_PHASE6`) that constrained Phase 3's pilot. A global find/replace of `ADR-857` would have destroyed a correct citation. Each of the seven sites was edited individually; that reference survives byte-identical, outside every diff hunk.

- `npm run lint:ci` — **exit 0**. Includes `gen-adr-index.cjs --check` reporting *"docs/adr/README.md index is up to date (71 ADRs)"*, which empirically confirms the `Relates:` edit is generator-inert. (Predicted first by reading `parseAdr`: `RELATION_FIELDS` covers only supersedes/subsumes, so `Relates:`/`Extends:` values are never validated — then confirmed behaviorally rather than trusted.)
- `GITHUB_BASE_REF=next node scripts/changeset/lint.cjs` → `ok_no_user_facing_changes`, exit 0
- `GITHUB_BASE_REF=next node scripts/lint-docs-required.cjs` → `ok_no_triggering_fragments`, exit 0
- Both base-ref gates run the way CI runs them — a bare local invocation false-passes.
- Remote runner green on this exact commit.

**Reviews.** An isolated reviewer with no authoring context re-verified all nine factual claims independently (**9/9 CONFIRMED, zero findings**), and additionally corroborated PR #1809's 2026-06-28 merge date, the `role: runtime` count, and the MCP-primitives claim. Security review: zero findings — docs-only, no reachable input path, and `docs/` is not in `package.json` `files[]`, so the file is neither published nor installed.

**No changeset**: the diff touches no path the changeset gate watches, confirmed by the lint above rather than asserted. **No template**: `docs/**` is in `pr-template-policy.cjs`'s `TOOLING_PATH_ALLOWLIST`, so doc-only PRs take the auto-detected carve-out.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/3080"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788526694&installation_model_id=22188&pr_number=3080&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F3080&signature=48e99de16659c13ae443e013536717f667994fc8129b88516d831871da5deaa1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->