### PR TITLE
docs(#3346): add gsd-reasonix EoS entry

### DIFF
--- a/docs/registries/eos-registry.md
+++ b/docs/registries/eos-registry.md
@@ -10,6 +10,7 @@ _To add your integration, see the [registry README](./README.md)._
 |---|---|---|---|---|
 | [GSD Cursor Model Profiles](https://github.com/clezcoding/gsd-cursor) | Adds six researched Cursor runtime profiles \(max / hybrid / value / budget / frontier / openweight\) to GSD, writes current and legacy tier-map surfaces, routes all six GSD phases, validates local model availability, and restores prior managed settings on uninstall without modifying gsd-core. | ![release](https://img.shields.io/github/v/release/clezcoding/gsd-cursor?sort=semver&include_prereleases) | `>=1.0.0` | [discuss](https://github.com/open-gsd/gsd-core/discussions/2578) |
 | [GSD for Oh My Pi](https://github.com/tchivs/gsd-omp) | Embeds GSD in Oh My Pi through OMP's native ExtensionAPI, programmatic slash commands, task isolation, lifecycle events, filesystem state, and managed agent and skill projection. | ![release](https://img.shields.io/github/v/release/tchivs/gsd-omp?sort=semver&include_prereleases) | `>=1.7.0` | [discuss](https://github.com/open-gsd/gsd-core/discussions/2342) |
+| [GSD for Reasonix](https://github.com/onionviolet/gsd-reasonix) | Renders the GSD workflow set as native Reasonix slash-command launchers, mapping GSD's host-neutral instructions onto Reasonix's own tools \(task/fleet for subagents, ask for questions, todo\_write for plans, complete\_step for evidence-backed sign-off\), and excludes the shared \~/.agents/skills convention root so the Codex launcher tree stops shadowing them. | ![release](https://img.shields.io/github/v/release/onionviolet/gsd-reasonix?sort=semver&include_prereleases) | `>=1.10.0` | [discuss](https://github.com/open-gsd/gsd-core/discussions/3379) |
 
 ## GSD Cursor Model Profiles
 - **Repository:** https://github.com/clezcoding/gsd-cursor — [latest release](https://github.com/clezcoding/gsd-cursor/releases/latest)
@@ -44,3 +45,20 @@ gsd-omp uninstall && npm uninstall --global gsd-omp
 - **GSD compatibility:** `>=1.7.0`, protocol v1
 - **License:** MIT
 - **Discussion / ranking:** https://github.com/open-gsd/gsd-core/discussions/2342
+
+## GSD for Reasonix
+- **Repository:** https://github.com/onionviolet/gsd-reasonix — [latest release](https://github.com/onionviolet/gsd-reasonix/releases/latest)
+- **What it is:** Renders the GSD workflow set as native Reasonix slash-command launchers, mapping GSD's host-neutral instructions onto Reasonix's own tools \(task/fleet for subagents, ask for questions, todo\_write for plans, complete\_step for evidence-backed sign-off\), and excludes the shared \~/.agents/skills convention root so the Codex launcher tree stops shadowing them.
+- **Author:** onionviolet
+- **Every interaction with GSD:** Interface points: command, artifact; profile: declarative-cli; protocol v1; axes: embeddingMode=declarative, commandSurface=slash-file, dispatch=Named and nested Reasonix subagent dispatch to a documented depth of 2 with background execution, and a subagent toolkit and isolation model that Reasonix's own documentation does not state, modelMode=passive, hookBus=host, stateIO=filesystem, transport=mcp, runtime=go
+- **Install:**
+```sh
+npm install --global github:onionviolet/gsd-reasonix#v1.0.0 && gsd-reasonix install
+```
+- **Uninstall:**
+```sh
+gsd-reasonix uninstall && npm uninstall --global gsd-reasonix
+```
+- **GSD compatibility:** `>=1.10.0`, protocol v1
+- **License:** MIT
+- **Discussion / ranking:** https://github.com/open-gsd/gsd-core/discussions/3379

--- a/docs/registries/eos.json
+++ b/docs/registries/eos.json
@@ -64,5 +64,36 @@
       }
     },
     "discussion": "https://github.com/open-gsd/gsd-core/discussions/2342"
+  },
+  {
+    "id": "gsd-reasonix",
+    "name": "GSD for Reasonix",
+    "type": "eos",
+    "repo": "onionviolet/gsd-reasonix",
+    "description": "Renders the GSD workflow set as native Reasonix slash-command launchers, mapping GSD's host-neutral instructions onto Reasonix's own tools (task/fleet for subagents, ask for questions, todo_write for plans, complete_step for evidence-backed sign-off), and excludes the shared ~/.agents/skills convention root so the Codex launcher tree stops shadowing them.",
+    "author": "onionviolet",
+    "license": "MIT",
+    "enginesGsd": ">=1.10.0",
+    "protocolVersion": 1,
+    "install": "npm install --global github:onionviolet/gsd-reasonix#v1.0.0 && gsd-reasonix install",
+    "uninstall": "gsd-reasonix uninstall && npm uninstall --global gsd-reasonix",
+    "interactions": {
+      "interfacePoints": [
+        "command",
+        "artifact"
+      ],
+      "profile": "declarative-cli",
+      "axes": {
+        "embeddingMode": "declarative",
+        "commandSurface": "slash-file",
+        "dispatch": "Named and nested Reasonix subagent dispatch to a documented depth of 2 with background execution, and a subagent toolkit and isolation model that Reasonix's own documentation does not state",
+        "modelMode": "passive",
+        "hookBus": "host",
+        "stateIO": "filesystem",
+        "transport": "mcp",
+        "runtime": "go"
+      }
+    },
+    "discussion": "https://github.com/open-gsd/gsd-core/discussions/3379"
   }
 ]


