### PR TITLE
fix(#3033): resolve zero-plan split-parent phase as complete when roadmap checkbox is checked

### DIFF
--- a/.changeset/curious-jaguars-gather.md
+++ b/.changeset/curious-jaguars-gather.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**A split-parent phase marked complete in the ROADMAP is no longer permanently reported as `current_phase`** — a phase split into sub-phases (parent kept as shared context, zero plans by design) was stuck as `researched` because the roadmap-checkbox override required `completion.phase_complete` (always false for zero-plan phases). The override now fires for zero-plan phases when the roadmap checkbox is checked. (#3033)

--- a/.changeset/curious-jaguars-gather.md
+++ b/.changeset/curious-jaguars-gather.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 3114
 ---
 **A split-parent phase marked complete in the ROADMAP is no longer permanently reported as `current_phase`** — a phase split into sub-phases (parent kept as shared context, zero plans by design) was stuck as `researched` because the roadmap-checkbox override required `completion.phase_complete` (always false for zero-plan phases). The override now fires for zero-plan phases when the roadmap checkbox is checked. (#3033)

--- a/src/init.cts
+++ b/src/init.cts
@@ -2263,7 +2263,15 @@ function cmdInitManager(cwd: string, raw: boolean): void {
     }
 
     const roadmapComplete = _checkboxStates.get(phaseNum) || false;
-    if (roadmapComplete && completion.phase_complete && diskStatus !== 'complete') {
+    // #3033: a zero-plan phase (split parent — intentionally plan-less, holds
+    // shared context for sub-phases) whose roadmap checkbox is marked complete
+    // must resolve as complete. The original gate required completion.phase_complete
+    // (derived from plan/summary counts), which is always false for zero-plan
+    // phases — so the checkbox override never fired and the parent was permanently
+    // stuck as 'researched' (an in-progress state eligible for current-phase
+    // selection). Now: when the roadmap marks it complete AND it has zero plans,
+    // treat it as complete regardless of the plan-count derivation.
+    if (roadmapComplete && (completion.phase_complete || planCount === 0) && diskStatus !== 'complete') {
       diskStatus = 'complete';
     }
 


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3033

## What was broken

A phase split into sub-phases (parent kept as shared context, zero plans by design) was permanently stuck as `researched` — an in-progress state eligible for `current_phase` selection and re-planning recommendations — even after the parent was checked `[x]` in ROADMAP.md and all sub-phases completed. The roadmap-checkbox override required `completion.phase_complete` (derived from plan/summary counts), which is always `false` for zero-plan phases.

## What this fix does

The checkbox override now fires when `roadmapComplete && (completion.phase_complete || planCount === 0)`. A zero-plan phase whose roadmap checkbox is checked resolves as `complete`. A zero-plan phase whose checkbox is still unchecked stays `researched`. Ordinary phases with plans are unchanged.

## Testing

- **gsd-test**: 30669/30669 both lanes, 0 failures.

## Checklist

- [x] Issue linked · [x] confirmed-bug · [x] scoped · [x] all tests pass · [x] changeset added · [x] no new deps

## Breaking changes

None. Only zero-plan phases with a checked roadmap checkbox are affected; all other phase shapes are unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/3114"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788604249&installation_model_id=22188&pr_number=3114&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F3114&signature=eb61c615aa208578bdeb7a636906cc84ada97dbfcc0c04904875797f48cdda17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->