### PR TITLE
fix(#2969): ratchet completed_plans up for gap-closure plans under deriveProgressKeys

### DIFF
--- a/.changeset/lucky-tunas-leap.md
+++ b/.changeset/lucky-tunas-leap.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`progress.completed_plans` no longer stays pinned after a gap-closure cycle** — when plan-phase re-planned a phase and added gap-closure plans, `total_plans` corrected upward but `completed_plans` was restored to its pre-growth value, so STATE.md showed `completed_plans < total_plans` permanently even after every plan (including the gap-closure ones) was summarized. `completed_plans` and `completed_phases` now ratchet up to the disk-derived count under the plan-phase progress opt-in (never deriving downward, preserving the curated-progress ratchet for unrelated edits). (#2969)

--- a/.changeset/lucky-tunas-leap.md
+++ b/.changeset/lucky-tunas-leap.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 3091
 ---
 **`progress.completed_plans` no longer stays pinned after a gap-closure cycle** — when plan-phase re-planned a phase and added gap-closure plans, `total_plans` corrected upward but `completed_plans` was restored to its pre-growth value, so STATE.md showed `completed_plans < total_plans` permanently even after every plan (including the gap-closure ones) was summarized. `completed_plans` and `completed_phases` now ratchet up to the disk-derived count under the plan-phase progress opt-in (never deriving downward, preserving the curated-progress ratchet for unrelated edits). (#2969)

--- a/src/state-transition.cts
+++ b/src/state-transition.cts
@@ -195,11 +195,27 @@ export function applyStatePreservation(input: StatePreservationInput): StatePres
       const derived = (postFm['progress'] ?? {}) as Record<string, unknown>;
       const merged: Record<string, unknown> = { ...derived };
       if (curated) {
+        // #2440: total_plans and total_phases always take the derived value.
+        // #2969: completed_plans and completed_phases take the derived value
+        // when it is GREATER than the curated value (gap-closure plans that
+        // completed after the plan count grew) — ratcheting UP only, never
+        // deriving downward (preserves the #3242 curated-progress protection
+        // for cases unrelated to plan-count growth, e.g. a deleted SUMMARY).
+        const ratchetUpKeys = new Set(['completed_plans', 'completed_phases']);
         for (const [key, value] of Object.entries(curated)) {
-          if (key !== 'total_plans' && key !== 'total_phases') {
+          if (key === 'total_plans' || key === 'total_phases') continue;
+          if (ratchetUpKeys.has(key)) {
+            const derivedNum = typeof derived[key] === 'number' ? derived[key] : -Infinity;
+            const curatedNum = typeof value === 'number' ? value : -Infinity;
+            // Take the derived value only when it ratchets up; else keep curated.
+            if (derivedNum > curatedNum) continue;
+            merged[key] = value;
+          } else {
             merged[key] = value;
           }
         }
+        // percent recomputes from the final completed/total — prefer derived
+        // (the resync already computed it from disk counts).
       }
       postFm['progress'] = merged;
     } else {

--- a/src/state-transition.cts
+++ b/src/state-transition.cts
@@ -201,9 +201,12 @@ export function applyStatePreservation(input: StatePreservationInput): StatePres
         // completed after the plan count grew) — ratcheting UP only, never
         // deriving downward (preserves the #3242 curated-progress protection
         // for cases unrelated to plan-count growth, e.g. a deleted SUMMARY).
+        // percent also takes the derived value — the resync recomputed it from
+        // disk counts, and a stale curated percent would be incoherent against
+        // the ratcheted-up completed counts (e.g. 54/54 at 93%).
         const ratchetUpKeys = new Set(['completed_plans', 'completed_phases']);
         for (const [key, value] of Object.entries(curated)) {
-          if (key === 'total_plans' || key === 'total_phases') continue;
+          if (key === 'total_plans' || key === 'total_phases' || key === 'percent') continue;
           if (ratchetUpKeys.has(key)) {
             const derivedNum = typeof derived[key] === 'number' ? derived[key] : -Infinity;
             const curatedNum = typeof value === 'number' ? value : -Infinity;
@@ -214,8 +217,6 @@ export function applyStatePreservation(input: StatePreservationInput): StatePres
             merged[key] = value;
           }
         }
-        // percent recomputes from the final completed/total — prefer derived
-        // (the resync already computed it from disk counts).
       }
       postFm['progress'] = merged;
     } else {

--- a/tests/state-transition.test.cjs
+++ b/tests/state-transition.test.cjs
@@ -1340,6 +1340,61 @@ describe('ADR-1769 #1796: applyStatePreservation — table-driven post-sync cons
       'total_plans equality → derived value (identity)');
   });
 
+  test('#2969: deriveProgressKeys=true — completed_plans ratchets UP when disk count exceeds curated (gap-closure plans completed)', () => {
+    // Gap-closure scenario: a phase had 50 plans all summarized (completed_plans: 50),
+    // then 4 gap-closure plans were added (total_plans -> 54) and all 4 got SUMMARYs.
+    // Disk scan now counts 54 summaries. The curated completed_plans (50) must
+    // ratchet UP to the derived value (54), not stay pinned at 50 — otherwise
+    // completed_plans < total_plans forever even though every plan is summarized.
+    const curated = { progress: { total_plans: 54, completed_plans: 50, total_phases: 2, completed_phases: 1, percent: 93 } };
+    const r = applyStatePreservation({
+      preFm: curated,
+      preFmSnapshot: curated,
+      postFm: { progress: { total_plans: 54, completed_plans: 54, total_phases: 2, completed_phases: 1, percent: 100 } },
+      resync: false,
+      deriveProgressKeys: true,
+      ...untouched,
+    });
+    assert.equal(r.postFm.progress.total_plans, 54, 'total_plans takes derived value');
+    assert.equal(r.postFm.progress.completed_plans, 54,
+      'completed_plans must ratchet UP to derived (54 > curated 50 — gap-closure plans completed) (#2969)');
+    assert.equal(r.postFm.progress.percent, 100,
+      'percent must reflect the true completion fraction (54/54) (#2969)');
+  });
+
+  test('#2969 ratchet-down protection: deriveProgressKeys=true keeps curated when disk count < curated', () => {
+    // The ratchet must only go UP. If the disk count is somehow LOWER than
+    // curated (e.g. a SUMMARY was deleted), keep the curated value — do not
+    // derive downward. (#3242 curated-progress protection, scoped to deriveProgressKeys.)
+    const curated = { progress: { total_plans: 54, completed_plans: 50, percent: 93 } };
+    const r = applyStatePreservation({
+      preFm: curated,
+      preFmSnapshot: curated,
+      postFm: { progress: { total_plans: 54, completed_plans: 47, percent: 87 } },
+      resync: false,
+      deriveProgressKeys: true,
+      ...untouched,
+    });
+    assert.equal(r.postFm.progress.completed_plans, 50,
+      'completed_plans must NOT derive downward (47 < curated 50) — ratchet-up only (#2969/#3242)');
+  });
+
+  test('#2969 body-only write protection: deriveProgressKeys absent keeps wholesale restore', () => {
+    // state.update/patch (no deriveProgressKeys flag) must keep the full #3242
+    // wholesale curated restore — completed_plans never moves for a body-only edit.
+    const curated = { progress: { total_plans: 54, completed_plans: 50, percent: 93 } };
+    const r = applyStatePreservation({
+      preFm: curated,
+      preFmSnapshot: curated,
+      postFm: { progress: { total_plans: 54, completed_plans: 54, percent: 100 } },
+      resync: false,
+      // deriveProgressKeys NOT set — body-only write path
+      ...untouched,
+    });
+    assert.equal(r.postFm.progress.completed_plans, 50,
+      'body-only write must keep curated completed_plans (no deriveProgressKeys) (#2969/#3242)');
+  });
+
   test('progress: NOT restored when transition re-derives from disk (resync=true) — sync/advancePlan/completePhase path', () => {
     const recomputed = { progress: { total_phases: 5, completed_phases: 1, percent: 20 } };
     const r = applyStatePreservation({


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #2969

## What was broken

When `plan-phase` re-planned a phase and added gap-closure plans, `progress.total_plans` corrected upward (the disk scan re-derived it) but `progress.completed_plans` was restored to its pre-growth curated value — and no subsequent per-plan execution update re-derived it. STATE.md ended up at `completed_plans < total_plans` permanently, even after every plan (including the gap-closure ones) was summarized. The STATE.md prose line "N/N plans with SUMMARY" (computed independently) visibly disagreed with the frontmatter counters in the same file.

## What this fix does

Extends the `deriveProgressKeys` opt-in path in `applyStatePreservation` (`src/state-transition.cts`) to also let `completed_plans`, `completed_phases`, and `percent` take the disk-derived value — but **ratcheted UP only** (derived > curated). When the disk count of summaries exceeds the curated `completed_plans` (gap-closure plans that completed), the derived value wins; when it's lower (e.g. a deleted SUMMARY), the curated value is kept (the #3242 curated-progress protection stays intact). `percent` takes the derived value (the resync recomputed it from disk counts; a stale curated percent would be incoherent against the ratcheted-up completed counts).

Scoped to `deriveProgressKeys` (plan-phase's explicit opt-in only); body-only writes (`state.update`/`patch` without the flag) keep the full #3242 wholesale curated restore.

## Root cause

`applyStatePreservation` lines 193-207: under `deriveProgressKeys=true`, the exclusion list at line 199 only let `total_plans` and `total_phases` take the derived value — `completed_plans`/`completed_phases`/`percent` were all restored to curated. So adding plans bumped the total but the completed count could never catch up without a manual full `state sync`.

## Testing

### How I verified the fix

- **RED proven** at `ba82fe646` (pre-fix): 2 failures — the ratchet-up regression test + the describe-level block.
- **GREEN** at `587a4301c` (post-fix incl. the percent correction): 30496/30496 both lanes, 0 failures. Re-verified on rebased HEAD.
- The isolated adversarial review caught a **blocker** in the first fix iteration: `percent` fell into the `else` branch and was overwritten with the stale curated value, contradicting the inline comment and leaving STATE.md incoherent (e.g. 54/54 at 93%). Fixed by also skipping `percent` in the ratchet loop.

### Regression test added?

- [x] Yes — 3 tests in `tests/state-transition.test.cjs`: (1) ratchet-up (derived 54 > curated 50 → takes 54, percent 100); (2) ratchet-down protection (derived 47 < curated 50 → keeps curated 50); (3) body-only write protection (no `deriveProgressKeys` → wholesale curated restore). The existing #2440 test (derived 49 < curated 50) still passes — ratchet holds in both directions.

### Platforms tested

- [ ] macOS
- [ ] Windows
- [x] Linux (gsd-test matrix: linux-node22 + linux-node24, both green)
- [ ] N/A

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] N/A (core state-transition logic, runtime-agnostic)

## Reviews

- **isolated adversarial**: found a BLOCKER (percent overwrite) in the first iteration — fixed. Re-confirmed clean on all other axes (ratchet direction correct, #3242 body-only path intact, #2440 test still passes, tests non-vacuous).

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug (state-transition.cts ratchet logic + tests + changeset)
- [x] Regression test added
- [x] All existing tests pass (gsd-test 30496/30496 both lanes)
- [x] `.changeset/` fragment added
- [x] No unnecessary dependencies added

## Breaking changes

None. The ratchet only releases upward under plan-phase's explicit `deriveProgressKeys` opt-in; body-only writes and the downward ratchet are unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/3091"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788554522&installation_model_id=22188&pr_number=3091&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F3091&signature=1a48438c451bc1b01fbd31084fc8472014c00cb16df351ffc1e6f54815dca323"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->