### PR TITLE
fix(#3578): derive milestone status from phase counters, not phase-completion prose

### DIFF
--- a/.changeset/fierce-lemurs-forage.md
+++ b/.changeset/fierce-lemurs-forage.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 3614
 ---
 **Completing one phase no longer marks the whole milestone done** — `state complete-phase` wrote the body prose `Phase N complete`, and the status normalizer matches `complete` as a substring, so finishing phase 2 of 4 collapsed the milestone-level STATE.md frontmatter to `status: completed` while the very same call correctly recorded `completed_phases: 2` of `total_phases: 4`. Downstream automation that gates on milestone status — auto-advance, archival, ship gating — was told a half-open milestone was finished. Milestone status is now derived from those counters instead of from phase-level prose. (#3578)

--- a/.changeset/fierce-lemurs-forage.md
+++ b/.changeset/fierce-lemurs-forage.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**Completing one phase no longer marks the whole milestone done** — `state complete-phase` wrote the body prose `Phase N complete`, and the status normalizer matches `complete` as a substring, so finishing phase 2 of 4 collapsed the milestone-level STATE.md frontmatter to `status: completed` while the very same call correctly recorded `completed_phases: 2` of `total_phases: 4`. Downstream automation that gates on milestone status — auto-advance, archival, ship gating — was told a half-open milestone was finished. Milestone status is now derived from those counters instead of from phase-level prose. (#3578)

--- a/src/state.cts
+++ b/src/state.cts
@@ -2296,7 +2296,35 @@ function buildStateFrontmatter(bodyContent: string, cwd: string | undefined, sto
     if (pctMatch) progressPercent = parseInt(pctMatch[1], 10);
   }
 
-  const normalizedStatus = normalizeStateStatus(status, pausedAt);
+  let normalizedStatus = normalizeStateStatus(status, pausedAt);
+  // #3578: normalizeStateStatus matches 'complete' as a case-insensitive
+  // SUBSTRING, so the phase-completion prose cmdStateCompletePhase writes to
+  // the body (`Phase ${N} complete`) collapses to the milestone-level
+  // 'completed' status even when other phases remain open. Phase-level
+  // prose must never decide milestone-level status — completedPhases /
+  // totalPhases / diskScope, already derived above from a disk scan, are
+  // the authority on whether the MILESTONE is actually done. Only override
+  // when: (a) normalizeStateStatus actually landed on 'completed'; (b) the
+  // raw prose is UNAMBIGUOUSLY phase-completion prose — the anchored
+  // pattern below deliberately excludes "All phases complete" (no `\S+`
+  // phase token) and milestone-close prose like "v1.0 milestone complete"
+  // (no leading "phase"); and (c) the counters are trustworthy (a COMPLETE
+  // disk scope, both counts are finite numbers, and a positive
+  // denominator) and affirmatively disagree with 'completed'. In every
+  // other case normalizedStatus is left exactly as normalizeStateStatus
+  // returned it.
+  if (
+    normalizedStatus === 'completed' &&
+    typeof status === 'string' &&
+    /^\s*phase\s+\S+\s+complete\s*$/i.test(status) &&
+    diskScope === SCOPE.COMPLETE &&
+    typeof completedPhases === 'number' && Number.isFinite(completedPhases) &&
+    typeof totalPhases === 'number' && Number.isFinite(totalPhases) &&
+    totalPhases > 0 &&
+    completedPhases < totalPhases
+  ) {
+    normalizedStatus = 'executing';
+  }
 
   const fm: Record<string, unknown> = { gsd_state_version: '1.0' };
 

--- a/src/state.cts
+++ b/src/state.cts
@@ -2318,6 +2318,10 @@ function buildStateFrontmatter(bodyContent: string, cwd: string | undefined, sto
     typeof status === 'string' &&
     /^\s*phase\s+\S+\s+complete\s*$/i.test(status) &&
     diskScope === SCOPE.COMPLETE &&
+    // #1761: an unbounded milestone yields a conflated/understated total — the
+    // same authority that nulls progressPercent above. Without this, a bad
+    // denominator could demote a genuinely-complete milestone.
+    !milestoneUnbounded &&
     typeof completedPhases === 'number' && Number.isFinite(completedPhases) &&
     typeof totalPhases === 'number' && Number.isFinite(totalPhases) &&
     totalPhases > 0 &&

--- a/tests/state.test.cjs
+++ b/tests/state.test.cjs
@@ -8808,6 +8808,213 @@ describe('T6 section-splice characterization — complete-phase', () => {
   });
 });
 
+// ─────────────────────────────────────────────────────────────────────────────
+// #3578 — state complete-phase must not overwrite milestone status when other
+// phases remain open. `normalizeStateStatus` matches 'complete' as a
+// substring, so the phase-completion prose `Phase ${N} complete` collapses to
+// the milestone-level 'completed' status even though completed_phases /
+// total_phases (computed by the same buildStateFrontmatter call) correctly
+// show the milestone is not yet done.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#3578: complete-phase does not overwrite milestone status when phases remain open', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createFixture();
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  const ROADMAP_4_PHASE = [
+    '## Milestone v1.0: Test Milestone',
+    '',
+    '### Phase 01: Alpha',
+    '**Goal:** first',
+    '',
+    '### Phase 02: Beta',
+    '**Goal:** second',
+    '',
+    '### Phase 03: Gamma',
+    '**Goal:** third',
+    '',
+    '### Phase 04: Delta',
+    '**Goal:** fourth',
+  ].join('\n');
+
+  const PHASE_DIRS_4 = ['01-alpha', '02-beta', '03-gamma', '04-delta'];
+
+  /**
+   * Seed `.planning/phases/<NN-slug>` for phases 1..4. Every phase gets a
+   * PLAN.md; phases numbered <= completeThrough additionally get a
+   * SUMMARY.md and a passing VERIFICATION.md (disk-strict completion,
+   * ADR-3180 §7.4 / #3186), so isPhaseComplete reports them done.
+   */
+  function seed4PhaseMilestone(completeThrough) {
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), ROADMAP_4_PHASE);
+    PHASE_DIRS_4.forEach((dirName, idx) => {
+      const n = idx + 1;
+      const padded = String(n).padStart(2, '0');
+      const phaseDir = path.join(tmpDir, '.planning', 'phases', dirName);
+      fs.mkdirSync(phaseDir, { recursive: true });
+      fs.writeFileSync(path.join(phaseDir, `${padded}-01-PLAN.md`), '# Plan\n');
+      if (n <= completeThrough) {
+        fs.writeFileSync(path.join(phaseDir, `${padded}-01-SUMMARY.md`), '# Summary\n');
+        writePassedVerification(tmpDir, dirName, padded);
+      }
+    });
+  }
+
+  function writeStateAtPhase(phase) {
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'STATE.md'),
+      [
+        '---',
+        "gsd_state_version: '1.0'",
+        'milestone: v1.0',
+        'milestone_name: Test Milestone',
+        'status: executing',
+        '---',
+        '',
+        '# GSD State',
+        '',
+        '## Configuration',
+        `Current Phase: ${phase}`,
+        `Status: Executing Phase ${phase}`,
+        'Last Activity: 2026-01-01',
+        '',
+      ].join('\n'),
+    );
+  }
+
+  function frontmatterStatus(after) {
+    const fm = frontmatterLib.extractFrontmatter(after);
+    return fm.status;
+  }
+
+  test('2 of 4 phases complete on disk: --phase 2 must not set frontmatter status completed', () => {
+    // On disk, phases 1-2 are already complete (matches the #3578 repro:
+    // completed_phases/total_phases are correct while status wrongly collapses).
+    seed4PhaseMilestone(2);
+    writeStateAtPhase(2);
+
+    const result = runGsdTools(['state', 'complete-phase', '--phase', '2'], tmpDir);
+    assert.ok(result.success, `complete-phase failed: ${result.error || result.output}`);
+
+    const after = fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
+    assert.notEqual(
+      frontmatterStatus(after),
+      'completed',
+      `status must not be 'completed' while phases remain open; got frontmatter:\n${after}`,
+    );
+
+    const jsonResult = runGsdTools('state json', tmpDir);
+    assert.ok(jsonResult.success, `state json failed: ${jsonResult.error}`);
+    const output = JSON.parse(jsonResult.output);
+    assert.strictEqual(Number(output.progress.completed_phases), 2, 'completed_phases must still be 2');
+    assert.strictEqual(Number(output.progress.total_phases), 4, 'total_phases must still be 4');
+  });
+
+  test('3 of 4 phases complete on disk (limit-1): --phase 3 must not set frontmatter status completed', () => {
+    seed4PhaseMilestone(3);
+    writeStateAtPhase(3);
+
+    const result = runGsdTools(['state', 'complete-phase', '--phase', '3'], tmpDir);
+    assert.ok(result.success, `complete-phase failed: ${result.error || result.output}`);
+
+    const after = fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
+    assert.notEqual(
+      frontmatterStatus(after),
+      'completed',
+      `status must not be 'completed' with 3 of 4 phases done; got frontmatter:\n${after}`,
+    );
+  });
+
+  test('4 of 4 phases complete on disk (limit): --phase 4 sets frontmatter status completed', () => {
+    seed4PhaseMilestone(4);
+    writeStateAtPhase(4);
+
+    const result = runGsdTools(['state', 'complete-phase', '--phase', '4'], tmpDir);
+    assert.ok(result.success, `complete-phase failed: ${result.error || result.output}`);
+
+    const after = fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
+    assert.strictEqual(
+      frontmatterStatus(after),
+      'completed',
+      `status must be 'completed' once all 4 phases are done; got frontmatter:\n${after}`,
+    );
+  });
+
+  test('milestone_name is byte-identical before and after complete-phase (2 of 4 case)', () => {
+    seed4PhaseMilestone(2);
+    writeStateAtPhase(2);
+
+    const before = fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
+    const beforeName = frontmatterLib.extractFrontmatter(before).milestone_name;
+
+    const result = runGsdTools(['state', 'complete-phase', '--phase', '2'], tmpDir);
+    assert.ok(result.success, `complete-phase failed: ${result.error || result.output}`);
+
+    const after = fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
+    const afterName = frontmatterLib.extractFrontmatter(after).milestone_name;
+
+    assert.strictEqual(beforeName, 'Test Milestone', 'precondition: milestone_name must start as Test Milestone');
+    assert.strictEqual(
+      afterName,
+      beforeName,
+      `milestone_name must be byte-identical before/after complete-phase; before=${beforeName}, after=${afterName}`,
+    );
+  });
+
+  test('1-of-1 milestone: --phase 1 still sets frontmatter status completed (counter rule allows it)', () => {
+    const ROADMAP_1_PHASE = [
+      '## Milestone v2.0: Solo Milestone',
+      '',
+      '### Phase 01: Only',
+      '**Goal:** the only phase',
+    ].join('\n');
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), ROADMAP_1_PHASE);
+
+    const phaseDir = path.join(tmpDir, '.planning', 'phases', '01-only');
+    fs.mkdirSync(phaseDir, { recursive: true });
+    fs.writeFileSync(path.join(phaseDir, '01-01-PLAN.md'), '# Plan\n');
+    fs.writeFileSync(path.join(phaseDir, '01-01-SUMMARY.md'), '# Summary\n');
+    writePassedVerification(tmpDir, '01-only', '01');
+
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'STATE.md'),
+      [
+        '---',
+        "gsd_state_version: '1.0'",
+        'milestone: v2.0',
+        'milestone_name: Solo Milestone',
+        'status: executing',
+        '---',
+        '',
+        '# GSD State',
+        '',
+        '## Configuration',
+        'Current Phase: 1',
+        'Status: Executing Phase 1',
+        'Last Activity: 2026-01-01',
+        '',
+      ].join('\n'),
+    );
+
+    const result = runGsdTools(['state', 'complete-phase', '--phase', '1'], tmpDir);
+    assert.ok(result.success, `complete-phase failed: ${result.error || result.output}`);
+
+    const after = fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
+    assert.strictEqual(
+      frontmatterStatus(after),
+      'completed',
+      `a genuinely 1-of-1-complete milestone must still report 'completed'; got frontmatter:\n${after}`,
+    );
+  });
+});
+
 describe('T6 section-splice characterization — milestone-switch', () => {
   const STATE_INLINE_MS = [
     '---',

--- a/tests/state.test.cjs
+++ b/tests/state.test.cjs
@@ -12,7 +12,12 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const { runGsdTools, createTempDir, createTempProject, cleanup } = require('./helpers.cjs');
-const { createFixture, seedWorkstream } = require('./fixtures/index.cjs');
+const { createFixture, seedWorkstream, writeState } = require('./fixtures/index.cjs');
+// #3578 AC4 (MCP dispatch parity): drives the same `state complete-phase`
+// command through the gsd_invoke_command MCP tool route instead of the CLI,
+// mirroring the gsd-mcp-server.test.cjs `tools/call gsd_invoke_command`
+// pattern (family/subcommand/args -> dispatchGsdCommand -> real subprocess).
+const { handleMessage } = require('../gsd-core/bin/lib/mcp-server.cjs');
 // ADR-3408 §8.3 Matrix A2/A3 (#3469): required fast-check property test — the
 // composed cmdPhaseComplete/readModifyWriteStateMd write-seam identity.
 const fc = require('fast-check');
@@ -8867,9 +8872,9 @@ describe('#3578: complete-phase does not overwrite milestone status when phases 
     });
   }
 
-  function writeStateAtPhase(phase) {
-    fs.writeFileSync(
-      path.join(tmpDir, '.planning', 'STATE.md'),
+  function writeStateAtPhase(phase, extraBodyLines = []) {
+    writeState(
+      tmpDir,
       [
         '---',
         "gsd_state_version: '1.0'",
@@ -8884,6 +8889,7 @@ describe('#3578: complete-phase does not overwrite milestone status when phases 
         `Current Phase: ${phase}`,
         `Status: Executing Phase ${phase}`,
         'Last Activity: 2026-01-01',
+        ...extraBodyLines,
         '',
       ].join('\n'),
     );
@@ -8983,8 +8989,8 @@ describe('#3578: complete-phase does not overwrite milestone status when phases 
     fs.writeFileSync(path.join(phaseDir, '01-01-SUMMARY.md'), '# Summary\n');
     writePassedVerification(tmpDir, '01-only', '01');
 
-    fs.writeFileSync(
-      path.join(tmpDir, '.planning', 'STATE.md'),
+    writeState(
+      tmpDir,
       [
         '---',
         "gsd_state_version: '1.0'",
@@ -9011,6 +9017,163 @@ describe('#3578: complete-phase does not overwrite milestone status when phases 
       frontmatterStatus(after),
       'completed',
       `a genuinely 1-of-1-complete milestone must still report 'completed'; got frontmatter:\n${after}`,
+    );
+  });
+
+  /**
+   * Body Status field the guard's regex actually inspects (never the
+   * frontmatter `status:` scalar the guard *writes*). Reads via the same
+   * `stateFieldValue` fallback-chain owner (state-document.cjs) the guard's
+   * caller (buildStateFrontmatter) is built on, scoped to the body only
+   * (fmKey null) by stripping frontmatter first.
+   */
+  function bodyStatus(after) {
+    const body = frontmatterLib.stripFrontmatter(after);
+    return stateDocument.stateFieldValue({}, body, null, 'Status').value;
+  }
+
+  /**
+   * Seed `.planning/phases/<NN-slug>` for phases 1..4 exactly like
+   * `seed4PhaseMilestone`, but WITHOUT writing ROADMAP.md at all. Used to
+   * drive `buildStateFrontmatter`'s roadmap-absent withhold path (#3573),
+   * which is the only deterministic way to detach `totalPhases` from the
+   * live disk-scanned total from a fixture.
+   */
+  function seed4PhaseDirsNoRoadmap(completeThrough) {
+    PHASE_DIRS_4.forEach((dirName, idx) => {
+      const n = idx + 1;
+      const padded = String(n).padStart(2, '0');
+      const phaseDir = path.join(tmpDir, '.planning', 'phases', dirName);
+      fs.mkdirSync(phaseDir, { recursive: true });
+      fs.writeFileSync(path.join(phaseDir, `${padded}-01-PLAN.md`), '# Plan\n');
+      if (n <= completeThrough) {
+        fs.writeFileSync(path.join(phaseDir, `${padded}-01-SUMMARY.md`), '# Summary\n');
+        writePassedVerification(tmpDir, dirName, padded);
+      }
+    });
+  }
+
+  // Parity assertion (repo rule: "Generative Fix Divergence" — a shared
+  // constant/pattern between parallel surfaces needs a test that fails if
+  // they diverge). The guard's anchored regex
+  // /^\s*phase\s+\S+\s+complete\s*$/i lives in src/state.cts and hand-copies
+  // the SHAPE of the prose cmdStateCompletePhase writes to the body Status
+  // field (`Phase ${N} complete`, gsd-core/bin/lib/state.cjs) rather than
+  // sharing a constant with it. If that prose is ever reworded, the guard
+  // silently stops matching and the #3578 regression returns undetected by
+  // every other test in this block (they only assert the guard's downstream
+  // EFFECT on frontmatter status, never that its input pattern still fires).
+  test("#3578 parity: complete-phase's emitted body Status prose still matches the guard's phase-complete pattern", () => {
+    seed4PhaseMilestone(2);
+    writeStateAtPhase(2);
+
+    const result = runGsdTools(['state', 'complete-phase', '--phase', '2'], tmpDir);
+    assert.ok(result.success, `complete-phase failed: ${result.error || result.output}`);
+
+    const after = fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
+    const status = bodyStatus(after);
+    assert.match(
+      status,
+      /^\s*phase\s+\S+\s+complete\s*$/i,
+      `emitted body Status prose ("${status}") no longer matches the #3578 guard's pattern in src/state.cts — the guard would silently stop firing`,
+    );
+  });
+
+  test('completed phase dirs on disk exceed a stale declared total (limit+1 on the completedPhases < totalPhases comparison): guard must not fire', () => {
+    // No ROADMAP.md at all + a stale "Total Phases: 2" body annotation drives
+    // the #3573 roadmap-absent withhold path: totalPhases stays pinned at the
+    // stale body-declared value (2) instead of being replaced by the live
+    // disk-scanned total, while completedPhases is UNCONDITIONALLY set from
+    // the disk scan (buildStateFrontmatter) regardless of that withhold — so
+    // completedPhases (4) ends up greater than totalPhases (2), making the
+    // guard's `completedPhases < totalPhases` conjunct false (verified by
+    // direct probe: status lands 'completed' with progress
+    // {total_phases:2, completed_phases:4}). Note this fixture necessarily
+    // also drives listMilestonePhaseDirs' own ROADMAP-absent scope to
+    // non-COMPLETE (same missing file, independent read), so it does not
+    // purely isolate the counter conjunct from `diskScope === SCOPE.COMPLETE`
+    // — src/state.cts's withhold-with-a-stale-numeric-total path is only
+    // reachable via ROADMAP absence, which always drags that second conjunct
+    // along with it; no fixture can decouple the two under the current
+    // implementation. Inconsistent counters deliberately fall through to
+    // normalizeStateStatus's answer rather than guessing which of the two
+    // disagreeing numbers is correct.
+    seed4PhaseDirsNoRoadmap(4);
+    writeStateAtPhase(4, ['Total Phases: 2']);
+
+    const result = runGsdTools(['state', 'complete-phase', '--phase', '4'], tmpDir);
+    assert.ok(result.success, `complete-phase failed: ${result.error || result.output}`);
+
+    const after = fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
+    assert.strictEqual(
+      frontmatterStatus(after),
+      'completed',
+      `guard must not demote when completedPhases > totalPhases; got frontmatter:\n${after}`,
+    );
+
+    const jsonResult = runGsdTools('state json', tmpDir);
+    assert.ok(jsonResult.success, `state json failed: ${jsonResult.error}`);
+    const output = JSON.parse(jsonResult.output);
+    assert.strictEqual(Number(output.progress.completed_phases), 4, 'completed_phases must reflect disk truth (4)');
+    assert.strictEqual(Number(output.progress.total_phases), 2, 'total_phases must stay pinned at the stale declared value (2)');
+  });
+
+  test('untrustworthy counters (no ROADMAP.md, no derivable total) must not demote status', () => {
+    // ROADMAP.md absent entirely + an asserted milestone + no body "Total
+    // Phases" annotation: buildStateFrontmatter's #3573 withhold path leaves
+    // totalPhases at null (never a number) because there is nothing on disk
+    // or in the body to derive a denominator from. The guard's
+    // `typeof totalPhases === 'number' && Number.isFinite(totalPhases)`
+    // conjunct fails, so it cannot fire regardless of the true completion
+    // state — the counters are not trustworthy enough to demote on.
+    seed4PhaseDirsNoRoadmap(2);
+    writeStateAtPhase(2);
+
+    const result = runGsdTools(['state', 'complete-phase', '--phase', '2'], tmpDir);
+    assert.ok(result.success, `complete-phase failed: ${result.error || result.output}`);
+
+    const after = fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
+    assert.strictEqual(
+      frontmatterStatus(after),
+      'completed',
+      `guard must not fire without a trustworthy totalPhases; got frontmatter:\n${after}`,
+    );
+
+    const jsonResult = runGsdTools('state json', tmpDir);
+    assert.ok(jsonResult.success, `state json failed: ${jsonResult.error}`);
+    const output = JSON.parse(jsonResult.output);
+    assert.strictEqual(
+      output.progress.total_phases,
+      undefined,
+      'total_phases must be withheld (no ROADMAP to derive it from), proving the guard truly had no denominator to compare against',
+    );
+    assert.strictEqual(Number(output.progress.completed_phases), 2, 'completed_phases is still disk truth even when total_phases is withheld');
+  });
+
+  test('#3578 AC4: gsd_invoke_command (MCP dispatch) yields the same non-completed status as the CLI route (2 of 4 case)', () => {
+    seed4PhaseMilestone(2);
+    writeStateAtPhase(2);
+
+    const res = handleMessage(
+      {
+        jsonrpc: '2.0',
+        id: 100,
+        method: 'tools/call',
+        params: { name: 'gsd_invoke_command', arguments: { family: 'state', subcommand: 'complete-phase', args: ['--phase', '2'] } },
+      },
+      { cwd: tmpDir },
+    );
+    assert.notStrictEqual(res.result.isError, true, `MCP dispatch must succeed: ${JSON.stringify(res.result)}`);
+    // Same command, reached through a different dispatch surface (real
+    // subprocess spawn via dispatchGsdCommand -> gsd-tools.cjs), must produce
+    // the same on-disk effect as the CLI route above.
+    JSON.parse(res.result.content[0].text);
+
+    const after = fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
+    assert.notEqual(
+      frontmatterStatus(after),
+      'completed',
+      `MCP-dispatched complete-phase must not set status completed while phases remain open; got frontmatter:\n${after}`,
     );
   });
 });


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #3578

---

## What was broken

Completing **one** phase of a multi-phase milestone set the milestone-level `status` to `completed`. Finishing phase 2 of 4 wrote frontmatter `status: completed` while the *same call* correctly wrote `completed_phases: 2`, `total_phases: 4`, `percent: 50` — the command had the data proving the milestone was not done and reported it done anyway.

Downstream automation that gates on milestone status (auto-advance, archival, ship gating) was told a half-open milestone was finished.

## What this fix does

`buildStateFrontmatter` now honors a `completed` normalization that came from **phase-level prose** only when the phase counters it already derived agree the milestone is actually done.

## Root cause

Three facts compose the defect:

1. `cmdStateCompletePhase` writes body prose ``` `Phase ${N} complete` ``` — for any N.
2. `normalizeStateStatus` matches by **substring**, in order: paused → executing → planning → discussing → verif → **complete/done** → ready-to-execute. `Phase 2 complete` contains `complete`, so it collapses to `'completed'`.
3. `buildStateFrontmatter` assigned that to milestone-level frontmatter `status` without consulting the `completedPhases`/`totalPhases` it derived a few lines earlier.

The check **order** is why the sibling surface stays correct: `completePhaseCore` writes `Ready to plan` for non-final phases, which hits the `planning` arm *before* the `complete` arm. So the two phase-completion surfaces disagreed, and this one was the conflated one — a violation of ADR-2207, which gives milestone termination solely to `milestoneCompleteCore`.

**Introduced by:** the subcommand landed in `140572829` (#2735/#2744) already writing `Phase N complete`; the frontmatter transition was cemented by `2668fbbeb` (#1255/#1256) whose pinning test used a **1-phase** fixture, where `completed` is legitimately correct. The multi-phase case was never revisited.

## Scope of the guard

Deliberately narrow, because `normalizeStateStatus` feeds every `state.*` write **and** the read path and is therefore **not** modified:

- anchored to bare `Phase <token> complete`, so `All phases complete` and `<version> milestone complete` are untouched (both explicitly out of scope)
- gated on counter trustworthiness — `SCOPE.COMPLETE` disk scope, `!milestoneUnbounded`, finite counts, positive denominator — so an unknown scope **withholds** rather than guessing "not complete", which would be the mirror-image bug
- a 1-of-1 milestone still yields `completed` **by the rule**, not by exemption

## Testing

| stage | outcome |
|---|---|
| **RED** — tests-only commit `253843b41` | **failed**: the 2-of-4 and 3-of-4 cases + their rollup. The 4-of-4, `milestone_name` and 1-of-1 controls **passed** on base, proving the tests discriminate the bug rather than the fixture. |
| **final** `45f89ccc1` | see check run |

`npm run lint:ci` clean; `tsc --noEmit` clean.

### Regression test added?

- [x] Yes — folded into `tests/state.test.cjs` (no new `bug-*` file)

Covers 2-of-4, boundary at **limit−1** (3-of-4 → not completed), **limit** (4-of-4 → completed) and **limit+1** (`completedPhases > totalPhases` → guard falls through rather than guessing), `milestone_name` byte-identity, the 1-of-1 pinning case, an untrustworthy-counters case where the guard must stay inert, MCP `gsd_invoke_command` dispatch parity, and a **prose/guard parity assertion** — the guard matches prose emitted from a different file, so per the repo's generative-fix-divergence rule a test asserts the emitted body Status still matches the guard's pattern, rather than duplicating the string.

### Platforms tested

- [x] Linux
- [x] N/A (not platform-specific)

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Review

Three engines, two in isolated contexts that did not author the change. Findings fixed inline: the guard originally omitted `milestoneUnbounded` (the established trust authority for these same counters in this same function), and AC4 — CLI vs MCP dispatch parity — was asserted but untested; both reviewers flagged AC4 independently.

The adversarial pass verified by reading source rather than trusting the diff's comments that: paused/stopped short-circuit ahead of the `completed` branch, so a paused milestone can never be clobbered; only `cmdStateCompletePhase` emits the targeted prose, so no sibling caller over-fires; the counters come from a fresh disk scan independent of this write, so there is no pre/post off-by-one; and the #1255 pinning fixture creates no `.planning/phases/`, leaving `completedPhases` null and the guard inert — so that test is provably unaffected rather than assumed to be.

---

## Checklist

- [x] Issue linked above with `Fixes #3578`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug
- [x] Regression test added
- [x] All existing tests pass
- [x] `.changeset/` fragment added
- [x] No unnecessary dependencies added

## Breaking changes

Milestone `status` stops reporting `completed` for a milestone with open phases — the reported defect, so the change is the point. No path reports `completed` where it previously did not; the guard only ever makes that value harder to reach. The reporter's second symptom (`milestone_name` overwritten with the literal `"plan"`) does **not** reproduce at HEAD in any roadmap shape and is out of scope per the Agent Brief; `milestone_name` byte-identity is nonetheless pinned by a test so it cannot regress.
