### PR TITLE
docs(#3198): record project-gitignore-for-third-party-agent-runtime as out-of-scope

### DIFF
--- a/.out-of-scope/project-gitignore-for-third-party-agent-runtime.md
+++ b/.out-of-scope/project-gitignore-for-third-party-agent-runtime.md
@@ -1,0 +1,73 @@
+# Scaffolding a project `.gitignore` for third-party agent runtime state
+
+**Source:** [#3198](https://github.com/open-gsd/gsd-core/issues/3198)
+**Decision:** wontfix — closed as filed; the premise the request rests on does not hold
+**Date:** 2026-08-08
+
+## Proposal summary
+
+Reporter observed 436 of 556 dirty `git status` entries in a real project coming from agent
+runtime state — `.omc/state/checkpoints/*`, `.omo/run-continuation/*`, and replay/loop logs —
+being versioned in the project repo. Attributing this to GSD, the request was to add `.omc/`,
+`.omo/` and "any other agent-runtime dirs the toolchain writes" to what the report calls "the
+`.gitignore` shipped by the init template", which the report characterises as excluding only
+`__pycache__/` and `*.pyc`. A `git rm -r --cached` migration note for existing projects was
+proposed alongside.
+
+The underlying complaint is real and well-evidenced: continuously-rewritten runtime state buried
+296 genuine changed files under 436 runtime entries.
+
+## Why GSD does not own this
+
+- **There is no init-template `.gitignore`.** This repo contains exactly one `.gitignore` — its
+  own. The `__pycache__/` + `*.pyc` pair the report quotes is `.gitignore:261-262` of the
+  gsd-core working tree, immediately followed by `.venv/`, `venv/` and `target/`; it is neither
+  "only two entries" nor installed anywhere. No copy manifest, installer path, or workflow ships
+  it into a user project.
+- **The only project-`.gitignore` write GSD performs is a single `.planning/` line**, and only
+  when the operator answers `commit_docs = No` at init (`gsd-core/workflows/new-project.md:638`,
+  and again for the multi-repo path at `:676`). There is no template to extend.
+- **`.omc` and `.omo` are not GSD artifacts.** Zero occurrences across `src/`, `bin/`,
+  `gsd-core/`, `commands/`, `agents/`, `capabilities/`, `docs/`, and every shipped `.md`, `.json`
+  and `.yml`. GSD neither creates, reads, nor has any knowledge of those directories. Ignoring
+  another tool's runtime state is that tool's responsibility; a GSD-authored ignore list naming
+  third-party paths would silently rot as those tools rename their directories, and GSD would
+  have no signal that it had.
+- **The one GSD-owned path named in the report is already governed.** `.planning/forensics/` is
+  ours (`gsd-core/workflows/forensics.md:171`), but it lives under `.planning/`, whose
+  tracked-vs-local status is an explicit init decision. A project that answered `commit_docs = No`
+  already ignores it; a project that answered `Yes` is versioning `.planning/` on purpose.
+
+The report was right that the churn is a genuine problem worth solving. It is not right about
+which component is producing it.
+
+## What this does NOT cover
+
+This entry denies exactly one thing: **GSD enumerating third-party agent-runtime directories in a
+`.gitignore` it writes.** The keyword surface here (`gitignore`, "runtime state", "dirty tree") is
+broad, and the following remain welcome and are **not** denied by this decision:
+
+- A report that **GSD itself** writes churning runtime state outside `.planning/`. That would be a
+  live defect, and this entry is not a precedent against fixing it.
+- Making the existing `.planning/` ignore write more robust — idempotency, ordering, handling a
+  missing or malformed `.gitignore`.
+- Ignore-list handling for directories a **GSD capability** creates.
+- Documentation telling users which paths their own toolchain should ignore alongside a GSD
+  project, as prose rather than as a generated file.
+
+## Re-open criteria
+
+Concrete and checkable:
+
+- GSD begins shipping or generating a project `.gitignore` with substantive content (beyond the
+  single `.planning/` line), at which point what belongs in it becomes a real design question.
+- A reproduction demonstrates a directory **created by gsd-core or one of its capabilities**
+  producing continuous working-tree churn and not already covered by the `commit_docs` decision.
+
+A request to ignore paths owned by a different tool is not re-openable on volume of churn alone;
+the churn is evidence about the writing tool, not about GSD.
+
+## Related
+
+- `gsd-core/workflows/new-project.md` — the `commit_docs` decision and the `.planning/` ignore write
+- `gsd-core/workflows/forensics.md` — writes `.planning/forensics/`, under the `.planning/` umbrella


### PR DESCRIPTION
<!-- pr-template-exempt: doc-only — adds an `.out-of-scope/` knowledge-base document. No code, no runtime-loaded text, no behavior change. -->

## What

Adds one `.out-of-scope/` knowledge-base entry recording the 2026-08-08 triage denial of #3198.

## Why

`.out-of-scope/` is what a future triage sweep's prior-denial check actually reads. A denial whose reasoning lives only in a closed-issue comment is invisible to that check, so the same request returns and gets re-litigated from scratch. The tracker half of the disposition (labels, close, rationale comment) is already done; this is the half that makes it discoverable.

## The denial being recorded

#3198 asked to add `.omc/` and `.omo/` to "the `.gitignore` shipped by the init template". The premise does not hold:

- **gsd-core ships no init-template `.gitignore`.** The repo contains exactly one, its own. The `__pycache__/` + `*.pyc` pair the report quotes is `.gitignore:261-262` of the gsd-core working tree — immediately followed by `.venv/`, `venv/`, `target/`, so not "only two entries" either. Nothing installs it into a user project.
- **The only project-`.gitignore` write GSD performs** is appending a single `.planning/` line, and only when `commit_docs = No` (`gsd-core/workflows/new-project.md:638` and `:676`).
- **`.omc` and `.omo` have zero occurrences** across `src/`, `bin/`, `gsd-core/`, `commands/`, `agents/`, `capabilities/`, `docs/`, and every shipped `.md`/`.json`/`.yml`. They are not GSD artifacts.
- **`.planning/forensics/` is ours** (`gsd-core/workflows/forensics.md:171`) but sits under `.planning/`, already governed by the `commit_docs` decision.

The reported churn (436 of 556 dirty entries) is real; it is attributable to a different tool.

## Scope guard

The entry carries a **"What this does NOT cover"** section, because the keyword surface here (`gitignore`, "runtime state", "dirty tree") is broad enough that a future keyword match could misapply it. Explicitly still welcome: any report that **gsd-core itself** writes churning runtime state outside `.planning/`, hardening of the existing `.planning/` ignore write, and ignore handling for directories a GSD capability creates.

Re-open criteria are concrete and checkable rather than judgment calls.

## Verification

- `npm run lint:ci` → exit 0
- `GITHUB_BASE_REF=next node scripts/changeset/lint.cjs` → `ok_no_user_facing_changes` (a KB document is not user-facing code, so no changeset fragment)
- `GITHUB_BASE_REF=next node scripts/lint-docs-required.cjs` → `ok_no_triggering_fragments`
- Remote runner recorded a pass for the exact sha being shipped

## Review

Doc-only diff: no code, no runtime-loaded text, no behavior change, so there is no test surface and no orthogonal-review surface. The lints above are the applicable gates.

Closes #3198

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/3219"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788800510&installation_model_id=22188&pr_number=3219&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F3219&signature=e52cf18ab848112c6f7e7250044503bb248cedfc707ed55d91f35ddf2fd8c90c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->