### PR TITLE
fix(#3498): escapeRegex falls back below Node 24 (no RegExp.escape)

### DIFF
--- a/.changeset/lively-orcas-climb.md
+++ b/.changeset/lively-orcas-climb.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 3499
+---
+**The build no longer requires Node 24: `escapeRegex` falls back to an in-file metachar escape when `RegExp.escape` is absent** (#3498) — `RegExp.escape` is ES2026 (Node 24+), and `src/pattern.cts` called it unconditionally, so `npm run build` itself failed on Node 22 (`gen-loop-host-contract` consumes the module), breaking the gsd-test `linux-node22` verification lane. The seam now prefers the built-in when present and falls back otherwise — still the single owner of escaping (#3212 invariant preserved). Behavior on Node 24+ is unchanged; match behavior below Node 24 is verified equivalent by regression tests that neuter `RegExp.escape` in a child process.

--- a/src/pattern.cts
+++ b/src/pattern.cts
@@ -6,10 +6,10 @@
  * (gitignored), per the repo's ADR-457 build-at-publish convention.
  *
  * Sole owner of building a `RegExp` from a runtime value. `escapeRegex`
- * delegates to the built-in `RegExp.escape` (ES2026 / Node 24+) rather than
- * hand-rolling yet another copy of the metacharacter-escape helper this
- * module replaces — see ADR §1 ("No module outside the seam escapes a value
- * for regex use").
+ * delegates to the built-in `RegExp.escape` (ES2026 / Node 24+) when present,
+ * falling back to an in-file metacharacter escape below Node 24 (#3498) —
+ * still the one owner: no module outside this seam escapes a value for regex
+ * use (ADR §1).
  *
  * Counts, corrected during implementation (design doc "Ground truth" #1;
  * .gsd/phase/chore-3412-pattern-seam/40-design.md): the ADR's census counted
@@ -41,8 +41,24 @@
  * migration-equivalence property sweep in tests/pattern.test.cjs (rows 15-17).
  */
 
+// #3498: RegExp.escape is ES2026 (first shipped in Node 24). The gsd-test
+// matrix still runs a linux-node22 lane, and the build itself consumes this
+// module (scripts/gen-loop-host-contract.cjs), so a hard dependency breaks
+// `npm run build` on Node 22. Prefer the built-in when present; otherwise use
+// the local metachar escape — still inside this file, so the #3212 sole-owner
+// invariant (and lint-no-adhoc-regex-escape's scope) is preserved. Captured at
+// module load so a runtime mutation of RegExp.escape cannot flip the path
+// mid-process.
+const escapeBuiltin: ((value: string) => string) | undefined =
+  typeof RegExp.escape === 'function'
+    ? RegExp.escape.bind(RegExp)
+    : undefined;
+
+const escapeMetachars = (value: string): string =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
 export function escapeRegex(value: string): string {
-  return RegExp.escape(value);
+  return (escapeBuiltin ?? escapeMetachars)(value);
 }
 
 export function literalPattern(value: string, flags?: string): RegExp {

--- a/tests/pattern.test.cjs
+++ b/tests/pattern.test.cjs
@@ -202,3 +202,50 @@ describe('migration equivalence (row-9 sweep)', () => {
     );
   });
 });
+
+// ─── Section 4: #3498 — Node-22 fallback (no RegExp.escape) ─────────────────
+
+describe('escapeRegex without RegExp.escape (#3498 Node-22 fallback)', () => {
+  // `RegExp.escape` is ES2026 (first shipped in Node 24). The gsd-test matrix
+  // runs a linux-node22 lane and the BUILD consumes this module
+  // (scripts/gen-loop-host-contract.cjs), so the seam must work when the
+  // builtin is absent. Simulated in a child process: neuter RegExp.escape
+  // BEFORE require (module-load capture must select the fallback), then assert
+  // match-behavior correctness — this file's doctrine (pattern TEXT differs
+  // between builtin and fallback; match behavior must not).
+  const { runNode, OUTCOME } = require('./helpers/process-seam.cjs');
+  const path = require('node:path');
+  const LIB = path.join(__dirname, '..', 'gsd-core', 'bin', 'lib', 'pattern.cjs');
+
+  const PROBE = [
+    "RegExp.escape = undefined;",
+    "const { escapeRegex, literalPattern } = require(" + JSON.stringify(LIB) + ");",
+    "const corpus = ['a.b*c', '^dollar$', '(group|alt)', '[b]{1,2}', 'back\\\\slash', 'plain', 'q+x?y', 'a-b-c', ''];",
+    "for (const v of corpus) {",
+    "  if (!new RegExp(escapeRegex(v)).test(v)) { console.error('self-match fail: ' + JSON.stringify(v)); process.exit(1); }",
+    "  if (!literalPattern(v).test(v)) { console.error('literalPattern fail: ' + JSON.stringify(v)); process.exit(1); }",
+    "}",
+    "if (new RegExp(escapeRegex('a.b*c')).test('aXbZc')) { console.error('metachar reinterpreted'); process.exit(1); }",
+    "if (new RegExp(escapeRegex('(a|b)')).test('a')) { console.error('alternation reinterpreted'); process.exit(1); }",
+    "console.log('fallback-ok');",
+  ].join('\n');
+
+  test('builds and escapes correctly when RegExp.escape is absent (Node 22 semantics)', () => {
+    const r = runNode(['-e', PROBE], { timeoutMs: 30_000 });
+    assert.strictEqual(r.outcome, OUTCOME.EXITED, `probe must run: ${r.stderr}`);
+    assert.strictEqual(r.exitCode, 0, `fallback path failed: ${r.stdout}\n${r.stderr}`);
+    assert.match(r.stdout, /fallback-ok/);
+  });
+
+  test('neutering AFTER require must not flip the path mid-process (capture at load)', () => {
+    const PROBE2 = [
+      "const { escapeRegex } = require(" + JSON.stringify(LIB) + ");",
+      "RegExp.escape = undefined;",
+      "if (!new RegExp(escapeRegex('a.b')).test('a.b')) { console.error('post-load neuter broke escaping'); process.exit(1); }",
+      "console.log('capture-ok');",
+    ].join('\n');
+    const r = runNode(['-e', PROBE2], { timeoutMs: 30_000 });
+    assert.strictEqual(r.outcome, OUTCOME.EXITED, `probe must run: ${r.stderr}`);
+    assert.strictEqual(r.exitCode, 0, `post-load capture failed: ${r.stdout}\n${r.stderr}`);
+  });
+});


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3498

> #3498 was filed by this sweep identifying the regression (introduced by `dc3c81e93` / #3212 Phase 1), with direct maintainer instruction to fix.

---

## What was broken

`src/pattern.cts` — the #3212-mandated sole owner of regex-value escaping — called the built-in `RegExp.escape` unconditionally. That API is ES2026, first shipped in **Node 24**. Because the build itself consumes the module (`scripts/gen-loop-host-contract.cjs:23` requires `gsd-core/bin/lib/pattern.cjs`), **`npm run build` failed on Node 22** with `TypeError: RegExp.escape is not a function` — breaking the `gsd-test` `linux-node22` verification lane at the `build` step (it could never reach `run_tests`), on every branch since `dc3c81e93` landed.

## What this fix does

`escapeRegex` now prefers the built-in `RegExp.escape` when present and falls back to an in-file metacharacter escape when absent. The fallback lives **inside `src/pattern.cts`**, preserving the #3212 single-owner invariant and the `lint-no-adhoc-regex-escape` scope. The builtin is captured at module load, so a runtime mutation of `RegExp.escape` cannot flip the code path mid-process.

## Root cause

`dc3c81e93` (#3212 Phase 1) introduced the hard dependency in the same commit that raised `.nvmrc` 22→24 — but the gsd-test verification matrix retained its `linux-node22` lane, so the mandated agent verification path broke at build.

## Testing

### How I verified the fix
- **RED proven**: a child process with `RegExp.escape` neutered, requiring the pre-fix built lib, throws exactly the lane's error.
- **GREEN**: the same probe against the fixed lib passes a match-behavior corpus (self-match for metachar/unicode/empty values, no metachar/alternation reinterpretation, `literalPattern` agreement) — asserting match behavior per the seam's own doctrine (pattern TEXT differs between builtin and fallback; match behavior must not).
- Node-24 path unchanged: `escapeRegex('a b') === RegExp.escape('a b')` on the unneutered runtime.
- New regression tests in `tests/pattern.test.cjs` §4 (two child-process probes: neuter-before-require and neuter-after-require). Suite: 19/19.

### Regression test added?
- [x] Yes — `tests/pattern.test.cjs` section 4 (failing-first: the probe throws pre-fix).

### Platforms tested
- [x] macOS (local); Linux via CI (the node22 lane itself is gsd-test-side; GitHub CI node24 verifies no regression on the primary target).

### Runtimes tested
- [x] N/A — Node-version concern, runtime-agnostic.

---

## Checklist
- [x] Issue linked with `Fixes #3498`
- [x] Fix is scoped to the reported bug — one function + its module-load capture + tests
- [x] Regression test added
- [x] `lint:ci` exit 0; changeset fragment added (`lively-orcas-climb.md`, Fixed)
- [x] No unnecessary dependencies

## Breaking changes

None. Node 24+ behavior is byte-identical (builtin path); Node 22 gains a working build with match-equivalent escaping.
