### PR TITLE
fix(#3052): preserve frontmatter last_activity_desc on same-date body prose conflict

### DIFF
--- a/.changeset/rapid-sloths-romp.md
+++ b/.changeset/rapid-sloths-romp.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`state planned-phase` no longer overwrites authoritative `last_activity_desc`** — when the frontmatter and body had the same activity date but different descriptions, the write path preserved the date but overwrote the frontmatter's description with stale body prose. Same-date frontmatter desc is now preserved. (#3052)

--- a/.changeset/rapid-sloths-romp.md
+++ b/.changeset/rapid-sloths-romp.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 3140
 ---
 **`state planned-phase` no longer overwrites authoritative `last_activity_desc`** — when the frontmatter and body had the same activity date but different descriptions, the write path preserved the date but overwrote the frontmatter's description with stale body prose. Same-date frontmatter desc is now preserved. (#3052)

--- a/src/state.cts
+++ b/src/state.cts
@@ -1392,6 +1392,13 @@ function preferNewerLastActivity(
     if (existingFm['last_activity_desc'] !== undefined) {
       derivedFm['last_activity_desc'] = existingFm['last_activity_desc'];
     }
+  } else if (derDate === exDate) {
+    // #3052: same-date — frontmatter is authoritative for this date, so
+    // preserve its last_activity_desc rather than letting the derived body
+    // prose (which may be stale) overwrite it.
+    if (existingFm['last_activity_desc'] !== undefined) {
+      derivedFm['last_activity_desc'] = existingFm['last_activity_desc'];
+    }
   }
 }
 

--- a/tests/state.test.cjs
+++ b/tests/state.test.cjs
@@ -2896,6 +2896,63 @@ describe('state planned-phase command', () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
+// #3052: state planned-phase must not overwrite authoritative same-date
+// last_activity_desc from stale body prose
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#3052: planned-phase preserves same-date last_activity_desc', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createFixture();
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('same-date conflicting desc: frontmatter desc is preserved', () => {
+    // Frontmatter has authoritative desc; body has stale desc for the SAME date
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'STATE.md'),
+      [
+        '---',
+        'last_activity: 2020-09-10',
+        'last_activity_desc: authoritative description',
+        '---',
+        '',
+        '# Project State',
+        '',
+        '**Status:** Planning',
+        '**Last Activity:** 2020-09-10 — stale description',
+        '**Current Phase:** 1',
+        '',
+      ].join('\n'),
+    );
+
+    const result = runGsdTools(
+      ['state', 'planned-phase', '--phase', '1', '--plans', '3'],
+      tmpDir,
+      { GSD_NOW_MS: String(Date.parse('2020-09-10T15:00:00.000Z')) },
+    );
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const stateContent = fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
+    // Extract only the frontmatter (between --- fences) to check the desc
+    const fmMatch = stateContent.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+    const frontmatter = fmMatch ? fmMatch[1] : '';
+    assert.ok(
+      frontmatter.includes('authoritative description'),
+      'frontmatter last_activity_desc must be preserved when same-date body prose conflicts',
+    );
+    assert.ok(
+      !frontmatter.includes('stale description'),
+      'stale body desc must NOT appear in frontmatter (it may remain in body prose)',
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
 // bug #1070 regression: "Complete ✓" terminal status must yield to planned-phase
 // ─────────────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Fixes #3052

When `state planned-phase` wrote STATE.md and the frontmatter `last_activity` date matched the body's `Last Activity` date, the write path preserved the date but overwrote the frontmatter's authoritative `last_activity_desc` with stale body prose. The fix extends `preferNewerLastActivity` to also preserve `last_activity_desc` when dates are equal (same-date = frontmatter is authoritative).

## Fix

`src/state.cts` `preferNewerLastActivity` — added an `else if (derDate === exDate)` branch that preserves the existing frontmatter `last_activity_desc` when the derived date matches the existing date.

## Verification

- gsd-test 30760/30760 both lanes on `3326af63b`
- `npm run lint:ci` clean
- Regression test in `state.test.cjs`: creates STATE.md with same-date conflicting desc, runs `state planned-phase`, asserts frontmatter desc is preserved

- [x] Issue linked above with `Fixes #NNN`
- [x] `.changeset/` fragment added
- [x] `GSD_PR_GATES_OK=1` — gsd-test passed, lint:ci clean

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/3140"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788689069&installation_model_id=22188&pr_number=3140&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F3140&signature=d6a5c7822f984d903a1673e8b1debe5a9ef01394010f654634a215bd045f08b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->