### PR TITLE
fix(#3044): add zh-CN verification-patterns.md to secret-scan exclusions

### DIFF
--- a/.changeset/rapid-cranes-wander.md
+++ b/.changeset/rapid-cranes-wander.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**Secret-scan no longer reports a false positive on the zh-CN verification-patterns translation** — the translated document carries the same illustrative placeholder examples as its English source, but the exclusion was never extended to the translation. The strict-mode scan now passes. (#3044)

--- a/.changeset/rapid-cranes-wander.md
+++ b/.changeset/rapid-cranes-wander.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 3122
 ---
 **Secret-scan no longer reports a false positive on the zh-CN verification-patterns translation** — the translated document carries the same illustrative placeholder examples as its English source, but the exclusion was never extended to the translation. The strict-mode scan now passes. (#3044)

--- a/.secretscanignore
+++ b/.secretscanignore
@@ -28,3 +28,5 @@ gsd-core/workflows/plan-phase.md
 
 # allow: gsd-core/references/verification-patterns.md  reason="documents stub/placeholder RED-FLAG examples for env vars (illustrative Stripe test-key, database-URL and API-key placeholders shown as what NOT to ship) — not real credentials"  owner="@open-gsd/maintainers"  expires="2027-06-30"
 gsd-core/references/verification-patterns.md
+# allow: docs/zh-CN/references/verification-patterns.md  reason="translated copy of the English verification-patterns.md — carries the same illustrative placeholder examples (Stripe test-key, database-URL, API-key) as what NOT to ship"  owner="@open-gsd/maintainers"  expires="2027-06-30"
+docs/zh-CN/references/verification-patterns.md


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3044

## What was broken

`scripts/secret-scan.sh --dir docs --strict` failed on `docs/zh-CN/references/verification-patterns.md` — a translated copy of the English source that carries the same illustrative placeholder examples (Stripe test-key, database-URL, API-key). The English source was already excluded; the exclusion was never extended to the translation.

## What this fix does

Added the zh-CN translation to `.secretscanignore` with its own structured annotation (reason, owner, expires). Verified no other locale (ja-JP, ko-KR, pt-BR) has a translation of this file.

## Testing

- **gsd-test**: 30669/30669 both lanes, 0 failures.

## Checklist

- [x] Issue linked · [x] confirmed-bug · [x] scoped · [x] all tests pass · [x] changeset added · [x] no new deps

## Breaking changes

None. CI hygiene only.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/3122"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788621963&installation_model_id=22188&pr_number=3122&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F3122&signature=ff9cf09801f547ef93a1965118815aec9aeed81a6dbad3fd58ac9b775e555013"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->