### PR TITLE
docs(#3523): correct allow-test-rule placement guidance for site-scoping

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -795,19 +795,49 @@ Some tests legitimately read source files. There are six recognized categories:
 | `structural-implementation-guard` | A feature's interception or wiring point is not reachable end-to-end via `runGsdTools`. Used temporarily until a behavioral path exists. |
 | `pending-migration-to-typed-ir` | **Tracked for correction, not exempted.** Test was identified by the lint as carrying a raw-text-matching pattern that contradicts the rule above. Each annotated file MUST cite the open migration issue (e.g. `// allow-test-rule: pending-migration-to-typed-ir [#NNNN]`) so the tracking is auditable. New tests cannot use this category — they must refactor production to expose typed IR. The annotation is removed when the test is corrected. |
 
-Annotate with a standalone `//` comment before the file's opening block comment:
+**Suppression is site-scoped, not file-wide.** A marker suppresses only the violation it sits next
+to. Put it immediately above the flagged line — or trailing on that line — with nothing but blank
+lines and other comment lines in between, and no more than **8 lines** above it
+(`MAX_MARKER_LOOKAHEAD_LINES` in `eslint-rules/no-source-grep.cjs`). A single line of real code
+between the marker and the call ends the window, even when the two are physically close.
 
 ```javascript
-// allow-test-rule: architectural-invariant
-// state.cjs locking must use Atomics.wait(), not a spin-loop. Behavioral tests
-// cannot observe which sleep primitive was chosen — only source inspection can.
-
-/**
- * Regression tests for locking bugs #1909...
- */
+test('locking uses Atomics.wait, not a spin-loop', () => {
+  // allow-test-rule: architectural-invariant (#1909)
+  // state.cjs locking must use Atomics.wait(). Behavioral tests cannot observe
+  // which sleep primitive was chosen — only source inspection can.
+  const src = fs.readFileSync(STATE_PATH, 'utf8');
+  assert.ok(src.includes('Atomics.wait'));
+});
 ```
 
-The annotation **must** be a standalone `// allow-test-rule:` line, not inside a `/** */` block comment — the CI linter scans for the pattern `// allow-test-rule:`.
+A violation is a **read + search pair**, and a marker adjacent to *either* half suppresses it — so
+annotating the `readFileSync` directly (the intuitive placement) works just as well as annotating
+the `.includes()`.
+
+> **A marker parked at the top of the file no longer suppresses anything below it.** Before #3508
+> suppression was file-wide, so one justified exemption silently absolved every other source-grep
+> in that file — including ones added later by someone else. If you are copying the old
+> file-header placement from an existing test, it is almost certainly inert: the file's `require`
+> block sits between it and the code, and real code closes the window.
+
+The annotation **must** be a standalone `// allow-test-rule:` line — the marker text must be the
+first thing on its comment line (a leading JSDoc `*` is fine), not buried mid-sentence in prose.
+The reason **must** cite a tracking issue (`#NNN`) or an `https://` URL, per
+[ADR-456](docs/adr/456-test-rigor-architecture.md); `scripts/lint-allow-test-rule-refs.cjs` fails
+the build on an uncited one.
+
+That gate reports two separate numbers, and they mean different things:
+
+| Number | Meaning | Gated? |
+|---|---|---|
+| **Effective exemptions** | markers that actually suppress a violation the rule detects | tightly ratcheted — it may only go down |
+| **Unverified markers** | marker-bearing files where the rule detects nothing to suppress | tracked with a loose ceiling; growth fails, shrinkage never does |
+
+A marker landing in the *unverified* bucket does **not** mean it is vestigial and safe to delete —
+it usually means the rule cannot yet see the read (identifier indirection, a dynamic path, a `.sh`
+file). Shrinking that pool is a rule-coverage job backed by measurement, not a delete-the-markers
+job.
 
 ### Prohibited: Raw Text Matching on Test Outputs (file content, stdout, stderr)
 


### PR DESCRIPTION
## Docs correction

## Linked Issue

Refs #3523 · Refs #3464

Non-closing by design. #3523 was closed by #3548, which landed the test rewrites. This PR carries
the one deliverable of epic #3464 that no phase ever claimed, and it closes no issue of its own.

Per [CONTRIBUTING.md](../../CONTRIBUTING.md#pull-request-guidelines): *"Test-only and docs-only
follow-up PRs may reference without closing… Do not write a closing keyword against an already-closed
issue to satisfy the check."* The diff qualifies for that weaker form — a single root-level `*.md`.

---

## What this corrects

Phase 4 of epic #3464 (#3508) changed `allow-test-rule` suppression from **file-wide** to
**site-scoped**, bounded by an 8-line comment-pure lookahead. No phase of that epic updated the
contributor docs.

So CONTRIBUTING.md still instructed contributors to annotate *"before the file's opening block
comment"* — and post-#3508 that placement suppresses **nothing** below the require block, because a
single line of real code closes the lookahead window. The documented remedy did not work, and a
contributor copying the documented example would get an inert marker and a red build with no
explanation.

## How it was found

Running `/adr-phase-coverage` over epic #3464. The checker reported exactly one `orphan-decision`:
contributor-facing documentation of the marker mechanism, owned by no phase. Every other deliverable
of the epic traced to exactly one phase.

Verified against the merge commits of all five merged phases (#3465, #3466, #3502, #3508, #3520):
none of them touch `CONTRIBUTING.md` or `TESTING-STANDARDS.md`.

## Before / After

**Before** — the documented placement, which no longer suppresses anything below itself:

```javascript
// allow-test-rule: architectural-invariant
// ...rationale...

/**
 * Regression tests for locking bugs #1909...
 */
```

**After** — placement bound to the violation site, plus what the gate's two numbers actually mean.

Specifically the correction now states:

- Suppression is **site-scoped**: same line, or within `MAX_MARKER_LOOKAHEAD_LINES` (8) above, with
  only blank/comment lines between. One line of real code ends the window even at close range.
- A violation is a **read + search pair**, and a marker adjacent to *either* half suppresses it — so
  annotating the `readFileSync` directly works as well as annotating the `.includes()`.
- An explicit warning that copying the old file-header placement from an existing test yields an
  **inert** marker.
- The citation requirement (`#NNN` or an `https://` URL) that `scripts/lint-allow-test-rule-refs.cjs`
  enforces, per [ADR-456](docs/adr/456-test-rigor-architecture.md).
- A table distinguishing **effective exemptions** (tightly ratcheted) from **unverified markers**
  (loose ceiling, growth-only) — and the point that an unverified marker is *not* evidence the marker
  is vestigial. Shrinking that pool is a rule-coverage job, not a delete-the-markers job, which is
  what #3520 concluded and what forced the Phase 1 revert of 295 files before it.

## Testing

### How I verified

Documentation accuracy was checked against the shipped implementation on this branch's base, which
already includes #3548:

| Claim | Verified against |
|---|---|
| 8-line comment-pure lookahead | `MAX_MARKER_LOOKAHEAD_LINES` / `isSuppressedAt` in `eslint-rules/no-source-grep.cjs` |
| marker binds to either half of the read+search pair | `reportUnlessSuppressed`, which ORs the search line and the originating read line |
| marker must be first content on its comment line | `extractGenuineMarkerReasons` in `scripts/lint-allow-test-rule-refs.cjs` |
| citation required (`#NNN` / URL) | `ISSUE_REF_RE` + `assertWithinAllowlist` |
| two numbers, only the first ratcheted | `npm run lint:allow-test-rule-refs` on this base reports `effective exemptions: 10/10 site(s)` (ratcheted) and `unverified markers: 272/280 file(s)` (tracked, not ratcheted) |

### Platforms tested

- [x] N/A (documentation only)

### Runtimes tested

- [x] N/A (documentation only)

---

## Documentation

- [x] The change *is* the documentation update. `CONTRIBUTING.md` is the reference for this
      mechanism; no page under `docs/` describes it.
- [x] All content is written in English (American spelling, per repo house style)
- [x] `no-changelog` label applied — no user-facing behavior changes

## Checklist

- [x] Issue referenced above (non-closing form, per the docs-only rule)
- [x] Scope is a single concern: one documentation correction
- [x] No code changes — nothing to test beyond the accuracy check above
- [x] `no-changelog` label applied

## Breaking changes

None. Documentation only; no code, config, or behavior is touched.
