### PR TITLE
fix(#3171): init execute-phase emits display name, not directory slug

### DIFF
--- a/.changeset/bold-jaguars-run.md
+++ b/.changeset/bold-jaguars-run.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`init execute-phase` no longer hands a directory slug to the phase-start flow as the phase display name.** When a phase's working directory already exists on disk, the disk-lookup path derived `phase_name` from the directory-name remainder — itself an already-slugified value (`phase.add` writes `${num}-${slug}` dirs) — so `phase_name` and `phase_slug` came out byte-identical. The execute-phase workflow forwards `phase_name` into `state begin-phase --name`, which wrote that raw slug into STATE.md's `current_phase_name` on every phase start (`loop-termination-and-baseline-correctness` instead of `Loop-Termination and Baseline Correctness`). `init execute-phase` now prefers the ROADMAP's curated display name (`### Phase N: <Name>`) for `phase_name`, matching the no-disk fallback path that already did this correctly; `phase_slug` is unchanged so branch-name construction is unaffected. The `state begin-phase` override mechanism (#2821/#2736) is untouched. (#3171)

--- a/.changeset/bold-jaguars-run.md
+++ b/.changeset/bold-jaguars-run.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 3429
 ---
 **`init execute-phase` no longer hands a directory slug to the phase-start flow as the phase display name.** When a phase's working directory already exists on disk, the disk-lookup path derived `phase_name` from the directory-name remainder — itself an already-slugified value (`phase.add` writes `${num}-${slug}` dirs) — so `phase_name` and `phase_slug` came out byte-identical. The execute-phase workflow forwards `phase_name` into `state begin-phase --name`, which wrote that raw slug into STATE.md's `current_phase_name` on every phase start (`loop-termination-and-baseline-correctness` instead of `Loop-Termination and Baseline Correctness`). `init execute-phase` now prefers the ROADMAP's curated display name (`### Phase N: <Name>`) for `phase_name`, matching the no-disk fallback path that already did this correctly; `phase_slug` is unchanged so branch-name construction is unaffected. The `state begin-phase` override mechanism (#2821/#2736) is untouched. (#3171)

--- a/src/init.cts
+++ b/src/init.cts
@@ -910,7 +910,17 @@ function cmdInitExecutePhase(
       ? toPosixPath(path.join(cwd, phaseInfo['directory'] as string))
       : null,
     phase_number: phaseInfo?.['phase_number'] || null,
-    phase_name: phaseInfo?.['phase_name'] || null,
+    // #3171: prefer the ROADMAP's curated display name for `phase_name`. When
+    // the phase directory already exists on disk, the disk-lookup path
+    // (searchPhaseInDir) derives phase_name from the directory-name remainder
+    // — itself an already-slugified value (`phase.add` writes `${num}-${slug}`
+    // dirs), so phase_name and phase_slug come out byte-identical. An
+    // orchestrator wiring this field into `state begin-phase --name` then
+    // lands a raw slug in STATE.md's current_phase_name. The ROADMAP carries
+    // the human-curated display name (`### Phase N: <Name>`); prefer it,
+    // matching the no-disk fallback above. phase_slug stays disk-derived — it
+    // correctly feeds branch-name construction below and is unchanged here.
+    phase_name: (roadmapPhase?.['phase_name']) || (phaseInfo?.['phase_name']) || null,
     phase_slug: phaseInfo?.['phase_slug'] || null,
     phase_req_ids,
 

--- a/tests/init.test.cjs
+++ b/tests/init.test.cjs
@@ -7,7 +7,7 @@ const assert = require('node:assert/strict');
 const fs = require('fs');
 const path = require('path');
 const { spawnSync } = require('node:child_process');
-const { runGsdTools, cleanup, absPlanningPath, TOOLS_PATH } = require('./helpers.cjs');
+const { runGsdTools, cleanup, absPlanningPath, TOOLS_PATH, parseFrontmatter } = require('./helpers.cjs');
 const { createFixture, seedPhase } = require('./fixtures/index.cjs');
 const { createTempProject, createTempDir } = require('./helpers.cjs');
 const { executionContextRefs } = require('../scripts/command-contract-helpers.cjs');
@@ -4064,5 +4064,110 @@ describe('init section manifest', () => {
         );
       }
     });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #3171 (Claim 3): the phase-start flow must not land a directory slug in
