### PR TITLE
fix(#3581): derive init.progress's next_phase from roadmap order, not artifact presence

### DIFF
--- a/.changeset/sturdy-foxes-gather.md
+++ b/.changeset/sturdy-foxes-gather.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 3603
 ---
 **`init.progress` no longer infers the next phase from stray out-of-order artifacts** — a phase directory created out of order (e.g. a phase-9 UAT evidence file while roadmap phase 8 was still pending and unscaffolded) dragged the reported frontier forward, making `init.progress` skip Phase 8 and disagree with `roadmap.analyze`; the frontier is now derived from roadmap order, with artifacts as corroborating evidence only. (#3581)

--- a/.changeset/sturdy-foxes-gather.md
+++ b/.changeset/sturdy-foxes-gather.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`init.progress` no longer infers the next phase from stray out-of-order artifacts** — a phase directory created out of order (e.g. a phase-9 UAT evidence file while roadmap phase 8 was still pending and unscaffolded) dragged the reported frontier forward, making `init.progress` skip Phase 8 and disagree with `roadmap.analyze`; the frontier is now derived from roadmap order, with artifacts as corroborating evidence only. (#3581)

--- a/src/init.cts
+++ b/src/init.cts
@@ -3082,7 +3082,8 @@ function cmdInitProgress(cwd: string, raw: boolean, options: Record<string, unkn
   // completion flow.
   {
     const frontier = phases.find((p) => {
-      return p['status'] !== 'complete' && p['roadmap_complete'] !== true;
+      const st = p['status'];
+      return (st === 'pending' || st === 'not_started') && p['roadmap_complete'] !== true;
     });
     if (frontier) nextPhase = frontier;
   }

--- a/src/init.cts
+++ b/src/init.cts
@@ -3069,6 +3069,25 @@ function cmdInitProgress(cwd: string, raw: boolean, options: Record<string, unkn
     (a, b) => parseInt(a['number'] as string, 10) - parseInt(b['number'] as string, 10),
   );
 
+  // #3581: the frontier is ROADMAP ORDER, not artifact presence. The disk loop
+  // above could claim nextPhase from a stray out-of-order artifact directory
+  // (a phase-9 UAT evidence dir while roadmap phase 8 was pending and
+  // unscaffolded), silently skipping 8 — and init.progress then disagreed with
+  // roadmap.analyze on the same tree. Re-derive from the sorted union: the
+  // first phase that has not begun ('pending' | 'not_started') and is not
+  // roadmap-complete wins; artifacts still feed each entry's status and
+  // completion (corroborating evidence) but no longer outrank the ordering.
+  // Aligned trees derive the identical frontier as the loops above; an
+  // all-complete milestone finds none and keeps nextPhase null for the
+  // completion flow.
+  {
+    const frontier = phases.find((p) => {
+      const st = p['status'];
+      return (st === 'pending' || st === 'not_started') && p['roadmap_complete'] !== true;
+    });
+    if (frontier) nextPhase = frontier;
+  }
+
   let pausedAt: string | null = null;
   const state = platformReadSync(path.join(planningDir(cwd), 'STATE.md'));
   if (state !== null) {

--- a/src/init.cts
+++ b/src/init.cts
@@ -3082,8 +3082,7 @@ function cmdInitProgress(cwd: string, raw: boolean, options: Record<string, unkn
   // completion flow.
   {
     const frontier = phases.find((p) => {
-      const st = p['status'];
-      return (st === 'pending' || st === 'not_started') && p['roadmap_complete'] !== true;
+      return p['status'] !== 'complete' && p['roadmap_complete'] !== true;
     });
     if (frontier) nextPhase = frontier;
   }

--- a/tests/init.test.cjs
+++ b/tests/init.test.cjs
@@ -4480,3 +4480,74 @@ describe('#3171: init execute-phase emits the display name, not the directory sl
     );
   });
 });
+
+// ─── #3581: init.progress frontier prefers roadmap order over stray artifacts ──
+describe('#3581: init.progress next_phase prefers the roadmap frontier', () => {
+  function writeProgressFixture(t, { strayNine, completeAll }) {
+    fs.writeFileSync(path.join(tmpDirOf(t), '.planning', 'ROADMAP.md'),
+      ['# Roadmap', '', '## Milestone v1.1.0', '', '### Phase 8: Payments', '**Goal:** g', '', '### Phase 9: Compatibility', '**Goal:** g', ''].join('\n'));
+    fs.writeFileSync(path.join(tmpDirOf(t), '.planning', 'STATE.md'), [
+      '---', 'gsd_state_version: 1.0', 'milestone: v1.1.0', 'milestone_name: Active',
+      'status: executing', 'current_phase: 8', 'progress:', '  total_phases: 9',
+      '  completed_phases: 7', '  percent: 78', '---', '', '# Project State', '',
+      '## Current Position', '', 'Phase: 8', 'Status: Executing',
+    ].join('\n'));
+    if (strayNine) {
+      const nine = path.join(tmpDirOf(t), '.planning', 'phases', '09-live-compatibility-diagnostics');
+      fs.mkdirSync(nine, { recursive: true });
+      fs.writeFileSync(path.join(nine, 'UAT.md'), '# UAT evidence\n');
+    }
+    if (completeAll) {
+      // both phases complete on disk + roadmap checkboxes
+      for (const dir of ['08-payments', '09-compatibility']) {
+        const d = path.join(tmpDirOf(t), '.planning', 'phases', dir);
+        fs.mkdirSync(d, { recursive: true });
+        fs.writeFileSync(path.join(d, 'PLAN.md'), '# p\n');
+        fs.writeFileSync(path.join(d, 'SUMMARY.md'), '# s\n');
+      }
+    }
+  }
+  // local alias so the helper reads the same as the suite's own fixtures
+  function tmpDirOf(t) { return t.tmpDir3581 ?? (t.tmpDir3581 = createTempProject('gsd-3581-')); }
+
+  test('#3581: init.progress prefers the roadmap frontier over a stray out-of-order artifact', (t) => {
+    writeProgressFixture(t, { strayNine: true });
+    t.after(() => cleanup(tmpDirOf(t)));
+    const result = runGsdTools(['init', 'progress', '--raw'], tmpDirOf(t));
+    assert.ok(result.success, `init progress failed: ${result.error}`);
+    const out = JSON.parse(result.output);
+    assert.ok(out.next_phase, `next_phase present; got keys ${Object.keys(out)}`);
+    assert.equal(String(out.next_phase.number).replace(/^0+/, ''), '8',
+      `the roadmap's Phase 8 (pending, unscaffolded) must be the frontier — not the stray 09 artifact dir; got ${out.next_phase.number}`);
+    const eight = (out.phases || []).find((p) => String(p.number).replace(/^0+/, '') === '8');
+    assert.ok(eight, 'Phase 8 present in the phases array (roadmap-derived)');
+    assert.equal(eight.directory, null, 'Phase 8 has no directory (corroborating the stray-only-disk shape)');
+  });
+
+  test('#3581 (control): aligned tree derives the same frontier', (t) => {
+    writeProgressFixture(t, { strayNine: false });
+    // aligned: give BOTH 8 and 9 directories with a plan in 8 (pending)
+    const eight = path.join(tmpDirOf(t), '.planning', 'phases', '08-payments');
+    fs.mkdirSync(eight, { recursive: true });
+    fs.writeFileSync(path.join(eight, 'PLAN.md'), '# p\n');
+    const nine = path.join(tmpDirOf(t), '.planning', 'phases', '09-compatibility');
+    fs.mkdirSync(nine, { recursive: true });
+    t.after(() => cleanup(tmpDirOf(t)));
+    const result = runGsdTools(['init', 'progress', '--raw'], tmpDirOf(t));
+    assert.ok(result.success, `init progress failed: ${result.error}`);
+    const out = JSON.parse(result.output);
+    assert.equal(String(out.next_phase.number).replace(/^0+/, ''), '8',
+      'aligned tree: the in-progress (plan-bearing, unsummarized) Phase 8 remains the frontier');
+  });
+
+  test('#3581 (boundary): completed milestone yields no frontier', (t) => {
+    writeProgressFixture(t, { strayNine: false, completeAll: true });
+    fs.writeFileSync(path.join(tmpDirOf(t), '.planning', 'ROADMAP.md'),
+      ['# Roadmap', '', '## Milestone v1.1.0', '', '- [x] **Phase 8: Payments**', '- [x] **Phase 9: Compatibility**', ''].join('\n'));
+    t.after(() => cleanup(tmpDirOf(t)));
+    const result = runGsdTools(['init', 'progress', '--raw'], tmpDirOf(t));
+    assert.ok(result.success, `init progress failed: ${result.error}`);
+    const out = JSON.parse(result.output);
+    assert.equal(out.next_phase, null, 'all-complete milestone: no frontier (completion flow owns the answer)');
+  });
+});

--- a/tests/init.test.cjs
+++ b/tests/init.test.cjs
@@ -4498,12 +4498,14 @@ describe('#3581: init.progress next_phase prefers the roadmap frontier', () => {
       fs.writeFileSync(path.join(nine, 'UAT.md'), '# UAT evidence\n');
     }
     if (completeAll) {
-      // both phases complete on disk + roadmap checkboxes
+      // both phases complete on disk (plans, summaries, PASSING verification —
+      // the #3168 disk-strict bar) + roadmap checkboxes
       for (const dir of ['08-payments', '09-compatibility']) {
         const d = path.join(tmpDirOf(t), '.planning', 'phases', dir);
         fs.mkdirSync(d, { recursive: true });
         fs.writeFileSync(path.join(d, 'PLAN.md'), '# p\n');
         fs.writeFileSync(path.join(d, 'SUMMARY.md'), '# s\n');
+        fs.writeFileSync(path.join(d, `${dir.split('-')[0]}-VERIFICATION.md`), '---\nstatus: passed\n---\n\n# V\n');
       }
     }
   }
@@ -4524,12 +4526,11 @@ describe('#3581: init.progress next_phase prefers the roadmap frontier', () => {
     assert.equal(eight.directory, null, 'Phase 8 has no directory (corroborating the stray-only-disk shape)');
   });
 
-  test('#3581 (control): aligned tree derives the same frontier', (t) => {
+  test('#3581 (control): a pending roadmap-only phase outranks a later pending directory', (t) => {
     writeProgressFixture(t, { strayNine: false });
-    // aligned: give BOTH 8 and 9 directories with a plan in 8 (pending)
-    const eight = path.join(tmpDirOf(t), '.planning', 'phases', '08-payments');
-    fs.mkdirSync(eight, { recursive: true });
-    fs.writeFileSync(path.join(eight, 'PLAN.md'), '# p\n');
+    // pure ordering property, no stray artifacts: roadmap-only pending 8 vs a
+    // pending 9 DIRECTORY (empty). The pinned mixed-statuses contract (an
+    // in-progress phase is currentPhase's lane, not nextPhase's) is untouched.
     const nine = path.join(tmpDirOf(t), '.planning', 'phases', '09-compatibility');
     fs.mkdirSync(nine, { recursive: true });
     t.after(() => cleanup(tmpDirOf(t)));
@@ -4537,7 +4538,7 @@ describe('#3581: init.progress next_phase prefers the roadmap frontier', () => {
     assert.ok(result.success, `init progress failed: ${result.error}`);
     const out = JSON.parse(result.output);
     assert.equal(String(out.next_phase.number).replace(/^0+/, ''), '8',
-      'aligned tree: the in-progress (plan-bearing, unsummarized) Phase 8 remains the frontier');
+      'the unscaffolded roadmap Phase 8 is the frontier even against a legitimately-pending 9 directory');
   });
 
   test('#3581 (boundary): completed milestone yields no frontier', (t) => {


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #3581

---

## What was broken

`init.progress` inferred the next phase from on-disk artifact presence: a phase
directory created out of order (the issue's phase-9 UAT evidence file, while roadmap
phase 8 was pending and unscaffolded) dragged the reported frontier to `09` — skipping
Phase 8 and disagreeing with `roadmap.analyze` on the same tree. Automation resuming
from `init.progress` would have started at Phase 9.

## What this fix does

After the disk and roadmap loops build the phase union, the frontier is re-derived
from **roadmap order**: the first `pending`/`not_started` phase that is not
roadmap-complete wins. Artifact directories still feed each entry's status and
completion (corroborating evidence) but no longer outrank the ordering. The
suite-pinned contract that an in-progress phase belongs to `currentPhase`'s lane, not
`next_phase`'s, is preserved (an initial resume-semantics refinement was reverted in
review when it broke that pinned test).

## Root cause

The disk loop assigned `nextPhase` from the first *pending directory*, and the roadmap
loop could never override it (`!nextPhase` gate) — filesystem-as-authority, the class
epic #3473 explicitly listed as independently fixable (#3354/#3355's sibling).

## Testing

### How I verified the fix

- Reproduced the issue's exact shape pre-fix (`next_phase: "09"`); post-fix: `8`,
  agreeing with `roadmap.analyze`.
- Failing-first: test commit verified RED via `gsd-test` (3 failures = the new block);
  fix verified GREEN on the shipping sha.
- Rows: the issue shape (stray 09 UAT dir, roadmap 8 pending), the pure ordering
  control (roadmap-only pending 8 beats a legitimately-pending 9 directory), and the
  all-complete boundary (passing verification reports per the #3168 disk-strict bar →
  no frontier).

### Regression test added?

- [x] Yes — added a test that would have caught this bug

### Platforms tested

- [x] macOS
- [x] Windows (including backslash path handling) — via gsd-test matrix (no platform-specific code)
- [x] Linux

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #3581`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`gsd-test` full matrix on the shipping sha)
- [x] `.changeset/` fragment added (`sturdy-foxes-gather.md`, type Fixed)
- [x] No unnecessary dependencies added

## Breaking changes

None for aligned trees — the frontier the loops computed before is what the
re-derivation computes for every dir/roadmap-consistent shape; only the
stray-artifact ordering changes.
