### PR TITLE
fix(#3231): resolve add-decision's phase from STATE.md, not a literal `?`

### DIFF
--- a/.changeset/curious-bears-romp.md
+++ b/.changeset/curious-bears-romp.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 3347
+---
+**`state add-decision` no longer persists a literal `[Phase ?]`** — omitting `--phase` wrote `- [Phase ?]:` into STATE.md even when that file's own frontmatter carried a resolvable `current_phase`, permanently losing the decision's provenance unless someone noticed and hand-edited it. The phase is now resolved from the document being written, via the same frontmatter → `Current Phase` field → scoped prose ladder `state prune` already used. An explicit `--phase` still wins, and a genuinely unresolvable phase still renders `?` rather than a guess. (#3231)

--- a/src/state.cts
+++ b/src/state.cts
@@ -869,7 +869,21 @@ function cmdStateAddDecision(cwd: string, options: StateAddDecisionOptions, raw:
 
   if (!summaryText) { output({ error: 'summary required' }, raw, undefined); return; }
 
-  const entry = `- [Phase ${phase || '?'}]: ${summaryText}${rationaleText ? ` — ${rationaleText}` : ''}`;
+  // #3231: `--phase` omitted → resolve from the STATE.md being written, via the
+  // same canonical ladder `state prune` uses. A decision entry is a permanent
+  // record, so a literal `[Phase ?]` written while `current_phase` sat three
+  // lines above the insertion point loses that decision's provenance for good.
+  // Explicit `--phase` still wins, and its path is untouched — the file is not
+  // even read. When no rung resolves, `?` is still written: an unknown phase
+  // stays visibly unknown rather than being guessed or defaulted to a number.
+  let phaseId: string | undefined = phase;
+  if (!phaseId) {
+    const rawState = fs.readFileSync(statePath, 'utf-8');
+    const fm = extractFrontmatter(rawState, statePath) as Record<string, unknown>;
+    phaseId = resolveCurrentPhaseId(fm, stripFrontmatter(rawState)) ?? undefined;
+  }
+
+  const entry = `- [Phase ${phaseId || '?'}]: ${summaryText}${rationaleText ? ` — ${rationaleText}` : ''}`;
   let _added = false;
   let created = false;
 
@@ -1490,6 +1504,55 @@ function resolveStatePhase(fm: Record<string, unknown>, body: string): {
       ?? prosePhase.name,
     sources,
   };
+}
+
+/**
+ * Resolve a STATE.md's own current phase id from the document itself.
+ *
+ * The ladder is the canonical one owned by state-document.cjs's
+ * `stateFieldValue` (#3187, ADR-3180 §7.7): frontmatter `current_phase` → body
+ * `Current Phase` field → prose `Phase: X of Y` scoped to `## Current
+ * Position`.
+ *
+ * #1776: the prose rung stays scoped to `## Current Position`. Over the whole
+ * body, `stateExtractField`'s pipe-table fallback matches any `| Phase | N |`
+ * row — e.g. a historical verification table — and would resolve a stale phase.
+ * Frontmatter and the explicit `Current Phase` field are unambiguous, so they
+ * stay document-wide. `cmdStateSnapshot` deliberately keeps the looser
+ * whole-body fallback for its own prose rung and is not routed through here.
+ *
+ * Returns the id exactly as written, NOT parsed to a number: phase ids are not
+ * always integers (`11-01` and `04.1` are both real). Callers needing an
+ * integer parse it themselves. Returns null when no rung carries a value — a
+ * genuinely absent phase is a real answer (§7.7 behavior table row 4), and
+ * callers must render it as unknown rather than guess one.
+ *
+ * NOT the same function as `resolveStatePhase` above (#3208), and deliberately
+ * not routed through it — the difference is one line and it is the whole point:
+ *
+ *   resolveStatePhase:     matchCurrentPositionSection(body) ?? body
+ *   resolveCurrentPhaseId: null when the section is absent
+ *
+ * That `?? body` fallback is exactly the #1776 hazard. With no `## Current
+ * Position` section, the prose rung widens to the entire document, where
+ * `stateExtractField`'s pipe-table fallback matches any `| Phase | N |` row —
+ * a historical verification table included — and resolves a stale phase.
+ *
+ * `resolveStatePhase`'s callers (`cmdStateSnapshot`, `cmdStateValidate`) READ
+ * and report; a stale guess there is a wrong line in output a human is already
+ * looking at. This function's callers WRITE: `cmdStateAddDecision` persists the
+ * result into a decision record that outlives the session, and `cmdStatePrune`
+ * decides what to delete from it. A wrong phase there is durable and silent, so
+ * the write path takes the strict rung and renders `?` rather than guessing.
+ *
+ * Reconcile the two only by giving `resolveStatePhase` an explicit scope
+ * parameter — never by pointing this at it and dropping the difference.
+ */
+function resolveCurrentPhaseId(fm: Record<string, unknown>, body: string): string | null {
+  const positionSection = sliceCurrentPositionSection(body);
+  const prosePhase =
+    positionSection !== null ? parseProsePhaseField(stateFieldValue(fm, positionSection, null, 'Phase').value).phase : null;
+  return stateFieldValue(fm, body, 'current_phase', 'Current Phase').value ?? prosePhase;
 }
 
 function parseProseLastActivityField(value: string | null): { date: string | null; description: string | null } {
@@ -3530,30 +3593,18 @@ function cmdStatePrune(cwd: string, options: StatePruneOptions, raw: boolean): v
 
   const keepRecent = parseInt(String(options.keepRecent), 10) || 3;
   const dryRun = !!options.dryRun;
-  // Resolve the current phase via the same canonical chain buildStateFrontmatter
-  // uses (frontmatter `current_phase` → `Current Phase` field → prose `Phase: X
-  // of Y`), so prune engages on template-conformant STATE.md instead of bailing
-  // "Only 0 phases" (#1760).
-  // #1776: scope ONLY the prose `Phase:` term to the canonical `## Current
-  // Position` section. Over the whole body, `stateExtractField`'s pipe-table
-  // fallback matches any `| Phase | N |` row (e.g. a historical verification
-  // table), resolving a stale phase and computing a wrong cutoff. Frontmatter and
-  // the explicit `Current Phase` field are unambiguous, so they stay document-wide;
-  // the shared extractor is not narrowed for any other caller.
+  // Resolve the current phase via `resolveCurrentPhaseId` — the shared owner of
+  // the canonical frontmatter → `Current Phase` field → scoped prose ladder
+  // (#1760 origin, #1776 scoping, #3187 ownership; see its doc comment). Prune
+  // engages on a template-conformant STATE.md instead of bailing "Only 0
+  // phases" (#1760). #3231 routed `state add-decision` through the same helper
+  // rather than adding a second copy of the ladder here.
   const rawState = fs.readFileSync(statePath, 'utf-8');
   const fm = extractFrontmatter(rawState, statePath) as Record<string, unknown>;
   const body = stripFrontmatter(rawState);
-  // #3187: frontmatter-scalar-then-body-field precedence is owned by
-  // state-document.cjs's `stateFieldValue` (ADR-3180 §7.7). This comment
-  // previously claimed to mirror `buildStateFrontmatter`'s fmScalar — that
-  // attribution was stale: buildStateFrontmatter (state.cts:1620) reads body
-  // only and never consults frontmatter at all; this actually mirrored
-  // cmdStateSnapshot's now-removed closure instead.
-  const positionSection = sliceCurrentPositionSection(body);
-  const prosePhase =
-    positionSection !== null ? parseProsePhaseField(stateFieldValue(fm, positionSection, null, 'Phase').value).phase : null;
-  const currentPhaseRaw = stateFieldValue(fm, body, 'current_phase', 'Current Phase').value ?? prosePhase;
-  const currentPhase = parseInt(String(currentPhaseRaw), 10) || 0;
+  // Prune needs an integer cutoff, so it parses the resolved id itself; a
+  // non-numeric or absent id lands on 0 and prune bails, as before.
+  const currentPhase = parseInt(String(resolveCurrentPhaseId(fm, body)), 10) || 0;
   const cutoff = currentPhase - keepRecent;
 
   if (cutoff <= 0) {

--- a/tests/state.test.cjs
+++ b/tests/state.test.cjs
@@ -12724,3 +12724,183 @@ const HEX_RE = /^[0-9a-f]{4,40}$/i;
     assert.strictEqual(r.commits_behind, 0);
   });
 });
