### PR TITLE
fix(#2786): skip sentinel phase ids in phase-complete stage 2 heading scan

### DIFF
--- a/.changeset/clever-ravens-romp.md
+++ b/.changeset/clever-ravens-romp.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`phase complete` no longer advances `next_phase` into 999.x backlog headings** — the roadmap heading scan (stage 2 of the next-phase cascade) accepted any higher-numbered heading without checking the sentinel convention, so a `Phase 999.1: Backlog Item` heading was treated as the next real phase. Sentinel phase ids (999.x backlog, 0.x drafts) are now skipped. (#2786)

--- a/.changeset/clever-ravens-romp.md
+++ b/.changeset/clever-ravens-romp.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 3130
 ---
 **`phase complete` no longer advances `next_phase` into 999.x backlog headings** — the roadmap heading scan (stage 2 of the next-phase cascade) accepted any higher-numbered heading without checking the sentinel convention, so a `Phase 999.1: Backlog Item` heading was treated as the next real phase. Sentinel phase ids (999.x backlog, 0.x drafts) are now skipped. (#2786)

--- a/src/phase.cts
+++ b/src/phase.cts
@@ -2576,6 +2576,11 @@ function cmdPhaseComplete(cwd: string, phaseNum: string, raw: boolean): void {
           );
           let pm: RegExpExecArray | null;
           while ((pm = phasePattern.exec(roadmapForPhases)) !== null) {
+            // #2786: skip sentinel phase ids (999.x backlog, 0.x drafts) — stage 1
+            // already skips 999 dirs on disk; stage 2's heading scan must not
+            // advance into backlog headings. Mirrors the /^999(?:\.|$)/ guard
+            // stage 1 uses at line 2536, but via isSentinelPhaseId for both ranges.
+            if (isSentinelPhaseId(pm[1])) continue;
             if (comparePhaseNum(pm[1], phaseNum) > 0) {
               nextPhaseNum = pm[1];
               nextPhaseName = pm[2]


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #2786

## What was broken

Stage 2 of the next-phase cascade in `cmdPhaseComplete` accepted any higher-numbered roadmap heading without checking the 999.x backlog sentinel convention. A `Phase 999.1: Backlog Item` heading was treated as the next real phase, advancing STATE.md into the backlog and making the milestone perpetually "Ready to plan" instead of "All phases complete."

## What this fix does

Added `isSentinelPhaseId(pm[1])` guard to the stage 2 heading scan, mirroring stage 1's existing `/^999(?:\.|$)/` check. Both sentinel ranges (0.x drafts, 999.x backlog) are now skipped.

## Testing

- **gsd-test**: 30669/30669 both lanes, 0 failures.

## Checklist

- [x] Issue linked · [x] confirmed-bug · [x] scoped · [x] all tests pass · [x] changeset added · [x] no new deps

## Breaking changes

None. Real next-phase headings still resolve; only sentinel-range ids are skipped.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/3130"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788647592&installation_model_id=22188&pr_number=3130&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F3130&signature=6d95471efc5277d2ead64d12e328049cc4494c0b96ae8653bdb30ab838b03b97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->