### PR TITLE
fix(#3022): suppress spurious typebox fallback warning on Pi startup

### DIFF
--- a/.changeset/daring-hawks-bark.md
+++ b/.changeset/daring-hawks-bark.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**Pi no longer emits a `typebox unavailable` warning at every startup** — the warning fired because the Pi adapter attempts to `require('typebox')` (not a gsd-core dependency) and falls back to a plain JSON-Schema object on every startup. The fallback is the normal path; the warning is now suppressed. (#3022)

--- a/.changeset/daring-hawks-bark.md
+++ b/.changeset/daring-hawks-bark.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 3111
 ---
 **Pi no longer emits a `typebox unavailable` warning at every startup** — the warning fired because the Pi adapter attempts to `require('typebox')` (not a gsd-core dependency) and falls back to a plain JSON-Schema object on every startup. The fallback is the normal path; the warning is now suppressed. (#3022)

--- a/pi/gsd.cjs
+++ b/pi/gsd.cjs
@@ -148,11 +148,10 @@ function buildGsdInvokeParameters() {
       });
     }
   } catch {
-    // typebox is not installed in this environment — fall through.
+    // typebox is not installed in this environment — fall through to the
+    // plain JSON-Schema fallback below. This is the normal path (typebox is
+    // NOT a gsd-core dependency), so no warning is emitted (#3022).
   }
-  process.stderr.write(
-    'gsd: typebox unavailable — gsd_invoke "parameters" falling back to a plain JSON-schema object.\n',
-  );
   return {
     type: 'object',
     properties: {


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3022

## What was broken

Every Pi startup printed `gsd: typebox unavailable — gsd_invoke "parameters" falling back to a plain JSON-schema object.` The Pi adapter's `buildGsdInvokeParameters` attempts `require('typebox')` (not a gsd-core dependency) and falls back to a plain JSON-Schema object — but emits a warning every time, alarming users. The fallback is the normal, expected path since typebox is never installed in a Pi extension context.

## What this fix does

Removed the `process.stderr.write` warning. The catch comment now explains the fallback is normal (#3022).

## Testing

- **gsd-test**: 30665/30665 both lanes, 0 failures.

## Checklist

- [x] Issue linked · [x] confirmed-bug · [x] scoped · [x] all tests pass · [x] changeset added · [x] no new deps

## Breaking changes

None. The fallback schema is unchanged; only the spurious warning is removed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/3111"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788597763&installation_model_id=22188&pr_number=3111&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F3111&signature=73e64e5c5f111b61797e7d4eb9636f3b0009c978162cc541410e01715b022345"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->