### PR TITLE
fix(#3163): scope phase.add insertion to the current milestone

### DIFF
--- a/.changeset/daring-koalas-zip.md
+++ b/.changeset/daring-koalas-zip.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 3400
 ---
 **`phase add` no longer files new phases inside archived roadmap history** — the insertion point used the file's last horizontal rule, which on a long roadmap sits deep in shipped/archive content, so new phases landed under an unrelated archived phase's heading instead of at the end of the active phase list. Insertion is now scoped to the current milestone. (#3163)

--- a/.changeset/daring-koalas-zip.md
+++ b/.changeset/daring-koalas-zip.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`phase add` no longer files new phases inside archived roadmap history** — the insertion point used the file's last horizontal rule, which on a long roadmap sits deep in shipped/archive content, so new phases landed under an unrelated archived phase's heading instead of at the end of the active phase list. Insertion is now scoped to the current milestone. (#3163)

--- a/src/phase.cts
+++ b/src/phase.cts
@@ -982,6 +982,27 @@ function describeGoalShapedTitle(description: string): string | null {
   );
 }
 
+/**
+ * #3163: compute the byte offset in `rawContent` where a new `### Phase N:`
+ * entry should be inserted — at the end of the active phase list, scoped to the
+ * CURRENT MILESTONE so the entry can never land before a trailing `---` in
+ * shipped/history/backlog material (the file's last `---` on a long roadmap
+ * sits deep in archive). When no current milestone can be resolved (no
+ * STATE.md `milestone:` and no in-progress `🚧`/`🔄` marker), fall back to the
+ * legacy whole-file lastIndexOf('\n---') so simple no-milestone roadmaps keep
+ * their existing behavior.
+ */
+function phaseEntryInsertOffset(rawContent: string, cwd: string): number {
+  const ranges = currentMilestoneRawRanges(rawContent, cwd);
+  if (!ranges) {
+    const legacy = rawContent.lastIndexOf('\n---');
+    return legacy > 0 ? legacy : rawContent.length;
+  }
+  const window = rawContent.slice(ranges.primary.start, ranges.primary.end);
+  const lastSeparator = window.lastIndexOf('\n---');
+  return lastSeparator > 0 ? ranges.primary.start + lastSeparator : ranges.primary.end;
+}
+
 function cmdPhaseAdd(cwd: string, description: string, raw: boolean, customId?: string): void {
   if (!description) {
     error('description required for phase add');
@@ -1072,13 +1093,8 @@ function cmdPhaseAdd(cwd: string, description: string, raw: boolean, customId?: 
     const phaseEntry =
       `\n### Phase ${_newPhaseId}: ${description}\n\n**Goal:** [To be planned]\n**Requirements**: TBD${dependsOn}\n**Plans:** 0 plans\n\nPlans:\n- [ ] TBD (run ${formatGsdSlash('plan-phase', resolveRuntime(cwd)) as string} ${_newPhaseId} to break down)\n`;
 
-    let updatedContent: string;
-    const lastSeparator = rawContent.lastIndexOf('\n---');
-    if (lastSeparator > 0) {
-      updatedContent = rawContent.slice(0, lastSeparator) + phaseEntry + rawContent.slice(lastSeparator);
-    } else {
-      updatedContent = rawContent + phaseEntry;
-    }
+    const insertAt = phaseEntryInsertOffset(rawContent, cwd);
+    const updatedContent = rawContent.slice(0, insertAt) + phaseEntry + rawContent.slice(insertAt);
 
     platformWriteSync(roadmapPath, updatedContent);
     return { newPhaseId: _newPhaseId, dirName: _dirName };
@@ -1163,11 +1179,8 @@ function cmdPhaseAddBatch(cwd: string, descriptions: string[], raw: boolean): vo
           : `\n**Depends on:** Phase ${typeof newPhaseId === 'number' ? newPhaseId - 1 : 'TBD'}`;
       const phaseEntry =
         `\n### Phase ${newPhaseId}: ${description}\n\n**Goal:** [To be planned]\n**Requirements**: TBD${dependsOn}\n**Plans:** 0 plans\n\nPlans:\n- [ ] TBD (run ${formatGsdSlash('plan-phase', resolveRuntime(cwd)) as string} ${newPhaseId} to break down)\n`;
-      const lastSeparator = rawContent.lastIndexOf('\n---');
-      rawContent =
-        lastSeparator > 0
-          ? rawContent.slice(0, lastSeparator) + phaseEntry + rawContent.slice(lastSeparator)
-          : rawContent + phaseEntry;
+      const insertAt = phaseEntryInsertOffset(rawContent, cwd);
+      rawContent = rawContent.slice(0, insertAt) + phaseEntry + rawContent.slice(insertAt);
       added.push({
         phase_number: typeof newPhaseId === 'number' ? newPhaseId : String(newPhaseId),
         padded:

--- a/tests/phase.test.cjs
+++ b/tests/phase.test.cjs
@@ -1627,6 +1627,109 @@ describe('phase add command', () => {
 // phase add — orphan directory collision prevention (#2026)
 // ─────────────────────────────────────────────────────────────────────────────
 
+describe('#3163: phase add inserts in the active milestone phase list, not the trailing archive', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempProject();
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  // Fixture: a v1.0 ACTIVE milestone with a phase list, followed by a shipped
+  // v0.9 archive whose own `---` is the FILE's last `---`. The bug places the
+  // new phase before that archive `---`; the fix scopes to v1.0's window.
+  function writeArchiveRoadmap(dir, { singlePhase = false } = {}) {
+    fs.writeFileSync(
+      path.join(dir, '.planning', 'STATE.md'),
+      'milestone: v1.0\ncurrent_phase: 2\n'
+    );
+    const phases = singlePhase
+      ? '### Phase 1: Foundation\n**Goal:** setup\n'
+      : '### Phase 1: Foundation\n**Goal:** setup\n\n### Phase 2: API\n**Goal:** build\n';
+    fs.writeFileSync(
+      path.join(dir, '.planning', 'ROADMAP.md'),
+      '# Roadmap\n\n## v1.0: Active Milestone\n\n' +
+        phases +
+        '\n---\n\n## v0.9: Shipped Archive\n\n### Phase 0 (original scope): Bootstrap\n**Goal:** init\n\n#### Operator decisions\n- decided X\n\n---\n'
+    );
+  }
+
+  test('row 1 — phase add lands in the active milestone, before the archive', () => {
+    writeArchiveRoadmap(tmpDir);
+    const result = runGsdTools('phase add New Feature', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const roadmap = fs.readFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), 'utf-8');
+    const phase3 = roadmap.indexOf('### Phase 3: New Feature');
+    const phase2 = roadmap.indexOf('### Phase 2: API');
+    const archive = roadmap.indexOf('## v0.9: Shipped Archive');
+    assert.notStrictEqual(phase3, -1, 'new phase entry should exist in the roadmap');
+    assert.ok(phase2 > -1 && phase2 < phase3, `Phase 3 must come after Phase 2; got p2@${phase2} p3@${phase3}`);
+    assert.ok(
+      phase3 < archive,
+      `#3163: Phase 3 must land INSIDE the active v1.0 milestone (before the v0.9 archive), not before the file's last \`---\`; got phase3@${phase3} archive@${archive}`
+    );
+  });
+
+  test('row 2 — phase add-batch is also scoped to the active milestone', () => {
+    writeArchiveRoadmap(tmpDir);
+    const result = runGsdTools(
+      ['phase', 'add-batch', '--descriptions', '["First Add","Second Add"]'],
+      tmpDir
+    );
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const roadmap = fs.readFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), 'utf-8');
+    const archive = roadmap.indexOf('## v0.9: Shipped Archive');
+    for (const [num, title] of [['3', 'First Add'], ['4', 'Second Add']]) {
+      const at = roadmap.indexOf(`### Phase ${num}: ${title}`);
+      assert.notStrictEqual(at, -1, `Phase ${num} (${title}) should exist`);
+      assert.ok(
+        at < archive,
+        `#3163: Phase ${num} must land before the archive; got @${at} archive@${archive}`
+      );
+    }
+  });
+
+  test('row 3 — no-milestone fallback keeps legacy insertion before the trailing ---', () => {
+    // No STATE.md milestone field and no WIP marker → currentMilestoneRawRanges
+    // returns null → the legacy whole-file lastIndexOf('\n---') path is used.
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      '# Roadmap\n\n### Phase 1: Foundation\n**Goal:** setup\n\n---\n'
+    );
+    const result = runGsdTools('phase add Next Phase', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const roadmap = fs.readFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), 'utf-8');
+    const phase2 = roadmap.indexOf('### Phase 2: Next Phase');
+    const sep = roadmap.indexOf('\n---');
+    assert.notStrictEqual(phase2, -1, 'Phase 2 should exist');
+    assert.ok(
+      phase2 < sep,
+      `no-milestone fallback must preserve legacy placement (before the trailing ---); got phase2@${phase2} sep@${sep}`
+    );
+  });
+
+  test('row 4 — single-phase milestone still scopes to the active window', () => {
+    writeArchiveRoadmap(tmpDir, { singlePhase: true });
+    const result = runGsdTools('phase add Second Phase', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const roadmap = fs.readFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), 'utf-8');
+    const phase2 = roadmap.indexOf('### Phase 2: Second Phase');
+    const archive = roadmap.indexOf('## v0.9: Shipped Archive');
+    assert.notStrictEqual(phase2, -1, 'Phase 2 should exist');
+    assert.ok(
+      phase2 < archive,
+      `Phase 2 must land inside the single-phase v1.0 window, before the archive; got @${phase2} archive@${archive}`
+    );
+  });
+});
+
 describe('phase add — orphan directory collision prevention (#2026)', () => {
   let tmpDir;
 


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3163

> #3163 carries the `confirmed-bug` label.

---

## What was broken

`phase add` (and `phase add-batch`) picked the roadmap insertion point via `rawContent.lastIndexOf('\n---')` — the file's LAST horizontal rule. On any roadmap that keeps shipped milestones / history / backlog after the active phase list, that rule sits deep in trailing archive, so the new `### Phase N:` entry was filed under an unrelated archived phase's heading (e.g. inside an archived phase's "Operator decisions"), nowhere near the active phase list. Deterministic; a pure function of where the last `---` sits.

## What this fix does

Extract `phaseEntryInsertOffset(rawContent, cwd)` and route both `cmdPhaseAdd` and `cmdPhaseAddBatch` through it. It scopes the `lastIndexOf('\n---')` search to the current milestone's raw byte range (`currentMilestoneRawRanges`), so the entry lands at the end of the active phase list and can never reach trailing archive. When no current milestone can be resolved (no STATE.md `milestone:` and no `🚧`/`🔄` marker), it falls back to the legacy whole-file heuristic so simple no-milestone roadmaps keep their existing behavior. The phase number / slug / directory logic and the (already-correct, header-anchored) decimal-insert path are untouched.

## Root cause

`---` is a horizontal rule, not a phase-list terminator. The insertion was the one part of these functions that wasn't milestone-aware — every other part (`extractCurrentMilestone`, the sentinel-999 filter, the on-disk dir scan) already was.

## Testing

### How I verified the fix

- Reproduced the defect: a `currentMilestoneRawRanges` probe showed the file's last `---` at offset 236 (inside the v0.9 archive) vs the milestone window's last `---` at offset 112 (the phase-list terminator) — so the old code placed the entry at 236, the fix at 112.
- Added a 4-row regression suite in `tests/phase.test.cjs` exercising the real `phase add` / `phase add-batch` CLI.
- `gsd-test --base next --head <sha>` → `outcome:"passed"`, 0 failures on linux-node22 + linux-node24 (re-verified on the rebased HEAD after `next` advanced).

### Regression test added?

- [x] Yes — `tests/phase.test.cjs` → `#3163: phase add inserts in the active milestone phase list, not the trailing archive` (4 rows): row 1 the archive case for `add`; row 2 the same for `add-batch`; row 3 the no-milestone legacy fallback; row 4 a single-phase milestone window.

### Platforms tested

- [x] Linux (gsd-test matrix: linux-node22, linux-node24)
- [ ] macOS
- [ ] Windows

Pure string-offset computation over ROADMAP text; no platform-specific behavior.

### Runtimes tested

- [x] N/A (not runtime-specific — CLI roadmap mutation)

---

## Checklist

- [x] Issue linked above with `Fixes #3163`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — one helper + two call sites; number/slug/dir logic and the decimal path untouched
- [x] Regression test added
- [x] All existing tests pass (`gsd-test` green, 0 failures)
- [x] `.changeset/` fragment added (`Fixed`, user-visible)
- [x] No unnecessary dependencies added

## Reviews

- `/code-review` (Standards + Spec, parallel sub-agents): clean — no standard violations; the PR *removes* a Duplicated Code smell. Spec-compliant (fix #2 as specified; `currentMilestoneRawRanges` is a strictly-better offset-remapping primitive than `extractCurrentMilestone`).
- Security review (graph-backed YAML rule pack + dedicated subagent): no surface — pure string offsets over locally-authored content.
- Isolated adversarial review (fresh subagent): APPROVE — offset arithmetic, fallback byte-identity, CRLF, and the batch accumulation loop all verified.
- Memtrace graph pass (`find_code_review_issues`, strict, fresh graph): 0 issues.

## Breaking changes

None. The no-milestone fallback preserves the legacy whole-file `lastIndexOf('\n---')` behavior byte-for-byte, so simple roadmaps (the existing tests' path) are unaffected. Only milestone-scoped roadmaps with trailing archive get the corrected placement.

---

`GSD_PR_GATES_OK=1` — `/code-review`, security review, and `npm run lint:ci` ran; every finding is addressed. (The explicit RED `gsd-test` run on the test-only commit was reaped by shared-bench contention; RED is instead evidenced by the `currentMilestoneRawRanges` offset probe — old insert at byte 236 inside the archive vs corrected insert at byte 112 in the phase list — and the GREEN run on the fixed commit.)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-gsd/codesmith/gsd-core/pr/3400"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789173680&installation_model_id=22188&pr_number=3400&repository=open-gsd%2Fgsd-core&return_to=https%3A%2F%2Fgithub.com%2Fopen-gsd%2Fgsd-core%2Fpull%2F3400&signature=3ba4f884bf46cbb324891c51a0f7c730f5acde4af2ee74c44a387c14d371dc56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->