### PR TITLE
fix(#3582): stop the cold-tree guard from racing the builders it guards against

### DIFF
--- a/tests/gsd-check-update-worker-platform-gate.test.cjs
+++ b/tests/gsd-check-update-worker-platform-gate.test.cjs
@@ -163,7 +163,7 @@ describe('worker delegates the npm spawn (does not re-open the gate, #498)', () 
   const fs = require('node:fs');
   const os = require('node:os');
   const path = require('node:path');
-  const { buildColdInstallTree, REPO_ROOT } = require('./helpers/cold-runtime-lib-fixture.cjs');
+  const { buildColdInstallTree, REPO_ROOT, shouldCopyHookEntry } = require('./helpers/cold-runtime-lib-fixture.cjs');
   const { cleanup } = require('./helpers.cjs');
 
   describe('cold-runtime-lib-fixture.cjs: #3582 tolerates a concurrent hooks/.dist-staging-<pid> dir', () => {
@@ -198,7 +198,21 @@ describe('worker delegates the npm spawn (does not re-open the gate, #498)', () 
         path.join(fakeBinDir, 'ensure-runtime-build.cjs'),
       );
 
-      const realHooksBefore = fs.readdirSync(path.join(REPO_ROOT, 'hooks')).sort();
+      // Filtered by shouldCopyHookEntry — the same predicate the fixture
+      // itself uses to decide what to copy. Up to nine other test files'
+      // before() hooks concurrently invoke scripts/build-hooks.js, which
+      // creates/removes hooks/.dist-staging-<pid> at unpredictable times, so
+      // a RAW (unfiltered) before/after listing comparison of the live
+      // hooks/ dir is itself racy — it can observe a sibling build's
+      // transient staging dir appear or vanish between the two snapshots and
+      // fail with no real defect. Filtering both snapshots the same way the
+      // fixture does preserves the actual intent (this test adds/removes no
+      // REAL entry in the repo's hooks/) while tolerating scratch that is
+      // not this test's doing and is excluded from the fixture anyway.
+      const realHooksBefore = fs
+        .readdirSync(path.join(REPO_ROOT, 'hooks'))
+        .filter(shouldCopyHookEntry)
+        .sort();
 
       const cold = buildColdInstallTree({ repoRoot: fakeRepoRoot });
       t.after(cold.cleanup);
@@ -216,11 +230,16 @@ describe('worker delegates the npm spawn (does not re-open the gate, #498)', () 
         'fixture must still contain the representative hooks/lib/ subdir file',
       );
 
-      const realHooksAfter = fs.readdirSync(path.join(REPO_ROOT, 'hooks')).sort();
+      const realHooksAfter = fs
+        .readdirSync(path.join(REPO_ROOT, 'hooks'))
+        .filter(shouldCopyHookEntry)
+        .sort();
       assert.deepEqual(
         realHooksAfter,
         realHooksBefore,
-        'the real repo hooks/ directory listing must be unchanged by this test',
+        'the real repo hooks/ directory listing, filtered by shouldCopyHookEntry, must be unchanged by ' +
+          'this test (transient hooks/.dist-staging-<pid> entries from concurrent build-hooks.js runs are ' +
+          'excluded from the comparison since this test does not own them)',
       );
     });
   });


### PR DESCRIPTION
## Fix PR

## Linked Issue

Refs #3582

> Non-closing reference. The only changed file is under `tests/`, which is the shape `scripts/require-issue-link-policy.cjs` accepts a `Refs #N` for (#3211). This is a follow-up to #3656, fixing a defect in the guard that PR added.

---

## What was broken

The guard added in #3656 asserts that the cold-tree fixture test leaves the real repo `hooks/` directory alone. It compared a **raw** directory listing before and after — and failed on the remote runner:

```
the real repo hooks/ directory listing must be unchanged by this test
+ actual - expected
  [
-   '.dist-staging-20858',
      'dist',
      'gsd-agent-isolation-guard.js',
      ...
```

Nothing was wrong with the test's own behavior. A **concurrent** `scripts/build-hooks.js` — nine test files invoke it from their `before()` hooks — created `hooks/.dist-staging-20858` inside the comparison window.

## Root cause

The assertion assumed the shared `hooks/` directory is stable for the duration of a test. That is exactly the assumption #3656 exists to disprove: I fixed the fixture's version of it and then made the identical assumption one assertion over. **The race-detector raced.**

## What this fix does

Keeps the intent — this test must not add or remove anything in the repo — and changes only the comparison. Both snapshots now filter through `shouldCopyHookEntry`, the same rule the fixture itself uses, so transient build scratch that is not this test's doing (and is excluded from the fixture anyway) no longer registers as a difference.

## Testing

Remote runner **GREEN** on the shipped commit.

Proven by execution rather than asserted, in both directions:

| check | result |
|---|---|
| filtered listings, with a `.dist-staging` dir injected mid-window | **equal** — immune |
| unfiltered listings, same window | **differ by exactly `.dist-staging-99998`** — the old comparison would have failed |
| injected dir removed afterwards | yes, `hooks/` byte-identical |

That second row is the point: it shows the fix is real rather than merely quieting the assertion.

Swept for the same shape — this is the only raw listing comparison of the live `hooks/` directory in the file or the repo. (The second title in the failure output is the `describe()` wrapper around this same test, not a sibling.)

### Regression test added?

- [x] The changed assertion **is** the regression coverage — it now fails only for a real repo mutation, and tolerates concurrent build scratch by construction.

### Platforms tested

- [x] macOS — probe executed locally
- [x] Linux — remote runner
- [ ] Windows — no platform-specific logic; a name filter over `readdirSync` entries
- [ ] N/A

### Runtimes tested

- [x] N/A

---

## Checklist

- [x] Issue linked above — non-closing `Refs`, permitted for a tests-only diff (#3211)
- [x] Fix is scoped to the reported breakage
- [x] All existing tests pass — via the remote runner (local `node --test` is hard-blocked)
- [x] No `.changeset/` fragment: `changeset-lint`'s `USER_FACING_PREFIXES` does not include `tests/`
- [x] No unnecessary dependencies added

## Breaking changes

None. Test-only.
