### PR TITLE
fix(#3133): keep global Claude @-references on tilde, not $HOME

### DIFF
--- a/.changeset/humble-lemurs-roar.md
+++ b/.changeset/humble-lemurs-roar.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**Global Claude installs load skill content correctly again** — the installer rewrote `@~/.claude/` file references to `@$HOME/.claude/`, which Claude Code does not expand, silently leaving every GSD skill with an empty execution_context (the model got scaffolding but never the workflow body). @-references now stay on the tilde form Claude resolves. (#3133)

--- a/.changeset/humble-lemurs-roar.md
+++ b/.changeset/humble-lemurs-roar.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 3393
 ---
 **Global Claude installs load skill content correctly again** — the installer rewrote `@~/.claude/` file references to `@$HOME/.claude/`, which Claude Code does not expand, silently leaving every GSD skill with an empty execution_context (the model got scaffolding but never the workflow body). @-references now stay on the tilde form Claude resolves. (#3133)

--- a/src/runtime-artifact-conversion.cts
+++ b/src/runtime-artifact-conversion.cts
@@ -2744,6 +2744,18 @@ function _applyRuntimeRewrites(content, runtime, pathPrefix, isGlobal = false, a
       content = content.replace(/~\/\.claude\//g, pathPrefix);
       content = content.replace(/\$HOME\/\.claude\//g, pathPrefix);
       content = content.replace(/\.\/\.claude\//g, `./${dirName}/`);
+      // #3133: Claude Code expands `~` and absolute paths in @-file references
+      // but NOT `$HOME`. computePathPrefix returns the $HOME/.claude/ form for
+      // global installs under $HOME (correct for double-quoted shell commands —
+      // `~` does not expand inside double quotes, causing MODULE_NOT_FOUND,
+      // #1284), so the substitutions above rewrite @~/.claude/… → @$HOME/.claude/…
+      // which silently resolves to nothing and leaves skills with an empty
+      // execution_context. Restore the tilde form Claude expands (the form the
+      // shipped tarball uses). Local installs use an absolute pathPrefix (already
+      // @-resolvable) and are unaffected — the guard fires only for the $HOME form.
+      if (pathPrefix.startsWith('$HOME')) {
+        content = content.replace(/@\$HOME\/\.claude\//g, '@~/.claude/');
+      }
       content = processAttribution(content, attribution);
       break;
 

--- a/tests/path-replacement.test.cjs
+++ b/tests/path-replacement.test.cjs
@@ -541,8 +541,11 @@ describe('#3133: global Claude @-references resolve on tilde, not $HOME', () => 
   });
 
   test('row 9 — global Claude @-ref preserves the full tail path', () => {
+    // Deeper subpath than row 1 — ensures the @-ref normalization does not
+    // truncate the tail. (No `$` anchor: a realistic @-ref line ends with `\n`.)
     const src = '@~/.claude/gsd-core/references/ui-brand.md\n';
     const out = _applyRuntimeRewrites(src, 'claude', globalClaudePrefix, true, undefined);
-    assert.match(out, /@~\/\.claude\/gsd-core\/references\/ui-brand\.md$/, `tail must be intact; got:\n${out}`);
+    assert.match(out, /@~\/\.claude\/gsd-core\/references\/ui-brand\.md/, `tail must be intact; got:\n${out}`);
+    assert.doesNotMatch(out, /@\$HOME/, `no @$HOME; got:\n${out}`);
   });
 });

--- a/tests/path-replacement.test.cjs
+++ b/tests/path-replacement.test.cjs
@@ -438,3 +438,111 @@ describe('bug-2831: OpenCode pathPrefix uses absolute path on all platforms', ()
 });
   });
 }
+
+
+// ────────────────────────────────────────────────────────────────────────
+// #3133: global Claude @-references must resolve (tilde), not $HOME.
+//
+// Claude Code expands `~` and absolute paths in @-file references but NOT
+// `$HOME`. computePathPrefix returns `$HOME/.claude/` for global installs
+// (correct for double-quoted shell commands — `~` does not expand inside
+// double quotes, #1284), so context-blind substitution rewrote every
+// `@~/.claude/…` include to `@$HOME/.claude/…`, which silently resolves to
+// nothing — skills load with an empty <execution_context>. OpenCode already
+// has an absolute-path carve-out for the identical limitation (#2376/#2831);
+// Claude is not special. Fix: in the `claude` rewrite case, restore the
+// tilde form for @-references when the prefix is the $HOME (global) form.
+// ────────────────────────────────────────────────────────────────────────
+describe('#3133: global Claude @-references resolve on tilde, not $HOME', () => {
+  // Re-require to also pull _applyRuntimeRewrites (module is cached under GSD_TEST_MODE).
+  const conv = require('../gsd-core/bin/lib/runtime-artifact-conversion.cjs');
+  const _computePathPrefix = conv._computePathPrefix;
+  const _applyRuntimeRewrites = conv._applyRuntimeRewrites;
+
+  const homeDir = os.homedir().replace(/\\/g, '/');
+  const isWin = process.platform === 'win32';
+  const globalClaudePrefix = _computePathPrefix({
+    isGlobal: true, isOpencode: false, isWindowsHost: isWin,
+    resolvedTarget: homeDir + '/.claude', homeDir,
+  });
+  // Sanity: the global claude prefix IS the $HOME form (the precondition for the bug).
+  assert.ok(globalClaudePrefix.startsWith('$HOME/'), `expected $HOME prefix, got ${globalClaudePrefix}`);
+
+  test('row 1 — global Claude @-reference stays on tilde (resolves), not $HOME', () => {
+    const src = '---\nname: gsd-stats\n---\n<execution_context>\n@~/.claude/gsd-core/workflows/stats.md\n</execution_context>\n';
+    const out = _applyRuntimeRewrites(src, 'claude', globalClaudePrefix, true, undefined);
+    assert.match(out, /@~\/\.claude\/gsd-core\/workflows\/stats\.md/, `@-ref must stay on tilde; got:\n${out}`);
+    assert.doesNotMatch(out, /@\$HOME/, `must not emit @$HOME (Claude does not expand it); got:\n${out}`);
+  });
+
+  test('row 2 — global Claude normalizes an @$HOME source reference to @~', () => {
+    // Source may already carry @$HOME (e.g. a prior bad render); it must end on @~.
+    const src = '<execution_context>\n@$HOME/.claude/gsd-core/references/ui-brand.md\n</execution_context>\n';
+    const out = _applyRuntimeRewrites(src, 'claude', globalClaudePrefix, true, undefined);
+    assert.match(out, /@~\/\.claude\/gsd-core\/references\/ui-brand\.md/, `@$HOME source must normalize to @~; got:\n${out}`);
+    assert.doesNotMatch(out, /@\$HOME/, `no @$HOME may remain; got:\n${out}`);
+  });
+
+  test('row 3 — global Claude shell contexts keep $HOME (#1284 preserved)', () => {
+    // `~` does NOT expand inside double quotes; $HOME does. Shell commands must stay $HOME.
+    const src = 'Run: node "$HOME/.claude/gsd-core/bin/gsd-tools.cjs" query state\n';
+    const out = _applyRuntimeRewrites(src, 'claude', globalClaudePrefix, true, undefined);
+    assert.match(out, /node "\$HOME\/\.claude\/gsd-core\/bin\/gsd-tools\.cjs"/, `shell $HOME must be preserved; got:\n${out}`);
+    assert.doesNotMatch(out, /node "~\//, `must not introduce quoted-tilde (re-introduces #1284); got:\n${out}`);
+  });
+
+  test('row 4 — global Claude bare ~/ shell (unquoted) becomes $HOME', () => {
+    const src = 'cat ~/.claude/gsd-core/VERSION\n';
+    const out = _applyRuntimeRewrites(src, 'claude', globalClaudePrefix, true, undefined);
+    assert.match(out, /cat \$HOME\/\.claude\/gsd-core\/VERSION/, `unquoted ~/ shell must become $HOME; got:\n${out}`);
+  });
+
+  test('row 5 — local Claude @-reference rewrites to the absolute target', () => {
+    // Local install is NOT under $HOME/.claude; @~/ would point at global home.
+    // pathPrefix is absolute; @-refs must follow it (Claude resolves absolute).
+    const localPrefix = _computePathPrefix({
+      isGlobal: false, isOpencode: false, isWindowsHost: isWin,
+      resolvedTarget: '/abs/projects/foo/.claude', homeDir,
+    });
+    assert.ok(!localPrefix.startsWith('$HOME'), `local prefix must be absolute, got ${localPrefix}`);
+    const src = '<execution_context>\n@~/.claude/gsd-core/workflows/stats.md\n</execution_context>\n';
+    const out = _applyRuntimeRewrites(src, 'claude', localPrefix, false, undefined);
+    assert.match(out, /@\/abs\/projects\/foo\/\.claude\/gsd-core\/workflows\/stats\.md/, `local @-ref must rewrite to absolute target; got:\n${out}`);
+    assert.doesNotMatch(out, /@~\/\.claude/, `local @-ref must not stay on global ~/; got:\n${out}`);
+  });
+
+  test('row 6 — global Claude @-ref normalization is idempotent (re-surface safe)', () => {
+    const src = '<execution_context>\n@~/.claude/gsd-core/workflows/stats.md\n</execution_context>\n';
+    const once = _applyRuntimeRewrites(src, 'claude', globalClaudePrefix, true, undefined);
+    const twice = _applyRuntimeRewrites(once, 'claude', globalClaudePrefix, true, undefined);
+    assert.equal(twice, once, `re-running the rewrite must be stable (idempotent)`);
+    assert.doesNotMatch(twice, /@\$HOME/, `no @$HOME after 2nd pass; got:\n${twice}`);
+  });
+
+  test('row 7 — global Claude emits no resolved homedir literal (#3503 preserved)', () => {
+    const src = '<execution_context>\n@~/.claude/gsd-core/workflows/stats.md\n</execution_context>\nnode "$HOME/.claude/gsd-core/bin/gsd-tools.cjs"\n';
+    const out = _applyRuntimeRewrites(src, 'claude', globalClaudePrefix, true, undefined);
+    // A real homedir leak is followed by a path separator (#3503 trailing-slash rule).
+    assert.ok(!out.includes(homeDir + '/'), `must not leak resolved homedir ${homeDir}/; got:\n${out}`);
+  });
+
+  test('row 8 — non-Claude runtime (codex) is unaffected by the claude @-ref fix', () => {
+    // The claude normalization targets @$HOME/.claude/; codex rewrites to .codex/,
+    // so its output must be byte-identical to pre-fix (no @~/.claude/ restoration).
+    const codexPrefix = _computePathPrefix({
+      isGlobal: true, isOpencode: false, isWindowsHost: isWin,
+      resolvedTarget: homeDir + '/.codex', homeDir,
+    });
+    const src = '<execution_context>\n@~/.claude/gsd-core/workflows/stats.md\n</execution_context>\n';
+    const out = _applyRuntimeRewrites(src, 'codex', codexPrefix, true, undefined);
+    // Codex rewrites .claude -> .codex; the @-ref must NOT have been restored to @~/.claude/.
+    assert.doesNotMatch(out, /@~\/\.claude\//, `codex must not get the claude @~/.claude restoration; got:\n${out}`);
+    assert.match(out, /@\$HOME\/\.codex\/gsd-core\/workflows\/stats\.md/, `codex keeps its own rewrite; got:\n${out}`);
+  });
+
+  test('row 9 — global Claude @-ref preserves the full tail path', () => {
+    const src = '@~/.claude/gsd-core/references/ui-brand.md\n';
+    const out = _applyRuntimeRewrites(src, 'claude', globalClaudePrefix, true, undefined);
+    assert.match(out, /@~\/\.claude\/gsd-core\/references\/ui-brand\.md$/, `tail must be intact; got:\n${out}`);
+  });
+});


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3133

> #3133 carries the `confirmed-bug` label.

---

## What was broken

On a **global Claude install**, the installer rewrote every `@~/.claude/…` file-reference in skill markdown to `@$HOME/.claude/…`. Claude Code expands `~` and absolute paths in `@`-file references but **not** `$HOME`, so each rewritten include silently resolved to nothing — skills loaded with an empty `<execution_context>` (the model got the objective scaffolding but never the workflow body it was supposed to execute). No error was emitted.

## What this fix does

In the `claude` case of `_applyRuntimeRewrites` (`src/runtime-artifact-conversion.cts`), after the existing substitutions, add one conditional normalization: when the path prefix is the `$HOME` (global-under-home) form, restore `@$HOME/.claude/` → `@~/.claude/` (the tilde form Claude expands and the form the shipped tarball uses). `computePathPrefix` is untouched.

## Root cause

`computePathPrefix` returns `$HOME/.claude/` for global installs under `$HOME` — the **correct** prefix for shell contexts, because `~` does not expand inside double-quoted shell commands (`MODULE_NOT_FOUND`, #1284). That single prefix was substituted **context-blindly** into `@`-references too, where the expansion rules are inverted. OpenCode already had an absolute-path carve-out (#2376/#2831) for the identical limitation; Claude Code has the same limitation and was simply the first runtime where it went unnoticed at scale. The shipped tarball uses the working `@~/` form; the installer converted it to the broken `@$HOME/` form.

## Testing

### How I verified the fix

- Reproduced the defect against the real `_applyRuntimeRewrites` (global Claude pathPrefix) — output was `@$HOME/.claude/…` (broken).
- Added 9-row regression suite in `tests/path-replacement.test.cjs` exercising `_applyRuntimeRewrites` directly.
- TDD: committed the test first, proved RED under `gsd-test` on `next` (rows 1/2/6/9 failed exactly as predicted; negative guards passed), then applied the fix.
- `gsd-test --base next --head <sha>` → `outcome:"passed"`, 32691/32691, 0 failures on linux-node22 + linux-node24. (Re-verified on the rebased HEAD after `next` advanced.)

### Regression test added?

- [x] Yes — `tests/path-replacement.test.cjs` → `#3133: global Claude @-references resolve on tilde, not $HOME` (9 rows). Rows 1/2/6/9 fail on `next` and pass after the fix; rows 3/4 guard #1284 (shell `$HOME` preserved); row 5 guards local installs (absolute redirect); row 7 guards the #3503 no-resolved-homedir-leak invariant; row 8 guards non-Claude isolation (codex untouched); row 6 guards idempotency.

### Platforms tested

- [x] Linux (gsd-test matrix: linux-node22, linux-node24)
- [ ] macOS
- [ ] Windows (including backslash path handling)

The fix is pure POSIX-form string normalization on `.claude/` literals that `computePathPrefix` already normalized (`#1615`); it does not touch any platform-specific path handling. `computePathPrefix`'s existing Windows backslash normalization and the existing Windows-style `computePathPrefix` tests are unchanged.

### Runtimes tested

- [x] Claude Code (the affected runtime; fix is scoped to the `claude` rewrite case)

---

## Checklist

- [x] Issue linked above with `Fixes #3133`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — one 3-line guard + comment in the `claude` case; no unrelated changes
- [x] Regression test added
- [x] All existing tests pass (`gsd-test` green, 32691/32691)
- [x] `.changeset/` fragment added (`Fixed`, user-visible)
- [x] No unnecessary dependencies added

## Reviews

- `/code-review` (Standards + Spec axes, parallel sub-agents): clean — no hard standard violations; faithfully meets the #3133 spec, preserves #1284. Two non-blocking pre-existing judgement-call smells noted (repeated-switch idiom; primitive-typed pathPrefix) — both match the file's established idiom and are out of scope.
- Security review (graph-backed YAML security rule pack + dedicated security subagent): no surface — `pathPrefix` is install-derived; pattern + replacement are static literals; no injection/ReDoS/secret/traversal/subprocess/prompt-injection surface.
- Isolated adversarial review (fresh subagent, not the author context): APPROVE. One non-blocking note: a custom global config dir like `~/.config/claude` would still be unresolvable — pre-existing (byte-identical to before), out of scope for #3133's default `~/.claude` install.
- Memtrace graph pass (`find_code_review_issues`, strict, fresh graph): 0 issues.

## Breaking changes

None. The fix restores the documented/shipped behavior (skill `@`-references resolve on global Claude installs). `computePathPrefix` output is unchanged, so shell contexts and every other runtime are byte-identical.

---

`GSD_PR_GATES_OK=1` — `/code-review`, security review, and `npm run lint:ci` ran; every finding is addressed (the only `lint:ci` discrepancy is a pre-existing inventory-manifest drift on `next`, reproduced identically on `origin/next` and unrelated to this change — CI `lint-tests` is green on `next` per recent merges #3386/#3387).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/3393"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789165159&installation_model_id=22188&pr_number=3393&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F3393&signature=5ae5ec0fe39057237c2a0aa8b598fc68c07a2e48f6a3846064171a6e4f94eeef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->