### PR TITLE
fix(#3685): derive roadmap_updated/state_updated from the actual write

### DIFF
--- a/src/phase.cts
+++ b/src/phase.cts
@@ -2258,6 +2258,15 @@ function cmdPhaseComplete(cwd: string, phaseNum: string, raw: boolean): void {
     ? (phaseInfo['summaries'] as string[]).length
     : 0;
   let requirementsUpdated = false;
+  // #2316-3 pattern, extended to the other two planning files: each of these
+  // must reflect whether the file's content actually CHANGED in the
+  // transaction, never merely that the file exists on disk. `existsSync` here
+  // reported `true` for a ROADMAP the transaction never touched — e.g. a phase
+  // with no row in the Progress table — which made a silent no-op
+  // indistinguishable from a successful rollup write (the failure mode #2012
+  // named as `roadmap_updated` masking the skip).
+  let roadmapUpdated = false;
+  let stateUpdated = false;
 
   const warnings: string[] = [];
   // ADR-3408 §8.5 / D2 (#3374): "liberal but visible" — when the write-seam
@@ -2668,6 +2677,7 @@ function cmdPhaseComplete(cwd: string, phaseNum: string, raw: boolean): void {
           before: originalRoadmapContent,
           after: roadmapContent,
         });
+        roadmapUpdated = roadmapContent !== originalRoadmapContent;
 
         const reqPath = path.join(planningDir(cwd), 'REQUIREMENTS.md');
         if (fs.existsSync(reqPath)) {
@@ -3241,6 +3251,7 @@ function cmdPhaseComplete(cwd: string, phaseNum: string, raw: boolean): void {
         }
 
         writes.push({ filePath: statePath, before: originalStateContent, after: stateContent });
+        stateUpdated = stateContent !== originalStateContent;
       }
 
       writePlanningFileSet(writes);
@@ -3307,8 +3318,8 @@ function cmdPhaseComplete(cwd: string, phaseNum: string, raw: boolean): void {
     next_phase_name: nextPhaseName,
     is_last_phase: isLastPhase,
     date: today,
-    roadmap_updated: fs.existsSync(roadmapPath),
-    state_updated: fs.existsSync(statePath),
+    roadmap_updated: roadmapUpdated,
+    state_updated: stateUpdated,
     requirements_updated: requirementsUpdated,
     auto_pruned: autoPruned,
     warnings,

--- a/tests/phase.test.cjs
+++ b/tests/phase.test.cjs
@@ -3296,6 +3296,52 @@ describe('phase complete canonical verification gate (#1522)', () => {
     assert.match(state, /\*\*Current Phase:\*\* 02/);
   });
 
+  // ─── roadmap_updated / state_updated must reflect an actual content change ──
+  // Same class as #2640 (state_updated on phase remove) and the failure #2012
+  // named: `roadmap_updated` was `fs.existsSync(roadmapPath)`, so it reported
+  // `true` for a ROADMAP the transaction never wrote. A caller cannot then tell
+  // a successful rollup from a silently-skipped one, which is exactly how a
+  // no-op rollup goes unnoticed. `requirements_updated` already had the
+  // diff-tracking treatment (#2316-3); these two now match it.
+
+  test('roadmap_updated and state_updated are true when both files actually change', () => {
+    writePhaseCompleteVerificationGateFixture(tmpDir, 'passed');
+
+    const result = runGsdTools(['phase', 'complete', '1'], tmpDir);
+
+    assert.equal(result.success, true, `phase complete failed: ${result.error}`);
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.roadmap_updated, true,
+      'roadmap_updated must be true when the checkbox and Progress row were rewritten');
+    assert.strictEqual(output.state_updated, true,
+      'state_updated must be true when STATE.md was advanced to the next phase');
+  });
+
+  test('roadmap_updated is false when the transaction leaves ROADMAP.md byte-identical', () => {
+    writePhaseCompleteVerificationGateFixture(tmpDir, 'passed');
+    const roadmapPath = path.join(tmpDir, '.planning', 'ROADMAP.md');
+
+    // First completion does the real work.
+    const first = runGsdTools(['phase', 'complete', '1'], tmpDir);
+    assert.equal(first.success, true, `first phase complete failed: ${first.error}`);
+    assert.strictEqual(JSON.parse(first.output).roadmap_updated, true,
+      'precondition: the first completion must genuinely rewrite ROADMAP.md');
+
+    const afterFirst = fs.readFileSync(roadmapPath, 'utf-8');
+
+    // Re-completing the same phase has nothing left to rewrite: the checkbox is
+    // already [x], the Progress row already Complete, the plan count already
+    // final. The file must come out byte-identical, and the flag must say so.
+    const second = runGsdTools(['phase', 'complete', '1'], tmpDir);
+    assert.equal(second.success, true, `second phase complete failed: ${second.error}`);
+
+    assert.strictEqual(fs.readFileSync(roadmapPath, 'utf-8'), afterFirst,
+      'precondition: re-completing an already-complete phase must not alter ROADMAP.md');
+    assert.strictEqual(JSON.parse(second.output).roadmap_updated, false,
+      'roadmap_updated must be false when ROADMAP.md was not written — '
+      + 'fs.existsSync() reported true here, masking the no-op');
+  });
+
   test('blocks stale passed verification when summaries changed later', () => {
     writePhaseCompleteVerificationGateFixture(tmpDir, 'passed');
     const roadmapPath = path.join(tmpDir, '.planning', 'ROADMAP.md');


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3685

> Note: #3685 is currently `needs-triage`, not yet `confirmed-bug`. Opening the PR now because the repro is deterministic and the diff is five lines — happy to let it sit until a maintainer confirms, and to close it if this turns out to be works-as-designed.

---

## What was broken

`phase complete` returned `roadmap_updated` and `state_updated` from `fs.existsSync(...)`, so both reported `true` whenever the file merely existed — including when the transaction wrote nothing to it. A no-op rollup was indistinguishable from a successful one.

## What this fix does

Both flags are now set from a content comparison at the point each file is queued for writing, so they report whether that file actually changed.

## Root cause

`cmdPhaseComplete` builds a `writes: WriteSpec[]` array where every entry already carries `{ filePath, before, after }`. `requirements_updated` uses that data correctly (`src/phase.cts:2987`), and its comment describes the intended pattern:

```ts
// #2316-3: `requirements_updated` must reflect whether REQUIREMENTS.md
// content actually CHANGED, not merely that the file existed in the
// transaction — mirrors the `writes.push({filePath,before,after})`
// diff-tracking pattern used for the ROADMAP write above.
```

The comment asserts the ROADMAP write already does this. It did not — the return object reached past the transaction to `fs.existsSync` instead. This change makes the code match the comment.

Same class as #2640 (`cmdPhaseRemove` reporting `state_updated: true`), and it is the masking #2012 named in its title. #2012 fixed the *skip* via #2032; the flag that concealed it was never touched.

## Testing

### How I verified the fix

Added `roadmap_updated is false when the transaction leaves ROADMAP.md byte-identical` to `tests/phase.test.cjs`. It completes the same phase twice — the second run has nothing left to rewrite, so it asserts the file is byte-identical and then asserts the flag agrees.

Verified it genuinely fails first: with `src/phase.cts` reverted to `next` and rebuilt, the test fails with

```
roadmap_updated must be false when ROADMAP.md was not written — fs.existsSync() reported true here, masking the no-op
```

and passes with the fix applied.

This mattered, because the two existing assertions of `roadmap_updated === true` (`tests/phase.test.cjs:889`, `:1214`) pass vacuously — `existsSync` is true in those fixtures either way, so neither would catch a regression here. I added a companion test pinning the true-when-genuinely-changed direction so the flag cannot be "fixed" into always-false.

Results:

- `node --test tests/phase.test.cjs` — 351 tests, **350 pass, 0 fail**, 1 pre-existing skip
- `node --test` over `state`, `milestone`, `frontmatter`, `auto-chain-transition-delegation`, `planning-snapshot`, `milestone-lock`, `milestone-archive`, `phase-lifecycle` — **847 pass, 0 fail**
- `npx eslint src/phase.cts tests/phase.test.cjs --max-warnings 0` — clean

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [x] N/A (not platform-specific)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [ ] Linked issue has the `confirmed-bug` label — still `needs-triage`, see note above
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass
- [x] `.changeset/` fragment added if this is a user-facing fix
- [x] No unnecessary dependencies added

## Breaking changes

A caller that treated `roadmap_updated` / `state_updated` as "the file exists" will now see `false` when nothing was written. That is the point of the fix, but it is a visible change in the returned values for no-op completions.
