### PR TITLE
fix(#3231): resolve add-decision phase from frontmatter instead of persisting '[Phase ?]'

### DIFF
--- a/src/state.cts
+++ b/src/state.cts
@@ -814,6 +814,25 @@ function cmdStateUpdateProgress(cwd: string, raw: boolean): void {
   }
 }
 
+/**
+ * Read `current_phase` from STATE.md frontmatter as a display scalar.
+ *
+ * Returns null when the file is unreadable, has no frontmatter, or carries a
+ * non-scalar `current_phase` — every one of which must leave the caller's own
+ * fallback in charge rather than producing a plausible-looking wrong phase.
+ */
+function readCurrentPhaseFromFrontmatter(statePath: string): string | null {
+  try {
+    const fm = extractFrontmatter(fs.readFileSync(statePath, 'utf-8'), statePath) as Record<string, unknown>;
+    const rawPhase = fm?.current_phase;
+    if (typeof rawPhase === 'string') return rawPhase.trim() || null;
+    if (typeof rawPhase === 'number' || typeof rawPhase === 'boolean') return String(rawPhase);
+    return null;
+  } catch {
+    return null;
+  }
+}
+
 function cmdStateAddDecision(cwd: string, options: StateAddDecisionOptions, raw: boolean): void {
   const statePath = planningPaths(cwd).state;
   if (!fs.existsSync(statePath)) { output({ error: 'STATE.md not found' }, raw, undefined); return; }
@@ -832,7 +851,19 @@ function cmdStateAddDecision(cwd: string, options: StateAddDecisionOptions, raw:
 
   if (!summaryText) { output({ error: 'summary required' }, raw, undefined); return; }
 
-  const entry = `- [Phase ${phase || '?'}]: ${summaryText}${rationaleText ? ` — ${rationaleText}` : ''}`;
+  // A decision entry is a permanent record. Writing "[Phase ?]" persists a
+  // placeholder for a fact STATE.md already carries in its own frontmatter, so
+  // the provenance is lost unless a human notices and hand-edits it. When
+  // --phase is omitted, fall back to current_phase.
+  //
+  // The scalar rule mirrors buildStateFrontmatter's fmScalar: only
+  // string/number/boolean are usable, so an object/array current_phase is
+  // ignored rather than stringified into "[object Object]". An explicit --phase
+  // still wins, and "?" is retained for the genuinely unresolvable case — an
+  // unknown phase should stay visibly unknown, never guessed.
+  const resolvedPhase = phase || readCurrentPhaseFromFrontmatter(statePath) || '?';
+
+  const entry = `- [Phase ${resolvedPhase}]: ${summaryText}${rationaleText ? ` — ${rationaleText}` : ''}`;
   let _added = false;
   let created = false;
 

--- a/tests/state.test.cjs
+++ b/tests/state.test.cjs
@@ -5502,6 +5502,70 @@ describe('T6 section-splice characterization — add-decision', () => {
       cleanup(d);
     }
   });
+
+  // A decision recorded without --phase used to be written as a literal
+  // "- [Phase ?]:" even though STATE.md's own frontmatter names the current
+  // phase. The placeholder is persisted, so the provenance of that decision is
+  // lost permanently unless a human notices and hand-edits it.
+  const STATE_FM_PHASE = [
+    '---',
+    "gsd_state_version: '1.0'",
+    'current_phase: 3',
+    'current_phase_name: Sourcing Coverage',
+    'status: executing',
+    '---',
+    '',
+    '# Project State',
+    '',
+    '## Decisions',
+    '',
+  ].join('\n');
+
+  test('add-decision without --phase resolves the phase from frontmatter', () => {
+    const d = createTempProject();
+    try {
+      fs.writeFileSync(path.join(d, '.planning', 'STATE.md'), STATE_FM_PHASE);
+      const result = runGsdTools(['state', 'add-decision', '--summary', 'Threshold set by sweep'], d);
+      assert.ok(result.success, `Command failed: ${result.error}`);
+      const after = fs.readFileSync(path.join(d, '.planning', 'STATE.md'), 'utf-8');
+      assert.ok(
+        after.includes('- [Phase 3]: Threshold set by sweep'),
+        'phase must come from frontmatter current_phase when --phase is omitted',
+      );
+      assert.ok(!after.includes('[Phase ?]'), 'no literal "?" placeholder may be persisted');
+    } finally {
+      cleanup(d);
+    }
+  });
+
+  test('add-decision still honours an explicit --phase over frontmatter', () => {
+    const d = createTempProject();
+    try {
+      fs.writeFileSync(path.join(d, '.planning', 'STATE.md'), STATE_FM_PHASE);
+      const result = runGsdTools(['state', 'add-decision', '--phase', '4', '--summary', 'Explicit wins'], d);
+      assert.ok(result.success, `Command failed: ${result.error}`);
+      const after = fs.readFileSync(path.join(d, '.planning', 'STATE.md'), 'utf-8');
+      assert.ok(after.includes('- [Phase 4]: Explicit wins'), 'explicit --phase must take precedence');
+    } finally {
+      cleanup(d);
+    }
+  });
+
+  test('add-decision keeps the "?" placeholder when no phase can be resolved', () => {
+    const d = createTempProject();
+    try {
+      fs.writeFileSync(path.join(d, '.planning', 'STATE.md'), STATE_NO_DECISIONS);
+      const result = runGsdTools(['state', 'add-decision', '--summary', 'No phase anywhere'], d);
+      assert.ok(result.success, `Command failed: ${result.error}`);
+      const after = fs.readFileSync(path.join(d, '.planning', 'STATE.md'), 'utf-8');
+      assert.ok(
+        after.includes('- [Phase ?]: No phase anywhere'),
+        'unresolvable phase must stay visibly unknown rather than be guessed',
+      );
+    } finally {
+      cleanup(d);
+    }
+  });
 });
 
 describe('T6 section-splice characterization — add-blocker', () => {


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #3231

> Filed today. It does **not** yet carry `confirmed-bug` — per CONTRIBUTING I would
> normally wait, and I am happy for this to sit unreviewed or be closed until a
> maintainer confirms. It is opened now only because the fix and its tests were already
> written while reproducing. Also flagged on the issue: this may fall inside the #3180
> epic, in which case close both.

---

## What was broken

`state add-decision` without `--phase` wrote a literal `- [Phase ?]:` entry into
STATE.md, even when the frontmatter of the file being written carried `current_phase`.

## What this fix does

Falls back to frontmatter `current_phase` when `--phase` is omitted. Explicit `--phase`
still wins, and `?` is still written when no phase is resolvable anywhere.

## Root cause

`cmdStateAddDecision` never consulted frontmatter — `src/state.cts:835` was
`` `- [Phase ${phase || '?'}]: ...` `` — and `state-command-router.cts:142` passes
`--phase` through with no fallback.

The resolution already existed in the same file: `cmdStatePruneDecisions` reads
`fm.current_phase` behind a scalar guard (`src/state.cts:3111-3117`). It just was not
reused here. This extracts that read into `readCurrentPhaseFromFrontmatter` and calls it.

The scalar guard is kept deliberately — a non-scalar `current_phase` returns `null`
rather than stringifying to `[object Object]`, which would have replaced a visible
placeholder with an invisible wrong one.

Why it matters beyond cosmetics: a decision entry is a permanent record. The `?` is
persisted, so provenance is lost unless a human notices and hand-edits it. Across one
11-plan phase, every executor agent that recorded a decision without `--phase` produced
a `[Phase ?]` and hand-repaired it — the same defect paid for eleven times, with the
information needed to render it correctly sitting three lines above the insertion point.

## Testing

### How I verified the fix

Reproduced on `next` @ 86bebce before changing anything (repro script in #3231): a bare
STATE.md with `current_phase: 3` yielded `- [Phase ?]: ...`. After the fix, `- [Phase 3]: ...`.

Full `tests/state.test.cjs`: **330/330 pass** (327 before, plus the 3 added here).

`npm run test:unit`: 1485 tests, 1481 pass, 2 fail. **Both failures are pre-existing and
unrelated** — I verified this by checking out pristine `86bebce`, rebuilding, and running
the two owning files with none of my changes present; they fail identically there:

| Test file | Failing test | Base 86bebce | With this PR |
|---|---|---|---|
| `tests/gsd-statusline.test.cjs` | non-repo directory yields null | 161/162 | 161/162 |
| `tests/workstream-inventory.test.cjs` | broken symlink at the ledger path fails closed (#2645) | 67/68 | 67/68 |

Both look like Windows environment limitations (creating a broken symlink needs
privilege; non-repo detection under a temp dir), not code defects. Worth a separate
issue if they are not already known — happy to file one.

### Regression test added?

- [x] Yes — added a test that would have caught this bug

Three tests, in `describe('T6 section-splice characterization — add-decision')`:

1. **`without --phase resolves the phase from frontmatter`** — the fix. Fails against
   unfixed code with `phase must come from frontmatter current_phase when --phase is omitted`.
2. **`still honours an explicit --phase over frontmatter`** — precedence guard, so the
   fallback cannot start overriding callers.
3. **`keeps the "?" placeholder when no phase can be resolved`** — control. Passes both
   before and after, so the suite distinguishes this fix from a blanket "never write ?"
   change. An unknown phase should stay visibly unknown, never guessed.

Each was run against the unfixed build first; (1) was observed failing, (3) was observed
passing. A test that cannot fail on the defect is not coverage.

### Platforms tested

- [ ] macOS
- [x] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [ ] Linked issue has the `confirmed-bug` label — **not yet; awaiting maintainer triage of #3231**
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`) — 2 pre-existing Windows failures, proven unrelated against pristine `86bebce` (table above)
- [x] `.changeset/` fragment added — `.changeset/3231-add-decision-phase-fallback.md`
- [x] No unnecessary dependencies added

## Breaking changes

None. Behavior is unchanged whenever `--phase` is passed, which is how every in-repo
workflow currently calls `add-decision`. The only path that changes is the one that was
producing `[Phase ?]`, and the `?` itself is retained for the genuinely unresolvable case.

## Scope

Three files, +97/-1: `src/state.cts` (+33/-1), `tests/state.test.cjs` (+64), and the
changeset fragment.
