### PR TITLE
fix(#3224): register WINDOWS.md as a canonical .planning/ artifact

### DIFF
--- a/.changeset/calm-fern-meadow.md
+++ b/.changeset/calm-fern-meadow.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 3369
 ---
 **`gsd-tools validate health` no longer flags `.planning/WINDOWS.md` as an unrecognized file** — the broken-windows ledger that gsd-core's own `windows` command writes is now registered as a canonical `.planning/` artifact. Previously the W019 warning advised archiving or deleting a file that, with `workflow.windows_enforce` on, gates `/gsd-ship`. (#3224)

--- a/.changeset/calm-fern-meadow.md
+++ b/.changeset/calm-fern-meadow.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`gsd-tools validate health` no longer flags `.planning/WINDOWS.md` as an unrecognized file** — the broken-windows ledger that gsd-core's own `windows` command writes is now registered as a canonical `.planning/` artifact. Previously the W019 warning advised archiving or deleting a file that, with `workflow.windows_enforce` on, gates `/gsd-ship`. (#3224)

--- a/src/artifacts.cts
+++ b/src/artifacts.cts
@@ -24,6 +24,7 @@ export const CANONICAL_EXACT: ReadonlySet<string> = new Set([
   'config.json',
   'CLAUDE.md',
   'RETROSPECTIVE.md',
+  'WINDOWS.md', // #3224: broken-windows ledger (src/broken-windows.cts, LEDGER_FILE_NAME)
 ]);
 
 // Pattern-match canonical file names (regex tests on the basename)

--- a/tests/artifacts.test.cjs
+++ b/tests/artifacts.test.cjs
@@ -23,7 +23,7 @@ describe('CANONICAL_EXACT', () => {
     const expected = [
       'PROJECT.md', 'ROADMAP.md', 'STATE.md', 'REQUIREMENTS.md',
       'MILESTONES.md', 'BACKLOG.md', 'LEARNINGS.md', 'THREADS.md',
-      'config.json', 'CLAUDE.md', 'RETROSPECTIVE.md',
+      'config.json', 'CLAUDE.md', 'RETROSPECTIVE.md', 'WINDOWS.md',
     ];
     for (const name of expected) {
       assert.ok(CANONICAL_EXACT.has(name), `expected ${name} in CANONICAL_EXACT`);
@@ -56,6 +56,15 @@ describe('isCanonicalPlanningFile', () => {
 
   test('returns true for exact match config.json', () => {
     assert.strictEqual(isCanonicalPlanningFile('config.json'), true);
+  });
+
+  test('#3224: WINDOWS.md (broken-windows ledger) is a canonical .planning/ artifact', () => {
+    // gsd-core itself writes .planning/WINDOWS.md (src/broken-windows.cts,
+    // LEDGER_FILE_NAME = 'WINDOWS.md'). Before #3224 it was absent from the
+    // registry, so validate health flagged it W019 "Unrecognized" with advice to
+    // delete a ledger that can gate /gsd-ship under workflow.windows_enforce.
+    assert.ok(CANONICAL_EXACT.has('WINDOWS.md'), 'WINDOWS.md must be in CANONICAL_EXACT');
+    assert.strictEqual(isCanonicalPlanningFile('WINDOWS.md'), true);
   });
 
   test('returns false for unrecognized file', () => {


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3224

## What was broken

`gsd-tools validate health` emitted W019 "Unrecognized .planning/ file: WINDOWS.md — not a canonical GSD artifact" with fix advice to archive or delete it — for a file gsd-core itself creates and maintains (`gsd-tools windows append/waive/fixed`; `LEDGER_FILE_NAME = 'WINDOWS.md'` in `src/broken-windows.cts:51`, written to `.planning/WINDOWS.md` at `:653`). With `workflow.windows_enforce` on, that ledger gates `/gsd-ship`, so following the W019 advice would delete a ship-gating file.

## What this fix does

Add `'WINDOWS.md'` to `CANONICAL_EXACT` in `src/artifacts.cts` — exactly the maintenance step the registry header mandates ("Add entries here whenever a new workflow produces a .planning/ root file"), missed when the broken-windows capability (#1950/#2441) landed. `isCanonicalPlanningFile('WINDOWS.md')` now returns true, suppressing the false W019.

## Root cause

A registry-omission: `CANONICAL_EXACT` had 11 entries; `WINDOWS.md` was never added. `isCanonicalPlanningFile` returned false → W019 fired (`src/verify.cts:2261`).

## Testing

### How I verified the fix

- **RED proven** at `49fccc5d1` (gsd-test, both lanes): the new `#3224: WINDOWS.md is canonical` test + the updated "expected canonical files" list failed (4 failures — the omission).
- **GREEN** at `4c9a23548 (32644/32644 both lanes, 0 failures)` (gsd-test, both lanes): all pass after the one-line registry addition. The existing negative tests (`random-file.md`, empty string → false) stay green, so genuinely-unrecognized files still trigger W019.

### Regression test added?

- [x] Yes — dedicated `#3224: WINDOWS.md is a canonical .planning/ artifact` test + `WINDOWS.md` added to the registry's "expected canonical files" source-of-truth list.

### Platforms tested

- [x] macOS (local gsd-test dispatch)
- [x] Linux (gsd-test linux-node22 + linux-node24 lanes)
- [ ] Windows (no platform-specific code — a one-line Set addition)

### Runtimes tested

- [x] N/A (pure data-registry change)

## Checklist

- [x] Issue linked with `Fixes #3224`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — one Set entry
- [x] Regression test added
- [x] All existing tests pass (gsd-test GREEN); W019 still fires for genuinely-unrecognized files
- [x] `.changeset/` fragment added (`Fixed`)
- [x] No unnecessary dependencies added

## Breaking changes

None. The predicate only grows its accept set; genuinely-unrecognized files are still flagged W019. The only observable change is that `WINDOWS.md` is no longer a false positive.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/3369"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789084474&installation_model_id=22188&pr_number=3369&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F3369&signature=7d8d697fa6ad447a9d1fbf08bd92c2e50c2c2c5e753784d4e75204e2c014f7a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->