### PR TITLE
docs(#3268): next does require up-to-date before merging

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,12 +147,21 @@ If you target the wrong branch by accident, the `PR Target Validator`
 workflow will post a comment with the one-line fix (click "Edit" by the PR
 title and change the base branch — no need to recreate the PR).
 
-**Why this matters:** Under the old single-branch model, every PR required
-rebasing onto `main` because branch protection required "up-to-date before
-merging" and `main` moved on every merge. With `next` as the integration
-branch and that flag disabled on `next`, concurrent PRs can merge in any
-order as long as they don't conflict on the same lines. The rebase
-treadmill is gone for the 95% case.
+**Why this matters:** Under the old single-branch model, every PR rebased onto
+`main`, which moved on every merge. `next` moves far less often — only when
+another PR to `next` lands — so in practice you rebase much less.
+
+**But `next` does still require "up-to-date before merging".** Branch
+protection has `required_status_checks.strict = true`; check it yourself with
+`gh api repos/open-gsd/gsd-core/branches/next/protection --jq '.required_status_checks.strict'`.
+If another PR lands while yours is open, yours goes `BEHIND` and must be
+rebased before it can merge.
+
+Budget for that, because the rebase is not free here: **it changes your HEAD
+sha, which invalidates the sha-bound pass marker the push gate reads**, so a
+rebase means re-running the full remote verification and another CI cycle
+before the gate clears again. Rebase *last* — immediately before you push for
+review — rather than paying for a verification you are about to discard.
 
 ---
 

--- a/docs/branching.md
+++ b/docs/branching.md
@@ -111,12 +111,16 @@ gh pr create --base next --repo open-gsd/gsd-core
 **Why this rarely needs a rebase:**
 
 - `next` moves slower than `main` did in the old single-branch model — only
-  changes when other PRs to `next` merge.
-- Branch protection on `next` does **not** require "up-to-date before merge"
-  — only requires CI to be green. So another PR landing on `next` while yours
-  is open doesn't force you to rebase.
+  changes when other PRs to `next` merge. Fewer landings means fewer rebases.
 - Squash-merge means each PR becomes one commit on `next` — easy to revert,
   easy to read, no merge-noise.
+
+**It does still need a rebase when `next` moves under you.** Branch protection
+on `next` requires "up-to-date before merge" (`required_status_checks.strict =
+true`), so a PR that goes `BEHIND` must be rebased before it can merge. And
+because the push gate binds its pass marker to an exact sha, that rebase
+invalidates the marker and costs a full re-verification plus another CI cycle
+— so rebase *last*, right before you push for review.
 
 ### Flow 2 — Hotfix (urgent patch release)
 
@@ -191,18 +195,27 @@ The old single-branch model:
 - 10 PRs in flight = 9 of them need to rebase every time one lands. The
   last one to merge has rebased N times.
 
-The new model removes the pressure in three ways:
+The new model reduces the pressure in two ways:
 
 1. **`main` rarely moves.** Only release/hotfix merges land. Most days `main`
    doesn't change at all.
-2. **`next` does NOT require "up-to-date before merge".** Branch protection
-   on `next` only requires CI green. Two PRs to `next` can merge in either
-   order without rebasing each other — git will handle the merge as long as
-   they don't touch the same lines.
-3. **Squash-merge into `next`.** One commit per PR. No "merge main into my
-   branch" noise. If you ever do need to bring `next` into your branch
-   (because of a real conflict), it's one rebase per conflict, not per PR
-   that lands somewhere else.
+2. **Squash-merge into `next`.** One commit per PR. No "merge main into my
+   branch" noise, and a clean revert.
+
+**It does not remove the up-to-date requirement.** `next` carries
+`required_status_checks.strict = true`, exactly as `main` did — so a PR that
+another merge pushes `BEHIND` still has to rebase. What changed is the
+*frequency*: `next` moves only when a PR to `next` lands, not on every release,
+so far fewer PRs go stale.
+
+Two consequences worth planning around:
+
+- The rebase changes your HEAD sha, which **invalidates the sha-bound pass
+  marker** the push gate reads. Re-verification and another CI cycle follow.
+  Rebase last, immediately before pushing for review.
+- With several PRs in flight, the last to merge may still rebase more than
+  once. That is the treadmill, reduced but not gone — size the queue with that
+  in mind rather than assuming order-independence.
 
 You'll still occasionally rebase — when your branch genuinely conflicts with
 something that landed on `next`. But that's a real conflict you'd have to


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3268

---

## What was broken

`CONTRIBUTING.md` told contributors that `next` has the "up-to-date before merging" branch-protection flag **disabled**, and that *"the rebase treadmill is gone for the 95% case."* `docs/branching.md` repeated the claim three times. Branch protection on `next` actually has `required_status_checks.strict = true` — the requirement is on.

## What this fix does

Both files now state the real requirement, show the one-line command to verify it, and name the consequence that follows from it in this repo: a rebase changes the HEAD sha, which invalidates the sha-bound pass marker the push gate reads, so it costs a full remote re-verification plus another CI cycle. The practical advice — rebase *last*, immediately before pushing for review — is stated rather than left to be inferred.

What was true in the original text is kept: `next` moves far less often than `main` did, so rebase *frequency* really is much lower. The claim that was wrong was that the requirement does not exist.

## Root cause

The text describes the intent of the `main` → `next` migration rather than the protection as configured. Either the flag was never disabled or it was re-enabled later; the docs were not reconciled against the API either way.

## Testing

### How I verified the fix

The claim was checked against the live API rather than assumed:

```console
$ gh api repos/open-gsd/gsd-core/branches/next/protection \
    --jq '{strict_up_to_date: .required_status_checks.strict,
           required_reviews: .required_pull_request_reviews.required_approving_review_count,
           enforce_admins: .enforce_admins.enabled}'
{"enforce_admins":false,"required_reviews":1,"strict_up_to_date":true}
```

Observed in practice on PR #3261: CI green and `MERGEABLE`, but `mergeStateStatus: BEHIND` blocked the merge — the situation the old text said could not arise.

Swept `CONTRIBUTING.md`, all of `docs/`, and `README.md` for other copies of the claim; the four occurrences fixed here are all of them. `GITHUB_BASE_REF=next npm run lint:ci` exits 0 (after `npm ci` + `npm run build:lib` in the worktree — a fresh worktree fails the lint on a missing compiled artifact, not on this diff).

### Regression test added?

- [x] No — explain why: the assertion would be about live GitHub branch-protection state, not about this repo's code. A test pinning `strict: true` would fail the moment a maintainer legitimately changed the setting, turning a policy change into a red build. The durable fix is that both documents now tell the reader how to check the API themselves.

### Platforms tested

- [x] N/A (not platform-specific)

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #3268`
- [ ] Linked issue has the `confirmed-bug` label — filed today as a docs bug; label is the maintainer's to apply
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass
- [x] `.changeset/` fragment added if this is a user-facing fix — not required: the changeset gate covers `bin/`, `gsd-core/`, `src/`, `agents/`, `commands/`, `hooks/`, `sdk/src/`, and this diff touches none of them
- [x] No unnecessary dependencies added

## Breaking changes

None. Documentation only.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/3269"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788899856&installation_model_id=22188&pr_number=3269&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F3269&signature=e5b8d826d843d852954931c7fd2e37111c85fc120d0f6940410fb8fbe372b002"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->