### PR TITLE
fix(#3001): indent continuation lines in serializeChangelog

### DIFF
--- a/.changeset/nimble-hawks-hop.md
+++ b/.changeset/nimble-hawks-hop.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 3101
 ---
 **Multi-paragraph changeset bodies no longer truncate and lose their PR trailer** — `serializeChangelog` wrote bullet bodies verbatim, so an embedded newline became a column-0 line that `parseChangelog` treated as the end of the bullet, silently dropping the continuation and the `(#NNNN)` trailer. Continuation lines are now indented so the round-trip preserves content and attribution. (#3001)

--- a/.changeset/nimble-hawks-hop.md
+++ b/.changeset/nimble-hawks-hop.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**Multi-paragraph changeset bodies no longer truncate and lose their PR trailer** — `serializeChangelog` wrote bullet bodies verbatim, so an embedded newline became a column-0 line that `parseChangelog` treated as the end of the bullet, silently dropping the continuation and the `(#NNNN)` trailer. Continuation lines are now indented so the round-trip preserves content and attribution. (#3001)

--- a/scripts/changeset/serialize.cjs
+++ b/scripts/changeset/serialize.cjs
@@ -26,7 +26,11 @@ function serializeChangelog(ir) {
     lines.push(`### ${section.type}`);
     lines.push('');
     for (const b of section.bullets) {
-      lines.push(`- ${b.body} (#${b.pr})`);
+      // #3001: indent continuation lines so parseChangelog's continuation-fold
+      // (/^\s+/) picks them up instead of terminating the bullet at the first
+      // blank line. A multi-paragraph body round-trips with content preserved.
+      const body = b.body.replace(/\n/g, '\n  ');
+      lines.push(`- ${body} (#${b.pr})`);
     }
     lines.push('');
   }

--- a/tests/changeset-serialize.test.cjs
+++ b/tests/changeset-serialize.test.cjs
@@ -152,3 +152,32 @@ describe('changeset serialize: multi-section + prior content (#2975)', () => {
     assert.equal(back.releases[1].sections[0].bullets[0].pr, 100);
   });
 });
+
+// ─── #3001: multi-paragraph body round-trip ────────────────────────────────
+
+describe('#3001: multi-paragraph changeset body round-trips without truncation', () => {
+  test('a body containing \\n\\n retains content from both paragraphs AND its PR number', () => {
+    const ir = {
+      releaseHeader: { version: '1.42.0', date: '2026-08-05' },
+      sections: [{
+        type: 'Fixed',
+        bullets: [{
+          pr: 2595,
+          body: 'First paragraph, load-bearing.\n\nSecond paragraph, also load-bearing.',
+        }],
+      }],
+      priorChangelog: null,
+    };
+    const text = serializeChangelog(ir);
+    const back = parseChangelog(text);
+    const bullet = back.releases[0].sections[0].bullets[0];
+    // PR trailer must survive (was lost pre-fix because the trailer was on the dropped side).
+    assert.equal(bullet.pr, 2595,
+      `PR number must survive round-trip; got: ${bullet.pr}`);
+    // Content from BOTH paragraphs must be present (was truncated pre-fix).
+    assert.ok(bullet.body.includes('First paragraph'),
+      `first paragraph must survive; got: ${JSON.stringify(bullet.body)}`);
+    assert.ok(bullet.body.includes('Second paragraph'),
+      `second paragraph must survive; got: ${JSON.stringify(bullet.body)}`);
+  });
+});


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3001

## What was broken

`serializeChangelog` wrote bullet bodies verbatim, so an embedded newline in a multi-paragraph changeset body became a column-0 line. `parseChangelog`'s continuation-fold (`/^\s+/`) didn't pick it up, so it terminated the bullet early — dropping the continuation text and the `(#NNNN)` PR trailer (recorded as `pr: null`). The round-trip property `serialize(IR) → parse(text) === IR` was false for any body containing a newline.

## What this fix does

Indents continuation lines (`body.replace(/\n/g, '\n  ')`) so `parseChangelog` folds them correctly. The round-trip now preserves content from every paragraph and the PR attribution. Round-trip test asserts both paragraphs' content AND the PR number survive.

## Testing

- **gsd-test**: 30562/30562 both lanes, 0 failures.

## Checklist

- [x] Issue linked · [x] confirmed-bug · [x] scoped · [x] round-trip test added · [x] all tests pass · [x] changeset added · [x] no new deps

## Breaking changes

None. Serializer output for multi-paragraph bodies now round-trips correctly; single-paragraph bodies are unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/3101"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788574115&installation_model_id=22188&pr_number=3101&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F3101&signature=56e9a829512717f3ede4a1ce1a14b016613cbfa196dc9b33ed0337a393875301"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->