### PR TITLE
fix(#3293): execNpm still flashes a console window on Windows (shell:true defeats windowsHide:true)

### DIFF
--- a/src/shell-command-projection.cts
+++ b/src/shell-command-projection.cts
@@ -631,9 +631,22 @@ export function execGit(args: string[], opts: { cwd?: string; env?: Record<strin
 }
 
 export function execNpm(args: string[], opts: { cwd?: string; timeout?: number } = {}): SpawnResultOutput {
-  const result = childProcess.spawnSync('npm', args, {
+  // Windows: spawn cmd.exe ourselves rather than passing shell:true. Node's
+  // shell:true path wraps the command in its own internal cmd.exe invocation,
+  // and combining that with windowsHide:true is a long-standing Node/Windows
+  // bug (nodejs/node#21825) where the wrapper's console window still briefly
+  // flashes on screen for a console-less (detached) parent — see #799, which
+  // this same file was previously fixed for (#688) by adding windowsHide:true
+  // alone; that sweep didn't remove the shell:true that defeats it here.
+  // Invoking cmd.exe directly as the spawned program makes windowsHide:true
+  // apply to the CreateProcess call we control, which reliably suppresses the
+  // window. Mirrors the no-shell-for-argv-array .cmd-shim pattern already used
+  // elsewhere in this codebase (gsd-tools.cjs, #2667/#3086).
+  const isWin = process.platform === 'win32';
+  const command = isWin ? 'cmd.exe' : 'npm';
+  const commandArgs = isWin ? ['/d', '/s', '/c', 'npm', ...args] : args;
+  const result = childProcess.spawnSync(command, commandArgs, {
     cwd: opts.cwd,
-    shell: process.platform === 'win32',
     encoding: 'utf-8',
     stdio: ['ignore', 'pipe', 'pipe'],
     timeout: opts.timeout ?? 15_000,

--- a/tests/gsd-check-update-worker-platform-gate.test.cjs
+++ b/tests/gsd-check-update-worker-platform-gate.test.cjs
@@ -45,28 +45,58 @@ function codeOnly(file) {
     .replace(/(^|[^:])\/\/[^\r\n]*/g, '$1');
 }
 
+// Slice the exact body of one spawn site (comment-stripped) so the assertion
+// binds that site, not merely "the pattern appears somewhere in the file" —
+// mirrors regionBetween() in tests/windows-robustness.test.cjs.
+function regionInFile(file, startAnchor, endAnchor) {
+  const src = codeOnly(file);
+  const i = src.indexOf(startAnchor);
+  assert.notEqual(i, -1, `start anchor not found: ${startAnchor}`);
+  const j = src.indexOf(endAnchor, i);
+  assert.notEqual(j, -1, `end anchor not found after start: ${endAnchor}`);
+  return src.slice(i, j);
+}
+
 describe('execNpm: Windows npm spawn platform gate (PR #3102, relocated #498)', () => {
   test('projection seam exists', () => {
     assert.ok(fs.existsSync(PROJECTION_PATH), `not found at ${PROJECTION_PATH}`);
   });
 
-  test('execNpm gates shell to process.platform === "win32"', () => {
+  // #3102's original fix used `shell: process.platform === 'win32'` to resolve
+  // npm.cmd on Windows without adding shell overhead on POSIX. #3293 found
+  // that shape defeats windowsHide:true (Node's shell:true wraps the command in
+  // its own internal cmd.exe, and windowsHide:true does not reliably apply to
+  // that wrapper — nodejs/node#21825), so execNpm was rewritten to spawn cmd.exe
+  // itself directly on Windows only (still resolving npm.cmd via PATHEXT) and to
+  // spawn npm directly (no shell) on POSIX. The contract this test locks is
+  // unchanged — Windows-only shell-equivalent resolution, zero overhead on
+  // POSIX — only the mechanism moved.
+  test('execNpm resolves npm via a Windows-only gate (isWin), not shell:true', () => {
+    const code = codeOnly(PROJECTION_PATH);
     assert.match(
-      codeOnly(PROJECTION_PATH),
-      /shell:\s*process\.platform\s*===\s*['"]win32['"]/,
+      code,
+      /isWin\s*=\s*process\.platform\s*===\s*['"]win32['"]/,
       [
-        'execNpm must gate shell to `process.platform === "win32"`.',
-        'A regression to `shell: true` would spawn /bin/sh -c on POSIX',
-        '(adds shell overhead, changes signal/exit semantics). See PR #3102.',
+        'execNpm must gate its Windows-only npm-resolution path to',
+        '`process.platform === "win32"`; POSIX must take the plain `npm` spawn.',
       ].join(' '),
+    );
+    assert.match(
+      code,
+      /isWin\s*\?\s*['"]cmd\.exe['"]/,
+      'execNpm must spawn cmd.exe directly (not via shell:true) to resolve npm.cmd on Windows.',
     );
   });
 
-  test('no unconditional shell: true on the npm spawn', () => {
+  test('no shell:true or shell:process.platform on the npm spawn (defeats windowsHide)', () => {
+    // PROJECTION_PATH is the compiled .cjs; TS `export function` compiles to a
+    // plain `function` declaration plus a separate `exports.x = x` line, so the
+    // anchor must match the compiled form, not the .cts source's `export function`.
+    const region = regionInFile(PROJECTION_PATH, 'function execNpm', "_spawnResult(result, 'npm')");
     assert.doesNotMatch(
-      codeOnly(PROJECTION_PATH),
-      /shell\s*:\s*true\s*[,\s}]/,
-      'shell: true is forbidden — use the `process.platform === "win32"` gate.',
+      region,
+      /shell\s*:\s*(true|process\.platform)/,
+      'shell:true/shell:process.platform is forbidden on execNpm — it defeats windowsHide:true on Windows (nodejs/node#21825); spawn cmd.exe directly instead.',
     );
   });
 });

--- a/tests/windows-robustness.test.cjs
+++ b/tests/windows-robustness.test.cjs
@@ -255,6 +255,29 @@ describe('bug #685: Windows spawns must set windowsHide:true (no console-window 
     });
   }
 
+  // Regression test for the #685/#688 fix's residual gap (see #3293): adding
+  // windowsHide:true alone is not sufficient. Node's shell:true path wraps the
+  // command in Node's own internal cmd.exe invocation, and windowsHide:true does not
+  // reliably apply to that wrapper (nodejs/node#21825) — so execNpm kept flashing a
+  // console window on Windows even after #688 landed. windowsHide:true must be paired
+  // with NOT using shell:true; a direct cmd.exe /d /s /c invocation (as execTool's
+  // .cmd-shim callers already do elsewhere in this codebase) is the pattern that
+  // actually suppresses the window.
+  test('execNpm spawnSync does not use shell:true (defeats windowsHide on Windows)', () => {
+    const region = regionBetween(cts(), 'export function execNpm', "_spawnResult(result, 'npm')");
+    // Strip // line comments first: this region's own explanatory comment discusses
+    // the shell:true bug pattern in prose, which would otherwise self-match.
+    const code = region
+      .split('\n')
+      .map((line) => line.replace(/\/\/.*$/, ''))
+      .join('\n');
+    assert.doesNotMatch(
+      code,
+      /shell:\s*(true|process\.platform)/,
+      'execNpm spawnSync must not use shell:true — it defeats windowsHide:true on Windows (nodejs/node#21825); invoke cmd.exe directly instead',
+    );
+  });
+
   test('gsd-worktree-path-guard SPAWNOPT sets windowsHide', () => {
     const region = regionBetween(read('hooks/gsd-worktree-path-guard.js'), 'const SPAWNOPT', '};');
     assert.match(region, /windowsHide:\s*true/, 'gsd-worktree-path-guard SPAWNOPT must set windowsHide: true');


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3293

> Issue currently carries `needs-reproduction`, not yet `confirmed-bug`. I captured a live WMI process-creation trace reproducing the flash on 1.10.0 (details in the issue and in Root Cause below) — flagging for maintainer triage/label.

---

## What was broken

`execNpm` in `src/shell-command-projection.cts` still flashed a visible console window on Windows during every SessionStart update check, even though `windowsHide: true` was already set — a regression that survived the #688 fix for #799.

## What this fix does

Removes `shell: process.platform === 'win32'` from `execNpm`. On Windows only, it now spawns `cmd.exe` directly as the program with an explicit `['/d', '/s', '/c', 'npm', ...args]` argv (still resolving `npm.cmd` via PATHEXT, same as `shell: true` did), so `windowsHide: true` applies to the process this code actually controls. POSIX is unaffected — still spawns `npm` directly, no shell.

## Root cause

On Windows, `shell: true` makes Node wrap the command in its own internal `cmd.exe /d /s /c "..."` invocation, and `windowsHide: true` does not reliably apply to that internal wrapper — a long-standing Node/Windows bug ([nodejs/node#21825](https://github.com/nodejs/node/issues/21825)). #688 added `windowsHide: true` (the fix suggested in #799) without removing the `shell: true` that defeats it, so `npm view @opengsd/gsd-core version` kept flashing a console window, unchanged from the original report. This mirrors the no-shell-for-argv-array `.cmd`-shim pattern already used elsewhere in this codebase (`gsd-tools.cjs`'s reviewer-CLI spawn, #2667/#3086) for the identical Windows PATHEXT-resolution problem #3102/#3103 solved the same way.

## Testing

### How I verified the fix

Captured a WMI process-creation trace during normal Claude Code usage on Windows before and after the change — `cmd.exe /d /s /c "npm view @opengsd/gsd-core version"` no longer opens a visible window — and confirmed `checkLatestVersion()` still returns a correct version afterward.

```
node --test tests/capability-source.test.cjs tests/faulty-deps.test.cjs tests/gsd-check-update-worker-platform-gate.test.cjs tests/shell-command-projection-dispatch.test.cjs tests/shell-command-projection-path-sep.test.cjs tests/windows-robustness.test.cjs
# tests 351, pass 349, fail 0, skipped 2 (pre-existing/unrelated)
```

`npm run lint` clean on the changed files.

### Regression test added?

- [x] Yes — added a test that would have caught this bug

Updated the #3102 platform-gate test (`tests/gsd-check-update-worker-platform-gate.test.cjs`) to assert the new Windows-only `cmd.exe` mechanism instead of the specific `shell: process.platform === 'win32'` code shape it replaces, plus an explicit "no `shell:true`/`shell:process.platform`" guard. Added a regression test to `tests/windows-robustness.test.cjs` (existing `bug #685` describe block) locking that `execNpm` never reintroduces `shell:true`/`shell:process.platform` — `windowsHide:true` alone (the existing test in that block) is not sufficient, which is the exact gap this bug slipped through.

### Platforms tested

- [x] Windows (including backslash path handling)
- [ ] macOS
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [ ] Linked issue has the `confirmed-bug` label — pending maintainer triage (currently `needs-reproduction`)
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr 3294 --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None