+// STATE.md's `current_phase_name`. When a phase directory already exists on
+// disk, `init execute-phase`'s disk-lookup path derived `phase_name` from the
+// directory-name remainder — itself an already-slugified value (`phase.add`
+// writes `${num}-${slug}` dirs) — so `phase_name` and `phase_slug` came out
+// byte-identical, and the execute-phase workflow forwarded that slug into
+// `state begin-phase --name`. The milestone-name half of #3171 was subsumed
+// by #3216 / PR #3226; these tests cover the remaining current_phase_name half.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#3171: init execute-phase emits the display name, not the directory slug', () => {
+  const DISPLAY_NAME = 'Loop-Termination and Baseline Correctness';
+  const PHASE_SLUG_DIR = '35-loop-termination-and-baseline-correctness';
+  const ROADMAP_3171 = [
+    '# Roadmap',
+    '',
+    `### Phase 35: ${DISPLAY_NAME}`,
+    '**Goal:** Fix loop termination',
+    '**Plans:** 1 plans',
+    '',
+  ].join('\n');
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = fs.realpathSync(createFixture());
+    seedPhase(tmpDir, PHASE_SLUG_DIR, { '35-01-PLAN.md': '# Plan' });
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), ROADMAP_3171);
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('phase_name is the ROADMAP display name when the phase directory exists', () => {
+    const result = runGsdTools('init execute-phase 35 --raw', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.phase_found, true, 'phase must be found on disk');
+    assert.ok(
+      typeof output.phase_dir === 'string' && output.phase_dir.includes(PHASE_SLUG_DIR),
+      `phase_dir must point at the on-disk directory; got ${JSON.stringify(output.phase_dir)}`,
+    );
+    assert.strictEqual(
+      output.phase_name,
+      DISPLAY_NAME,
+      `phase_name must be the ROADMAP display name, not the directory slug; got ${JSON.stringify(output.phase_name)}`,
+    );
+    assert.strictEqual(output.phase_slug, 'loop-termination-and-baseline-correctness');
+    assert.notStrictEqual(output.phase_name, output.phase_slug,
+      'phase_name must differ from phase_slug — a byte-identical pair is the #3171 defect signature');
+  });
+
+  test('the phase-start flow does not land a slug in current_phase_name', () => {
+    // 1. init execute-phase → the value the execute-phase workflow forwards to begin-phase.
+    const initResult = runGsdTools('init execute-phase 35 --raw', tmpDir);
+    assert.ok(initResult.success, `init execute-phase failed: ${initResult.error}`);
+    const initOutput = JSON.parse(initResult.output);
+    assert.strictEqual(initOutput.phase_name, DISPLAY_NAME);
+
+    // 2. Seed a STATE.md the transition module can rewrite (frontmatter + body).
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'STATE.md'),
+      [
+        '---',
+        'gsd_state_version: 1.0',
+        'current_phase: 34',
+        'current_phase_name: Prior Phase',
+        'status: planning',
+        '---',
+        '',
+        '# Project State',
+        '',
+        '## Current Position',
+        '',
+        'Phase: 34 — Prior Phase',
+        'Plan: Not started',
+        'Status: Ready to execute',
+        '',
+      ].join('\n'),
+    );
+
+    // 3. The orchestrator wiring: feed init's phase_name into begin-phase --name.
+    const beginResult = runGsdTools(
+      ['state', 'begin-phase', '--phase', '35', '--name', initOutput.phase_name, '--plans', '1'],
+      tmpDir,
+    );
+    assert.ok(beginResult.success, `state begin-phase failed: ${beginResult.error}`);
+
+    // 4. current_phase_name in STATE.md must be the display name, never the slug.
+    const stateContent = fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
+    const fm = parseFrontmatter(stateContent);
+    assert.strictEqual(
+      fm.current_phase_name,
+      DISPLAY_NAME,
+      `current_phase_name must hold the display name, not a directory slug; got ${JSON.stringify(fm.current_phase_name)}`,
+    );
+    assert.ok(
+      !/^[a-z0-9]+(-[a-z0-9]+)+$/.test(String(fm.current_phase_name)),
+      `current_phase_name must not be slug-shaped; got ${JSON.stringify(fm.current_phase_name)}`,
+    );
   });
 });


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3171