### PR DESCRIPTION
Refs #3346

## Registry type

- [ ] Capability Registry entry — adds/updates one object in `docs/registries/capabilities.json`
- [x] EoS Registry entry — adds/updates one object in `docs/registries/eos.json`
- [ ] Reviewer Lane Registry entry — adds/updates one object in `docs/registries/reviewers.json`

## The entry

```json
{
  "id": "gsd-reasonix",
  "name": "GSD for Reasonix",
  "type": "eos",
  "repo": "onionviolet/gsd-reasonix",
  "description": "Renders the GSD workflow set as native Reasonix slash-command launchers, mapping GSD's host-neutral instructions onto Reasonix's own tools (task/fleet for subagents, ask for questions, todo_write for plans, complete_step for evidence-backed sign-off), and excludes the shared ~/.agents/skills convention root so the Codex launcher tree stops shadowing them.",
  "author": "onionviolet",
  "license": "MIT",
  "enginesGsd": ">=1.10.0",
  "protocolVersion": 1,
  "install": "npm install --global github:onionviolet/gsd-reasonix#v1.0.0 && gsd-reasonix install",
  "uninstall": "gsd-reasonix uninstall && npm uninstall --global gsd-reasonix",
  "interactions": {
    "interfacePoints": ["command", "artifact"],
    "profile": "declarative-cli",
    "axes": {
      "embeddingMode": "declarative",
      "commandSurface": "slash-file",
      "dispatch": "Named and nested Reasonix subagent dispatch to a documented depth of 2 with background execution, and a subagent toolkit and isolation model that Reasonix's own documentation does not state",
      "modelMode": "passive",
      "hookBus": "host",
      "stateIO": "filesystem",
      "transport": "mcp",
      "runtime": "go"
    }
  },
  "discussion": "https://github.com/open-gsd/gsd-core/discussions/3379"
}
```

---

## Required-field checklist

- [x] `id`, `name`, `type`, `repo`, `description`, `author`, `license`, `enginesGsd`, `install`, `uninstall`, `interactions`, `discussion` are all present and non-empty
- [ ] **(Capability entries only)** n/a
- [x] **(EoS entries only)** `protocolVersion` is an integer ≥ 1, `interactions.interfacePoints` is a non-empty subset of the six interface points, `interactions.profile` is one of `programmatic-cli` / `declarative-cli` / `ide`, and `interactions.axes` has exactly the eight required axis keys plus, optionally, `effortSurface` (`argv` / `none`)
- [ ] **(Reviewer entries only)** n/a

## Ownership & non-endorsement

- [x] `repo` links to a repository **I own or am the primary maintainer of** — not a fork, mirror, or someone else's project
- [x] I understand that inclusion in this registry means only that a maintainer merged this PR — it is **not** an endorsement, and GSD has not reviewed, tested, audited, or verified my solution or its claimed GSD interactions
- [x] I understand this entry is removed only for illegal content, malware, spam, or a dead/non-functional link — never for quality — and a maintainer may remove it on that narrow basis without further notice

## One entry, one PR

- [x] This PR adds or updates exactly **one** entry, in exactly one of `capabilities.json` / `eos.json` / `reviewers.json`
- [x] I have not bundled any other registry entry, code change, or unrelated docs change into this PR

---

## Notes for the reviewer

**This supersedes #3346.** That issue proposed an in-tree `capabilities/reasonix/capability.json` and was closed as filed against the wrong surface. This is the EoS-Registry resubmission it was pointed to. The branch is named for #3346 as the tracking issue; happy to rename if a fresh issue number is preferred for a registry docs PR.

**Verification run before opening this:**

- `node scripts/gen-registry.cjs --check` reports `docs/registries/*.md are up to date.` The generated markdown was produced by `npm run gen:registry`, never hand-edited.
- `registry-schema.cjs` validates all three entries in `eos.json` with zero errors.
- The diff is two files and purely additive (18 insertions to the generated markdown, 31 to the JSON, no deletions).
- The published package installs and uninstalls cleanly via the exact `install` string above, verified from the tagged release against a throwaway `REASONIX_HOME`.

**On `effortSurface`:** deliberately omitted rather than guessed. Reasonix resolves effort from config (`supported_efforts` / `default_effort`) and its `/effort` command, with no argv route, so neither `argv` nor `none` is an honest fit. The field is optional, so omitting it seemed better than asserting a value its docs do not support. Happy to set it to `none` if you read that as the correct mapping for a config-only effort surface.

**On the two axes Reasonix does not document:** its docs state neither the subagent toolkit nor whether a background-dispatched subagent may spawn further subagents, so `shouldFlattenDispatch` fails closed and the orchestrator runs inline. That is stated plainly in the `dispatch` summary and in the discussion thread rather than papered over. If those get documented upstream in Reasonix, I will open a follow-up PR to revise the entry.
