### PR TITLE
fix(#3427): teach full-form depends_on ids in phase-prompt template

### DIFF
--- a/.changeset/tidy-ravens-sing.md
+++ b/.changeset/tidy-ravens-sing.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 3475
 ---
 phase-plan-index silently drops short-form depends_on references (e.g. ["01"]), collapsing every plan into wave 1. The planner template's two worked dependency examples taught exactly that broken short form; they now teach the full-form plan id (e.g. ["01-01"]) the file's own frontmatter comment and other examples already document, so newly authored plans keep resolvable dependency edges. Resolver-side short-form handling is tracked separately in #3473.

--- a/.changeset/tidy-ravens-sing.md
+++ b/.changeset/tidy-ravens-sing.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+phase-plan-index silently drops short-form depends_on references (e.g. ["01"]), collapsing every plan into wave 1. The planner template's two worked dependency examples taught exactly that broken short form; they now teach the full-form plan id (e.g. ["01-01"]) the file's own frontmatter comment and other examples already document, so newly authored plans keep resolvable dependency edges. Resolver-side short-form handling is tracked separately in #3473.

--- a/gsd-core/templates/phase-prompt.md
+++ b/gsd-core/templates/phase-prompt.md
@@ -187,7 +187,7 @@ autonomous: true
 
 # Plan 02 - Protected features (needs auth)
 wave: 2
-depends_on: ["01"]
+depends_on: ["01-01"]
 files_modified: [src/features/dashboard.ts]
 autonomous: true
 ```
@@ -199,7 +199,7 @@ Plan 02 in Wave 2 waits for Plan 01 in Wave 1 - genuine dependency on auth types
 ```yaml
 # Plan 03 - UI with verification
 wave: 3
-depends_on: ["01", "02"]
+depends_on: ["01-01", "01-02"]
 files_modified: [src/components/Dashboard.tsx]
 autonomous: false  # Has checkpoint:human-verify
 ```

--- a/scripts/lint-allow-test-rule-refs.ceiling.json
+++ b/scripts/lint-allow-test-rule-refs.ceiling.json
@@ -1,4 +1,4 @@
 {
-  "maxFiles": 304,
+  "maxFiles": 305,
   "grace": 3
 }

--- a/tests/template-phase-prompt-dependson-3427.test.cjs
+++ b/tests/template-phase-prompt-dependson-3427.test.cjs
@@ -1,0 +1,111 @@
+// allow-test-rule: source-text-is-the-product (see #3427)
+// Reads gsd-core/templates/phase-prompt.md — the template's deployed text IS
+// what the planner loads, so testing its worked `depends_on` examples tests the
+// contract the wave DAG depends on.
+
+/**
+ * Regression guard for #3427 / #3473 criterion B8.
+ *
+ * `resolveDependencyId` (src/phase.cts) resolves a `depends_on` token only
+ * when it is a FULL plan id (`planMap` exact match) or a canonical id
+ * (`canonicalToId` prefix match). A bare short-form suffix (`"01"`) resolves
+ * to nothing and every caller silently drops the edge, collapsing the phase
+ * into wave 1 (#3427; the resolver half is rewritten by #3473 B4/B5).
+ *
+ * Until short-form resolution exists — and regardless, per the template's own
+ * documented convention (`depends_on: [] # e.g., ["01-01"]`) — the planner
+ * template must only ever TEACH full-form ids in its worked `depends_on`
+ * examples. This suite pins that: every non-empty `depends_on:` example in
+ * templates/phase-prompt.md lists `NN-NN` full-form plan ids only.
+ */
+
+'use strict';
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const TEMPLATE = path.join(__dirname, '..', 'gsd-core', 'templates', 'phase-prompt.md');
+
+/** Full-form plan id: two-digit phase + two-digit plan, e.g. "03-01". */
+const FULL_FORM_ID = /^\d{2}-\d{2}$/;
+
+/**
+ * Extract every `depends_on:` example line from a template body.
+ * Returns [{ line, tokens }] where tokens is the parsed string array
+ * ([] for `depends_on: []`, null for a non-literal/unparsable value — the
+ * caller treats null as a failure so an example can never opt out by
+ * obfuscating its array).
+ */
+function extractDependsOnExamples(body) {
+  const out = [];
+  const lines = body.split('\n');
+  lines.forEach((line, i) => {
+    const match = line.match(/^\s*depends_on:\s*(\[[^\]]*\])\s*(?:#.*)?$/);
+    if (!match) return;
+    const raw = match[1].trim();
+    if (raw === '[]') {
+      out.push({ line: i + 1, text: line, tokens: [] });
+      return;
+    }
+    const inner = raw.slice(1, -1).trim();
+    const tokens = inner
+      .split(',')
+      .map((piece) => piece.trim().replace(/^["']|["']$/g, ''));
+    out.push({ line: i + 1, text: line, tokens });
+  });
+  return out;
+}
+
+/** Every token in every non-empty example is a full-form plan id. */
+function shortFormTokens(examples) {
+  const bad = [];
+  for (const example of examples) {
+    for (const token of example.tokens) {
+      if (!FULL_FORM_ID.test(token)) bad.push({ ...example, token });
+    }
+  }
+  return bad;
+}
+
+describe('phase-prompt template teaches only full-form depends_on ids (#3427 / #3473 B8)', () => {
+  const body = fs.readFileSync(TEMPLATE, 'utf8');
+  const examples = extractDependsOnExamples(body);
+
+  test('template carries depends_on examples to check (non-vacuous)', () => {
+    assert.ok(examples.length >= 8, `expected >= 8 depends_on examples, found ${examples.length}`);
+    assert.ok(
+      examples.some((e) => e.tokens.length > 0),
+      'expected at least one non-empty depends_on example'
+    );
+  });
+
+  test('every non-empty depends_on example lists full-form plan ids only', () => {
+    const bad = shortFormTokens(examples);
+    assert.deepEqual(
+      bad.map((b) => `line ${b.line}: token "${b.token}" in ${b.text.trim()}`),
+      [],
+      'depends_on examples must use full-form plan ids (e.g. ["03-01"]), never ' +
+        'bare short-form suffixes like ["01"] — the resolver drops those edges ' +
+        'silently (#3427)'
+    );
+  });
+
+  test('checker: known good/bad samples classify correctly', () => {
+    const good = extractDependsOnExamples(
+      [
+        'depends_on: []',
+        'depends_on: ["03-01"]',
+        'depends_on: ["03-01", "03-02"]  # trailing comment',
+        'depends_on: ["01-01"]',
+      ].join('\n')
+    );
+    assert.deepEqual(shortFormTokens(good), []);
+
+    const bad = extractDependsOnExamples(
+      ['depends_on: ["01"]', 'depends_on: ["01", "02"]'].join('\n')
+    );
+    assert.equal(shortFormTokens(bad).length, 3); // both tokens of line 2 + line 1
+  });
+});


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3427

> The linked issue carries the `confirmed-bug` label. #3427 was closed as a duplicate of epic #3473, whose closing comment explicitly unblocks this template half as criterion **B8**: "B8 — new, and it lands FIRST, independently of everything else. Your fix 4 (`phase-prompt.md` L190/L202 → full form) touches no seam any other criterion touches. If you still want to open that PR, please do." This is that PR. The resolver-side half (short-form resolution tier, the dedicated cannot-resolve warning, typed `resolveDependencyId` result) is deliberately NOT touched here — it is #3473 B4/B5 territory, and editing `resolveDependencyId` against the epic's rewrite is the collision the epic exists to prevent.

---

## What was broken

The phase planner template's two worked dependency examples taught the short-form `depends_on` syntax (`depends_on: ["01"]`, `depends_on: ["01", "02"]`) that `phase-plan-index` cannot resolve — `resolveDependencyId` only understands full plan ids and canonical ids, so a stock planner run following the template's own examples silently loses every dependency edge and collapses the phase into wave 1 (#3427).

## What this fix does

Corrects the two broken examples in `gsd-core/templates/phase-prompt.md` (L190, L202) to the full-form plan-id syntax the same file already documents everywhere else — the frontmatter comment at L20 (`e.g., ["01-01"]`) and the worked examples at L372/L441 (`["03-01"]`, `["03-01", "03-02"]`):

- `depends_on: ["01"]` → `depends_on: ["01-01"]`
- `depends_on: ["01", "02"]` → `depends_on: ["01-01", "01-02"]`

The template is now internally consistent and stops steering planners into the form that silently drops dependency edges.

## Root cause

The template's parallel/sequential examples predate the pinning of `depends_on` to full-form plan ids and were never corrected with it; the `shortFormToId` resolution tier that once made short forms work lived on the retired SDK surface (`sdk/src/query/phase.ts`, #3488/PR #3501) and was never backfilled into the `.cts` lineage.

## Testing

### How I verified the fix

New suite `tests/template-phase-prompt-dependson-3427.test.cjs` (3 tests) pins the invariant: every non-empty `depends_on:` example in `templates/phase-prompt.md` lists full-form `NN-NN` plan ids only. Verified failing-first on unfixed `next` — it named exactly the two broken lines (`line 190: token "01"`, `line 202: token "01"/"02"`) — and passing after the fix. The suite carries the `allow-test-rule: source-text-is-the-product` marker (the template's deployed text is what the planner loads) with the marker-file ceiling bumped 304 → 305; `lint:ci` and the changeset lint (GITHUB_BASE_REF=next) both exit 0.

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added (`npm run changeset -- --type Fixed --pr <NNN>`)
- [x] No unnecessary dependencies added

## Breaking changes

None. A two-line correction to two worked examples in the planner template; no code, no output format, no API. Plans already authored with short-form `depends_on` are unaffected by this PR (their resolution gap is #3473 B4/B5).
