### PR TITLE
enhance(#2115): replace bare eval with llm eval and drop ai system in the AI-integration gate

### DIFF
--- a/.changeset/2115-plan-phase-ai-keyword-precision.md
+++ b/.changeset/2115-plan-phase-ai-keyword-precision.md
@@ -1,0 +1,6 @@
+---
+type: Changed
+pr: 0
+---
+<!-- docs-exempt: internal prompt-precision change to the plan-phase workflow's AI-keyword gate; no docs surface documents the keyword list or the gate's trigger keywords (re-verified on next @ 7976b1ca0 — no docs/ file mentions the list's distinctive tokens) -->
+**The `plan-phase` AI-integration capability gate no longer lists substring-collidable keywords** — bare `eval` (a substring of ordinary phase-goal words like `evaluation` and `retrieval`) is replaced by `llm eval`, and the under-specified `ai system` is dropped, per maintainer triage on the linked issue. The gate is a capability prompt, not a hard block, so this is a precision improvement: phase goals like "add evaluation metrics" or "build the retrieval layer" no longer invite a spurious AI-SPEC branch, and genuinely AI-flavored goals still match on the precise framework and technique names. (#2115)

--- a/.changeset/2115-plan-phase-ai-keyword-precision.md
+++ b/.changeset/2115-plan-phase-ai-keyword-precision.md
@@ -1,6 +1,6 @@
 ---
 type: Changed
-pr: 0
+pr: 3431
 ---
 <!-- docs-exempt: internal prompt-precision change to the plan-phase workflow's AI-keyword gate; no docs surface documents the keyword list or the gate's trigger keywords (re-verified on next @ 7976b1ca0 — no docs/ file mentions the list's distinctive tokens) -->
 **The `plan-phase` AI-integration capability gate no longer lists substring-collidable keywords** — bare `eval` (a substring of ordinary phase-goal words like `evaluation` and `retrieval`) is replaced by `llm eval`, and the under-specified `ai system` is dropped, per maintainer triage on the linked issue. The gate is a capability prompt, not a hard block, so this is a precision improvement: phase goals like "add evaluation metrics" or "build the retrieval layer" no longer invite a spurious AI-SPEC branch, and genuinely AI-flavored goals still match on the precise framework and technique names. (#2115)

--- a/gsd-core/workflows/plan-phase.md
+++ b/gsd-core/workflows/plan-phase.md
@@ -453,7 +453,7 @@ Read the `activeHooks` array directly from `PLAN_PRE_HOOKS_JSON` / `HOOKS_JSON` 
 - If `ref.agent` is set, dispatch with `Agent(prompt=filled_hook_fragment, subagent_type=ref.agent, model="{researcher_model}")`. Use the hook's `fragment.inline` as the prompt body and fill phase fields before spawning.
 - The `research` hook is handled by §5.1's research decision. The `pattern-mapper` hook is handled by §7.8 after `RESEARCH_PATH` is known. Future plan:pre agent hooks use the same `ref.agent` fragment contract.
 
-**AI integration capability:** If the active `ai-integration` step hook is present, `AI_SPEC_PATH` is empty, and the phase goal contains AI keywords (`agent`, `llm`, `rag`, `chatbot`, `embedding`, `langchain`, `llamaindex`, `crewai`, `langgraph`, `openai`, `anthropic`, `vector`, `eval`, `ai system`), then:
+**AI integration capability:** If the active `ai-integration` step hook is present, `AI_SPEC_PATH` is empty, and the phase goal contains AI keywords (`agent`, `llm`, `rag`, `chatbot`, `embedding`, `langchain`, `llamaindex`, `crewai`, `langgraph`, `openai`, `anthropic`, `vector`, `llm eval`), then:
 - In pipeline / `--auto` mode, invoke the hook's `ref.skill` via `Skill(skill="gsd-${ref.skill}", args="${PHASE} --auto ${GSD_WS}")`.
 - In manual mode, display the existing non-blocking `/gsd:ai-integration-phase {N}` recommendation and let the user continue planning without AI-SPEC or stop to run the capability workflow first.
 


### PR DESCRIPTION
## Enhancement PR

---

## Linked Issue

Closes #2115

The linked issue carries the `approved-enhancement` label (applied at the 2026-07-31 re-triage).

---

## What this enhancement improves

The **`plan-phase` AI-integration capability gate** (`gsd-core/workflows/plan-phase.md`, "AI integration capability" step). Its keyword set listed two substring-collidable tokens — bare `eval` (a substring of `evaluate`, `evaluation`, `evaluator`, `retrieval`, `medieval`) and the under-specified `ai system` — so a phase goal like *"add evaluation metrics"* or *"build the retrieval layer"* invited the AI-integration branch to fire with no actual AI-framework intent.

This PR applies **exactly the scope pinned by the maintainer re-triage on #2115** (2026-07-31): `eval` → `llm eval`, `ai system` dropped, every other token and the surrounding sentence byte-identical.

## Before / After

**Before:**

> …and the phase goal contains AI keywords (`agent`, `llm`, `rag`, `chatbot`, `embedding`, `langchain`, `llamaindex`, `crewai`, `langgraph`, `openai`, `anthropic`, `vector`, `eval`, `ai system`), then:

**After:**

> …and the phase goal contains AI keywords (`agent`, `llm`, `rag`, `chatbot`, `embedding`, `langchain`, `llamaindex`, `crewai`, `langgraph`, `openai`, `anthropic`, `vector`, `llm eval`), then:

The gate is a capability *prompt*, not a hard block, so the improvement is precision: fewer spurious AI-SPEC branch prompts on non-AI phases; genuinely AI-flavored goals still match on the precise framework and technique names.

**Relationship to PR #3131:** this supersedes the stale-closed #3131 (same issue, same author). Two deltas from that attempt: (1) the diff is conformed to the re-triage scope pin — #3131 shipped a broader whole-word-matching rework that went beyond the pinned tokens; (2) the branch is cut fresh from current `next`, so the modify/delete conflict that blocked #3131's review (`tests/emitted-drift-acks/2650-plan-phase-stall-detection.json`) no longer exists — `next` itself has since removed that file (#3327). If maintainers would rather see the whole-word qualifier from #3131, happy to file it as a follow-up proposal instead.

Evidence — the keyword line on current `next`, commit-pinned:

https://github.com/open-gsd/gsd-core/blob/7976b1ca0d88038a35c300218b135c30d409ae6e/gsd-core/workflows/plan-phase.md#L456

## How it was implemented

One-line edit to the keyword sentence in `gsd-core/workflows/plan-phase.md` (the gate's specification is the prompt itself — there is no code matcher), plus the changeset fragment. No behavior outside the gate's trigger condition changes.

**Sibling-site census (same defect class, declared out of scope per the pinned scope):** the class is "model-interpreted keyword list with substring-collidable bare tokens." Two other sites exist and are *not* touched here: `agents/gsd-roadmapper.md` UI detection keywords (`view` ⊂ *review*/*preview*, `form` ⊂ *format*/*performance*, `page` ⊂ *homepage*) and `plan-phase.md`'s thinking-partner tradeoff keyword scan (low collision risk). If maintainers want the same tightening there, happy to file a follow-up.

## Testing

### How I verified the enhancement works

- The change is to an LLM-interpreted instruction in a workflow prompt file; there is no code path or unit-test target for the keyword list itself. `tests/ai-evals.test.cjs` ("plan-phase.md contains AI keyword detection") asserts only a loose combination of `agent` / `llm` / `rag` / `AI`, all of which remain in the file — verified against this branch's checkout; neither `eval` nor `ai system` is asserted anywhere.
- Ran the repo's own validators locally against the change: `scripts/release-notes/conventional-title.cjs` `evaluatePrTitle` on the PR title (`valid: true`), and `scripts/changeset/parse.cjs` `parseFragment` on the fragment (`ok: true`, type `Changed`, docs-exempt reason captured; the `pr:` field ships as the `0` placeholder and is backfilled to the real number after the PR exists, per the repo's fragment pattern).
- Did not run the full `npm run lint:ci` / `npm run test:coverage:unit:raw` chain locally; the diff touches only two Markdown files (workflow prose + changeset fragment), and CI runs the identical orchestrated set (`.github/workflows/test.yml`: `build:lib`, `lint:ci`, sharded `test:coverage:unit:raw`, `test:integration`, `test:security`, `test:install`, `test:slow`).

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [x] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue — no additions or removals
- [x] If scope changed during implementation, I updated the issue and got re-approval before continuing

*(The diff is byte-for-byte the maintainer's re-triage pin: `eval` → `llm eval`, `ai system` dropped, everything else identical.)*

---

## Documentation

- [ ] Updated the relevant file(s) under `docs/` to reflect this change
- [x] All `docs/` content added in this PR is written in English
- [x] If genuinely no user-facing docs impact (infrastructure / internal refactor / test-only), apply the `no-docs` label **or** add `<!-- docs-exempt: <reason> -->` inside each triggering changeset fragment and leave a comment explaining why.

No docs surface documents the keyword list or the gate's trigger keywords (re-verified on `next` @ `7976b1ca0`: no file under `docs/` mentions the list's distinctive tokens — `llamaindex`, `crewai`, `langgraph`). The changeset fragment carries the `docs-exempt` marker with this reason.

## Checklist

- [x] Issue linked above with `Closes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `approved-enhancement` label — **PR will be closed if missing**
- [x] Changes are scoped to the approved enhancement — nothing extra included
- [x] All existing tests pass (`npm test`) — attested via CI; no test pins the edited tokens (see Testing)
- [x] New or updated tests cover the enhanced behavior — N/A: prompt-precision edit to an LLM-interpreted instruction; the repo's own re-triage confirmed no test pins these tokens
- [x] `.changeset/` fragment added (`npm run changeset -- --type Changed --pr <NNN> --body "..."`) — or `no-changelog` label applied if not user-facing
- [x] No unnecessary dependencies added

## Breaking changes

None

Fixes #2115
