### PR TITLE
docs(#3531): document where inherit must be set to reach tiered agents

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1426,6 +1426,12 @@ an absent key as the correct in-sync state and strips a present one; no runtime 
 the literal. An explicit `inherit` also never escalates on failed attempts — your choice
 outranks the automatic ladder.
 
+Where you set `inherit` matters: every GSD agent has a routing tier, and the merged tier
+ladder (#3531) answers for tiered agents before `effort.default` is consulted — so a bare
+`effort.default: "inherit"` only affects agents **without** a catalog tier. To make tiered
+agents follow the session, set `effort.routing_tier_defaults` (per tier, or all three) or the
+agent's `agent_overrides` entry to `"inherit"`. `query resolve-execution` shows both views.
+
 `query resolve-execution --json` reports two effort views ([#3534](https://github.com/open-gsd/gsd-core/issues/3534)):
 `effort` is the **resolved** config-cascade value; `effort_effective` is what the installed
 agent will actually run at — read from the installed agent's `effort:` frontmatter for the


### PR DESCRIPTION
## Linked Issue

Refs #3531 (docs-only follow-up to merged PR #3539; the sub-issue and epic #3160 tracking is complete — nothing here closes)

## What this changes

One paragraph in `docs/CONFIGURATION.md`'s effort-`inherit` section: it now states where `inherit` must be set to actually reach **tiered** agents. The merged tier ladder from #3531 answers for every tiered agent before `effort.default` is consulted, so a bare `effort.default: "inherit"` only affects agents without a catalog tier — to make tiered agents follow the session, set `effort.routing_tier_defaults` (per tier or all three) or the agent's `agent_overrides` entry. The paragraph points at `query resolve-execution` (#3534) for seeing both views.

## Why

This combined rule exists only at the intersection of two independently merged PRs (#3539 and #3541), so neither one's docs carried it alone. It surfaced when the #3539 rebase updated cross-phase test fixtures to the combined semantics; this makes the rule explicit for users instead of leaving it implicit in test diffs.

## Testing

Docs-only change; no code, no tests. `GITHUB_BASE_REF=next node scripts/lint-docs-required.cjs` passes; diff is entirely under `docs/`.

- [x] N/A (not platform-specific)
- [x] N/A (not runtime-specific)

## Documentation

- [x] This PR **is** the documentation update (`docs/CONFIGURATION.md`)
- [x] All content is in English
- [ ] n/a

## Checklist

- [x] Refs #3531 — non-closing reference per CONTRIBUTING's docs-only diff-shape rule
- [x] No changeset needed (docs-only; no `bin/`, `gsd-core/`, `src/`, `agents/`, `commands/`, `hooks/`, or `sdk/src/` files touched)
- [x] No scope beyond the approved clarification
