### PR TITLE
fix(#2947): preserve preamble phase details when milestone section has none

### DIFF
--- a/.changeset/quick-birds-jump.md
+++ b/.changeset/quick-birds-jump.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`roadmap.analyze` no longer silently drops phases when the phase-listing heading isn't version-bearing** — if the phase list lives under a plain `## Phases` heading (the shipped greenfield template's own shape) and a later version-bearing progress/notes heading exists, the milestone scope previously latched onto the later heading and stripped every `### Phase N:` detail from the preamble, returning `phase_count: 0` with exit 0 and empty stderr. Phase details in the preamble are now preserved when the selected milestone section has none of its own. (#2947)

--- a/.changeset/quick-birds-jump.md
+++ b/.changeset/quick-birds-jump.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 3084
 ---
 **`roadmap.analyze` no longer silently drops phases when the phase-listing heading isn't version-bearing** — if the phase list lives under a plain `## Phases` heading (the shipped greenfield template's own shape) and a later version-bearing progress/notes heading exists, the milestone scope previously latched onto the later heading and stripped every `### Phase N:` detail from the preamble, returning `phase_count: 0` with exit 0 and empty stderr. Phase details in the preamble are now preserved when the selected milestone section has none of its own. (#2947)

--- a/src/roadmap-parser.cts
+++ b/src/roadmap-parser.cts
@@ -235,9 +235,19 @@ function extractCurrentMilestone(content: string, cwd?: string, ws?: string | nu
     );
   }
 
+  // #2947: the preamble strip removes `### Phase N:` detail headings from the
+  // pre-milestone region so they don't duplicate the ones inside the selected
+  // milestone section. But when the phase list lives under a non-version-bearing
+  // `## Phases` heading (the shipped greenfield template's own shape) and the
+  // selected version-bearing heading is a LATER progress/notes sub-heading with
+  // NO phase details of its own, stripping the preamble phases silently drops
+  // every phase (phase_count: 0, exit 0). Only strip preamble phase details when
+  // the selected milestone section actually contains its own — otherwise the
+  // preamble phases ARE this milestone's phases and must be preserved.
+  const currentSectionHasPhaseDetails = /^#{2,4}\s*Phase\s+\S/im.test(currentSection);
   const preamble = stripTaggedBlocks(beforeMilestones, 'details')
     // #1729: `(?:\s*\([^)\n]{0,200}\))?` tolerates a pre-colon ( ) tag (literal mirror of OPTIONAL_PHASE_TAG_SOURCE).