+// ─────────────────────────────────────────────────────────────────────────────
+// #3231: `state add-decision` resolves the phase from STATE.md's own frontmatter
+// and body when `--phase` is omitted, instead of persisting a literal `[Phase ?]`.
+// ─────────────────────────────────────────────────────────────────────────────
+{
+  const { describe, test, beforeEach, afterEach } = require('node:test');
+  const assert = require('node:assert');
+  const fs = require('node:fs');
+  const path = require('node:path');
+  const { runGsdTools, createTempProject, cleanup } = require('./helpers.cjs');
+
+  describe('#3231 add-decision resolves phase from STATE.md when --phase is omitted', () => {
+    let tmpDir;
+
+    beforeEach(() => { tmpDir = createTempProject(); });
+    afterEach(() => { cleanup(tmpDir); });
+
+    const statePathIn = (d) => path.join(d, '.planning', 'STATE.md');
+
+    // Write a STATE.md verbatim, bypassing the project scaffold, so each test
+    // controls exactly which rung of the resolution ladder is populated.
+    const writeState = (d, content) => fs.writeFileSync(statePathIn(d), content);
+
+    const addDecision = (d, args) => {
+      const result = runGsdTools(['state', 'add-decision', ...args], d);
+      assert.ok(result.success, `add-decision must succeed, got: ${result.error}`);
+      return JSON.parse(result.output);
+    };
+
+    // Assert on the persisted file, not only the JSON echo — the defect in #3231
+    // is that the placeholder is written to disk permanently.
+    const persistedDecisions = (d) =>
+      fs.readFileSync(statePathIn(d), 'utf-8')
+        .split(/\r?\n/)
+        .filter(l => l.startsWith('- [Phase '));
+
+    test('frontmatter current_phase resolves the entry when --phase is omitted', () => {
+      writeState(tmpDir, [
+        '---',
+        'gsd_state_version: 1.0',
+        'current_phase: 3',
+        'current_phase_name: Sourcing Coverage',
+        'status: executing',
+        '---',
+        '',
+        '# Project State',
+        '',
+        '## Decisions',
+        '',
+      ].join('\n'));
+
+      const parsed = addDecision(tmpDir, ['--summary', 'Dedup threshold set to 0.85 by sweep']);
+
+      assert.strictEqual(
+        parsed.decision,
+        '- [Phase 3]: Dedup threshold set to 0.85 by sweep',
+        'omitted --phase must resolve from frontmatter current_phase, not render "?"',
+      );
+      assert.deepStrictEqual(
+        persistedDecisions(tmpDir),
+        ['- [Phase 3]: Dedup threshold set to 0.85 by sweep'],
+        'the resolved phase must be what lands in STATE.md',
+      );
+    });
+
+    test('explicit --phase wins over a resolvable frontmatter current_phase', () => {
+      writeState(tmpDir, [
+        '---',
+        'gsd_state_version: 1.0',
+        'current_phase: 3',
+        'status: executing',
+        '---',
+        '',
+        '# Project State',
+        '',
+        '## Decisions',
+        '',
+      ].join('\n'));
+
+      const parsed = addDecision(tmpDir, ['--phase', '7', '--summary', 'Explicit wins']);
+
+      assert.strictEqual(
+        parsed.decision,
+        '- [Phase 7]: Explicit wins',
+        'an explicitly passed --phase must never be overridden by the resolved value',
+      );
+      assert.deepStrictEqual(persistedDecisions(tmpDir), ['- [Phase 7]: Explicit wins']);
+    });
+
+    test('body "Current Phase" field resolves when frontmatter carries no current_phase', () => {
+      writeState(tmpDir, [
+        '# GSD State',
+        '',
+        '## Configuration',
+        'Current Phase: 2',
+        'Status: Executing',
+        '',
+        '## Decisions',
+        '',
+      ].join('\n'));
+
+      const parsed = addDecision(tmpDir, ['--summary', 'Body field rung']);
+
+      assert.strictEqual(parsed.decision, '- [Phase 2]: Body field rung');
+    });
+
+    test('prose "Phase:" under ## Current Position resolves, preserving a non-integer id', () => {
+      writeState(tmpDir, [
+        '# Project State',
+        '',
+        '## Current Position',
+        '',
+        'Phase: 04.1 of 7',
+        '',
+        '## Decisions',
+        '',
+      ].join('\n'));
+
+      const parsed = addDecision(tmpDir, ['--summary', 'Prose rung']);
+
+      // Phase ids are not always integers — 04.1 must survive verbatim, not be
+      // parsed to 4 or to 4.1.
+      assert.strictEqual(parsed.decision, '- [Phase 04.1]: Prose rung');
+    });
+
+    // Counter-test (TESTING-STANDARDS.md contract 6): assert the specific
+    // degraded verdict. When no rung resolves, the entry must still read
+    // "?" — an unknown phase stays visibly unknown and is never guessed.
+    test('CONTROL: no phase resolvable from any rung still writes a literal "?"', () => {
+      writeState(tmpDir, [
+        '---',
+        'gsd_state_version: 1.0',
+        'status: executing',
+        '---',
+        '',
+        '# Project State',
+        '',
+        '## Decisions',
+        '',
+      ].join('\n'));
+
+      const parsed = addDecision(tmpDir, ['--summary', 'Unresolvable stays unknown']);
+
+      assert.strictEqual(
+        parsed.decision,
+        '- [Phase ?]: Unresolvable stays unknown',
+        'with no frontmatter current_phase, no body "Current Phase" field and no prose Phase line, the entry must degrade to "?" — not to a default, an empty string, or a guessed number',
+      );
+      assert.deepStrictEqual(persistedDecisions(tmpDir), ['- [Phase ?]: Unresolvable stays unknown']);
+    });
+
+    // Counter-test: a non-scalar frontmatter value is not a phase. stateFieldValue's
+    // scalar guard must reject it and the ladder must continue past it, landing on
+    // "?" here rather than serialising "[object Object]" or "3,4".
+    test('CONTROL: non-scalar frontmatter current_phase is unresolvable, not stringified', () => {
+      writeState(tmpDir, [
+        '---',
+        'gsd_state_version: 1.0',
+        'current_phase:',
+        '  - 3',
+        '  - 4',
+        'status: executing',
+        '---',
+        '',
+        '# Project State',
+        '',
+        '## Decisions',
+        '',
+      ].join('\n'));
+
+      const parsed = addDecision(tmpDir, ['--summary', 'Non-scalar is not a phase']);
+
+      assert.strictEqual(
+        parsed.decision,
+        '- [Phase ?]: Non-scalar is not a phase',
+        'a list-valued current_phase must be treated as unresolvable, consistent with the scalar guard used elsewhere',
+      );
+    });
+  });
+}

