### PR TITLE
docs(#3316): standing counter-test rule for error/fallback branches

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -612,6 +612,8 @@ Happy-path tests are not enough for code that accepts user input, reads project 
 
 See [`TEST-EXAMPLES.md`](TEST-EXAMPLES.md) for concrete demo tests that show these requirements in practice.
 
+**Standing rule for error/fallback branches:** feeding an adversarial input is not sufficient on its own — if the code degrades permissively instead of throwing, the test must assert the *specific* degraded verdict, not just that the call survived. See [`TESTING-STANDARDS.md` — "Standing rule: assert the degraded verdict"](TESTING-STANDARDS.md#standing-rule-assert-the-degraded-verdict-not-just-did-not-throw).
+
 Use this matrix when it applies to the changed surface:
 
 1. Happy path

--- a/TESTING-STANDARDS.md
+++ b/TESTING-STANDARDS.md
@@ -83,6 +83,44 @@ See [`CONTRIBUTING.md` — "QA Matrix Requirements"](CONTRIBUTING.md#qa-matrix-r
 
 **Enforcement:** Code review, `no-only-tests/no-only-tests` ESLint rule (prevents happy-path-only merges via `test.only`).
 
+#### Standing rule: assert the degraded verdict, not just "did not throw"
+
+A counter-test that feeds a hostile or failing input satisfies the letter of contract 6 above and can still be worthless. If a function has an error or fallback branch — a guard that degrades permissively on bad input, a resolver that falls back to a default root, a lock that expires — the test for that branch must assert the **specific degraded verdict** the branch produces, not merely that the call completed without throwing or returned *some* value of the right type.
+
+**Non-compliant (the actual pre-fix shape of `tests/worktree-safety.test.cjs`'s `resolveWorktreeContext` timeout counter-test, per [#3050](https://github.com/open-gsd/gsd-core/issues/3050) finding 2 and epic [#3051](https://github.com/open-gsd/gsd-core/issues/3051) Phase 3, generalized here as [#3053](https://github.com/open-gsd/gsd-core/issues/3053) H4):**
+
+```javascript
+// A liveness test wearing a correctness test's name — it proves the call
+// survived a timeout, not that it degraded to the RIGHT shape.
+test('resolveWorktreeContext handles a timeout', () => {
+  const result = resolveWorktreeContext('/repo/wt', { execGit: makeTimeoutStub() });
+  assert.doesNotThrow(() => resolveWorktreeContext('/repo/wt', { execGit: makeTimeoutStub() }));
+  assert.strictEqual(typeof result.effectiveRoot, 'string'); // true of ANY string, including the wrong one
+});
+```
+
+**Compliant (the actual fixed test, `tests/worktree-safety.test.cjs`):**
+
+```javascript
+test('returns effectiveRoot=cwd, mode=current_directory, reason=git_timed_out on timeout, not throw', () => {
+  const result = resolveWorktreeContext('/tmp', { execGit: makeTimeoutStub() });
+  assert.deepStrictEqual(result, {
+    effectiveRoot: '/tmp',           // the specific degraded value, not just "a string"
+    mode: 'current_directory',
+    reason: 'git_timed_out',
+  });
+});
+```
+
+This is not the same requirement as the input-rejection rule above it. A test can already satisfy "feed the SUT a hostile input" while still failing this one, if it never checks *what the SUT did in response*. Two shapes are explicitly out of scope for this rule — they are not fail-open guards and adding this counter-test to them would be noise, not signal:
+
+- A branch that re-throws or propagates the error rather than producing a degraded verdict — contract 4 above ("test the claimed path") already covers it via `assert.throws`.
+- A branch that returns a documented, structured error signal that the test already asserts on directly (a three-state policy that fails closed on malformed input, a dispatch convention, an `{isError: true}` return shape) — the structured field *is* the verdict; asserting on it already satisfies this rule.
+
+**Why this isn't a lint rule.** A pattern scan for fail-open shapes was measured directly against this repo's `src/*.cts` during epic #3051: it scored 1 true positive against 3 false positives (a documented three-state policy, a dispatch convention, and a structured `isError` return each looked like a fail-open guard and were not). The permissive-verdict shape is module-specific, not mechanically enumerable, so a lint rule here would be both incomplete and noisy. This is a code-review expectation, not a CI gate — it will not fail a build on its own; it fails when a reviewer (human or `/code-review`) lets a "did not throw" test stand in for a correctness test.
+
+**Enforcement:** Code review only — deliberately not lint-enforced (see above). Cross-linked from [`CONTRIBUTING.md` — "QA Matrix Requirements"](CONTRIBUTING.md#qa-matrix-requirements) so reviewers see it at the point they already apply the negative-space matrix.
+
 ---
 
 ## New policies (ADR 456)


### PR DESCRIPTION
## Enhancement PR

## Linked Issue

Closes #3316

H4 of epic #3053. Unblocked by #3051 (closed 2026-08-10, all 14 enumerated modules drained).

## What this enhancement improves

`TESTING-STANDARDS.md` documents six test-rigor contracts, but contract 6 ("Counter-tests for negative space") only required feeding the SUT a hostile/failing input — it never required asserting *what the SUT did in response*. Epic #3051 found this gap live: `worktree-safety.test.cjs`'s `resolveWorktreeContext` timeout counter-test fed a real timeout stub and then asserted only `typeof result.effectiveRoot === 'string'` — true of any string, including the wrong one. A liveness test wearing a correctness test's name.

#3051 fixed that one instance as part of an enumerated, one-time sweep over 14 named modules (now closed, every checkbox verified). This PR is the standing rule that generalizes the fix so the same gap doesn't quietly reopen somewhere else: any test on an error/fallback branch must assert the *specific degraded verdict* the branch produces, not merely that the call survived.

## Before / After

**Before** — contract 6 doesn't distinguish "fed a hostile input" from "checked what happened":

```javascript
test('resolveWorktreeContext handles a timeout', () => {
  const result = resolveWorktreeContext('/repo/wt', { execGit: makeTimeoutStub() });
  assert.doesNotThrow(() => resolveWorktreeContext('/repo/wt', { execGit: makeTimeoutStub() }));
  assert.strictEqual(typeof result.effectiveRoot, 'string'); // true of ANY string, including the wrong one
});
```

**After** — `TESTING-STANDARDS.md` § 6 now has a worked example (the real pre-fix and post-fix shapes of `tests/worktree-safety.test.cjs`) making the distinction explicit, plus two named carve-outs (re-thrown errors; already-structured error signals) so the rule doesn't get over-applied. Cross-linked from `CONTRIBUTING.md`'s QA Matrix Requirements section, where reviewers already look.

## How it was implemented

Two-file, docs-only diff:
- `TESTING-STANDARDS.md` — extended contract 6 in place (not a new parallel section — the two concepts are closely related enough that splitting them would fragment one topic) with a "Standing rule" subsection: the rule statement, non-compliant/compliant worked examples verified against the real `tests/worktree-safety.test.cjs` source, two explicit out-of-scope carve-outs, and an honest "why this isn't a lint rule" note (a pattern scan for fail-open shapes scored 1 true positive against 3 false positives during #3051's own measurement — the shape is module-specific, not mechanically enumerable).
- `CONTRIBUTING.md` — one cross-link line in QA Matrix Requirements.

Deliberately **not** lint-enforced. Enforcement is code review (`/code-review`, or a human reviewer) — the doc says so plainly rather than implying automated enforcement that doesn't exist.

**Caught during review, fixed before push:** the first draft's "compliant" example invented a `MAIN_WORKTREE_ROOT` fallback that doesn't exist in the real test. Verified against `tests/worktree-safety.test.cjs` directly — the actual degraded verdict is `{effectiveRoot: cwd, mode: 'current_directory', reason: 'git_timed_out'}` (it keeps the caller's cwd, it does not fall back to any "main worktree root"). Corrected before this branch was ever pushed.

## Testing

### How I verified the enhancement works

Docs-only change — no `src/**` or `tests/**` files touched, so `gsd-test` does not apply (doc-only push-gate exemption, both changed files are root-level `*.md`). Verified instead:
- Both worked examples checked against the real `tests/worktree-safety.test.cjs` source via `mcp__memtrace__get_source_window` (this is what caught the fabricated example above).
- Cross-link anchor (`TESTING-STANDARDS.md#standing-rule-assert-the-degraded-verdict-not-just-did-not-throw`) verified against GitHub's heading-slug algorithm.
- `npm run lint` (eslint) — clean, 0 errors.
- `GITHUB_BASE_REF=next npm run lint:ci` — clean, 0 errors, run the way CI runs it (not the false-passing bare local invocation).

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [x] N/A (not platform-specific — prose-only change)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue — no additions or removals
- [x] If scope changed during implementation, I updated the issue and got re-approval before continuing — N/A, scope unchanged

---

## Documentation

- [x] Updated the relevant file(s) under `docs/` to reflect this change — this PR's entire content *is* the doc update (`TESTING-STANDARDS.md` + `CONTRIBUTING.md` cross-link); no separate `docs/` page applies to a contributor-facing testing-policy contract
- [x] All `docs/` content added in this PR is written in English
- [x] If genuinely no user-facing docs impact (infrastructure / internal refactor / test-only), apply the `no-docs` label **or** add `<!-- docs-exempt: <reason> -->` — N/A, this PR *is* the docs change; `no-changelog` applied instead since there is no user-facing (CLI/output/config) behavior to log

## Checklist

- [x] Issue linked above with `Closes #NNN`
- [x] Linked issue has the `approved-enhancement` label
- [x] Changes are scoped to the approved enhancement — nothing extra included
- [x] All existing tests pass (`npm test`) — N/A, no test files touched; `npm run lint` and `GITHUB_BASE_REF=next npm run lint:ci` both clean
- [x] New or updated tests cover the enhanced behavior — N/A, docs-only; the worked examples are themselves verified against real, already-passing test source
- [x] `no-changelog` label applied (no user-facing command/output/config change)
- [x] No unnecessary dependencies added

## Breaking changes

None.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/3317"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788965985&installation_model_id=22188&pr_number=3317&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F3317&signature=c501a3a66d526955d3c5bea8d0b45441bcb433d7a8dcafb6b6039421b30b7a72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->