-    .replace(/^#{2,4}\s*Phase\s+[\w][\w.-]*(?:\s*\([^)\n]{0,200}\))?\s*:[^\n]*(?:\n(?!#{1,6}\s)[^\n]*)*\n?/gim, '')
+    .replace(currentSectionHasPhaseDetails ? /^#{2,4}\s*Phase\s+[\w][\w.-]*(?:\s*\([^)\n]{0,200}\))?\s*:[^\n]*(?:\n(?!#{1,6}\s)[^\n]*)*\n?/gim : /$/, '')
     .replace(/^#{1,4}\s*Phase Details\b[^\n]*\n?/gim, '');
 
   return detailsSection

--- a/tests/roadmap-parser.test.cjs
+++ b/tests/roadmap-parser.test.cjs
@@ -23,7 +23,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 
 const roadmapParser = require('../gsd-core/bin/lib/roadmap-parser.cjs');
-const { createTempProject, cleanup } = require('./helpers.cjs');
+const { createTempProject, cleanup, runGsdTools } = require('./helpers.cjs');
 
 const {
   stripShippedMilestones,
@@ -200,6 +200,162 @@ describe('roadmap-parser: extractCurrentMilestone', () => {
     // The section should include Phase 1 content; the fenced heading should not terminate section early
     assert.ok(result.includes('real goal'), 'phase 1 content included');
     assert.ok(result.includes('Also Real'), 'phase 2 content also included');
+  });
+
+  // ─── #2947: milestone anchor must prefer the heading whose section contains
+  // Phase details, not just the first version-bearing heading anywhere. ────────
+
+  test('#2947 — prefers the heading whose section contains Phase details over a later version-bearing progress heading', () => {
+    // The shipped greenfield template's `## Phases` is NOT version-bearing,
+    // but a later `### v9.0 phase progress` heading (under `## Progress`) is.
+    // The anchor must not latch onto the progress heading and drop the phases.
+    writeState(tmpDir, { milestone: 'v9.0' });
+    const content = [
+      '# ROADMAP',
+      '',
+      '## Milestones',
+      '',
+      '- 🚧 **v9.0 Test Milestone** — Phases 1-2 (in progress)',
+      '',
+      '## Phases',
+      '',
+      '### Phase 1: Alpha',
+      '',
+      '**Goal:** do alpha',
+      '',
+      '### Phase 2: Beta',
+      '',
+      '**Goal:** do beta',
+      '',
+      '## Progress',
+      '',
+      '### v9.0 phase progress',
+      '',
+      '| Phase | Status |',
+      '|-------|--------|',
+      '| 1     | Planned |',
+      '| 2     | Planned |',
+    ].join('\n');
+    writeRoadmap(tmpDir, content);
+    const roadmap = fs.readFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), 'utf-8');
+    const result = extractCurrentMilestone(roadmap, tmpDir);
+    // The Phase detail headings must be inside the extracted section.
+    assert.ok(result.includes('Phase 1: Alpha'), 'Phase 1 detail must be in scope (got dropped — #2947)');
+    assert.ok(result.includes('Phase 2: Beta'), 'Phase 2 detail must be in scope (got dropped — #2947)');
+    // The progress heading should NOT be the anchor (it has no phase details).
+    assert.ok(!result.startsWith('### v9.0 phase progress'), 'progress heading must not be the anchor');
+  });
+
+  test('#2947 — version-bearing phase-listing heading still resolves (control, no regression)', () => {
+    // The one-word control from the issue: rename `## Phases` → `## v9.0 Phases`.
+    // This already works today and must keep working after the fix.
+    writeState(tmpDir, { milestone: 'v9.0' });
+    const content = [
+      '# ROADMAP',
+      '',
+      '## v9.0 Phases',
+      '',
+      '### Phase 1: Alpha',
+      '',
+      '**Goal:** do alpha',
+      '',
+      '### Phase 2: Beta',
+      '',
+      '**Goal:** do beta',
+      '',
+      '## Progress',
+      '',
+      '### v9.0 phase progress',
+      '',
+      '| Phase | Status |',
+    ].join('\n');
+    writeRoadmap(tmpDir, content);
+    const roadmap = fs.readFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), 'utf-8');
+    const result = extractCurrentMilestone(roadmap, tmpDir);
+    assert.ok(result.includes('Phase 1: Alpha'), 'control: Phase 1 in scope');
+    assert.ok(result.includes('Phase 2: Beta'), 'control: Phase 2 in scope');
+  });
+
+  test('#2947 — falls back to first non-closed when no candidate section has Phase details', () => {
+    // No `### Phase N:` details anywhere — the fix's fallback must preserve
+    // today's behavior (no crash, returns a section).
+    writeState(tmpDir, { milestone: 'v9.0' });
+    const content = [
+      '# ROADMAP',
+      '',
+      '## v9.0 Milestone',
+      '',
+      'Some prose, no phase detail headings.',
+      '',
+      '### v9.0 notes',
+      '',
+      'More prose.',
+    ].join('\n');
+    writeRoadmap(tmpDir, content);
+    const roadmap = fs.readFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), 'utf-8');
+    const result = extractCurrentMilestone(roadmap, tmpDir);
+    assert.ok(typeof result === 'string', 'fallback returns a string section without throwing');
+    assert.ok(result.includes('v9.0'), 'fallback still includes the milestone content');
+  });
+
+  test('#2947 — closed milestone heading is not preferred over an open one with phase details', () => {
+    // A closed (✅) version-bearing heading must not win over an open one
+    // whose section contains the phase details.
+    writeState(tmpDir, { milestone: 'v2.0' });
+    const content = [
+      '# ROADMAP',
+      '',
+      '## ✅ v1.0 Shipped',
+      '',
+      '### Phase 1: Old',
+      '',
+      '## 🚧 v2.0 Current',
+      '',
+      '### Phase 2: New',
+      '',
+      '**Goal:** new work',
+    ].join('\n');
+    writeRoadmap(tmpDir, content);
+    const roadmap = fs.readFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), 'utf-8');
+    const result = extractCurrentMilestone(roadmap, tmpDir);
+    assert.ok(result.includes('Phase 2: New'), 'open milestone phase selected');
+    assert.ok(!result.includes('Phase 1: Old'), 'closed milestone phase excluded');
+  });
+
+  test('#2947 — roadmap.analyze on the issue fixture reports phase_count 2 (end-to-end)', () => {
+    writeState(tmpDir, { milestone: 'v9.0', gsd_state_version: '1.0' });
+    const content = [
+      '# ROADMAP',
+      '',
+      '## Milestones',
+      '',
+      '- 🚧 **v9.0 Test Milestone** — Phases 1-2 (in progress)',
+      '',
+      '## Phases',
+      '',
+      '### Phase 1: Alpha',
+      '',
+      '**Goal:** do alpha',
+      '',
+      '### Phase 2: Beta',
+      '',
+      '**Goal:** do beta',
+      '',
+      '## Progress',
+      '',
+      '### v9.0 phase progress',
+      '',
+      '| Phase | Status |',
+      '|-------|--------|',
+      '| 1     | Planned |',
+      '| 2     | Planned |',
+    ].join('\n');
+    writeRoadmap(tmpDir, content);
+
+    const result = runGsdTools(['query', 'roadmap.analyze', '--raw'], tmpDir);
+    assert.ok(result.success, `roadmap.analyze should succeed; got: ${result.error}`);
+    const payload = JSON.parse(result.output);
+    assert.strictEqual(payload.phase_count, 2, `expected phase_count 2, got ${payload.phase_count} (phases dropped — #2947)`);
   });
 });
 


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #2947

