### PR TITLE
fix(#2979): document ExitError plain-text carve-out in json-errors.md

### DIFF
--- a/.changeset/kind-sloths-climb.md
+++ b/.changeset/kind-sloths-climb.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 3093
 ---
 **`docs/json-errors.md` now documents the ExitError plain-text carve-out** — the page previously claimed every CLI error emits a structured JSON envelope on stderr, but usage errors (ExitError) intentionally emit plain text with their own exit code. The structured-envelope guidance is now scoped to non-usage failures, with the carve-out stated explicitly and a characterization test pinning both paths. (#2979)

--- a/.changeset/kind-sloths-climb.md
+++ b/.changeset/kind-sloths-climb.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`docs/json-errors.md` now documents the ExitError plain-text carve-out** — the page previously claimed every CLI error emits a structured JSON envelope on stderr, but usage errors (ExitError) intentionally emit plain text with their own exit code. The structured-envelope guidance is now scoped to non-usage failures, with the carve-out stated explicitly and a characterization test pinning both paths. (#2979)

--- a/docs/json-errors.md
+++ b/docs/json-errors.md
@@ -2,11 +2,12 @@
 
 ## Overview
 
-`gsd-tools` supports a **JSON error mode** that emits all errors as structured
+`gsd-tools` supports a **JSON error mode** that emits most errors as structured
 JSON objects on stderr instead of free-form text.  This is the recommended
 surface for tests and tooling that need to assert on error types without
 grepping raw text (see `CONTRIBUTING.md` — "Prohibited: Raw Text Matching on
-Test Outputs").
+Test Outputs"). Usage errors are an intentional exception — see the
+`ExitError` carve-out below.
 
 ## Activating
 
@@ -36,6 +37,20 @@ Fields:
 | `ok`      | `false` | Always `false` for error objects. |
 | `reason`  | string  | Typed reason code from the taxonomy below. |
 | `message` | string  | Human-readable description (may change; do not assert on it). |
+
+### `ExitError` carve-out (plain text, not JSON)
+
+Usage errors and explicit exit-code signals take a **different path**: they
+throw `ExitError` (`src/cli-exit.cts`), which `runMain` catches *before* the
+JSON-envelope branch. An `ExitError` writes its `message` as **plain text**
+to stderr (not a JSON object) and exits with the error's own `code` (which
+may differ from 1). This is intentional — usage messages are operator-facing
+prose, not structured failures.
+
+If you are testing a usage/flag error, do **not** parse stderr as JSON;
+assert on the exit code and (if needed) the plain-text message. The
+"parse stderr as JSON" guidance below applies only to the structured-envelope
+branch (non-`ExitError` failures).
 
 ## Error code taxonomy
 
@@ -99,8 +114,9 @@ text (unstable).
 
 ## Writing tests
 
-Always parse stderr with `JSON.parse` and assert on typed fields.  Never use
-`.includes()`, `.match()`, or regex on the raw error string.
+For **non-usage** errors (the structured-envelope branch), parse stderr with
+`JSON.parse` and assert on typed fields.  Never use `.includes()`, `.match()`,
+or regex on the raw error string.
 
 ```js
 // CORRECT: parse then assert on typed field

--- a/tests/cli-exit.test.cjs
+++ b/tests/cli-exit.test.cjs
@@ -183,11 +183,18 @@ describe('runMain', () => {
 describe('regressions', () => {
   /** Spawn a one-shot script that sets json-error mode and calls runMain with a throwing handler. */
   function spawnJsonErrorRun({ jsonMode, errorType = 'TypeError', message = 'unexpected boom' } = {}) {
+    // ExitError lives in the same module as runMain; import it when the test
+    // wants to exercise the ExitError carve-out path. ExitError takes (code, message).
+    const isExitError = errorType === 'ExitError';
+    const destructure = isExitError ? '{ runMain, ExitError }' : '{ runMain }';
+    const throwExpr = isExitError
+      ? `new ExitError(1, ${JSON.stringify(message)})`
+      : `new ${errorType}(${JSON.stringify(message)})`;
     const script = `
       const io = require(${JSON.stringify(IO_PATH)});
-      const { runMain } = require(${JSON.stringify(BUILT_CLI_EXIT_PATH)});
+      const ${destructure} = require(${JSON.stringify(BUILT_CLI_EXIT_PATH)});
       io.setJsonErrorMode(${jsonMode ? 'true' : 'false'});
-      runMain(() => { throw new ${errorType}(${JSON.stringify(message)}); });
+      runMain(() => { throw ${throwExpr}; });
       setImmediate(() => {});
     `;
     return spawnSync(process.execPath, ['-e', script], { encoding: 'utf-8' });
@@ -244,6 +251,36 @@ describe('regressions', () => {
         stderrTrimmed.includes('unexpected boom'),
         `expected "unexpected boom" in stderr, got: ${stderrTrimmed.slice(0, 200)}`
       );
+    });
+
+    // #2979: characterization test pinning the two error paths under json-errors
+    // mode. The structured envelope covers non-ExitError failures; ExitError
+    // (usage errors) intentionally emits plain text with its own exit code.
+    // Both halves asserted together so the code cannot drift toward the doc's
+    // prior overstated claim that EVERY error emits JSON.
+    test('#2979: ExitError emits plain text (not JSON) even under --json-errors; non-ExitError emits the envelope', () => {
+      // ExitError path: plain text, own exit code, NOT a JSON object.
+      const exitResult = spawnJsonErrorRun({
+        jsonMode: true,
+        errorType: 'ExitError',
+        message: 'Usage: gsd-tools <command> [args]',
+      });
+      assert.strictEqual(exitResult.status, 1, 'ExitError exits with its code');
+      const exitStderr = exitResult.stderr.trim();
+      let exitParsed = null;
+      try { exitParsed = JSON.parse(exitStderr); } catch { /* expected — plain text */ }
+      assert.strictEqual(exitParsed, null,
+        `ExitError must emit plain text, not JSON; got: ${exitStderr.slice(0, 200)}`);
+      assert.ok(exitStderr.includes('Usage'),
+        `ExitError plain-text message must reach stderr; got: ${exitStderr.slice(0, 200)}`);
+
+      // Non-ExitError path: structured JSON envelope.
+      const envResult = spawnJsonErrorRun({ jsonMode: true });
+      assert.strictEqual(envResult.status, 1);
+      const envParsed = JSON.parse(envResult.stderr.trim());
+      assert.strictEqual(envParsed.ok, false);
+      assert.strictEqual(envParsed.reason, 'sdk_fail_fast');
+      assert.ok(envParsed.message, 'envelope must carry a message');
     });
   });
 });


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #2979

## What was broken

`docs/json-errors.md` claimed unconditionally that every CLI error emits a structured JSON envelope on stderr, and instructed test authors to always parse stderr as JSON. In reality usage errors (`ExitError`) intentionally emit **plain text** with their own exit code — `runMain` catches `ExitError` before the JSON-envelope branch (`src/cli-exit.cts:36-39`). Anyone following the doc's guidance against a usage error got a parse failure.

## What this fix does

Amends `docs/json-errors.md` (Overview, Wire format, Writing tests sections) to:
- Scope the structured-envelope claim to non-`ExitError` failures.
- State the `ExitError` plain-text carve-out explicitly, with a pointer to `src/cli-exit.cts`.
- Scope the "parse stderr as JSON" instruction to the envelope branch.

Adds a characterization test pinning both paths together (`ExitError` → plain text + own code; non-`ExitError` → JSON envelope) so the code cannot drift toward the doc's prior overstated claim. No runtime change — the test passes before and after the doc edit.

## Root cause

The doc was written to a simpler model than the code ever implemented. `runMain`'s own docstring (`src/cli-exit.cts:22-29`) states the contract correctly; the standalone doc page drifted.

## Re-scope note

The maintainer triage re-scoped this issue: the `smart-entry --json` part is already satisfied (the shipped payload exposes the recommended action's command token). Only the json-errors.md doc correction + characterization test remain.

## Testing

- **gsd-test**: 30546/30546 both lanes, 0 failures.
- The characterization test asserts both paths: `ExitError` emits non-JSON plain text + exit 1; non-`ExitError` under `--json-errors` emits `{ok:false, reason, message}` JSON.

## Checklist

- [x] Issue linked · [x] confirmed-bug · [x] scoped · [x] test pins existing behavior · [x] all tests pass · [x] changeset added · [x] no new deps

## Breaking changes

None. Documentation correction + characterization test only; no runtime change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/3093"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788562004&installation_model_id=22188&pr_number=3093&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F3093&signature=2581e5057e54d6d74d0e065d84131a919ec23cccd1f764c350ea007aa6be47ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->