--- a/tests/state.test.cjs
+++ b/tests/state.test.cjs
@@ -12902,5 +12902,45 @@ const HEX_RE = /^[0-9a-f]{4,40}$/i;
         'a list-valued current_phase must be treated as unresolvable, consistent with the scalar guard used elsewhere',
       );
     });
+
+    // #1776, re-confirmed against #3208 while rebasing this PR onto next.
+    //
+    // `resolveStatePhase` (#3208, behind snapshot/validate) scopes its prose
+    // rung with `matchCurrentPositionSection(body) ?? body`. On this exact
+    // fixture that fallback selects "7" off the historical table — verified
+    // live: `state validate --raw` reports `drift.phase_directory.selected:
+    // "7"`. That is tolerable for a command reporting to a human who is already
+    // reading the output.
+    //
+    // It is not tolerable here. add-decision PERSISTS the phase into a record
+    // that outlives the session, so a stale guess becomes durable and silent.
+    // The two ladders differ on purpose; this pins that.
+    test('a historical Phase row outside Current Position must not resolve (#1776)', () => {
+      writeState(tmpDir, [
+        '---',
+        'gsd_state_version: 1.0',
+        'status: executing',
+        '---',
+        '',
+        '# Project State',
+        '',
+        '## Verification History',
+        '',
+        '| Field | Value |',
+        '|---|---|',
+        '| Phase | 7 |',
+        '',
+        '## Decisions',
+        '',
+      ].join('\n'));
+
+      const parsed = addDecision(tmpDir, ['--summary', 'Stale table must not win']);
+
+      assert.strictEqual(
+        parsed.decision,
+        '- [Phase ?]: Stale table must not win',
+        'the prose rung is scoped to ## Current Position; a | Phase | N | row in a historical table is not this document\'s current phase',
+      );
+    });
   });
 }


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3231

