### PR TITLE
fix(#3582): stop the cold-tree fixture racing concurrent hook builds

### DIFF
--- a/tests/gsd-check-update-worker-platform-gate.test.cjs
+++ b/tests/gsd-check-update-worker-platform-gate.test.cjs
@@ -144,32 +144,63 @@ describe('worker delegates the npm spawn (does not re-open the gate, #498)', () 
   });
 }
 
-// ─── #3631: cold-tree fixture must tolerate a concurrent build-hooks.js
-// staging dir in the live hooks/ tree ───────────────────────────────────
+// ─── #3582: cold-tree fixture must tolerate a concurrent build-hooks.js
+// staging dir, without mutating the live hooks/ tree ─────────────────────
 //
 // scripts/build-hooks.js writes atomically via a per-PID staging dir
 // (hooks/.dist-staging-<pid>) that it creates and removes; up to nine test
 // files invoke it concurrently from their `before()` hooks, so the live
-// hooks/ dir is never guaranteed stable during a test run. This proves
-// buildColdInstallTree() copies the tree without erroring even while such a
-// staging dir is present, and that it never lands in the fixture.
+// hooks/ dir is never guaranteed stable during a test run. This is proven
+// HERMETICALLY, against a fake source tree under a temp dir — planting a
+// staging dir inside the REAL repo's hooks/ would itself be the exact
+// shared-state race this fixture exists to guard against (other test files
+// read hooks/ concurrently), and cleanup() (tests/helpers.cjs) deliberately
+// refuses to remove any path outside the known temp roots, so a real-repo
+// plant can never be cleaned up through it either.
 {
   const { describe, test } = require('node:test');
   const assert = require('node:assert/strict');
   const fs = require('node:fs');
+  const os = require('node:os');
   const path = require('node:path');
   const { buildColdInstallTree, REPO_ROOT } = require('./helpers/cold-runtime-lib-fixture.cjs');
   const { cleanup } = require('./helpers.cjs');
 
-  describe('cold-runtime-lib-fixture.cjs: #3631 tolerates a concurrent hooks/.dist-staging-<pid> dir', () => {
+  describe('cold-runtime-lib-fixture.cjs: #3582 tolerates a concurrent hooks/.dist-staging-<pid> dir', () => {
     test('a live .dist-staging-test-<random> dir does not break the fixture copy, and is excluded from it', (t) => {
-      const stagingName = `.dist-staging-test-${Math.random().toString(36).slice(2)}`;
-      const stagingDir = path.join(REPO_ROOT, 'hooks', stagingName);
+      // Build a hermetic fake source tree — never touch the real repo's hooks/.
+      const fakeRepoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-fake-repo-'));
+      t.after(() => cleanup(fakeRepoRoot));
+
+      const fakeHooksDir = path.join(fakeRepoRoot, 'hooks');
+      fs.mkdirSync(fakeHooksDir, { recursive: true });
+      // Representative real hook entries the fixture must still carry over.
+      fs.writeFileSync(path.join(fakeHooksDir, 'hooks.json'), '{}');
+      fs.writeFileSync(path.join(fakeHooksDir, 'top-level-hook.js'), '// fake hook\n');
+      fs.mkdirSync(path.join(fakeHooksDir, 'lib'), { recursive: true });
+      fs.writeFileSync(path.join(fakeHooksDir, 'lib', 'helper.js'), '// fake lib helper\n');
+      // Build output dir — must be excluded.
+      fs.mkdirSync(path.join(fakeHooksDir, 'dist'), { recursive: true });
+      fs.writeFileSync(path.join(fakeHooksDir, 'dist', 'built.js'), '// built output\n');
+      // Concurrent build-hooks.js staging dir — must be excluded, and must
+      // not break the copy even while "live".
+      const stagingName = `.dist-staging-99999`;
+      const stagingDir = path.join(fakeHooksDir, stagingName);
       fs.mkdirSync(stagingDir);
       fs.writeFileSync(path.join(stagingDir, 'scratch.txt'), 'transient build output');
-      t.after(() => cleanup(stagingDir));
 
-      const cold = buildColdInstallTree();
+      // The fixture also copies gsd-core/bin/ensure-runtime-build.cjs — give
+      // the fake tree a real copy of it so buildColdInstallTree() succeeds.
+      const fakeBinDir = path.join(fakeRepoRoot, 'gsd-core', 'bin');
+      fs.mkdirSync(fakeBinDir, { recursive: true });
+      fs.copyFileSync(
+        path.join(REPO_ROOT, 'gsd-core', 'bin', 'ensure-runtime-build.cjs'),
+        path.join(fakeBinDir, 'ensure-runtime-build.cjs'),
+      );
+
+      const realHooksBefore = fs.readdirSync(path.join(REPO_ROOT, 'hooks')).sort();
+
+      const cold = buildColdInstallTree({ repoRoot: fakeRepoRoot });
       t.after(cold.cleanup);
 
       const entries = fs.readdirSync(cold.hooksDir);
@@ -177,7 +208,48 @@ describe('worker delegates the npm spawn (does not re-open the gate, #498)', () 
         !entries.some((e) => e.startsWith('.dist-staging')),
         `fixture hooks/ must not contain any .dist-staging* entry, got: ${entries.join(', ')}`,
       );
-      assert.ok(entries.includes('hooks.json'), 'fixture must still contain the real hooks/ tree');
+      assert.ok(!entries.includes('dist'), `fixture hooks/ must not contain dist/, got: ${entries.join(', ')}`);
+      assert.ok(entries.includes('hooks.json'), 'fixture must still contain the representative hooks.json');
+      assert.ok(entries.includes('top-level-hook.js'), 'fixture must still contain the representative top-level hook');
+      assert.ok(
+        fs.existsSync(path.join(cold.hooksDir, 'lib', 'helper.js')),
+        'fixture must still contain the representative hooks/lib/ subdir file',
+      );
+
+      const realHooksAfter = fs.readdirSync(path.join(REPO_ROOT, 'hooks')).sort();
+      assert.deepEqual(
+        realHooksAfter,
+        realHooksBefore,
+        'the real repo hooks/ directory listing must be unchanged by this test',
+      );
+    });
+  });
+
+  // Direct pin on shouldCopyHookEntry() itself — the predicate IS the fix
+  // (exact 'dist' match plus a '.dist-staging' PREFIX, not a loose
+  // startsWith('dist')/includes('dist') substring match). Pinning it only
+  // indirectly, via the fixture-shape assertions above, would let a looser
+  // implementation (e.g. name.startsWith('dist')) pass every case above
+  // while still being wrong — this pins the exact rule.
+  describe('cold-runtime-lib-fixture.cjs: shouldCopyHookEntry() name-filter rule', () => {
+    const { shouldCopyHookEntry } = require('./helpers/cold-runtime-lib-fixture.cjs');
+
+    test('excludes the build output dir and any .dist-staging* prefix name', () => {
+      assert.equal(shouldCopyHookEntry('dist'), false);
+      assert.equal(shouldCopyHookEntry('.dist-staging-20836'), false);
+      assert.equal(shouldCopyHookEntry('.dist-staging-test-abc'), false);
+      assert.equal(shouldCopyHookEntry('.dist-staging'), false);
+    });
+
+    test('keeps real hook entries', () => {
+      assert.equal(shouldCopyHookEntry('hooks.json'), true);
+      assert.equal(shouldCopyHookEntry('lib'), true);
+      assert.equal(shouldCopyHookEntry('gsd-check-update.js'), true);
+    });
+
+    test('does not over-match on a bare "dist" substring/prefix', () => {
+      assert.equal(shouldCopyHookEntry('dist-staging-no-dot'), true);
+      assert.equal(shouldCopyHookEntry('distant.js'), true);
     });
   });
 }

--- a/tests/gsd-check-update-worker-platform-gate.test.cjs
+++ b/tests/gsd-check-update-worker-platform-gate.test.cjs
@@ -144,6 +144,44 @@ describe('worker delegates the npm spawn (does not re-open the gate, #498)', () 
   });
 }
 
