### PR TITLE
fix(context-monitor): reset warn sentinel on PreCompact

### DIFF
--- a/hooks/gsd-context-monitor.js
+++ b/hooks/gsd-context-monitor.js
@@ -53,6 +53,27 @@ process.stdin.on('end', () => {
       process.exit(0);
     }
 
+    // #772 wires this hook to PreCompact on some hosts. A compaction restarts the
+    // context lifecycle: usage drops back to Normal and the next climb toward
+    // WARNING/CRITICAL is a fresh cycle. Without clearing the sentinel here,
+    // `lastLevel` stays pinned at 'critical' for the remainder of the session, so
+    // the documented "severity escalation (WARNING -> CRITICAL) bypasses debounce"
+    // rule can never fire again — the agent gets the critical warning up to
+    // DEBOUNCE_CALLS tool uses late, in exactly the window where immediacy matters.
+    // `criticalRecorded` is likewise sticky, suppressing the /gsd-resume-work
+    // breadcrumb (#1974) for every later exhaustion, so the record describes the
+    // first near-miss instead of the actual crash moment.
+    // Reset and exit: PreCompact is not injection-capable, so it never emits
+    // advisory output anyway.
+    if (data.hook_event_name && data.hook_event_name.trim() === 'PreCompact') {
+      try {
+        fs.unlinkSync(path.join(os.tmpdir(), `claude-ctx-${sessionId}-warned.json`));
+      } catch (e) {
+        // No sentinel yet (or already gone) — nothing to reset.
+      }
+      process.exit(0);
+    }
+
     // Check if context warnings are disabled via config.
     // Collapsed existsSync+readFileSync into a single read guarded by try/catch
     // (ENOENT or parse error → use defaults, same as old "planningDir absent" branch).

--- a/tests/context-monitor-precompact.test.cjs
+++ b/tests/context-monitor-precompact.test.cjs
@@ -1,0 +1,161 @@
+/**
+ * Tests gsd-context-monitor.js PreCompact sentinel reset.
+ *
+ * Regression guard for: after a context compaction the warn sentinel was never
+ * cleared, so `lastLevel` stayed pinned at 'critical' for the rest of the
+ * session. That permanently disables the documented rule
+ * "Severity escalation (WARNING -> CRITICAL) bypasses debounce"
+ * (docs/context-monitor.md), and leaves `criticalRecorded` sticky so the
+ * /gsd-resume-work breadcrumb (#1974) is never re-recorded for the exhaustion
+ * that actually ends the session.
+ *
+ * The hook exports nothing (it reads stdin and exits), so it is exercised as a
+ * subprocess, the same way the host runtimes invoke it.
+ */
+
+'use strict';
+
+const { test, describe, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const HOOK = path.join(__dirname, '..', 'hooks', 'gsd-context-monitor.js');
+
+let sessionId;
+let bridgePath;
+let warnPath;
+
+function bridgeFile(id) {
+  return path.join(os.tmpdir(), `claude-ctx-${id}.json`);
+}
+
+function warnFile(id) {
+  return path.join(os.tmpdir(), `claude-ctx-${id}-warned.json`);
+}
+
+/** Run the hook with a payload on stdin, returning its result. */
+function runHook(payload) {
+  return spawnSync(process.execPath, [HOOK], {
+    input: JSON.stringify(payload),
+    encoding: 'utf8',
+    timeout: 15000,
+  });
+}
+
+function writeBridge(remaining) {
+  fs.writeFileSync(
+    bridgePath,
+    JSON.stringify({
+      session_id: sessionId,
+      remaining_percentage: remaining,
+      used_pct: 100 - remaining,
+      timestamp: Math.floor(Date.now() / 1000),
+    })
+  );
+}
+
+function rm(p) {
+  try {
+    fs.unlinkSync(p);
+  } catch (e) {
+    /* already gone */
+  }
+}
+
+describe('gsd-context-monitor PreCompact sentinel reset', () => {
+  beforeEach(() => {
+    sessionId = `test-ctxmon-${process.pid}-${Math.random().toString(36).slice(2, 10)}`;
+    bridgePath = bridgeFile(sessionId);
+    warnPath = warnFile(sessionId);
+  });
+
+  afterEach(() => {
+    rm(bridgePath);
+    rm(warnPath);
+  });
+
+  test('PreCompact clears a sentinel left pinned at critical', () => {
+    // A CRITICAL warning already fired before the compaction.
+    fs.writeFileSync(
+      warnPath,
+      JSON.stringify({ callsSinceWarn: 0, lastLevel: 'critical', criticalRecorded: true })
+    );
+    writeBridge(20); // 80% used — what triggered the CRITICAL
+
+    const res = runHook({
+      session_id: sessionId,
+      hook_event_name: 'PreCompact',
+      cwd: os.tmpdir(),
+    });
+
+    assert.equal(res.status, 0, 'hook must exit 0');
+    assert.equal(res.stdout, '', 'PreCompact is not injection-capable: no stdout');
+    assert.equal(
+      fs.existsSync(warnPath),
+      false,
+      'sentinel must be cleared so the next cycle can escalate again'
+    );
+  });
+
+  test('PreCompact is a no-op when no sentinel exists', () => {
+    writeBridge(90);
+
+    const res = runHook({
+      session_id: sessionId,
+      hook_event_name: 'PreCompact',
+      cwd: os.tmpdir(),
+    });
+
+    assert.equal(res.status, 0, 'missing sentinel must not fail the hook');
+    assert.equal(fs.existsSync(warnPath), false);
+  });
+
+  test('PreCompact does not consume the metrics bridge', () => {
+    fs.writeFileSync(warnPath, JSON.stringify({ callsSinceWarn: 3, lastLevel: 'warning' }));
+    writeBridge(30);
+
+    runHook({ session_id: sessionId, hook_event_name: 'PreCompact', cwd: os.tmpdir() });
+
+    assert.equal(
+      fs.existsSync(bridgePath),
+      true,
+      'the statusline owns the bridge file; the monitor must not remove it'
+    );
+  });
+
+  test('after a PreCompact reset, a fresh CRITICAL escalates immediately', () => {
+    // Pre-compaction: CRITICAL already seen.
+    fs.writeFileSync(
+      warnPath,
+      JSON.stringify({ callsSinceWarn: 0, lastLevel: 'critical', criticalRecorded: true })
+    );
+
+    writeBridge(20);
+    runHook({ session_id: sessionId, hook_event_name: 'PreCompact', cwd: os.tmpdir() });
+
+    // Post-compaction the context climbs back into WARNING, then CRITICAL.
+    writeBridge(30); // WARNING
+    const warn = runHook({
+      session_id: sessionId,
+      hook_event_name: 'PostToolUse',
+      cwd: os.tmpdir(),
+    });
+    assert.match(warn.stdout, /CONTEXT WARNING/, 'first post-reset warning fires immediately');
+    assert.equal(JSON.parse(fs.readFileSync(warnPath, 'utf8')).lastLevel, 'warning');
+
+    writeBridge(20); // CRITICAL on the very next tool use
+    const crit = runHook({
+      session_id: sessionId,
+      hook_event_name: 'PostToolUse',
+      cwd: os.tmpdir(),
+    });
+    assert.match(
+      crit.stdout,
+      /CONTEXT CRITICAL/,
+      'WARNING -> CRITICAL must bypass debounce, per docs/context-monitor.md'
+    );
+  });
+});


### PR DESCRIPTION
## Linked Issue

Fixes #3709

> Opened alongside the report rather than after triage, since the fix is small and self-contained and the regression test demonstrates the behaviour. Happy to hold until the `confirmed-bug` label lands.

---

## What was broken

`gsd-context-monitor.js` never cleared its warn sentinel (`/tmp/claude-ctx-{session_id}-warned.json`) on a context compaction, so `lastLevel` stayed pinned at `'critical'` for the remainder of the session.

## What the fix does

Handles `PreCompact` up front: clears the sentinel and exits, so the post-compaction cycle starts clean.

## Root cause

The hook is already wired to `PreCompact` (#772), but `hook_event_name` was only read at the end of the handler — and only to pick the output envelope (#2289). No branch ever used the event to reset state.

Two documented behaviours broke as a result:

- **Escalation bypass** — `docs/context-monitor.md` documents *"Severity escalation (WARNING -> CRITICAL) bypasses debounce"*. The guard is `currentLevel === 'critical' && warnData.lastLevel === 'warning'`. With `lastLevel` stuck at `'critical'`, it can never be true again, so every later CRITICAL waits out the full 5-tool-use debounce.
- **Crash breadcrumb** — `criticalRecorded` is equally sticky, so `state record-session` (#1974) only ever fires for the first near-exhaustion. The recorded "crash moment" then describes a near-miss rather than the exhaustion that actually ended the session.

Deliberately **not** changed: the debounce counter also advances on non-tool lifecycle events. The comment at `hooks/gsd-context-monitor.js:190-192` calls that out as known, so it is out of scope here — noted in the issue instead.

## Testing

### How I verified the fix

New file `tests/context-monitor-precompact.test.cjs` drives the hook as a subprocess with real stdin payloads, matching how the runtimes invoke it. Four cases:

1. `PreCompact` clears a sentinel pinned at critical, exits 0, emits no stdout.
2. `PreCompact` with no sentinel present is a no-op (does not fail).
3. `PreCompact` does not delete the metrics bridge file (the statusline owns it).
4. End to end: after a `PreCompact` reset, a fresh WARNING fires immediately and the following CRITICAL bypasses debounce — the documented rule.

```
# with the fix
$ node --test tests/context-monitor-precompact.test.cjs
# pass 4   # fail 0

# with the fix reverted (git stash), same test file
# pass 2   # fail 2
#   - 'sentinel must be cleared so the next cycle can escalate again'
#   - 'first post-reset warning fires immediately'
```

`npx eslint hooks/gsd-context-monitor.js tests/context-monitor-precompact.test.cjs --max-warnings 0` is clean.

Also reproduced outside the test harness, in a live Claude Code session on a 1M window, where the bridge and the sentinel disagreed after an auto-compact:

```
/tmp/claude-ctx-<id>.json         {"remaining_percentage":59,"used_pct":41}   <- healthy again
/tmp/claude-ctx-<id>-warned.json  {"callsSinceWarn":0,"lastLevel":"critical"} <- still pinned
```

### Regression test added?

- [x] Yes — added a test that would have caught the bug
- [ ] No

### Note on pre-existing failures

`tests/hooks-commonjs-marker.test.cjs` has 2 failures (incl. `#2717 CommonJS marker for staged .js hooks`). These reproduce on a clean `next` checkout with this branch stashed, so they are unrelated to this change.
