### PR TITLE
refactor(#3408): close the two known limits instead of recording them

### DIFF
--- a/.changeset/tidy-tunas-rally.md
+++ b/.changeset/tidy-tunas-rally.md
@@ -1,5 +1,0 @@
----
-type: Changed
-pr: 0
----
-**Internal cleanup with no behavior change** — the STATE.md write-seam helpers took eight positional arguments with three optional trailing ones, so a call site could silently pass the wrong thing in the wrong slot, and phase-completion reporting re-derived by string matching which of its entries were fields and which was a whole section. Both are now expressed directly in the types. No command output changes. (#3408)

--- a/.changeset/tidy-tunas-rally.md
+++ b/.changeset/tidy-tunas-rally.md
@@ -1,0 +1,5 @@
+---
+type: Changed
+pr: 0
+---
+**Internal cleanup with no behavior change** — the STATE.md write-seam helpers took eight positional arguments with three optional trailing ones, so a call site could silently pass the wrong thing in the wrong slot, and phase-completion reporting re-derived by string matching which of its entries were fields and which was a whole section. Both are now expressed directly in the types. No command output changes. (#3408)

--- a/src/milestone.cts
+++ b/src/milestone.cts
@@ -935,10 +935,11 @@ function cmdMilestoneComplete(cwd: string, version: string, options: MilestoneCo
         result.content,
         statePath,
         cwd,
-        true,
-        Object.keys(authoritativeFm).length > 0 ? authoritativeFm : undefined,
-        undefined,
-        divergedFields,
+        {
+          resync: true,
+          authoritativeFm: Object.keys(authoritativeFm).length > 0 ? authoritativeFm : undefined,
+          divergedFields,
+        },
       );
       platformWriteSync(statePath, finalContent);
       for (const field of divergedFields) {

--- a/src/phase.cts
+++ b/src/phase.cts
@@ -3059,10 +3059,11 @@ function cmdPhaseComplete(cwd: string, phaseNum: string, raw: boolean): void {
           stateContent,
           statePath,
           cwd,
-          true,
-          authoritativeFm,
-          undefined,
-          divergedFields,
+          {
+            resync: true,
+            authoritativeFm,
+            divergedFields,
+          },
         );
         for (const field of divergedFields) {
           preservationWarnings.push({ field, reason: 'preserved-over-disagreeing-derived' });

--- a/src/state.cts
+++ b/src/state.cts
@@ -120,24 +120,14 @@ interface ReadModifyWriteOptions {
  * signatures (a Data Clump / out-param smell flagged in review and deferred
  * pending "a third consumer"; `cmdMilestoneComplete` is that third consumer).
  * Same shape as `ReadModifyWriteOptions` minus `resync` being required here
- * (every existing call site already passes it explicitly).
+ * (every existing call site already passes it explicitly) — derived below
+ * so the two interfaces cannot drift out of hand-sync.
+ *
+ * `divergedFields` (ADR-3408 §8.5 D4) stays an out-param (not a return
+ * value) deliberately: converting it ripples into every caller's control
+ * flow for no behavior change.
  */
-interface StatePreservationOptions {
-  resync: boolean;
-  /**
-   * #2736: intent-first frontmatter values forwarded to syncStateFrontmatter.
-   * See `ReadModifyWriteOptions.authoritativeFm` for the full rationale.
-   */
-  authoritativeFm?: Record<string, unknown>;
-  deriveProgressKeys?: boolean;
-  /**
-   * ADR-3408 §8.5 (D4): out-param — every frontmatter field name whose value
-   * preservation restored over a disagreeing freshly-derived one during THIS
-   * write. Stays an out-param (not a return value) deliberately: converting
-   * it ripples into every caller's control flow for no behavior change.
-   */
-  divergedFields?: string[];
-}
+type StatePreservationOptions = Omit<ReadModifyWriteOptions, 'resync'> & { resync: boolean };
 
 interface StateRecordMetricOptions {
   phase: string;
@@ -2937,8 +2927,8 @@ function writeStateMd(statePath: string, content: string, cwd?: string, clock?: 
 function assertStatePreservationOptions(options: unknown, caller: string): asserts options is StatePreservationOptions {
   if (typeof options !== 'object' || options === null || Array.isArray(options)) {
     const err = new Error(
-      `${caller}: options argument must be a StatePreservationOptions object, got ${typeof options === 'object' ? 'array/null' : typeof options} ` +
-      `(${JSON.stringify(options)}). This function takes a single options object as its final ` +
+      `${caller}: options argument must be a StatePreservationOptions object, got ${typeof options === 'object' ? 'array/null' : typeof options}. ` +
+      'This function takes a single options object as its final ' +
       'parameter, not positional resync/authoritativeFm/deriveProgressKeys/divergedFields arguments (#3471).',
     ) as Error & { code: string; receivedType: string };
     err.code = 'STATE_PRESERVATION_OPTIONS_INVALID';

--- a/src/state.cts
+++ b/src/state.cts
@@ -2922,6 +2922,31 @@ function writeStateMd(statePath: string, content: string, cwd?: string, clock?: 
  * sync only rewrites the frontmatter block, so its body IS the post-write
  * body), and `syncedContent` is what `syncStateFrontmatter` produced.
  */
+/**
+ * #3471 Fix: `StatePreservationOptions` is silently mis-consumable by any
+ * non-TypeScript caller — `tsc` only type-checks src/, so a plain-.cjs test
+ * (or any future JS caller) can pass a boolean where this options object
+ * goes and both functions below would previously proceed with `resync`,
+ * `authoritativeFm`, `deriveProgressKeys`, and `divergedFields` all
+ * `undefined`, degrading to a well-formed-looking but silently-empty
+ * `divergedFields: []` — exactly the "stale but present" failure shape
+ * ADR-3408 exists to remove. This is a contract assertion (caller-shape
+ * only), not field-level validation — mirrors `throwUnwiredRow`'s
+ * structured-error shape in src/state-transition.cts.
+ */
+function assertStatePreservationOptions(options: unknown, caller: string): asserts options is StatePreservationOptions {
+  if (typeof options !== 'object' || options === null || Array.isArray(options)) {
+    const err = new Error(
+      `${caller}: options argument must be a StatePreservationOptions object, got ${typeof options === 'object' ? 'array/null' : typeof options} ` +
+      `(${JSON.stringify(options)}). This function takes a single options object as its final ` +
+      'parameter, not positional resync/authoritativeFm/deriveProgressKeys/divergedFields arguments (#3471).',
+    ) as Error & { code: string; receivedType: string };
+    err.code = 'STATE_PRESERVATION_OPTIONS_INVALID';
+    err.receivedType = Array.isArray(options) ? 'array' : typeof options;
+    throw err;
+  }
+}
+
 function applyPostSyncPreservation(
   originalContent: string,
   transformedContent: string,
@@ -2929,6 +2954,7 @@ function applyPostSyncPreservation(
   statePath: string,
   options: StatePreservationOptions,
 ): string {
+  assertStatePreservationOptions(options, 'applyPostSyncPreservation');
   const { resync, authoritativeFm, deriveProgressKeys, divergedFields } = options;
   // Snapshot the existing progress block BEFORE the transform so we can
   // restore it when resync is false.
@@ -3151,6 +3177,7 @@ function syncAndPreserveStateMd(
   cwd: string | undefined,
   options: StatePreservationOptions,
 ): string {
+  assertStatePreservationOptions(options, 'syncAndPreserveStateMd');
   const synced = syncStateFrontmatter(transformedContent, cwd, options.authoritativeFm);
   return applyPostSyncPreservation(
     originalContent,

--- a/src/state.cts
+++ b/src/state.cts
@@ -114,6 +114,31 @@ interface ReadModifyWriteOptions {
   divergedFields?: string[];
 }
 
+/**
+ * #3408 review (close-known-limits): options for `applyPostSyncPreservation`
+ * and `syncAndPreserveStateMd` — replaces the 8-positional-parameter
+ * signatures (a Data Clump / out-param smell flagged in review and deferred
+ * pending "a third consumer"; `cmdMilestoneComplete` is that third consumer).
+ * Same shape as `ReadModifyWriteOptions` minus `resync` being required here
+ * (every existing call site already passes it explicitly).
+ */
+interface StatePreservationOptions {
+  resync: boolean;
+  /**
+   * #2736: intent-first frontmatter values forwarded to syncStateFrontmatter.
+   * See `ReadModifyWriteOptions.authoritativeFm` for the full rationale.
+   */
+  authoritativeFm?: Record<string, unknown>;
+  deriveProgressKeys?: boolean;
+  /**
+   * ADR-3408 §8.5 (D4): out-param — every frontmatter field name whose value
+   * preservation restored over a disagreeing freshly-derived one during THIS
+   * write. Stays an out-param (not a return value) deliberately: converting
+   * it ripples into every caller's control flow for no behavior change.
+   */
+  divergedFields?: string[];
+}
+
 interface StateRecordMetricOptions {
   phase: string;
   plan: string;
@@ -2902,11 +2927,9 @@ function applyPostSyncPreservation(
   transformedContent: string,
   syncedContent: string,
   statePath: string,
-  resync: boolean,
-  authoritativeFm?: Record<string, unknown>,
-  deriveProgressKeys?: boolean,
-  divergedFields?: string[],
+  options: StatePreservationOptions,
 ): string {
+  const { resync, authoritativeFm, deriveProgressKeys, divergedFields } = options;
   // Snapshot the existing progress block BEFORE the transform so we can
   // restore it when resync is false.
   const preFm = resync ? null : extractFrontmatter(originalContent, statePath) as Record<string, unknown>;
@@ -3126,21 +3149,15 @@ function syncAndPreserveStateMd(
   transformedContent: string,
   statePath: string,
   cwd: string | undefined,
-  resync: boolean,
-  authoritativeFm?: Record<string, unknown>,
-  deriveProgressKeys?: boolean,
-  divergedFields?: string[],
+  options: StatePreservationOptions,
 ): string {
-  const synced = syncStateFrontmatter(transformedContent, cwd, authoritativeFm);
+  const synced = syncStateFrontmatter(transformedContent, cwd, options.authoritativeFm);
   return applyPostSyncPreservation(
     originalContent,
     transformedContent,
     synced,
     statePath,
-    resync,
-    authoritativeFm,
-    deriveProgressKeys,
-    divergedFields,
+    options,
   );
 }
 
@@ -3193,10 +3210,12 @@ function readModifyWriteStateMd(statePath: string, transformFn: (content: string
       modified,
       statePath,
       cwd,
-      resync,
-      options?.authoritativeFm,
-      options?.deriveProgressKeys === true,
-      options?.divergedFields,
+      {
+        resync,
+        authoritativeFm: options?.authoritativeFm,
+        deriveProgressKeys: options?.deriveProgressKeys === true,
+        divergedFields: options?.divergedFields,
+      },
     );
 
     platformWriteSync(statePath, synced);
@@ -4605,6 +4624,21 @@ function resolvePhaseIdForCompletePhase(fm: Record<string, unknown>, body: strin
   return parsePhaseFromProse(candidate).phase;
 }
 
+/**
+ * #3408 review (close-known-limits): `cmdStateCompletePhase`'s `updated`
+ * tracks two different kinds of thing — a single FIELD `reconcileReportedFields`
+ * can look up against the persisted bytes, or the whole `Current Position`
+ * SECTION block, which is not a field at all. Typing the distinction at the
+ * producer (each `updated.push(...)` site) means the reconciliation step
+ * below reads the kind directly instead of re-deriving it by matching the
+ * entry's `name` against a hardcoded Set of section names. The command's
+ * OUTPUT CONTRACT is unaffected: `updated` is still flattened to a flat
+ * `string[]` (same entries, same order) at the single `output()` call site.
+ */
+type StateCompletePhaseUpdateEntry =
+  | { kind: 'field'; name: string }
+  | { kind: 'section'; name: string };
+
 function cmdStateCompletePhase(cwd: string, raw: boolean, overridePhase?: string): void {
   const statePath = planningPaths(cwd).state;
   if (!fs.existsSync(statePath)) {
@@ -4671,7 +4705,16 @@ function cmdStateCompletePhase(cwd: string, raw: boolean, overridePhase?: string
   }
 
   const today = realClock.localToday();
-  const updated: string[] = [];
+  // #3408 review (close-known-limits): `updated` mixes two different kinds of
+  // thing — FIELD names (Status, Last Activity, ...), each reconcilable
+  // against the persisted bytes via `reconcileReportedFields`, and the
+  // SECTION name `Current Position` (the whole Current-Position block, not a
+  // single field `stateExtractField` can look up). Rather than re-deriving
+  // the distinction downstream by string-matching against a Set, each entry
+  // now carries its kind at the point it is PRODUCED; the flattening to a
+  // flat `string[]` (the command's OUTPUT CONTRACT — unchanged) happens once
+  // below, right before `output()`.
+  const updated: StateCompletePhaseUpdateEntry[] = [];
   let preSyncContent = '';
   const divergedFields: string[] = [];
 
@@ -4690,16 +4733,16 @@ function cmdStateCompletePhase(cwd: string, raw: boolean, overridePhase?: string
     // Update Status field (body only — #1255)
     const statusValue = `Phase ${currentPhase} complete`;
     let result = stateReplaceField(body, 'Status', statusValue);
-    if (result) { body = result; updated.push('Status'); }
+    if (result) { body = result; updated.push({ kind: 'field', name: 'Status' }); }
 
     // Update Last Activity date
     result = stateReplaceField(body, 'Last Activity', today);
-    if (result) { body = result; updated.push('Last Activity'); }
+    if (result) { body = result; updated.push({ kind: 'field', name: 'Last Activity' }); }
 
     // Update Last Activity Description
     const activityDesc = `Phase ${currentPhase} marked complete`;
     result = stateReplaceField(body, 'Last Activity Description', activityDesc);
-    if (result) { body = result; updated.push('Last Activity Description'); }
+    if (result) { body = result; updated.push({ kind: 'field', name: 'Last Activity Description' }); }
 
     // Update ## Current Position section
     // ADR-1372 T6: positionPattern → tokenizeHeadings; stop at level ≥ 2.
@@ -4753,7 +4796,7 @@ function cmdStateCompletePhase(cwd: string, raw: boolean, overridePhase?: string
         }
 
         body = body.slice(0, cpBodyStart) + posBody + body.slice(cpBodyEnd);
-        updated.push('Current Position');
+        updated.push({ kind: 'section', name: 'Current Position' });
       }
     }
 
@@ -4764,18 +4807,19 @@ function cmdStateCompletePhase(cwd: string, raw: boolean, overridePhase?: string
 
   // ADR-3408 §8.4 (D4): traced for this phase (design doc: "not traced in
   // the analysis pass"). Unlike the transitionCore-based commands, this
-  // adapter's `updated` mixes FIELD names (Status, Last Activity, Last
+  // adapter's `updated` mixes FIELD entries (Status, Last Activity, Last
   // Activity Description — each reconcilable against the persisted bytes,
-  // same as every other command in this phase) with the SECTION name
+  // same as every other command in this phase) with the SECTION entry
   // `Current Position` (the whole Current-Position block, not a single
   // field `stateExtractField` can look up — reconciling it the same way as
   // a field would always drop it as a false negative). Reconcile only the
   // field-shaped entries (#3351's direction), pass the section entry
   // through unconditionally, and fold in any field preservation restored
-  // that this transform never touched (#3345's direction).
-  const SECTION_ENTRIES = new Set(['Current Position']);
-  const sectionEntries = updated.filter((f) => SECTION_ENTRIES.has(f));
-  const fieldEntries = updated.filter((f) => !SECTION_ENTRIES.has(f));
+  // that this transform never touched (#3345's direction). The kind was
+  // decided at PUSH time above (typed producer), not re-derived here by
+  // string-matching a name against a Set.
+  const sectionEntries = updated.filter((e) => e.kind === 'section').map((e) => e.name);
+  const fieldEntries = updated.filter((e) => e.kind === 'field').map((e) => e.name);
   const reconciled = [...sectionEntries, ...reconcileReportedFields(statePath, preSyncContent, fieldEntries, divergedFields)];
 
   output(

--- a/tests/state-write-path-drift-guard.test.cjs
+++ b/tests/state-write-path-drift-guard.test.cjs
@@ -621,10 +621,11 @@ describe('E2 — a legitimate single call to the composition is not detected', (
       '        result.content,',
       '        statePath,',
       '        cwd,',
-      '        true,',
-      '        undefined,',
-      '        undefined,',
-      '        divergedFields,',
+      '        {',
+      '          resync: true,',
+      '          authoritativeFm: Object.keys(authoritativeFm).length > 0 ? authoritativeFm : undefined,',
+      '          divergedFields,',
+      '        },',
       '      );',
     ].join('\n');
 

--- a/tests/state.test.cjs
+++ b/tests/state.test.cjs
@@ -5115,7 +5115,7 @@ describe('ADR-3408 §8.5 Matrix (#3471): stale-but-present, and the report resid
       const transformed = original.replace('Status: Executing', 'Status: Verifying');
       const statePath = path.join(tmp, 'STATE.md');
       const divergedFields = [];
-      const out = stateLib.syncAndPreserveStateMd(original, transformed, statePath, tmp, false, undefined, undefined, divergedFields);
+      const out = stateLib.syncAndPreserveStateMd(original, transformed, statePath, tmp, { resync: false, divergedFields });
       const fm = frontmatterLib.extractFrontmatter(out);
       assert.strictEqual(fm.current_phase, '5', 'current_phase must be restored by the executor, not lost');
       assert.strictEqual(fm.current_phase_name, 'Curated Name', 'current_phase_name must be restored by the executor, not lost');
@@ -5135,7 +5135,7 @@ describe('ADR-3408 §8.5 Matrix (#3471): stale-but-present, and the report resid
       const tmp = createTempDir('gsd-3471-a2-');
       const statePath = path.join(tmp, 'STATE.md');
       const divergedFields = [];
-      const out = stateLib.syncAndPreserveStateMd(original, transformed, statePath, tmp, false, undefined, undefined, divergedFields);
+      const out = stateLib.syncAndPreserveStateMd(original, transformed, statePath, tmp, { resync: false, divergedFields });
       cleanup(tmp);
       return { fm: frontmatterLib.extractFrontmatter(out), divergedFields };
     }
@@ -5205,7 +5205,7 @@ describe('ADR-3408 §8.5 Matrix (#3471): stale-but-present, and the report resid
       const statePath = path.join(tmp, 'STATE.md');
       const divergedFields = [];
       assert.doesNotThrow(() => {
-        const out = stateLib.syncAndPreserveStateMd(original, transformed, statePath, tmp, false, undefined, undefined, divergedFields);
+        const out = stateLib.syncAndPreserveStateMd(original, transformed, statePath, tmp, { resync: false, divergedFields });
         const fm = frontmatterLib.extractFrontmatter(out);
         assert.strictEqual(fm.current_phase, undefined);
         assert.strictEqual(fm.current_phase_name, undefined);
@@ -5235,7 +5235,7 @@ describe('ADR-3408 §8.5 Matrix (#3471): stale-but-present, and the report resid
       ].join('\n');
       const transformed = original.replace('Total Phases: 3', 'Total Phases: 10');
       const statePath = path.join(tmp, 'STATE.md');
-      const out = stateLib.syncAndPreserveStateMd(original, transformed, statePath, tmp, false, undefined, true);
+      const out = stateLib.syncAndPreserveStateMd(original, transformed, statePath, tmp, { resync: false, deriveProgressKeys: true });
       const fm = frontmatterLib.extractFrontmatter(out);
       // #3471 review: extractFrontmatter's mini-YAML parser returns nested
       // `progress.*` scalars as raw strings — see `numericProgress` above
@@ -5262,7 +5262,7 @@ describe('ADR-3408 §8.5 Matrix (#3471): stale-but-present, and the report resid
       const statePath = path.join(tmp, 'STATE.md');
       fs.writeFileSync(statePath, original);
       const divergedFields = [];
-      const written = stateLib.syncAndPreserveStateMd(original, transformed, statePath, tmp, false, undefined, undefined, divergedFields);
+      const written = stateLib.syncAndPreserveStateMd(original, transformed, statePath, tmp, { resync: false, divergedFields });
       fs.writeFileSync(statePath, written);
 
       // Consumer-level: read the real file back, never compare the owner's
@@ -5293,7 +5293,7 @@ describe('ADR-3408 §8.5 Matrix (#3471): stale-but-present, and the report resid
       fs.writeFileSync(statePath, original);
       const divergedFields = [];
       // No transform this write — delta unchanged (transformedContent === originalContent).
-      const written = stateLib.syncAndPreserveStateMd(original, original, statePath, tmp, false, undefined, undefined, divergedFields);
+      const written = stateLib.syncAndPreserveStateMd(original, original, statePath, tmp, { resync: false, divergedFields });
       fs.writeFileSync(statePath, written);
 
       const onDisk = fs.readFileSync(statePath, 'utf8');
@@ -5314,9 +5314,45 @@ describe('ADR-3408 §8.5 Matrix (#3471): stale-but-present, and the report resid
       ].join('\n');
       const transformed = original.replace('Executing', 'Verifying');
       const statePath = path.join(tmp, 'STATE.md');
-      const out = stateLib.syncAndPreserveStateMd(original, transformed, statePath, tmp, false);
+      const out = stateLib.syncAndPreserveStateMd(original, transformed, statePath, tmp, { resync: false });
       const fm = frontmatterLib.extractFrontmatter(out);
       assert.strictEqual(fm.custom_unknown_key, 'preserved-value', 'an unknown/custom frontmatter key must still carry forward — a different mechanism from the six deleted guards');
+    });
+
+    // A8 (#3471): the actual defect the 14-failure incident exposed — a
+    // plain-.cjs caller passing the OLD positional `resync` boolean where the
+    // options object now goes. `tsc` never catches this (it only
+    // type-checks src/); before this guard the function silently proceeded
+    // with every option `undefined`, producing a well-formed-looking but
+    // empty `divergedFields: []` rather than failing loudly. Assert on the
+    // structured `code`/`receivedType`, never on prose (CONTRIBUTING.md,
+    // "Prohibited: Raw Text Matching on Test Outputs").
+    test('A8: passing a boolean in the options slot throws a structured error instead of silently degrading', () => {
+      const tmp = createTempDir('gsd-3471-a8-');
+      const original = ['---', 'gsd_state_version: 1.0', '---', '', '# Project State', '', '## Current Position', '', 'Status: Executing', ''].join('\n');
+      const transformed = original.replace('Status: Executing', 'Status: Verifying');
+      const statePath = path.join(tmp, 'STATE.md');
+      cleanup(tmp);
+
+      assert.throws(
+        () => stateLib.syncAndPreserveStateMd(original, transformed, statePath, tmp, false),
+        (err) => {
+          assert.strictEqual(err.code, 'STATE_PRESERVATION_OPTIONS_INVALID');
+          assert.strictEqual(err.receivedType, 'boolean');
+          return true;
+        },
+        'syncAndPreserveStateMd must throw a structured error, not silently return with every option undefined',
+      );
+
+      assert.throws(
+        () => stateLib.applyPostSyncPreservation(original, transformed, transformed, statePath, false),
+        (err) => {
+          assert.strictEqual(err.code, 'STATE_PRESERVATION_OPTIONS_INVALID');
+          assert.strictEqual(err.receivedType, 'boolean');
+          return true;
+        },
+        'applyPostSyncPreservation must throw a structured error, not silently return with every option undefined',
+      );
     });
   });
 
@@ -5731,7 +5767,7 @@ describe('ADR-3408 §8.5 Matrix (#3471): stale-but-present, and the report resid
             // Write-side: syncAndPreserveStateMd with an UNCHANGED delta
             // (transformedContent === originalContent) — the same regime
             // cmdStateJson's synthetic {pre,post} delta represents.
-            const written = stateLib.syncAndPreserveStateMd(content, content, statePath, tmp, false);
+            const written = stateLib.syncAndPreserveStateMd(content, content, statePath, tmp, { resync: false });
             const writeFm = frontmatterLib.extractFrontmatter(written);
             const writeVal = writeFm[field] !== undefined && writeFm[field] !== null ? String(writeFm[field]) : null;
 
@@ -10889,7 +10925,7 @@ describe('ADR-3408 §8.3 Matrix A1/A2/A3 (property): the shared write-seam compo
           // syncAndPreserveStateMd, then the adapter's own write.
           const pathA = path.join(tmp, 'A.md');
           fs.writeFileSync(pathA, original);
-          const composed = stateLib.syncAndPreserveStateMd(original, transformed, pathA, tmp, resync, authoritativeFm);
+          const composed = stateLib.syncAndPreserveStateMd(original, transformed, pathA, tmp, { resync, authoritativeFm });
           fs.writeFileSync(pathA, composed);
 
           // Path B: readModifyWriteStateMd's owner shape — same composition,


### PR DESCRIPTION
## Enhancement PR

## Linked Issue

Closes #3408

The final piece of epic #3408. This closes two items that were wrongly **recorded as known limits instead of fixed**, and corrects two claims in the epic's closing comment that were simply wrong.

---

## Why this PR exists

I closed #3408 with a comment listing four items under *"Still open, deliberately."* That is a silent deferral, and `CLAUDE.md` says so directly:

> A note in a code comment, commit message, or PR body is NOT a fix and is NOT "surfacing"; it is a silent defer.

A **closing** comment is worse than the venues that rule names — the issue is archived the moment it posts. It is also the exact pattern this epic exists to remove, performed on the epic itself, in its last act. #3408 has been reopened; this PR closes it properly.

Two of the four items were also wrong:

- **#3311 was never open.** It is `CLOSED/COMPLETED`. I carried "deliberately out of scope" forward from the Phase-0 design docs, where it was true at the time, and restated it at close time without checking — the same failure this epic is about, in my own summary.
- **The `warnings` asymmetry was overstated.** Both `cmdPhaseComplete` and `cmdMilestoneComplete` expose `preservation_warnings` with the same structured `{field, reason}` shape. The only asymmetry is a legacy prose `warnings`/`has_warnings` on one command that predates this epic and is unrelated to preservation. There was nothing to unify.

## What this enhancement improves

Two internal seams in `src/state.cts`, plus a runtime contract that the first fix turned out to need.

## Before / After

**Before — 8 positional parameters, three optional, one an out-param:**

```
syncAndPreserveStateMd(originalContent, transformedContent, statePath, cwd, resync,
                       authoritativeFm?, deriveProgressKeys?, divergedFields?)
applyPostSyncPreservation(originalContent, transformedContent, syncedContent, statePath,
                          resync, authoritativeFm?, deriveProgressKeys?, divergedFields?)
```

Review flagged it. I wrote *"a third consumer should trigger an options-object refactor"* — a deferral wearing a trigger condition nobody would notice firing.

**After:** content and path stay positional; `resync`, `authoritativeFm`, `deriveProgressKeys` and `divergedFields` move into a named `StatePreservationOptions`, **derived** from `ReadModifyWriteOptions` rather than restated:

```ts
type StatePreservationOptions = Omit<ReadModifyWriteOptions, 'resync'> & { resync: boolean };
```

**Before — `cmdStateCompletePhase`'s `updated` mixed two kinds of thing:** field labels *and* a section name (`Current Position`, a whole block, not a field `stateExtractField` can look up), worked around by a `SECTION_ENTRIES` Set that re-derived the distinction by string matching.

**After:** the kinds are typed where they are **produced** (`{kind: 'field' | 'section', name}`) and flattened once at output. **The output contract is unchanged** — `updated` is still a flat `string[]` with the same entries in the same order.

## How it was implemented — and what went wrong first

The first attempt shipped a commit claiming *"`tsc` is the proof a site was not missed."* **That was wrong, and I asserted it as settling the question.** `tsc` type-checks `src/`. The test call sites are plain `.cjs` and are not checked at all.

The remote runner returned **14 failures**: nine test call sites still passed the old positional arguments, so a `resync` boolean landed in the options slot, every option came through `undefined`, and the function returned `divergedFields: []`.

**That is the deeper defect, and it is worth naming.** An options-object parameter is silently mis-consumable by any caller TypeScript doesn't check — pass the wrong thing and you get a well-formed, plausible, empty result. That is ADR-3408's own Context section, reintroduced by the change meant to tidy this epic up. The tests caught it only because they assert on `divergedFields` *content*; had they asserted "does not throw", it would have shipped.

So both functions now assert their options argument is a non-null object and throw `STATE_PRESERVATION_OPTIONS_INVALID` carrying the offending type — mirroring `throwUnwiredRow`'s precedent from Phase 1. A wrong call is loud for every caller, typed or not, and a test pins the exact mistake that produced the 14 failures.

The sweep also found the drift-guard suite's E2 fixture embedding the old call shape, labelled *"verbatim from `src/milestone.cts`"* — a fixture that mirrors production and had drifted from it. The same class the guard exists to detect, inside the guard's own tests.

### What the two orthogonal reviews then caught

Both reviews ran against this diff. Three findings, all fixed here rather than recorded:

1. **The first options object relocated the Data Clump instead of removing it.** `StatePreservationOptions` repeated all four `ReadModifyWriteOptions` fields, differing only in `resync` being required — and `divergedFields` carried a *second, independently worded* docstring. Two hand-synced declarations of one shape, which is the smell the refactor was supposed to close. Now derived via `Omit`.
2. **The guard echoed its argument into the error message.** `assertStatePreservationOptions` embedded `JSON.stringify(options)`. Its contract is a structured code plus the offending *type*; the value is broader than that and would become a disclosure path the first time a caller passes user-derived data. Removed from the message text; `err.code` and `err.receivedType` — the properties the test asserts on — are unchanged.
3. **This PR body claimed both functions were module-private and unreachable.** They are exported, deliberately, at `src/state.cts:4870` and `:4877`. Corrected under *Breaking changes* below.

Finding 3 is the one worth dwelling on: the false claim was doing real work — it was the entire argument for why the new throw is safe to ship. Reviewing it required checking the export list rather than accepting a sentence that already sounded settled.

## Testing

| Run | Sha | Result |
|---|---|---|
| 1 | `b6d591acd` | `failed` — 14/34450, all from unconverted `.cjs` call sites |
| 2 | `62cf9e923` | `passed` — 34478/34478 |
| 3 | `df46d7224` | **`passed` — 34478/34478**, after the two review fixes below |

Both refactors are behavior-preserving, proven rather than asserted: the compiled lib was built at `411196bc3` and post-fix, and the same fixtures run through each — byte-identical, modulo the clock-driven `last_updated`.

Probes on the final build: a correct options call returns the expected `divergedFields`; a legacy positional call throws the structured code instead of silently returning empty.

Local gates: `build:lib` clean, `lint:ci` exit 0, drift guard `ok: true` — `policyDispatchViolations: 0`, `seamBypassesObserved: 2`, `seamBypassesAcknowledged: 2`, `ratchetViolations: 0`.

### Platforms tested

- [x] N/A — no platform-specific code; the remote matrix lane is linux-node24

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue — this is #3408's own recorded debt, closed rather than carried
- [x] Scope changed during implementation and was surfaced before continuing — the runtime guard was added after the 14 failures showed the refactor had introduced a silent-degradation path

---

## Documentation

- [x] Updated the relevant file(s) under `docs/` — not applicable; no contract change. ADR-3408's rules are unaffected: this is an internal signature and typing change with no behavioral surface
- [x] All `docs/` content added in this PR is written in English — no docs content added
- [x] Not applicable — a `Changed` fragment with no user-facing behavior change; the changeset states plainly that no command output moves

## Checklist

- [x] Issue linked above with `Closes #3408`
- [x] Linked issue has the `approved-enhancement` label
- [x] Changes are scoped to the approved enhancement
- [x] All existing tests pass — 34478/34478 on the remote runner
- [x] New or updated tests cover the enhanced behavior — nine call sites converted, plus a new test pinning that a boolean in the options slot throws the structured code
- [x] `.changeset/` fragment added — `Changed`, `pr` backfilled
- [x] No unnecessary dependencies added

## Breaking changes

**None to any command's output.** Both refactors are behavior-preserving and verified byte-identical against the pre-change compiled lib.

One internal contract is newly enforced: passing a non-object where `StatePreservationOptions` belongs now throws instead of silently proceeding with every option undefined.

Both functions are **exported** from `src/state.cts` — deliberately, so `cmdPhaseComplete` and `cmdMilestoneComplete` can supply their own I/O envelope around the composition — and the package ships no `exports` map, so a deep import of `bin/lib/state.cjs` is possible in principle. No consumer in this repo calls either function outside `src/` and `tests/`.

The throw is still not a breaking change, for a reason that does not depend on reachability: **it fires only on a call that was already broken.** A caller passing a well-formed options object is unaffected. A caller passing the old positional arguments was already getting every option `undefined` and an empty `divergedFields`, silently — that is the exact degradation this PR exists to make loud.

*An earlier revision of this body claimed both functions were module-private and unreachable. That was false; review caught it. The claim was doing real work — it was the whole argument for why the throw is safe — so it is replaced above rather than deleted.*

## What is left open after this

**Nothing.** That is the point of this PR. The epic's coverage check is clean, the guard is at its correct end state of 2 sanctioned-permanent entries, and the two real items from the closing comment are fixed rather than recorded.
