### PR TITLE
fix(#3207): create-and-switch on the first phase/milestone commit

### DIFF
--- a/.changeset/lazy-otter-purchase.md
+++ b/.changeset/lazy-otter-purchase.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`branching_strategy: "phase"`/`"milestone"` once again lands the first strategy-scoped commit on the strategy branch** — `gsd-tools query commit` now creates *and* switches to a brand-new phase/milestone branch (restoring the #1278 intent), instead of creating it without switching and leaving the commit on the base branch. The #3079 protection is preserved: an *already-existing* strategy branch is still never silently switched to (it warns and commits on the current branch). The first fresh create is now logged to stderr instead of being silent, and the misleading "already exists" warning no longer recurs on every subsequent commit once HEAD is on the strategy branch. (#3207)

--- a/.changeset/lazy-otter-purchase.md
+++ b/.changeset/lazy-otter-purchase.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 3363
 ---
 **`branching_strategy: "phase"`/`"milestone"` once again lands the first strategy-scoped commit on the strategy branch** — `gsd-tools query commit` now creates *and* switches to a brand-new phase/milestone branch (restoring the #1278 intent), instead of creating it without switching and leaving the commit on the base branch. The #3079 protection is preserved: an *already-existing* strategy branch is still never silently switched to (it warns and commits on the current branch). The first fresh create is now logged to stderr instead of being silent, and the misleading "already exists" warning no longer recurs on every subsequent commit once HEAD is on the strategy branch. (#3207)

--- a/src/commands.cts
+++ b/src/commands.cts
@@ -1052,22 +1052,29 @@ function cmdCommit(cwd: string, message: string | undefined, files: string[] | u
     if (branchName) {
       const currentBranch = execGit(['rev-parse', '--abbrev-ref', 'HEAD'], { cwd });
       if (currentBranch.exitCode === 0 && currentBranch.stdout.trim() !== branchName) {
-        // #2539/#3079: the #1278 intent is to CREATE the phase/milestone branch
-        // before the FIRST commit on it — not to force-switch an already-
-        // checked-out working branch onto a DIFFERENT existing branch. The
-        // prior `git checkout -b` both created AND switched (silently moving
-        // HEAD), which resurrected merged-and-deleted phase branches (#3079).
-        // Now: create-if-absent WITHOUT switching, using `git branch` instead
-        // of `git checkout -b`. The commit always lands on the current branch.
-        // If the resolved branch already exists, log the resolution so the
-        // operator sees that the phase branch was resolved and deliberately
-        // not switched to (#2539 AC2: an auto-checkout mid-commit must never
-        // happen silently).
+        // #2539/#3079/#3207: two cases the prior (#3079) code collapsed into one.
+        // #1278 intent: CREATE the phase/milestone branch before the FIRST commit
+        // on it so the phase's work accumulates there. #3079/#2539 hazard: never
+        // silently switch an already-checked-out working branch onto a DIFFERENT
+        // EXISTING branch — that resurrects merged-and-deleted phase branches and
+        // silently moves HEAD onto a stale ref (#2539 AC2: an auto-checkout
+        // mid-commit must never happen silently).
+        // Reconciliation (#3207): a brand-new branch has no resurrection target,
+        // so create-and-switch is safe here and is exactly the #1278 intent; an
+        // EXISTING branch is never switched to (the else arm logs + commits in
+        // place). The fresh create is logged so the first phase-scoped commit is
+        // not silent about where the work is landing (#3207 AC3).
         const verify = execGit(['rev-parse', '--verify', `refs/heads/${branchName}`], { cwd });
         if (verify.exitCode !== 0) {
-          // Branch does not exist — create it WITHOUT switching.
-          const create = execGit(['branch', branchName], { cwd });
-          if (create.exitCode !== 0) {
+          // Branch does not exist — CREATE AND SWITCH (the #1278 first-commit
+          // case). checkout -b cannot resurrect anything: the branch was just
+          // verified absent, so it is created fresh at HEAD.
+          const create = execGit(['checkout', '-b', branchName], { cwd });
+          if (create.exitCode === 0) {
+            process.stderr.write(
+              `${branchingStrategy} branch "${branchName}" created; switched to it for this commit.\n`
+            );
+          } else {
             process.stderr.write(
               `Warning: could not create ${branchingStrategy} branch "${branchName}" ` +
               `(${create.stderr.trim()}); committing on the current branch "${currentBranch.stdout.trim()}".\n`

--- a/tests/commands.test.cjs
+++ b/tests/commands.test.cjs
@@ -1447,7 +1447,7 @@ describe('commit command', () => {
     const logCount = gitOrThrow(['log', '--oneline'], { cwd: tmpDir }).trim().split('\n').length;
     assert.strictEqual(logCount, 2, 'should have 2 commits (initial + amended)');
   });
-  test('creates strategy branch before first commit when branching_strategy is milestone (#3079: no switch)', () => {
+  test('#3207: creates AND switches to the milestone branch before first commit', () => {
     // Configure milestone branching strategy
     fs.writeFileSync(
       path.join(tmpDir, '.planning', 'config.json'),
@@ -1472,15 +1472,17 @@ describe('commit command', () => {
     const output = JSON.parse(result.output);
     assert.strictEqual(output.committed, true, 'should have committed');
 
-    // #3079: the branch should be CREATED but NOT switched to.
+    // #3207: the branch should be CREATED and HEAD switched to it, so the first
+    // milestone-scoped commit lands on the milestone branch (#1278 intent). The
+    // prior #3079 no-switch behavior regressed this for fresh creates.
     const branch = gitOrThrow(['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: tmpDir }).trim();
-    assert.notStrictEqual(branch, 'gsd/v1.0-initial-release', '#3079: must NOT switch to the milestone branch');
-    // Verify the branch WAS created (exists as a ref)
-    const branchExists = gitOrThrow(['rev-parse', '--verify', 'gsd/v1.0-initial-release'], { cwd: tmpDir });
-    assert.ok(branchExists.trim(), 'milestone branch should be created even without switching');
+    assert.strictEqual(branch, 'gsd/v1.0-initial-release', '#3207: must switch to the milestone branch');
+    // The commit must be reachable on the milestone branch (HEAD is on it).
+    const committedFile = gitOrThrow(['show', 'HEAD:.planning/test-context.md'], { cwd: tmpDir });
+    assert.ok(committedFile.includes('# Context'), 'milestone commit must land on the milestone branch');
   });
 
-  test('creates strategy branch before first commit when branching_strategy is phase (#3079: no switch)', () => {
+  test('#3207: creates AND switches to the phase branch before first commit', () => {
     // Configure phase branching strategy
     fs.writeFileSync(
       path.join(tmpDir, '.planning', 'config.json'),
@@ -1509,14 +1511,16 @@ describe('commit command', () => {
     const output = JSON.parse(result.output);
     assert.strictEqual(output.committed, true, 'should have committed');
 
-    // #3079: the branch should be CREATED but NOT switched to. The commit
-    // lands on the current branch (master/main), and the phase branch exists
-    // as a ref but HEAD did not move.
+    // #3207: the branch should be CREATED and HEAD switched to it, so the first
+    // phase-scoped commit lands on the phase branch (#1278 intent). The prior
+    // #3079 no-switch behavior regressed this for fresh creates.
     const branch = gitOrThrow(['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: tmpDir }).trim();
-    assert.notStrictEqual(branch, 'gsd/phase-01-setup', '#3079: must NOT switch to the phase branch');
-    // Verify the branch WAS created (exists as a ref)
-    const branchExists = gitOrThrow(['rev-parse', '--verify', 'gsd/phase-01-setup'], { cwd: tmpDir });
-    assert.ok(branchExists.trim(), 'phase branch should be created even without switching');
+    assert.strictEqual(branch, 'gsd/phase-01-setup', '#3207: must switch to the phase branch');
+    // The commit must be reachable on the phase branch (HEAD is on it).
+    const committedFile = gitOrThrow(
+      ['show', 'HEAD:.planning/phases/01-setup/01-CONTEXT.md'], { cwd: tmpDir }
+    );
+    assert.ok(committedFile.includes('# Context'), 'phase commit must land on the phase branch');
   });
 
   test('decimal phase numbers are captured correctly in branching strategy', () => {
@@ -1548,9 +1552,9 @@ describe('commit command', () => {
     const output = JSON.parse(result.output);
     assert.strictEqual(output.committed, true, 'should have committed');
 
-    // #3079: verify branch is created but NOT switched to (decimal phase)
+    // #3207: the branch should be CREATED and HEAD switched to it (decimal phase).
     const branch = gitOrThrow(['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: tmpDir }).trim();
-    assert.notStrictEqual(branch, 'gsd/phase-45.14-golden-capture', '#3079: must NOT switch to the phase branch');
+    assert.strictEqual(branch, 'gsd/phase-45.14-golden-capture', '#3207: must switch to the decimal phase branch');
     // Verify the correct branch name was resolved (not integer-only)
     const branchExists = gitOrThrow(['rev-parse', '--verify', 'gsd/phase-45.14-golden-capture'], { cwd: tmpDir });
     assert.ok(branchExists.trim(), 'decimal phase branch should be created (45.14, not 14)');
@@ -1610,14 +1614,20 @@ describe('commit command', () => {
     const output = JSON.parse(result.output);
     assert.strictEqual(output.committed, true, 'should have committed');
 
-    // #3079: the commit no longer switches to the phase branch. The phase-07
-    // branch should be CREATED (resolving correctly to 07, not the archived 02),
-    // but the commit lands on the current branch.
+    // #3207: the commit now CREATES and SWITCHES to the phase branch. The
+    // resolved branch is phase-07 (correct, not the archived 02), and HEAD
+    // moves onto it so the phase's work accumulates there.
     const branch = gitOrThrow(['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: tmpDir }).trim();
     assert.notStrictEqual(
       branch,
       'gsd/phase-02-archived-phase',
       `must NOT be on the archived phase-02 branch (got ${branch})`
+    );
+    // #3207: HEAD must land on the CORRECT freshly-created phase-07 branch.
+    assert.strictEqual(
+      branch,
+      'gsd/phase-07-active-phase',
+      `must switch onto the correct phase-07 branch (got ${branch})`
     );
     // Verify the correct phase-07 branch was created (not the archived 02)
     const phase07Exists = gitOrThrow(
@@ -1700,6 +1710,96 @@ describe('commit command', () => {
     assert.ok(
       /Warning: resolved.*branch .* already exists/.test(stderr),
       `expected a non-silent warning on stderr when the resolved branch already exists; got stderr=${stderr}`
+    );
+  });
+
+  // #3207 AC3: the fresh-create path must NOT be silent. Pre-fix the first
+  // phase-scoped commit produced no output at all, so the divergence between
+  // "phase branch exists" and "phase work is on it" started invisibly. The fix
+  // logs the create+switch on stderr.
+  test('#3207: fresh phase-branch create is non-silent (logs create+switch)', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({
+        commit_docs: true,
+        branching_strategy: 'phase',
+        phase_branch_template: 'gsd/phase-{phase}-{slug}',
+      })
+    );
+    fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '01-setup'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      '# Roadmap\n\n## Phase 1: Setup\nGoal: Initial setup\n'
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'phases', '01-setup', '01-CONTEXT.md'), '# Context\n'
+    );
+
+    // Observe stderr on the success path via the process seam (execFileSync
+    // discards stderr on success — same reason the #2539 test uses runNode).
+    const { TOOLS_PATH } = require('./helpers.cjs');
+    const proc = runNode([
+      TOOLS_PATH, 'commit', 'docs(01): add context',
+      '--files', '.planning/phases/01-setup/01-CONTEXT.md',
+    ], { cwd: tmpDir });
+    throwIfFailed(proc, 'gsd-tools commit (#3207 non-silent fixture)');
+    const stderr = proc.stderr || '';
+
+    // The fresh create must announce itself — not the "already exists" wording
+    // (that belongs to the existing-branch path) but a create+switch notice.
+    assert.ok(
+      /created.*switched|switched.*created/i.test(stderr) ||
+        /phase-01-setup/i.test(stderr),
+      `expected a non-silent create+switch notice on stderr; got stderr=${stderr}`
+    );
+  });
+
+  // #3207 AC5: once the first commit has switched HEAD onto the phase branch,
+  // a second phase-scoped commit must NOT emit the misleading "already exists"
+  // warning — the currentBranch === branchName guard skips the block entirely.
+  test('#3207: second phase commit does not re-warn once HEAD is on the phase branch', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({
+        commit_docs: true,
+        branching_strategy: 'phase',
+        phase_branch_template: 'gsd/phase-{phase}-{slug}',
+      })
+    );
+    fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '01-setup'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      '# Roadmap\n\n## Phase 1: Setup\nGoal: Initial setup\n'
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'phases', '01-setup', '01-CONTEXT.md'), '# Context\n'
+    );
+
+    const { TOOLS_PATH } = require('./helpers.cjs');
+
+    // First commit — fresh create, switches onto the phase branch.
+    const first = runNode([
+      TOOLS_PATH, 'commit', 'docs(01): first',
+      '--files', '.planning/phases/01-setup/01-CONTEXT.md',
+    ], { cwd: tmpDir });
+    throwIfFailed(first, 'gsd-tools commit (#3207 first)');
+    const branchAfterFirst = gitOrThrow(['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: tmpDir }).trim();
+    assert.strictEqual(branchAfterFirst, 'gsd/phase-01-setup', 'first commit must switch onto the phase branch');
+
+    // Second commit — HEAD is already on the phase branch, so the block is
+    // skipped and NO "already exists" warning should appear.
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'phases', '01-setup', '02-NOTES.md'), '# Notes\n'
+    );
+    const second = runNode([
+      TOOLS_PATH, 'commit', 'docs(01): second',
+      '--files', '.planning/phases/01-setup/02-NOTES.md',
+    ], { cwd: tmpDir });
+    throwIfFailed(second, 'gsd-tools commit (#3207 second)');
+    const secondStderr = second.stderr || '';
+    assert.ok(
+      !/already exists/i.test(secondStderr),
+      `second commit must not re-warn once on the phase branch; got stderr=${secondStderr}`
     );
   });
 });


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3207

## What was broken

With `branching_strategy: "phase"` (or `"milestone"`), `gsd-tools query commit` created the strategy branch but never switched to it, so the first phase/milestone-scoped commit landed on the base branch instead of the strategy branch. The strategy branch was left as an empty marker pointing at the pre-phase tip, and every subsequent commit warned `… already exists; committing on the current branch …` — wording that misleads, since the tool itself had created the branch seconds earlier.

## What this fix does

Re-separates the two cases that #3079 (PR #3141) collapsed into one:

- **Branch does not exist** → create *and* switch (`git checkout -b`), and log it. This is the #1278 "first commit on the strategy branch" case; the commit now lands on the strategy branch.
- **Branch already exists** → unchanged: do not switch, commit on the current branch, and emit the non-silent "already exists" warning (#2539/#3079).

Once the first commit switches HEAD onto the strategy branch, the `currentBranch !== branchName` guard skips the block on subsequent commits, so the misleading warning no longer recurs.

## Root cause

The #3079 fix replaced `git checkout -b` (create + switch) with `git branch` (create-only) **unconditionally** to stop resurrecting merged-and-deleted phase branches. That hazard only applies to *existing* branches; for a brand-new branch there is nothing to resurrect (it was just verified absent). Applying create-only to the fresh-create case regressed #1278. The first phase-scoped commit was also silent (the create path only warned when `git branch` failed), so the divergence started invisibly.

## Testing

### How I verified the fix

- **RED proven** at `ece5bc8e` (gsd-test, linux-node22 + linux-node24): the four fresh-create tests — inverted from the #3079 no-switch assertions — plus two new tests failed on the unfixed code (6 leaf failures, all expected).
- **GREEN** at `85f000907` (gsd-test, both lanes, 32535/32535 0 failures); the doc-only changeset commit `a62375b56` carried the pass forward (no executable content changed).
- The existing #2539 existing-branch test (no-switch + warn) is byte-for-byte unchanged and still passes — the #3079/#2539 protection is preserved.
- `recall_decision` / `verify_intent`: the related #2669 decision ("drop silent wrong-branch switch") is `held` and is **honored** by this fix (the existing-branch arm is untouched; only the fresh-create arm changes).

### Regression test added?

- [x] Yes — four fresh-create tests inverted to assert create+switch; two new tests: (a) fresh-create is non-silent (logs create+switch) (#3207 AC3); (b) a second phase commit does not re-warn once HEAD is on the phase branch (#3207 AC5).

### Platforms tested

- [x] macOS (local gsd-test dispatch)
- [x] Linux (gsd-test linux-node22 + linux-node24 lanes)
- [ ] Windows (no platform-specific code in the diff; git `checkout -b` is portable)

### Runtimes tested

- [x] N/A (not runtime-specific — pure git-invocation fix)

## Checklist

- [x] Issue linked above with `Fixes #3207`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — one conditional arm + comment; no unrelated changes
- [x] Regression test added
- [x] All existing tests pass (gsd-test GREEN)
- [x] `.changeset/` fragment added (`Fixed`)
- [x] No unnecessary dependencies added

## Breaking changes

None for the documented contract. The one observable behavior change is intentional and **is** the fix: a freshly-created strategy branch now receives the first phase/milestone commit (restoring #1278). Anyone who relied on the 1.10.0 no-switch behavior (a single minor release) will see commits land on the strategy branch again — which is the documented intent of `branching_strategy: phase`/`milestone`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/3363"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789075882&installation_model_id=22188&pr_number=3363&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F3363&signature=14f6afb6dca741b0bd4ea19b1a0a18462c0c4acafaf5835092a708391490aca2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->