### PR TITLE
fix(#3086): apply #2667 .cmd-shim gate to deps.spawn + surface errorCode in review lanes

### DIFF
--- a/.changeset/nimble-sloths-jump.md
+++ b/.changeset/nimble-sloths-jump.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 3142
 ---
 **Cross-AI reviewer lanes no longer silently drop on Windows** — `deps.spawn` used `shell: false` with a bare binary name, which fails with ENOENT on Windows .cmd shims (npm-installed CLIs). Now applies the #2667 `cmd.exe /d /s /c` shim gate. Spawn errors (ENOENT, ETIMEDOUT) are also surfaced in the reviewer err file instead of being silently dropped. (#3086)

--- a/.changeset/nimble-sloths-jump.md
+++ b/.changeset/nimble-sloths-jump.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**Cross-AI reviewer lanes no longer silently drop on Windows** — `deps.spawn` used `shell: false` with a bare binary name, which fails with ENOENT on Windows .cmd shims (npm-installed CLIs). Now applies the #2667 `cmd.exe /d /s /c` shim gate. Spawn errors (ENOENT, ETIMEDOUT) are also surfaced in the reviewer err file instead of being silently dropped. (#3086)

--- a/gsd-core/bin/gsd-tools.cjs
+++ b/gsd-core/bin/gsd-tools.cjs
@@ -1330,7 +1330,16 @@ function dispatchOverlayCapabilityCommand({ command, args, cwd, raw, error, load
     // cannot be interrupted by --test-force-exit and hangs a whole CI chunk to its 10-minute kill.
     const deps = {
       spawn: (binary, argv, opts) => {
-        const r = cp.spawnSync(binary, argv, {
+        // #3086: on Windows, reviewer CLIs (gemini, codex, etc.) are installed
+        // as .cmd shims. spawnSync with a bare name + shell:false fails with
+        // ENOENT (CreateProcess cannot start .cmd). Apply the same #2667 shim
+        // gate used in runWithTimeout: detect .cmd/.bat and mediate through
+        // cmd.exe /d /s /c with an explicit argv array (no shell:true).
+        const isWin = process.platform === 'win32';
+        const winShim = isWin && /\.(cmd|bat)$/i.test(path.basename(binary));
+        const spawnBinary = winShim ? (process.env.ComSpec || 'cmd.exe') : binary;
+        const spawnArgv = winShim ? ['/d', '/s', '/c', binary, ...argv] : argv;
+        const r = cp.spawnSync(spawnBinary, spawnArgv, {
           input: opts.input,
           encoding: 'utf8',
           timeout: opts.timeoutMs,

--- a/src/review-lane-runner.cts
+++ b/src/review-lane-runner.cts
@@ -664,7 +664,13 @@ function runSpawnLane(plan: SpawnPlan, deps: RunnerDeps, repoRoot: string): Lane
       : plan.argv;
 
   const out = deps.spawn(plan.binary, argv, { input, timeoutMs: plan.timeoutMs });
-  deps.writeFile(plan.errPath, out.stderr ?? '');
+  // #3086: surface spawn errors (ENOENT, ETIMEDOUT, etc.) that would otherwise
+  // be silently dropped — the review path read only stdout/stderr and treated
+  // an empty-stderr spawn failure as "the model had nothing to say".
+  const errContent = out.errorCode
+    ? `${out.stderr ?? ''}\n[spawn error: ${out.errorCode}]\n`
+    : (out.stderr ?? '');
+  deps.writeFile(plan.errPath, errContent);
 
   // `file-arg` lanes write the review themselves and their stdout is deliberately discarded (#1698).
   let review =

--- a/tests/review-lane-runner.test.cjs
+++ b/tests/review-lane-runner.test.cjs
@@ -663,3 +663,44 @@ describe('runner — orchestration', () => {
     }
   });
 });
+
+// #3086: spawn errors (ENOENT on Windows .cmd shims, ETIMEDOUT, etc.) must be
+// surfaced in the err file so the stub reviewer output explains WHY the lane
+// produced nothing, rather than silently dropping the error code.
+
+describe('runner — #3086: spawn errorCode surfaced in err file', () => {
+  test('a spawn ENOENT writes the error code to the err file', async () => {
+    const p = plan('gemini');
+    const d = deps({
+      spawn: () => ({ status: null, stdout: '', stderr: '', errorCode: 'ENOENT' }),
+    });
+    await runLane(p, d, { repoRoot: ROOT });
+    const errContent = d.files[p.errPath] || '';
+    assert.ok(errContent.includes('ENOENT'),
+      `err file must include the spawn error code; got: ${errContent}`);
+  });
+
+  test('a spawn ETIMEDOUT writes the error code to the err file', async () => {
+    const p = plan('codex');
+    const d = deps({
+      spawn: () => ({ status: null, stdout: '', stderr: '', errorCode: 'ETIMEDOUT' }),
+    });
+    await runLane(p, d, { repoRoot: ROOT });
+    const errContent = d.files[p.errPath] || '';
+    assert.ok(errContent.includes('ETIMEDOUT'),
+      `err file must include the spawn error code; got: ${errContent}`);
+  });
+
+  test('a successful spawn with stderr does NOT add a spawn error marker', async () => {
+    const p = plan('gemini');
+    const d = deps({
+      spawn: () => ({ status: 0, stdout: '## Review\nok', stderr: 'some warning', errorCode: undefined }),
+    });
+    await runLane(p, d, { repoRoot: ROOT });
+    const errContent = d.files[p.errPath] || '';
+    assert.ok(!errContent.includes('[spawn error:'),
+      `err file must NOT contain a spawn error marker on success; got: ${errContent}`);
+    assert.ok(errContent.includes('some warning'),
+      'legitimate stderr should still be written');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #3086

On Windows, `deps.spawn` used `shell: false` with a bare binary name. npm-installed reviewer CLIs (`gemini`, `codex`, etc.) are `.cmd` shims that `CreateProcess` cannot start, producing ENOENT + empty stderr. Every spawn-transport reviewer lane silently dropped, and the review stub said "failed or returned empty output" with no indication the tool never started.

## Fix

1. **`deps.spawn`** (`gsd-core/bin/gsd-tools.cjs`): applied the same #2667 `.cmd`/`.bat` shim gate used in `runWithTimeout` — detect Windows shim extensions and mediate through `cmd.exe /d /s /c` with an explicit argv array (no `shell: true`).
2. **`runSpawnLane`** (`src/review-lane-runner.cts`): surface `errorCode` (ENOENT, ETIMEDOUT, etc.) in the err file instead of silently dropping it. The stub reviewer output now explains WHY the lane produced nothing.

## Verification

- gsd-test 30770/30770 both lanes on `30e6a8230`
- `npm run lint:ci` clean
- 3 regression tests: ENOENT surfaces in err file, ETIMEDOUT surfaces in err file, successful spawn with stderr does NOT add error marker

- [x] Issue linked above with `Fixes #NNN`
- [x] `.changeset/` fragment added
- [x] `GSD_PR_GATES_OK=1` — gsd-test passed, lint:ci clean

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/3142"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788693673&installation_model_id=22188&pr_number=3142&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F3142&signature=46a99cd947309e8702b60643a1dff71a3dd37c994a557b827fa56812876c6474"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->