### PR TITLE
fix(#3036): accept non-numeric-leading phase ids in roadmap.analyze

### DIFF
--- a/.changeset/lucky-newts-squeak.md
+++ b/.changeset/lucky-newts-squeak.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`roadmap.analyze` now discovers non-numeric-leading phase ids** — the phase-heading and checklist discovery regexes required a digit-first id (e.g. `07`), so a project using letter-prefixed ids (e.g. `B7`) got `phase_count: 0` even though `get-phase`/`execute-phase` resolved the same ids fine. The regexes now accept an optional leading letter prefix. (#3036)

--- a/.changeset/lucky-newts-squeak.md
+++ b/.changeset/lucky-newts-squeak.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 3117
 ---
 **`roadmap.analyze` now discovers non-numeric-leading phase ids** — the phase-heading and checklist discovery regexes required a digit-first id (e.g. `07`), so a project using letter-prefixed ids (e.g. `B7`) got `phase_count: 0` even though `get-phase`/`execute-phase` resolved the same ids fine. The regexes now accept an optional leading letter prefix. (#3036)

--- a/src/roadmap.cts
+++ b/src/roadmap.cts
@@ -315,7 +315,11 @@ function cmdRoadmapAnalyze(cwd: string, raw: boolean): void {
   // Extract all phase headings: ## Phase N: Name or ### Phase N: Name
   // #1729: `(?:\s*\([^)\n]{0,200}\))?` tolerates a pre-colon ( ) tag (literal mirror of OPTIONAL_PHASE_TAG_SOURCE).
   // phase-id-owner: uses the [.-] (dot-or-dash) separator variant, not the canonical dot-only token; a swap to PHASE_NUMBER_TOKEN_SOURCE would drop hyphenated phase-id matches.
-  const phasePattern = /#{2,4}\s*(?:\[[^\]]{1,200}\]\s*)?Phase\s+(\d+[A-Z]?(?:[.-]\d+)*)(?:\s*\([^)\n]{0,200}\))?\s*:\s*([^\n]+)/gi;
+  // #3036: widen the id capture to accept non-numeric-leading ids (e.g. B7, P0.3-2)
+  // that get-phase/execute-phase already resolve. An optional leading letter prefix
+  // ([A-Za-z]?) covers letter-prefixed ids without breaking numeric-leading ones.
+  // phase-id-owner: uses the [.-] (dot-or-dash) separator variant, not the canonical dot-only token; a swap to PHASE_NUMBER_TOKEN_SOURCE would drop hyphenated phase-id matches.
+  const phasePattern = /#{2,4}\s*(?:\[[^\]]{1,200}\]\s*)?Phase\s+([A-Za-z]?\d+[A-Z]?(?:[.-]\d+)*)(?:\s*\([^)\n]{0,200}\))?\s*:\s*([^\n]+)/gi;
   const phases: Array<{
     number: string;
     name: string;
@@ -359,8 +363,9 @@ function cmdRoadmapAnalyze(cwd: string, raw: boolean): void {
     const sectionStart = match.index;
     const restOfContent = content.slice(sectionStart);
     // #3691: `\d` → `\d[\d.]*` so decimal phase headings (e.g. `### Phase 02.3:`) are
-    // recognised as section boundaries.
-    const nextHeader = restOfContent.match(/\n#{2,4}\s+(?:\[[^\]]{1,200}\]\s*)?Phase\s+\d[\d.-]*/i);
+    // recognised as section boundaries. #3036: `[A-Za-z]?\d` so non-numeric-leading ids
+    // (e.g. B7) are also recognised.
+    const nextHeader = restOfContent.match(/\n#{2,4}\s+(?:\[[^\]]{1,200}\]\s*)?Phase\s+[A-Za-z]?\d[\d.-]*/i);
     const sectionEnd = nextHeader ? sectionStart + nextHeader.index! : content.length;
     const section = content.slice(sectionStart, sectionEnd);
 
@@ -459,7 +464,9 @@ function cmdRoadmapAnalyze(cwd: string, raw: boolean): void {
   // IDs (e.g. `1-01`) match the detail-heading scanner above; otherwise they truncate
   // at the dash (`1-01` -> `1`) and every such phase reports a phantom missing detail.
   // phase-id-owner: uses the [.-] (dot-or-dash) separator variant, not the canonical dot-only token; a swap to PHASE_NUMBER_TOKEN_SOURCE would drop hyphenated phase-id matches.
-  const checklistPattern = /-\s*\[[ x]\]\s*\*\*Phase\s+(\d+[A-Z]?(?:[.-]\d+)*)/gi;
+  // #3036: widen to accept non-numeric-leading ids (same widening as the detail-heading pattern above).
+  // phase-id-owner: uses the [.-] (dot-or-dash) separator variant, not the canonical dot-only token; a swap to PHASE_NUMBER_TOKEN_SOURCE would drop hyphenated phase-id matches.
+  const checklistPattern = /-\s*\[[ x]\]\s*\*\*Phase\s+([A-Za-z]?\d+[A-Z]?(?:[.-]\d+)*)/gi;
   const checklistPhases = new Set<string>();
   let checklistMatch: RegExpExecArray | null;
   while ((checklistMatch = checklistPattern.exec(content)) !== null) {


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3036

## What was broken

`roadmap.analyze`'s phase-heading and checklist discovery regexes required a digit-first id (`\d+...`), so a project using letter-prefixed ids (e.g. `B7`, `P0.3-2`) got `phase_count: 0`, `current_phase: null`, `next_phase: null` — even though `get-phase`/`execute-phase` resolved the same ids fine. The cross-surface inconsistency made auto-detect appear completely broken with no diagnostic pointing at id format.

## What this fix does

Widened all three regex sites in `src/roadmap.cts` (phasePattern, checklistPattern, nextHeader section boundary) to accept an optional leading letter prefix (`[A-Za-z]?\d+...`). Added `// phase-id-owner:` annotations to satisfy the drift guard. Existing numeric-leading ids are unchanged.

## Testing

- **gsd-test**: 30669/30669 both lanes, 0 failures.

## Checklist

- [x] Issue linked · [x] confirmed-bug · [x] scoped · [x] all tests pass · [x] changeset added · [x] no new deps

## Breaking changes

None. Only letter-prefixed ids are newly recognized; all existing id shapes are unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/3117"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788609532&installation_model_id=22188&pr_number=3117&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F3117&signature=9f8b81324a567066e65e9f041dfe278a17ef0420540b6b3e36ee89bce507cc98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->