### PR TITLE
fix(#3263): warn in roadmap validate on truncated milestone window

### DIFF
--- a/.changeset/serene-tigers-gather.md
+++ b/.changeset/serene-tigers-gather.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 3444
 ---
 roadmap validate now emits a V005 warning and exits non-zero when the active milestone's window is truncated — phase entries exist in ROADMAP.md but are excluded from the milestone's resolved section (e.g. an intervening version-bearing heading closes the window before its own Phase sections). Previously this passed silently with {"warnings":[]}.

--- a/.changeset/serene-tigers-gather.md
+++ b/.changeset/serene-tigers-gather.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+roadmap validate now emits a V005 warning and exits non-zero when the active milestone's window is truncated — phase entries exist in ROADMAP.md but are excluded from the milestone's resolved section (e.g. an intervening version-bearing heading closes the window before its own Phase sections). Previously this passed silently with {"warnings":[]}.

--- a/src/roadmap-command-router.cts
+++ b/src/roadmap-command-router.cts
@@ -24,6 +24,12 @@ const { loadConfig } = configLoaderMod;
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import cliExitMod = require('./cli-exit.cjs');
 const { ExitError } = cliExitMod;
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import roadmapParserMod = require('./roadmap-parser.cjs');
+const { extractCurrentMilestoneScoped } = roadmapParserMod;
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import planningScopeMod = require('./planning-scope.cjs');
+const { SCOPE } = planningScopeMod;
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -183,6 +189,32 @@ function routeRoadmapCommand({ roadmap, args, cwd, raw, error }: RouteRoadmapCom
         const hasPhaseEntry = /^#{2,4}\s*Phase\s+\S/im.test(roadmapContent);
         if (!hasPhaseEntry && !warnings.some((w) => w.code === 'V002')) {
           warnings.push({ code: 'V004', message: 'ROADMAP.md contains no recognizable phase entries (no "### Phase N:" headings)' });
+        }
+
+        // #3263: a whole-document phase check (V004 above) is satisfied by a
+        // document whose phase entries live OUTSIDE the active milestone's
+        // resolved window — e.g. an intervening version-bearing heading closes
+        // the window before its own `### Phase N:` sections. That truncation
+        // is exactly what the #3184 scope discriminator classifies, so ask
+        // the single owner (never re-derive the window shape here —
+        // lint-milestone-window-drift bans local copies) and surface a
+        // non-COMPLETE-but-not-empty verdict. TRUNCATED only: a genuinely
+        // phase-less milestone classifies COMPLETE (V004 owns that case) and
+        // an unscoped/unreadable window is a different failure mode with a
+        // different remediation, deliberately not warned here.
+        try {
+          const scoped = extractCurrentMilestoneScoped(contentAfterBom, cwd);
+          if (scoped.scope === SCOPE.TRUNCATED) {
+            warnings.push({
+              code: 'V005',
+              message:
+                'Active milestone window is truncated: phase entries exist in ROADMAP.md but are excluded from the ' +
+                'active milestone\'s resolved window (check for a heading between the milestone heading and its "### Phase N:" sections)',
+            });
+          }
+        } catch {
+          // The classifier is best-effort here — a throw must not mask the
+          // structural warnings already collected above.
         }
 
         // W021 only fires when phase_id_convention is explicitly 'milestone-prefixed'.

--- a/tests/roadmap.test.cjs
+++ b/tests/roadmap.test.cjs
@@ -3708,3 +3708,111 @@ describe('bug #2978: roadmap validate performs structural validation', () => {
     } finally { cleanup(tmpDir); }
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// bug #3263: roadmap validate is silent when the active milestone window is
+// truncated (phase entries exist in the document but are excluded from the
+// resolved window). The scope discriminator (#3184) already classifies this
+// as SCOPE.TRUNCATED; validate must surface it as V005 + non-zero exit.
+// Matrix: .gsd/bug/fix-3263-milestone-window-truncation-retest/50-test-matrix.md
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('bug #3263: roadmap validate warns on a truncated milestone window', () => {
+  function writeFixture(tmpDir, roadmapContent, stateFields) {
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), roadmapContent);
+    if (stateFields) {
+      const lines = ['---'];
+      for (const [k, v] of Object.entries(stateFields)) lines.push(`${k}: ${v}`);
+      lines.push('---', '');
+      fs.writeFileSync(path.join(tmpDir, '.planning', 'STATE.md'), lines.join('\n'));
+    }
+  }
+
+  test('window closed before its phase entries → V005 warning, non-zero exit', () => {
+    const tmpDir = createTempProject('gsd-3263-truncated-');
+    try {
+      // v3.0's window closes at the intervening `## v4.0 Next` heading,
+      // before the phase entries — which exist in the document, under v4.0.
+      writeFixture(tmpDir, [
+        '# Roadmap',
+        '',
+        '## v3.0 In Progress 🚧',
+        '',
+        'Some preamble notes. No phase headings here.',
+        '',
+        '## v4.0 Next',
+        '',
+        '### Phase 1: Foo',
+        '',
+        '### Phase 2: Bar',
+      ].join('\n'), { milestone: 'v3.0' });
+      const result = runGsdTools(['roadmap', 'validate', '--raw'], tmpDir);
+      assert.strictEqual(result.success, false, 'truncated window must exit non-zero');
+      const payload = JSON.parse(result.output);
+      const v005 = payload.warnings.find((w) => w.code === 'V005');
+      assert.ok(v005, `truncated window must produce a V005 warning; got: ${JSON.stringify(payload)}`);
+      assert.ok(v005.message.length > 0, 'V005 carries a message');
+    } finally { cleanup(tmpDir); }
+  });
+
+  test('phases inside the window → no V005, exit 0 (no false positive)', () => {
+    const tmpDir = createTempProject('gsd-3263-normal-');
+    try {
+      writeFixture(tmpDir, [
+        '# Roadmap',
+        '',
+        '## v3.0 In Progress 🚧',
+        '',
+        '### Phase 1: Foo',
+        '',
+        '### Phase 2: Bar',
+        '',
+        '## v4.0 Next',
+        '',
+        'Later plans.',
+      ].join('\n'), { milestone: 'v3.0' });
+      const result = runGsdTools(['roadmap', 'validate', '--raw'], tmpDir);
+      assert.ok(result.success, `normal roadmap must exit 0; got: ${result.error}`);
+      const payload = JSON.parse(result.output);
+      assert.deepStrictEqual(payload.warnings, [], 'normal roadmap must have no warnings');
+    } finally { cleanup(tmpDir); }
+  });
+
+  test('genuinely phase-less milestone → V004 only, no V005', () => {
+    const tmpDir = createTempProject('gsd-3263-empty-');
+    try {
+      writeFixture(tmpDir, [
+        '# Roadmap',
+        '',
+        '## v1.0 Current 🚧',
+        '',
+        'Nothing planned yet.',
+      ].join('\n'), { milestone: 'v1.0' });
+      const result = runGsdTools(['roadmap', 'validate', '--raw'], tmpDir);
+      assert.strictEqual(result.success, false, 'phase-less roadmap must exit non-zero');
+      const payload = JSON.parse(result.output);
+      assert.ok(payload.warnings.some((w) => w.code === 'V004'),
+        `V004 still owns the no-phase-entries case; got: ${JSON.stringify(payload)}`);
+      assert.ok(!payload.warnings.some((w) => w.code === 'V005'),
+        `a genuinely phase-less milestone must not produce V005; got: ${JSON.stringify(payload)}`);
+    } finally { cleanup(tmpDir); }
+  });
+
+  test('unscoped versioned roadmap (no STATE.md milestone) → no V005 over-fire', () => {
+    const tmpDir = createTempProject('gsd-3263-unscoped-');
+    try {
+      // No STATE.md: scope is UNSCOPED, not TRUNCATED — must not fire V005.
+      writeFixture(tmpDir, [
+        '# Roadmap',
+        '',
+        '## v1.0 Old ✅ SHIPPED',
+        '',
+        '### Phase 1: Foo',
+      ].join('\n'));
+      const result = runGsdTools(['roadmap', 'validate', '--raw'], tmpDir);
+      assert.ok(result.success, `unscoped roadmap must exit 0; got: ${result.error}`);
+      const payload = JSON.parse(result.output);
+      assert.deepStrictEqual(payload.warnings, [], 'unscoped roadmap must have no warnings');
+    } finally { cleanup(tmpDir); }
+  });
+});


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3263

## What was broken

`roadmap validate` returned `{"warnings":[]}` with exit 0 for a ROADMAP.md whose active milestone window is truncated — an intervening version-bearing heading closes the window before the milestone's own `### Phase N:` entries, so those phases exist in the document but are excluded from the resolved window. Re-tested empirically against current `next` (8ecbac035, including #3428 for #3165): still silent, while `roadmap analyze` on the same fixture reports `scope: "truncated"`.

## What this fix does

The `validate` handler now consults the existing single-owner scope discriminator — `extractCurrentMilestoneScoped` (`src/roadmap-parser.cts`, #3184/ADR-3180) — and emits a new `V005` warning when the active milestone's scope is `TRUNCATED`, which the handler's existing warnings-present tail converts to a non-zero exit, per validate's documented contract. No window logic is re-derived locally (the milestone-window drift guard's exact ban); no classification behavior changes.

## Root cause

The validate handler's only phase check (V004) tests the whole raw file for any phase heading (`src/roadmap-command-router.cts`), so a document whose phases live outside the active milestone's resolved window satisfies it. The #3184 scope machinery classifies exactly this case as `SCOPE.TRUNCATED` (window has no phase entries; the document does), but the handler never asked — it predates the scope machinery (#2978) and was never migrated onto it. Distinct from and complementary to #3428, which repaired `roadmap analyze`'s phase count on the same scope signal without touching validate.

## Testing

### How I verified the fix

Reproduced via the `roadmap validate --raw` CLI seam with a STATE.md-driven fixture (active `v3.0` window closed by a `## v4.0 Next` heading before its phase entries). Before the fix: `{"warnings":[]}`, exit 0. After: `V005` warning with a message naming the truncation, exit 1.

### Regression test added?

- [x] Yes — added a 4-case describe block in `tests/roadmap.test.cjs` beside the #2978 validate block: truncated window → V005 + non-zero exit; phases inside the window → no V005, exit 0 (no false positive); genuinely phase-less milestone → V004 only, no V005; unscoped versioned roadmap (no STATE.md milestone) → no V005 over-fire. Existing #2978 V001-V004 tests all still pass unchanged.

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific — pure Node CLI logic)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific — pure CLI/query logic)

---

## Checklist

- [x] Issue linked above with `Fixes #3263`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — one handler in `src/roadmap-command-router.cts`; analyze/stats/progress/milestone-complete surfaces untouched, per the issue's out-of-scope list
- [x] Regression test added
- [x] All existing tests pass (`tests/roadmap.test.cjs`, `tests/milestone-window-single-owner.test.cjs`, `tests/milestone-prefixed-convention.test.cjs` locally; GitHub CI for the full suite)
- [x] `.changeset/` fragment added (`npm run changeset -- --type Fixed --pr 0 ...`, PR number backfilled post-open)
- [x] No unnecessary dependencies added

## Breaking changes

`roadmap validate` now exits non-zero with a `V005` warning on documents it previously passed silently — that is the fix, matching the issue's acceptance criteria ("exits non-zero on any error or warning" is validate's own documented contract). V001-V004 behavior is unchanged; a genuinely phase-less milestone still produces V004 only.
