### PR TITLE
fix(#3213): segment-boundary membership for letter-named phase dirs

### DIFF
--- a/.changeset/tame-river-song.md
+++ b/.changeset/tame-river-song.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 3368
 ---
 **Milestone phase counts no longer drop every letter-named phase directory** — `getMilestonePhaseFilter` now includes letter-named phase directories (`Phase A:`…`Phase L:`, GSD's own non-numeric phase convention per ADR-612) in milestone progress and plan counts. A greedy regex previously captured the whole hyphenated directory name (`A-tool-output-contract` was read as `A-tool-output-contract` instead of `A`), so every letter-named phase silently fell out of its milestone and the progress/plan totals were fabricated over whatever numeric directory happened to survive — a well-formed, plausible number that could even look correct at a phase boundary. Numeric and milestone-prefixed phases are unchanged. (#3213)

--- a/.changeset/tame-river-song.md
+++ b/.changeset/tame-river-song.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**Milestone phase counts no longer drop every letter-named phase directory** — `getMilestonePhaseFilter` now includes letter-named phase directories (`Phase A:`…`Phase L:`, GSD's own non-numeric phase convention per ADR-612) in milestone progress and plan counts. A greedy regex previously captured the whole hyphenated directory name (`A-tool-output-contract` was read as `A-tool-output-contract` instead of `A`), so every letter-named phase silently fell out of its milestone and the progress/plan totals were fabricated over whatever numeric directory happened to survive — a well-formed, plausible number that could even look correct at a phase boundary. Numeric and milestone-prefixed phases are unchanged. (#3213)

--- a/src/roadmap-parser.cts
+++ b/src/roadmap-parser.cts
@@ -1366,6 +1366,10 @@ function getMilestonePhaseFilter(cwd: string, versionOverride?: string | null, p
   );
 
   const roadmapUsesHyphenedIds = [...normalized].some(n => n.includes('-'));
+  // #3213: longest-first so a hyphenated declared ID (e.g. "proj-42") is tested
+  // before a prefix of it (e.g. "proj") in the segment-boundary membership loop
+  // below — otherwise the shorter id would admit a dir that belongs to the longer.
+  const normalizedIdsLongestFirst = [...normalized].sort((a, b) => b.length - a.length);
   // #2043: milestone-prefixed sub-phase components must be zero-padded — so a
   // single-digit slug word after the phase
   // number (e.g. dir "46-6-rs-…") captures "46" and is not silently excluded from
@@ -1383,8 +1387,27 @@ function getMilestonePhaseFilter(cwd: string, versionOverride?: string | null, p
   function isDirInMilestone(dirName: string): boolean {
     const m2 = dirName.match(numericRe);
     if (m2 && normalized.has(normalizePhaseIdSegments(m2[1]).toLowerCase())) return true;
-    const customMatch = dirName.match(/^([A-Za-z][A-Za-z0-9]*(?:-[A-Za-z0-9]+)*)/);
-    if (customMatch && normalized.has(customMatch[1].toLowerCase())) return true;
+    // #3213: segment-boundary membership test, scoped to LETTER-LEADING (custom-
+    // ID) directories only. The prior greedy capture
+    // `^([A-Za-z][A-Za-z0-9]*(?:-[A-Za-z0-9]+)*)` swallowed the WHOLE hyphenated
+    // directory name (A-tool-output-contract was captured as
+    // "A-tool-output-contract", not "A"), so every letter-named phase directory
+    // (Phase A:..Phase L: — GSD's own convention, ADR-612 first-class non-numeric
+    // IDs) fell out of the milestone and counts were silently fabricated over
+    // whatever numeric directory survived. A letter-leading directory belongs if
+    // its lowercased name EQUALS a declared phase ID, or BEGINS with that ID
+    // followed by "-" (so "A-tool-output-contract" matches ID "a";
+    // "PROJ-42-description" matches ID "proj-42"; "AB-combined" does NOT match
+    // "a"). SCOPED TO LETTER-LEADING DIRS because numeric dirs are owned by
+    // numericRe above, which respects the #2232 continuation grammar — a bare
+    // startsWith here would wrongly admit "14-02-photos-…" to phase "14" when its
+    // real token is "14-02" (continuation-absorbed, not declared).
+    if (/^[A-Za-z]/.test(dirName)) {
+      const lowerDir = dirName.toLowerCase();
+      for (const id of normalizedIdsLongestFirst) {
+        if (lowerDir === id || lowerDir.startsWith(id + '-')) return true;
+      }
+    }
     const stripped = stripProjectCodePrefix(dirName);
     if (stripped !== dirName) {
       const sm = stripped.match(numericRe);

--- a/tests/roadmap-parser.test.cjs
+++ b/tests/roadmap-parser.test.cjs
@@ -1233,6 +1233,53 @@ describe('roadmap-parser: getMilestonePhaseFilter', () => {
     assert.strictEqual(filter('02-01-setup'), true, 'bracket-prefixed phase 2-01 matched');
     assert.strictEqual(filter('02-02-build'), true, 'bracket-prefixed phase 2-02 matched');
   });
+
+  // #3213: the custom-ID branch used a greedy capture
+  // `^([A-Za-z][A-Za-z0-9]*(?:-[A-Za-z0-9]+)*)` that swallowed the whole
+  // hyphenated directory name (A-tool-output-contract → captured
+  // "A-tool-output-contract", not "A"). Every letter-named phase directory
+  // (GSD's own Phase A:..Phase L: convention; ADR-612 first-class non-numeric
+  // IDs) was silently excluded and milestone counts were fabricated over
+  // whatever numeric dir survived. The fix is a segment-boundary membership
+  // test: a dir belongs if it equals a declared phase ID or begins with id + "-".
+  test('#3213: letter-named phase dir is included in the milestone', () => {
+    writeRoadmap(tmpDir, [
+      '## v1.0: Letters',
+      '### Phase A: Tool Output Contract',
+      '**Goal:** contract',
+      '',
+      '### Phase 01: Inventory',
+      '**Goal:** inventory',
+    ].join('\n'));
+
+    const filter = getMilestonePhaseFilter(tmpDir);
+    assert.strictEqual(filter.phaseCount, 2, 'Phase A + Phase 01 declared');
+    assert.strictEqual(filter('A-tool-output-contract'), true, 'letter phase A dir must be in-milestone (#3213)');
+    assert.strictEqual(filter('01-inventory'), true, 'numeric phase 01 dir still matches');
+    assert.strictEqual(filter('B-evidence-artifact-contract'), false, 'undeclared letter phase B stays excluded');
+  });
+
+  test('#3213: letter-named phases A..L all count (not just the numeric dir)', () => {
+    const headings = ['## v1.0: Alpha', '### Phase 00: Inventory', '**Goal:** inv', ''];
+    for (const letter of ['A','B','C','D','E','F','G','H','I','J','K','L']) {
+      headings.push(`### Phase ${letter}: Phase ${letter}`, '**Goal:** g', '');
+    }
+    writeRoadmap(tmpDir, headings.join('\n'));
+
+    const filter = getMilestonePhaseFilter(tmpDir);
+    assert.strictEqual(filter.phaseCount, 13, 'Phase 00 + A..L = 13 phases');
+    assert.strictEqual(filter('00-inventory-approval-gate'), true, '00 in-milestone');
+    const dirFor = {
+      A: 'A-tool-output-contract',
+      B: 'B-evidence-artifact-contract',
+      C: 'C-attention-triage',
+      L: 'L-framework-distribution',
+    };
+    for (const [letter, dir] of Object.entries(dirFor)) {
+      assert.strictEqual(filter(dir), true, `letter phase ${letter} dir "${dir}" must be in-milestone (#3213)`);
+    }
+    assert.strictEqual(filter('M-not-declared'), false, 'undeclared letter M stays excluded');
+  });
 });
 
 // ─── withPhaseSection (ADR-2143 §4 — bounded mutation) ────────────────────────


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3213

## What was broken

`getMilestonePhaseFilter`'s custom-ID branch used a greedy regex `^([A-Za-z][A-Za-z0-9]*(?:-[A-Za-z0-9]+)*)` that swallowed the **whole** hyphenated directory name. `A-tool-output-contract` was captured as `A-tool-output-contract` (not `A`), the set lookup failed, and every letter-named phase directory (`Phase A:`…`Phase L:` — GSD's own convention, ADR-612 first-class non-numeric IDs) silently fell out of its milestone. Milestone progress/plan counts were then fabricated over whatever numeric directory survived — a well-formed, plausible number that recurred 26 times across 8 phases in the reporter's project before anyone checked it against the tree.

## What this fix does

Replace the greedy capture with a **segment-boundary membership test**, scoped to letter-leading (custom-ID) directories only: a directory belongs if its lowercased name equals a declared phase ID or begins with that ID + `-` (so `A-tool-output-contract` matches ID `a`; `PROJ-42-description` matches ID `proj-42`; `AB-combined` does NOT match `a`). IDs are checked longest-first. The loop is guarded to letter-leading dirs so numeric directories stay owned by `numericRe`, which respects the #2232 continuation grammar (without the guard, `14-02-photos-…` would be wrongly admitted to phase `14`).

## Root cause

The `(?:-[A-Za-z0-9]+)*` quantifier is greedy and consumes every hyphenated segment. The capture-then-set-lookup shape is fundamentally wrong for a slug-bearing directory name; a segment-boundary prefix test is correct. The numeric branch (`numericRe`) and the `extractPhaseToken` last-resort did not recover letter dirs: `numericRe` needs a leading digit, and `extractPhaseToken` returns empty for a pure-letter leading segment.

## Testing

### How I verified the fix

- **RED proven** at `0d8999e9a` (gsd-test, both lanes): the two new letter-phase regression tests failed on the unfixed code (2 leaf failures + parent).
- **First GREEN attempt** (`60609f22`) **failed**: the unguarded loop broke 2 existing `#2232 continuation-grammar parity` tests — it wrongly admitted `14-02-photos-performance` to phase `14` (real token `14-02`, not declared). Root-caused (removed `customMatch`'s `^[A-Za-z]` anchor), fixed by scoping the loop to letter-leading dirs.
- **GREEN** at `2e412e3bb (32643/32643 both lanes, 0 failures — parity tests pass)` (gsd-test, both lanes): all pass, including the parity tests and the 2 new regressions.
- No recorded decision protects the greedy regex (`recall_decision` returned only unrelated decisions; ADR-612 supports the fix).

### Regression test added?

- [x] Yes — two new tests: a single letter phase + numeric control (`A-tool-output-contract` in, `01-inventory` in, undeclared `B-…` out), and the full `Phase 00` + `Phase A..L` tree from the issue's reproduction (all 13 in, undeclared `M` out).

### Platforms tested

- [x] macOS (local gsd-test dispatch)
- [x] Linux (gsd-test linux-node22 + linux-node24 lanes)
- [ ] Windows (no platform-specific code)

### Runtimes tested

- [x] N/A (pure string-predicate fix)

## Checklist

- [x] Issue linked with `Fixes #3213`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — one predicate branch + one sorted constant
- [x] Regression test added
- [x] All existing tests pass (gsd-test GREEN), including the #2232 continuation-grammar parity tests
- [x] `.changeset/` fragment added (`Fixed`)
- [x] No unnecessary dependencies added

## Breaking changes

None. Numeric and milestone-prefixed phase directories are byte-for-byte unaffected (the loop is guarded to letter-leading dirs; `numericRe` still owns every leading-digit directory). The only observable change is that letter-named phase directories are now correctly counted — restoring the ADR-612 contract.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/3368"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789081621&installation_model_id=22188&pr_number=3368&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F3368&signature=b5592cf00f6f9a80520101297f203a5ea381cdd6373a8aa89bb84af370288d03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->