### PR TITLE
fix(#2989): anchor code-review diff-base grep to phase-mention convention

### DIFF
--- a/.changeset/proud-pumas-bark.md
+++ b/.changeset/proud-pumas-bark.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 3096
 ---
 **`/gsd-code-review` no longer picks a wrong diff base from unanchored commit-message grep** — the diff-base fallback searched all commit messages for the bare phase number as a substring, matching version strings, dates, and issue refs, then took the oldest match. The grep is now anchored to the phase-mention convention (`Phase N` with a word boundary), so the fail-closed branch is reachable when no commit genuinely references the phase. (#2989)

--- a/.changeset/proud-pumas-bark.md
+++ b/.changeset/proud-pumas-bark.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`/gsd-code-review` no longer picks a wrong diff base from unanchored commit-message grep** — the diff-base fallback searched all commit messages for the bare phase number as a substring, matching version strings, dates, and issue refs, then took the oldest match. The grep is now anchored to the phase-mention convention (`Phase N` with a word boundary), so the fail-closed branch is reachable when no commit genuinely references the phase. (#2989)

--- a/gsd-core/workflows/code-review.md
+++ b/gsd-core/workflows/code-review.md
@@ -236,8 +236,13 @@ Additionally, whenever a reliable diff base is available, cross-check the SUMMAR
 against the diff and warn about (then add) any changed files the SUMMARY extractor did not
 surface — so a partial SUMMARY result can no longer silently mask the rest of the phase.
 ```bash
-# Compute diff base from phase commits — fail closed if no reliable base found
-PHASE_COMMITS=$(git log --oneline --all --grep="${PADDED_PHASE}" --format="%H" 2>/dev/null)
+# Compute diff base from phase commits — fail closed if no reliable base found.
+# #2989: anchor the grep to the phase-mention convention ("Phase N" / "phase N"
+# with a word boundary) so a bare digit substring doesn't match version strings,
+# dates, issue refs, or other phases' numbers. With --extended-regexp, \b is
+# a word boundary. When no commit genuinely references the phase, this yields
+# empty and the fail-closed warning below actually fires.
+PHASE_COMMITS=$(git log --oneline --all --grep="[Pp]hase ${PADDED_PHASE}\b" --extended-regexp --format="%H" 2>/dev/null)
 DIFF_BASE=""
 if [ -n "$PHASE_COMMITS" ]; then
   DIFF_BASE=$(echo "$PHASE_COMMITS" | tail -1)^

--- a/tests/emitted-drift-acks/2989-code-review-anchored-diff-base.json
+++ b/tests/emitted-drift-acks/2989-code-review-anchored-diff-base.json
@@ -1,0 +1,6 @@
+{
+  "version": 1,
+  "paths": {
+    "code-review.md": "#2989: the diff-base fallback's git log --grep was changed from an unanchored bare phase number (matching version strings, dates, issue refs) to an anchored '[Pp]hase N\\b' with --extended-regexp, plus a 5-line comment explaining the anchor. Makes the fail-closed branch reachable when no commit genuinely references the phase."
+  }
+}


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #2989

## What was broken

`code-review.md` derived its diff base (`DIFF_BASE`) by searching all commit messages for the bare phase number as an unanchored substring (`--grep="${PADDED_PHASE}"`), then taking the oldest match. A bare number like `7` matched 2153 of 5299 commits in this repo — version strings, dates, issue refs, byte counts. The derived base was routinely a commit from months or years before the phase existed. The fail-closed branch was dead code because a bare digit almost always matches something.

## What this fix does

Anchored the grep to the phase-mention convention: `--grep="[Pp]hase ${PADDED_PHASE}\b"` with `--extended-regexp`. This matches only commits that genuinely reference the phase by name. When no commit carries the phase's real scope marker, the derivation yields empty and the existing fail-closed warning actually fires (now reachable). All three consumers of `DIFF_BASE` (Tier 3 file scope, fallow pre-pass, agent context) use the same corrected value.

## Testing

- **gsd-test**: 30553/30553 both lanes, 0 failures.
- This is shipped workflow `.md` content (source-text-is-the-product); the emitted-attribution gate passes with a per-PR ack fragment.

## Checklist

- [x] Issue linked · [x] confirmed-bug · [x] scoped · [x] all tests pass · [x] changeset added · [x] no new deps

## Breaking changes

None. The grep now resolves to the correct base (or correctly fails closed); the matched case behavior is unchanged for commits that genuinely reference the phase.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/3096"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788565771&installation_model_id=22188&pr_number=3096&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F3096&signature=ecc0aca87ac13a1b67e5512acf01ea45db374ce72cbd418113905704f786471e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->