---

## What was broken

`state add-decision` built its entry from the raw `--phase` flag alone, so omitting the flag persisted a literal `- [Phase ?]:` into STATE.md even when that same file's frontmatter carried a resolvable `current_phase` three lines above the insertion point. A decision entry is a permanent record, so the placeholder loses that decision's provenance unless a human notices and hand-edits it — and the command is mostly invoked from agents that do not know to pass `--phase`.

## What this fix does

When `--phase` is omitted, the phase is resolved from the STATE.md being written, using the same ladder `state prune` already ran. Explicit `--phase` still wins, and a genuinely unresolvable phase still renders `?`.

## Root cause

`cmdStateAddDecision` never consulted the document it was writing — the entry came straight from the CLI flag (`src/state.cts:868` on `next`), and `state-command-router.cts:142` passes `--phase` through with no fallback. `git blame` traces this to the predecessor repo (`77d434709d`, 2026-02-23), so it is long-standing rather than a regression.

The resolution it needed already existed in the codebase — `cmdStatePrune` ran the ladder inline. Rather than adding a second copy, this PR extracts it:

- **New `resolveCurrentPhaseId(fm, body)`** — frontmatter `current_phase` → body `Current Phase` field → prose `Phase: X of Y` scoped to `## Current Position`. The ladder itself is unchanged and still delegates to `state-document`'s `stateFieldValue` (#3187, ADR-3180 §7.7). #1776's prose scoping is preserved verbatim.
- **`cmdStateAddDecision`** calls it only when `--phase` is falsy. The explicit path is untouched — STATE.md is not even read.
- **`cmdStatePrune`** now calls the helper and parses its own integer cutoff, so its behavior is byte-identical.
- **`cmdStateSnapshot` is deliberately not routed through here** — it uses a looser whole-body fallback for its prose rung, and changing it is out of scope for this issue.

