### PR TITLE
fix(#3311): raise allow-test-rule ceiling to match real exemption count

### DIFF
--- a/scripts/lint-allow-test-rule-refs.ceiling.json
+++ b/scripts/lint-allow-test-rule-refs.ceiling.json
@@ -1,4 +1,4 @@
 {
-  "maxFiles": 301,
+  "maxFiles": 302,
   "grace": 3
 }


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #3461

---

## What was broken

`next`'s Tests workflow has been red since commit `6b34557ba` (#3311, PR #3455). Every push to `next` since then fails `lint-tests` and unit-test shard 3/3 on all three OSes with `[allow-test-rule-total-files] Regression: artifact value 302 exceeds budget ceiling 301`.

## What this fix does

Bumps `scripts/lint-allow-test-rule-refs.ceiling.json`'s `maxFiles` from 301 to 302 to match the real, current count of distinct `tests/**/*.test.cjs` files carrying an `allow-test-rule:` marker.

## Root cause

PR #3455 (#3311) added `tests/milestone-lock.test.cjs` with a properly-cited exemption marker, legitimately growing the tracked count from 301 to 302 — but didn't bump the ceiling the way the immediately-prior commit (`011153c07`, #3300) correctly did for the same kind of change. Every subsequent merge to `next` inherited the stale ceiling and stayed red.

## Testing

### How I verified the fix

`node scripts/lint-allow-test-rule-refs.cjs` reproduces the failure at `next`'s HEAD and passes after the bump. A full `npm run lint:ci` run (after `npm run build:lib`) is fully green with only this change — confirming no other regression on `next`. Verified via the `gsd-test` remote runner against this exact commit sha before opening this PR.

### Regression test added?

- [ ] Yes — added a test that would have caught this bug
- [x] No — explain why: this is a committed-config drift (a JSON ceiling value falling out of sync with the real repo state), not a code-behavior bug; the existing `tests/lint-allow-test-rule-refs.test.cjs` "repo baseline passes" test already asserts the real ceiling matches the real count on every CI run and is what caught this regression.

### Platforms tested

- [x] macOS
- [x] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (verified via `gsd-test` remote runner, not local `npm test`)
- [ ] `.changeset/` fragment added if this is a user-facing fix — not applicable: `scripts/` is not a user-facing path per `scripts/changeset/lint.cjs`'s `USER_FACING_PREFIXES`, so this is `ok_no_user_facing_changes`
- [x] No unnecessary dependencies added

## Breaking changes

None
