### PR TITLE
fix(#3458): audit-open scans archived milestones/v*-phases/ in all four phase scanners

### DIFF
--- a/scripts/lint-phase-enumeration-drift.cjs
+++ b/scripts/lint-phase-enumeration-drift.cjs
@@ -168,15 +168,19 @@
  *     inside it to match — not an enumeration of the phases directory at
  *     all; only shaped like one because `phasesDir` is a substring of the
  *     joined path.
- *   - `src/audit.cts` `scanUatGaps`, `scanVerificationGaps`,
- *     `scanContextQuestions`, `scanDeferredItems`: the pre-milestone-close
- *     audit gate (`gsd-tools.cjs audit-open`, called by `/gsd:complete-
- *     milestone`'s pre-close gate). Each deliberately SWEEPS EVERY phase
- *     directory on disk to report open UAT/VERIFICATION/CONTEXT/deferred-item
+ *   - `src/audit.cts` `collectPhaseScanTargets`: the shared enumerator the
+ *     four pre-milestone-close audit scanners (`scanUatGaps`,
+ *     `scanVerificationGaps`, `scanContextQuestions`, `scanDeferredItems`)
+ *     read through (`gsd-tools.cjs audit-open`, called by `/gsd:complete-
+ *     milestone`'s pre-close gate; #3458 hoisted the four per-scanner
+ *     readdirs here and added the archived `milestones/v*-phases/` root).
+ *     It deliberately SWEEPS EVERY phase directory on disk — active and
+ *     archived — to report open UAT/VERIFICATION/CONTEXT/deferred-item
  *     gaps — the audit's whole purpose is catching stragglers before a
  *     milestone closes, so scoping it to the current milestone's window
  *     would hide exactly the drift (e.g. a still-open item in a phase that
- *     somehow fell outside the window) it exists to surface.
+ *     somehow fell outside the window, or was archived still-open) it
+ *     exists to surface.
  *   - `src/roadmap-upgrade.cts` `computeMigrationPlan`: a legacy-id-to-
  *     milestone-prefixed-id MIGRATION. It must see and rename EVERY existing
  *     phase directory across every milestone in one pass (a legacy phase
@@ -276,7 +280,7 @@ const FUNCTION_SCOPED_EXEMPTIONS = new Map([
   [path.join('src', 'init.cts'), new Set(['detectHasPriorPhases', 'detectUiPhaseActive', 'cmdInitMilestoneOp'])],
   [path.join('src', 'milestone.cts'), new Set(['archivePhaseDirectories', 'cmdMilestoneComplete', 'cmdPhasesClear'])],
   [path.join('src', 'phase.cts'), new Set(['cmdPhasesList', 'cmdPhaseNextDecimal', 'cmdPhasePlanIndex', 'cmdPhaseInsert', 'renameDecimalPhases', 'renameIntegerPhases'])],
-  [path.join('src', 'audit.cts'), new Set(['scanUatGaps', 'scanVerificationGaps', 'scanContextQuestions', 'scanDeferredItems'])],
+  [path.join('src', 'audit.cts'), new Set(['collectPhaseScanTargets'])],
   [path.join('src', 'commands.cts'), new Set(['cmdHistoryDigest'])],
   [path.join('src', 'state.cts'), new Set(['cmdStateValidate', 'cmdStateSync', 'cmdStateRebuild'])],
   [path.join('src', 'roadmap-upgrade.cts'), new Set(['computeMigrationPlan'])],

--- a/src/audit.cts
+++ b/src/audit.cts
@@ -25,6 +25,9 @@ const { extractFrontmatter } = frontmatter;
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import phaseIdMod = require('./phase-id.cjs');
 const { PHASE_NUMBER_TOKEN_SOURCE } = phaseIdMod;
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import phaseLocator = require('./phase-locator.cjs');
+const { getArchivedPhaseDirs } = phaseLocator;
 import { requireSafePath, sanitizeForDisplay } from './security.cjs';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -75,6 +78,7 @@ interface UatGapItem {
   file: string;
   status: string;
   open_scenario_count: number;
+  milestone?: string;
   scan_error?: boolean;
 }
 
@@ -82,6 +86,7 @@ interface VerificationGapItem {
   phase: string;
   file: string;
   status: string;
+  milestone?: string;
   scan_error?: boolean;
 }
 
@@ -90,6 +95,7 @@ interface ContextQuestionItem {
   file: string;
   question_count: number;
   questions: string[];
+  milestone?: string;
   scan_error?: boolean;
 }
 
@@ -97,6 +103,7 @@ interface DeferredItem {
   phase: string;
   file: string;
   text: string;
+  milestone?: string;
   scan_error?: boolean;
 }
 
@@ -494,29 +501,83 @@ function scanSeeds(planDir: string): SeedItem[] {
   return results;
 }
 
+// ─── collectPhaseScanTargets ──────────────────────────────────────────────────
+
+interface PhaseScanTarget {
+  dir: string;
+  phaseDir: string;
+  /** Archive milestone version (`v<X.Y>`), undefined for an active phase dir. */
+  milestone?: string;
+}
+
+/**
+ * Enumerate the phase directories the four phase-scoped scanners below read,
+ * from BOTH roots: the active `.planning/phases/` tree and every archived
+ * `.planning/milestones/v<X.Y>-phases/` tree (#3458).
+ *
+ * Milestone close MOVES phase dirs into the archive (#1871), so a scanner that
+ * resolves only the active root goes blind to an item exactly one milestone
+ * after it was left unresolved — the `[R]/[A]/[C]` prompt's "carry forward"
+ * answer produces precisely that item. `src/uat.cts` (#2766) is the reference
+ * implementation; the archive layout convention stays owned by
+ * `phase-locator.cts`'s `getArchivedPhaseDirs`, so a future layout change has
+ * one home.
+ *
+ * Active dirs are enumerated unfiltered, exactly as these scanners always did.
+ * Archived dirs are deliberately NOT milestone-filtered — archived phases
+ * belong to past milestones by definition, so a current-milestone filter would
+ * discard every one of them and silently reinstate the bug.
+ *
+ * Archived targets carry their archive's milestone version so items can be
+ * labeled with provenance instead of presenting archived and in-flight work
+ * identically — phase numbers repeat across milestones (same rationale as
+ * `uat.cts`'s `archived_milestone`).
+ *
+ * `scanError` reports an unreadable active root (EACCES/EIO — distinct from
+ * absent). Each caller maps it to its own scan_error sentinel shape, as
+ * before — but still scans the archived targets, which are unaffected by an
+ * unreadable active root; dropping them would be the same silent loss one
+ * root over.
+ */
+function collectPhaseScanTargets(planDir: string, cwd: string): { targets: PhaseScanTarget[]; scanError: boolean } {
+  const targets: PhaseScanTarget[] = [];
+  let scanError = false;
+
+  const phasesDir = path.join(planDir, 'phases');
+  if (fs.existsSync(phasesDir)) {
+    try {
+      const dirs = fs.readdirSync(phasesDir, { withFileTypes: true })
+        .filter(e => e.isDirectory())
+        .map(e => e.name)
+        .sort();
+      for (const dir of dirs) {
+        targets.push({ dir, phaseDir: path.join(phasesDir, dir) });
+      }
+    } catch {
+      scanError = true;
+    }
+  }
+
+  for (const archived of getArchivedPhaseDirs(cwd)) {
+    targets.push({ dir: archived.name, phaseDir: archived.fullPath, milestone: archived.milestone });
+  }
+
+  return { targets, scanError };
+}
+
 // ─── scanUatGaps ──────────────────────────────────────────────────────────────
 
 /**
- * Scan .planning/phases for UAT gaps (UAT files with status != 'complete').
+ * Scan active and archived phase dirs for UAT gaps (UAT files with
+ * status != 'complete').
  */
-function scanUatGaps(planDir: string): UatGapItem[] {
-  const phasesDir = path.join(planDir, 'phases');
-  if (!fs.existsSync(phasesDir)) return [];
+function scanUatGaps(planDir: string, cwd: string): UatGapItem[] {
+  const { targets, scanError } = collectPhaseScanTargets(planDir, cwd);
+  const results: UatGapItem[] = scanError
+    ? [{ scan_error: true, phase: '', file: '', status: '', open_scenario_count: 0 }]
+    : [];
 
-  let dirs: string[];
-  try {
-    dirs = fs.readdirSync(phasesDir, { withFileTypes: true })
-      .filter(e => e.isDirectory())
-      .map(e => e.name)
-      .sort();
-  } catch {
-    return [{ scan_error: true, phase: '', file: '', status: '', open_scenario_count: 0 }];
-  }
-
-  const results: UatGapItem[] = [];
-
-  for (const dir of dirs) {
-    const phaseDir = path.join(phasesDir, dir);
+  for (const { dir, phaseDir, milestone } of targets) {
     const phaseMatch = dir.match(new RegExp(`^(${PHASE_NUMBER_TOKEN_SOURCE})`, 'i'));
     const phaseNum = phaseMatch ? phaseMatch[1] : dir;
 
@@ -557,6 +618,7 @@ function scanUatGaps(planDir: string): UatGapItem[] {
         file: sanitizeForDisplay(file),
         status: sanitizeForDisplay(status),
         open_scenario_count: pendingMatches,
+        ...(milestone !== undefined ? { milestone: sanitizeForDisplay(milestone) } : {}),
       });
     }
   }
@@ -567,26 +629,15 @@ function scanUatGaps(planDir: string): UatGapItem[] {
 // ─── scanVerificationGaps ─────────────────────────────────────────────────────
 
 /**
- * Scan .planning/phases for VERIFICATION gaps.
+ * Scan active and archived phase dirs for VERIFICATION gaps.
  */
-function scanVerificationGaps(planDir: string): VerificationGapItem[] {
-  const phasesDir = path.join(planDir, 'phases');
-  if (!fs.existsSync(phasesDir)) return [];
+function scanVerificationGaps(planDir: string, cwd: string): VerificationGapItem[] {
+  const { targets, scanError } = collectPhaseScanTargets(planDir, cwd);
+  const results: VerificationGapItem[] = scanError
+    ? [{ scan_error: true, phase: '', file: '', status: '' }]
+    : [];
 
-  let dirs: string[];
-  try {
-    dirs = fs.readdirSync(phasesDir, { withFileTypes: true })
-      .filter(e => e.isDirectory())
-      .map(e => e.name)
-      .sort();
-  } catch {
-    return [{ scan_error: true, phase: '', file: '', status: '' }];
-  }
-
-  const results: VerificationGapItem[] = [];
-
-  for (const dir of dirs) {
-    const phaseDir = path.join(phasesDir, dir);
+  for (const { dir, phaseDir, milestone } of targets) {
     const phaseMatch = dir.match(new RegExp(`^(${PHASE_NUMBER_TOKEN_SOURCE})`, 'i'));
     const phaseNum = phaseMatch ? phaseMatch[1] : dir;
 
@@ -619,6 +670,7 @@ function scanVerificationGaps(planDir: string): VerificationGapItem[] {
         phase: sanitizeForDisplay(phaseNum),
         file: sanitizeForDisplay(file),
         status: sanitizeForDisplay(status),
+        ...(milestone !== undefined ? { milestone: sanitizeForDisplay(milestone) } : {}),
       });
     }
   }
@@ -629,26 +681,15 @@ function scanVerificationGaps(planDir: string): VerificationGapItem[] {
 // ─── scanContextQuestions ─────────────────────────────────────────────────────
 
 /**
- * Scan .planning/phases for CONTEXT files with open_questions.
+ * Scan active and archived phase dirs for CONTEXT files with open_questions.
  */
-function scanContextQuestions(planDir: string): ContextQuestionItem[] {
-  const phasesDir = path.join(planDir, 'phases');
-  if (!fs.existsSync(phasesDir)) return [];
+function scanContextQuestions(planDir: string, cwd: string): ContextQuestionItem[] {
+  const { targets, scanError } = collectPhaseScanTargets(planDir, cwd);
+  const results: ContextQuestionItem[] = scanError
+    ? [{ scan_error: true, phase: '', file: '', question_count: 0, questions: [] }]
+    : [];
 
-  let dirs: string[];
-  try {
-    dirs = fs.readdirSync(phasesDir, { withFileTypes: true })
-      .filter(e => e.isDirectory())
-      .map(e => e.name)
-      .sort();
-  } catch {
-    return [{ scan_error: true, phase: '', file: '', question_count: 0, questions: [] }];
-  }
-
-  const results: ContextQuestionItem[] = [];
-
-  for (const dir of dirs) {
-    const phaseDir = path.join(phasesDir, dir);
+  for (const { dir, phaseDir, milestone } of targets) {
     const phaseMatch = dir.match(new RegExp(`^(${PHASE_NUMBER_TOKEN_SOURCE})`, 'i'));
     const phaseNum = phaseMatch ? phaseMatch[1] : dir;
 
@@ -704,6 +745,7 @@ function scanContextQuestions(planDir: string): ContextQuestionItem[] {
         file: sanitizeForDisplay(file),
         question_count: questions.length,
         questions: questions.slice(0, 3),
+        ...(milestone !== undefined ? { milestone: sanitizeForDisplay(milestone) } : {}),
       });
     }
   }
@@ -723,7 +765,10 @@ function scanContextQuestions(planDir: string): ContextQuestionItem[] {
  * unresolved at MILESTONE close surfaces in the pre-close audit alongside the
  * other eight categories and the existing `[R]/[A]/[C]` prompt applies to it.
  * Without this, phase directories archive to `milestones/vX.Y-phases/` (#1871)
- * and the entry leaves the live tree having never been triaged.
+ * and the entry leaves the live tree having never been triaged. #3458 made
+ * that promise reach the archive itself: an entry carried forward past its own
+ * milestone close now stays visible at every later close, via the shared
+ * collectPhaseScanTargets dual-root enumeration.
  *
  * The resolved/unresolved predicate is NOT reimplemented here: `uat.cjs`
  * already exports `parseDeferredItems`, which owns the parsing rule (entries
@@ -734,27 +779,20 @@ function scanContextQuestions(planDir: string): ContextQuestionItem[] {
  * inside the scan, to preserve `audit-command-router.cts`'s property that a
  * route never loads the module it does not need.
  */
-function scanDeferredItems(planDir: string): DeferredItem[] {
-  const phasesDir = path.join(planDir, 'phases');
-  if (!fs.existsSync(phasesDir)) return [];
+function scanDeferredItems(planDir: string, cwd: string): DeferredItem[] {
+  const { targets, scanError } = collectPhaseScanTargets(planDir, cwd);
+  const results: DeferredItem[] = scanError
+    ? [{ scan_error: true, phase: '', file: '', text: '' }]
+    : [];
 
-  let dirs: string[];
-  try {
-    dirs = fs.readdirSync(phasesDir, { withFileTypes: true })
-      .filter(e => e.isDirectory())
-      .map(e => e.name)
-      .sort();
-  } catch {
-    return [{ scan_error: true, phase: '', file: '', text: '' }];
-  }
+  // Nothing to scan → skip the lazy require entirely (pre-fix, an absent
+  // phases dir returned before it too).
+  if (targets.length === 0) return results;
 
   // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-unsafe-assignment
   const uat: UatDeferredModule = require('./uat.cjs');
 
-  const results: DeferredItem[] = [];
-
-  for (const dir of dirs) {
-    const phaseDir = path.join(phasesDir, dir);
+  for (const { dir, phaseDir, milestone } of targets) {
     const phaseMatch = dir.match(new RegExp(`^(${PHASE_NUMBER_TOKEN_SOURCE})`, 'i'));
     const phaseNum = phaseMatch ? phaseMatch[1] : dir;
 
@@ -776,6 +814,7 @@ function scanDeferredItems(planDir: string): DeferredItem[] {
         phase: sanitizeForDisplay(phaseNum),
         file: DEFERRED_ITEMS_FILENAME,
         text: sanitizeForDisplay(item.name),
+        ...(milestone !== undefined ? { milestone: sanitizeForDisplay(milestone) } : {}),
       });
     }
   }
@@ -815,19 +854,19 @@ function auditOpenArtifacts(cwd: string): AuditResult {
   })();
 
   const uatGaps = (() => {
-    try { return scanUatGaps(planDir); } catch { return [{ scan_error: true, phase: '', file: '', status: '', open_scenario_count: 0 }]; }
+    try { return scanUatGaps(planDir, cwd); } catch { return [{ scan_error: true, phase: '', file: '', status: '', open_scenario_count: 0 }]; }
   })();
 
   const verificationGaps = (() => {
-    try { return scanVerificationGaps(planDir); } catch { return [{ scan_error: true, phase: '', file: '', status: '' }]; }
+    try { return scanVerificationGaps(planDir, cwd); } catch { return [{ scan_error: true, phase: '', file: '', status: '' }]; }
   })();
 
   const contextQuestions = (() => {
-    try { return scanContextQuestions(planDir); } catch { return [{ scan_error: true, phase: '', file: '', question_count: 0, questions: [] }]; }
+    try { return scanContextQuestions(planDir, cwd); } catch { return [{ scan_error: true, phase: '', file: '', question_count: 0, questions: [] }]; }
   })();
 
   const deferredItems = (() => {
-    try { return scanDeferredItems(planDir); } catch { return [{ scan_error: true, phase: '', file: '', text: '' }]; }
+    try { return scanDeferredItems(planDir, cwd); } catch { return [{ scan_error: true, phase: '', file: '', text: '' }]; }
   })();
 
   // Count real items (not scan_error sentinels)
@@ -906,7 +945,7 @@ function formatAuditReport(auditResult: AuditResult): string {
     lines.push('');
     lines.push(`🔴 UAT Gaps (${counts.uat_gaps} phases with incomplete UAT)`);
     for (const item of items.uat_gaps.filter(i => !i.scan_error)) {
-      lines.push(`   • Phase ${item.phase}: ${item.file} [${item.status}] — ${item.open_scenario_count} pending scenarios`);
+      lines.push(`   • Phase ${item.phase}${item.milestone ? ` (${item.milestone})` : ''}: ${item.file} [${item.status}] — ${item.open_scenario_count} pending scenarios`);
     }
   }
 
@@ -915,7 +954,7 @@ function formatAuditReport(auditResult: AuditResult): string {
     lines.push('');
     lines.push(`🔴 Verification Gaps (${counts.verification_gaps} unresolved)`);
     for (const item of items.verification_gaps.filter(i => !i.scan_error)) {
-      lines.push(`   • Phase ${item.phase}: ${item.file} [${item.status}]`);
+      lines.push(`   • Phase ${item.phase}${item.milestone ? ` (${item.milestone})` : ''}: ${item.file} [${item.status}]`);
     }
   }
 
@@ -971,7 +1010,7 @@ function formatAuditReport(auditResult: AuditResult): string {
     lines.push('');
     lines.push(`🔵 CONTEXT Open Questions (${counts.context_questions} phases with open questions)`);
     for (const item of items.context_questions.filter(i => !i.scan_error)) {
-      lines.push(`   • Phase ${item.phase}: ${item.file} (${item.question_count} question${item.question_count !== 1 ? 's' : ''})`);
+      lines.push(`   • Phase ${item.phase}${item.milestone ? ` (${item.milestone})` : ''}: ${item.file} (${item.question_count} question${item.question_count !== 1 ? 's' : ''})`);
       for (const q of item.questions) {
         lines.push(`     - ${q}`);
       }
@@ -984,7 +1023,7 @@ function formatAuditReport(auditResult: AuditResult): string {
     lines.push('');
     lines.push(`🔵 Deferred Items (${counts.deferred_items} unresolved)`);
     for (const item of items.deferred_items.filter(i => !i.scan_error)) {
-      lines.push(`   • Phase ${item.phase}: ${item.text}`);
+      lines.push(`   • Phase ${item.phase}${item.milestone ? ` (${item.milestone})` : ''}: ${item.text}`);
     }
   }
 

--- a/tests/audit-command-cutover.test.cjs
+++ b/tests/audit-command-cutover.test.cjs
@@ -1095,3 +1095,123 @@ describe('bug #950: quick-task SUMMARY must carry status: complete', () => {
 });
   });
 }
+
+// ─── #3458: archived phases are audited too ──────────────────────────────────
+//
+// Milestone close MOVES phase dirs to `.planning/milestones/v<X.Y>-phases/`
+// (#1871). The four phase-scoped scanners (uat_gaps, verification_gaps,
+// context_questions, deferred_items) resolved only `.planning/phases/`, so an
+// item carried forward at one milestone close was invisible to every later
+// pre-close audit — and could flip `has_open_items` to false on its own.
+// Failing-first per the triage brief on #3458; the fix reuses
+// `getArchivedPhaseDirs` (phase-locator.cjs), the same seam #2766 gave uat.cjs.
+
+describe('#3458: the four phase scanners read milestones/v*-phases/', () => {
+  const fs3458 = require('node:fs');
+  const path3458 = require('node:path');
+  const helpers3458 = require('./helpers.cjs');
+
+  let tmpDir;
+  beforeEach(() => { tmpDir = helpers3458.createTempProject(); });
+  afterEach(() => { helpers3458.cleanup(tmpDir); });
+
+  /** Write the four open-artifact kinds into one phase dir (relative to tmpDir). */
+  function writeOpenArtifacts(relPhaseDir) {
+    const phaseDir = path3458.join(tmpDir, relPhaseDir);
+    fs3458.mkdirSync(phaseDir, { recursive: true });
+    fs3458.writeFileSync(path3458.join(phaseDir, '01-UAT.md'),
+      '---\nstatus: pending\n---\n\n# UAT\n\nresult: pending\n');
+    fs3458.writeFileSync(path3458.join(phaseDir, '01-VERIFICATION.md'),
+      '---\nstatus: gaps_found\n---\n\n# Verification\n');
+    fs3458.writeFileSync(path3458.join(phaseDir, '01-CONTEXT.md'),
+      '# Context\n\n## Open Questions\n\n- Is the retry budget per-call or global?\n');
+    fs3458.writeFileSync(path3458.join(phaseDir, 'deferred-items.md'),
+      '## Deferred Items\n\n- STILL-OPEN: survived a milestone close.\n');
+  }
+
+  function auditJson3458() {
+    const result = helpers3458.runGsdTools('audit-open --json', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+    return JSON.parse(result.output);
+  }
+
+  test('fully-archived project (no .planning/phases/ at all): all four categories surface', () => {
+    writeOpenArtifacts('.planning/milestones/v1.0-phases/01-alpha');
+    // ROADMAP names a LATER current milestone — archived items must not be
+    // discarded by current-milestone scoping (AC 4).
+    fs3458.writeFileSync(path3458.join(tmpDir, '.planning', 'ROADMAP.md'),
+      '# Roadmap\n\n## Milestone v1.1\n');
+
+    const out = auditJson3458();
+
+    assert.strictEqual(out.counts.uat_gaps, 1);
+    assert.strictEqual(out.counts.verification_gaps, 1);
+    assert.strictEqual(out.counts.context_questions, 1);
+    assert.strictEqual(out.counts.deferred_items, 1);
+    assert.strictEqual(out.has_open_items, true);
+    // Archived items carry their archive's milestone as provenance (the AC's
+    // "without mixing up items across milestones" — phase numbers repeat).
+    assert.strictEqual(out.items.deferred_items[0].milestone, 'v1.0');
+    assert.strictEqual(out.items.uat_gaps[0].milestone, 'v1.0');
+
+    // And the human report labels them.
+    const report = helpers3458.runGsdTools('audit-open', tmpDir);
+    assert.ok(report.success, `Command failed: ${report.error}`);
+    assert.match(report.output, /Phase 01 \(v1\.0\)/);
+  });
+
+  test('mixed active + archived: items from both roots, no double-counting', () => {
+    writeOpenArtifacts('.planning/milestones/v1.0-phases/01-alpha');
+    const activeDir = path3458.join(tmpDir, '.planning', 'phases', '02-beta');
+    fs3458.mkdirSync(activeDir, { recursive: true });
+    fs3458.writeFileSync(path3458.join(activeDir, 'deferred-items.md'),
+      '## Deferred Items\n\n- Active-tree item, distinct from the archived one.\n');
+
+    const out = auditJson3458();
+
+    assert.strictEqual(out.counts.deferred_items, 2);
+    assert.deepStrictEqual(
+      [...new Set(out.items.deferred_items.map(i => i.phase))].sort(),
+      ['01', '02'],
+    );
+    // Provenance separates the roots: archived carries its milestone, active none.
+    const byPhase = Object.fromEntries(out.items.deferred_items.map(i => [i.phase, i.milestone]));
+    assert.strictEqual(byPhase['01'], 'v1.0');
+    assert.strictEqual(byPhase['02'], undefined);
+    // The archived phase's other three artifacts are counted exactly once each.
+    assert.strictEqual(out.counts.uat_gaps, 1);
+    assert.strictEqual(out.counts.verification_gaps, 1);
+    assert.strictEqual(out.counts.context_questions, 1);
+  });
+
+  test('fully-archived project with everything resolved stays all-clear (no new noise)', () => {
+    const phaseDir = path3458.join(tmpDir, '.planning', 'milestones', 'v1.0-phases', '01-alpha');
+    fs3458.mkdirSync(phaseDir, { recursive: true });
+    fs3458.writeFileSync(path3458.join(phaseDir, '01-UAT.md'),
+      '---\nstatus: complete\n---\n\n# UAT\n');
+    fs3458.writeFileSync(path3458.join(phaseDir, '01-VERIFICATION.md'),
+      '---\nstatus: passed\n---\n\n# Verification\n');
+    fs3458.writeFileSync(path3458.join(phaseDir, '01-CONTEXT.md'),
+      '# Context\n\n## Open Questions\n\nNone\n');
+    fs3458.writeFileSync(path3458.join(phaseDir, 'deferred-items.md'),
+      '## Deferred Items\n\n- Was handled.\n  status: resolved\n');
+
+    const out = auditJson3458();
+
+    assert.strictEqual(out.counts.uat_gaps, 0);
+    assert.strictEqual(out.counts.verification_gaps, 0);
+    assert.strictEqual(out.counts.context_questions, 0);
+    assert.strictEqual(out.counts.deferred_items, 0);
+    assert.strictEqual(out.has_open_items, false);
+  });
+
+  test('archives across multiple milestones are all scanned', () => {
+    writeOpenArtifacts('.planning/milestones/v1.0-phases/01-alpha');
+    writeOpenArtifacts('.planning/milestones/v1.1-phases/03-gamma');
+
+    const out = auditJson3458();
+
+    assert.strictEqual(out.counts.deferred_items, 2);
+    assert.strictEqual(out.counts.uat_gaps, 2);
+  });
+});


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #3458

---

## What was broken

The four phase-scoped scanners behind `gsd-tools query audit-open` (`scanUatGaps`, `scanVerificationGaps`, `scanContextQuestions`, `scanDeferredItems` in `src/audit.cts`) resolved only `.planning/phases/`. Milestone close moves phase dirs to `.planning/milestones/v<X.Y>-phases/` (#1871), so an item carried forward at one milestone close was invisible to every later pre-close audit — and could flip `has_open_items` to `false` on its own, letting `/gsd-complete-milestone` assert a clean close it did not verify.

## What this fix does

A shared enumerator, `collectPhaseScanTargets(planDir, cwd)`, hoists the four per-scanner `readdirSync` blocks and appends the archived roots via `getArchivedPhaseDirs(cwd)` (`phase-locator.cjs`) — the same seam #2766 gave `uat.cts` — so the archive layout convention keeps a single owner. All four scanners iterate the combined target list; `auditOpenArtifacts` threads `cwd` through (the archive locator takes `cwd`, the scanners took `planDir` — the signature note called out in the issue).

Two additions shaped by a pre-file adversarial review of the diff:

- **Archived items carry a `milestone` provenance field** (rendered `Phase NN (vX.Y)` in the human report), mirroring `uat.cts`'s `archived_milestone` and its rationale — phase numbers repeat across milestones, and the acceptance criteria ask that items from different milestones not be mixed up.
- **An unreadable active root no longer discards archived results.** The pre-fix contract returned a `scan_error` sentinel alone; the sentinel is kept, but the archived targets collected alongside it are still scanned — dropping them would be the same silent loss one root over.

Behavior deliberately preserved:

- **Active dirs stay unfiltered**, exactly as these scanners always enumerated them (the phase-enumeration drift guard's written exemption for these scanners — the audit wants the physical set — is transferred to the new function, with the four now-clean scanner names removed from the exemption map).
- **Archived dirs are NOT milestone-filtered** — archived phases belong to past milestones by definition; applying the current-milestone filter would discard every one and silently reinstate the bug (the subtlety `src/uat.cts` documents at its own scan-target build).
- The `existsSync` guard no longer short-circuits: a fully-archived project (no `.planning/phases/` at all) proceeds to the archive walk — that guard firing first was the whole bug in the fully-archived case.

`requireSafePath` continues to bound every read to `planDir`; archived files live under `planDir/milestones/`, so the containment check holds for both roots.

## Root cause

`scanDeferredItems` (#2983, for #2646) was introduced already scoped to the active root, and the three older scanners shared the same single-root shape. #3082 (for #2766) fixed this exact defect class in `src/uat.cts` four days later but was never propagated to `src/audit.cts` — a day-one gap, not a regression. `scanDeferredItems`' own doc comment names the archive transition as the thing it was built to survive; the implementation eleven lines below could not read the archive.

Pre-fix references at the merge base:

- `scanUatGaps` — https://github.com/open-gsd/gsd-core/blob/e2f4c16d9/src/audit.cts#L503
- `scanVerificationGaps` — https://github.com/open-gsd/gsd-core/blob/e2f4c16d9/src/audit.cts#L573
- `scanContextQuestions` — https://github.com/open-gsd/gsd-core/blob/e2f4c16d9/src/audit.cts#L635
- `scanDeferredItems` — https://github.com/open-gsd/gsd-core/blob/e2f4c16d9/src/audit.cts#L738
- Reference implementation reused — https://github.com/open-gsd/gsd-core/blob/e2f4c16d9/src/uat.cts#L100-L130

## Testing

### How I verified the fix

The linked issue carries an executed repro (byte-identical artifact files, only the directory varies): the active copy reports `has_open_items = true`, the archived copy reported `false` pre-fix, with the #2766-fixed `uat.cjs` scanner reading the same archived file correctly as the control. Locally on this branch: `npm run build:lib` green, the full `npm run lint:ci` chain green, and the audit suites (`tests/audit-command-cutover.test.cjs`, `tests/feat-2646-deferred-items-audit-scanner.test.cjs`, `tests/audit-fix-command.test.cjs`) 97/97 green, run with `HOME` and `CLAUDE_CONFIG_DIR` pointed at throwaway dirs.

### Regression test added?

- [x] Yes — added a test that would have caught this bug

Regression cases live in the owning module suite, `tests/audit-command-cutover.test.cjs` (per the regression placement policy — no new `fix-NNNN` top-level file), covering the agent brief's acceptance criteria:

1. **Fully-archived project** (no `.planning/phases/` at all) with one open item of each of the four kinds → all four counts are 1 and `has_open_items` is `true`; the fixture's ROADMAP names a *later* current milestone, so this also proves archived items are not swallowed by current-milestone scoping. Also asserts the `milestone` provenance in JSON and the `Phase 01 (v1.0)` label in the report.
2. **Mixed active + archived** → items from both roots, exact counts, no double-counting; archived carries `milestone`, active does not.
3. **Fully-archived but fully-resolved** → still all-clear (no new noise).
4. **Multiple archive milestones** (`v1.0-phases/` and `v1.1-phases/`) → both scanned.

Failing-first verified: the new tests were run against the pre-fix build and 3 of 4 fail (the all-clear case is green either way, by design).

### Platforms tested

- [x] Linux
- [ ] macOS
- [ ] Windows (including backslash path handling)
- [ ] N/A (not platform-specific)

(All path handling goes through `path.join` and the existing `getArchivedPhaseDirs` seam, which is already exercised cross-platform by the `uat.cts` tests.)

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix — not required: the diff touches only `src/`, `tests/`, and `scripts/` (no user-facing paths)
- [x] No unnecessary dependencies added

## Out of scope

- Deferred-item parsing (table-shaped entries) — #2766/#3082 territory, untouched; the lazy `parseDeferredItems` reuse is unchanged.
- `isSentinelPhaseId` filtering (#3372) — same file, different defect, untouched.
- The issue's low-confidence secondary note (a `deferred-items.md` at the `phases/` root itself) — unsupported layout, not addressed.
- Two properties of the canonical `getArchivedPhaseDirs` seam, shared with `uat.cts` and surfaced by the pre-file review: an unreadable `milestones/` root (or one archive dir) is silently treated as empty by `listArchiveVersionDirs`, and the locator recognizes only `v[\d.]+-phases` (not the `archived-YYYYMMDD-phases` fallback). Both affect every consumer of the seam equally and belong to `phase-locator.cts`, not this fix.
- The five non-phase-scoped audit categories (todos, seeds, threads, quick tasks, debug sessions) resolve different roots; a sweep of every `phases`-root resolution under `src/` found the remaining readers are active-tree by design (phase CRUD, init scaffolding, workstream moves, roadmap-upgrade migration), so the defect class is fully contained in these four scanners.

## Breaking changes

None — the `milestone` field is additive and optional on the four item shapes; active items serialize byte-identically to before, and report lines change only for archived items (which were previously absent entirely).