Two notes on the resolved value:

- It is returned **as written, never parsed to a number**. Phase ids are not always integers — `11-01` and `04.1` are both real, and an int parse would corrupt them. `cmdStatePrune` still parses its own cutoff.
- A **non-scalar** `current_phase` (list/object) is treated as unresolvable by `stateFieldValue`'s existing scalar guard, so it can never be stringified into an entry as `3,4` or `[object Object]`.

## Testing

### How I verified the fix

Ran the issue's repro against a real build, plus the three other rungs and both negative cases, then encoded all six as tests in `tests/state.test.cjs`:

| Case | Entry written |
|---|---|
| frontmatter `current_phase: 3`, no `--phase` | `- [Phase 3]:` |
| explicit `--phase 7` over frontmatter `3` | `- [Phase 7]:` |
| body `Current Phase: 2`, no frontmatter | `- [Phase 2]:` |
| prose `Phase: 04.1 of 7` under `## Current Position` | `- [Phase 04.1]:` |
| **control** — no rung resolvable anywhere | `- [Phase ?]:` |
| **control** — non-scalar `current_phase` | `- [Phase ?]:` |

The two controls follow TESTING-STANDARDS.md contract 6's standing rule: they assert the specific degraded verdict, not merely that the call succeeded. Assertions check the persisted STATE.md, not only the JSON echo, since persistence is the actual defect.

