### PR TITLE
fix(#3321): exclude .claude/.planning from no-phantom-issue-refs SKIP_DIRS

### DIFF
--- a/tests/no-phantom-issue-refs.test.cjs
+++ b/tests/no-phantom-issue-refs.test.cjs
@@ -131,6 +131,45 @@ test('walk() skips broken symlinks and does not throw ENOENT (#1545)', (t) => {
   }
 });
 
+test('walk() does not scan ambient .claude/.planning content (#3321)', (t) => {
+  const fixture = fs.mkdtempSync(path.join(os.tmpdir(), 'nophantom-ambient-'));
+  try {
+    fs.writeFileSync(path.join(fixture, 'real.md'), '# real, no phantom refs\n');
+
+    const claudeDir = path.join(fixture, '.claude', 'worktrees', 'some-agent-worktree');
+    fs.mkdirSync(claudeDir, { recursive: true });
+    fs.writeFileSync(path.join(claudeDir, 'offender.md'), '#94729 sentinel phantom ref\n');
+
+    const planningDir = path.join(fixture, '.planning', 'notes');
+    fs.mkdirSync(planningDir, { recursive: true });
+    fs.writeFileSync(path.join(planningDir, 'offender.md'), '#94729 sentinel phantom ref\n');
+
+    const found = walk(fixture, []).map((f) => path.relative(fixture, f));
+
+    assert.ok(found.includes('real.md'), 'walk() must still include real.md at fixture root');
+    assert.ok(
+      !found.some((f) => f.startsWith('.claude' + path.sep)),
+      'walk() must NOT descend into .claude/',
+    );
+    assert.ok(
+      !found.some((f) => f.startsWith('.planning' + path.sep)),
+      'walk() must NOT descend into .planning/',
+    );
+
+    // Prove the offending content WOULD have matched if scanned -- i.e. this isn't a vacuous
+    // "no file happened to match" pass. Use a test-local sentinel, never the module PHANTOM.
+    const sentinelRe = buildRefRe(['94729']);
+    const offenderContent = fs.readFileSync(path.join(claudeDir, 'offender.md'), 'utf8');
+    assert.ok(
+      sentinelRe.test(offenderContent),
+      'sanity: sentinel ref pattern must actually match the offender content',
+    );
+  } finally {
+    // eslint-disable-next-line local/no-raw-rmsync-in-tests -- local cleanup in standalone guard test; no helpers import available (would introduce a test-dep cycle)
+    fs.rmSync(fixture, { recursive: true, force: true });
+  }
+});
+
 test('buildRefRe() boundaries — empty list is inert, single/double entries match exactly', () => {
   assert.strictEqual(buildRefRe([]), null, 'empty list must build no regex');
 

--- a/tests/no-phantom-issue-refs.test.cjs
+++ b/tests/no-phantom-issue-refs.test.cjs
@@ -53,7 +53,7 @@ function buildRefRe(phantom) {
 const REF_RE = buildRefRe(PHANTOM);
 
 const SCAN_EXT = new Set(['.md', '.cjs', '.js', '.cts', '.ts']);
-const SKIP_DIRS = new Set(['node_modules', '.git', 'dist', 'coverage', '.changeset']);
+const SKIP_DIRS = new Set(['node_modules', '.git', 'dist', 'coverage', '.changeset', '.claude', '.planning']);
 // This guard file itself names the phantom numbers (by necessity); exclude it.
 const SELF = path.relative(ROOT, __filename);
 
@@ -131,7 +131,7 @@ test('walk() skips broken symlinks and does not throw ENOENT (#1545)', (t) => {
   }
 });
 
-test('walk() does not scan ambient .claude/.planning content (#3321)', (t) => {
+test('walk() does not scan ambient .claude/.planning content (#3321)', () => {
   const fixture = fs.mkdtempSync(path.join(os.tmpdir(), 'nophantom-ambient-'));
   try {
     fs.writeFileSync(path.join(fixture, 'real.md'), '# real, no phantom refs\n');


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3321

---

## What was broken

`tests/no-phantom-issue-refs.test.cjs`'s `SKIP_DIRS` did not exclude `.claude` or `.planning` — the two directories where this repo's own agent tooling writes ambient, developer-local, gitignored state (worktrees, session artifacts). Currently dormant (the guard's `PHANTOM` list is empty, so the main test short-circuits via `t.skip()` before `walk()` ever runs), but the next time `PHANTOM` is repopulated, `walk()` would descend into `.claude/worktrees/**` — which can hold thousands of files across concurrent agent worktrees — making the guard's pass/fail depend on the developer's local worktree layout rather than the shipped, committed tree.

## What this fix does

Adds `.claude` and `.planning` to `SKIP_DIRS` (`tests/no-phantom-issue-refs.test.cjs:56`).

## Root cause

`SKIP_DIRS`'s original set (`node_modules`, `.git`, `dist`, `coverage`, `.changeset`) predates `.claude`/`.planning` becoming part of this repo's own agent-tooling surface; the guard's skip-list never grew to match. This is the live continuation of #1885 (F23).

## Testing

### How I verified the fix

- Added a failing-first regression test (`walk() does not scan ambient .claude/.planning content (#3321)`) that seeds a fixture with offending content under both `.claude/worktrees/<name>/` and `.planning/notes/`, using a test-local sentinel ref pattern (never the module's own `PHANTOM` array), and asserts `walk()` does not descend into either while still finding a legitimate file at the fixture root.
- Confirmed RED: `gsd-test` on commit `2e66fec27` — 1 unique failure (the new test), both Linux Node lanes, nothing else broke.
- Confirmed GREEN: `gsd-test` on commit `c4b05188a` — 32692/32692 passed, both lanes.
- Two orthogonal reviews (Standards+Spec code-review, isolated security-review) plus a Memtrace graph pass (`find_code_review_issues`, `find_cross_module_issues`, `find_yaml_rule_matches`) — 0 issues. One Standards-axis finding (possible sibling defect in `scripts/affected-tests-lib.cjs:listTestFiles`) investigated and closed as not-a-defect: that walker's root is `<repoRoot>/tests`, never repo root, so `.claude`/`.planning` (which live at repo root) are structurally unreachable there regardless of any skip-list.

### Regression test added?

- [x] Yes — added a test that would have caught this bug (proven RED before the fix, GREEN after)

### Platforms tested

- [x] N/A (not platform-specific — pure directory-name skip-list addition + Node fs-based test)

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass (verified via `gsd-test`, not local `npm test`)
- [x] `no-changelog` label applied — issue's own Done-when requires "No change to user-facing behavior"; this is a test-infra-only guard

## Breaking changes

None.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/3396"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789170859&installation_model_id=22188&pr_number=3396&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F3396&signature=377183644c7f795a973b2d76002608d6ec7adbdc54b1771116a8b45c66a3fb92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->