### PR TITLE
fix(#3637): carry the executor contract across the process-spawn boundary

### DIFF
--- a/.changeset/sturdy-cats-snooze.md
+++ b/.changeset/sturdy-cats-snooze.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 3692
+---
+**Process-spawned executors now receive the executor role and contract instead of inferring them** — on runtimes that use GSD-managed worktrees (Codex, Kimi, Kimi Code, OpenCode), a parallel executor was launched with a five-line prompt carrying no role, no plan path and no execution context, and success criteria that demanded an unconditional SUMMARY.md commit — pushing it to force-stage gitignored planning artifacts. (#3637)

--- a/gsd-core/workflows/execute-phase/steps/executor-isolation-dispatch.md
+++ b/gsd-core/workflows/execute-phase/steps/executor-isolation-dispatch.md
@@ -130,37 +130,144 @@ Run the loop below once per runnable plan in the wave, **one plan at a time** (`
 
 **Before running the bash block, substitute the plan's identifiers into it** exactly as you do for the `Agent()` prompt on the harness path: replace `{plan_number}` and `{phase_number}` with this plan's values. They are template placeholders, not shell variables. `$ORCH_ROOT` and `$EXPECTED_BASE` are real shell variables, already assigned earlier in this step; `$WAVE_WORKTREE_MANIFEST` was initialized above.
 
-First build the executor prompt. It is the **same prompt text the harness path's `Agent()` call uses**, with the harness-only framing removed — drop the `<worktree_branch_check>` build-time embed note and the `<parallel_execution>` harness block, keep `<objective>`, the execution context, and `<success_criteria>` verbatim. The checkpoint gate rule (#3370, in `per-plan-executor-routing.md`) applies here too: add no prompt text refusing or overriding auto-approval for the default `gate="blocking"` — only `blocking-human` always surfaces. Assign it to a shell variable so it can be passed as one argument:
+First compose the executor prompt — **to a file, not a shell literal**. A process spawn has no `subagent_type`, so nothing on this transport loads the `gsd-executor` role for the child (#3637): everything the harness dispatch delivers through the agent definition and its `<execution_context>` embed must instead ride in this prompt, or the spawned process starts as a generic model that reconstructs its role by inference. Two transport constraints shape the composition: the prompt travels as a single argv argument (Windows caps a command line at ~32 KiB, so the multi-hundred-KiB build-time embeds the harness path inlines cannot ride along), and a shell-literal assignment cannot carry arbitrary file content. So: the small, contract-critical text goes INLINE; the large execution-context files are listed as MANDATORY first reads with resolvable paths — a process-spawned executor, unlike an `Agent()` prompt (#3324), can and must Read files.
 
-```bash
-# Compose the executor prompt for THIS plan. Single-quoted multi-line
-# assignment (NOT a heredoc): these blocks are indented inside the workflow,
-# and a heredoc terminator must sit at column 0 — `<<-` strips only tabs, not
-# the leading spaces, so a heredoc here would never terminate. Single quotes
-# also stop the shell expanding anything in the prompt body.
-EXECUTOR_PROMPT='<objective>
+First ensure the destination directory exists (do not rely on any runtime's Write tool creating intermediate directories): run `mkdir -p "${ORCH_ROOT}/.claude/worktrees"`. Then write the composed prompt with your Write tool to exactly this path (the file is the inspectable provenance of what this dispatch injected, and it survives worktree cleanup):
+
+`${ORCH_ROOT}/.claude/worktrees/executor-prompt-p{plan_number}.md`
+
+Compose it from the template below, substituting every `{placeholder}` — leave NO unexpanded template text behind; the spawn block validates this and halts. Two substitutions need care:
+
+- `{EXECUTOR_ROLE_FILE}` — the absolute path of the INSTALLED `gsd-executor` agent definition on this runtime (the same file `query agent-skills` reads for its persona fallback). This, not an inline embed, is how the role's full substance (deviation rules, destructive-git prohibitions, the final-commit SDK contract) reaches the child: the prompt must stay a single small argv argument (Windows caps a command line at ~32 KiB), and the installed agent alone is ~49 KiB. The spawn block verifies the path is readable before anything launches.
+- `{AGENT_SKILLS_BLOCK}` — ONLY the configured custom-skills block (when `.planning/config.json` configures `agent_skills` for `gsd-executor`). When it is not configured, substitute the EMPTY string — on AGENTS-native runtimes the unconfigured `query agent-skills` falls back to injecting the full installed persona (#2454), which would blow the argv cap this design exists to respect; the persona already rides `{EXECUTOR_ROLE_FILE}` above. The spawn block enforces this with a hard byte cap.
+
+```text
+<provenance>plan {plan_number} of phase {phase_number} at {ORCH_ROOT}</provenance>
+
+<role>
+You are the gsd-executor agent, dispatched by the GSD execute-phase orchestrator
+into a git worktree it created for you. No agent file is loaded on this
+transport, so this prompt plus the files below ARE your role. Before ANY other
+work, read every file in <required_reading> with your file-reading tool — the
+gsd-executor definition and execute-plan.md are your execution contract
+(deviation rules, commit protocol, checkpoint gates, destructive-git
+prohibitions, the final-commit SDK contract). If any listed file cannot be
+read, STOP and report the failure — do not improvise the contract.
+</role>
+
+<objective>
 Execute plan {plan_number} of phase {phase_number}-{phase_name}.
+Plan file: {ORCH_ROOT}/{phase_dir}/{plan_file}
 Commit each task atomically. Create SUMMARY.md.
 Do NOT update STATE.md or ROADMAP.md — the orchestrator owns those writes after all worktree agents in the wave complete.
 </objective>
 
+<required_reading>
+Read these BEFORE starting, in this order. Paths under {GSD_ROOT} are the
+installed GSD tree (outside your worktree — readable; your sandbox restricts
+writes, not reads). Paths under {ORCH_ROOT} are the orchestrator's checkout.
+- {EXECUTOR_ROLE_FILE}                            (your role definition)
+- {GSD_ROOT}/workflows/execute-plan.md            (your execution contract)
+- {GSD_ROOT}/templates/summary.md                 (SUMMARY.md structure)
+- {GSD_ROOT}/references/checkpoints.md            (checkpoint + tracer gate rules)
+- {GSD_ROOT}/references/tdd.md                    (TDD execution)
+- {GSD_ROOT}/references/worktree-path-safety.md   (cwd-drift and path guards)
+- {ORCH_ROOT}/{phase_dir}/{plan_file}             (your plan)
+- {ORCH_ROOT}/.planning/PROJECT.md                (project context)
+- {ORCH_ROOT}/.planning/STATE.md                  (state)
+- {ORCH_ROOT}/.planning/config.json               (config, if it exists)
+- {ORCH_ROOT}/CLAUDE.md or AGENTS.md              (project instructions, if either exists)
+</required_reading>
+
 <execution_context>
-You are running as an executor in a git worktree GSD created for you. Your
-working directory IS that worktree. Do not cd elsewhere, and do not run any
-git command that targets the main checkout. Use normal git commits WITH hooks.
-Do NOT use --no-verify.
+Your working directory IS the worktree GSD created. Do not cd elsewhere, and do
+not run any git command that targets the main checkout. Use normal git commits
+WITH hooks; do NOT pass --no-verify. execute-plan.md auto-detects worktree mode
+(`.git` is a file) and skips shared-file updates automatically.
 REQUIRED ORDER: Write SUMMARY.md, commit, then any narration.
 </execution_context>
+
+{AGENT_SKILLS_BLOCK}
 
 <success_criteria>
 - [ ] All tasks executed
 - [ ] Each task committed individually
-- [ ] SUMMARY.md created AND committed in the plan directory
-</success_criteria>'
-[ -n "$EXECUTOR_PROMPT" ] || { echo "FATAL: executor prompt is empty for plan {plan_number}." >&2; exit 1; }
+- [ ] SUMMARY.md created in the plan directory, and committed via execute-plan.md's
+      git_commit_metadata step. When that SDK step reports
+      `skipped_gitignored` or `skipped_commit_docs_false`, the skip IS success —
+      record it and move on. NEVER force-stage planning artifacts
+      (`git add -f .planning/...` is forbidden, #3678); an uncommitted SUMMARY.md
+      is rescued by the orchestrator at merge (#2070), not by you.
+</success_criteria>
 ```
 
-The prompt body must contain no single-quote character, since the assignment above is single-quoted; keep apostrophes out of it when editing.
+Substitute `{GSD_ROOT}` with the installed gsd-core root this workflow itself was loaded from (the directory containing `workflows/execute-phase.md`), as an absolute path. The checkpoint gate rule (#3370, in `per-plan-executor-routing.md`) applies here too: add no prompt text refusing or overriding auto-approval for the default `gate="blocking"` — only `blocking-human` always surfaces.
+
+Then load and validate the prompt file — **fail closed on any gap** rather than spawning a reduced-context executor (#3637):
+
+```bash
+PROMPT_FILE="${ORCH_ROOT}/.claude/worktrees/executor-prompt-p{plan_number}.md"
+[ -s "$PROMPT_FILE" ] || { echo "FATAL: executor prompt file missing or empty for plan {plan_number}: $PROMPT_FILE" >&2; exit 1; }
+
+# 1. Identity: the provenance stamp must name THIS plan, phase, and root — a
+#    surviving file from another phase or run passes every structural check
+#    below, so identity is checked first and exactly.
+grep -qF '<provenance>plan {plan_number} of phase {phase_number} at '"$ORCH_ROOT"'</provenance>' "$PROMPT_FILE" || {
+  echo "FATAL: executor prompt at $PROMPT_FILE is not the prompt for plan {plan_number} of phase {phase_number} (stale or foreign provenance stamp). Re-compose it." >&2; exit 1; }
+
+# 1b. Freshness: the provenance stamp cannot distinguish a leftover from a
+#     PREVIOUS attempt of this same plan (same plan, phase, and root). The
+#     wave manifest is initialized at wave start, so any prompt composed for
+#     THIS wave is newer than it — an older file is a stale leftover whose
+#     plan text, skills, or contract paths may have changed since.
+[ "$PROMPT_FILE" -nt "$WAVE_WORKTREE_MANIFEST" ] || {
+  echo "FATAL: executor prompt at $PROMPT_FILE predates this wave's manifest — a leftover from a previous attempt. Re-compose it." >&2; exit 1; }
+
+# 2. Structure: every contract block present AND closed — a truncated compose
+#    can carry every opening tag and still be missing its tail.
+for TAG in '<provenance>' '<role>' '</role>' '<objective>' '</objective>' '<required_reading>' '</required_reading>' '<execution_context>' '</execution_context>' '<success_criteria>' '</success_criteria>' 'skipped_gitignored'; do
+  grep -qF "$TAG" "$PROMPT_FILE" || { echo "FATAL: executor prompt for plan {plan_number} is missing required block: $TAG (see $PROMPT_FILE)" >&2; exit 1; }
+done
+
+# 3. No surviving template text.
+grep -qE '\{(GSD_ROOT|ORCH_ROOT|EXECUTOR_ROLE_FILE|AGENT_SKILLS_BLOCK|phase_dir|plan_file|plan_number|phase_number|phase_name)\}' "$PROMPT_FILE" && {
+  echo "FATAL: executor prompt for plan {plan_number} still contains unexpanded template placeholders (see $PROMPT_FILE)." >&2; exit 1; }
+
+# 4. Contract files must be READABLE now, before anything spawns — this is the
+#    preflight that makes a wrong {GSD_ROOT} or {EXECUTOR_ROLE_FILE}
+#    substitution fail here instead of inside a half-launched executor.
+# Anchor both range delimiters to WHOLE lines: the <role> prose mentions
+# <required_reading> inline, and an unanchored range would open there, feed
+# prose to the entry grep, and reject every valid prompt. Entries are the
+# "- <path>" lines only; the path ends at the 2+ space gap before the
+# parenthesized comment, so a path containing single spaces survives.
+# `tr -d '\r'` first: a prompt written on Windows (or through a CRLF-normalizing
+# tool) leaves a trailing CR that whole-line sed anchors will not match and that
+# would ride into every extracted path, so a perfectly valid prompt would be
+# rejected. Strip once, parse the clean text.
+PROMPT_LF=$(tr -d '\r' < "$PROMPT_FILE")
+RR_BLOCK=$(printf '%s\n' "$PROMPT_LF" | sed -n '/^<required_reading>$/,/^<\/required_reading>$/p')
+for BASE in gsd-executor execute-plan.md summary.md checkpoints.md tdd.md worktree-path-safety.md; do
+  RR_LINE=$(printf '%s\n' "$RR_BLOCK" | grep -E -- "^- .*$BASE" | head -1)
+  [ -n "$RR_LINE" ] || { echo "FATAL: executor prompt for plan {plan_number} lists no required-reading entry for $BASE." >&2; exit 1; }
+  # Strip the leading bullet and ONLY a trailing parenthesized comment — not
+  # every run of spaces. A path may legitimately contain consecutive spaces,
+  # and truncating at the first such run would reject it as unreadable.
+  RR_PATH=$(printf '%s\n' "$RR_LINE" | sed -E 's/^- +//; s/[[:space:]]+\([^()]*\)[[:space:]]*$//; s/[[:space:]]+$//')
+  [ -r "$RR_PATH" ] || { echo "FATAL: required-reading file for $BASE is not readable at: $RR_PATH — the {GSD_ROOT}/{EXECUTOR_ROLE_FILE} substitution is wrong for this install." >&2; exit 1; }
+done
+PLAN_PATH=$(printf '%s\n' "$PROMPT_LF" | grep -m1 '^Plan file: ' | sed 's/^Plan file: //')
+[ -n "$PLAN_PATH" ] && [ -r "$PLAN_PATH" ] || { echo "FATAL: the prompt's plan path is missing or unreadable: '$PLAN_PATH'." >&2; exit 1; }
+
+# 5. Size: one argv argument on every host — Windows caps a command line at
+#    ~32 KiB, so 24000 bytes leaves headroom for the exec argv around it. This
+#    is also the hard backstop against the #2454 persona fallback being inlined.
+PROMPT_BYTES=$(wc -c < "$PROMPT_FILE" | tr -d ' ')
+[ "$PROMPT_BYTES" -lt 24000 ] || { echo "FATAL: executor prompt is $PROMPT_BYTES bytes (cap 24000) — an inline embed (likely the full agent persona) does not fit a single argv argument; large content belongs in <required_reading>." >&2; exit 1; }
+
+EXECUTOR_PROMPT="$(cat "$PROMPT_FILE")"
+echo "Executor prompt for plan {plan_number}: $PROMPT_FILE (${PROMPT_BYTES} bytes; role + contract via preflighted required reading)"
+```
 
 Then create the worktree and resolve the spawn:
 

--- a/gsd-core/workflows/execute-phase/steps/executor-isolation-dispatch.md
+++ b/gsd-core/workflows/execute-phase/steps/executor-isolation-dispatch.md
@@ -220,7 +220,11 @@ grep -qF '<provenance>plan {plan_number} of phase {phase_number} at '"$ORCH_ROOT
 #     wave manifest is initialized at wave start, so any prompt composed for
 #     THIS wave is newer than it — an older file is a stale leftover whose
 #     plan text, skills, or contract paths may have changed since.
-[ "$PROMPT_FILE" -nt "$WAVE_WORKTREE_MANIFEST" ] || {
+# `! -ot` (not OLDER than), not `-nt` (strictly newer): composition can land in
+# the same filesystem timestamp tick as the manifest on a coarse-granularity
+# filesystem, and a strict comparison would then reject a perfectly fresh
+# prompt. Equal is fine; only a genuinely older file is the leftover.
+[ ! "$PROMPT_FILE" -ot "$WAVE_WORKTREE_MANIFEST" ] || {
   echo "FATAL: executor prompt at $PROMPT_FILE predates this wave's manifest — a leftover from a previous attempt. Re-compose it." >&2; exit 1; }
 
 # 2. Structure: every contract block present AND closed — a truncated compose

--- a/tests/codex-config.test.cjs
+++ b/tests/codex-config.test.cjs
@@ -6902,6 +6902,276 @@ describe('#3360 — execute-phase fails closed for unsupported worktree isolatio
       'the adapter header must no longer claim Codex has no worktree mapping — #2584 Phase 3 gave it one');
   });
 });
+
+describe('#3637 — orchestrator-worktree dispatch carries the executor contract', () => {
+  // A process spawn has no `subagent_type`, so nothing on this transport loads
+  // the gsd-executor role for the child. The EXECUTOR_PROMPT template is the
+  // ONLY carrier of the executor identity and execution contract — before
+  // #3637 it was a 5-line hand-written paragraph whose <success_criteria>
+  // demanded an unconditional SUMMARY.md commit, which a process-spawned
+  // executor (never having loaded agents/gsd-executor.md) could only satisfy
+  // on a gitignored .planning/ by the forbidden `git add -f` (#3678).
+  //
+  // Behavioral assertions parsed from the fragment, in the style the triage
+  // brief prescribed: each failed against the pre-#3637 fragment.
+  const FRAGMENT_PATH = path.join(
+    ROOT, 'gsd-core', 'workflows', 'execute-phase', 'steps', 'executor-isolation-dispatch.md',
+  );
+  const fragment = fs.readFileSync(FRAGMENT_PATH, 'utf8');
+
+  /** Slice a tag-delimited section, refusing to produce accidental content when
+   * either delimiter is absent — indexOf() returning -1 must be a loud failure,
+   * not a slice that still happens to match (review finding on this test's v1). */
+  function section(openTag, closeTag) {
+    // Whole-line anchors: the <role> prose MENTIONS other tags inline, and an
+    // unanchored indexOf opens the section at the mention — the exact
+    // mis-anchoring that made v2's bash preflight reject every valid prompt.
+    const { escapeRegex } = require(path.join(ROOT, 'gsd-core', 'bin', 'lib', 'pattern.cjs'));
+    const openRe = new RegExp(`^${escapeRegex(openTag)}$`, 'm');
+    const closeRe = new RegExp(`^${escapeRegex(closeTag)}$`, 'm');
+    const start = fragment.search(openRe);
+    const endMatch = closeRe.exec(fragment);
+    assert.notEqual(start, -1, `fragment must contain ${openTag} on its own line`);
+    assert.ok(endMatch, `fragment must contain ${closeTag} on its own line — an unclosed block is a truncation, not a section`);
+    assert.ok(endMatch.index > start, `${closeTag} must close ${openTag}, not precede it`);
+    return fragment.slice(start, endMatch.index);
+  }
+
+  // ── Executable harness: run the REAL validation block, not a description of it ──
+  //
+  // v1 and v2 of this suite pinned the fragment's text; both times a live
+  // defect stayed green (a vacuous regex, then a preflight that rejected every
+  // valid prompt). The block up to EXECUTOR_PROMPT uses only shell builtins +
+  // grep/sed/awk/wc, so it runs hermetically: extract it verbatim, substitute
+  // the plan/phase placeholders, point ORCH_ROOT and the manifest at a temp
+  // dir, and assert on real exit codes.
+  const { spawnSync: runBash } = require('node:child_process');
+  const { createTempDir } = require('./helpers.cjs');
+
+  function validationBlock() {
+    // Bounded, line-based extraction (no unbounded [\s\S] over file content —
+    // local/no-unbounded-quantifier, and CRLF-safe via splitLines).
+    const { splitLines } = require(path.join(ROOT, 'gsd-core', 'bin', 'lib', 'text-lines.cjs'));
+    const lines = splitLines(fragment);
+    const anchor = lines.findIndex((l) => l.includes('Then load and validate'));
+    assert.notEqual(anchor, -1, 'the fragment must carry the fail-closed validation section');
+    const open = lines.findIndex((l, i) => i > anchor && l.trim() === '```bash');
+    assert.notEqual(open, -1, 'the validation section must carry a bash block');
+    const close = lines.findIndex((l, i) => i > open && l.trim() === '```');
+    assert.notEqual(close, -1, 'the validation bash block must be closed');
+    const m = [null, lines.slice(open + 1, close).join('\n')];
+    assert.ok(m, 'the fragment must carry the fail-closed validation bash block');
+    return m[1];
+  }
+
+  function makeContractFiles(dir) {
+    const names = ['gsd-executor.md', 'execute-plan.md', 'summary.md', 'checkpoints.md', 'tdd.md', 'worktree-path-safety.md'];
+    for (const n of names) fs.writeFileSync(path.join(dir, n), `stub ${n}\n`);
+    fs.writeFileSync(path.join(dir, 'plan.md'), 'stub plan\n');
+    return names;
+  }
+
+  function makeContractFilesIn(dir) {
+    fs.mkdirSync(dir, { recursive: true });
+    for (const n of ['gsd-executor.md', 'execute-plan.md', 'summary.md', 'checkpoints.md', 'tdd.md', 'worktree-path-safety.md']) {
+      fs.writeFileSync(path.join(dir, n), `stub ${n}\n`);
+    }
+  }
+
+  function composePrompt(dir, { plan = '7', phase = '2', root = dir, breakEntry = null, pad = 0, dropTail = false, leavePlaceholder = false, crlf = false, contractDir = null } = {}) {
+    const cdir = contractDir || dir;
+    const rr = [
+      `- ${breakEntry === 'gsd-executor' ? '/nonexistent-3637/gsd-executor.md' : path.join(cdir, 'gsd-executor.md')}                (your role definition)`,
+      `- ${path.join(cdir, 'execute-plan.md')}            (your execution contract)`,
+      `- ${path.join(cdir, 'summary.md')}                 (SUMMARY.md structure)`,
+      `- ${path.join(cdir, 'checkpoints.md')}             (checkpoint + tracer gate rules)`,
+      `- ${path.join(cdir, 'tdd.md')}                     (TDD execution)`,
+      `- ${path.join(cdir, 'worktree-path-safety.md')}    (cwd-drift and path guards)`,
+    ].join('\n');
+    let body = `<provenance>plan ${plan} of phase ${phase} at ${root}</provenance>\n\n`
+      // The role prose deliberately reproduces the real template's trap: an
+      // INLINE mention of <required_reading> plus the strings gsd-executor and
+      // execute-plan.md in running text. v2's unanchored sed/grep opened the
+      // section at this line and extracted prose as a "path" — a faithful
+      // fixture is what lets this harness catch that class of bug.
+      + `<role>\nYou are the gsd-executor agent. Read every file in <required_reading> below - the\ngsd-executor definition and execute-plan.md are your execution contract.\n</role>\n\n`
+      + `<objective>\nExecute plan ${plan}.\nPlan file: ${path.join(dir, 'plan.md')}\n</objective>\n\n`
+      + `<required_reading>\n${rr}\n</required_reading>\n\n`
+      + `<execution_context>\nworktree rules\n</execution_context>\n\n`
+      + `<success_criteria>\n- [ ] skipped_gitignored is success${leavePlaceholder ? ' at {GSD_ROOT}' : ''}\n</success_criteria>\n`;
+    if (dropTail) body = body.slice(0, body.indexOf('</required_reading>'));
+    if (pad > 0) body += `\n<!-- ${'x'.repeat(pad)} -->\n`;
+    if (crlf) body = body.split('\n').join('\r\n');
+    fs.writeFileSync(path.join(dir, 'executor-prompt-p7.md'), body);
+  }
+
+  function runValidation(dir, { plan = '7', phase = '2' } = {}) {
+    const script = 'set -u\n'
+      + `ORCH_ROOT=${JSON.stringify(dir)}\n`
+      + `WAVE_WORKTREE_MANIFEST=${JSON.stringify(path.join(dir, 'manifest.json'))}\n`
+      + `mkdir -p "$ORCH_ROOT/.claude/worktrees"\n`
+      + `cp -p ${JSON.stringify(path.join(dir, 'executor-prompt-p7.md'))} "$ORCH_ROOT/.claude/worktrees/executor-prompt-p7.md" 2>/dev/null || true\n`
+      + validationBlock().replaceAll('{plan_number}', plan).replaceAll('{phase_number}', phase)
+      + '\nprintf VALIDATED';
+    return runBash('bash', ['-c', script], { encoding: 'utf8', timeout: 15_000 });
+  }
+
+  function freshDir(t, opts) {
+    const dir = createTempDir('prohib-3637-');
+    t.after(() => cleanup(dir));
+    fs.writeFileSync(path.join(dir, 'manifest.json'), '{}\n');
+    makeContractFiles(dir);
+    composePrompt(dir, opts); // written AFTER the manifest -> fresh by mtime
+    return dir;
+  }
+
+  test('EXECUTABLE: a well-formed prompt passes the real validation block', (t) => {
+    const dir = freshDir(t, {});
+    const r = runValidation(dir);
+    assert.equal(r.status, 0, `valid prompt must pass; stderr: ${r.stderr}`);
+    assert.match(r.stdout, /VALIDATED/, 'the block must fall through to the spawn, not exit early');
+  });
+
+  test('EXECUTABLE: truncation, foreign identity, unreadable root, oversize, and placeholders each fail closed', (t) => {
+    const cases = [
+      ['truncated (no closing tags)', { dropTail: true }, {}],
+      ['foreign provenance (other plan)', { plan: '9' }, {}],
+      ['unreadable role-file root', { breakEntry: 'gsd-executor' }, {}],
+      ['oversized (argv cap)', { pad: 25_000 }, {}],
+      ['surviving template placeholder', { leavePlaceholder: true }, {}],
+    ];
+    for (const [label, composeOpts, runOpts] of cases) {
+      const dir = freshDir(t, composeOpts);
+      const r = runValidation(dir, runOpts);
+      assert.notEqual(r.status, 0, `${label}: must fail closed`);
+      assert.doesNotMatch(r.stdout || '', /VALIDATED/, `${label}: must never reach the spawn`);
+      assert.match(r.stderr || '', /FATAL/, `${label}: must name the failure`);
+    }
+  });
+
+  test('EXECUTABLE: a CRLF prompt is accepted, not rejected as malformed', (t) => {
+    // Windows checkouts / CRLF-normalizing tooling leave a trailing \r that
+    // whole-line sed anchors do not match and that rides into every extracted
+    // path — a valid prompt would be rejected. Regression guard for that.
+    const dir = createTempDir('prohib-3637-');
+    t.after(() => cleanup(dir));
+    fs.writeFileSync(path.join(dir, 'manifest.json'), '{}\n');
+    makeContractFiles(dir);
+    composePrompt(dir, { crlf: true });
+    const raw = fs.readFileSync(path.join(dir, 'executor-prompt-p7.md'), 'utf8');
+    assert.ok(raw.includes('\r\n'), 'fixture must actually be CRLF or it proves nothing');
+    const r = runValidation(dir);
+    assert.equal(r.status, 0, `a CRLF prompt must pass; stderr: ${r.stderr}`);
+    assert.match(r.stdout, /VALIDATED/);
+  });
+
+  test('EXECUTABLE: a contract path containing consecutive spaces is not truncated', (t) => {
+    // The entry lines pad with 2+ spaces before their parenthesized comment, so
+    // a naive "cut at the first double space" strip silently truncates any path
+    // that legitimately contains one — rejecting a valid install.
+    const dir = createTempDir('prohib-3637-');
+    t.after(() => cleanup(dir));
+    fs.writeFileSync(path.join(dir, 'manifest.json'), '{}\n');
+    makeContractFiles(dir);
+    const spacey = path.join(dir, 'gsd  core');
+    makeContractFilesIn(spacey);
+    composePrompt(dir, { contractDir: spacey });
+    const r = runValidation(dir);
+    assert.equal(r.status, 0, `a path with consecutive spaces must pass; stderr: ${r.stderr}`);
+    assert.match(r.stdout, /VALIDATED/);
+  });
+
+  test('EXECUTABLE: a leftover prompt from a previous attempt fails freshness', (t) => {
+    const dir = createTempDir('prohib-3637-');
+    t.after(() => cleanup(dir));
+    makeContractFiles(dir);
+    composePrompt(dir, {}); // prompt FIRST...
+    const past = new Date(Date.now() - 60_000);
+    fs.utimesSync(path.join(dir, 'executor-prompt-p7.md'), past, past);
+    fs.writeFileSync(path.join(dir, 'manifest.json'), '{}\n'); // ...manifest AFTER -> prompt is stale
+    const r = runValidation(dir);
+    assert.notEqual(r.status, 0, 'a prompt older than this wave manifest is a stale leftover and must fail');
+    assert.match(r.stderr || '', /predates this wave/, 'the failure must name staleness');
+  });
+
+  test('the prompt template carries a required_reading block that pulls in the role file and execute-plan.md', () => {
+    const rr = section('<required_reading>', '</required_reading>');
+    assert.match(rr, /\{EXECUTOR_ROLE_FILE\}/,
+      'the installed gsd-executor definition is how the full role substance reaches the child — it must lead the required reading');
+    assert.match(rr, /execute-plan\.md/,
+      'execute-plan.md is the self-contained executor contract for paths where the agent file is never loaded — it must be in the required reading');
+  });
+
+  test('the prompt template declares the executor role, not a generic process', () => {
+    const role = section('<role>', '</role>');
+    assert.match(role, /gsd-executor agent/,
+      'the role block must name the gsd-executor identity');
+    const obj = section('<objective>', '</objective>');
+    assert.match(obj, /\{plan_file\}/,
+      'the executor must receive an explicit plan path, not reconstruct it by inference');
+  });
+
+  test('success criteria accommodate skipped_gitignored instead of demanding an unconditional commit', () => {
+    const sc = section('<success_criteria>', '</success_criteria>');
+    assert.match(sc, /skipped_gitignored/,
+      'a process-spawned executor has no other way to know the gitignored-planning skip is sanctioned (#3678)');
+    assert.doesNotMatch(sc, /SUMMARY\.md created AND committed/,
+      'the unconditional commit demand is what drove executors to git add -f — it must not return');
+  });
+
+  test('dispatch fails closed when the composed prompt is reduced, stale, unreadable, or oversized', () => {
+    // The bash validation is the executable half of #3637's fix — pin its
+    // text and its ORDER, not just the English around it. A regression that
+    // restores the old hand-written prompt as the launch input while leaving
+    // the template as prose must fail here (review finding on this test's v1).
+    assert.match(fragment, /\[ -s "\$PROMPT_FILE" \]/,
+      'an absent or empty prompt file must halt the dispatch');
+    // Closing tags in the TAG loop: a truncated compose carries every opening tag.
+    for (const tag of ['<role>', '</role>', '</required_reading>', '</success_criteria>', 'skipped_gitignored']) {
+      assert.ok(fragment.includes(`'${tag}'`),
+        `the fail-closed loop must verify the composed prompt carries ${tag}`);
+    }
+    assert.match(fragment, /<provenance>plan \{plan_number\} of phase \{phase_number\}/,
+      'the identity stamp is what makes a stale prompt from another phase fail instead of pass structurally');
+    assert.match(fragment, /\[ -r "\$RR_PATH" \]/,
+      'every contract file must be preflighted READABLE before spawn — a wrong {GSD_ROOT} fails here, not inside a half-launched executor');
+    assert.match(fragment, /-lt 24000/,
+      'the argv byte cap is the hard backstop for the Windows command-line limit and the #2454 persona-fallback inline');
+    assert.match(fragment, /EXECUTOR_PROMPT="\$\(cat "\$PROMPT_FILE"\)"/,
+      'the spawned prompt must be sourced from the file the validation just checked — nothing else');
+    assert.match(fragment, /unexpanded template placeholders/,
+      'surviving {placeholder} text must halt the dispatch, not ride into the spawn');
+    // ORDER: every validation must run before the worktree is created, so a bad
+    // prompt costs nothing and needs no teardown.
+    const validationAt = fragment.indexOf('[ -s "$PROMPT_FILE" ]');
+    const worktreeCreateAt = fragment.indexOf('worktree.create');
+    assert.ok(validationAt !== -1 && worktreeCreateAt !== -1 && validationAt < worktreeCreateAt,
+      'prompt validation must precede worktree.create');
+  });
+
+  test('the persona fallback cannot be inlined: AGENT_SKILLS_BLOCK is scoped and capped', () => {
+    // On AGENTS-native runtimes an unconfigured `query agent-skills` injects the
+    // full installed persona (#2454, ~49 KiB) — over the Windows argv cap by
+    // itself. The template must scope the block to configured custom skills and
+    // route the persona through {EXECUTOR_ROLE_FILE} in required reading.
+    assert.match(fragment, /\{AGENT_SKILLS_BLOCK\}/,
+      'the skills slot must be the scoped block, not a bare ${AGENT_SKILLS} expansion');
+    assert.doesNotMatch(fragment, /\n\$\{AGENT_SKILLS\}\n/,
+      'a bare ${AGENT_SKILLS} line in the template is the config-dependent silent reduction the review found');
+    assert.match(fragment, /substitute the EMPTY string/,
+      'the unconfigured case must be the empty string, never the persona fallback');
+  });
+
+  test('the fragment no longer claims the prompt is the harness text kept verbatim', () => {
+    // The pre-#3637 prose said the prompt keeps the harness execution context
+    // "verbatim" while shipping a 5-line paraphrase — the claim itself was the
+    // sync-gap's camouflage (triage: inaccurate since 6ad30f74b).
+    assert.doesNotMatch(fragment, /keep .objective., the execution context, and .success_criteria. verbatim/,
+      'the false verbatim claim must not survive');
+    assert.doesNotMatch(fragment, /same prompt text the harness path.s .Agent\(\). call uses/,
+      'the companion claim — that this prompt IS the harness text — must not survive either');
+  });
+});
   });
 }
 

--- a/tests/codex-config.test.cjs
+++ b/tests/codex-config.test.cjs
@@ -7021,7 +7021,12 @@ describe('#3637 — orchestrator-worktree dispatch carries the executor contract
     t.after(() => cleanup(dir));
     fs.writeFileSync(path.join(dir, 'manifest.json'), '{}\n');
     makeContractFiles(dir);
-    composePrompt(dir, opts); // written AFTER the manifest -> fresh by mtime
+    composePrompt(dir, opts);
+    // Backdate the MANIFEST explicitly rather than relying on write order:
+    // both files land in the same filesystem tick on a fast Linux runner, and
+    // a fixture whose freshness depends on tick luck is a flake, not a test.
+    const past = new Date(Date.now() - 60_000);
+    fs.utimesSync(path.join(dir, 'manifest.json'), past, past);
     return dir;
   }
 
@@ -7058,6 +7063,8 @@ describe('#3637 — orchestrator-worktree dispatch carries the executor contract
     fs.writeFileSync(path.join(dir, 'manifest.json'), '{}\n');
     makeContractFiles(dir);
     composePrompt(dir, { crlf: true });
+    const past0 = new Date(Date.now() - 60_000);
+    fs.utimesSync(path.join(dir, 'manifest.json'), past0, past0);
     const raw = fs.readFileSync(path.join(dir, 'executor-prompt-p7.md'), 'utf8');
     assert.ok(raw.includes('\r\n'), 'fixture must actually be CRLF or it proves nothing');
     const r = runValidation(dir);
@@ -7076,8 +7083,27 @@ describe('#3637 — orchestrator-worktree dispatch carries the executor contract
     const spacey = path.join(dir, 'gsd  core');
     makeContractFilesIn(spacey);
     composePrompt(dir, { contractDir: spacey });
+    const past1 = new Date(Date.now() - 60_000);
+    fs.utimesSync(path.join(dir, 'manifest.json'), past1, past1);
     const r = runValidation(dir);
     assert.equal(r.status, 0, `a path with consecutive spaces must pass; stderr: ${r.stderr}`);
+    assert.match(r.stdout, /VALIDATED/);
+  });
+
+  test('EXECUTABLE: an equal-mtime prompt is fresh, not stale (coarse-granularity filesystems)', (t) => {
+    // The CI-caught case: on a fast Linux runner the manifest and the prompt
+    // land in the same timestamp tick, and a strict `-nt` rejects a perfectly
+    // fresh prompt. Pin the boundary explicitly rather than leaving it to luck.
+    const dir = createTempDir('prohib-3637-');
+    t.after(() => cleanup(dir));
+    fs.writeFileSync(path.join(dir, 'manifest.json'), '{}\n');
+    makeContractFiles(dir);
+    composePrompt(dir, {});
+    const same = new Date(Date.now() - 5_000);
+    fs.utimesSync(path.join(dir, 'manifest.json'), same, same);
+    fs.utimesSync(path.join(dir, 'executor-prompt-p7.md'), same, same);
+    const r = runValidation(dir);
+    assert.equal(r.status, 0, `equal mtimes must be treated as fresh; stderr: ${r.stderr}`);
     assert.match(r.stdout, /VALIDATED/);
   });
 


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3637

---

## What was broken

A process spawn has no `subagent_type`, so nothing on the `orchestrator-worktree` transport loads the `gsd-executor` role for the child. The `EXECUTOR_PROMPT` was a five-line hand-written paragraph — while the fragment claimed it kept the harness path's execution context *"verbatim"* — so spawned executors started as generic models and reconstructed their role by inference.

The coupled defect made that worse: the prompt's own `<success_criteria>` demanded *"SUMMARY.md created AND committed"* unconditionally. An executor that never loaded `agents/gsd-executor.md` has no way to know the gitignored-planning skip is sanctioned, so `git add -f .planning/...` — explicitly forbidden, #3678 — is the locally-consistent way to satisfy its launch instruction.

Not Codex-only: `codex`, `kimi`, `kimi-code` and `opencode` all negotiate this backend.

## What this fix does

The prompt is composed to a file — `${ORCH_ROOT}/.claude/worktrees/executor-prompt-p{plan_number}.md`, which persists past cleanup as inspectable provenance — from a template carrying `<role>` (the executor identity, this transport's substitute for `subagent_type`), an explicit plan path, `<required_reading>`, `<execution_context>`, a scoped skills slot, and success criteria that sanction `skipped_gitignored`, forbid `git add -f`, and name the orchestrator's #2070 rescue.

A bash block then validates it and **fails closed before `worktree.create`**, so a bad prompt costs nothing and needs no teardown.

## Root cause

`6ad30f74b` (#2584 Phase 3) shipped the backend and its prompt together and never kept the prompt in sync; the "verbatim" claim has been inaccurate since that commit. `5452f1a70` (#3324) then widened the gap by enriching only the harness path.

## Design note — why mandate-read rather than inline

The harness path build-time-embeds five files. That cannot ride this transport: the prompt travels as **one argv argument** and Windows caps a command line at ~32 KiB. So the small, contract-critical text is inline and the large execution context is mandatory first reads — a process-spawned executor, unlike an `Agent()` prompt (#3324's `@`-include problem), *can* read files.

The role's full substance rides `{EXECUTOR_ROLE_FILE}` (the installed `gsd-executor` definition) in required reading, **not** an inline `${AGENT_SKILLS}` expansion. That distinction is load-bearing: on AGENTS-native runtimes an unconfigured `agent-skills` query falls back to injecting the whole ~49 KiB persona (#2454) — over the argv cap by itself — while a *configured* custom-skills block silently drops the persona. `{AGENT_SKILLS_BLOCK}` is the configured block or the empty string, with a hard 24000-byte cap backstopping both.

## Testing

### How I verified

**Fail-first:** all 11 tests red against `upstream/next`'s fragment, green after.

**Executable, not descriptive.** Two earlier versions of this suite pinned the fragment's *text*, and each time a live defect stayed green — first a vacuous regex, then a preflight that would have rejected **every** valid prompt in production. The tests now extract the real validation bash block from the fragment, compose fixture prompts in a temp dir, run the block, and assert exit codes. The well-formed fixture deliberately reproduces the template's trap (an inline `<required_reading>` mention plus `gsd-executor` and `execute-plan.md` in the role prose) — that is what makes the harness able to catch this class at all.

Each guard is mutation-verified — reintroduce the defect, watch the specific test go red, restore, watch it pass:

| guard | mutation that must red it |
|---|---|
| whole-line RR anchors | unanchored `sed` → extracts prose, fails with `not readable at: You` |
| comment-only path strip | cut-at-`{2,}`-spaces → truncates a path containing consecutive spaces |
| `tr -d '\r'` | remove it → a CRLF prompt is rejected as malformed |
| provenance stamp | — foreign plan/phase/root fails identity |
| freshness (`-nt` manifest) | — a leftover from a previous attempt of the *same* plan fails |
| closing tags in the TAG loop | — a truncated compose carries every opening tag |
| readability preflight | — a wrong `{GSD_ROOT}` fails pre-spawn |
| 24000-byte cap | — an inlined persona fails |

**Suites:** `lint:ci` exit 0; `eslint` clean (the first harness tripped `local/no-adhoc-regex-escape`, `no-unbounded-quantifier` and `no-crlf-fragile-split` — now routed through the shipped `escapeRegex`/`splitLines`); `emitted-attribution` passes; full `npm test` 30725 / 30707 — remaining failures are the two long-standing `capability-state` ones and `plugin-manifest` C/C2 (issue #3613, PR #3627, not yet on `next`).

### Regression test added?

- [x] Yes — 11 tests in `tests/codex-config.test.cjs`, which already owns this fragment's contracts

### Platforms tested

- [x] macOS
- [ ] Windows (CRLF prompt handling is covered by an executable fixture; the argv cap is enforced by the byte check)
- [ ] Linux (this PR's CI lanes)

### Runtimes tested

- [x] N/A — the fragment is shared by all four `orchestrator-worktree` runtimes; the fix is transport-level, not runtime-specific

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug
- [x] Regression test added
- [x] All existing tests pass — remaining failures pre-existing and named above
- [ ] `.changeset/` fragment — follow-up commit once the PR number exists
- [x] No unnecessary dependencies added

## Breaking changes

None to verdict or merge semantics. Behavior changes only in what the spawned executor receives, which is the point. One deliberate follow-up left open per the brief: **provenance file cleanup** — `executor-prompt-p*.md` files persist in `.claude/worktrees/` by design (inspectability), and pruning policy is a separate call.

## Out of scope, per the brief

Worktree create/merge/cleanup mechanics, `harness-worktree` and `none` isolation, and any upstream Codex CLI change — the fix works within Codex's current process-spawn constraints.
