### PR TITLE
fix(#3284): prepare the emitted baseline before the parallel suite runs

### DIFF
--- a/.changeset/sturdy-orcas-greet.md
+++ b/.changeset/sturdy-orcas-greet.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`gsd-test` runs can now prepare the emitted-attribution baseline before the test suite starts** — the dockerized runner has no access to the GitHub-Actions-only cache CI restores, so both `tests/emitted-attribution.test.cjs` checks fell through to an in-job build that ran inside the parallel suite and timed out. A new opt-in `gsd:pretest-baseline` script generates the baseline once, serially, at the base ref when the runner supplies `GSD_TEST_BASE_REF`; it exits 0 on every failure path, so a run degrades to the previous in-job-build behavior rather than failing. (#3284)

--- a/.changeset/sturdy-orcas-greet.md
+++ b/.changeset/sturdy-orcas-greet.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 3286
 ---
 **`gsd-test` runs can now prepare the emitted-attribution baseline before the test suite starts** — the dockerized runner has no access to the GitHub-Actions-only cache CI restores, so both `tests/emitted-attribution.test.cjs` checks fell through to an in-job build that ran inside the parallel suite and timed out. A new opt-in `gsd:pretest-baseline` script generates the baseline once, serially, at the base ref when the runner supplies `GSD_TEST_BASE_REF`; it exits 0 on every failure path, so a run degrades to the previous in-job-build behavior rather than failing. (#3284)

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "version": "node scripts/sync-manifest-versions.cjs --stage && node scripts/gen-capability-registry.cjs --write && git add gsd-core/bin/lib/capability-registry.cjs",
     "prepublishOnly": "npm run build:lib && npm run build:hooks",
     "pretest": "npm run build:lib && npm run lint:skill-deps",
+    "gsd:pretest-baseline": "node scripts/gsd-pretest-baseline.cjs",
     "pretest:coverage": "npm run build:lib && npm run lint:skill-deps",
     "lint": "eslint . --cache --cache-location node_modules/.cache/eslint/",
     "lint:fix": "eslint . --fix",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "hooks",
     "scripts",
     "!scripts/gen-emitted-baseline.cjs",
+    "!scripts/gsd-pretest-baseline.cjs",
     "!scripts/qa-smell-ratchet.cjs",
     "!scripts/live-config-guard.cjs",
     "!scripts/run-tests.cjs",

--- a/scripts/gsd-pretest-baseline.cjs
+++ b/scripts/gsd-pretest-baseline.cjs
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * gsd-pretest-baseline.cjs — the "gsd:pretest-baseline" project hook the
+ * gsd-test-runner remote runner invokes (see `reporter/run-and-die.sh` in
+ * open-gsd/gsd-test-runner) AFTER `npm ci`/`npm run build` and BEFORE the
+ * watchdog handoff — i.e. entirely OUTSIDE the watchdog deadline (ADR-0021
+ * Decision 1, gsd-test-runner).
+ *
+ * ## Why this exists
+ *
+ * `tests/emitted-attribution.test.cjs`'s differential-attribution gate needs an
+ * emitted-baseline artifact built at the BASE ref (`resolveBaseline()`,
+ * `tests/helpers/emitted-baseline.cjs`). GitHub CI publishes that artifact via
+ * `actions/cache/save` (`.github/workflows/test.yml`'s `publish-emitted-baseline`
+ * job) — a GitHub-Actions-only API the dockerized gsd-test remote runner cannot
+ * reach. Absent a cache hit, `resolveBaseline()` falls back to an in-job build
+ * (`buildBaselineAtRef`, `tests/helpers/emitted-runtime.cjs`): a `git worktree
+ * add` + `npm run build:lib` + ~20 sequential installer spawns, run from INSIDE
+ * the parallel `node --test` suite in the runner's `--cpus 2 --memory 2g`
+ * container. That contention is what makes the in-job fallback slow/flaky there.
+ *
+ * Running the exact same build ONCE, SERIALLY, before the parallel suite starts
+ * — on an otherwise-idle container with both CPUs to itself — is materially
+ * faster and removes the contention. That is the entirety of what this script
+ * does: it is a thin CLI wrapper around `buildBaselineAtRef`, not a second copy
+ * of its procedure (a second copy is exactly the divergence class ADR-3180
+ * exists to remove).
+ *
+ * ## THE correctness trap this script exists to avoid
+ *
+ * `gen-emitted-baseline.cjs --out ...` (no `--dir`) measures the CURRENT tree,
+ * and CI only ever runs that form on `next`. Inside the remote-runner
+ * container the checked-out tree is the BRANCH UNDER TEST, not the base. If
+ * this script measured HEAD and published that as "the base ref's baseline",
+ * the differential-attribution diff would come back EMPTY — a false pass that
+ * is worse than the failure this script exists to avoid.
+ *
+ * This script NEVER measures HEAD. It always builds at `GSD_TEST_BASE_REF` via
+ * `buildBaselineAtRef(ref, ...)`, which checks out a THROWAWAY `git worktree` at
+ * `ref` and measures THAT — see that function's doc comment in
+ * `tests/helpers/emitted-runtime.cjs` for the full mechanics. If
+ * `GSD_TEST_BASE_REF` is unset, empty, or does not resolve, this script writes
+ * NOTHING and exits 0 — `resolveBaseline()`'s existing in-job-build fallback
+ * covers that case exactly as it does today.
+ *
+ * ## Failure posture
+ *
+ * This is pre-work, not a gate. It NEVER fails the run: every error path logs to
+ * stderr and returns/exits 0. A pre-step that could abort `run-and-die.sh`
+ * before a single test runs would be strictly worse than doing nothing and
+ * letting `resolveBaseline()`'s documented fallback run in-job.
+ *
+ * The write to `.gsd-cache/emitted-baseline.json` is atomic (write to a
+ * same-directory tmp file, then `fs.renameSync`) so a crash mid-write can never
+ * leave `resolveBaseline()` reading a partial/corrupt file as "valid".
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const crypto = require('node:crypto');
+
+const { REPO_ROOT, git, buildBaselineAtRef } = require('../tests/helpers/emitted-runtime.cjs');
+const { DEFAULT_CACHE_PATH } = require('../tests/helpers/emitted-baseline.cjs');
+
+/**
+ * Resolve `ref` to a 40-hex commit sha via `git rev-parse --verify`, or return
+ * null. Mirrors `resolveBase()`'s own resolution check in emitted-runtime.cjs
+ * (same command, same regex) without touching that function's env-derived
+ * candidate list — that list answers a different question (what base is THIS
+ * test run being evaluated against) than this script's (did the CALLER's
+ * explicit `GSD_TEST_BASE_REF` resolve at all).
+ */
+function resolveRef(ref) {
+  let sha;
+  try {
+    sha = git(['rev-parse', '--verify', `${ref}^{commit}`]).trim();
+  } catch {
+    return null;
+  }
+  return /^[0-9a-f]{40}$/.test(sha) ? sha : null;
+}
+
+function main() {
+  const ref = process.env.GSD_TEST_BASE_REF;
+  if (!ref || !ref.trim()) {
+    process.stderr.write(
+      'gsd:pretest-baseline: GSD_TEST_BASE_REF unset/empty; nothing to do '
+      + '(resolveBaseline()\'s in-job-build fallback covers this).\n',
+    );
+    return;
+  }
+
+  const resolvedSha = resolveRef(ref);
+  if (!resolvedSha) {
+    process.stderr.write(
+      `gsd:pretest-baseline: base ref "${ref}" (GSD_TEST_BASE_REF) did not resolve to a `
+      + 'commit; skipping (the in-job-build fallback covers this).\n',
+    );
+    return;
+  }
+
+  let artifact;
+  try {
+    // buildBaselineAtRef checks out a THROWAWAY worktree AT ref and measures
+    // THAT — never the caller's own working tree (see file doc above).
+    artifact = buildBaselineAtRef(ref, { cwd: REPO_ROOT });
+  } catch (err) {
+    process.stderr.write(
+      `gsd:pretest-baseline: buildBaselineAtRef("${ref}") failed: `
+      + `${err && err.stack ? err.stack : err}\n`,
+    );
+    return;
+  }
+
+  const outPath = path.join(REPO_ROOT, DEFAULT_CACHE_PATH);
+  const tmpPath = path.join(
+    path.dirname(outPath),
+    `.emitted-baseline.tmp-${process.pid}-${crypto.randomBytes(4).toString('hex')}.json`,
+  );
+  try {
+    fs.mkdirSync(path.dirname(outPath), { recursive: true });
+    fs.writeFileSync(tmpPath, `${JSON.stringify(artifact, null, 2)}\n`, 'utf8');
+    // Same-directory rename is atomic on the filesystems this ever runs on
+    // (POSIX rename(2) within one filesystem): resolveBaseline() can never
+    // observe a partially-written file at outPath.
+    fs.renameSync(tmpPath, outPath);
+  } catch (err) {
+    process.stderr.write(
+      `gsd:pretest-baseline: writing ${outPath} failed: ${err && err.stack ? err.stack : err}\n`,
+    );
+    try {
+      fs.rmSync(tmpPath, { force: true });
+    } catch {
+      /* best-effort cleanup; never mask the primary error above */
+    }
+    return;
+  }
+
+  process.stderr.write(
+    `gsd:pretest-baseline: wrote ${outPath} (ref=${ref}, sha=${resolvedSha.slice(0, 12)})\n`,
+  );
+}
+
+// No runMain/ExitError here (scripts/lib/cli-exit.cjs): this hook's contract is
+// "never fail the run" (see file doc above), which is the opposite of
+// cli-exit.cjs's generic-error -> exit(1) behavior. Every failure path inside
+// main() above already logs + returns; this outer try/catch is the backstop
+// for a genuinely unexpected throw (a bug in this script), and it degrades
+// exactly the same way: log, exit 0.
+try {
+  main();
+} catch (err) {
+  process.stderr.write(
+    `gsd:pretest-baseline: unexpected error (ignored, exiting 0): `
+    + `${err && err.stack ? err.stack : err}\n`,
+  );
+}
+process.exitCode = 0;
+
+module.exports = { resolveRef, main };

--- a/tests/packaging-shipped-scripts-require-only-shipped.test.cjs
+++ b/tests/packaging-shipped-scripts-require-only-shipped.test.cjs
@@ -198,6 +198,18 @@ describe('#2858 — shipped scripts require only shipped paths', () => {
     );
   });
 
+  test('gsd-pretest-baseline.cjs does NOT ship (repo-only CI tooling)', () => {
+    // Same class as gen-emitted-baseline.cjs above — it delegates to
+    // ../tests/helpers/emitted-runtime.cjs, which does not ship. It is
+    // repo-only CI tooling that the gsd-test runner invokes via the
+    // gsd:pretest-baseline npm script from a checkout, never from a
+    // published install. It must be excluded from the npm tarball.
+    assert.ok(
+      !shippedFiles.has('scripts/gsd-pretest-baseline.cjs'),
+      'scripts/gsd-pretest-baseline.cjs must NOT ship — it requires tests/ which does not ship (#3284)',
+    );
+  });
+
   test('a script requiring a sibling in the same shipped dir resolves as shipped (positive case)', () => {
     // Sanity: scripts/lib/cli-exit.cjs ships and is required by shipped scripts.
     // This confirms the guard's positive path works — a valid intra-shipped require


### PR DESCRIPTION
## Fix PR

## Linked Issue

Closes #3284

## What was broken

`tests/emitted-attribution.test.cjs` fails **2 tests on both Node lanes** under the dockerized `gsd-test` runner, on **unmodified `next`**:

- `buildBaselineAtRef resolves a baseline via the in-job build even when the generator script is absent at the ref (#2767 regression)` — `spawnSync /usr/local/bin/node ETIMEDOUT`
- `differential attribution over the real tree` — `no usable emitted baseline for origin/next@<sha> (tried cache:.gsd-cache/emitted-baseline.json, build):`

Baseline resolution (`tests/helpers/emitted-baseline.cjs:133-220`) is `GSD_EMITTED_BASELINE` → `.gsd-cache/emitted-baseline.json` → in-job build → hard fail. GitHub Actions supplies the cache via `publish-emitted-baseline` + `actions/cache/save` — **an Actions-only API the dockerized runner cannot reach by construction** — so CI is green while the docker runner always falls through to the build.

That build (`tests/helpers/emitted-runtime.cjs:671-729`) runs a generator performing **~20 sequential installer spawns**, from **inside** the parallel `node --test` suite (~31.8k tests) in a container capped at **`--cpus 2`**. Both consuming tests trigger it independently, so the suite pays for it twice.

## Evidence it is pre-existing, not branch-caused

A control run of **unmodified `origin/next` @ `58d73dd2`** reproduced both failures byte-identically:

| Run | Tests | Failed |
|---|---|---|
| Control — unmodified `next` | 31,821 | 2 |
| A feature branch off the same base | 31,886 | 2 (the same two, no others) |

## The fix

A project half of a generic runner hook. `scripts/gsd-pretest-baseline.cjs`, exposed as `npm run gsd:pretest-baseline`:

- reads `GSD_TEST_BASE_REF` (forwarded by the runner); exits 0 silently when unset or unresolvable;
- generates `.gsd-cache/emitted-baseline.json` **at the base ref**, reusing the existing `buildBaselineAtRef` rather than re-deriving it;
- writes atomically (tmp + rename), so a partial file can never be read as valid;
- exits 0 on **every** failure path — a pre-step that can fail a whole run is worse than the fallback it replaces.

The runner calls it in `run-and-die.sh`'s pre-work phase, which ADR-0021 Decision 1 deliberately places **outside** the watchdog deadline — so it runs once, serially, on an otherwise-idle container instead of competing with the parallel suite.

## The correctness trap this deliberately avoids

The CI command is `gen-emitted-baseline.cjs --out …` with **no `--dir`** — it measures the *current* tree, and CI only ever runs it on `next`. In the container the checked-out tree is the **branch under test**. Generating a baseline of HEAD and storing it as the base's baseline would make the differential diff **empty** and the gate **permanently green** — a false-green strictly worse than the failure it replaces, and exactly the class ADR-3180 exists to remove.

`gsd-pretest-baseline.cjs` therefore delegates to `buildBaselineAtRef(ref, …)`, which does `git worktree add --detach <tmp> <ref>` and measures **that worktree**, never `cwd`.

## Testing

- `npm run build:lib` — clean
- `npx eslint .` — clean
- `npm run lint:ci` — exit 0, all sub-checks pass

**This change is inert until its runner counterpart lands.** The script only executes when the runner invokes the hook, so `gsd-test` on this branch still shows the same two pre-existing failures — that is expected, and is why the control run above is the relevant evidence. GitHub CI is unaffected by the gap (it has the cache), so this PR's own CI is a real signal.

## Companion

[open-gsd/gsd-test-runner#129](https://github.com/open-gsd/gsd-test-runner/pull/129) forwards `GSD_TEST_BASE_REF` and calls the hook. Each side degrades gracefully without the other, so they can land in either order.

## Breaking changes

None. The script is opt-in, runs only when the runner supplies `GSD_TEST_BASE_REF`, and exits 0 on every failure path.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/3286"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788915606&installation_model_id=22188&pr_number=3286&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F3286&signature=a7bd4d6586aaa6c6d01c9b8cc14e58245882a66983f87f4c06ecac86f2291e31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->