### PR TITLE
fix(#3440): retire GAP CLOSURE PLANS CREATED marker, document artifact return contract

### DIFF
--- a/.changeset/jolly-geese-wake.md
+++ b/.changeset/jolly-geese-wake.md
@@ -1,0 +1,5 @@
+---
+type: Changed
+pr: 0
+---
+**Gap-closure planning no longer documents a completion marker nothing reads** — the planner emitted `## GAP CLOSURE PLANS CREATED` but no workflow had a dispatch branch for it, so completion was always detected via the `gap_closure: true` fix-plan artifacts anyway; the dead marker is retired and the artifact route (verify-work `--gaps` spawn → plans → `execute-phase --gaps-only`) is now the documented contract. (#3440)

--- a/.changeset/jolly-geese-wake.md
+++ b/.changeset/jolly-geese-wake.md
@@ -1,5 +1,5 @@
 ---
 type: Changed
-pr: 0
+pr: 3443
 ---
 **Gap-closure planning no longer documents a completion marker nothing reads** — the planner emitted `## GAP CLOSURE PLANS CREATED` but no workflow had a dispatch branch for it, so completion was always detected via the `gap_closure: true` fix-plan artifacts anyway; the dead marker is retired and the artifact route (verify-work `--gaps` spawn → plans → `execute-phase --gaps-only`) is now the documented contract. (#3440)

--- a/.changeset/jolly-geese-wake.md
+++ b/.changeset/jolly-geese-wake.md
@@ -3,3 +3,4 @@ type: Changed
 pr: 3443
 ---
 **Gap-closure planning no longer documents a completion marker nothing reads** — the planner emitted `## GAP CLOSURE PLANS CREATED` but no workflow had a dispatch branch for it, so completion was always detected via the `gap_closure: true` fix-plan artifacts anyway; the dead marker is retired and the artifact route (verify-work `--gaps` spawn → plans → `execute-phase --gaps-only`) is now the documented contract. (#3440)
+<!-- docs-exempt: the retirement and its replacement contract live in gsd-core/references/planner-guidance.md, the runtime-loaded reference for this seam; no docs/ page documents the marker today (verified) and none is owed for its removal -->

--- a/agents/gsd-planner.md
+++ b/agents/gsd-planner.md
@@ -934,7 +934,7 @@ Return structured planning outcome to orchestrator.
 
 <structured_returns>
 
-See @~/.claude/gsd-core/references/planner-guidance.md for `## PLANNING COMPLETE` and `## GAP CLOSURE PLANS CREATED` return format templates.
+See @~/.claude/gsd-core/references/planner-guidance.md for return formats; gap-closure returns are artifact-based (#3440).
 
 See @~/.claude/gsd-core/references/planner-chunked.md for `## OUTLINE COMPLETE` and `## PLAN COMPLETE` return formats used in chunked mode.
 

--- a/gsd-core/references/planner-guidance.md
+++ b/gsd-core/references/planner-guidance.md
@@ -162,24 +162,18 @@ Derive plans from actual work. Granularity determines compression tolerance, not
 Run `/clear` first for a fresh context window, then execute: `/gsd:execute-phase {phase}`
 ```
 
-## Gap Closure Plans Created Return Format
+## Gap Closure Return (artifact-based — #3440)
 
-```markdown
-## GAP CLOSURE PLANS CREATED
+Gap-closure completion has **no completion marker**: nothing consumes one. The return contract is the artifacts themselves — `verify-work.md` spawns you in `--gaps` mode, and your output is complete when the fix plans are on disk carrying `gap_closure: true` in their frontmatter; the spawning workflow detects the files (never a return string), and `/gsd:execute-phase {phase} --gaps-only` consumes them. (The former `GAP CLOSURE PLANS CREATED` completion marker was retired as vestigial — it had no dispatch branch anywhere.)
 
 **Phase:** {phase-name}
 **Closing:** {N} gaps from {VERIFICATION|UAT}.md
-
-### Plans
 
 | Plan | Gaps Addressed | Files |
 |------|----------------|-------|
 | {phase}-04 | [gap truths] | [files] |
 
-### Next Steps
-
-Execute: `/gsd:execute-phase {phase} --gaps-only`
-```
+**Next step for the orchestrator:** `/gsd:execute-phase {phase} --gaps-only`
 
 ## Checkpoint Reached / Revision Complete
 

--- a/tests/planner-decomposition.test.cjs
+++ b/tests/planner-decomposition.test.cjs
@@ -120,6 +120,32 @@ describe('reference files contain key content from original mode sections', () =
     assert.ok(hasGapContent, 'planner-gap-closure.md must contain gap closure mode content');
   });
 
+  // #3440: the planner's gap-closure return has NO completion marker — nothing
+  // consumed `## GAP CLOSURE PLANS CREATED` (no dispatch branch anywhere), so
+  // emitting it was a lie about the return contract. Completion is detected via
+  // the `gap_closure: true` fix-plan artifacts. This guard goes red if the
+  // marker (or an equivalent unconsumed sentinel) reappears in either producer.
+  test('gap-closure return is artifact-based — no unconsumed completion marker (#3440)', () => {
+    const guidance = fs.readFileSync(
+      path.join(PROJECT_ROOT, 'gsd-core', 'references', 'planner-guidance.md'), 'utf-8');
+    const planner = fs.readFileSync(
+      path.join(PROJECT_ROOT, 'agents', 'gsd-planner.md'), 'utf-8');
+    for (const [label, content] of [['planner-guidance.md', guidance], ['gsd-planner.md', planner]]) {
+      assert.ok(
+        !content.includes('## GAP CLOSURE PLANS CREATED'),
+        `${label} must not emit the retired marker — no workflow dispatches on it (#3440)`,
+      );
+    }
+    assert.ok(
+      guidance.includes('gap_closure: true'),
+      'planner-guidance.md must document the artifact return contract (gap_closure: true plans)',
+    );
+    assert.ok(
+      guidance.includes('--gaps-only'),
+      'planner-guidance.md must name the consumer route (execute-phase --gaps-only)',
+    );
+  });
+
   test('planner-revision.md contains revision content', () => {
     const content = fs.readFileSync(REVISION_REF, 'utf-8');
     const hasRevisionContent = content.includes('revision') ||


### PR DESCRIPTION
## Linked Issue

Closes #3440

> Child of epic #1891 (F9). Direction decided by the maintainer in chat 2026-08-14: retire the marker; the `gap_closure: true` artifact route is canonical.

## What this enhancement improves

The planner emitted `## GAP CLOSURE PLANS CREATED` as its sanctioned gap-closure return, but no workflow has a dispatch branch for it — every gap-closure completion was already detected via the fix-plan artifacts. The marker was a lie about the return contract (the epic's "sentinel drift" class).

## Before / After

**Before:** planner-guidance.md documented a marker template nothing consumes; every gap-closure run "completed" through the filesystem-fallback path with a prose return no orchestrator reads.

**After:** the marker is retired from both producers (`planner-guidance.md`, `gsd-planner.md`); the documented contract is the artifact route that actually runs — `verify-work.md` spawns the planner in `--gaps` mode, fix plans land with `gap_closure: true` frontmatter, and `/gsd:execute-phase --gaps-only` consumes them. A regression guard pins it: the marker may not reappear in either producer, and the artifact contract (`gap_closure: true`, `--gaps-only`) must stay documented.

## How it was implemented

- `gsd-core/references/planner-guidance.md`: the marker return-format template replaced by the artifact-return contract statement (with the retirement note); net prose growth confined to the reference
- `agents/gsd-planner.md`: structured-returns pointer updated; edit sized **net −19 bytes** so every planner size-cap assertion (45K-char extraction proof, 49152 caps in three suites) stays at its base-passing value
- `tests/planner-decomposition.test.cjs`: new regression test (RED at base — the marker exists there; GREEN at HEAD)

## Testing

### How I verified the enhancement works

- Regression test red-by-construction at base, green at HEAD
- `eslint` clean; `GITHUB_BASE_REF=next npm run lint:ci` exit 0 (incl. `lint-fix-has-regression-test`)
- `gsd-test` verdict `passed`, 33,412/33,412 (node24, plex2), marker recorded for sha `e489e301d25b60ee856aaf1b622b40b5c1b2284b`
- Live-marker independence: `## PLANNING COMPLETE` / `## PLAN COMPLETE` / `## OUTLINE COMPLETE` (all matched by plan-phase) untouched and still pinned green

### Platforms tested

- [ ] macOS / [ ] Windows / [ ] Linux
- [x] N/A (markdown prompt-layer + structural tests; CI matrix covers all OSes)

### Runtimes tested

- [x] N/A (not runtime-specific)

## Scope confirmation

- [x] Matches the approved direction exactly (retire; declare artifact route canonical)
- [x] No scope changes during implementation

## Documentation

- [x] The contract statement lives in `planner-guidance.md` itself (the runtime-loaded reference for this seam)
- [x] All docs content in English
- [x] `Changed`-type changeset present, docs-rule satisfied via the guidance contract rewrite

## Checklist

- [x] Issue linked with `Closes #3440`
- [x] Linked issue carries maintainer approval (epic #1891 + in-chat direction)
- [x] Scoped to the approved change
- [x] All existing tests pass (verdict above)
- [x] Regression test added
- [x] `.changeset/` fragment added (`pr:` backfilled below)
- [x] No unnecessary dependencies added

## Breaking changes

None — gap-closure completion detection was already artifact-based; this removes dead prose and pins the real contract.
