### PR TITLE
fix(#3029): remove redundant hooks declaration from plugin manifest

### DIFF
--- a/.changeset/sharp-cranes-hum.md
+++ b/.changeset/sharp-cranes-hum.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**Claude Code plugin installs no longer silently disable all hooks** — the plugin manifest (`.claude-plugin/plugin.json`) explicitly declared `hooks/hooks.json`, which Claude Code also auto-loads by default, causing a duplicate-declaration rejection that silently disabled every hook (security guards, monitors, injection scanners). The redundant declaration is removed; Claude Code's auto-load path handles it. (#3029)

--- a/.changeset/sharp-cranes-hum.md
+++ b/.changeset/sharp-cranes-hum.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 3113
 ---
 **Claude Code plugin installs no longer silently disable all hooks** — the plugin manifest (`.claude-plugin/plugin.json`) explicitly declared `hooks/hooks.json`, which Claude Code also auto-loads by default, causing a duplicate-declaration rejection that silently disabled every hook (security guards, monitors, injection scanners). The redundant declaration is removed; Claude Code's auto-load path handles it. (#3029)

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -19,6 +19,5 @@
     "gsd"
   ],
   "commands": "./commands/gsd/",
-  "skills": "./skills/",
-  "hooks": "./hooks/hooks.json"
+  "skills": "./skills/"
 }

--- a/tests/fixtures/plugin-manifest-schema.json
+++ b/tests/fixtures/plugin-manifest-schema.json
@@ -11,8 +11,7 @@
     "repository",
     "homepage",
     "license",
-    "commands",
-    "hooks"
+    "commands"
   ],
   "additionalProperties": true,
   "properties": {

--- a/tests/issue-766-plugin-manifest.test.cjs
+++ b/tests/issue-766-plugin-manifest.test.cjs
@@ -92,11 +92,12 @@ describe('A: .claude-plugin/plugin.json', () => {
     assert.ok(mdFiles.length > 0, `commands dir must contain at least one .md file`);
   });
 
-  test('hooks field is "./hooks/hooks.json" and that file exists', (t) => {
+  test('#3029: hooks field is ABSENT — Claude Code auto-loads hooks/hooks.json (explicit declaration caused duplicate-rejection)', (t) => {
     if (!manifest) { t.skip('manifest could not be parsed'); return; }
-    assert.equal(manifest.hooks, './hooks/hooks.json', 'hooks must be "./hooks/hooks.json"');
-    const resolvedHooks = path.resolve(path.dirname(PLUGIN_JSON_PATH), '..', manifest.hooks);
-    assert.ok(fs.existsSync(resolvedHooks), `resolved hooks file must exist: ${resolvedHooks}`);
+    assert.ok(!manifest.hooks, 'plugin.json must NOT declare hooks — Claude Code auto-loads hooks/hooks.json; an explicit declaration causes a duplicate-rejection that silently disables all hooks (#3029)');
+    // The auto-loaded hooks file must still exist on disk.
+    const resolvedHooks = path.resolve(path.dirname(PLUGIN_JSON_PATH), '..', 'hooks', 'hooks.json');
+    assert.ok(fs.existsSync(resolvedHooks), `hooks/hooks.json must exist for auto-loading: ${resolvedHooks}`);
   });
 
   test('no "$schema" key (intentionally omitted)', (t) => {


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3029

## What was broken

The Claude Code plugin manifest (`.claude-plugin/plugin.json`) explicitly declared `"hooks": "./hooks/hooks.json"`. Claude Code already auto-loads `hooks/hooks.json` by default, so the explicit declaration caused a duplicate-rejection that silently disabled every hook the plugin ships — security guards, monitors, injection scanners. The failure had no visible signal in normal command/skill use.

## What this fix does

Removed the redundant `hooks` field from the plugin manifest. Updated the manifest test to assert the field is absent and the auto-loaded file still exists on disk. Updated the schema fixture to not require `hooks`.

## Testing

- **gsd-test**: 30667/30667 both lanes, 0 failures.

## Checklist

- [x] Issue linked · [x] confirmed-bug · [x] scoped · [x] tests updated · [x] all tests pass · [x] changeset added · [x] no new deps

## Breaking changes

None. The hooks file is still loaded (via Claude Code's auto-load path); only the redundant explicit declaration is removed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/3113"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788602469&installation_model_id=22188&pr_number=3113&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F3113&signature=18bcf59fd02161c55e0d9a043a30eaa891f3fa9cc492af71ef45df7eaa692c0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->