### PR TITLE
fix(#3374): phase.complete writes its continuity line and preserves fresher frontmatter stopped_at

### DIFF
--- a/.changeset/3374-phase-complete-stopped-at.md
+++ b/.changeset/3374-phase-complete-stopped-at.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 3442
 ---
 **`phase.complete` no longer overwrites a fresher frontmatter `stopped_at` with a stale body `Stopped at:` line** — the transition now refreshes the session continuity line it implies (`Phase N complete, ready to plan Phase N+1`) so the frontmatter projects this completion rather than pre-completion prose, and its frontmatter sync applies the same `applyStatePreservation` policy every other STATE.md write path uses as a backstop. Separately, `state record-session` now reports a field in `updated` only when its on-disk content actually changed — a `--stopped-at` value already present in the body no longer claims a write that never happened (and no longer risks the session-section rewrite resetting an executor-authored resume file). (#3374)

--- a/.changeset/3374-phase-complete-stopped-at.md
+++ b/.changeset/3374-phase-complete-stopped-at.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`phase.complete` no longer overwrites a fresher frontmatter `stopped_at` with a stale body `Stopped at:` line** — the transition now refreshes the session continuity line it implies (`Phase N complete, ready to plan Phase N+1`) so the frontmatter projects this completion rather than pre-completion prose, and its frontmatter sync applies the same `applyStatePreservation` policy every other STATE.md write path uses as a backstop. Separately, `state record-session` now reports a field in `updated` only when its on-disk content actually changed — a `--stopped-at` value already present in the body no longer claims a write that never happened (and no longer risks the session-section rewrite resetting an executor-authored resume file). (#3374)

--- a/src/phase.cts
+++ b/src/phase.cts
@@ -63,7 +63,7 @@ import stateMod = require('./state.cjs');
 import { platformWriteSync, platformReadSync, platformEnsureDir, retryRenameSync } from './shell-command-projection.cjs';
 import { formatGsdSlash, resolveRuntime } from './runtime-slash.cjs';
 import { realClock } from './clock.cjs';
-import { transitionCore } from './state-transition.cjs';
+import { transitionCore, applyStatePreservation } from './state-transition.cjs';
 import { updateTableCell, deleteTableRow, escapeCell } from './markdown-table.cjs';
 import { deleteSection, updateBullet } from './markdown-sectionizer.cjs';
 // eslint-disable-next-line @typescript-eslint/no-require-imports -- uat-predicate.cjs is an export= CommonJS module
@@ -85,12 +85,13 @@ const { planningDir, withPlanningLock, listAvailableWorkstreams, getActiveWorkst
   planningWorkspace;
 // eslint-disable-next-line @typescript-eslint/no-require-imports -- milestone-lock.cjs is an export= CommonJS module
 import milestoneLockMod = require('./milestone-lock.cjs');
-const { extractFrontmatter } = frontmatterMod;
+const { extractFrontmatter, stripFrontmatter, reconstructFrontmatter } = frontmatterMod;
 const {
   readModifyWriteStateMd,
   stateExtractField,
   stateReplaceField,
   syncStateFrontmatter,
+  matchSessionSection,
   withStateLock,
   updatePerformanceMetricsSection,
 } = stateMod;
@@ -2971,6 +2972,23 @@ function cmdPhaseComplete(cwd: string, phaseNum: string, raw: boolean): void {
           planCount,
           summaryCount,
         );
+        // #3374: this direct syncStateFrontmatter call bypasses
+        // readModifyWriteStateMd by design (STATE.md is committed atomically
+        // with ROADMAP/REQUIREMENTS), which also bypassed the #948/#1230
+        // preservation pass every RMW write gets — so a stale body
+        // `Stopped at:` line (which this transition never touches) silently
+        // clobbered a fresher frontmatter stopped_at on every completion.
+        // Mirror the RMW post-sync sequence here: snapshot the body source
+        // fields the preservation deltas key on (pre = on-disk content, post =
+        // the transformed content; the sync only rewrites the frontmatter
+        // block, so either side of it has the same body), then
+        // applyStatePreservation, then the #2736 authoritative re-assert.
+        const preFmSnapshot = extractFrontmatter(originalStateContent, statePath) as Record<string, unknown>;
+        const preBody = stripFrontmatter(originalStateContent);
+        const preSessionScope = matchSessionSection(preBody) ?? preBody;
+        const postBody = stripFrontmatter(stateContent);
+        const postSessionScope = matchSessionSection(postBody) ?? postBody;
+
         // #2736: the transition holds the next phase's exact display name in
         // the intent; pass it as authoritative so the sync's prose
         // re-derivation cannot rewrite current_phase_name to the name's own
@@ -2980,6 +2998,38 @@ function cmdPhaseComplete(cwd: string, phaseNum: string, raw: boolean): void {
           cwd,
           nextPhaseDisplayName ? { current_phase_name: nextPhaseDisplayName } : undefined,
         );
+
+        // #3374: the same table-driven policy the RMW path applies. preFm null
+        // + resync true = lifecycle-transition posture (progress recomputed
+        // from disk; only the preserve-when-unchanged deltas apply). Fields
+        // the transition legitimately rewrote (Status, Phase) have changed
+        // body sources, so their deltas do not fire.
+        const postFm = extractFrontmatter(stateContent, statePath) as Record<string, unknown>;
+        const preservation = applyStatePreservation({
+          preFm: null,
+          postFm,
+          preFmSnapshot,
+          resync: true,
+          preBodyStatus: stateExtractField(preBody, 'Status'),
+          postBodyStatus: stateExtractField(postBody, 'Status'),
+          preBodyStoppedAt: stateExtractField(preSessionScope, 'Stopped At') || stateExtractField(preSessionScope, 'Stopped at'),
+          postBodyStoppedAt: stateExtractField(postSessionScope, 'Stopped At') || stateExtractField(postSessionScope, 'Stopped at'),
+          preBodyPhaseSource: stateExtractField(preBody, 'Phase'),
+          postBodyPhaseSource: stateExtractField(postBody, 'Phase'),
+        });
+        // #2736 re-assert (mirrors readModifyWriteStateMd): on layouts with no
+        // body `Phase:` line both phase-source snapshots are null (equal), so
+        // the #1695 restore fires and would put the stale pre-transition name
+        // back over the authoritative one. Intent beats the curated restore.
+        let preservationMutated = preservation.mutated;
+        if (nextPhaseDisplayName && preservation.postFm['current_phase_name'] !== nextPhaseDisplayName) {
+          preservation.postFm['current_phase_name'] = nextPhaseDisplayName;
+          preservationMutated = true;
+        }
+        if (preservationMutated) {
+          const yamlStr = reconstructFrontmatter(preservation.postFm as Parameters<typeof reconstructFrontmatter>[0]);
+          stateContent = `---\n${yamlStr}\n---\n\n${stripFrontmatter(stateContent)}`;
+        }
 
         writes.push({ filePath: statePath, before: originalStateContent, after: stateContent });
       }

--- a/src/phase.cts
+++ b/src/phase.cts
@@ -2976,7 +2976,9 @@ function cmdPhaseComplete(cwd: string, phaseNum: string, raw: boolean): void {
         // readModifyWriteStateMd by design (STATE.md is committed atomically
         // with ROADMAP/REQUIREMENTS), which also bypassed the #948/#1230
         // preservation pass every RMW write gets — so a stale body
-        // `Stopped at:` line (which this transition never touches) silently
+        // `Stopped at:` line (which this transition historically never
+        // touched — completePhaseCore now refreshes it, so this pass is the
+        // backstop for layouts whose line that writer cannot reach) silently
         // clobbered a fresher frontmatter stopped_at on every completion.
         // Mirror the RMW post-sync sequence here: snapshot the body source
         // fields the preservation deltas key on (pre = on-disk content, post =

--- a/src/state-transition.cts
+++ b/src/state-transition.cts
@@ -1041,6 +1041,7 @@ function completePhaseCore(
     'current_plan',
     'last_activity',
     'last_activity_desc',
+    'stopped_at',
     'progress',
   ]) {
     const cls = getFieldClassification(fmKey);
@@ -1139,6 +1140,26 @@ function completePhaseCore(
   if (ladAfter) {
     body = ladAfter;
     updated.push('Last Activity Description');
+  }
+
+  // Stopped At — #3374: write the continuity line this transition implies.
+  // The frontmatter `stopped_at` is a projection of this body line
+  // (source: 'body' in FIELD_CLASSIFICATION), and phase completion is exactly
+  // the event the line describes — leaving it stale made the post-sync harvest
+  // overwrite a fresher frontmatter value with pre-completion prose on every
+  // completion, and left the workflow's later prose refresh as a divergence
+  // source. Replace-only (no insertion): a STATE.md with no session continuity
+  // line keeps its shape, and the unchanged body source then lets the
+  // preservation delta keep an existing frontmatter value. Last-phase wording
+  // reuses the ADR-2207 status phrase; milestone termination wording stays
+  // owned by milestoneCompleteCore.
+  const stoppedAtLine = intent.isLastPhase
+    ? `Phase ${intent.phaseNum} complete — all phases complete`
+    : `Phase ${intent.phaseNum} complete${intent.nextPhaseNum ? `, ready to plan Phase ${intent.nextPhaseNum}` : ''}`;
+  const stoppedAfter = stateReplaceFieldWithFallback(body, 'Stopped At', null, stoppedAtLine);
+  if (stoppedAfter !== body) {
+    body = stoppedAfter;
+    updated.push('Stopped At');
   }
 
   // Progress block — re-derive completed/total phases from the roadmap when

--- a/src/state.cts
+++ b/src/state.cts
@@ -1222,10 +1222,22 @@ function cmdStateRecordSession(cwd: string, options: StateRecordSessionOptions, 
     if (result) { content = result; updated.push('Last Date'); }
 
     // Update Stopped at
+    // #3374 Variant B: stateReplaceField returns the replaced string on any
+    // label MATCH, including when the value is already the target. Pushing
+    // 'Stopped At' on match alone reported a write that never changed a byte
+    // (and that the #948 no-op guard may then discard entirely), leaving a
+    // stale frontmatter stopped_at undetectable to the caller. Report only on
+    // real change — and track the match separately so an identical value does
+    // not read as "label missing" to the #944 DWIM insertion below (whose
+    // section rewrite would reset an executor-authored resume file to None).
+    let stoppedAtMatched = false;
     if (options.stopped_at) {
       result = stateReplaceField(content, 'Stopped At', options.stopped_at);
       if (!result) result = stateReplaceField(content, 'Stopped at', options.stopped_at);
-      if (result) { content = result; updated.push('Stopped At'); }
+      if (result) {
+        stoppedAtMatched = true;
+        if (result !== content) { content = result; updated.push('Stopped At'); }
+      }
     }
 
     // Update Resume File — only when the caller explicitly passed a value OR the
@@ -1276,7 +1288,10 @@ function cmdStateRecordSession(cwd: string, options: StateRecordSessionOptions, 
     // missing canonical fields are inserted while the heading and any prose are
     // preserved (#1101). Only append a brand-new section when NEITHER heading exists.
     const callerSuppliedValues = !!(options.stopped_at || (options.resume_file !== undefined && options.resume_file !== null));
-    const needsStoppedAt = options.stopped_at && !updated.includes('Stopped At');
+    // #3374: keyed on the label MATCH, not on updated[] — a matched-but-
+    // identical value is persisted (it is already on disk) and must not
+    // trigger the insertion rewrite.
+    const needsStoppedAt = options.stopped_at && !stoppedAtMatched;
     const needsResumeFile = options.resume_file !== undefined && options.resume_file !== null && !updated.includes('Resume File');
     const needsLastSession = !updated.includes('Last session') && !updated.includes('Last Date');
 
@@ -2312,13 +2327,15 @@ function syncStateFrontmatter(content: string, cwd: string | undefined, authorit
   // survive every writeStateMd call.
   //
   // For stopped_at / paused_at: the original #905 "fall back when derived is
-  // absent" rule is preserved here. The stale-body-overwrites-frontmatter
-  // scenario from #948 is prevented by the no-op guard in
-  // readModifyWriteStateMd: when the transform produces no change the file is
-  // never written, so syncStateFrontmatter never even runs. Attempting to
-  // "always prefer frontmatter" here breaks legitimate callers like phase.complete
-  // that intentionally write a new stopped_at value to the body and expect
-  // syncStateFrontmatter to pick it up.
+  // absent" rule is preserved here — this block handles the EMPTY case only.
+  // The disagreeing case (a present-but-stale body value vs a fresher
+  // frontmatter value, #948/#3374) is NOT handled here: it is governed by
+  // applyStatePreservation's preserve-when-unchanged delta, applied post-sync
+  // by readModifyWriteStateMd and by cmdPhaseComplete's adapter (the one
+  // caller that deliberately bypasses the RMW wrapper for the atomic
+  // ROADMAP/REQUIREMENTS/STATE commit — #3374). "Always prefer frontmatter"
+  // would still be wrong here: it would break callers whose transform
+  // legitimately writes a new body value and expects this sync to pick it up.
   if (!derivedFm['stopped_at'] && existingFm['stopped_at']) {
     derivedFm['stopped_at'] = existingFm['stopped_at'];
   }
@@ -4152,6 +4169,10 @@ export = {
   stateExtractField,
   stateReplaceField,
   stateReplaceFieldWithFallback,
+  // #3374: exported for phase.cts's cmdPhaseComplete adapter, whose direct
+  // syncStateFrontmatter call must snapshot the same ## Session scope the
+  // RMW path snapshots for applyStatePreservation's stopped_at delta.
+  matchSessionSection,
   acquireStateLock,
   releaseStateLock,
   writeStateMd,

--- a/tests/frontmatter.test.cjs
+++ b/tests/frontmatter.test.cjs
@@ -2218,6 +2218,179 @@ test('extractFrontmatter handles large frontmatter blocks without body bleed', (
 }
 
 
+// #3374 regressions — `phase complete`'s adapter calls syncStateFrontmatter
+// directly (deliberately bypassing readModifyWriteStateMd for the atomic
+// ROADMAP/REQUIREMENTS/STATE commit), which also bypassed the #948/#1230
+// preservation pass every RMW write gets. A stale body `Stopped at:` line then
+// silently clobbered a fresher frontmatter `stopped_at` on every phase
+// completion. Placed beside the #2736 suite (the same defect family: the
+// adapter's post-sync policy diverging from the RMW path's). The fix is
+// two-layered: completePhaseCore now refreshes the body continuity line it
+// implies (`Phase N complete, ready to plan Phase N+1`) so the harvest
+// projects a value this very completion produced (keeping #3517's refresh
+// expectation), and the adapter mirrors the RMW post-sync sequence —
+// applyStatePreservation, then the #2736 authoritative re-assert — so a
+// layout whose body line the transition could not refresh (no session
+// continuity line) preserves a fresher frontmatter value instead of
+// harvesting nothing over it.
+// ────────────────────────────────────────────────────────────────────────
+{
+  const { describe: __d3374, test: __t3374, beforeEach: __be3374, afterEach: __ae3374 } = require('node:test');
+  const __assert3374 = require('node:assert/strict');
+  const __fs3374 = require('node:fs');
+  const __path3374 = require('node:path');
+  const { runGsdTools: __run3374, createTempProject: __mk3374, cleanup: __rm3374 } = require('./helpers.cjs');
+
+  const FRESH_3374 = 'Phase 2 gap closure executed — FRESH frontmatter value';
+  const STALE_3374 = 'Phase 1 complete, ready to plan Phase 2';
+
+  // Mirrors the issue's repro: a 3-phase roadmap completing phase 2 (not-last),
+  // body `## Session Continuity` holding a stale plain-label `Stopped at:` line
+  // that phase.complete's transition never touches.
+  function writeCompleteFixture3374(tmpDir, fmStoppedAtLine) {
+    const planningDir = __path3374.join(tmpDir, '.planning');
+    const phase2Dir = __path3374.join(planningDir, 'phases', '02-second-phase');
+    __fs3374.mkdirSync(phase2Dir, { recursive: true });
+
+    __fs3374.writeFileSync(
+      __path3374.join(planningDir, 'ROADMAP.md'),
+      [
+        '# Roadmap',
+        '',
+        '### Phase 1: First phase',
+        '**Plans:** 1 plans',
+        '',
+        '### Phase 2: Second phase',
+        '**Plans:** 1 plans',
+        '',
+        '### Phase 3: Third phase',
+        '**Plans:** 1 plans',
+        '',
+        '## Progress',
+        '',
+        '- [x] **Phase 1: First phase** - done',
+        '- [ ] **Phase 2: Second phase** - pending',
+        '- [ ] **Phase 3: Third phase** - pending',
+        '',
+      ].join('\n'),
+    );
+
+    __fs3374.writeFileSync(
+      __path3374.join(planningDir, 'STATE.md'),
+      [
+        '---',
+        "gsd_state_version: '1.0'",
+        'milestone: v1.0',
+        'current_phase: 2',
+        'current_phase_name: Second phase',
+        'status: executing',
+        ...(fmStoppedAtLine ? [fmStoppedAtLine] : []),
+        '---',
+        '',
+        '# Project State',
+        '',
+        '## Current Position',
+        '',
+        'Phase: 2 (Second phase)',
+        'Plan: 1 of 1',
+        'Status: In progress',
+        'Last activity: 2026-08-11 — phase 2 executing',
+        '',
+        '## Session Continuity',
+        '',
+        'Last session: 2026-08-10',
+        `Stopped at: ${STALE_3374}`,
+        'Resume file: None',
+        '',
+      ].join('\n'),
+    );
+
+    __fs3374.writeFileSync(__path3374.join(phase2Dir, '02-01-PLAN.md'), '# Plan\n');
+    __fs3374.writeFileSync(__path3374.join(phase2Dir, '02-01-SUMMARY.md'), '# Summary\n');
+    __fs3374.writeFileSync(
+      __path3374.join(phase2Dir, '02-VERIFICATION.md'),
+      ['---', 'status: passed', '---', '', '# Verification', ''].join('\n'),
+    );
+  }
+
+  __d3374('#3374: phase complete must not harvest a stale body Stopped at over fresher frontmatter', () => {
+    let tmpDir;
+    __be3374(() => { tmpDir = __mk3374(); });
+    __ae3374(() => { __rm3374(tmpDir); });
+
+    const COMPLETION_LINE_3374 = 'Phase 2 complete, ready to plan Phase 3';
+
+    __t3374('AC1: the stale body Stopped at never reaches the frontmatter — the transition refreshes the line it implies', () => {
+      writeCompleteFixture3374(tmpDir, `stopped_at: "${FRESH_3374}"`);
+
+      const result = __run3374(['phase', 'complete', '2'], tmpDir);
+      __assert3374.ok(result.success, `phase complete failed: ${result.error}`);
+
+      const stateContent = __fs3374.readFileSync(__path3374.join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
+      const fm = extractFrontmatter(stateContent);
+      __assert3374.notStrictEqual(
+        fm.stopped_at,
+        STALE_3374,
+        `phase.complete harvested the stale pre-completion body value into the frontmatter (#3374 Variant A)`,
+      );
+      __assert3374.strictEqual(
+        fm.stopped_at,
+        COMPLETION_LINE_3374,
+        `the frontmatter must project the continuity line this completion wrote; got ${JSON.stringify(fm.stopped_at)}`,
+      );
+      __assert3374.match(
+        stateContent,
+        /Stopped at: Phase 2 complete, ready to plan Phase 3/,
+        'the body continuity line must be refreshed by the transition itself, not left for a later prose step',
+      );
+    });
+
+    __t3374('AC1 preservation leg: when the writer misses the session line the harvest reads, preservation keeps the fresher frontmatter', () => {
+      writeCompleteFixture3374(tmpDir, `stopped_at: "${FRESH_3374}"`);
+      // Divergence fixture — the class applyStatePreservation backstops: the
+      // replace helpers try the BOLD pattern first against the whole body, so
+      // a bold `**Stopped at:**` decoy in an earlier non-session section
+      // absorbs the transition's refresh, while the harvest (scoped to the
+      // session section) still reads the untouched stale plain line. Without
+      // the adapter's preservation pass, that unrefreshed stale value clobbers
+      // the fresher frontmatter — the original #3374 shape, reachable even
+      // with the transition's own continuity write in place.
+      const statePath = __path3374.join(tmpDir, '.planning', 'STATE.md');
+      const withDecoy = __fs3374.readFileSync(statePath, 'utf-8').replace(
+        '# Project State',
+        ['# Project State', '', '## Archive notes', '', '**Stopped at:** old prose from June'].join('\n'),
+      );
+      __fs3374.writeFileSync(statePath, withDecoy);
+
+      const result = __run3374(['phase', 'complete', '2'], tmpDir);
+      __assert3374.ok(result.success, `phase complete failed: ${result.error}`);
+
+      const fm = extractFrontmatter(__fs3374.readFileSync(statePath, 'utf-8'));
+      __assert3374.strictEqual(
+        fm.stopped_at,
+        FRESH_3374,
+        `the session-scoped body source was not refreshed by this write, so the fresher frontmatter value must be preserved; got ${JSON.stringify(fm.stopped_at)}`,
+      );
+    });
+
+    __t3374('AC2 (no-regress): with no pre-existing frontmatter stopped_at, the body line populates it', () => {
+      writeCompleteFixture3374(tmpDir, null);
+
+      const result = __run3374(['phase', 'complete', '2'], tmpDir);
+      __assert3374.ok(result.success, `phase complete failed: ${result.error}`);
+
+      const stateContent = __fs3374.readFileSync(__path3374.join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
+      const fm = extractFrontmatter(stateContent);
+      __assert3374.strictEqual(
+        fm.stopped_at,
+        COMPLETION_LINE_3374,
+        `first-write population from the (refreshed) body line must keep working; got ${JSON.stringify(fm.stopped_at)}`,
+      );
+    });
+  });
+}
+
+
 // ────────────────────────────────────────────────────────────────────────
 // Folded from tests/fix-2847-gap-closure-frontmatter.test.cjs — test-hygiene sweep #3335 (H3 Wave 3)
 // ────────────────────────────────────────────────────────────────────────

--- a/tests/state.test.cjs
+++ b/tests/state.test.cjs
@@ -2124,6 +2124,66 @@ describe('cmdStateRecordSession (state record-session)', () => {
     assert.strictEqual(output.recorded, false, 'recorded should be false when no session fields found');
     assert.ok(output.reason !== undefined, 'should have a reason');
   });
+
+  // #3374 Variant B: stateReplaceField returns the replaced string on any label
+  // MATCH, including when the value is already the target — so `updated` used
+  // to report 'Stopped At' for a write that never changed a byte, while the
+  // caller's frontmatter stayed stale. The report must reflect real change,
+  // and a matched-but-identical value must NOT arm the #944 DWIM insertion
+  // branch (which wholesale-rewrites the session section and would reset an
+  // executor-authored resume file to 'None').
+  test('#3374: --stopped-at with the value already in the body does not report Stopped At as updated', () => {
+    const executorResume = '.planning/phases/02/02-01-PLAN.md';
+    const fixture = [
+      '# Project State',
+      '',
+      '## Session Continuity',
+      '',
+      '**Last session:** 2024-01-10',
+      '**Stopped at:** Phase 2, Plan 1',
+      `**Resume file:** ${executorResume}`,
+    ].join('\n') + '\n';
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'STATE.md'), fixture);
+
+    const result = runGsdTools('state record-session --stopped-at "Phase 2, Plan 1"', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.ok(
+      !((output.updated || []).includes('Stopped At')),
+      `updated must not report a Stopped At write that changed nothing; got ${JSON.stringify(output.updated)} (#3374 Variant B)`,
+    );
+
+    const updated = fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
+    const stoppedMatches = updated.match(/\*\*Stopped at:\*\*\s*Phase 2, Plan 1/gi) || [];
+    assert.strictEqual(stoppedMatches.length, 1, 'the Stopped at line must be unchanged, not duplicated');
+    assert.ok(
+      updated.includes(`**Resume file:** ${executorResume}`),
+      'an identical --stopped-at must not arm the DWIM section rewrite (executor-authored resume file reset to None)',
+    );
+  });
+
+  test('#3374: --stopped-at with a new value still reports Stopped At and syncs the frontmatter', () => {
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'STATE.md'), sessionFixture);
+
+    const result = runGsdTools('state record-session --stopped-at "Phase 3 complete, ready to plan Phase 4"', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.ok(
+      (output.updated || []).includes('Stopped At'),
+      `a real change must keep reporting Stopped At; got ${JSON.stringify(output.updated)}`,
+    );
+
+    const updated = fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
+    assert.ok(updated.includes('Phase 3 complete, ready to plan Phase 4'), 'body Stopped at should carry the new value');
+    const fm = frontmatterLib.extractFrontmatter(updated);
+    assert.strictEqual(
+      fm.stopped_at,
+      'Phase 3 complete, ready to plan Phase 4',
+      `the RMW sync must reflect the new value in frontmatter; got ${JSON.stringify(fm.stopped_at)}`,
+    );
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
# fix(#3374): phase.complete writes its continuity line and preserves fresher frontmatter stopped_at

## Fix PR

## Linked Issue

Fixes #3374

The linked issue carries `bug` + `confirmed-bug`.

## What was broken

Completing a phase silently rewrote frontmatter `stopped_at` to a stale pre-completion value harvested from the body's `Stopped at:` line — a line `phase.complete` never refreshed — with `warnings: []`. Separately, `state record-session --stopped-at <value already in the body>` reported `updated: ["Stopped At"]` for a write that never changed a byte, so the desync was undetectable to a caller.

## What this fix does

Two layers for Variant A (chosen so #3517's refresh expectation — a stale frontmatter `stopped_at` must be refreshed by completion — keeps holding; that existing test constrains a preservation-only fix from the other freshness direction):

1. **`completePhaseCore` now writes the continuity line it implies** (issue's proposed fix 5): `Stopped at: Phase N complete, ready to plan Phase N+1` (ADR-2207's `all phases complete` phrasing on the last phase; milestone-termination wording stays owned by `milestoneCompleteCore`). The frontmatter projection then reflects this completion rather than pre-completion prose, and the transition workflow's later prose refresh (`transition.md` `update_session_continuity_after_transition`) becomes a confirmation instead of a divergence source. Replace-only: a STATE.md with no session continuity line keeps its shape.
2. **The `phase.complete` adapter routes its direct `syncStateFrontmatter` result through `applyStatePreservation`** (issue's proposed fix 1) — the field-classification table already classifies `stopped_at` as `preserve-when-unchanged`; this path was the only lifecycle write not consulting it — followed by the same #2736 authoritative re-assert `readModifyWriteStateMd` performs. This is the backstop for layouts where the writer cannot refresh the line the harvest reads (e.g. a bold `**Stopped at:**` decoy in an earlier section absorbing the first-match replace — the regression suite pins exactly that divergence).

For Variant B (issue's proposed fix 3): `cmdStateRecordSession` pushes `'Stopped At'` onto `updated[]` only when the replacement actually changed content (the `!== body` idiom `completePhaseCore` already uses for `Completed Phases` per #3057 B9). The label match is tracked separately so a matched-but-identical value does not read as "label missing" to the #944 DWIM insertion branch — pre-fix, making the report honest naively would have armed a section rewrite that resets an executor-authored resume file to `None`.

Also corrects the `state.cts` comment that justified the old design by citing `phase.complete` as a caller that "intentionally writes a new stopped_at value to the body and expect syncStateFrontmatter to pick it up" — it never did, until this PR makes that claim true.

## Root cause

`cmdPhaseComplete`'s adapter deliberately bypasses `readModifyWriteStateMd` (STATE.md commits atomically with ROADMAP/REQUIREMENTS, per its own comment at `src/phase.cts`), but the #948 no-op guard and the #1796 `applyStatePreservation` pass live exclusively inside that wrapper — so this second write path re-derived `stopped_at` from a body source the same command never refreshed, with no divergence handling (`buildStateFrontmatter`'s fallback covers the *empty* case only). For Variant B, `stateReplaceField` returns the substituted string on any label match, including an identical value, and the `updated[]` push keyed on the match.

**Write-path census** (the domain this fix's class lives in — every `syncStateFrontmatter` reachability):
- `readModifyWriteStateMd` (`src/state.cts`) — already guarded (preservation + no-op guard); unchanged.
- `cmdPhaseComplete` adapter (`src/phase.cts`) — **fixed here**.
- `writeStateMd` (`src/state.cts`) → callers `cmdStateSync` (full re-derive is that command's contract — body-wins is intended there), `cmdMilestoneComplete` (`src/milestone.cts`), and `health-diagnostic`'s `runRepairAction` — **not reached by this fix**; the latter two can in principle still project a stale body value over fresher frontmatter. Out of scope per the issue's acceptance criteria (which name only `phase.complete` and `record-session`); flagged for a follow-up rather than silently widened here.
- `record-session` sibling fields (`Last session`, `Last Date`, `Resume File`) still push `updated` on match rather than change — the same reporting class, explicitly declared out of scope by the issue brief; not touched.

**Known limitation (surfaced by pre-file adversarial review, filed knowingly):** the new continuity write uses the same `stateReplaceField` primitive `record-session` already uses — bold-pattern-first, first-match-anywhere. In a pathological layout with a bold `**Stopped at:**` line in a non-session section, that decoy absorbs the write (as it already absorbs `record-session`'s), the session line stays stale, and `state get "Stopped At"` (same whole-document read) returns the rewritten decoy. The frontmatter stays honest in that layout — the session-scoped preservation delta keeps the fresher value, and the regression suite pins exactly that fixture — but session-scoping the *writers* is a separate, wider change shared with `record-session`, out of this PR's scope.

## Testing

### How I verified the fix

- Re-verified the issue's mechanism at `next` HEAD (`7976b1ca0`) before authoring: harvest at `src/state.cts` (`stateExtractField(sessionBodyScope, 'Stopped At')`), unconditional assign (`if (stoppedAt) fm['stopped_at'] = stoppedAt;`), direct sync at the adapter, `updated.push('Stopped At')` on match in `cmdStateRecordSession`.
- All five regression tests below verified **RED against pre-fix sources** (sources checked out at HEAD, lib rebuilt, tests run, then the fix restored) — including the preservation-leg divergence fixture — and green after.
- Full affected suites green post-fix: `tests/frontmatter.test.cjs` + `tests/state.test.cjs` + `tests/phase.test.cjs` (the #3517 block that constrains the design) + `tests/state-transition.test.cjs` — 917/917.
- Required-check chain locally: `tsc -p tsconfig.build.json` and `tsc --noEmit` clean; `eslint --max-warnings 0` clean on all five changed files; `lint-fix-has-regression-test` PASS; `lint-state-field-drift` PASS; `npm run test:unit` run in a sandboxed `HOME`/`CLAUDE_CONFIG_DIR` — remaining failures are environment-only (worktree-local `node_modules` resolution and sandbox-HOME skills-root fixtures), none in the changed surfaces.
- `.changeset/3374-phase-complete-stopped-at.md` added (`type: Fixed`); `pr:` carries the placeholder and will be backfilled with this PR's number immediately after creation.

### Regression test added?

- [x] Yes — added a test that would have caught this bug

`tests/frontmatter.test.cjs` (#3374 block beside the #2736 suite, per the regression-placement policy): stale-body clobber (AC1), writer-miss preservation leg (bold-decoy divergence fixture), first-write population (AC2). `tests/state.test.cjs` (inside `cmdStateRecordSession`'s describe): identical-value honest reporting + DWIM non-arming (AC3), new-value reporting + frontmatter sync (AC4).

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [ ] N/A (not runtime-specific)

The change is runtime-agnostic core (`gsd-tools` state/phase/transition modules); verified on Linux (WSL2) under Claude Code, Node v24.

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

Two deliberate observable-behavior changes, both mandated by the issue's acceptance criteria:

1. `phase.complete` now rewrites the body session continuity `Stopped at:` line (when one exists) to `Phase N complete, ready to plan Phase N+1`, and its `updated[]` gains `'Stopped At'` when that write changes content. A consumer that depended on completion leaving the continuity line untouched will see the refreshed value — that untouched-line behavior is the bug.
2. `state record-session`'s `updated` no longer lists `'Stopped At'` when the supplied value is already the body's current content (AC3). A caller that treated the label-match report as success-signal will now correctly see the field absent; the body content is unchanged in exactly those cases.

Fixes #3374
