### PR TITLE
fix(#3561): route /gsd-map-codebase --fast to a scan.md path the runtime can resolve

### DIFF
--- a/.changeset/gentle-wolves-hum.md
+++ b/.changeset/gentle-wolves-hum.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`/gsd-map-codebase --fast` now actually runs the fast scan** — the flag routed to "the scan workflow" in prose but named no path any runtime could resolve, and the command loaded only the full four-agent map workflow, so `scan.md` was never read and the single-agent scan was improvised rather than executed. (#3561)

--- a/.changeset/gentle-wolves-hum.md
+++ b/.changeset/gentle-wolves-hum.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 3562
 ---
 **`/gsd-map-codebase --fast` now actually runs the fast scan** — the flag routed to "the scan workflow" in prose but named no path any runtime could resolve, and the command loaded only the full four-agent map workflow, so `scan.md` was never read and the single-agent scan was improvised rather than executed. (#3561)

--- a/commands/gsd/map-codebase.md
+++ b/commands/gsd/map-codebase.md
@@ -34,7 +34,7 @@ Output: .planning/codebase/ folder with 7 structured documents about the codebas
 Arguments: $ARGUMENTS
 
 Parse the first token of $ARGUMENTS:
-- If it is `--fast`: strip the flag, run the scan workflow (passing remaining args including optional --focus).
+- If it is `--fast`: strip the flag, then read and execute `~/.claude/gsd-core/workflows/scan.md` (passing remaining args including optional --focus). Load it on demand here — it is deliberately not in `<execution_context>`, so the common full-map path does not pay for it.
 - If it is `--query`: strip the flag, run the intel workflow (passing remaining args as the subcommand).
 - Otherwise: pass all of $ARGUMENTS as focus area to the map-codebase workflow.
 

--- a/scripts/command-contract-helpers.cjs
+++ b/scripts/command-contract-helpers.cjs
@@ -89,6 +89,10 @@ function executionContextRefs(content) {
  * Traversal segments (`..`) are dropped rather than surfaced: this resolver
  * only ever reports paths under `workflows/`, never something a `..` could
  * walk outside of it. Results are de-duplicated, first-seen order preserved.
+ *
+ * Both regexes anchor `\.md` with a trailing `(?![A-Za-z0-9_])` negative
+ * lookahead so a longer extension (`.mdx`, `.md5`) is rejected outright
+ * rather than silently truncated into a plausible-looking `.md` path.
  */
 function workflowPathRefs(content) {
   const refs = [];
@@ -101,7 +105,7 @@ function workflowPathRefs(content) {
     refs.push(normalized);
   }
 
-  const shapeARe = /@?(?:(?:~|\$HOME)\/)?(?:\.claude\/)?(?:gsd-core\/)?workflows\/[A-Za-z0-9._/-]+\.md/g;
+  const shapeARe = /@?(?:(?:~|\$HOME)\/)?(?:\.claude\/)?(?:gsd-core\/)?workflows\/[A-Za-z0-9._/-]+\.md(?![A-Za-z0-9_])/g;
   let m;
   while ((m = shapeARe.exec(content)) !== null) {
     const normalized = m[0]
@@ -112,7 +116,7 @@ function workflowPathRefs(content) {
     addRef(normalized);
   }
 
-  const shapeCRe = /(?:^|[\s`("'>])([A-Za-z0-9._-]+\/(?:steps|modes|templates)\/[A-Za-z0-9._-]+\.md)/gm;
+  const shapeCRe = /(?:^|[\s`("'>])([A-Za-z0-9._-]+\/(?:steps|modes|templates)\/[A-Za-z0-9._-]+\.md(?![A-Za-z0-9_]))/gm;
   while ((m = shapeCRe.exec(content)) !== null) {
     addRef('workflows/' + m[1]);
   }

--- a/scripts/command-contract-helpers.cjs
+++ b/scripts/command-contract-helpers.cjs
@@ -61,4 +61,63 @@ function executionContextRefs(content) {
   return refs;
 }
 
-module.exports = { CANONICAL_TOOLS, parseFrontmatter, executionContextRefs };
+/**
+ * workflowPathRefs(content)
+ *
+ * Locates every gsd-core-relative workflow path referenced in a markdown
+ * string, whether the reference is an eager @-include (already covered by
+ * executionContextRefs) or a *lazy* path mentioned only in prose/code — a
+ * path a command reads on demand via Read/Bash rather than an @-inclusion
+ * the harness inlines automatically. Both kinds are load-bearing: the
+ * progressive-disclosure split (#717) deliberately keeps most workflow
+ * content out of the eager path so the common case stays cheap, but that
+ * means a command naming a workflow only in prose is invisible to
+ * executionContextRefs even though the runtime still needs the file to
+ * exist. Recognizes three reference shapes:
+ *
+ *   A. Any path whose segments include `workflows/`, optionally preceded by
+ *      an eager `@`, a home-dir prefix (`~/` or `$HOME/`), `.claude/`, and/or
+ *      `gsd-core/` — e.g. `@~/.claude/gsd-core/workflows/scan.md`,
+ *      `gsd-core/workflows/x.md`, or a bare `workflows/x.md`.
+ *   B. Same as A but without the eager `@` — a lazy reference read on
+ *      demand rather than inlined at load time.
+ *   C. Parent-relative sub-file paths with no `workflows/` prefix at all —
+ *      `execute-phase/steps/post-merge-gate.md` — implicitly rooted under
+ *      `workflows/` because that's the only place `steps/`, `modes/`, and
+ *      `templates/` subdirectories live.
+ *
+ * Traversal segments (`..`) are dropped rather than surfaced: this resolver
+ * only ever reports paths under `workflows/`, never something a `..` could
+ * walk outside of it. Results are de-duplicated, first-seen order preserved.
+ */
+function workflowPathRefs(content) {
+  const refs = [];
+  const seen = new Set();
+
+  function addRef(normalized) {
+    if (normalized.split('/').includes('..')) return;
+    if (seen.has(normalized)) return;
+    seen.add(normalized);
+    refs.push(normalized);
+  }
+
+  const shapeARe = /@?(?:(?:~|\$HOME)\/)?(?:\.claude\/)?(?:gsd-core\/)?workflows\/[A-Za-z0-9._/-]+\.md/g;
+  let m;
+  while ((m = shapeARe.exec(content)) !== null) {
+    const normalized = m[0]
+      .replace(/^@/, '')
+      .replace(/^(?:~|\$HOME)\//, '')
+      .replace(/^\.claude\//, '')
+      .replace(/^gsd-core\//, '');
+    addRef(normalized);
+  }
+
+  const shapeCRe = /(?:^|[\s`("'>])([A-Za-z0-9._-]+\/(?:steps|modes|templates)\/[A-Za-z0-9._-]+\.md)/gm;
+  while ((m = shapeCRe.exec(content)) !== null) {
+    addRef('workflows/' + m[1]);
+  }
+
+  return refs;
+}
+
+module.exports = { CANONICAL_TOOLS, parseFrontmatter, executionContextRefs, workflowPathRefs };

--- a/skills/gsd-map-codebase/SKILL.md
+++ b/skills/gsd-map-codebase/SKILL.md
@@ -34,7 +34,7 @@ Output: .planning/codebase/ folder with 7 structured documents about the codebas
 Arguments: $ARGUMENTS
 
 Parse the first token of $ARGUMENTS:
-- If it is `--fast`: strip the flag, run the scan workflow (passing remaining args including optional --focus).
+- If it is `--fast`: strip the flag, then read and execute `~/.claude/gsd-core/workflows/scan.md` (passing remaining args including optional --focus). Load it on demand here — it is deliberately not in `<execution_context>`, so the common full-map path does not pay for it.
 - If it is `--query`: strip the flag, run the intel workflow (passing remaining args as the subcommand).
 - Otherwise: pass all of $ARGUMENTS as focus area to the map-codebase workflow.
 

--- a/tests/command-contract.test.cjs
+++ b/tests/command-contract.test.cjs
@@ -32,6 +32,7 @@ const {
   CANONICAL_TOOLS,
   parseFrontmatter,
   executionContextRefs,
+  workflowPathRefs,
 } = require('../scripts/command-contract-helpers.cjs');
 
 const commandFiles = fs
@@ -110,6 +111,135 @@ describe('command contract: execution_context @-refs on own line (ADR-0002)', ()
         `${name}: @-refs with trailing prose in execution_context: ` +
         bad.map(r => r.token).join(', '),
       );
+    });
+  }
+});
+
+describe('#3561 — workflowPathRefs resolver', () => {
+  test('eager @-include', () => {
+    assert.deepEqual(
+      workflowPathRefs('@~/.claude/gsd-core/workflows/x.md'),
+      ['workflows/x.md'],
+    );
+  });
+
+  test('lazy tilde path', () => {
+    assert.deepEqual(
+      workflowPathRefs('read `~/.claude/gsd-core/workflows/x.md` now'),
+      ['workflows/x.md'],
+    );
+  });
+
+  test('repo-relative path', () => {
+    assert.deepEqual(
+      workflowPathRefs('see gsd-core/workflows/x.md'),
+      ['workflows/x.md'],
+    );
+  });
+
+  test('bare workflows path', () => {
+    assert.deepEqual(
+      workflowPathRefs('see workflows/x.md'),
+      ['workflows/x.md'],
+    );
+  });
+
+  test('parent-relative steps path', () => {
+    assert.deepEqual(
+      workflowPathRefs('run execute-phase/steps/post-merge-gate.md'),
+      ['workflows/execute-phase/steps/post-merge-gate.md'],
+    );
+  });
+
+  test('parent-relative modes path', () => {
+    assert.deepEqual(
+      workflowPathRefs('use discuss-phase/modes/power.md'),
+      ['workflows/discuss-phase/modes/power.md'],
+    );
+  });
+
+  test('empty content yields no refs', () => {
+    assert.deepEqual(workflowPathRefs(''), []);
+  });
+
+  test('unrelated prose yields no refs', () => {
+    assert.deepEqual(workflowPathRefs('nothing to see here'), []);
+  });
+
+  test('whitespace-only yields no refs', () => {
+    assert.deepEqual(workflowPathRefs('   \n\t \n'), []);
+  });
+
+  test('de-duplicates repeated refs', () => {
+    const refs = workflowPathRefs('workflows/x.md and again workflows/x.md');
+    assert.deepEqual(refs, ['workflows/x.md']);
+    assert.equal(refs.length, 1);
+  });
+
+  test('CRLF-tolerant', () => {
+    assert.deepEqual(
+      workflowPathRefs('workflows/a.md\r\nworkflows/b.md'),
+      ['workflows/a.md', 'workflows/b.md'],
+    );
+  });
+
+  test('ignores non-workflow md paths', () => {
+    assert.deepEqual(
+      workflowPathRefs('docs/GUIDE.md README.md references/r.md'),
+      [],
+    );
+  });
+
+  test('surfaces a ref whose target is absent', () => {
+    assert.deepEqual(
+      workflowPathRefs('workflows/does-not-exist.md'),
+      ['workflows/does-not-exist.md'],
+    );
+  });
+
+  test('does not emit a traversing path', () => {
+    const refs = workflowPathRefs('workflows/../../etc/passwd.md');
+    for (const ref of refs) {
+      assert.ok(!ref.includes('..'), `traversal path leaked: ${ref}`);
+    }
+  });
+
+  test('tolerates an overlong path', () => {
+    const content = 'workflows/' + 'a'.repeat(5000) + '.md';
+    assert.doesNotThrow(() => workflowPathRefs(content));
+  });
+});
+
+describe('#3561 — /gsd-map-codebase --fast routes to a loadable workflow', () => {
+  const mapCodebasePath = path.join(COMMANDS_DIR, 'map-codebase.md');
+  const mapCodebaseContent = fs.readFileSync(mapCodebasePath, 'utf-8');
+
+  test('map-codebase: --fast routing names a loadable scan.md', () => {
+    const refs = workflowPathRefs(mapCodebaseContent);
+    assert.ok(
+      refs.includes('workflows/scan.md'),
+      '#3561: --fast routes to the scan workflow but commands/gsd/map-codebase.md ' +
+      'names no resolvable "workflows/scan.md" path, so the scan workflow is never loaded',
+    );
+  });
+
+  test('full map does not eagerly load scan.md', () => {
+    const refs = executionContextRefs(mapCodebaseContent);
+    assert.equal(refs.length, 1);
+    assert.equal(refs[0].normalized, 'workflows/map-codebase.md');
+  });
+});
+
+describe('#3561 — every workflow path referenced by a command exists on disk', () => {
+  for (const { name, full } of commandFiles) {
+    test(`${name}: all workflowPathRefs paths exist on disk`, () => {
+      const refs = workflowPathRefs(fs.readFileSync(full, 'utf-8'));
+      for (const ref of refs) {
+        assert.ok(
+          fs.existsSync(path.join(GSD_ROOT, ref)),
+          `${name}: referenced workflow path "${ref}" does not exist under ${GSD_ROOT}`,
+        );
+      }
     });
   }
 });

--- a/tests/command-contract.test.cjs
+++ b/tests/command-contract.test.cjs
@@ -208,6 +208,37 @@ describe('#3561 — workflowPathRefs resolver', () => {
     const content = 'workflows/' + 'a'.repeat(5000) + '.md';
     assert.doesNotThrow(() => workflowPathRefs(content));
   });
+
+  test('rejects a .mdx path', () => {
+    assert.deepEqual(workflowPathRefs('workflows/foobar.mdx'), []);
+  });
+
+  test('rejects a .md5 path', () => {
+    assert.deepEqual(workflowPathRefs('workflows/foo.md5'), []);
+  });
+
+  test('still accepts a .md path followed by punctuation', () => {
+    assert.deepEqual(
+      workflowPathRefs('see workflows/x.md, then stop'),
+      ['workflows/x.md'],
+    );
+  });
+
+  test('binds to the --fast line, not the whole file', () => {
+    const syntheticFile = [
+      '- If it is `--fast`: strip the flag, run the scan workflow.',
+      '<!-- see gsd-core/workflows/scan.md -->',
+    ].join('\n');
+    const fastLine = syntheticFile
+      .split(/\r?\n/)
+      .find(line => /^-\s*If it is\s*`--fast`/.test(line));
+    assert.ok(fastLine, 'setup error: synthetic fixture missing --fast routing line');
+    assert.ok(
+      !workflowPathRefs(fastLine).includes('workflows/scan.md'),
+      'regression guard: the --fast routing line itself names no resolvable path — ' +
+      'an unrelated comment elsewhere in the file must not make this test pass',
+    );
+  });
 });
 
 describe('#3561 — /gsd-map-codebase --fast routes to a loadable workflow', () => {
@@ -215,11 +246,19 @@ describe('#3561 — /gsd-map-codebase --fast routes to a loadable workflow', () 
   const mapCodebaseContent = fs.readFileSync(mapCodebasePath, 'utf-8');
 
   test('map-codebase: --fast routing names a loadable scan.md', () => {
-    const refs = workflowPathRefs(mapCodebaseContent);
+    const fastLine = mapCodebaseContent
+      .split(/\r?\n/)
+      .find(line => /^-\s*If it is\s*`--fast`/.test(line));
+    assert.ok(
+      fastLine,
+      '#3561: commands/gsd/map-codebase.md has no "--fast" routing bullet ' +
+      '(expected a line matching /^-\\s*If it is\\s*`--fast`/) — the routing logic is missing entirely',
+    );
+    const refs = workflowPathRefs(fastLine);
     assert.ok(
       refs.includes('workflows/scan.md'),
-      '#3561: --fast routes to the scan workflow but commands/gsd/map-codebase.md ' +
-      'names no resolvable "workflows/scan.md" path, so the scan workflow is never loaded',
+      '#3561: --fast routes to the scan workflow but the routing line names no path ' +
+      'the runtime can resolve, so scan.md is never loaded',
     );
   });
 


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3561

Epic #1891 (prompt-layer single-source-of-truth).

---

## What was broken

`/gsd-map-codebase --fast` dispatched to a workflow no runtime ever loaded. The command documented the flag and told the agent to "run the scan workflow", but named no resolvable path and included only `map-codebase.md` in its `<execution_context>` — so `gsd-core/workflows/scan.md` was never read and the single-agent scan was improvised instead of executed.

## What this fix does

Names the path in the routing line, so the token the agent is told to resolve actually exists:

```
- If it is `--fast`: strip the flag, then read and execute
  `~/.claude/gsd-core/workflows/scan.md` (passing remaining args including optional --focus).
```

It is a **lazy on-demand read, not an eager `@`-include**. `--fast` is the minority path, and the progressive-disclosure split (#717) exists precisely so the common full-map invocation does not pay to inline a workflow it will not use. A test pins that choice: `<execution_context>` must still carry exactly one `@`-ref.

`skills/gsd-map-codebase/SKILL.md` is regenerated by `npm run gen:plugin-skills`, not hand-edited (`gen-plugin-skills.cjs --check` → 71 skills up to date).

## Root cause

The same defect class epic #1891 was opened for — dispatch keyed on a token that never arrives — one layer above F8 and F9. `git log -S'workflows/scan.md' -- commands/gsd/map-codebase.md` is empty: the flag was documented and routed but never wired, from inception.

It surfaced from a Chesterton's-Fence check while scoping the epic's F12 row, which lists `scan.md` among three "command removed, workflow orphan retained" files slated for deletion. That premise is wrong for this file: the flag is live and documented (`docs/COMMANDS.md:1309/1314/1326`, `docs/INVENTORY.md:245`), and `scan.md` received a behavioral fix as recently as #2684. Deleting it as filed would have removed the only implementation of a shipped feature. The epic's other two F12 files are genuine orphans and are handled separately in #3560.

## Testing

### How I verified the fix

Remote runner, `--base next`, both lanes:

- **RED** on the failing-first commit `448359ccb` — 2 failures / 35,122, both in the `#3561` group, and nothing else. That is the proof the test binds to this defect rather than to prose that happened to be present.
- **GREEN** on the fix commit `5109dc516`.

`npm run lint:ci` exit 0. `node scripts/lint-command-contract.cjs` → 71 command files, 0 violations.

Behavioral check of the routing line itself:

```
workflowPathRefs(<--fast line only>)  →  ["workflows/scan.md"]
executionContextRefs(map-codebase.md) →  ["workflows/map-codebase.md"]   # still exactly one eager ref
```

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

22 tests in `tests/command-contract.test.cjs`. The regression test extracts the `- If it is `--fast`` bullet and scans **that line alone**, and a companion test drives a synthetic pre-fix fixture to prove a mention of `scan.md` elsewhere in the file cannot make it pass.

A shared pure resolver `workflowPathRefs()` lands in `scripts/command-contract-helpers.cjs` — the module that exists so the lint script and the test suite read one definition. It recognizes the three reference shapes this repo actually uses (eager `@`-include; lazy absolute-ish path; lazy parent-relative `steps/`/`modes/` path). #3560 consumes the same function for its repo-wide reachability rule rather than re-deriving it, which is what keeps this off the generative-fix-divergence path.

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

The remote matrix is Linux-only (node24). The change is a markdown routing line plus a pure string function with no path-separator or filesystem behavior, so it carries no platform-specific surface.

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [ ] N/A (not runtime-specific)

The routing line ships to all 19 runtimes through the same generated skill surface; `~/.claude/…` is the established form already used by the sibling lazy references in `discuss-phase.md` and `execute-phase.md`.

---

## Review

Two orthogonal engines, both in an isolated reviewer context that did not author the change: `/code-review` and `/security-review`.

Two majors were found and fixed before the green run:

1. **Resolver regexes ended at a literal `.md` with no boundary** — `workflows/foobar.mdx` was truncated to `workflows/foobar.md`. Fixed with a `(?![A-Za-z0-9_])` lookahead on both shapes; `.mdx` / `.md5` rejection is now pinned by tests.
2. **The regression test did not bind to the defect** — it scanned the whole file, so an unrelated comment mentioning `scan.md` made it pass while the dispatch defect remained. Fixed by isolating the `--fast` line, plus a test that proves the false-pass path is closed.

Security review returned no HIGH or MEDIUM findings: the resolver only processes repo-committed `commands/gsd/*.md`, and the routing line is a hardcoded literal, not derived from `$ARGUMENTS`.

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass — remote runner green on `5109dc516`
- [x] `.changeset/` fragment added
- [x] No unnecessary dependencies added

## Breaking changes

`--fast` previously produced improvised output because the workflow it named never reached context; it now runs `scan.md`'s defined single-agent, focus-scoped path. Anyone who had come to rely on the improvised behavior will see different output — the documented contract is what now holds.

## Known limits

The test proves the routed path is present and resolvable, not that an agent reads it on every execution path — structural, not semantic. The repo-wide version of this guard, covering every workflow rather than this one flag, is #3560.