## What was broken

`gsd-tools query roadmap.analyze` silently dropped phases (`phase_count: 0`, exit 0, empty stderr) when the phase list lived under a non-version-bearing `## Phases` heading (the shipped greenfield template's own shape) and a later version-bearing progress/notes heading (e.g. `### v9.0 phase progress` under `## Progress`) existed. The one-word control (`## Phases` → `## v9.0 Phases`) restored `phase_count: 2`.

The failure is silent and its blast radius is the widest in the sweep: every consumer that gates on `roadmap.analyze` — `/gsd-autonomous` phase discovery, `init.phase-op` disk-status resolution, plan/execute phase lookup — behaves as if the milestone has no phases.

## What this fix does

Gates the preamble `### Phase N:` detail strip on whether the selected milestone section (`currentSection`) actually contains its own phase details:
- When `currentSection` HAS phase details (the #730/#870 multi-milestone case with a dedicated Phase Details section), the preamble strip still fires — byte-identical behavior, no regression.
- When `currentSection` has NO phase details (the #2947 case — the selected heading is a progress/notes sub-heading), the preamble phases ARE the milestone's only phases and are preserved instead of stripped.

One conditional on an existing strip; no signature change; no change to `computeSectionEnd`, the anchor selection, or the #730 Phase Details append.

## Root cause

The issue title points at anchor selection, but the actual drop is one layer deeper — in the **preamble strip** (`src/roadmap-parser.cts:240`, from #870/#1729). `extractCurrentMilestone` builds `preamble + currentSection [+ detailsSection]`, where `preamble` is the pre-milestone region post-processed to strip `### Phase N:` detail headings (intended to avoid duplication with a Phase Details section). When the phase list lives in the preamble (under a non-version-bearing `## Phases`) and the selected version-bearing heading's section has no phase details of its own, the strip removes the milestone's only phases. The phases were *in* the extracted content momentarily, then stripped.

Long-standing (predates the issue by weeks, not a regression). Related to but distinct from #557 (closed), which covered the *no match at all* path; this is the *wrong match* path where the match exists but its section is empty of phases.

## Testing

### How I verified the fix

- **RED proven** at `6cf3d8f95` (pre-fix): 3 failures both lanes — the regression test, the end-to-end `roadmap.analyze` test, and the describe-level `extractCurrentMilestone`.
- **GREEN** at `8db6a565b` (post-fix): 30423/30423 both lanes (linux-node22 + linux-node24), 0 failures.
- Reproduced locally against the built lib with the issue's exact fixture; confirmed the one-word control restores `phase_count: 2`.
- `npm run lint:ci` clean (exit 0).

### Regression test added?

- [x] Yes — 5 tests in `tests/roadmap-parser.test.cjs` (`#2947 —` prefix): (1) the regression — preamble phases preserved when currentSection has none; (2) the version-bearing control (must keep working); (3) the no-phase-details-anywhere fallback; (4) closed-vs-open milestone preference; (5) end-to-end `roadmap.analyze --raw` asserting `phase_count === 2`.

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux (gsd-test matrix: linux-node22 + linux-node24, both green)
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (CLI-core fix, runtime-agnostic)

## Reviews

Two orthogonal reviews + graph deterministic pass (recorded in `.gsd/bug/fix-2947-.../60-review.json`):
- **isolated adversarial**: APPROVE — no findings at ≥80 confidence. Verified the gating condition is a strict superset of the strip (cannot false-negative), the `/$/` no-op is safe, the #730/#870 multi-milestone case is unaffected, and no double-counting.
- **Memtrace graph pass** (`find_code_review_issues`, strict): 0 issues, graph ready.

One sub-threshold observation (informational, out of scope): `getMilestonePhaseFilter`'s separate `versionOverride` slicing path does not use the preamble-strip logic and could exhibit the same shape with a version override — pre-existing, not introduced here, and `roadmap.analyze` does not exercise it.

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug (one gated conditional + tests + changeset)
- [x] Regression test added
- [x] All existing tests pass (gsd-test 30423/30423 both lanes)
- [x] `.changeset/` fragment added
- [x] No unnecessary dependencies added

## Breaking changes

Behavior change (restores correct intent): `roadmap.analyze` now reports phases that were previously silently dropped when the phase-listing heading isn't version-bearing. No roadmap that currently resolves phases correctly is affected — the gating falls back to today's strip behavior whenever the selected section has its own phase details.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/3084"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788541173&installation_model_id=22188&pr_number=3084&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F3084&signature=401f8a952d11b929da925b351fd01a34c1700e79df4d624898878f6ab9dc4f89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->