`tests/state.test.cjs` 353/353. `tests/state-prune.test.cjs`, `state-document`, `state-field-drift` and `issue-3204-state-writer-phase-count` 101/101 — `state prune` is refactored onto the shared helper here, so its own suite is the guard on that being behaviour-preserving.

`tsc -p tsconfig.build.json --noEmit` clean. `npm run lint` clean — it caught a CRLF-fragile `.split('\n')` in a test helper (`local/no-crlf-fragile-split`), corrected to `.split(/\r?\n/)`. `lint:frontmatter-scalar-broad-grep`, `lint:regression-names`, `lint:qa-smells` and `lint:test-file-count` all pass.

**I could not get a clean full `npm test` on my machine, so I am not claiming one.** Note that `npm test` exits 0 here regardless — the failures below do not propagate to the exit code, which is worth knowing on its own.

A full local run reports **77 failures across 14 groups**, concentrated in the install / section-manifest / registry-drift / symlink surfaces (`fragment-single-edit-propagation.install`, `installer-migration-pi-retire-hooks-dir`, and similar). **None of them are from this change.** I verified that directly rather than assuming it: rebuilding the lib with `upstream/next`'s unmodified `src/state.cts` and re-running a representative failing pair gives **15 pass / 22 fail** — identical to the same files on this branch. The surfaces this PR actually touches are green (`state.test.cjs` 353/353, and the `state-prune` / `state-document` / `state-field-drift` / `issue-3204` group 101/101).

They look environmental — Windows symlink-creation privileges for the symlink-safety cases, and the suite's own live-config hermeticity warning for the install cases. I have not bisected further, since it is outside #3231. **CI on a clean runner is the authority here, not my box.**

Separately, and also not a defect in `next`: `tests/smart-entry.unit.test.cjs`'s "idle-stranded action set recommends ship" fails on this machine because `os.tmpdir()` resolves under `C:\Users\Jason`, which is itself a git repository — so `git status` from a `makeProject` fixture walks up, finds the *home* repo dirty, sets `git_dirty: true`, short-circuits `isIdleStranded` (`src/smart-entry.cts:464`), and drops `classify` to `'unknown'`. The sibling test passes only because it calls `git init`, creating a boundary that stops the upward walk. Pointing `TMPDIR`/`TEMP`/`TMP` outside any repo gives 56/56. If that is worth hardening, `makeProject` could `git init` unconditionally or set `GIT_CEILING_DIRECTORIES` — but that is a separate concern and I have not touched it here.

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [ ] macOS
- [x] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [ ] All existing tests pass (`npm test`) — **not claimed.** The suites this PR touches pass (353/353 and 101/101), but a full local run has 77 pre-existing failures in unrelated install/symlink surfaces that also fail on unmodified `upstream/next`. See Testing above; deferring to CI.
- [x] `.changeset/` fragment added — `.changeset/curious-bears-romp.md`, `pr: 3347`
- [x] No unnecessary dependencies added

## Breaking changes

None. The explicit-`--phase` path is byte-identical, `state prune`'s resolution and cutoff are byte-identical, and an unresolvable phase still renders `?`. The only behavior change is the one the issue asks for: an omitted `--phase` now resolves instead of persisting a placeholder.
