### PR TITLE
fix(#3238): bump js-yaml to the patched 4.3.1 (high-severity devDep advisory)

### DIFF
--- a/.changeset/vivid-pumas-jump.md
+++ b/.changeset/vivid-pumas-jump.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 3246
 ---
 **Dev-dependency `js-yaml` bumped to the patched 4.3.1, resolving a high-severity quadratic-CPU advisory** — the lockfile now pins the backported `!!omap` fix (GHSA-5p4m-2wfm-xmqj, CVSS 7.5), reachable via eslint. A non-breaking in-range bump (no overrides, no major bump, one package moved); production `npm audit --omit=dev` is unaffected (devDependency only). (#3238)

--- a/.changeset/vivid-pumas-jump.md
+++ b/.changeset/vivid-pumas-jump.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**Dev-dependency `js-yaml` bumped to the patched 4.3.1, resolving a high-severity quadratic-CPU advisory** — the lockfile now pins the backported `!!omap` fix (GHSA-5p4m-2wfm-xmqj, CVSS 7.5), reachable via eslint. A non-breaking in-range bump (no overrides, no major bump, one package moved); production `npm audit --omit=dev` is unaffected (devDependency only). (#3238)

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "eslint-plugin-no-only-tests": "^3.4.0",
         "fast-check": "^4.8.0",
         "globals": "^16.5.0",
-        "js-yaml": "^4.2.1",
+        "js-yaml": "^4.3.1",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.60.0"
       },
@@ -3842,9 +3842,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "eslint-plugin-no-only-tests": "^3.4.0",
     "fast-check": "^4.8.0",
     "globals": "^16.5.0",
-    "js-yaml": "^4.2.1",
+    "js-yaml": "^4.3.1",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.60.0"
   },

--- a/tests/issue-3238-js-yaml-lockfile.test.cjs
+++ b/tests/issue-3238-js-yaml-lockfile.test.cjs
@@ -43,18 +43,33 @@ function npmLs(pkg) {
   return versions;
 }
 
-test('all installed js-yaml copies are patched (>=4.3.1 / >=3.15.1) — #3238', () => {
+// GHSA-5p4m-2wfm-xmqj names only the 3.x (<3.15.1) and 4.x (<4.3.1) lines. The SAME
+// weakness in the 5.x line is CVE-2026-59870 / GHSA-724g-mxrg-4qvm, fixed in 5.2.1 —
+// so a guard against this bug CLASS must require 5.2.1 there too rather than waving
+// every 5.x through, or an accidental major bump to 5.0.0 would reintroduce the exact
+// quadratic `!!omap` resolution this test exists to prevent.
+function isPatched(version) {
+  const core = String(version).split('+')[0]; // drop build metadata
+  // A prerelease of the patched version (e.g. 4.3.1-beta.1) sorts BELOW it in semver
+  // and may predate the fix — fail closed rather than guess.
+  if (core.includes('-')) return false;
+  const [maj, min, pat] = core.split('.').map(Number);
+  if (![maj, min, pat].every(Number.isInteger)) return false; // unparseable — fail closed
+  if (maj < 3) return true;                                   // predates the affected lines
+  if (maj === 3) return min > 15 || (min === 15 && pat >= 1);  // 3.x >= 3.15.1
+  if (maj === 4) return min > 3 || (min === 3 && pat >= 1);    // 4.x >= 4.3.1
+  if (maj === 5) return min > 2 || (min === 2 && pat >= 1);    // 5.x >= 5.2.1 (CVE-2026-59870)
+  return true;                                                // >5.x
+}
+
+test('all installed js-yaml copies are patched (>=4.3.1 / >=3.15.1 / >=5.2.1) — #3238', () => {
   const versions = npmLs('js-yaml');
   // Vacuity guard: an empty list would make every assertion below trivially true.
   assert.ok(versions.length > 0, 'js-yaml must be installed (devDependency) to guard');
   for (const v of versions) {
-    const [maj, min, pat] = v.split('.').map(Number);
-    const ok = (maj === 3 && (min > 15 || (min === 15 && pat >= 1)))  // 3.x >= 3.15.1
-      || (maj === 4 && (min > 3 || (min === 3 && pat >= 1)))          // 4.x >= 4.3.1
-      || (maj > 4);                                                   // >4.x
-    assert.ok(ok,
-      `js-yaml@${v} is within the vulnerable range (>=4.0.0 <4.3.1 / >=3.0.0 <3.15.1) — ` +
-      'lockfile regressed the #3238 patch bump (GHSA-5p4m-2wfm-xmqj). ' +
-      'Re-apply: npm install js-yaml@^4.3.1');
+    assert.ok(isPatched(v),
+      `js-yaml@${v} is not a patched version — the quadratic \`!!omap\` resolution bug is ` +
+      'present in 3.x <3.15.1 (GHSA-5p4m-2wfm-xmqj), 4.x <4.3.1 (same), and 5.x <5.2.1 ' +
+      '(CVE-2026-59870). Re-apply: npm install js-yaml@^4.3.1');
   }
 });

--- a/tests/issue-3238-js-yaml-lockfile.test.cjs
+++ b/tests/issue-3238-js-yaml-lockfile.test.cjs
@@ -1,0 +1,60 @@
+// allow-test-rule: structural-implementation-guard (#3238)
+'use strict';
+
+// Regression guard for #3238: the lockfile must pin a patched js-yaml (>=4.3.1 on the
+// 4.x line, >=3.15.1 on the 3.x line) to resolve GHSA-5p4m-2wfm-xmqj — a high-severity
+// (CVSS 7.5, CWE-407) quadratic-CPU DoS in `!!omap` resolution, vulnerable range
+// `>=4.0.0 <4.3.1`. `!!omap` is in the DEFAULT schema, so a plain yaml.load() is
+// affected. This is a lockfile-only devDependency bump (direct, plus an
+// @eslint/eslintrc dedupe); production (npm audit --omit=dev) was already clean.
+// The test pins every installed copy so the bump can't silently regress.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { execFileSync } = require('node:child_process');
+const path = require('node:path');
+
+const ROOT = path.join(__dirname, '..');
+
+// `npm` is not process.execPath, git, or a bash script/hook, so this does not
+// route through tests/helpers/process-seam.cjs (whose runNode/runGit/runHook
+// primitives cover exactly those three shapes and forward no `shell` option)
+// — `npm` needs `shell: true` on Windows (npm.cmd), which the seam has no
+// surface for. Bounding this directly with an explicit `timeout` is the
+// documented alternative in eslint-rules/no-unbounded-spawn.cjs.
+const NPM_LS_TIMEOUT_MS = 30000;
+
+function npmLs(pkg) {
+  // `npm ls <pkg> --json --all` lists every installed copy with its version. Collect
+  // the version of every node whose key is `pkg` (not the parent packages).
+  const out = execFileSync('npm', ['ls', pkg, '--json', '--all'], {
+    cwd: ROOT, encoding: 'utf8', shell: true, stdio: ['ignore', 'pipe', 'ignore'],
+    timeout: NPM_LS_TIMEOUT_MS,
+  });
+  const versions = [];
+  const walk = (node) => {
+    if (!node || !node.dependencies) return;
+    for (const [k, v] of Object.entries(node.dependencies)) {
+      if (k === pkg && v && v.version) versions.push(v.version);
+      walk(v);
+    }
+  };
+  walk(JSON.parse(out));
+  return versions;
+}
+
+test('all installed js-yaml copies are patched (>=4.3.1 / >=3.15.1) — #3238', () => {
+  const versions = npmLs('js-yaml');
+  // Vacuity guard: an empty list would make every assertion below trivially true.
+  assert.ok(versions.length > 0, 'js-yaml must be installed (devDependency) to guard');
+  for (const v of versions) {
+    const [maj, min, pat] = v.split('.').map(Number);
+    const ok = (maj === 3 && (min > 15 || (min === 15 && pat >= 1)))  // 3.x >= 3.15.1
+      || (maj === 4 && (min > 3 || (min === 3 && pat >= 1)))          // 4.x >= 4.3.1
+      || (maj > 4);                                                   // >4.x
+    assert.ok(ok,
+      `js-yaml@${v} is within the vulnerable range (>=4.0.0 <4.3.1 / >=3.0.0 <3.15.1) — ` +
+      'lockfile regressed the #3238 patch bump (GHSA-5p4m-2wfm-xmqj). ' +
+      'Re-apply: npm install js-yaml@^4.3.1');
+  }
+});


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3238

---

## What was broken

`js-yaml@4.3.0` was pinned in `package-lock.json`, inside the vulnerable range `>=4.0.0 <4.3.1` of **GHSA-5p4m-2wfm-xmqj** — high severity, CVSS 3.1 `AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H` = 7.5, CWE-407 (Inefficient Algorithmic Complexity). Dependabot alert [#14](https://github.com/open-gsd/gsd-core/security/dependabot/14).

`resolveYamlOmap()` enforces `!!omap` key uniqueness with a linear `objectKeys.indexOf()` scan inside the per-element loop, making resolution **O(n²)** in entry count. `!!omap` is registered in the **default** schema, so a plain `yaml.load(untrustedInput)` with no options is affected. The loop is synchronous, so it blocks the event loop — amplification is per-process, not per-request.

## What this fix does

Bumps `js-yaml` to **4.3.1**, the patched release on the `v4-legacy` line, and raises the declared floor `^4.2.1` → `^4.3.1` so a future resolution cannot land back on a vulnerable 4.3.x. The operative change is the lockfile, since `npm ci` is lockfile-driven.

Adds a regression guard mirroring the repo's existing precedent for this exact situation, `tests/issue-2765-brace-expansion-lockfile.test.cjs`.

## Root cause

Upstream, in `js-yaml`'s `lib/type/omap.js`. Not a regression introduced by any commit here — the advisory is newly published (2026-08-06) against a version this repo already had, and `js-yaml@4.3.1` was published 2026-08-01. Same weakness as CVE-2026-59870, fixed in the 5.x line at 5.2.1 and only now backported to 3.x/4.x.

## Testing

### How I verified the fix

**Reproduced before, measured after** — the advisory's own PoC, default schema, no options, same machine:

| n | 4.3.0 (before) | growth | 4.3.1 (after) | growth |
|---|---|---|---|---|
| 5000 | 22ms | — | 33ms | — |
| 10000 | 57ms | 2.59× | 33ms | 1.00× |
| 20000 | 199ms | 3.49× | 49ms | 1.48× |
| 40000 | **768ms** | **3.86×** | **96ms** | **1.96×** |

~4× per doubling (quadratic) collapses to ~2× (linear). Duplicate-key rejection is preserved — `!!omap` with a repeated key still raises `YAMLException`, so the upstream `indexOf` → `Set` swap kept the semantics it was guarding.

**Scope, verified not assumed:** `npm audit` went **1 high → 0**. `npm audit --omit=dev` was **0 before and after** — `js-yaml` is a devDependency and is absent from `package.json`'s `files` allowlist, so it never ships to consumers.

**Blast radius kept auditable:** a targeted `npm install js-yaml@^4.3.1` rather than `npm audit fix`. npm reports `changed 1 package`; the lockfile diff is 4 insertions / 4 deletions touching only `js-yaml`.

**Supply chain verified:** the lockfile's integrity hash for 4.3.1 is byte-for-byte identical to an independent `npm view js-yaml@4.3.1 dist.integrity`, and `resolved` points at the official `registry.npmjs.org` host. No added `scripts`, `overrides`, `resolutions`, or install hooks.

**Why not 5.x** (`latest` = 5.2.3): `@eslint/eslintrc@3.3.5` declares `"js-yaml": "^4.1.1"` — caret-locked to the **4** major. Moving the root to 5.x prevents dedupe, so eslintrc would resolve its **own nested 4.x copy**, which would still need `>=4.3.1` to clear this advisory. 5.x therefore adds a duplicate install without removing the 4.x patch requirement. Separately, 10 tracked files require `js-yaml` directly (1 script, 9 tests) and 5.x is a rewritten module layout — a migration with its own review, not a security patch.

Reviews: `/code-review` (Standards + Spec axes), `/security-review`, and an isolated adversarial pass that proved its conclusions with a synthetic-payload harness rather than by reasoning. Every finding fixed:

- **Spec, major** — the guard's `(maj > 4)` clause accepted any 5.x, but js-yaml **5.0.0–5.2.0 carry the same weakness** under CVE-2026-59870 (fixed 5.2.1). Predicate now requires `5.x >= 5.2.1`. The two reviewers disagreed here — the adversarial pass rated `5.0.0` correct against this advisory's literal ranges, the Spec axis was right about the bug class — and taking only the adversarial verdict would have shipped the hole.
- **Standards, major** — this diverged from precedent 54cb4145b (#2765) by typing the change `chore` with no changeset; `chore` is omitted from release notes entirely, so a security fix would have merged invisibly. Added a `type: Fixed` fragment and retyped as `fix`. Note the gate did *not* require a fragment here (`ok_no_user_facing_changes`) — it is added so users are told they received a security patch, not to satisfy CI.
- **Adversarial, minor** — `Number('4.3.1-beta.1')` produced `NaN`, and majors outside `{3,4}` were reported vulnerable. All failed *safe*, but by accident. The predicate is now explicit: build metadata stripped, prerelease and unparseable versions **fail closed**, `maj < 3` accepted as predating the affected lines.

The predicate is validated by a 27-row harness (12 accepted, 14 rejected, 1 build-metadata) with limit-1/limit boundary rows on all three affected lines: `3.15.0`/`3.15.1`, `4.3.0`/`4.3.1`, `5.2.0`/`5.2.1`.

`npm run lint:ci` exit 0; `changeset-lint` and `docs-lint` both 0 with `GITHUB_BASE_REF=next`.

### Regression test added?

- [x] Yes — added a test that would have caught this bug

`tests/issue-3238-js-yaml-lockfile.test.cjs` walks `npm ls --json --all`, so a **transitive** copy left behind still fails (verified against a synthetic non-deduped payload), and carries a vacuity guard so an empty version list cannot pass silently. No timing assertion: wall-clock assertions are barred by the clock-seam rule and would be load-sensitive on shared benches, so the measurements live in the PR body and the diagnosis artifact instead.

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [x] N/A (not platform-specific)

> A lockfile bump has no platform surface. The guard test itself is platform-aware — it uses `shell: true` precisely so `npm.cmd` resolves on Windows, matching the precedent. CI's Windows and macOS lanes cover it.

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label — **#3238 is labeled `type: chore` / `dependencies` / `security`.** Flagging a divergence rather than hiding it: the precedent issue #2765, same situation, carried `bug` + `confirmed-bug`. Applying a label to an issue is a GitHub issue write outside the PR flow, so it was not done unilaterally.
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass
- [x] `.changeset/` fragment added — `type: Fixed`
- [x] No unnecessary dependencies added

## Breaking changes

None. A patch bump within the same major line; the only documented upstream change is the `indexOf` → `Set` swap in the `!!omap` resolver, and duplicate-key rejection was verified preserved.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/3246"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788880529&installation_model_id=22188&pr_number=3246&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F3246&signature=3acfd35bc1626de46d232316d48c5862f0945ff8884fd214b8a0bd14dd209c8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->