### PR TITLE
fix(#3611): decode entity-escaped ampersands and split shell segments quote-aware

### DIFF
--- a/.changeset/zesty-ibex-chatter.md
+++ b/.changeset/zesty-ibex-chatter.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 3693
 ---
 **`verify plan-structure` no longer false-flags positively-asserted literals in entity-escaped verify chains** — planners emit `&amp;&amp;` as the chain operator, which the negative-grep gate's segment splitter did not recognize, so a `= 0` clause poisoned `-ge 3` clauses joined to it and pushed authors toward suppressing a real gate. The gate now scans the decoded text the shell would actually run. (#3611)

--- a/.changeset/zesty-ibex-chatter.md
+++ b/.changeset/zesty-ibex-chatter.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`verify plan-structure` no longer false-flags positively-asserted literals in entity-escaped verify chains** — planners emit `&amp;&amp;` as the chain operator, which the negative-grep gate's segment splitter did not recognize, so a `= 0` clause poisoned `-ge 3` clauses joined to it and pushed authors toward suppressing a real gate. The gate now scans the decoded text the shell would actually run. (#3611)

--- a/src/verify.cts
+++ b/src/verify.cts
@@ -294,10 +294,18 @@ function scanNegativeGrepCommentEcho(content: string): { errors: string[]; warni
   const warnings: string[] = [];
   // Normalize newlines; join backslash line-continuations so a verify command wrapped
   // across lines (grep ... \ <newline> == 0) is still seen as one segment.
+  // #3611: decode entity-escaped ampersands (&amp; → &) before any downstream
+  // scanning. Planners emit <automated> bodies with `&amp;&amp;` as the chain
+  // operator (66 occurrences vs 0 literal `&&` in the reporting repo), and the
+  // shell itself only ever sees the decoded form — the segment split, the
+  // zero-comparison, the count-grep literal harvest, and the action-echo scan
+  // must all operate on the same decoded text or a negative clause (`= 0`)
+  // poisons the literals of a POSITIVE clause (-ge 3) joined to it.
   const text = (content || '')
     .replace(/\r\n/g, '\n')
     .replace(/\r/g, '\n')
-    .replace(/\\\n/g, ' ');
+    .replace(/\\\n/g, ' ')
+    .replace(/&amp;/g, '&');
 
   // 1. Allowlisted literals: <!-- planner-discipline-allow: LIT -->
   const allow = new Set<string>();

--- a/src/verify.cts
+++ b/src/verify.cts
@@ -289,23 +289,78 @@ function cmdVerifySummary(
  * verify gate fails on the comment echo rather than a real regression. Conservative:
  * errors only on a confidently-extracted QUOTED literal; ambiguous (bareword) → warning.
  */
+/**
+ * Decode entity-escaped ampersands (&amp; → &) — #3611. Planners emit
+ * <automated> bodies with `&amp;&amp;` as the chain operator (66 occurrences
+ * vs 0 literal in the reporting repo), and the executing agent reads the
+ * decoded (rendered) form. Every downstream scan — segment split,
+ * zero-comparison, literal harvest, echo matching — must operate on the same
+ * decoded text or a negative clause (`= 0`) poisons the literals of a
+ * POSITIVE clause (-ge 3) joined to it. Shared by both plan-discipline
+ * scanners so the two gates cannot drift apart again.
+ */
+function decodeEntityAmps(s: string): string {
+  return s.replace(/&amp;/g, '&');
+}
+
+/**
+ * Split one shell line into &&/|| segments, QUOTE-AWARE (#3611 adversarial
+ * review): an operator inside a quoted literal (`grep -c 'a&&b'`) is part of
+ * the pattern, not a chain operator — a quote-blind split destroys the
+ * literal and silently disarms the gate for exactly the plans that spell
+ * patterns with ampersands. Backslash escapes count inside double quotes
+ * (POSIX single quotes have none, and over-staying a single-quoted span can
+ * only miss a split, never invent one).
+ */
+function splitShellSegments(line: string): string[] {
+  const segments: string[] = [];
+  let current = '';
+  let quote: string | null = null;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (quote === "'") {
+      if (ch === "'") quote = null;
+      current += ch;
+      continue;
+    }
+    if (quote === '"') {
+      if (ch === '\\') {
+        current += ch + (line[i + 1] ?? '');
+        i++;
+        continue;
+      }
+      if (ch === '"') quote = null;
+      current += ch;
+      continue;
+    }
+    if (ch === "'" || ch === '"') {
+      quote = ch;
+      current += ch;
+      continue;
+    }
+    if ((ch === '&' && line[i + 1] === '&') || (ch === '|' && line[i + 1] === '|')) {
+      segments.push(current.trim());
+      current = '';
+      i++;
+      continue;
+    }
+    current += ch;
+  }
+  segments.push(current.trim());
+  return segments.filter((s) => s !== '');
+}
+
 function scanNegativeGrepCommentEcho(content: string): { errors: string[]; warnings: string[] } {
   const errors: string[] = [];
   const warnings: string[] = [];
   // Normalize newlines; join backslash line-continuations so a verify command wrapped
   // across lines (grep ... \ <newline> == 0) is still seen as one segment.
-  // #3611: decode entity-escaped ampersands (&amp; → &) before any downstream
-  // scanning. Planners emit <automated> bodies with `&amp;&amp;` as the chain
-  // operator (66 occurrences vs 0 literal `&&` in the reporting repo), and the
-  // shell itself only ever sees the decoded form — the segment split, the
-  // zero-comparison, the count-grep literal harvest, and the action-echo scan
-  // must all operate on the same decoded text or a negative clause (`= 0`)
-  // poisons the literals of a POSITIVE clause (-ge 3) joined to it.
-  const text = (content || '')
+  // #3611: decode entity-escaped ampersands (see decodeEntityAmps) so every
+  // downstream scan reads the same decoded text the executing agent reads.
+  const text = decodeEntityAmps((content || '')
     .replace(/\r\n/g, '\n')
     .replace(/\r/g, '\n')
-    .replace(/\\\n/g, ' ')
-    .replace(/&amp;/g, '&');
+    .replace(/\\\n/g, ' '));
 
   // 1. Allowlisted literals: <!-- planner-discipline-allow: LIT -->
   const allow = new Set<string>();
@@ -356,7 +411,7 @@ function scanNegativeGrepCommentEcho(content: string): { errors: string[]; warni
   //    poisoning a negative gate (`== 0`) sharing the same physical line.
   const seenErr = new Set<string>();
   const seenWarn = new Set<string>();
-  const segments = text.split('\n').flatMap((line) => line.split(/\s*(?:&&|\|\|)\s*/));
+  const segments = text.split('\n').flatMap(splitShellSegments);
   for (const seg of segments) {
     if (!/grep(?:\s+-{1,2}[A-Za-z])/.test(seg) || !zeroCmp(seg)) continue;
     countGrepRe.lastIndex = 0;
@@ -404,10 +459,13 @@ function scanFileWideNegativeGateConflict(content: string): { warnings: string[]
   const warnings: string[] = [];
 
   // Normalize newlines; join backslash line-continuations (same as #429).
-  const text = (content || '')
+  // #3611: the SAME entity decode as the #429 scanner — the two gates share
+  // the caller and the input; a decode on one side only let an entity-escaped
+  // chain poison this detector's harvest exactly the same way.
+  const text = decodeEntityAmps((content || '')
     .replace(/\r\n/g, '\n')
     .replace(/\r/g, '\n')
-    .replace(/\\\n/g, ' ');
+    .replace(/\\\n/g, ' '));
 
   // Allowlisted patterns: <!-- planner-region-allow: PAT -->
   const allow = new Set<string>();
@@ -555,10 +613,8 @@ function scanFileWideNegativeGateConflict(content: string): { warnings: string[]
   for (let ai = 0; ai < tasks.length; ai++) {
     const taskA = tasks[ai];
 
-    // Split gate text into shell segments (split on && / || within lines).
-    const segments = taskA.gateText.split('\n').flatMap(line =>
-      line.split(/\s*(?:&&|\|\|)\s*/),
-    );
+    // Split gate text into shell segments (quote-aware, shared with #429 — #3611).
+    const segments = taskA.gateText.split('\n').flatMap(splitShellSegments);
 
     for (const seg of segments) {
       if (!/grep/.test(seg)) continue;

--- a/tests/verify.test.cjs
+++ b/tests/verify.test.cjs
@@ -2737,6 +2737,24 @@ describe('scanFileWideNegativeGateConflict — pure unit tests', () => {
   });
 
   // Case 2: region-scoped via sed → NO warn
+  test('case 1b — entity-escaped chain: positive clause pattern must not be harvested as a file-wide ban (#3611)', () => {
+    // Task A bans banned_thing file-wide (== 0) AND positively asserts
+    // required_thing (-ge 1), joined by &amp;&amp;. Task B mentions only
+    // required_thing. Pre-fix, the literal-only split kept the chain as ONE
+    // segment: zeroCmp saw the == 0 and the harvest took BOTH patterns,
+    // falsely warning that B conflicts with a file-wide ban on required_thing.
+    const content = makeTwoTaskPlan({
+      taskAGate: "grep -c 'banned_thing' app/page.py == 0 &amp;&amp; grep -c 'required_thing' app/page.py -ge 1",
+      taskBAction: 'Introduce required_thing usage the plan asserts positively.',
+    });
+    const result = scan(content);
+    assert.strictEqual(
+      result.warnings.filter(w => w.includes('#968')).length,
+      0,
+      `a positively-asserted pattern (-ge 1) joined by &amp;&amp; must not warn as a file-wide ban, got: ${JSON.stringify(result.warnings)}`,
+    );
+  });
+
   test('case 2 — region-scoped via sed pipe → NO warn', () => {
     const content = makeTwoTaskPlan({
       taskAGate: "! sed -n '12,40p' app/page.py | grep -Eq 'await .*refresh'",
@@ -4269,7 +4287,40 @@ describe('scanNegativeGrepCommentEcho — pure unit tests', () => {
     const verify = require(VERIFY_CJS);
     const result = verify.scanNegativeGrepCommentEcho(lines);
     assert.strictEqual(result.errors.length, 1, `the entity-bearing literal must still flag its action echo, got: ${JSON.stringify(result.errors)}`);
-    assert.ok(result.errors[0].includes('a'), `error must carry the decoded literal, got: ${result.errors[0]}`);
+    assert.ok(result.errors[0].includes('a&b'), `error must carry the decoded literal a&b, got: ${result.errors[0]}`);
+  });
+
+  test('case 12d — a quoted literal CONTAINING && is not shattered by the segment split (#3611 review)', () => {
+    // A negative grep banning a boolean shape (`grep -c 'a&&b' f == 0`) and an
+    // action echo mentioning a&&b. The split must be quote-aware: splitting on
+    // the operator inside the quotes would destroy the literal and silently
+    // disarm the gate — exactly the plans that spell patterns with ampersands.
+    const lines = [
+      '---',
+      'phase: 01-test',
+      'plan: 01',
+      'type: execute',
+      'wave: 1',
+      'depends_on: []',
+      'files_modified: [file.ts]',
+      'autonomous: true',
+      'must_haves:',
+      '  - AC1',
+      '---',
+      '',
+      '<task>',
+      '<name>Quoted operator literal task</name>',
+      '<action>',
+      'Remove the a&&b join.',
+      '</action>',
+      "<verify><automated>grep -c 'a&&b' f == 0</automated></verify>",
+      '<done>Done</done>',
+      '</task>',
+    ].join('\n');
+    const verify = require(VERIFY_CJS);
+    const result = verify.scanNegativeGrepCommentEcho(lines);
+    assert.strictEqual(result.errors.length, 1, `the quoted a&&b literal must still flag its action echo, got: ${JSON.stringify(result.errors)}`);
+    assert.ok(result.errors[0].includes('a&&b'), `error must carry the intact literal, got: ${result.errors[0]}`);
   });
 
   test('case 13 — grep -c -F (separate count+fixed flags) extracts literal', () => {

--- a/tests/verify.test.cjs
+++ b/tests/verify.test.cjs
@@ -4204,6 +4204,74 @@ describe('scanNegativeGrepCommentEcho — pure unit tests', () => {
     assert.ok(!result.errors[0].includes('presentTok'), `error must NOT name presentTok, got: ${result.errors[0]}`);
   });
 
+  test('case 12b — mixed gates joined by entity-escaped &amp;&amp;: no false positive for the positive token (#3611)', () => {
+    // #3611: planners emit <automated> bodies with the ampersands entity-escaped
+    // (&amp;&amp;). The literal-only segment splitter did not match that spelling,
+    // so the negative clause's `= 0` poisoned count-grep literals from the
+    // POSITIVE clause in the same chain — a `-ge 3` literal flagged as forbidden.
+    // Identical to case 12 except for the ampersand spelling.
+    const lines = [
+      '---',
+      'phase: 01-test',
+      'plan: 01',
+      'type: execute',
+      'wave: 1',
+      'depends_on: []',
+      'files_modified: [file.ts]',
+      'autonomous: true',
+      'must_haves:',
+      '  - AC1',
+      '---',
+      '',
+      '<task>',
+      '<name>Entity-escaped chain task</name>',
+      '<action>',
+      'Use presentTok for the new pattern.',
+      'Do not use absentTok any more.',
+      '</action>',
+      "<verify><automated>test \"$(grep -c 'absentTok' f)\" = 0 &amp;&amp; test \"$(grep -c 'presentTok' f)\" -ge 3</automated></verify>",
+      '<done>Done</done>',
+      '</task>',
+    ].join('\n');
+    const verify = require(VERIFY_CJS);
+    const result = verify.scanNegativeGrepCommentEcho(lines);
+    assert.strictEqual(result.errors.length, 1, `expected exactly 1 error (absentTok only), got: ${JSON.stringify(result.errors)}`);
+    assert.ok(result.errors[0].includes('absentTok'), `error must name absentTok, got: ${result.errors[0]}`);
+    assert.ok(!result.errors[0].includes('presentTok'), `a positively-asserted literal (-ge 3) must never be flagged regardless of ampersand spelling, got: ${result.errors[0]}`);
+  });
+
+  test('case 12c — entity-escaped literals and action echoes decode consistently (#3611)', () => {
+    // A literal that itself contains &amp; (e.g. "a&amp;b" as the grep pattern)
+    // and an action echo carrying the same entity spelling must still match
+    // after the decode — the flag stays correct for entity-bearing literals.
+    const lines = [
+      '---',
+      'phase: 01-test',
+      'plan: 01',
+      'type: execute',
+      'wave: 1',
+      'depends_on: []',
+      'files_modified: [file.ts]',
+      'autonomous: true',
+      'must_haves:',
+      '  - AC1',
+      '---',
+      '',
+      '<task>',
+      '<name>Entity literal task</name>',
+      '<action>',
+      'Remove the old a&amp;b join.',
+      '</action>',
+      "<verify><automated>grep -c 'a&amp;b' f == 0</automated></verify>",
+      '<done>Done</done>',
+      '</task>',
+    ].join('\n');
+    const verify = require(VERIFY_CJS);
+    const result = verify.scanNegativeGrepCommentEcho(lines);
+    assert.strictEqual(result.errors.length, 1, `the entity-bearing literal must still flag its action echo, got: ${JSON.stringify(result.errors)}`);
+    assert.ok(result.errors[0].includes('a'), `error must carry the decoded literal, got: ${result.errors[0]}`);
+  });
+
   test('case 13 — grep -c -F (separate count+fixed flags) extracts literal', () => {
     // Bug 2: grep -c -F 'LIT' was not extracted by the old regex that required -c
     // immediately before the pattern without intervening flags.


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3611

## What was broken

`verify plan-structure`'s negative-grep discipline gate split verify commands into shell segments on **literal** `&&`/`||` only. Planners emit `<automated>` bodies with the ampersands entity-escaped (`&amp;&amp;` — the reporting repo: 66 occurrences, 0 literal), so a mixed chain collapsed into ONE segment and the negative clause's `= 0` poisoned count-grep literals from the **positively-asserted** clauses (`-ge 3`) — false "forbidden literal" errors that pushed authors toward suppressing a real gate (`planner-discipline-allow`) or contorting correct greps.

## What this fix does

- **Decode once, everywhere**: a shared `decodeEntityAmps` runs in BOTH plan-discipline scanners' normalization (`scanNegativeGrepCommentEcho` and `scanFileWideNegativeGateConflict` — the adversarial review found the identical bug in the #968 detector, fed by the same caller), so the segment split, zero-comparison, literal harvest, and echo scan all read the same decoded text the executing agent reads.
- **Quote-aware splitting**: a shared `splitShellSegments` helper replaces the quote-blind regex split in both gates — an `&&` inside a quoted literal (`grep -c 'a&&b'`) is part of the pattern, not a chain operator. The review found the entity spelling had been accidentally immune to this shattering pre-fix; the decode alone would have created a false-negative/evasion class, now closed.
- Both gates share the helpers so they cannot drift apart again.

## Root cause

The verifier scanned a text no executor would run: the shell-facing operator is decoded, the gate's splitter matched only the literal spelling, and the split was not quote-aware.

## Testing

### How I verified the fix

- **RED first (twice)**: test-only commit `e5b0ee6d6` failed with the issue's exact entity-chain scenario; the review-driven second round `525cd7350` failed with the #968-detector entity chain and the quoted-`&&` shattering rows.
- The issue's unit repro: `&&` → ok, `&amp;&amp;` → ok (was: widget FLAGGED).
- **GREEN**: full matrix on the final HEAD (sha in CI).

### Regression test added?

- [x] Yes — 4 new rows in `tests/verify.test.cjs`: case 12b (entity chain, positive token never flagged — the issue's scenario), 12c (entity-bearing literal + entity-spelled echo still flags — decode consistency), 12d (quoted literal containing `&&` survives the split), and #968 case 1b (entity chain's positive pattern never harvested as a file-wide ban).

### Platforms tested

- [x] Linux (gsd-test matrix)
- [x] macOS (local repro runs, lint)

### Runtimes tested

- [x] N/A (verifier tooling; runtime-neutral)

## Checklist

- [x] Issue linked above with `Fixes #3611`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix scoped to the gate's scanning seam; #2965 (planner-side entity emission) left as the maintainer call the issue itself names
- [x] Regression tests added (fails-first proven on both RED commits)
- [x] gsd-test matrix pass on the shipping sha
- [x] `.changeset/` fragment added (`pr` backfilled on open)
- [x] No unnecessary dependencies added

## Breaking changes

None — plans with literal `&&` behave exactly as before; entity-escaped plans now get the same (correct) verdicts.