+// ─── #3631: cold-tree fixture must tolerate a concurrent build-hooks.js
+// staging dir in the live hooks/ tree ───────────────────────────────────
+//
+// scripts/build-hooks.js writes atomically via a per-PID staging dir
+// (hooks/.dist-staging-<pid>) that it creates and removes; up to nine test
+// files invoke it concurrently from their `before()` hooks, so the live
+// hooks/ dir is never guaranteed stable during a test run. This proves
+// buildColdInstallTree() copies the tree without erroring even while such a
+// staging dir is present, and that it never lands in the fixture.
+{
+  const { describe, test } = require('node:test');
+  const assert = require('node:assert/strict');
+  const fs = require('node:fs');
+  const path = require('node:path');
+  const { buildColdInstallTree, REPO_ROOT } = require('./helpers/cold-runtime-lib-fixture.cjs');
+  const { cleanup } = require('./helpers.cjs');
+
+  describe('cold-runtime-lib-fixture.cjs: #3631 tolerates a concurrent hooks/.dist-staging-<pid> dir', () => {
+    test('a live .dist-staging-test-<random> dir does not break the fixture copy, and is excluded from it', (t) => {
+      const stagingName = `.dist-staging-test-${Math.random().toString(36).slice(2)}`;
+      const stagingDir = path.join(REPO_ROOT, 'hooks', stagingName);
+      fs.mkdirSync(stagingDir);
+      fs.writeFileSync(path.join(stagingDir, 'scratch.txt'), 'transient build output');
+      t.after(() => cleanup(stagingDir));
+
+      const cold = buildColdInstallTree();
+      t.after(cold.cleanup);
+
+      const entries = fs.readdirSync(cold.hooksDir);
+      assert.ok(
+        !entries.some((e) => e.startsWith('.dist-staging')),
+        `fixture hooks/ must not contain any .dist-staging* entry, got: ${entries.join(', ')}`,
+      );
+      assert.ok(entries.includes('hooks.json'), 'fixture must still contain the real hooks/ tree');
+    });
+  });
+}
+
 
 // ────────────────────────────────────────────────────────────────────────
 // Folded from tests/bug-2992-check-latest-version.test.cjs — consolidation epic #1969 (B5 #1974)

