### PR TITLE
fix(#3257): preserve full-line frontmatter comments through the parse→reconstruct pair + syncStateFrontmatter

### DIFF
--- a/.changeset/loud-jade-canyon.md
+++ b/.changeset/loud-jade-canyon.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 3387
 ---
 **Full-line `#` comments in `.planning/STATE.md` (and every frontmatter surface) now survive a mutating write** — `parseYamlRegion` carries column-0 comments through to `reconstructFrontmatter` via a Symbol-keyed channel, and `syncStateFrontmatter` propagates that channel across its fresh-rebuild of the frontmatter object, so a comment like `# NOTE: current_phase is hand-maintained` is no longer silently destroyed on the next `state` verb. Comment-less frontmatter is unchanged; data identity (keys/values/arrays/nested) is preserved alongside the comments. (#3257)

--- a/.changeset/loud-jade-canyon.md
+++ b/.changeset/loud-jade-canyon.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**Full-line `#` comments in `.planning/STATE.md` (and every frontmatter surface) now survive a mutating write** — `parseYamlRegion` carries column-0 comments through to `reconstructFrontmatter` via a Symbol-keyed channel, and `syncStateFrontmatter` propagates that channel across its fresh-rebuild of the frontmatter object, so a comment like `# NOTE: current_phase is hand-maintained` is no longer silently destroyed on the next `state` verb. Comment-less frontmatter is unchanged; data identity (keys/values/arrays/nested) is preserved alongside the comments. (#3257)

--- a/src/frontmatter.cts
+++ b/src/frontmatter.cts
@@ -94,6 +94,20 @@ function isFrontmatterShaped(region: string): boolean {
 }
 
 /**
+ * #3257: a Symbol-keyed channel that carries full-line (column-0 `#`) YAML
+ * comments through a parse → reconstruct round-trip. Comments are otherwise
+ * unrepresentable on the Frontmatter object (Record<string, ...>) and were
+ * silently dropped by reconstructFrontmatter. The Symbol is invisible to
+ * Object.entries / Object.keys / JSON.stringify / for-in, so every existing
+ * reader is unchanged; only reconstructFrontmatter reads it. Leading comments
+ * are attached to the top-level key that follows them; comments after the last
+ * key go to `trailing`. Only set when a comment is actually seen, so comment-less
+ * frontmatter parses byte-identically to before.
+ */
+const FULL_LINE_COMMENTS = Symbol('fullLineComments');
+type FullLineCommentChannel = { leading: Record<string, string[]>; trailing: string[] };
+
+/**
  * Parse one already-delimited YAML region into a Frontmatter object.
  *
  * Extracted from `extractFrontmatter` (#1882) so the truncation probe below and the real
@@ -104,6 +118,10 @@ function parseYamlRegion(yaml: string): Frontmatter {
   const frontmatter: Frontmatter = {};
   const lines = yaml.split(/\r?\n/);
 
+  // #3257: pending column-0 full-line comments, attached to the next top-level key.
+  let pendingComments: string[] = [];
+  let commentChannel: FullLineCommentChannel | undefined;
+
   // Stack to track nested objects: [{obj, key, indent}]
   type StackEntry = { obj: Record<string, unknown> | unknown[]; key: string | null; indent: number };
   const stack: StackEntry[] = [{ obj: frontmatter, key: null, indent: -1 }];
@@ -111,6 +129,12 @@ function parseYamlRegion(yaml: string): Frontmatter {
   for (const line of lines) {
     // Skip empty lines
     if (line.trim() === '') continue;
+
+    // #3257: capture column-0 full-line comments; attach them to the next top-level key.
+    if (/^#/.test(line)) {
+      pendingComments.push(line);
+      continue;
+    }
 
     // Calculate indentation (number of leading spaces)
     const indentMatch = line.match(/^(\s*)/);
@@ -127,6 +151,12 @@ function parseYamlRegion(yaml: string): Frontmatter {
     const keyMatch = line.match(/^(\s*)([a-zA-Z0-9_-]+):\s*(.*)/);
     if (keyMatch) {
       const key = keyMatch[2];
+      // #3257: attach any pending comments to this (top-level) key.
+      if (pendingComments.length) {
+        if (!commentChannel) commentChannel = { leading: {}, trailing: [] };
+        commentChannel.leading[key] = pendingComments;
+        pendingComments = [];
+      }
       const value = keyMatch[3].trim();
 
       if (value === '' || value === '[') {
@@ -166,6 +196,15 @@ function parseYamlRegion(yaml: string): Frontmatter {
         current.obj.push(itemValue);
       }
     }
+  }
+
+  // #3257: trailing comments (after the last key) + attach the channel if any comment was seen.
+  if (pendingComments.length) {
+    if (!commentChannel) commentChannel = { leading: {}, trailing: [] };
+    commentChannel.trailing = pendingComments;
+  }
+  if (commentChannel) {
+    (frontmatter as Record<symbol, unknown>)[FULL_LINE_COMMENTS as unknown as symbol] = commentChannel;
   }
 
   return frontmatter;
@@ -282,8 +321,14 @@ function scalarNeedsDoubleQuoting(s: string): boolean {
 
 function reconstructFrontmatter(obj: Frontmatter): string {
   const lines: string[] = [];
+  // #3257: read the full-line-comment channel (set by parseYamlRegion when comments
+  // were present). Object.entries skips the Symbol key, so the data loop is unchanged.
+  const commentChannel = (obj as Record<symbol, unknown>)[FULL_LINE_COMMENTS as unknown as symbol] as FullLineCommentChannel | undefined;
   for (const [key, value] of Object.entries(obj)) {
     if (value === null || value === undefined) continue;
+    // #3257: re-emit this key's leading full-line comments before the key itself.
+    const leading = commentChannel?.leading[key];
+    if (leading) for (const c of leading) lines.push(c);
     if (Array.isArray(value)) {
       if (value.length === 0) {
         lines.push(`${key}: []`);
@@ -343,7 +388,32 @@ function reconstructFrontmatter(obj: Frontmatter): string {
       }
     }
   }
+  // #3257: re-emit any trailing full-line comments (those after the last key).
+  if (commentChannel?.trailing?.length) {
+    for (const c of commentChannel.trailing) lines.push(c);
+  }
   return lines.join('\n');
+}
+
+/**
+ * #3257: copy the full-line-comment channel from `source` onto `target`, filtering
+ * `leading` to keys still present in `target` (a deleted key's annotation goes with
+ * it — AC5). No-op when `source` carries no channel. Consumers that rebuild their
+ * target object fresh (syncStateFrontmatter builds derivedFm via buildStateFrontmatter
+ * and copies keys with Object.keys, which skips the Symbol) MUST call this before
+ * reconstructFrontmatter, or the channel parseYamlRegion attached to the extracted
+ * source is lost.
+ */
+function propagateCommentChannel(source: Frontmatter, target: Frontmatter): void {
+  const channel = (source as Record<symbol, unknown>)[FULL_LINE_COMMENTS as unknown as symbol] as FullLineCommentChannel | undefined;
+  if (!channel) return;
+  const filtered: FullLineCommentChannel = { leading: {}, trailing: channel.trailing };
+  for (const [key, comments] of Object.entries(channel.leading)) {
+    if (key in target) filtered.leading[key] = comments;
+  }
+  if (filtered.trailing.length || Object.keys(filtered.leading).length) {
+    (target as Record<symbol, unknown>)[FULL_LINE_COMMENTS as unknown as symbol] = filtered;
+  }
 }
 
 /**
@@ -826,4 +896,5 @@ export = {
   cmdFrontmatterSet,
   cmdFrontmatterMerge,
   cmdFrontmatterValidate,
+  propagateCommentChannel,
 };

--- a/src/state.cts
+++ b/src/state.cts
@@ -27,7 +27,7 @@ const { planningDir, planningPaths } = planningWorkspace;
 import { realClock } from './clock.cjs';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import frontmatter = require('./frontmatter.cjs');
-const { extractFrontmatter, reconstructFrontmatter, stripFrontmatter } = frontmatter;
+const { extractFrontmatter, reconstructFrontmatter, stripFrontmatter, propagateCommentChannel } = frontmatter;
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import scanPhasePlans = require('./plan-scan.cjs');
 // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -2361,6 +2361,12 @@ function syncStateFrontmatter(content: string, cwd: string | undefined, authorit
       }
     }
   }
+
+  // #3257: propagate full-line frontmatter comments from the extracted source onto the
+  // rebuilt derivedFm (buildStateFrontmatter + the Object.keys carry-forward above both
+  // skip the Symbol-keyed channel, so without this the comments would be lost here even
+  // though parseYamlRegion/reconstructFrontmatter preserve them in isolation).
+  propagateCommentChannel(existingFm as unknown as Frontmatter, derivedFm as unknown as Frontmatter);
 
   const yamlStr = reconstructFrontmatter(derivedFm as unknown as Frontmatter);
   return `---\n${yamlStr}\n---\n\n${body}`;

--- a/tests/frontmatter.test.cjs
+++ b/tests/frontmatter.test.cjs
@@ -295,6 +295,47 @@ describe('reconstructFrontmatter', () => {
     const extracted2 = extractFrontmatter(roundTrip);
     assert.deepStrictEqual(extracted2, extracted1, 'round-trip should preserve multiple data types');
   });
+
+  test('#3257: full-line comments survive an extract→reconstruct round-trip', () => {
+    const original = '---\ngsd_state_version: 1.0\n# NOTE: current_phase is hand-maintained here\ncurrent_phase: 3\nstatus: executing\n---';
+    const extracted = extractFrontmatter(original);
+    assert.strictEqual(extracted['gsd_state_version'], '1.0');
+    assert.strictEqual(extracted['current_phase'], '3');
+
+    const reconstructed = reconstructFrontmatter(extracted);
+    // #3257: the comment must survive in place (between gsd_state_version and current_phase).
+    assert.ok(
+      reconstructed.includes('# NOTE: current_phase is hand-maintained here'),
+      `comment should survive reconstruct; got:\n${reconstructed}`,
+    );
+    // data identity preserved alongside the comment.
+    assert.ok(reconstructed.includes('gsd_state_version: 1.0'));
+    assert.ok(reconstructed.includes('current_phase: 3'));
+    assert.ok(reconstructed.includes('status: executing'));
+    // the reconstructed output re-parses to the same data (idempotent round-trip).
+    const reextracted = extractFrontmatter(`---\n${reconstructed}\n---`);
+    assert.strictEqual(reextracted['current_phase'], '3');
+  });
+
+  test('#3257: leading (before first key) and trailing (after last key) comments survive', () => {
+    const original = '---\n# top comment\na: 1\nb: 2\n# trailing comment\n---';
+    const extracted = extractFrontmatter(original);
+    const reconstructed = reconstructFrontmatter(extracted);
+    assert.ok(reconstructed.includes('# top comment'), `leading comment lost:\n${reconstructed}`);
+    assert.ok(reconstructed.includes('# trailing comment'), `trailing comment lost:\n${reconstructed}`);
+  });
+
+  test('#3257: multiple consecutive comments survive in order', () => {
+    const original = '---\na: 1\n# first note\n# second note\nb: 2\n---';
+    const extracted = extractFrontmatter(original);
+    const reconstructed = reconstructFrontmatter(extracted);
+    assert.ok(reconstructed.includes('# first note') && reconstructed.includes('# second note'),
+      `consecutive comments lost:\n${reconstructed}`);
+    const aIdx = reconstructed.indexOf('a: 1');
+    const firstIdx = reconstructed.indexOf('# first note');
+    const secondIdx = reconstructed.indexOf('# second note');
+    assert.ok(aIdx < firstIdx && firstIdx < secondIdx, `order wrong (a:${aIdx} first:${firstIdx} second:${secondIdx})`);
+  });
 });
 
 // ─── spliceFrontmatter ──────────────────────────────────────────────────────

--- a/tests/state.test.cjs
+++ b/tests/state.test.cjs
@@ -915,6 +915,39 @@ team: platform
     assert.ok(content.includes('status: executing'), 'schema-owned status still preserved');
   });
 
+  test('#3257: full-line frontmatter comments survive a mutating state verb', () => {
+    // syncStateFrontmatter rebuilds frontmatter via buildStateFrontmatter (fresh object)
+    // + an Object.keys carry-forward. Without propagating the comment channel, the
+    // comment is lost HERE even though the parse→reconstruct pair preserves it in
+    // isolation. This is the e2e path the issue is filed against.
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'STATE.md'),
+      `---
+status: executing
+milestone: v1.0
+# NOTE: current_phase is hand-maintained here while the roadmap is in flux
+current_phase: 3
+---
+
+# Project State
+
+**Current Phase:** 03
+**Current Plan:** 03-02
+`
+    );
+
+    // Any writeStateMd triggers syncStateFrontmatter.
+    runGsdTools('state update "Current Plan" "03-03"', tmpDir);
+
+    const content = fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
+    assert.ok(
+      content.includes('# NOTE: current_phase is hand-maintained here while the roadmap is in flux'),
+      `full-line frontmatter comment must survive a mutating verb; got:\n${content}`,
+    );
+    // The mutation itself still applied.
+    assert.ok(content.includes('03-03'), 'the state update still took effect');
+  });
+
   test('round-trip: write then read via state json', () => {
     fs.writeFileSync(
       path.join(tmpDir, '.planning', 'STATE.md'),


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3257

## What was broken

Any full-line `#` comment in `.planning/STATE.md` frontmatter was silently destroyed on the next mutating state verb (`add-decision` / `begin-phase` / `advance-plan` / `update-progress` / …). `parseYamlRegion` dropped comment lines (no comment channel on the parsed object), and `reconstructFrontmatter` rebuilt from `Object.entries` alone.

## What this fix does (decision A — shared parser pair)

1. **`parseYamlRegion`** captures column-0 `^#` lines and attaches them to the next top-level key (leading) or a trailing slot, via a module-internal **Symbol-keyed channel** (`FULL_LINE_COMMENTS`). The Symbol is invisible to `Object.entries`/`Object.keys`/`JSON.stringify`/`for-in`, so every existing reader is unchanged; the channel is created only when a comment is seen.
2. **`reconstructFrontmatter`** re-emits each key's leading comments before the key, then trailing comments at the end.
3. **`syncStateFrontmatter`** (the actual loss site the issue names) builds a fresh `derivedFm` via `buildStateFrontmatter` + an `Object.keys` carry-forward — both skip the Symbol. So a new exported helper **`propagateCommentChannel(source, target)`** copies the channel onto `derivedFm` before reconstruct (leading filtered to keys still present, so a deleted key's annotation drops with it; trailing preserved).

## Root cause + the layer error the review caught

My first iteration preserved comments through the pair *in isolation* but missed that `syncStateFrontmatter` rebuilds its target object fresh — so STATE.md comments were still lost on the very verbs the issue filed against. The isolated adversarial review flagged this as a **Critical** finding (90%); I added `propagateCommentChannel` + an **e2e test** (a state verb on commented STATE.md) that proves the comment now survives the full path.

## Testing

### How I verified the fix

- **RED proven** at `da73ac1b1` (gsd-test, both lanes): 3 unit tests (the pair: comment between keys, leading+trailing, consecutive) + 1 **e2e test** (state verb on commented STATE.md) all failed on the unfixed code.
- **GREEN** at `2b02b46cd (32676/32676 both lanes, 0 failures — pair + propagation + e2e)` (gsd-test, both lanes): all pass — the pair preserves comments in isolation AND the e2e proves `syncStateFrontmatter` propagates them through its fresh-rebuild.
- Comment-less frontmatter is byte-identical (the channel is only set when a comment is seen); existing data round-trip tests stay green.

### Regression test added?

- [x] Yes — 3 unit tests (pair) + 1 e2e test (state verb → STATE.md comment survives the syncStateFrontmatter rebuild). With the negative space (comment-less unchanged) covered by the existing data round-trip tests.

### Platforms tested

- [x] macOS (local gsd-test dispatch) · [x] Linux (gsd-test linux-node22 + linux-node24) · [ ] Windows (no platform-specific code)

### Runtimes tested

- [x] N/A (pure frontmatter parse/serialize logic)

## Checklist

- [x] Issue linked with `Fixes #3257` · [x] confirmed-bug · [x] scoped (comment channel through the pair + the syncStateFrontmatter propagation) · [x] regression tests (unit + e2e) · [x] all existing tests pass · [x] changeset (`Fixed`) · [x] no new deps

## Breaking changes

None. Comment-less frontmatter parses and reconstructs byte-identically. The only change is that full-line comments now survive instead of being silently dropped. (Scope: column-0 full-line comments; inline `key: value # note` and indented comments inside nested blocks remain out of scope, as in the issue.)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/3387"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789131649&installation_model_id=22188&pr_number=3387&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F3387&signature=a0b5fe9e524bacd57631fece2346c7e4d36c08a97f3c7659676e253e7d995c4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->