### PR TITLE
fix(#3233): no-op state update-progress when the milestone scan finds zero plans

### DIFF
--- a/.changeset/quiet-marble-field.md
+++ b/.changeset/quiet-marble-field.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`gsd-tools query state update-progress` no longer rewrites Progress to 0% after a milestone close** — when the current-milestone phase scan finds zero plans (the post-archive state, where `.planning/phases/` is empty), the command is now a no-op that leaves STATE.md unchanged, instead of mapping 0/0 to 0% and destroying the shipped `[██████████] 100%` record. The legitimate 0% case (plans exist, none summarized) still writes 0%. (#3233)

--- a/.changeset/quiet-marble-field.md
+++ b/.changeset/quiet-marble-field.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 3375
 ---
 **`gsd-tools query state update-progress` no longer rewrites Progress to 0% after a milestone close** — when the current-milestone phase scan finds zero plans (the post-archive state, where `.planning/phases/` is empty), the command is now a no-op that leaves STATE.md unchanged, instead of mapping 0/0 to 0% and destroying the shipped `[██████████] 100%` record. The legitimate 0% case (plans exist, none summarized) still writes 0%. (#3233)

--- a/src/state.cts
+++ b/src/state.cts
@@ -804,6 +804,27 @@ function cmdStateUpdateProgress(cwd: string, raw: boolean): void {
     return;
   }
 
+  // #3233: zero plans in the current-milestone phases means there is nothing to
+  // measure — most often the milestone was just closed and its phases archived
+  // (.planning/phases/ empty, but scope COMPLETE — "a real empty"). clampPercent
+  // maps 0/0 to 0%, which would clobber the shipped Progress record (e.g.
+  // [██████████] 100% → [░░░░░░░░░░] 0%). No-op instead, mirroring the
+  // scope-withhold above and computeProgressPercent's null-for-empty contract
+  // ("nothing to measure" ≠ "0% done"). The legitimate 0% case (plans exist,
+  // none summarized → clampPercent(0, N>0) = 0) is unaffected: totalPlans > 0.
+  if (totalPlans === 0) {
+    process.stderr.write(
+      `[gsd-tools] WARNING: state update-progress skipped — no plans found in current-milestone phases (0 plans). ` +
+      `STATE.md's Progress field was left unchanged (milestone archived?).\n`
+    );
+    output(
+      { updated: false, reason: 'no plans found in current-milestone phases — STATE.md left unchanged (milestone archived?)' },
+      raw,
+      'false',
+    );
+    return;
+  }
+
   const percent = clampPercent(totalSummaries, totalPlans);
   const barWidth = 10;
   const filled = Math.round(percent / 100 * barWidth);

--- a/tests/state.test.cjs
+++ b/tests/state.test.cjs
@@ -1724,17 +1724,49 @@ describe('cmdStateUpdateProgress (state update-progress)', () => {
     assert.ok(updated.includes('50%'), 'STATE.md Progress should contain 50%');
   });
 
-  test('handles zero plans gracefully', () => {
+  test('#3233: zero plans (0/0) is a no-op — does not clobber the Progress record', () => {
+    // Post-milestone-close: .planning/phases/ holds no plans (0/0). The buggy path
+    // mapped 0/0 through clampPercent to 0% and rewrote the shipped 100% record.
+    // The fix no-ops when there are zero plans to measure.
     fs.writeFileSync(
       path.join(tmpDir, '.planning', 'STATE.md'),
-      '# Project State\n\n**Progress:** [░░░░░░░░░░] 0%\n'
+      '# Project State\n\n**Progress:** [██████████] 100% of v1.0\n'
     );
+    const before = fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
 
     const result = runGsdTools('state update-progress', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
-    assert.strictEqual(output.percent, 0, 'percent should be 0 when no plans found');
+    assert.strictEqual(output.updated, false, 'zero plans → no-op (updated:false)');
+    assert.ok(
+      /no plans found/i.test(String(output.reason)),
+      `should explain the no-op; got reason: ${output.reason}`
+    );
+
+    const after = fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
+    assert.strictEqual(after, before, 'STATE.md must be unchanged when no plans are found (#3233)');
+  });
+
+  test('#3233 negative-space: plans exist but none done still writes 0%', () => {
+    // The fix no-ops ONLY on totalPlans===0. A milestone with plans but none
+    // summarized must still write a legitimate 0% (not be suppressed).
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'STATE.md'),
+      '# Project State\n\n**Progress:** [██████████] 100%\n'
+    );
+    const phase01Dir = path.join(tmpDir, '.planning', 'phases', '01');
+    fs.mkdirSync(phase01Dir, { recursive: true });
+    fs.writeFileSync(path.join(phase01Dir, '01-01-PLAN.md'), '# Plan\n');
+
+    const result = runGsdTools('state update-progress', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.updated, true, 'plans exist → write (updated:true)');
+    assert.strictEqual(output.percent, 0, 'none done → 0% (legitimate, not suppressed)');
+    const after = fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
+    assert.ok(after.includes('0%'), 'STATE.md Progress should reflect 0%');
   });
 
   test('returns error when Progress field missing', () => {

--- a/tests/state.test.cjs
+++ b/tests/state.test.cjs
@@ -1774,13 +1774,22 @@ describe('cmdStateUpdateProgress (state update-progress)', () => {
       path.join(tmpDir, '.planning', 'STATE.md'),
       '# Project State\n\n**Status:** Active\n'
     );
+    // #3233: give the scan a plan so totalPlans > 0 clears the zero-plans
+    // no-op guard and this test reaches the 'Progress field not found' branch
+    // it is named for (otherwise the guard fires first and the branch is uncovered).
+    const phase01Dir = path.join(tmpDir, '.planning', 'phases', '01');
+    fs.mkdirSync(phase01Dir, { recursive: true });
+    fs.writeFileSync(path.join(phase01Dir, '01-01-PLAN.md'), '# Plan\n');
 
     const result = runGsdTools('state update-progress', tmpDir);
     assert.ok(result.success, `Command should exit 0: ${result.error}`);
 
     const output = JSON.parse(result.output);
     assert.strictEqual(output.updated, false, 'updated should be false');
-    assert.ok(output.reason !== undefined, 'should have a reason');
+    assert.ok(
+      /Progress field not found/i.test(String(output.reason)),
+      `should be the 'Progress field not found' reason; got: ${output.reason}`
+    );
   });
 
   // ── #2177: frontmatter `progress:` key must not shadow the body Progress: line ──


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3233

## What was broken

After `/gsd-complete-milestone` archives phases (`.planning/phases/` empty, scope COMPLETE), running `gsd-tools query state update-progress` scanned zero dirs → `totalPlans=0/totalSummaries=0` → `clampPercent(0,0)` returned 0 → the function unconditionally rewrote the body `Progress:` line, destroying the shipped `[██████████] 100% of vX.Y` record (→ `[░░░░░░░░░░] 0%`). An executor running the command as routine bookkeeping would silently clobber the milestone record.

## What this fix does

Add an early-return no-op when `totalPlans === 0` — mirroring the established scope-withholding no-op (`stderr` WARNING + `{updated:false, reason}`, exit 0) and `computeProgressPercent`'s null-for-empty contract ("nothing to measure" ≠ "0% done"). The legitimate 0% case (plans exist, none summarized → `clampPercent(0, N>0) = 0`) is unaffected.

## Root cause

`cmdStateUpdateProgress` had a scope no-op guard but none for "zero plans to measure." `clampPercent` returning 0 for a non-positive denominator is correct for its other callers; here "no data" silently became a destructive 0% write.

## Testing

### How I verified the fix

- **RED proven** at `b0db610c9` (gsd-test, both lanes): the #3233 no-op test failed on the unfixed code (the 100% record was clobbered to 0%). A negative-space test (plans exist, none done → 0% written) passed at RED and stays green.
- **GREEN** at `256a21aa7` (32647/32647 both lanes, 0 failures) — the core fix.
- **Isolated-adversarial review** surfaced one Important finding: the new guard shadowed the existing `'returns error when Progress field missing'` test (it had no phase dirs, so the guard fired first and the "Progress field not found" branch lost coverage). **Fixed inline** — that test now seeds a phase dir + PLAN so `totalPlans > 0` clears the guard and reaches the branch it's named for. Re-verified GREEN at `c328eda39`.

### Regression test added?

- [x] Yes — `#3233: zero plans (0/0) is a no-op` (100% record preserved) + `#3233 negative-space: plans exist but none done still writes 0%` + the unshadowed `Progress field missing` test.

### Platforms tested

- [x] macOS (local gsd-test dispatch)
- [x] Linux (gsd-test linux-node22 + linux-node24 lanes)
- [ ] Windows (no platform-specific code)

### Runtimes tested

- [x] N/A (pure control-flow guard)

## Checklist

- [x] Issue linked with `Fixes #3233`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix scoped to the reported bug (one early-return guard)
- [x] Regression tests added (with a negative-space guard for the legitimate 0% case)
- [x] All existing tests pass (gsd-test GREEN); the shadowed "Progress field missing" test was unshadowed
- [x] `.changeset/` fragment added (`Fixed`)
- [x] No unnecessary dependencies added

## Breaking changes

None. The only behavior change is that a 0/0 scan (no plans) no longer overwrites STATE.md. Callers that ran the command unconditionally (execute-plan) get a clean no-op instead of a destructive write — which is the documented expectation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/3375"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789094900&installation_model_id=22188&pr_number=3375&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F3375&signature=fd83d399108e6266a7419f2f75a7b250a2d9a43168e142da0fd1747857a99160"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->