--- a/tests/helpers/cold-runtime-lib-fixture.cjs
+++ b/tests/helpers/cold-runtime-lib-fixture.cjs
@@ -35,10 +35,34 @@ function buildColdInstallTree() {
   // managed-hooks-registry.cjs + hooks.json). hooks/dist/ (gitignored,
   // build-hooks.js output) is excluded — it is not present in a raw
   // marketplace checkout either.
-  fs.cpSync(path.join(REPO_ROOT, 'hooks'), path.join(dir, 'hooks'), {
-    recursive: true,
-    filter: (src) => path.basename(src) !== 'dist',
-  });
+  //
+  // This is NOT a single recursive fs.cpSync(hooks/, ...) with a `filter`
+  // callback. The live hooks/ directory is not stable during a test run:
+  // scripts/build-hooks.js writes atomically via a per-PID staging dir
+  // (hooks/.dist-staging-<pid>, gitignored — see .gitignore:21) that it
+  // creates and then removes once the atomic rename into hooks/dist/ is
+  // done, and up to nine test files invoke build-hooks.js concurrently from
+  // their `before()` hooks. A recursive cpSync enumerates hooks/, may
+  // observe another process's transient .dist-staging-<pid> entry, and can
+  // then lstat/copy it AFTER that process has already deleted it — an
+  // intermittent ENOENT ("no such file or directory, lstat
+  // '.../hooks/.dist-staging-<pid>'"). Excluding only the basename 'dist'
+  // does not help: '.dist-staging-<pid>' is a different name.
+  //
+  // Fix: enumerate hooks/ ourselves and skip transient entries BY NAME
+  // ONLY, before ever touching them — no stat/lstat on a name we're going
+  // to skip. Skipping by name (rather than filtering after readdir handed
+  // control to fs.cpSync's own traversal) is what closes the race: a
+  // vanishing .dist-staging-<pid> dir is never accessed at all once its
+  // name has excluded it.
+  const hooksDestDir = path.join(dir, 'hooks');
+  fs.mkdirSync(hooksDestDir, { recursive: true });
+  for (const entry of fs.readdirSync(path.join(REPO_ROOT, 'hooks'), { withFileTypes: true })) {
+    if (entry.name === 'dist' || entry.name.startsWith('.dist-staging')) continue;
+    fs.cpSync(path.join(REPO_ROOT, 'hooks', entry.name), path.join(hooksDestDir, entry.name), {
+      recursive: true,
+    });
+  }
 
   // gsd-core/bin/ensure-runtime-build.cjs — the seam itself. Deliberately
   // NOT gsd-core/bin/lib/ (absent — isBuilt() reads false) and NOT

--- a/tests/helpers/cold-runtime-lib-fixture.cjs
+++ b/tests/helpers/cold-runtime-lib-fixture.cjs
@@ -25,10 +25,28 @@ const path = require('node:path');
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
 
 /**
- * @param {(dir: string) => void} [t.after]  optional node:test `t` for auto-cleanup registration; caller may also ignore and use the returned `cleanup`.
+ * Pure name-filter decision for a single hooks/ top-level entry: should it be
+ * copied into the cold-tree fixture? Excludes the build output dir and any
+ * transient build-hooks.js staging dir (both by NAME ONLY — see the
+ * no-stat-on-a-skipped-name rationale in buildColdInstallTree below).
+ * @param {string} name
+ * @returns {boolean}
+ */
+function shouldCopyHookEntry(name) {
+  return name !== 'dist' && !name.startsWith('.dist-staging');
+}
+
+/**
+ * @param {object} [opts]
+ * @param {string} [opts.repoRoot]  TEST-ONLY: source tree root to copy hooks/
+ *   and gsd-core/bin/ensure-runtime-build.cjs from, in place of the real
+ *   REPO_ROOT. Lets a test point this fixture at a hermetic fake tree instead
+ *   of mutating the live repo's hooks/ directory (which other test files may
+ *   be concurrently reading). Defaults to REPO_ROOT.
  * @returns {{ dir: string, hooksDir: string, cleanup: () => void }}
  */
-function buildColdInstallTree() {
+function buildColdInstallTree(opts = {}) {
+  const repoRoot = opts.repoRoot || REPO_ROOT;
   const dir = fs.mkdtempSync(path.join(require('node:os').tmpdir(), 'gsd-cold-tree-'));
 
   // hooks/ — entire directory (top-level hook scripts + hooks/lib/*.js +
@@ -57,9 +75,9 @@ function buildColdInstallTree() {
   // name has excluded it.
   const hooksDestDir = path.join(dir, 'hooks');
   fs.mkdirSync(hooksDestDir, { recursive: true });
-  for (const entry of fs.readdirSync(path.join(REPO_ROOT, 'hooks'), { withFileTypes: true })) {
-    if (entry.name === 'dist' || entry.name.startsWith('.dist-staging')) continue;
-    fs.cpSync(path.join(REPO_ROOT, 'hooks', entry.name), path.join(hooksDestDir, entry.name), {
+  for (const entry of fs.readdirSync(path.join(repoRoot, 'hooks'), { withFileTypes: true })) {
+    if (!shouldCopyHookEntry(entry.name)) continue;
+    fs.cpSync(path.join(repoRoot, 'hooks', entry.name), path.join(hooksDestDir, entry.name), {
       recursive: true,
     });
   }
@@ -70,7 +88,7 @@ function buildColdInstallTree() {
   // "cannot auto-build" branch fires deterministically).
   fs.mkdirSync(path.join(dir, 'gsd-core', 'bin'), { recursive: true });
   fs.copyFileSync(
-    path.join(REPO_ROOT, 'gsd-core', 'bin', 'ensure-runtime-build.cjs'),
+    path.join(repoRoot, 'gsd-core', 'bin', 'ensure-runtime-build.cjs'),
     path.join(dir, 'gsd-core', 'bin', 'ensure-runtime-build.cjs'),
   );
 
@@ -81,4 +99,4 @@ function buildColdInstallTree() {
   return { dir, hooksDir: path.join(dir, 'hooks'), cleanup };
 }
 
-module.exports = { buildColdInstallTree, REPO_ROOT };
+module.exports = { buildColdInstallTree, REPO_ROOT, shouldCopyHookEntry };


### PR DESCRIPTION
## Fix PR

## Linked Issue

Refs #3582

> Non-closing reference. Every changed file is under `tests/`, which is the shape `scripts/require-issue-link-policy.cjs` accepts a `Refs #N` for (#3211). #3582 is already closed and its production code is correct — the defect is in a test helper it introduced. No new issue was filed because the fix is in hand rather than pending.

---

## What was broken

A verification run failed with:

```
ENOENT: no such file or directory, lstat '/work/hooks/.dist-staging-20836'
```

taking down two tests in `tests/gsd-check-update-worker-platform-gate.test.cjs`. It is a race, not a flake, and it had been latent since #3582 merged green.

`tests/helpers/cold-runtime-lib-fixture.cjs` copied the **live** repo `hooks/` directory with a filter excluding only the basename `dist`:

```js
fs.cpSync(path.join(REPO_ROOT, 'hooks'), path.join(dir, 'hooks'), {
  recursive: true,
  filter: (src) => path.basename(src) !== 'dist',
});
```

Meanwhile `scripts/build-hooks.js` writes atomically through a per-PID staging dir, `hooks/.dist-staging-<pid>` (`scripts/build-hooks.js:23`), and removes it when finished. `.changeset/archived/build-hooks-atomic-write.md` records that **nine test files** invoke `build-hooks.js` from their `before()` hooks. So several test processes create and delete staging directories inside `hooks/` while other tests read it. `cpSync` enumerated one and lstat'd it after its owner deleted it.

## What this fix does

Enumerates `hooks/` explicitly and skips `dist` and any `.dist-staging` prefix **by name**, before anything stats or copies the entry, then copies each surviving entry individually. A name-first skip means a vanishing staging dir is never touched at all.

The helper's own header already stated the governing rule — `hooks/dist` is excluded because it "is not present in a raw marketplace checkout either." `hooks/.dist-staging-*` is gitignored (`.gitignore:21`) and equally absent from a raw checkout. It was simply missed.

## Root cause

An incomplete application of a rule the file had already written down.

> **A correction worth recording.** This fix was written on the assumption that `cpSync`'s `filter` runs *after* the entry is lstat'd, which would make a filter-only fix useless. That assumption is **wrong**: the filter is invoked first, and returning `false` leaves the entry untouched — verified by deleting inside the callback and returning `false` without a throw. So simply adding `.dist-staging` to the old filter would also have closed the race. The explicit enumeration was kept anyway so correctness does not depend on that Node implementation detail.

## Testing

### How I verified the fix

Remote runner **GREEN** on the shipped commit.

Proven both directions by execution: with a staging dir planted, the **old** `cpSync`-with-filter form copied it straight through into the fixture; the new form succeeds and produces no `.dist-staging` entry with the real hook set intact.

**The first version of the regression test was itself wrong, twice**, and is fixed here:

1. It called `cleanup()` on a repo-internal path. `tests/helpers.cjs:452-487` deliberately **throws** for any path outside the known temp roots, so the after-hook failed. That guard is correct and untouched.
2. Worse, it mutated the live `hooks/` directory while other test files concurrently read it — reproducing the exact shared-state hazard this change exists to remove.

It is now hermetic: `buildColdInstallTree` takes an optional `opts.repoRoot` (defaulting to the real `REPO_ROOT`, used for both copies), so the test builds a fake repo root under the temp dir and plants `dist/` and `.dist-staging-99999/` **there**. All six pre-existing callers pass no arguments and are unaffected. The test additionally asserts the real `hooks/` listing is identical before and after, so a future edit that reintroduces live-tree mutation fails loudly.

The name rule is pinned directly, not only through the copy: `shouldCopyHookEntry` is exported and asserted across nine cases — including the two an over-broad implementation would get wrong, `dist-staging-no-dot` and `distant.js`, which must both be **kept**. Anything matching on a loose `dist` substring passes every other case and fails those two.

### Regression test added?

- [x] Yes

### Platforms tested

- [x] macOS — predicate and fixture behavior executed locally
- [ ] Windows — see note
- [x] Linux — remote runner
- [ ] N/A

> No path-separator or platform logic is involved; the change is a name filter over `readdirSync` entries. CI's targeted shards cover Windows.

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above — non-closing `Refs`, permitted for a tests-only diff (#3211)
- [x] Fix is scoped to the reported breakage
- [x] Regression test added, and pinned directly rather than only indirectly
- [x] All existing tests pass — via the remote runner (local `node --test` is hard-blocked)
- [x] No `.changeset/` fragment: `changeset-lint`'s `USER_FACING_PREFIXES` does not include `tests/`, so this is `OK_NO_USER_FACING_CHANGES`
- [x] No unnecessary dependencies added

## Breaking changes

None. Test-helper only; `scripts/build-hooks.js` is deliberately untouched — its per-PID staging is what makes its own writes atomic and is correct.
