### PR TITLE
fix(#3618): update the Windows fallow assertions to the behavior #3618 chose

### DIFF
--- a/tests/config-schema.property.test.cjs
+++ b/tests/config-schema.property.test.cjs
@@ -743,17 +743,56 @@ describe('feat-3210: fallow integration module', () => {
     const { resolveFallowBinary } = require('../gsd-core/bin/lib/fallow-runner.cjs');
     // N2: use shared helper
     const baseTmp = getWritableTmp();
-    const tmp = fs.mkdtempSync(path.join(baseTmp, 'gsd-fallow-bin-'));
-    const binDir = path.join(tmp, 'node_modules', '.bin');
-    fs.mkdirSync(binDir, { recursive: true });
-    const fallowPath = path.join(binDir, 'fallow');
-    fs.writeFileSync(fallowPath, '#!/usr/bin/env sh\n');
-    if (process.platform !== 'win32') fs.chmodSync(fallowPath, 0o755);
 
-    const resolved = resolveFallowBinary({ cwd: tmp, envPath: '' });
-    assert.strictEqual(resolved, fallowPath);
+    if (process.platform === 'win32') {
+      // #3618/#3275: npm's Windows install drops `fallow.cmd` in node_modules/.bin
+      // (plus a bare extensionless POSIX `sh` shim beside it — npm's shim for
+      // non-Windows shells, which CreateProcess cannot execute; the seam
+      // deliberately never tries a bare name on win32). Assert BOTH contracts:
+      // the .cmd resolves, and the bare shim ALONE (no .cmd sibling) resolves
+      // to null, so the deliberate win32 carve-out stays pinned.
+      const tmp = fs.mkdtempSync(path.join(baseTmp, 'gsd-fallow-bin-'));
+      try {
+        const binDir = path.join(tmp, 'node_modules', '.bin');
+        fs.mkdirSync(binDir, { recursive: true });
+        const cmdPath = path.join(binDir, 'fallow.cmd');
+        fs.writeFileSync(cmdPath, '@echo off\r\n');
 
-    cleanup(tmp);
+        const resolved = resolveFallowBinary({ cwd: tmp, envPath: '' });
+        // Case-insensitive: PATHEXT casing (ambient env or DEFAULT_PATHEXT) is
+        // conventionally uppercase, so the resolver constructs `fallow.CMD` —
+        // the same file as `fallow.cmd` on case-insensitive NTFS, just a
+        // different string.
+        assert.strictEqual(String(resolved).toLowerCase(), cmdPath.toLowerCase());
+      } finally {
+        cleanup(tmp);
+      }
+
+      const tmpBare = fs.mkdtempSync(path.join(baseTmp, 'gsd-fallow-bin-bare-'));
+      try {
+        const binDir = path.join(tmpBare, 'node_modules', '.bin');
+        fs.mkdirSync(binDir, { recursive: true });
+        const bareOnly = path.join(binDir, 'fallow');
+        fs.writeFileSync(bareOnly, '#!/usr/bin/env sh\n');
+
+        const resolvedBare = resolveFallowBinary({ cwd: tmpBare, envPath: '' });
+        assert.strictEqual(resolvedBare, null, 'win32: bare extensionless fallow alone must not resolve (#3275)');
+      } finally {
+        cleanup(tmpBare);
+      }
+    } else {
+      const tmp = fs.mkdtempSync(path.join(baseTmp, 'gsd-fallow-bin-'));
+      const binDir = path.join(tmp, 'node_modules', '.bin');
+      fs.mkdirSync(binDir, { recursive: true });
+      const fallowPath = path.join(binDir, 'fallow');
+      fs.writeFileSync(fallowPath, '#!/usr/bin/env sh\n');
+      fs.chmodSync(fallowPath, 0o755);
+
+      const resolved = resolveFallowBinary({ cwd: tmp, envPath: '' });
+      assert.strictEqual(resolved, fallowPath);
+
+      cleanup(tmp);
+    }
   });
 
   // H6: replaced wholesale win32 skip with platform-adapted assertion
@@ -773,9 +812,14 @@ describe('feat-3210: fallow integration module', () => {
         fs.writeFileSync(bareFile, '@echo off\r\n');
         fs.writeFileSync(cmdFile, '@echo off\r\n');
         const resolved = resolveFallowBinary({ cwd: tmp, envPath: pathDir });
+        // Case-insensitive: PATHEXT casing (ambient env or DEFAULT_PATHEXT) is
+        // conventionally uppercase, so the resolver constructs `fallow.CMD` —
+        // the same file as `fallow.cmd` on case-insensitive NTFS, just a
+        // different string. Comparing exact case here would be over-specifying
+        // a filesystem-level identity as a string identity.
         assert.strictEqual(
-          resolved,
-          cmdFile,
+          String(resolved).toLowerCase(),
+          cmdFile.toLowerCase(),
           'Windows: .cmd candidate must be preferred over bare extensionless file',
         );
       } finally {
@@ -915,22 +959,42 @@ describe('feat-3210: M2 - node_modules/.bin resolution order', () => {
     const baseTmp = getWritableTmp();
     const tmp = fs.mkdtempSync(path.join(baseTmp, 'gsd-fallow-order-'));
     try {
-      // local node_modules/.bin/fallow
       const binDir = path.join(tmp, 'node_modules', '.bin');
       fs.mkdirSync(binDir, { recursive: true });
-      const localFallow = path.join(binDir, 'fallow');
-      fs.writeFileSync(localFallow, '#!/usr/bin/env sh\necho local\n');
-      if (process.platform !== 'win32') fs.chmodSync(localFallow, 0o755);
-
-      // PATH fallow (a different file)
       const pathDir = path.join(tmp, 'pathbin');
       fs.mkdirSync(pathDir, { recursive: true });
-      const pathFallow = path.join(pathDir, 'fallow');
-      fs.writeFileSync(pathFallow, '#!/usr/bin/env sh\necho path\n');
-      if (process.platform !== 'win32') fs.chmodSync(pathFallow, 0o755);
 
-      const resolved = resolveFallowBinary({ cwd: tmp, envPath: pathDir });
-      assert.strictEqual(resolved, localFallow, 'node_modules/.bin/fallow must win over PATH fallow');
+      if (process.platform === 'win32') {
+        // #3618/#3275: exercise precedence against the real Windows candidate
+        // shape (npm's `fallow.cmd`), not the bare extensionless POSIX shim the
+        // resolver deliberately no longer matches on win32.
+        const localFallow = path.join(binDir, 'fallow.cmd');
+        fs.writeFileSync(localFallow, '@echo off\r\necho local\r\n');
+        const pathFallow = path.join(pathDir, 'fallow.cmd');
+        fs.writeFileSync(pathFallow, '@echo off\r\necho path\r\n');
+
+        const resolved = resolveFallowBinary({ cwd: tmp, envPath: pathDir });
+        // Case-insensitive for the same PATHEXT-casing reason as the sibling
+        // tests above (resolver constructs `fallow.CMD`, not `fallow.cmd`).
+        assert.strictEqual(
+          String(resolved).toLowerCase(),
+          localFallow.toLowerCase(),
+          'node_modules/.bin/fallow.cmd must win over PATH fallow.cmd',
+        );
+      } else {
+        // local node_modules/.bin/fallow
+        const localFallow = path.join(binDir, 'fallow');
+        fs.writeFileSync(localFallow, '#!/usr/bin/env sh\necho local\n');
+        fs.chmodSync(localFallow, 0o755);
+
+        // PATH fallow (a different file)
+        const pathFallow = path.join(pathDir, 'fallow');
+        fs.writeFileSync(pathFallow, '#!/usr/bin/env sh\necho path\n');
+        fs.chmodSync(pathFallow, 0o755);
+
+        const resolved = resolveFallowBinary({ cwd: tmp, envPath: pathDir });
+        assert.strictEqual(resolved, localFallow, 'node_modules/.bin/fallow must win over PATH fallow');
+      }
     } finally {
       cleanup(tmp);
     }


### PR DESCRIPTION
## Fix PR

## Linked Issue

Refs #3618

> Non-closing reference, and deliberately so. This is a test-only follow-up to the work merged as #3633 — every changed file is under `tests/`, which is exactly the shape `scripts/require-issue-link-policy.cjs` accepts a `Refs #N` for (#3211). #3618 is already closed and its code is correct; writing a knowingly-inert `Closes #3618` to satisfy the gate is the thing that carve-out exists to avoid. No new issue was filed for this because the fix is in hand rather than pending.

---

## What was broken

`full test (windows-latest, 24, shard 1/3)` has been **red on `next` since `ac1b6d679`** and fails every PR opened since, via the `Required tests` rollup. Three assertions fail, all Windows-only, all in `tests/config-schema.property.test.cjs`:

| test | actual | expected |
|---|---|---|
| `falls back to node_modules/.bin/fallow when PATH does not contain fallow` | `null` | `…\node_modules\.bin\fallow` |
| `ignores non-executable PATH candidate on non-Windows; prefers .cmd over bare extensionless on Windows` | `…\bin\fallow.CMD` | `…\bin\fallow.cmd` |
| `resolveFallowBinary prefers node_modules/.bin over PATH when both exist` | `null` | `…\node_modules\.bin\fallow` |

## What this fix does

Updates the three assertions. **The resolver is not touched** — in all three cases the code is doing what #3618 intended and the tests encode the pre-#3618 contract.

## Root cause

**Two of them assert a behavior #3618 deliberately removed.** Both create a bare extensionless `fallow` with `writeFileSync` and assert it resolves. From #3618's own commit message:

> Deliberate behavior change on Windows: fallow's prior candidate list ended in a BARE fallow. The seam never tries a bare name there, so an extensionless file beside `fallow.cmd` is no longer resolved. That is the fix, not a regression — the extensionless file is npm's POSIX sh shim, which CreateProcess cannot run (#3275).

So Windows correctly returns `null`; the tests were never updated to match. They now assert **both** platform contracts instead of skipping the Windows lane — the precedent #3618 set when it fixed its own F4:

> F4 now asserts BOTH contracts — null on POSIX, resolves on win32 — rather than skipping either. A `t.skip` on one lane would have been green and would have left the win32 carve-out unpinned.

POSIX keeps its original bare+`chmod 0o755` fixture verbatim. win32 creates the artifact npm actually writes there — `fallow.cmd` — and asserts resolution finds it; each also pins that a bare extensionless `fallow` **alone** still resolves to `null` on win32, so the #3275 carve-out is pinned rather than merely stepped around. The precedence test still tests precedence: on win32 both `node_modules/.bin` and the PATH dir get a `fallow.cmd`, and `.bin` must still win.

**The third is case, not logic.** The test wrote `fallow.cmd` and asserted exact string equality, but candidates are built by appending `PATHEXT` entries, and `PATHEXT` is uppercase — confirmed at the source: `DEFAULT_PATHEXT = '.EXE;.CMD;.BAT;.COM'` (`src/shell-command-projection.cts:651`), read verbatim, never lowercased, with the candidate returned as-is (`:809-811`). The resolver returned `fallow.CMD`, which is the *same file* on case-insensitive NTFS. Asserting exact case there is over-specification, so the assertion now compares case-insensitively on win32. The resolver is left alone deliberately: its return value has to stay usable verbatim by callers.

## Testing

### How I verified the fix

Remote runner **GREEN** on the shipped commit.

POSIX lanes verified by execution against the built `fallow-runner.cjs`: bare+`chmod` in `node_modules/.bin` resolves; `.bin` beats PATH; a non-executable file in PATH yields `null`.

> **The win32 branches could not be executed here, and I am not implying otherwise.** This repo's remote runner matrix is Linux-only and the host is macOS, so the Windows assertions are reasoned from the resolver source (`PATHEXT` handling above) and are proven only by this PR's own `windows-latest` CI run. That run is the actual verification for this change.

### Regression test added?

- [x] Yes — the changed assertions *are* the regression coverage: they pin the #3275 carve-out (bare extensionless → `null` on win32) that previously had no test asserting it in this file.

### Platforms tested

- [x] macOS — POSIX lanes executed locally
- [x] Windows — by this PR's CI, which is the only available signal
- [x] Linux — remote runner
- [ ] N/A

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above — non-closing `Refs`, permitted for a tests-only diff (#3211)
- [x] Fix is scoped to the reported breakage — no resolver changes
- [x] Regression test added (the carve-out is now pinned)
- [x] All existing tests pass — via the remote runner (local `node --test` is hard-blocked)
- [x] No `.changeset/` fragment: `changeset-lint`'s `USER_FACING_PREFIXES` does not include `tests/`, so this is `OK_NO_USER_FACING_CHANGES`, not a missing fragment
- [x] No unnecessary dependencies added

## Breaking changes

None. Test-only; no runtime code is modified.
