### PR TITLE
refactor(#1762): clarify verification-missing/unknown routing text

### DIFF
--- a/.changeset/vivid-moles-chatter.md
+++ b/.changeset/vivid-moles-chatter.md
@@ -1,0 +1,6 @@
+---
+type: Changed
+pr: 0
+---
+**`/gsd-progress` no longer implies re-execution when only the verification report is missing** — the routing message now explains that running `/gsd-execute-phase` on a historical phase resumes at the verification gates and does not re-run already-summarized plans, and softens the unrecognized-status message to acknowledge an intentional non-standard marker. (#1762)
+<!-- docs-exempt: advisory routing text only; no docs page documents this specific message today, so there is nothing to keep in sync -->

--- a/.changeset/vivid-moles-chatter.md
+++ b/.changeset/vivid-moles-chatter.md
@@ -1,6 +1,6 @@
 ---
 type: Changed
-pr: 0
+pr: 3439
 ---
 **`/gsd-progress` no longer implies re-execution when only the verification report is missing** — the routing message now explains that running `/gsd-execute-phase` on a historical phase resumes at the verification gates and does not re-run already-summarized plans, and softens the unrecognized-status message to acknowledge an intentional non-standard marker. (#1762)
 <!-- docs-exempt: advisory routing text only; no docs page documents this specific message today, so there is nothing to keep in sync -->

--- a/gsd-core/workflows/progress.md
+++ b/gsd-core/workflows/progress.md
@@ -458,7 +458,17 @@ UAT.md exists with `status: partial` — testing session ended before all items 
 All plans have summaries, but canonical verification has not passed. The phase is implementation-complete, not phase-complete.
 
 ```
-`/gsd:execute-phase {phase} ${GSD_WS}` — re-run execution verification
+---
+
+## Verification Report Missing
+
+**Phase {phase}** has all plans summarized, but no canonical `*-VERIFICATION.md` exists yet. ${VERIFICATION_NEXT_ACTION}
+
+`/clear` then:
+
+`/gsd:execute-phase {phase} ${GSD_WS}` — resumes at the verification gates (does not re-run already-summarized plans)
+
+---
 ```
 
 ---
@@ -468,7 +478,17 @@ All plans have summaries, but canonical verification has not passed. The phase i
 VERIFICATION.md has an unexpected status. The phase is implementation-complete, not phase-complete.
 
 ```
-`/gsd:execute-phase {phase} ${GSD_WS}` — regenerate verification
+---
+
+## Verification Status Unexpected
+
+**Phase {phase}** has all plans summarized, but its `*-VERIFICATION.md` reports an unexpected status. ${VERIFICATION_NEXT_ACTION}
+
+`/clear` then:
+
+`/gsd:execute-phase {phase} ${GSD_WS}` — regenerate verification (skip if this is an intentional closure marker)
+
+---
 ```
 
 ---

--- a/gsd-core/workflows/progress.md
+++ b/gsd-core/workflows/progress.md
@@ -466,7 +466,7 @@ All plans have summaries, but canonical verification has not passed. The phase i
 
 `/clear` then:
 
-`/gsd:execute-phase {phase} ${GSD_WS}` — resumes at the verification gates (does not re-run already-summarized plans)
+`/gsd:execute-phase {phase} ${GSD_WS}` — resumes at the verification gates
 
 ---
 ```
@@ -486,7 +486,7 @@ VERIFICATION.md has an unexpected status. The phase is implementation-complete, 
 
 `/clear` then:
 
-`/gsd:execute-phase {phase} ${GSD_WS}` — regenerate verification (skip if this is an intentional closure marker)
+`/gsd:execute-phase {phase} ${GSD_WS}` — regenerate verification
 
 ---
 ```

--- a/src/verification.cts
+++ b/src/verification.cts
@@ -113,7 +113,7 @@ const VERIFICATION_ROUTING_TABLE: Record<string, VerificationRoute> = {
   // the file has no parseable frontmatter status. Never emitted by the verifier.
   missing: {
     status: 'missing',
-    next_action: 'No verification report found — the verify step never completed. Re-run execute-phase.',
+    next_action: 'No verification report found — the verify step never completed. Running execute-phase is safe here: it resumes at the verification gates and does not re-run plans that already have a SUMMARY.md (see #2868).',
     next_command: 'execute-phase',
   },
   // INTERNAL SENTINEL: constructed when the file has a status value not in
@@ -504,7 +504,7 @@ function readVerificationStatus(
   const unknownRoute = VERIFICATION_ROUTING_TABLE['unknown'];
   return {
     status: unknownRoute.status,
-    next_action: `Unexpected verification status '${rawStatus}'. Re-run execute-phase verification.`,
+    next_action: `Unexpected verification status '${rawStatus}'. If this is an intentional non-standard marker (e.g. a hand-set failed/superseded state), no action is needed. Otherwise, run execute-phase to regenerate verification — it will not re-run plans that already have a SUMMARY.md.`,
     next_command: projectNextCommand(unknownRoute.next_command, runtime, phaseArg),
     ...(staleCheckIndeterminate ? { staleCheckIndeterminate: true } : {}),
   };

--- a/tests/emitted-drift-acks/1762-verification-routing-wording.json
+++ b/tests/emitted-drift-acks/1762-verification-routing-wording.json
@@ -1,0 +1,1 @@
+{"version":1,"paths":{"progress.md":{"reason":"#1762: Route V.missing and Route V.unknown now consume the dynamic ${VERIFICATION_NEXT_ACTION} block (matching the existing V.gaps/V.human format) instead of a hardcoded duplicate string, so the routing text stays reassuring and in sync with src/verification.cts's reworded next_action — deliberate growth, not drift."}}}

--- a/tests/emitted-drift-acks/3218-prompt-layer-plan-counts.json
+++ b/tests/emitted-drift-acks/3218-prompt-layer-plan-counts.json
@@ -6,9 +6,6 @@
     },
     "plan-review-convergence.md": {
       "reason": "Issue #3218 (epic #3180 phase 8): replaced a raw `ls *-PLAN.md | wc -l` re-derivation with a `gsd_run query find-phase` call plus jq extraction of the count field, routing the plan count through scanPhasePlans (ADR-3180 §7.5) so superseded plans are excluded and the review converges on the live set."
-    },
-    "progress.md": {
-      "reason": "Issue #3218 (epic #3180 phase 8): replaced a raw `ls *-PLAN.md | wc -l` re-derivation with a `gsd_run query find-phase` call plus jq extraction of the count field, and additionally carries the Route-0 dead-path fix (a branch that previously reported zero plans on the nested plans/ layout is now reachable and correct)."
     }
   }
 }

--- a/tests/verification-status.test.cjs
+++ b/tests/verification-status.test.cjs
@@ -138,6 +138,10 @@ describe('verification-status', () => {
       assert.equal(result.status, 'missing');
       assert.equal(result.next_command, '/gsd-execute-phase');
       assert.ok(result.next_action.includes('verify step never completed'));
+      assert.ok(
+        result.next_action.includes('does not re-run plans that already have a SUMMARY.md'),
+        `next_action must reassure the user execute-phase will not redo work (#1762); got: ${result.next_action}`,
+      );
     } finally {
       cleanup(dir);
     }
@@ -154,6 +158,10 @@ describe('verification-status', () => {
       assert.ok(
         result.next_action.includes('bogus'),
         `next_action should mention the raw value; got: ${result.next_action}`,
+      );
+      assert.ok(
+        result.next_action.includes('intentional non-standard marker'),
+        `next_action must acknowledge an unrecognized status may be an intentional marker (#1762); got: ${result.next_action}`,
       );
     } finally {
       cleanup(dir);


### PR DESCRIPTION
## Enhancement PR

---

## Linked Issue

Closes #1762

---

## What this enhancement improves

The advisory routing text `gsd-progress` (and every other caller of `readVerificationStatus`, including `phase complete`'s blocked-completion error) displays when a phase's `*-VERIFICATION.md` is `missing` or has an unrecognized (`unknown`) status. This is the `next_action` field in `src/verification.cts`'s `VERIFICATION_ROUTING_TABLE`, and the matching Route V.missing / Route V.unknown sections of `gsd-core/workflows/progress.md`.

## Before / After

**Before:**

```
36.1 verification missing        /gsd-execute-phase 36.1
36.2 verification unknown        /gsd-execute-phase 36.2
```

`next_action` for `missing`: *"No verification report found — the verify step never completed. Re-run execute-phase."*
`next_action` for `unknown`: *"Unexpected verification status 'X'. Re-run execute-phase verification."*

Both read as "redo the implementation", which is not what `/gsd:execute-phase` does for a phase whose plans are already fully summarized — but nothing in the message says so, so a historical phase that is actually done except for its verification artifact reads as risky to touch.

**After:**

`next_action` for `missing`: *"No verification report found — the verify step never completed. Running execute-phase is safe here: it resumes at the verification gates and does not re-run plans that already have a SUMMARY.md (see #2868)."*
`next_action` for `unknown`: *"Unexpected verification status 'X'. If this is an intentional non-standard marker (e.g. a hand-set failed/superseded state), no action is needed. Otherwise, run execute-phase to regenerate verification — it will not re-run plans that already have a SUMMARY.md."*

`progress.md`'s Route V.missing / Route V.unknown now render `${VERIFICATION_NEXT_ACTION}` dynamically (matching the existing Route V.gaps / Route V.human pattern) instead of a second hardcoded copy of the old, unreassuring text.

## How it was implemented

Traced the reported symptom to `src/verification.cts`'s `VERIFICATION_ROUTING_TABLE` — the single source every caller (workflows, `phase complete`'s gate, `init`, `state`) reads `next_action`/`next_command` from. Confirmed two things before touching anything:

1. `execute-phase.md`'s `discover_and_group_plans` step (`#2868`) already resumes at the verification gates and explicitly skips `cross_ai_delegation`/`execute_waves`/`checkpoint_handling` when every plan already has a matching `SUMMARY.md` and verification status is `missing`. The re-execution risk the issue describes does not exist in current code — only the message was misleading.
2. No formal `superseded`/`failed` administrative-closure status exists anywhere in this codebase (`agents/gsd-verifier.md` documents only `passed | gaps_found | human_needed`), and `verify-work.md` never spawns `gsd-verifier` and therefore cannot produce a canonical `*-VERIFICATION.md`.

Given (1) and (2), the issue's own two suggested example fixes turn out not to work: routing to `/gsd:verify-work` (the issue's example) would send the user through a redundant UAT pass that still ends at "run execute-phase"; a new batch/admin reconciliation command (the issue's other example) is a new command, outside what `approved-enhancement` covers per `CONTRIBUTING.md` ("does not add new commands, new workflows, or new concepts" — that requires `approved-feature`). This PR keeps `next_command` unchanged (still `execute-phase`, the only command that can produce the artifact) and instead corrects what the message says about it, which is the actual defect.

Key files:
- `src/verification.cts` — reworded the two `next_action` strings.
- `gsd-core/workflows/progress.md` — Route V.missing / Route V.unknown now consume `${VERIFICATION_NEXT_ACTION}` dynamically, matching the neighboring routes.
- `tests/verification-status.test.cjs` — regression assertions for the new wording (written failing-first, confirmed RED under `gsd-test` before the fix, GREEN after).
- `tests/emitted-drift-acks/1762-verification-routing-wording.json` — new acknowledgment for `progress.md`'s byte growth (ADR-2719 differential attribution).
- `tests/emitted-drift-acks/3218-prompt-layer-plan-counts.json` — removed a now-spent `progress.md` entry from an unrelated, already-landed fragment; it collided with the new one under the "two ack sources may never name the same path" rule.

## Testing

### How I verified the enhancement works

Failing-first regression test committed and run under `gsd-test` to confirm RED (2 new assertions failed, all 33,382 other tests green). Fix committed, local gates (`build:lib`, `lint:ci`) green, two orthogonal reviews run (Standards/Spec code-review pair + an isolated security-review subagent + the Memtrace graph-backed pass), findings fixed, then `gsd-test` run again to confirm GREEN (33,398/33,398 passed) — re-run once more after a rebase onto `next` picked up 3 unrelated commits.

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

*(This repo's remote test matrix is Linux-only; this is a pure string-content change with no platform-specific code path.)*

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [x] N/A (not runtime-specific)

*(The `next_action` text is runtime-agnostic prose; `next_command` runtime projection, `#2617`, is untouched by this diff.)*

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue — no additions or removals
- [x] If scope changed during implementation, I updated the issue and got re-approval before continuing

Note on scope: the issue's own two suggested example fixes were investigated and found non-viable/out-of-approved-scope (explained above under "How it was implemented"); the fix that landed addresses the same root defect (misleading routing text) within the boundaries `CONTRIBUTING.md` sets for an enhancement.

---

## Documentation

- [ ] Updated the relevant file(s) under `docs/` to reflect this change
- [x] All `docs/` content added in this PR is written in English
- [x] If genuinely no user-facing docs impact (infrastructure / internal refactor / test-only), apply the `no-docs` label **or** add `<!-- docs-exempt: <reason> -->` inside each triggering changeset fragment and leave a comment explaining why.

No `docs/` page documents this specific advisory message today, so there is nothing to keep in sync; the changeset fragment carries a `docs-exempt` marker with that reasoning.

## Checklist

- [x] Issue linked above with `Closes #1762`
- [x] Linked issue has the `approved-enhancement` label
- [x] Changes are scoped to the approved enhancement — nothing extra included
- [x] All existing tests pass (verified via `gsd-test`, the remote runner — this repo blocks local `node --test`)
- [x] New or updated tests cover the enhanced behavior
- [x] `.changeset/` fragment added (`type: Changed`, `docs-exempt` marker)
- [x] No unnecessary dependencies added

## Breaking changes

None. `next_command` values, `status` values, and the `isPhaseComplete` completeness predicate (still gated on `status === 'passed'`, per the maintainer's `#2957` DISK-STRICT decision) are all unchanged — this PR only reworded advisory prose.
