### PR TITLE
fix(#3255): updateTableCell scans for the table carrying the requested column

### DIFF
--- a/.changeset/amber-cobalt-spark.md
+++ b/.changeset/amber-cobalt-spark.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`requirements mark-complete` now flips the traceability row when `## Traceability` holds more than one table** — `updateTableCell` no longer binds to the first table in the section; it scans for the table that actually carries the requested column. A section with a phase-summary table above the requirement rows previously made the Status write silently bail (`table_unmatched`) while the checkbox still flipped, leaving the row at `Pending` indefinitely. Single-table sections are unchanged. (#3255)

--- a/.changeset/amber-cobalt-spark.md
+++ b/.changeset/amber-cobalt-spark.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 3377
 ---
 **`requirements mark-complete` now flips the traceability row when `## Traceability` holds more than one table** — `updateTableCell` no longer binds to the first table in the section; it scans for the table that actually carries the requested column. A section with a phase-summary table above the requirement rows previously made the Status write silently bail (`table_unmatched`) while the checkbox still flipped, leaving the row at `Pending` indefinitely. Single-table sections are unchanged. (#3255)

--- a/src/markdown-table.cts
+++ b/src/markdown-table.cts
@@ -326,36 +326,50 @@ export function updateTableCell(
 ): Result<string> {
   const lines = splitLinesWithOffsets(tableText);
 
+  // #3255: pick the first VALID table whose columns include `column`. The prior
+  // code bound to the FIRST table of any shape and returned 'unknown column' if
+  // that one lacked the column — so a section holding a summary table above the
+  // target (e.g. ## Traceability: a phase-summary table, then the requirement
+  // rows) never reached the target table. Scan for the first valid table that
+  // carries the column; if none does but a valid table exists, still return
+  // 'unknown column' (single-table behaviour unchanged). Track the first
+  // malformation reason so a lone malformed table keeps its specific error.
   let headerIdx = -1;
+  let columns: string[] = [];
+  let firstValidIdx = -1;
+  let firstMalformedReason: string | null = null;
+  const recordMalformed = (reason: string): void => {
+    if (firstMalformedReason === null && firstValidIdx === -1) firstMalformedReason = reason;
+  };
   for (let i = 0; i < lines.length; i++) {
     const trimmed = lines[i].line.trim();
-    if (trimmed.startsWith('|') && trimmed.indexOf('|', 1) !== -1) {
+    if (!trimmed.startsWith('|') || trimmed.indexOf('|', 1) === -1) continue;
+    const delimiterLine = lines[i + 1]?.line;
+    if (delimiterLine === undefined || !delimiterLine.trim().startsWith('|')) {
+      recordMalformed('missing delimiter row');
+      continue;
+    }
+    const candidateRanges = splitTableRowRanges(lines[i].line, lines[i].start);
+    const candidateColumns = candidateRanges.map((r) => unescapeCellText(tableText.slice(r.start, r.end)));
+    const delimiterCells = splitTableRow(delimiterLine);
+    if (!isDelimiterRow(delimiterCells)) {
+      recordMalformed('missing delimiter row');
+      continue;
+    }
+    if (delimiterCells.length !== candidateColumns.length) {
+      recordMalformed('delimiter/header column count mismatch');
+      continue;
+    }
+    if (firstValidIdx === -1) firstValidIdx = i;
+    if (candidateColumns.includes(column)) {
       headerIdx = i;
+      columns = candidateColumns;
       break;
     }
   }
   if (headerIdx === -1) {
-    return { ok: false, reason: 'no table found' };
-  }
-
-  const delimiterLine = lines[headerIdx + 1]?.line;
-  if (delimiterLine === undefined || !delimiterLine.trim().startsWith('|')) {
-    return { ok: false, reason: 'missing delimiter row' };
-  }
-
-  const headerRanges = splitTableRowRanges(lines[headerIdx].line, lines[headerIdx].start);
-  const columns = headerRanges.map((r) => unescapeCellText(tableText.slice(r.start, r.end)));
-
-  const delimiterCells = splitTableRow(delimiterLine);
-  if (!isDelimiterRow(delimiterCells)) {
-    return { ok: false, reason: 'missing delimiter row' };
-  }
-  if (delimiterCells.length !== columns.length) {
-    return { ok: false, reason: 'delimiter/header column count mismatch' };
-  }
-
-  if (!columns.includes(column)) {
-    return { ok: false, reason: `unknown column: ${column}` };
+    if (firstValidIdx !== -1) return { ok: false, reason: `unknown column: ${column}` };
+    return { ok: false, reason: firstMalformedReason ?? 'no table found' };
   }
   const targetColIdx = columns.indexOf(column);
 

--- a/tests/markdown-table.test.cjs
+++ b/tests/markdown-table.test.cjs
@@ -639,6 +639,29 @@ describe('updateTableCell', () => {
     assert.match(result.reason, /no table found/);
   });
 
+  test('#3255: reaches a later table when the first table lacks the requested column', () => {
+    // A ## Traceability section holding a phase-summary table (no Status) ABOVE
+    // the requirement table (with Status). The prior code bound to the FIRST
+    // table and returned 'unknown column: Status' without ever reaching the
+    // requirement table, so requirements.mark-complete left the row at Pending.
+    const multiTable = [
+      '| Phase | Name | Requirements |',
+      '|-------|------|--------------|',
+      '| 1 | Portal Spec | 4 (PORTAL-01..04) |',
+      '',
+      '| Requirement | Phase | Status |',
+      '|-------------|-------|--------|',
+      '| AUTHZ-02 | Phase 02.2 | Pending |',
+    ].join('\n');
+    const byReq = (row) => (Object.values(row)[0] ?? '').trim().toLowerCase() === 'authz-02';
+    const result = updateTableCell(multiTable, byReq, 'Status', ' Complete ');
+
+    assert.equal(result.ok, true, `expected ok:true (should reach the requirement table); got: ${result && result.reason}`);
+    assert.ok(result.value.includes('| Phase | Name | Requirements |'), 'first (summary) table header untouched');
+    assert.ok(result.value.includes('| 1 | Portal Spec | 4 (PORTAL-01..04) |'), 'first (summary) data row untouched');
+    assert.ok(/AUTHZ-02 \| Phase 02\.2 \| Complete/.test(result.value), 'second table Status cell flipped Pending → Complete');
+  });
+
   test('5-column milestone table: Milestone cell and other columns stay byte-identical', () => {
     const byPhase = (row) => row['Phase'].trim() === '1. Alpha';
     const result = updateTableCell(fiveCol, byPhase, 'Plans Complete', ' 2/2 ');


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3255

## What was broken

`requirements mark-complete <ID>` flipped the checkbox but silently left the traceability row at `Pending`, reporting `table_unmatched` + `write_set[traceability].applied:false` — when the row existed, in a table with a `Status` column, inside `## Traceability`. This happened whenever `## Traceability` held more than one table (e.g. a `| Phase | Name | Requirements |` summary above the `| Requirement | Phase | Status |` rows): `updateTableCell` bound to the **first** table, found no `Status` column there, and returned `unknown column` without ever reaching the requirement table.

## What this fix does

`updateTableCell` now scans candidate table headers and picks the first **valid** table (delimiter + matching column count) whose columns include the requested column — falling back to `unknown column` only when no table in the scoped text carries it. Single-table behavior is byte-identical; error semantics (`no table found` / `unknown column` / malformed-table reasons) are preserved. This also fixes the derived `tableHit`/`doneTable` reasoning (which probes via the same call), so an ID whose row exists is no longer reported as no-row.

## Root cause

`updateTableCell` is a primitive consumed by `milestone.cts` (traceability) and `roadmap.cts` (progress writes). The #2245 fix scoped calls to the right **section** (the `## Traceability` heading); the within-section multi-table case remained. The `milestone.cts:75` comment already documented this exact "binds to the FIRST GFM table" limitation.

## Testing

### How I verified the fix

- **RED proven** at `c92374d43` (gsd-test, both lanes): the multi-table `updateTableCell` test failed on the unfixed code (first table lacks `Status` → `unknown column`).
- **GREEN** at `c33833c37` (32655/32655 both lanes, 0 failures).
- **Isolated adversarial review**: SHIP IT — verified the scan logic, error semantics, all caller sites (`roadmap.cts`/`milestone.cts`/`phase.cts`/`state.cts` are single-table-scoped or the traceability multi-table case), and the `headerRanges` cleanup. No findings ≥70%.

### Regression test added?

- [x] Yes — `#3255: reaches a later table when the first table lacks the requested column` (primitive). Existing single-table tests (unknown column / no table found / no matching row / byte-identical single-cell update) stay green — the negative space.

### Platforms tested

- [x] macOS (local gsd-test dispatch)
- [x] Linux (gsd-test linux-node22 + linux-node24 lanes)
- [ ] Windows (no platform-specific code)

### Runtimes tested

- [x] N/A (pure table-parsing logic)

## Checklist

- [x] Issue linked with `Fixes #3255`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix scoped to the reported bug (table-selection in one primitive)
- [x] Regression test added; single-table negative space unchanged
- [x] All existing tests pass (gsd-test GREEN)
- [x] `.changeset/` fragment added (`Fixed`)
- [x] No unnecessary dependencies added

## Breaking changes

None. Single-table scoped text behaves identically. The only change is that multi-table scoped text now reaches the table carrying the requested column instead of bailing on the first.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/3377"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789098095&installation_model_id=22188&pr_number=3377&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F3377&signature=94078aec3344164877de82b2f437dd41633654ee0bc464e58a13b09d84209ee8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->