### PR TITLE
fix(#2988): local changeset/docs lint falls back to next, not main

### DIFF
--- a/.changeset/witty-yaks-munch.md
+++ b/.changeset/witty-yaks-munch.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**Local `lint:changeset` and `lint:docs-required` now diff against `next` instead of `main`** — the local fallback was the release branch (`main`), which lags far behind the integration branch (`next`), so the lint always passed by finding fragments from other already-merged PRs in the oversized diff range. The local invocation now matches the base CI uses. (#2988)

--- a/.changeset/witty-yaks-munch.md
+++ b/.changeset/witty-yaks-munch.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 3095
 ---
 **Local `lint:changeset` and `lint:docs-required` now diff against `next` instead of `main`** — the local fallback was the release branch (`main`), which lags far behind the integration branch (`next`), so the lint always passed by finding fragments from other already-merged PRs in the oversized diff range. The local invocation now matches the base CI uses. (#2988)

--- a/scripts/changeset/lint.cjs
+++ b/scripts/changeset/lint.cjs
@@ -12,6 +12,10 @@
  * Tests assert on the typed verdict, never on free text.
  */
 
+// #2988: the repo's integration/default branch — the base every PR targets.
+// Used as the local fallback when GITHUB_BASE_REF is unset (CI sets it).
+const DEFAULT_BASE = 'next';
+
 const LINT_REASON = Object.freeze({
   OK_FRAGMENT_PRESENT: 'ok_fragment_present',
   OK_OPT_OUT_LABEL: 'ok_opt_out_label',
@@ -80,7 +84,10 @@ function main() {
       labels = (event.pull_request?.labels || []).map((l) => l.name);
     } catch { /* fall through */ }
   }
-  const base = process.env.GITHUB_BASE_REF || 'main';
+  // #2988: local fallback must match the repo's integration branch (`next`),
+  // not the release branch (`main`). CI sets GITHUB_BASE_REF explicitly; the
+  // fallback only fires locally, where `next` is the base every PR targets.
+  const base = process.env.GITHUB_BASE_REF || DEFAULT_BASE;
   let changedFiles = [];
   try {
     // Use execFileSync with an argv array — the base ref is interpolated
@@ -145,4 +152,4 @@ function main() {
 
 if (require.main === module) runMain(main);
 
-module.exports = { evaluateLint, LINT_REASON, OPT_OUT_LABEL, isUserFacing, isFragment };
+module.exports = { evaluateLint, LINT_REASON, OPT_OUT_LABEL, isUserFacing, isFragment, DEFAULT_BASE };

--- a/scripts/lint-docs-required.cjs
+++ b/scripts/lint-docs-required.cjs
@@ -16,6 +16,10 @@
 const { parseFragment, FRAGMENT_ERROR } = require('./changeset/parse.cjs');
 const { ExitError, runMain } = require('./lib/cli-exit.cjs');
 
+// #2988: the repo's integration/default branch — the base every PR targets.
+// Used as the local fallback when GITHUB_BASE_REF is unset (CI sets it).
+const DEFAULT_BASE = 'next';
+
 const LINT_REASON = Object.freeze({
   OK_NO_TRIGGERING_FRAGMENTS: 'ok_no_triggering_fragments',
   OK_DOCS_UPDATED: 'ok_docs_updated',
@@ -149,7 +153,10 @@ function main() {
     } catch { /* fall through */ }
   }
 
-  const base = process.env.GITHUB_BASE_REF || 'main';
+  // #2988: local fallback must match the repo's integration branch (`next`),
+  // not the release branch (`main`). CI sets GITHUB_BASE_REF explicitly; the
+  // fallback only fires locally, where `next` is the base every PR targets.
+  const base = process.env.GITHUB_BASE_REF || DEFAULT_BASE;
   let changedFiles = [];
   try {
     // execFileSync with argv — no shell, so a malicious GITHUB_BASE_REF
@@ -216,6 +223,7 @@ module.exports = {
   OPT_OUT_LABEL,
   TRIGGERING_TYPES,
   FRAGMENT_ERROR,
+  DEFAULT_BASE,
   isFragmentPath,
   isDocsFile,
   isExemptFragment,

--- a/tests/changeset-lint.test.cjs
+++ b/tests/changeset-lint.test.cjs
@@ -8,7 +8,8 @@ const fs = require('node:fs');
 const os = require('node:os');
 const cp = require('node:child_process');
 
-const { evaluateLint, LINT_REASON } = require(path.join(__dirname, '..', 'scripts', 'changeset', 'lint.cjs'));
+const { evaluateLint, LINT_REASON, DEFAULT_BASE: CHANGESET_DEFAULT_BASE } = require(path.join(__dirname, '..', 'scripts', 'changeset', 'lint.cjs'));
+const { DEFAULT_BASE: DOCS_DEFAULT_BASE } = require(path.join(__dirname, '..', 'scripts', 'lint-docs-required.cjs'));
 
 const ROOT = path.join(__dirname, '..');
 const LINT_SCRIPT = path.join(ROOT, 'scripts', 'changeset', 'lint.cjs');
@@ -295,5 +296,21 @@ describe('changeset lint: main() end-to-end wiring (#1006)', () => {
     const failures = report.failures ?? [];
     const deletedEntry = failures.find((f) => f.file.endsWith('.changeset/old.md'));
     assert.ok(!deletedEntry, `deleted fragment must not appear in failures, got: ${JSON.stringify(failures)}`);
+  });
+});
+
+// ─── #2988: local base fallback parity ──────────────────────────────────────
+
+describe('#2988: changeset + docs lints resolve the same local base fallback', () => {
+  test('both lints default to `next` (the integration branch), not `main`', () => {
+    assert.strictEqual(CHANGESET_DEFAULT_BASE, 'next',
+      `changeset lint DEFAULT_BASE must be 'next', got '${CHANGESET_DEFAULT_BASE}'`);
+    assert.strictEqual(DOCS_DEFAULT_BASE, 'next',
+      `docs lint DEFAULT_BASE must be 'next', got '${DOCS_DEFAULT_BASE}'`);
+  });
+
+  test('both lints resolve the same base given the same environment (parity)', () => {
+    assert.strictEqual(CHANGESET_DEFAULT_BASE, DOCS_DEFAULT_BASE,
+      `the two lints must not diverge on base resolution: changeset='${CHANGESET_DEFAULT_BASE}' docs='${DOCS_DEFAULT_BASE}'`);
   });
 });


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #2988

## What was broken

`npm run lint:changeset` and the docs-required lint always passed locally because their diff base fell back to `'main'` (the release branch) when `GITHUB_BASE_REF` was unset. `main` lags far behind `next` (the integration branch every PR targets), so the oversized diff range swept in every changeset fragment merged since the last release — the lint passed on the first fragment it saw regardless of whether the current PR authored it. Structurally vacuous: a contributor could see a clean local "ok", push, and get a red CI check for a missing fragment.

## What this fix does

Changed the local fallback from `'main'` to `'next'` in both `scripts/changeset/lint.cjs` and `scripts/lint-docs-required.cjs`. Extracted a shared `DEFAULT_BASE = 'next'` constant (exported from both scripts) so the two lints cannot diverge. Added a parity test asserting both resolve the same base.

CI behavior is unchanged — `GITHUB_BASE_REF` is set explicitly in GitHub Actions, so the fallback never fires there.

## Testing

- **gsd-test**: 30555/30555 both lanes, 0 failures.
- Parity test asserts both lints default to `'next'` and resolve identically.

## Checklist

- [x] Issue linked · [x] confirmed-bug · [x] scoped · [x] parity test added · [x] all tests pass · [x] changeset added · [x] no new deps

## Breaking changes

None. CI behavior unchanged; the local fallback now matches the integration branch.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/3095"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788563924&installation_model_id=22188&pr_number=3095&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F3095&signature=aea6d4733a1761f2ff59ba0f3fa5613a355448cf991292d667fc41c9e36e6fc1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->