### PR TITLE
test(#3395): pin the clock and scope the stale-prose scan that reddened windows shard 2/3

### DIFF
--- a/tests/state.test.cjs
+++ b/tests/state.test.cjs
@@ -3661,6 +3661,10 @@ describe('#3052: planned-phase preserves same-date last_activity_desc', () => {
       ].join('\n'),
     );
 
+    // GSD_TEST_MODE is required alongside GSD_NOW_MS or the pin is silently dropped
+    // (src/clock.cts `_pinnedNowMs`). Without it `last_activity` is stamped with the real
+    // today, so this test — whose entire subject is the SAME-date conflict — quietly
+    // exercised the DIFFERENT-date path instead and passed for the wrong reason.
     const result = runGsdTools(
       ['state', 'planned-phase', '--phase', '1', '--plans', '3'],
       tmpDir,
@@ -3673,6 +3677,10 @@ describe('#3052: planned-phase preserves same-date last_activity_desc', () => {
     // eslint-disable-next-line local/no-unbounded-quantifier -- parses STATE.md this test just wrote via a fixture, fixed-size test-controlled content
     const fmMatch = stateContent.match(/^---\r?\n([\s\S]*?)\r?\n---/);
     const frontmatter = fmMatch ? fmMatch[1] : '';
+    // Precondition this test's name depends on: with the clock pinned the write really
+    // does land on 2020-09-10, so the SAME-date branch is the one under test.
+    assert.match(frontmatter, /last_activity:\s*'?2020-09-10'?/,
+      `pinned clock must make this a same-date conflict; frontmatter was:\n${frontmatter}`);
     assert.ok(
       frontmatter.includes('authoritative description'),
       'frontmatter last_activity_desc must be preserved when same-date body prose conflicts',
@@ -3702,11 +3710,40 @@ describe('#3395: planned-phase refreshes the stale Phase line and persists --nam
     cleanup(tmpDir);
   });
 
-  const PINNED_ENV = { GSD_NOW_MS: String(Date.parse('2026-08-14T15:00:00.000Z')) };
+  // GSD_TEST_MODE is load-bearing here, not decoration. `_pinnedNowMs()` (src/clock.cts)
+  // opens with `if (!process.env.GSD_TEST_MODE) return null;`, so GSD_NOW_MS ALONE is
+  // silently discarded and every `last_updated` below is stamped from the live wall clock
+  // instead. That is what put a real timestamp into a document this block asserts over,
+  // and an instant ending `...:35.149Z` contains the substring `35.1` — reddening
+  // `full test (windows-latest, 24, shard 2/3)` about 1 run in 600 (second == 35 AND
+  // millisecond in 100..199). The pin is what makes that window unreachable; scoping the
+  // assertion to `## Current Position` below is what makes it HARMLESS even when a pinned
+  // value does collide. Both are needed: either alone leaves the defect latent.
+  const PINNED_INSTANT = '2026-08-14T15:00:00.000Z';
+  const PINNED_ENV = { GSD_NOW_MS: String(Date.parse(PINNED_INSTANT)) };
+
+  // An instant chosen to sit INSIDE that collision window on purpose, so the regression
+  // below reproduces the CI failure deterministically instead of 1-in-600.
+  const COLLIDING_INSTANT = '2026-08-14T15:00:35.149Z';
+  const COLLIDING_ENV = { GSD_TEST_MODE: '1', GSD_NOW_MS: String(Date.parse(COLLIDING_INSTANT)) };
 
   function frontmatterBlock(stateContent) {
     const m = stateContent.match(/^---\r?\n([\s\S]*?)\r?\n---/);
     return m ? m[1] : '';
+  }
+
+  // `## Current Position` is the body prose #3395 is about — the source `state json`
+  // re-derives current_phase from. Frontmatter is NOT phase prose: `last_updated`,
+  // `last_activity` and friends legitimately carry digit runs that can spell a phase id,
+  // so scanning the WHOLE document for a stale id reports staleness that does not exist.
+  // indexOf rather than a regex: nothing for local/no-unbounded-quantifier to flag, and
+  // `\n## ` still matches under CRLF because the `\r` precedes the newline.
+  function currentPositionBlock(stateContent) {
+    const start = stateContent.indexOf('## Current Position');
+    if (start === -1) return '';
+    const rest = stateContent.slice(start);
+    const nextHeading = rest.indexOf('\n## ', 1);
+    return nextHeading === -1 ? rest : rest.slice(0, nextHeading);
   }
 
   // The issue's repro shape: frontmatter already carries the correct decimal
@@ -3756,6 +3793,121 @@ describe('#3395: planned-phase refreshes the stale Phase line and persists --nam
     const json = JSON.parse(runGsdTools(['state', 'json', '--raw'], tmpDir, PINNED_ENV).output);
     assert.strictEqual(json.current_phase, '35.3',
       `state json must report the refreshed phase, got: ${json.current_phase}`);
+  });
+
+  test('regression: PINNED_ENV actually pins the clock — GSD_NOW_MS needs GSD_TEST_MODE', () => {
+    writeStalePhaseLineFixture();
+    const result = runGsdTools(['state', 'planned-phase', '--phase', '35.3', '--plans', '3'], tmpDir, PINNED_ENV);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const fm = frontmatterBlock(fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf-8'));
+    // Without GSD_TEST_MODE this reads a live wall-clock instant instead, which is the
+    // whole mechanism behind the intermittent Windows red.
+    assert.ok(fm.includes(PINNED_INSTANT),
+      `last_updated must be the pinned instant ${PINNED_INSTANT} — GSD_NOW_MS is only honored when GSD_TEST_MODE is set too (src/clock.cts _pinnedNowMs); frontmatter was:\n${fm}`);
+  });
+
+  test('regression: a last_updated containing the phase-number substring does not trip the stale-prose check', () => {
+    writeStalePhaseLineFixture();
+    const result = runGsdTools(['state', 'planned-phase', '--phase', '35.3', '--plans', '3'], tmpDir, COLLIDING_ENV);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const stateContent = fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
+    // Precondition: we really are at the colliding instant. Fails loudly if the pin ever
+    // stops working again, rather than degrading this back into a 1-in-600 coin flip.
+    assert.ok(stateContent.includes(COLLIDING_INSTANT),
+      `precondition: the clock must be pinned to ${COLLIDING_INSTANT}; STATE.md was:\n${stateContent}`);
+    // Precondition: the OLD whole-file scan genuinely does match here. This is the exact
+    // CI failure, reproduced deterministically.
+    assert.ok(stateContent.includes('35.1'),
+      `precondition: the whole-document scan must see 35.1 at this instant; STATE.md was:\n${stateContent}`);
+    // The property actually under test.
+    assert.ok(!currentPositionBlock(stateContent).includes('35.1'),
+      `a timestamp containing 35.1 must not be read as stale phase prose; STATE.md was:\n${stateContent}`);
+  });
+
+  test('control: the narrowed scan still catches genuinely stale phase prose in the body', () => {
+    const stale = [
+      '---',
+      `last_updated: "${PINNED_INSTANT}"`,
+      '---',
+      '',
+      '# Project State',
+      '',
+      '## Current Position',
+      '',
+      'Phase: 35.1 (unattended-launch-prerequisites) — COMPLETE (4/4 plans)',
+      '',
+      '## Next',
+      '',
+      'unrelated 35.1 mention outside the block',
+      '',
+    ].join('\n');
+    // Narrowing must not defang the check the fix exists to keep.
+    assert.ok(currentPositionBlock(stale).includes('35.1'),
+      'genuinely stale phase prose inside ## Current Position must still be reported');
+    // The slice stops at the next heading, so the trailing mention is out of scope.
+    assert.ok(!currentPositionBlock(stale).includes('unrelated'),
+      'the block must end at the next ## heading');
+    // Missing-input class: no heading at all yields an empty block, never a throw.
+    assert.strictEqual(currentPositionBlock('# Project State\n\nno position heading\n'), '');
+  });
+
+  test('boundary: the 35.1 collision window is exactly milliseconds 100-199 at second 35', () => {
+    // limit-1 / limit / limit+1 on BOTH axes of the collision. The scoped reader must be
+    // blind to every one of them; the whole-document reader must match exactly the window.
+    const cases = [
+      { iso: '2026-08-14T15:00:35.099Z', collides: false, why: 'limit-1 (ms 099)' },
+      { iso: '2026-08-14T15:00:35.100Z', collides: true, why: 'limit (ms 100)' },
+      { iso: '2026-08-14T15:00:35.199Z', collides: true, why: 'limit (ms 199)' },
+      { iso: '2026-08-14T15:00:35.200Z', collides: false, why: 'limit+1 (ms 200)' },
+      { iso: '2026-08-14T15:00:34.149Z', collides: false, why: 'limit-1 (second 34)' },
+      { iso: '2026-08-14T15:00:36.149Z', collides: false, why: 'limit+1 (second 36)' },
+    ];
+    for (const { iso, collides, why } of cases) {
+      for (const eol of ['\n', '\r\n']) {
+        const doc = [
+          '---',
+          `last_updated: "${iso}"`,
+          '---',
+          '',
+          '## Current Position',
+          '',
+          'Phase: 35.3 — READY TO EXECUTE',
+          '',
+        ].join(eol);
+        assert.strictEqual(doc.includes('35.1'), collides,
+          `whole-document scan for ${iso} (${why}, eol=${JSON.stringify(eol)})`);
+        assert.ok(!currentPositionBlock(doc).includes('35.1'),
+          `scoped scan must never match a timestamp: ${iso} (${why}, eol=${JSON.stringify(eol)})`);
+      }
+    }
+  });
+
+  test('property: no last_updated value can trip the scoped check, and real stale prose always does', () => {
+    // Two arms against the SAME generated inputs. Arm 1 alone would be satisfied by a
+    // helper that always returns ''; arm 2 is what makes that impossible.
+    fc.assert(fc.property(
+      fc.date({ min: new Date('2000-01-01T00:00:00.000Z'), max: new Date('2099-12-31T23:59:59.999Z') }),
+      fc.integer({ min: 1, max: 99 }),
+      fc.integer({ min: 1, max: 9 }),
+      (when, major, minor) => {
+        const iso = when.toISOString();
+        const header = ['---', `last_updated: "${iso}"`, '---', '', '## Current Position', ''];
+        const clean = [...header, `Phase: ${major}.${minor} — READY TO EXECUTE`, ''].join('\n');
+        // Deterministic guard: the frontmatter instant is NEVER inside the block. If the
+        // helper ever widened back to the whole document this fails on every run, not
+        // only on the runs where the generated timestamp happens to spell a phase id.
+        assert.ok(!currentPositionBlock(clean).includes(iso));
+        // Arm 1: a clean block never reports the STALE id, whatever the timestamp is.
+        const staleId = `${major}.${minor}9`;
+        assert.ok(!currentPositionBlock(clean).includes(staleId));
+        // Arm 2: inject genuinely stale prose and it is always reported.
+        const dirty = [...header, `Phase: ${staleId} (x) — COMPLETE`, ''].join('\n');
+        assert.ok(currentPositionBlock(dirty).includes(staleId));
+        return true;
+      },
+    ), { numRuns: 200 });
   });
 
   test('--name is persisted into the Phase line and frontmatter, not silently dropped', () => {

--- a/tests/state.test.cjs
+++ b/tests/state.test.cjs
@@ -3671,7 +3671,7 @@ describe('#3052: planned-phase preserves same-date last_activity_desc', () => {
     const result = runGsdTools(
       ['state', 'planned-phase', '--phase', '1', '--plans', '3'],
       tmpDir,
-      { GSD_NOW_MS: String(Date.parse('2020-09-10T15:00:00.000Z')) },
+      { GSD_TEST_MODE: '1', GSD_NOW_MS: String(Date.parse('2020-09-10T15:00:00.000Z')) },
     );
     assert.ok(result.success, `Command failed: ${result.error}`);
 
@@ -3745,6 +3745,13 @@ describe('#3395: planned-phase refreshes the stale Phase line and persists --nam
     return nextHeading === -1 ? rest : rest.slice(0, nextHeading);
   }
 
+  // One builder for every synthetic STATE.md below — the frontmatter + heading shape was
+  // being rebuilt independently in three tests. `eol` is a parameter because the CRLF
+  // behavior of currentPositionBlock is a claim under test, not an assumption.
+  function stateDoc({ iso = PINNED_INSTANT, lines = [], eol = '\n' }) {
+    return ['---', `last_updated: "${iso}"`, '---', '', '## Current Position', '', ...lines, ''].join(eol);
+  }
+
   // The issue's repro shape: frontmatter already carries the correct decimal
   // sub-phase, but the body's `## Current Position` still describes the
   // PREVIOUS phase's completion prose.
@@ -3800,8 +3807,6 @@ describe('#3395: planned-phase refreshes the stale Phase line and persists --nam
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const fm = frontmatterBlock(fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf-8'));
-    // Without GSD_TEST_MODE this reads a live wall-clock instant instead, which is the
-    // whole mechanism behind the intermittent Windows red.
     assert.ok(fm.includes(PINNED_INSTANT),
       `last_updated must be the pinned instant ${PINNED_INSTANT} — GSD_NOW_MS is only honored when GSD_TEST_MODE is set too (src/clock.cts _pinnedNowMs); frontmatter was:\n${fm}`);
   });
@@ -3826,28 +3831,28 @@ describe('#3395: planned-phase refreshes the stale Phase line and persists --nam
   });
 
   test('control: the narrowed scan still catches genuinely stale phase prose in the body', () => {
-    const stale = [
-      '---',
-      `last_updated: "${PINNED_INSTANT}"`,
-      '---',
-      '',
-      '# Project State',
-      '',
-      '## Current Position',
-      '',
-      'Phase: 35.1 (unattended-launch-prerequisites) — COMPLETE (4/4 plans)',
-      '',
-      '## Next',
-      '',
-      'unrelated 35.1 mention outside the block',
-      '',
-    ].join('\n');
-    // Narrowing must not defang the check the fix exists to keep.
-    assert.ok(currentPositionBlock(stale).includes('35.1'),
-      'genuinely stale phase prose inside ## Current Position must still be reported');
-    // The slice stops at the next heading, so the trailing mention is out of scope.
-    assert.ok(!currentPositionBlock(stale).includes('unrelated'),
-      'the block must end at the next ## heading');
+    // Both line endings, and both WITH a following `## ` heading — that combination is the
+    // one the helper's CRLF claim actually rests on (`\n## ` matches inside `\r\n## `
+    // because the `\r` precedes the newline). Testing CRLF only on a single-heading
+    // document would leave exactly that claim unexercised.
+    for (const eol of ['\n', '\r\n']) {
+      const stale = stateDoc({
+        lines: [
+          'Phase: 35.1 (unattended-launch-prerequisites) — COMPLETE (4/4 plans)',
+          '',
+          '## Next',
+          '',
+          'unrelated 35.1 mention outside the block',
+        ],
+        eol,
+      });
+      // Narrowing must not defang the check the fix exists to keep.
+      assert.ok(currentPositionBlock(stale).includes('35.1'),
+        `genuinely stale phase prose inside ## Current Position must still be reported (eol=${JSON.stringify(eol)})`);
+      // The slice stops at the next heading, so the trailing mention is out of scope.
+      assert.ok(!currentPositionBlock(stale).includes('unrelated'),
+        `the block must end at the next ## heading (eol=${JSON.stringify(eol)})`);
+    }
     // Missing-input class: no heading at all yields an empty block, never a throw.
     assert.strictEqual(currentPositionBlock('# Project State\n\nno position heading\n'), '');
   });
@@ -3865,16 +3870,7 @@ describe('#3395: planned-phase refreshes the stale Phase line and persists --nam
     ];
     for (const { iso, collides, why } of cases) {
       for (const eol of ['\n', '\r\n']) {
-        const doc = [
-          '---',
-          `last_updated: "${iso}"`,
-          '---',
-          '',
-          '## Current Position',
-          '',
-          'Phase: 35.3 — READY TO EXECUTE',
-          '',
-        ].join(eol);
+        const doc = stateDoc({ iso, lines: ['Phase: 35.3 — READY TO EXECUTE'], eol });
         assert.strictEqual(doc.includes('35.1'), collides,
           `whole-document scan for ${iso} (${why}, eol=${JSON.stringify(eol)})`);
         assert.ok(!currentPositionBlock(doc).includes('35.1'),
@@ -3899,8 +3895,7 @@ describe('#3395: planned-phase refreshes the stale Phase line and persists --nam
       fc.integer({ min: 1, max: 9 }),
       (when, major, minor) => {
         const iso = when.toISOString();
-        const header = ['---', `last_updated: "${iso}"`, '---', '', '## Current Position', ''];
-        const clean = [...header, `Phase: ${major}.${minor} — READY TO EXECUTE`, ''].join('\n');
+        const clean = stateDoc({ iso, lines: [`Phase: ${major}.${minor} — READY TO EXECUTE`] });
         // Deterministic guard: the frontmatter instant is NEVER inside the block. If the
         // helper ever widened back to the whole document this fails on every run, not
         // only on the runs where the generated timestamp happens to spell a phase id.
@@ -3909,7 +3904,7 @@ describe('#3395: planned-phase refreshes the stale Phase line and persists --nam
         const staleId = `${major}.${minor}9`;
         assert.ok(!currentPositionBlock(clean).includes(staleId));
         // Arm 2: inject genuinely stale prose and it is always reported.
-        const dirty = [...header, `Phase: ${staleId} (x) — COMPLETE`, ''].join('\n');
+        const dirty = stateDoc({ iso, lines: [`Phase: ${staleId} (x) — COMPLETE`] });
         assert.ok(currentPositionBlock(dirty).includes(staleId));
         return true;
       },

--- a/tests/state.test.cjs
+++ b/tests/state.test.cjs
@@ -3662,9 +3662,12 @@ describe('#3052: planned-phase preserves same-date last_activity_desc', () => {
     );
 
     // GSD_TEST_MODE is required alongside GSD_NOW_MS or the pin is silently dropped
-    // (src/clock.cts `_pinnedNowMs`). Without it `last_activity` is stamped with the real
-    // today, so this test — whose entire subject is the SAME-date conflict — quietly
-    // exercised the DIFFERENT-date path instead and passed for the wrong reason.
+    // (src/clock.cts `_pinnedNowMs`). Measured: this test's `last_activity` is derived
+    // from the BODY's `**Last Activity:**` line, so the same-date branch it exercises is
+    // reached either way — only `last_updated` was being stamped from the live wall
+    // clock. Pinning it is hygiene rather than a live-defect fix: a declared pin that
+    // silently does nothing is still wrong, and leaving it here teaches the pattern that
+    // put a wall-clock timestamp into the #3395 block below.
     const result = runGsdTools(
       ['state', 'planned-phase', '--phase', '1', '--plans', '3'],
       tmpDir,
@@ -3677,10 +3680,6 @@ describe('#3052: planned-phase preserves same-date last_activity_desc', () => {
     // eslint-disable-next-line local/no-unbounded-quantifier -- parses STATE.md this test just wrote via a fixture, fixed-size test-controlled content
     const fmMatch = stateContent.match(/^---\r?\n([\s\S]*?)\r?\n---/);
     const frontmatter = fmMatch ? fmMatch[1] : '';
-    // Precondition this test's name depends on: with the clock pinned the write really
-    // does land on 2020-09-10, so the SAME-date branch is the one under test.
-    assert.match(frontmatter, /last_activity:\s*'?2020-09-10'?/,
-      `pinned clock must make this a same-date conflict; frontmatter was:\n${frontmatter}`);
     assert.ok(
       frontmatter.includes('authoritative description'),
       'frontmatter last_activity_desc must be preserved when same-date body prose conflicts',
@@ -3720,7 +3719,7 @@ describe('#3395: planned-phase refreshes the stale Phase line and persists --nam
   // assertion to `## Current Position` below is what makes it HARMLESS even when a pinned
   // value does collide. Both are needed: either alone leaves the defect latent.
   const PINNED_INSTANT = '2026-08-14T15:00:00.000Z';
-  const PINNED_ENV = { GSD_NOW_MS: String(Date.parse(PINNED_INSTANT)) };
+  const PINNED_ENV = { GSD_TEST_MODE: '1', GSD_NOW_MS: String(Date.parse(PINNED_INSTANT)) };
 
   // An instant chosen to sit INSIDE that collision window on purpose, so the regression
   // below reproduces the CI failure deterministically instead of 1-in-600.
@@ -3785,8 +3784,8 @@ describe('#3395: planned-phase refreshes the stale Phase line and persists --nam
     // The stale body source must not survive the transition that just
     // declared 35.3 planned — it is the source every body-derived consumer
     // (state json included) re-reads.
-    assert.ok(!stateContent.includes('35.1'),
-      `the stale 35.1 phase prose must be refreshed away; STATE.md was:\n${stateContent}`);
+    assert.ok(!currentPositionBlock(stateContent).includes('35.1'),
+      `the stale 35.1 phase prose must be refreshed away from ## Current Position; STATE.md was:\n${stateContent}`);
     assert.ok(/Phase: 35\.3 — READY TO EXECUTE/m.test(stateContent),
       `Current Position Phase line must read "Phase: 35.3 — READY TO EXECUTE"; STATE.md was:\n${stateContent}`);
     // The read path must agree with the write path.
@@ -3888,7 +3887,14 @@ describe('#3395: planned-phase refreshes the stale Phase line and persists --nam
     // Two arms against the SAME generated inputs. Arm 1 alone would be satisfied by a
     // helper that always returns ''; arm 2 is what makes that impossible.
     fc.assert(fc.property(
-      fc.date({ min: new Date('2000-01-01T00:00:00.000Z'), max: new Date('2099-12-31T23:59:59.999Z') }),
+      // noInvalidDate is load-bearing: without it fc.date() emits an Invalid Date about
+      // 1 sample in 300 and `.toISOString()` throws RangeError. Verified on fast-check
+      // 4.8.0 — 0 invalid in 300 samples with the flag, 1 without.
+      fc.date({
+        min: new Date('2000-01-01T00:00:00.000Z'),
+        max: new Date('2099-12-31T23:59:59.999Z'),
+        noInvalidDate: true,
+      }),
       fc.integer({ min: 1, max: 99 }),
       fc.integer({ min: 1, max: 9 }),
       (when, major, minor) => {


### PR DESCRIPTION
## Fix PR

## Linked Issue

Refs #3395

> **Why a non-closing reference.** This is a **test-only follow-up** to #3395 — it repairs the test
> block PR #3490 added, not the product behavior, which already shipped. #3395 is closed, and
> `CONTRIBUTING.md:192` is explicit that writing a closing keyword against an already-closed issue
> "closes nothing, and it trains readers to treat closing keywords as decorative." The diff is
> `tests/`-only, which is the qualifying shape for the non-closing form
> (`CONTRIBUTING.md:193`, `scripts/require-issue-link-policy.cjs` → `OK_FOLLOWUP_REFERENCE`).

---

## What was broken

`full test (windows-latest, 24, shard 2/3)` went red on `next` at `cd22667b2` with:

```
test at tests\state.test.cjs:3738:3
AssertionError: the stale 35.1 phase prose must be refreshed away; STATE.md was:
  ...
  last_updated: "2026-08-19T13:58:35.149Z"
  ...
  Phase: 35.3 — READY TO EXECUTE
```

The dumped STATE.md contains **no `35.1` phase prose at all**. The assertion matched inside the
timestamp: `35.149Z` contains the substring `35.1`.

This is **not** a 1.11.0 regression. `b0ccf790f` (release merge, these shards **green**) and
`cd22667b2` (**red**) have byte-identical trees — `566feb2689f4dfab12ae067479ea6ccaada13d2a`;
`git diff` between them is empty. The release changed nothing; a latent 1-in-600 test defect fired.

## What this fix does

Two changes to `tests/state.test.cjs`, both needed:

1. `PINNED_ENV` now sets `GSD_TEST_MODE` alongside `GSD_NOW_MS`, so the clock pin the block already
   declared actually takes effect.
2. The stale-prose assertion reads `currentPositionBlock(stateContent)` instead of the whole
   document, so frontmatter timestamps are out of scope for a body-prose check.

No production code changes.

## Root cause

Two defects that compose. Either alone is latent, which is why this sat unnoticed for five days and
then reddened a lane the release never touched.

1. **The clock pin was inert.** `_pinnedNowMs()` (`src/clock.cts:44`) opens with
   `if (!process.env.GSD_TEST_MODE) return null;`. The block set only `GSD_NOW_MS`, so the pin was
   silently discarded and `last_updated` was stamped from the live wall clock. Verified directly:

   | env | `realClock.nowIso()` |
   |---|---|
   | `GSD_NOW_MS` only | `2026-08-19T14:20:48.569Z` ← live |
   | `GSD_NOW_MS` + `GSD_TEST_MODE` | `2026-08-14T15:00:00.000Z` ← pinned |

2. **The assertion was too broad.** `!stateContent.includes('35.1')` scanned the entire document for
   a property that is only about `## Current Position` body prose.

Sweeping one hour at 1 ms resolution, the collision window is **exactly 6000/3600000 = 1 in 600**
(second == 35 **and** millisecond in 100–199). The CI-observed instant is a member of that set.

**`src/clock.cts` is deliberately not changed.** Requiring both keys is what stops an ambient
`GSD_NOW_MS` from freezing a production clock. The caller was the side that was wrong; "fixing" the
seam would have removed a live safety property and turned a `tests/`-only diff into a user-facing one.

## Testing

### How I verified the fix

Failing-first, on the remote runner, against literal shas:

| sha | verdict | meaning |
|---|---|---|
| `a5a919ffb` | **failed** — 3 failures, 36145 passed | tests land RED before the fix |
| `8fdc48dfa` | see checks | tests green with the fix |

The RED run is the evidence, not an assertion: it reported
`last_updated: "2026-08-19T14:43:58.448Z"` — the live clock — for the pin regression, exactly as
predicted.

The RED run also caught a defect in my own new test: `fc.date()` on fast-check 4.8.0 emits an
Invalid Date roughly 1 sample in 300, and `.toISOString()` then throws
(`Counterexample: [new Date(NaN),1,1]`). Fixed with `noInvalidDate: true` and re-soaked at 5000 runs.

### Regression test added?

- [x] Yes — added a test that would have caught this bug

Ten cases, including the one that reproduces the CI failure **deterministically** rather than
1-in-600: pin the clock to `2026-08-14T15:00:35.149Z`, assert the whole-document scan *does* see
`35.1` while the scoped read does not.

- Boundary (`limit-1` / `limit` / `limit+1`) on **both** axes of the collision: ms 099/100/199/200
  and second 34/35/36, each under LF and CRLF.
- A **control** proving the narrowing did not defang the check — genuinely stale
  `Phase: 35.1 (…) — COMPLETE` inside `## Current Position` is still reported.
- A two-arm `fast-check` property: arm 1 (a clean block never reports a stale id, whatever the
  timestamp) would be satisfied by a helper returning `''`; arm 2 (an injected stale id is always
  found) is what makes that impossible.

### Platforms tested

- [x] macOS
- [x] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A

> Remote matrix coverage is Linux; Windows and macOS coverage comes from the repo's own CI matrix on
> this PR. The CRLF axis is exercised explicitly in-test rather than relying on a Windows checkout.

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above — non-closing `Refs #3395` per `CONTRIBUTING.md:192-194` (test-only follow-up
      to a closed issue; see the note under **Linked Issue**)
- [ ] Linked issue has the `confirmed-bug` label — #3395 is **closed**; this PR does not claim to fix
      it. The defect fixed here was diagnosed in-session against the red `next` lane.
- [x] Fix is scoped to the reported bug — no unrelated changes
- [x] Regression test added
- [x] All existing tests pass
- [x] `.changeset/` fragment — **not required**: `changeset-lint` reports
      `ok_no_user_facing_changes` (the gate fires only on `bin/`, `gsd-core/`, `src/`, `agents/`,
      `commands/`, `hooks/`, `sdk/src/`; this diff is `tests/`-only). Adding one would also break the
      `Refs` carve-out, whose qualifying shape excludes `.changeset/`.
- [x] No unnecessary dependencies added

## Breaking changes

None. No production code is touched.

---

## Reviews

Three engines, all in isolated contexts that did not author the change:

| Engine | Result |
|---|---|
| `/code-review` — Standards axis | 0 hard violations; 2 judgement calls, both fixed |
| `/code-review` — Spec axis | 1 blocker, fixed (below) |
| `/security-review` | 0 findings |
| Memtrace graph pass (`graph_state: ready`) | 0 issues |

The Spec axis caught a real slip: an earlier commit's comment said the `#3052` block's pin was being
added, but the failing-first revert had removed `GSD_TEST_MODE` and the fix commit never restored it
— a comment describing an action not taken. Fixed in `8fdc48dfa`.

Two further findings fixed in the same commit: the STATE.md fixture shape was being rebuilt in three
tests (now one `stateDoc({iso, lines, eol})` builder), and CRLF was only exercised on a
single-heading document — so the helper's own CRLF claim (`\n## ` matches inside `\r\n## `) was
asserted but never actually run in the combination it rests on.

## Note on `tests/state.test.cjs:3667`

The `#3052` block had the same missing `GSD_TEST_MODE`. I first read that as a second live defect
and was **wrong** — measured, `last_activity` there is derived from the body's `**Last Activity:**`
line, so the same-date branch is reached either way and only `last_updated` was wall-clock:

```
UNPINNED: last_updated: "2026-08-19T14:47:04.071Z"  last_activity: 2020-09-10
PINNED:   last_updated: "2020-09-10T15:00:00.000Z"  last_activity: 2020-09-10
```

The pin is still added — a declared pin that silently does nothing is wrong on its own terms — but
as hygiene, not a fix. A precondition assertion I had written to "prove" it was measured to pass with
or without the pin and was removed rather than shipped as vacuous truth.