> #3171 carries `confirmed-bug`. Per trek-e's 2026-08-08 note, the `milestone_name` truncation half (Claim 1) was subsumed by #3216 / PR #3226. This PR fixes the remaining half (Claim 3): `state.begin-phase` clobbering `current_phase_name` with the phase directory slug.

## What was broken

When a phase's working directory already exists on disk, `init execute-phase` returned the directory-name remainder as `phase_name` — itself an already-slugified value (`phase.add` writes `${num}-${slug}` dirs) — so `phase_name` and `phase_slug` came out byte-identical. The execute-phase workflow forwards `phase_name` into `state begin-phase --name`, which wrote that raw slug into STATE.md's `current_phase_name` on every phase start (`loop-termination-and-baseline-correctness` instead of `Loop-Termination and Baseline Correctness`).

## What this fix does

`cmdInitExecutePhase` now prefers the ROADMAP's curated display name (`### Phase N: <Name>`) for `phase_name`, matching the no-disk fallback path that already did this correctly. `phase_slug` is unchanged (it still feeds branch-name construction). The `state.begin-phase` `authoritativeFm` override mechanism (#2821/#2736) is untouched — the correction is in the value fed into `--name`, exactly as the triage's "Coupled" note directs.

## Root cause

`src/phase-locator.cts::searchPhaseInDir` derives `phase_name` from the directory-name remainder (lines 182-185), which is a slug by construction. `cmdInitExecutePhase` (`src/init.cts:913`) emitted that slug verbatim for `phase_name` even though it had already resolved the human-curated display name from the ROADMAP one line earlier (`guardedGetRoadmapPhase`). The specific `current_phase_name` clobber became silent with PR #2821 (fixing #2736), which added the unconditional `authoritativeFm` override so a caller-supplied `--name` always wins — legitimate for protecting parenthetical names, but it now forwards a slug unchecked.

## Testing

### How I verified the fix

Failing-first, added to `tests/init.test.cjs` (`#3171: init execute-phase emits the display name, not the directory slug`):
- `phase_name is the ROADMAP display name when the phase directory exists` — seeds a slug-named phase dir + a ROADMAP display name, asserts `phase_name === 'Loop-Termination and Baseline Correctness'` (not the slug), `phase_slug` stays the slug, and the two differ (the defect's signature was a byte-identical pair).
- `the phase-start flow does not land a slug in current_phase_name` — end-to-end: runs `init execute-phase`, feeds the returned `phase_name` into `state begin-phase --name`, then asserts STATE.md's `current_phase_name` is the display name and is not slug-shaped.

Also confirmed before/after manually against the built lib on macOS: before, `phase_name` and `current_phase_name` were both `loop-termination-and-baseline-correctness`; after, both are `Loop-Termination and Baseline Correctness`, with `phase_slug` unchanged.

### Regression test added?

- [x] Yes — added a test that would have caught this bug

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

> Local manual verification on macOS; Linux + Windows covered by CI lanes. The change does not touch path handling.

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #3171`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — one consumer (`cmdInitExecutePhase`); sibling init commands and `state.begin-phase` deliberately untouched
- [x] Regression test added
- [x] `.changeset/` fragment added (`Fixed`, pr to backfill)
- [x] No unnecessary dependencies added

## Acceptance criteria (from triage Agent Brief)

- [x] A milestone heading with an inline parenthetical round-trips through `state.record-session` without truncation — already satisfied by #3226; not re-tested here (covered by `headingNameRetainsParentheticalInsteadOfTruncating` + fast-check property).
- [x] Running the phase-start flow against a phase whose directory already exists on disk does not produce a hyphenated/lowercase slug in `current_phase_name`. — this PR.
- [x] All existing preserve-guard behavior (placeholder rejection, punctuation-led-fragment rejection, parenthetical-name protection during phase transitions) continues to pass — `state.begin-phase`'s `authoritativeFm` override (#2821/#2736) is untouched; ROADMAP-fallback and `phase_slug` paths unchanged.

## Breaking changes

The `phase_name` field of `init execute-phase`'s JSON now carries the ROADMAP display name instead of the disk-derived slug when a phase directory exists. `phase_slug` continues to carry the slug, so branch-name construction (which reads `phase_slug`) is unaffected. No consumer is documented as relying on `phase_name` being a slug; the `phase_name` / `phase_slug` pair is now properly distinct, matching the no-disk fallback path. (#3171)
