### PR TITLE
fix(#3116): strip trailing CR per line in parseFrontmatterStrict for CRLF WINDOWS.md

### DIFF
--- a/.changeset/eager-lynx-squeak.md
+++ b/.changeset/eager-lynx-squeak.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 3137
 ---
 **`gsd-tools windows` no longer crashes on CRLF ledgers** — on repos with `core.autocrlf=true` (Windows default), the frontmatter parser threw on the last key of a CRLF `WINDOWS.md`, making the broken-windows status/waive/fixed subcommands unusable. (#3116)

--- a/.changeset/eager-lynx-squeak.md
+++ b/.changeset/eager-lynx-squeak.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`gsd-tools windows` no longer crashes on CRLF ledgers** — on repos with `core.autocrlf=true` (Windows default), the frontmatter parser threw on the last key of a CRLF `WINDOWS.md`, making the broken-windows status/waive/fixed subcommands unusable. (#3116)

--- a/src/broken-windows.cts
+++ b/src/broken-windows.cts
@@ -401,7 +401,12 @@ function parseFrontmatterStrict(raw: string): Record<string, number | string> {
   }
   const yamlBody = raw.slice(headerEnd, closeIdx);
   const out: Record<string, number | string> = {};
-  for (const line of yamlBody.split(/\r?\n/)) {
+  for (const rawLine of yamlBody.split(/\r?\n/)) {
+    // #3116: the `\n---` scan leaves the final line's CR attached on a CRLF
+    // ledger, and `.` never matches CR, so the key: value regex below fails on
+    // it. Strip the trailing CR per line so the rest of `raw` (which
+    // parseJsonBlock also slices by byte offset) is unaffected.
+    const line = rawLine.replace(/\r$/, '');
     if (line.trim() === '') continue;
     const m = line.match(/^([a-zA-Z0-9_]+):\s*(.*)$/);
     if (!m) {

--- a/tests/broken-windows.test.cjs
+++ b/tests/broken-windows.test.cjs
@@ -792,23 +792,13 @@ describe('broken-windows CLI: lifecycle', () => {
 // ---------------------------------------------------------------------------
 
 describe('#3116: parseLedger handles CRLF ledgers', () => {
+  // Build ledgers via renderLedger (the real writer) so the JSON fence
+  // format (4-backtick) and structure always match what production emits.
+
   test('CRLF ledger parses without throwing', () => {
-    // Build a CRLF ledger (every \n replaced with \r\n)
-    const lfLedger = [
-      '---',
-      'schema_version: 1',
-      'open_count: 0',
-      'waived_count: 0',
-      'fixed_count: 0',
-      'total_count: 0',
-      'last_updated: 2026-08-06T09:43:08.354Z',
-      '---',
-      '',
-      '```json',
-      '[]',
-      '```',
-      '',
-    ].join('\n');
+    const ledger = emptyLedger();
+    ledger.last_updated = '2026-08-06T09:43:08.354Z';
+    const lfLedger = renderLedger(ledger);
     const crlfLedger = lfLedger.replace(/\n/g, '\r\n');
 
     // Must not throw — before the fix this throws WINDOWS_LEDGER_MALFORMED
@@ -820,21 +810,13 @@ describe('#3116: parseLedger handles CRLF ledgers', () => {
   });
 
   test('CRLF ledger with non-zero counts parses correctly', () => {
-    const lfLedger = [
-      '---',
-      'schema_version: 1',
-      'open_count: 3',
-      'waived_count: 1',
-      'fixed_count: 2',
-      'total_count: 6',
-      'last_updated: 2026-08-06T12:00:00.000Z',
-      '---',
-      '',
-      '```json',
-      '[]',
-      '```',
-      '',
-    ].join('\n');
+    const ledger = emptyLedger();
+    ledger.open_count = 3;
+    ledger.waived_count = 1;
+    ledger.fixed_count = 2;
+    ledger.total_count = 6;
+    ledger.last_updated = '2026-08-06T12:00:00.000Z';
+    const lfLedger = renderLedger(ledger);
     const crlfLedger = lfLedger.replace(/\n/g, '\r\n');
 
     const parsed = parseLedger(crlfLedger);
@@ -845,21 +827,12 @@ describe('#3116: parseLedger handles CRLF ledgers', () => {
   });
 
   test('CRLF and LF ledgers produce identical parse results', () => {
-    const lfLedger = [
-      '---',
-      'schema_version: 1',
-      'open_count: 2',
-      'waived_count: 0',
-      'fixed_count: 1',
-      'total_count: 3',
-      'last_updated: 2026-08-06T09:43:08.354Z',
-      '---',
-      '',
-      '```json',
-      '[]',
-      '```',
-      '',
-    ].join('\n');
+    const ledger = emptyLedger();
+    ledger.open_count = 2;
+    ledger.fixed_count = 1;
+    ledger.total_count = 3;
+    ledger.last_updated = '2026-08-06T09:43:08.354Z';
+    const lfLedger = renderLedger(ledger);
 
     const lfParsed = parseLedger(lfLedger);
     const crlfParsed = parseLedger(lfLedger.replace(/\n/g, '\r\n'));

--- a/tests/broken-windows.test.cjs
+++ b/tests/broken-windows.test.cjs
@@ -794,8 +794,10 @@ describe('broken-windows CLI: lifecycle', () => {
 describe('#3116: parseLedger handles CRLF ledgers', () => {
   // Build ledgers via renderLedger (the real writer) so the JSON fence
   // format (4-backtick) and structure always match what production emits.
+  // parseLedger validates that frontmatter counts match the entries array,
+  // so non-zero counts require real entries (appendWindow).
 
-  test('CRLF ledger parses without throwing', () => {
+  test('CRLF empty ledger parses without throwing', () => {
     const ledger = emptyLedger();
     ledger.last_updated = '2026-08-06T09:43:08.354Z';
     const lfLedger = renderLedger(ledger);
@@ -809,29 +811,24 @@ describe('#3116: parseLedger handles CRLF ledgers', () => {
     assert.equal(parsed.last_updated, '2026-08-06T09:43:08.354Z');
   });
 
-  test('CRLF ledger with non-zero counts parses correctly', () => {
-    const ledger = emptyLedger();
-    ledger.open_count = 3;
-    ledger.waived_count = 1;
-    ledger.fixed_count = 2;
-    ledger.total_count = 6;
-    ledger.last_updated = '2026-08-06T12:00:00.000Z';
+  test('CRLF ledger with entries parses correctly', () => {
+    let ledger = emptyLedger();
+    const { ledger: led1 } = appendWindow(ledger, makeEntry(), { now: '2026-08-06T12:00:00Z' });
+    const { ledger: led2 } = appendWindow(led1, makeEntry({ description: 'second' }), { now: '2026-08-06T12:01:00Z' });
+    ledger = led2;
     const lfLedger = renderLedger(ledger);
     const crlfLedger = lfLedger.replace(/\n/g, '\r\n');
 
     const parsed = parseLedger(crlfLedger);
-    assert.equal(parsed.open_count, 3);
-    assert.equal(parsed.waived_count, 1);
-    assert.equal(parsed.fixed_count, 2);
-    assert.equal(parsed.total_count, 6);
+    assert.equal(parsed.open_count, 2);
+    assert.equal(parsed.total_count, 2);
+    assert.equal(parsed.entries.length, 2);
   });
 
   test('CRLF and LF ledgers produce identical parse results', () => {
-    const ledger = emptyLedger();
-    ledger.open_count = 2;
-    ledger.fixed_count = 1;
-    ledger.total_count = 3;
-    ledger.last_updated = '2026-08-06T09:43:08.354Z';
+    let ledger = emptyLedger();
+    const { ledger: led1 } = appendWindow(ledger, makeEntry(), { now: '2026-08-06T09:43:08Z' });
+    ledger = led1;
     const lfLedger = renderLedger(ledger);
 
     const lfParsed = parseLedger(lfLedger);

--- a/tests/broken-windows.test.cjs
+++ b/tests/broken-windows.test.cjs
@@ -783,3 +783,87 @@ describe('broken-windows CLI: lifecycle', () => {
     assert.equal(status.ledger.total_count, 2);
   });
 });
+
+// ---------------------------------------------------------------------------
+// #3116: parseFrontmatterStrict throws on CRLF WINDOWS.md
+// On repos with core.autocrlf=true (Windows default), .planning/WINDOWS.md is
+// checked out CRLF. The `\n---` close-fence scan leaves the last line's CR
+// attached, and `.` doesn't match CR, so the key:value regex fails.
+// ---------------------------------------------------------------------------
+
+describe('#3116: parseLedger handles CRLF ledgers', () => {
+  test('CRLF ledger parses without throwing', () => {
+    // Build a CRLF ledger (every \n replaced with \r\n)
+    const lfLedger = [
+      '---',
+      'schema_version: 1',
+      'open_count: 0',
+      'waived_count: 0',
+      'fixed_count: 0',
+      'total_count: 0',
+      'last_updated: 2026-08-06T09:43:08.354Z',
+      '---',
+      '',
+      '```json',
+      '[]',
+      '```',
+      '',
+    ].join('\n');
+    const crlfLedger = lfLedger.replace(/\n/g, '\r\n');
+
+    // Must not throw — before the fix this throws WINDOWS_LEDGER_MALFORMED
+    // on the last frontmatter key ("last_updated: ...\r")
+    const parsed = parseLedger(crlfLedger);
+    assert.equal(parsed.schema_version, 1);
+    assert.equal(parsed.open_count, 0);
+    assert.equal(parsed.last_updated, '2026-08-06T09:43:08.354Z');
+  });
+
+  test('CRLF ledger with non-zero counts parses correctly', () => {
+    const lfLedger = [
+      '---',
+      'schema_version: 1',
+      'open_count: 3',
+      'waived_count: 1',
+      'fixed_count: 2',
+      'total_count: 6',
+      'last_updated: 2026-08-06T12:00:00.000Z',
+      '---',
+      '',
+      '```json',
+      '[]',
+      '```',
+      '',
+    ].join('\n');
+    const crlfLedger = lfLedger.replace(/\n/g, '\r\n');
+
+    const parsed = parseLedger(crlfLedger);
+    assert.equal(parsed.open_count, 3);
+    assert.equal(parsed.waived_count, 1);
+    assert.equal(parsed.fixed_count, 2);
+    assert.equal(parsed.total_count, 6);
+  });
+
+  test('CRLF and LF ledgers produce identical parse results', () => {
+    const lfLedger = [
+      '---',
+      'schema_version: 1',
+      'open_count: 2',
+      'waived_count: 0',
+      'fixed_count: 1',
+      'total_count: 3',
+      'last_updated: 2026-08-06T09:43:08.354Z',
+      '---',
+      '',
+      '```json',
+      '[]',
+      '```',
+      '',
+    ].join('\n');
+
+    const lfParsed = parseLedger(lfLedger);
+    const crlfParsed = parseLedger(lfLedger.replace(/\n/g, '\r\n'));
+
+    assert.deepEqual(crlfParsed, lfParsed);
+  });
+});


### PR DESCRIPTION
<!-- pr-template-exempt: bug fix in src/broken-windows.cts (CRLF frontmatter parsing). One-line fix + regression tests. No workflow .md changes, no emitted-attribution impact. -->

## Summary

Fixes #3116

On repos with `core.autocrlf=true` (Windows default), `.planning/WINDOWS.md` is checked out CRLF. The frontmatter parser `parseFrontmatterStrict` scanned for the closing fence via `\n---`, which lands on the LF of the last frontmatter line's CRLF — leaving a bare `\r` on that line. The `key: value` regex's `.` doesn't match CR, so the parser threw `WINDOWS_LEDGER_MALFORMED` on the last key. This made `gsd-tools windows status/append/waive/fixed` unusable on Windows checkouts.

## Fix

Strip the trailing `\r` per line in the frontmatter loop: `const line = rawLine.replace(/\r$/, '')`. This is scoped to the frontmatter parsing loop only; the rest of `raw` (which `parseJsonBlock` slices by byte offset) is unaffected.

## Verification

- **RED proven** at `4b960ee2e` (3 tests failed — parser threw on CRLF input)
- **GREEN** at `98504c3a6` — gsd-test 30754/30754 both lanes, zero failures
- **Code review**: blocker (test fixtures used 3-backtick fences instead of the 4-backtick `JSON_FENCE_OPEN` constant — fixed by using `renderLedger(emptyLedger())`) + nit (misleading comment — fixed)
- **Security review**: clean — no injection, path traversal, or input-validation bypass
- `npm run lint:ci` clean

## Test coverage

Three regression tests using `renderLedger(emptyLedger())` (the real writer output, 4-backtick fence):
1. CRLF empty ledger parses without throwing
2. CRLF ledger with entries (via `appendWindow`) parses correctly
3. CRLF and LF ledgers produce identical parse results

- [x] Issue linked above with `Fixes #NNN`
- [x] `.changeset/` fragment added
- [x] `GSD_PR_GATES_OK=1` — gsd-test passed, lint:ci clean, two orthogonal reviews complete

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/3137"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788678202&installation_model_id=22188&pr_number=3137&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F3137&signature=b17a3ee6ae8c4b7ba9ec05dc4abfccab918e4b09712d79ff83cb11484b2c1f18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->