### PR TITLE
test(#3322): add dedicated secrets.cts test coverage — H8

### DIFF
--- a/tests/secrets.test.cjs
+++ b/tests/secrets.test.cjs
@@ -1,0 +1,104 @@
+'use strict';
+
+/**
+ * Dedicated coverage for src/secrets.cts (compiled to gsd-core/bin/lib/secrets.cjs).
+ * Closes #3322 (H8 of epic #3053): the module previously had one incidental masking
+ * assertion (landed via #2299) exercising only the >8-char branch; the s.length < 8
+ * reveal boundary was uncovered. See .gsd/phase/test-3322-secrets-reveal-boundary-coverage/
+ * for the design rationale and full test matrix.
+ */
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { maskSecret, isSecretKey, maskIfSecret } = require('../gsd-core/bin/lib/secrets.cjs');
+
+describe('maskSecret — unset triad', () => {
+  test('maskSecretReturnsUnsetForNull', () => {
+    assert.equal(maskSecret(null), '(unset)');
+  });
+
+  test('maskSecretReturnsUnsetForUndefined', () => {
+    assert.equal(maskSecret(undefined), '(unset)');
+  });
+
+  test('maskSecretReturnsUnsetForEmptyString', () => {
+    assert.equal(maskSecret(''), '(unset)');
+  });
+});
+
+describe('maskSecret — 8-char reveal boundary', () => {
+  test('maskSecretFullyMasksBelowEightChars', () => {
+    // length 7 (limit-1): fully masked, nothing revealed
+    assert.equal(maskSecret('abcdefg'), '****');
+  });
+
+  test('maskSecretRevealsLastFourAtEightChars', () => {
+    // length 8 (limit): threshold itself falls into the reveal branch
+    assert.equal(maskSecret('abcdefgh'), '****efgh');
+  });
+
+  test('maskSecretRevealsLastFourAboveEightChars', () => {
+    // length 9 (limit+1)
+    assert.equal(maskSecret('abcdefghi'), '****fghi');
+  });
+});
+
+describe('maskSecret — falsy-but-valid values are not treated as unset', () => {
+  test('maskSecretDoesNotTreatZeroAsUnset', () => {
+    assert.equal(maskSecret(0), '****');
+  });
+
+  test('maskSecretDoesNotTreatFalseAsUnset', () => {
+    assert.equal(maskSecret(false), '****');
+  });
+
+  test('maskSecretMasksBooleanTrue', () => {
+    assert.equal(maskSecret(true), '****');
+  });
+});
+
+describe('maskSecret — non-string scalar coercion and negative space', () => {
+  test('maskSecretRevealsLastFourForNumericAtEightDigits', () => {
+    assert.equal(maskSecret(12345678), '****5678');
+  });
+
+  test('maskSecretMasksLiteralNullString', () => {
+    // The string "null" (4 chars) must be masked like any other short secret,
+    // not mistaken for the actual `null` unset sentinel.
+    assert.equal(maskSecret('null'), '****');
+  });
+});
+
+describe('isSecretKey — membership', () => {
+  test('isSecretKeyMatchesConfiguredKeys', () => {
+    assert.equal(isSecretKey('brave_search'), true);
+    assert.equal(isSecretKey('firecrawl'), true);
+    assert.equal(isSecretKey('exa_search'), true);
+  });
+
+  test('isSecretKeyRejectsUnknownKey', () => {
+    assert.equal(isSecretKey('not_a_secret'), false);
+  });
+
+  test('isSecretKeyRejectsPrefixSuffixMatch', () => {
+    // Exact Set membership, not substring/prefix/suffix matching.
+    assert.equal(isSecretKey('brave_search_extra'), false);
+    assert.equal(isSecretKey('my_firecrawl'), false);
+  });
+});
+
+describe('maskIfSecret — wiring', () => {
+  test('maskIfSecretMasksWhenKeyIsSecret', () => {
+    assert.equal(maskIfSecret('firecrawl', 'abcdefgh'), '****efgh');
+  });
+
+  test('maskIfSecretPassesThroughNonSecretString', () => {
+    assert.equal(maskIfSecret('not_a_secret', 'abcdefgh'), 'abcdefgh');
+  });
+
+  test('maskIfSecretPassesThroughNonSecretNonString', () => {
+    // Passthrough must preserve type — not coerce to string.
+    assert.equal(maskIfSecret('not_a_secret', 42), 42);
+  });
+});


### PR DESCRIPTION
## Enhancement PR

---

## Linked Issue

Closes #3322

---

## What this enhancement improves

Dedicated test coverage for `src/secrets.cts`'s credential-masking logic — `maskSecret`, `isSecretKey`, `maskIfSecret` — specifically the `s.length < 8` reveal boundary, which previously had only one incidental assertion (landed via #2299) exercising the `>8`-char branch.

## Before / After

**Before:** No `tests/secrets.test.cjs` file existed. The 8-char reveal boundary (7/8/9-char inputs) was untested. Falsy-but-valid inputs (`0`, `false`) and `isSecretKey`'s exact-match-vs-substring semantics had no coverage at all.

**After:** `tests/secrets.test.cjs` added with 17 assertions across 7 `describe` blocks: the unset triad (`null`/`undefined`/`''`), the 8-char boundary at limit-1/limit/limit+1, falsy-but-valid values not mistaken for unset, non-string scalar coercion, `isSecretKey` membership including prefix/suffix negative-space, and `maskIfSecret`'s delegation + type-preserving passthrough.

## How it was implemented

Pure additive test file — **no production code changed**. Design rationale, behavior table, negative-space analysis, and full test matrix recorded in `.gsd/phase/test-3322-secrets-reveal-boundary-coverage/`.

RED-proof (since this is coverage of already-correct behavior, not a bug fix): temporarily mutated `src/secrets.cts`'s threshold (`<8`→`<7`) and unset check (dropped the `''` arm), confirmed via `gsd-test` that exactly the two boundary-bound tests failed (4 unique failures = 2 tests × 2 Node lanes, nothing else), then reverted and confirmed GREEN.

## Testing

### How I verified the enhancement works

`gsd-test` (linux-node22 + linux-node24):
- RED-proof run (mutated commit): failed exactly `maskSecretFullyMasksBelowEightChars` and `maskSecretReturnsUnsetForEmptyString`, both lanes — proves the suite binds to the real branches, not vacuous assertions.
- Clean run: 32295/32295 passed, both lanes, 0 failures.
- Final checkpoint after rebase onto `origin/next`: see CI status on this PR.

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

(The `gsd-test` remote matrix covers Linux only, per this repo's current CI coverage — not a gap introduced by this PR.)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue — no additions or removals
- [x] If scope changed during implementation, I updated the issue and got re-approval before continuing

---

## Documentation

- [ ] Updated the relevant file(s) under `docs/` to reflect this change
- [x] All `docs/` content added in this PR is written in English
- [x] If genuinely no user-facing docs impact (infrastructure / internal refactor / test-only),
      apply the `no-docs` label **or** add `<!-- docs-exempt: <reason> -->` inside each
      triggering changeset fragment and leave a comment explaining why.

<!-- docs-exempt: test-only coverage addition, no user-facing behavior, no changeset fragment (no-changelog label applied), no doc quadrant is affected -->

## Checklist

- [x] Issue linked above with `Closes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `approved-enhancement` label — **PR will be closed if missing**
- [x] Changes are scoped to the approved enhancement — nothing extra included
- [x] All existing tests pass (verified via `gsd-test`, the repo's mandated remote runner — see Testing above)
- [x] New or updated tests cover the enhanced behavior
- [x] `.changeset/` fragment added — or `no-changelog` label applied if not user-facing (**`no-changelog` applied** — pure test coverage, zero user-facing change)
- [x] No unnecessary dependencies added

## Breaking changes

None

---

## Named follow-ups (from issue #3322's own Done-when list)

Two related improvements are out of scope for this PR and are recorded here as named follow-ups, matching the issue's own Done-when item 3:

1. **Expanding Stryker's mutation-`COVERED` module set to include `secrets.cts`** — a scope/perf tradeoff (larger mutation runs, longer CI) for a separate change, not a mechanical fix.
2. **A lint requiring a test file for any new `src/*.cts` module** — requires a maintainer-approved allowlist of currently in-flight untested modules before it can be added without breaking existing PRs, per the issue's own readiness note.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/3328"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788975111&installation_model_id=22188&pr_number=3328&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F3328&signature=f81bf121240cb2a199420e8ca63a0e56c27a742891d6fa81a8a8dfe10ddf9f25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->