### PR TITLE
fix(#3640): isolate the drift cli e2e fixture via a --root override

### DIFF
--- a/scripts/lint-planning-prompt-drift.cjs
+++ b/scripts/lint-planning-prompt-drift.cjs
@@ -378,16 +378,29 @@ function writeBaseline(root, violations) {
  * that parallel test chunks observe mid-lifecycle (the emitted-provenance
  * manifest build copies the transient file into all 19 runtime manifests;
  * the #3333 TOCTOU ENOENT crash was the same writer's first symptom).
- * Fail-closed: `--root` without a value is a usage error, never a
- * `path.resolve(undefined)` TypeError.
+ *
+ * Usage errors exit 2 — a code distinct from the guard's own findings exit
+ * (1), so tests and CI can tell "bad invocation" from "drift found" without
+ * parsing stderr. Fail-closed on every bad shape, because a wrong root is
+ * not harmless: `--root --update` would otherwise resolve the flag itself
+ * into a cwd-relative path and --update would happily `mkdir -p` a stray
+ * baseline tree inside the shared source directory (#3640's write class).
+ * A value that starts with `-` (another flag) or does not name an existing
+ * directory is therefore a usage error, never a scan root. With repeated
+ * `--root` flags the first wins (same first-match convention as the boolean
+ * `--update` parse).
  */
 function resolveScanRoot() {
   const rootIdx = process.argv.indexOf('--root');
   if (rootIdx === -1) return path.join(__dirname, '..');
   const value = process.argv[rootIdx + 1];
-  if (value === undefined || value === '') {
-    process.stderr.write('planning-prompt-drift: --root requires a directory argument (usage: --root <dir>)\n');
-    process.exitCode = 1;
+  const isDir = value !== undefined
+    && !value.startsWith('-')
+    && fs.existsSync(value)
+    && fs.statSync(value).isDirectory();
+  if (!isDir) {
+    process.stderr.write('planning-prompt-drift: --root requires an existing directory argument (usage: --root <dir>)\n');
+    process.exitCode = 2;
     return null;
   }
   return path.resolve(value);

--- a/scripts/lint-planning-prompt-drift.cjs
+++ b/scripts/lint-planning-prompt-drift.cjs
@@ -370,8 +370,32 @@ function writeBaseline(root, violations) {
   return entries;
 }
 
+/**
+ * Resolve the scan root for a CLI run. Default: this repo — exactly what
+ * `lint:ci` invokes. `--root <dir>` overrides it (#3640) so the CLI
+ * end-to-end test can prove the guard's FAIL path against an isolated temp
+ * tree instead of writing its fixture into the shared `gsd-core/workflows/`
+ * that parallel test chunks observe mid-lifecycle (the emitted-provenance
+ * manifest build copies the transient file into all 19 runtime manifests;
+ * the #3333 TOCTOU ENOENT crash was the same writer's first symptom).
+ * Fail-closed: `--root` without a value is a usage error, never a
+ * `path.resolve(undefined)` TypeError.
+ */
+function resolveScanRoot() {
+  const rootIdx = process.argv.indexOf('--root');
+  if (rootIdx === -1) return path.join(__dirname, '..');
+  const value = process.argv[rootIdx + 1];
+  if (value === undefined || value === '') {
+    process.stderr.write('planning-prompt-drift: --root requires a directory argument (usage: --root <dir>)\n');
+    process.exitCode = 1;
+    return null;
+  }
+  return path.resolve(value);
+}
+
 function main() {
-  const root = path.join(__dirname, '..');
+  const root = resolveScanRoot();
+  if (root === null) return;
   const update = process.argv.includes('--update');
   const violations = scanRepo(root);
 

--- a/tests/planning-prompt-drift.test.cjs
+++ b/tests/planning-prompt-drift.test.cjs
@@ -340,10 +340,13 @@ test('scanRepo(repoRoot) matches the baseline exactly: zero fresh AND zero stale
 // end-to-end with zero writes into the shared source tree.
 
 describe('CLI end-to-end: --root scan-root override (#3640)', () => {
+  // The E5 fixture line, shared by every row that needs a violation present.
+  const DRIFT_FIXTURE_LINE = 'FIXTURE_COUNT=$(ls .planning/phases/zzz/*-PLAN.md 2>/dev/null | wc -l)\n';
+
   // A scan-root skeleton: the SCAN_DIR tree main() walks plus a valid empty
   // baseline, so the run exercises the real loadBaseline -> diff -> report
   // path rather than erroring on a missing baseline.
-  function makeRoot(prefix) {
+  function makeScanRoot(prefix) {
     const root = createTempDir(prefix);
     fs.mkdirSync(path.join(root, 'gsd-core', 'workflows'), { recursive: true });
     fs.mkdirSync(path.join(root, 'scripts', 'baselines'), { recursive: true });
@@ -355,24 +358,22 @@ describe('CLI end-to-end: --root scan-root override (#3640)', () => {
   }
 
   test('a fresh, unacknowledged plan-count re-derivation under --root exits 1 and names itself in stderr', (t) => {
-    const root = makeRoot('gsd-planning-prompt-drift-root-');
+    const root = makeScanRoot('gsd-planning-prompt-drift-root-');
     t.after(() => cleanup(root));
-    fs.writeFileSync(
-      path.join(root, 'gsd-core', 'workflows', 'zzz-e5-drift-fixture.md'),
-      'FIXTURE_COUNT=$(ls .planning/phases/zzz/*-PLAN.md 2>/dev/null | wc -l)\n',
-    );
+    fs.writeFileSync(path.join(root, 'gsd-core', 'workflows', 'zzz-e5-drift-fixture.md'), DRIFT_FIXTURE_LINE);
 
     const result = runNode([DRIFT_SCRIPT, '--root', root]);
     assert.strictEqual(result.outcome, 'exited');
     assert.strictEqual(result.exitCode, 1);
     // The reported rel path and the echoed violation text are DATA, not
-    // formatter prose — the same two anchors the E5 block asserts on.
+    // formatter prose — the same two anchors the E5 block asserted on. The
+    // exit code carries the verdict; these anchors carry the WHICH.
     assert.match(result.stderr, /gsd-core\/workflows\/zzz-e5-drift-fixture\.md/);
     assert.match(result.stderr, /FIXTURE_COUNT=/);
   });
 
   test('a clean tree under --root exits 0 (clean-fixture control for the row above)', (t) => {
-    const root = makeRoot('gsd-planning-prompt-drift-clean-');
+    const root = makeScanRoot('gsd-planning-prompt-drift-clean-');
     t.after(() => cleanup(root));
     fs.writeFileSync(path.join(root, 'gsd-core', 'workflows', 'clean.md'), 'no globs or counts here\n');
 
@@ -382,7 +383,7 @@ describe('CLI end-to-end: --root scan-root override (#3640)', () => {
   });
 
   test('an empty tree with a valid empty baseline under --root exits 0', (t) => {
-    const root = makeRoot('gsd-planning-prompt-drift-empty-');
+    const root = makeScanRoot('gsd-planning-prompt-drift-empty-');
 
     t.after(() => cleanup(root));
     const result = runNode([DRIFT_SCRIPT, '--root', root]);
@@ -401,12 +402,9 @@ describe('CLI end-to-end: --root scan-root override (#3640)', () => {
   test('a --root scan leaves the real gsd-core/workflows directory untouched', (t) => {
     const realWorkflows = path.join(REPO_ROOT, 'gsd-core', 'workflows');
     const before = fs.readdirSync(realWorkflows).sort();
-    const root = makeRoot('gsd-planning-prompt-drift-untouched-');
+    const root = makeScanRoot('gsd-planning-prompt-drift-untouched-');
     t.after(() => cleanup(root));
-    fs.writeFileSync(
-      path.join(root, 'gsd-core', 'workflows', 'zzz-e5-drift-fixture.md'),
-      'FIXTURE_COUNT=$(ls .planning/phases/zzz/*-PLAN.md 2>/dev/null | wc -l)\n',
-    );
+    fs.writeFileSync(path.join(root, 'gsd-core', 'workflows', 'zzz-e5-drift-fixture.md'), DRIFT_FIXTURE_LINE);
 
     const result = runNode([DRIFT_SCRIPT, '--root', root]);
     assert.strictEqual(result.outcome, 'exited');
@@ -416,12 +414,35 @@ describe('CLI end-to-end: --root scan-root override (#3640)', () => {
     assert.deepStrictEqual(fs.readdirSync(realWorkflows).sort(), before);
   });
 
-  test('--root without a value fails closed with a usage error', () => {
+  // ─── Usage errors: exit 2, the code distinct from the guard's findings
+  // exit (1) — a typed discriminator, so these rows assert the exit code
+  // alone and never parse stderr prose. ─────────────────────────────────
+
+  test('--root without a value is a usage error (exit 2)', () => {
     const result = runNode([DRIFT_SCRIPT, '--root']);
     assert.strictEqual(result.outcome, 'exited');
-    assert.strictEqual(result.exitCode, 1);
-    assert.match(result.stderr, /--root/);
-    assert.ok(!result.stderr.includes('TypeError'), 'must surface a usage error, not a raw path.resolve(undefined) throw');
+    assert.strictEqual(result.exitCode, 2);
+  });
+
+  test('--root with an empty-string value is a usage error (exit 2)', () => {
+    const result = runNode([DRIFT_SCRIPT, '--root', '']);
+    assert.strictEqual(result.outcome, 'exited');
+    assert.strictEqual(result.exitCode, 2);
+  });
+
+  test('--root with a flag-shaped value is a usage error, never a scan root (exit 2)', () => {
+    // `--root --update` must not resolve the FLAG into a cwd-relative path —
+    // composed with --update that would mkdir a stray baseline tree inside
+    // the shared source directory (#3640's own write class).
+    const result = runNode([DRIFT_SCRIPT, '--root', '--update', '--update']);
+    assert.strictEqual(result.outcome, 'exited');
+    assert.strictEqual(result.exitCode, 2);
+  });
+
+  test('--root naming an existing FILE is a usage error, not an ENOTDIR crash (exit 2)', () => {
+    const result = runNode([DRIFT_SCRIPT, '--root', path.join(REPO_ROOT, 'package.json')]);
+    assert.strictEqual(result.outcome, 'exited');
+    assert.strictEqual(result.exitCode, 2);
   });
 });
 

--- a/tests/planning-prompt-drift.test.cjs
+++ b/tests/planning-prompt-drift.test.cjs
@@ -326,6 +326,105 @@ test('scanRepo(repoRoot) matches the baseline exactly: zero fresh AND zero stale
   assert.deepStrictEqual(stale, []);
 });
 
+// ─── CLI end-to-end against an ISOLATED --root tree (#3640) ─────────────────
+//
+// The E5 block below writes its fixture directly into the real, shared
+// gsd-core/workflows/ because main() hardcoded its scan root — and any
+// parallel consumer of the real tree can then observe the fixture
+// mid-lifecycle (the emitted-provenance install bakes it into all 19
+// manifests and later fails its existsSync pass once t.after() removes it;
+// the #3333 TOCTOU ENOENT crash in copyWithPathReplacement was the same
+// writer's first documented symptom). These rows drive the SAME real CLI,
+// through the same exit path, with an explicit --root override pointing at
+// an isolated temp tree — the guard's fail path is proven end-to-end with
+// zero writes into the shared source tree.
+
+describe('CLI end-to-end: --root scan-root override (#3640)', () => {
+  // A scan-root skeleton: the SCAN_DIR tree main() walks plus a valid empty
+  // baseline, so the run exercises the real loadBaseline -> diff -> report
+  // path rather than erroring on a missing baseline.
+  function makeRoot(prefix) {
+    const root = createTempDir(prefix);
+    fs.mkdirSync(path.join(root, 'gsd-core', 'workflows'), { recursive: true });
+    fs.mkdirSync(path.join(root, 'scripts', 'baselines'), { recursive: true });
+    fs.writeFileSync(
+      path.join(root, 'scripts', 'baselines', 'planning-prompt-drift-baseline.json'),
+      `${JSON.stringify({ entries: [] }, null, 2)}\n`,
+    );
+    return root;
+  }
+
+  test('a fresh, unacknowledged plan-count re-derivation under --root exits 1 and names itself in stderr', (t) => {
+    const root = makeRoot('gsd-planning-prompt-drift-root-');
+    t.after(() => cleanup(root));
+    fs.writeFileSync(
+      path.join(root, 'gsd-core', 'workflows', 'zzz-e5-drift-fixture.md'),
+      'FIXTURE_COUNT=$(ls .planning/phases/zzz/*-PLAN.md 2>/dev/null | wc -l)\n',
+    );
+
+    const result = runNode([DRIFT_SCRIPT, '--root', root]);
+    assert.strictEqual(result.outcome, 'exited');
+    assert.strictEqual(result.exitCode, 1);
+    // The reported rel path and the echoed violation text are DATA, not
+    // formatter prose — the same two anchors the E5 block asserts on.
+    assert.match(result.stderr, /gsd-core\/workflows\/zzz-e5-drift-fixture\.md/);
+    assert.match(result.stderr, /FIXTURE_COUNT=/);
+  });
+
+  test('a clean tree under --root exits 0 (clean-fixture control for the row above)', (t) => {
+    const root = makeRoot('gsd-planning-prompt-drift-clean-');
+    t.after(() => cleanup(root));
+    fs.writeFileSync(path.join(root, 'gsd-core', 'workflows', 'clean.md'), 'no globs or counts here\n');
+
+    const result = runNode([DRIFT_SCRIPT, '--root', root]);
+    assert.strictEqual(result.outcome, 'exited');
+    assert.strictEqual(result.exitCode, 0);
+  });
+
+  test('an empty tree with a valid empty baseline under --root exits 0', (t) => {
+    const root = makeRoot('gsd-planning-prompt-drift-empty-');
+
+    t.after(() => cleanup(root));
+    const result = runNode([DRIFT_SCRIPT, '--root', root]);
+    assert.strictEqual(result.outcome, 'exited');
+    assert.strictEqual(result.exitCode, 0);
+  });
+
+  test('the default invocation (no --root) still scans the real repo green', () => {
+    // The override must not change the guard lint:ci actually runs: bare
+    // invocation scans the real repo against the committed (empty) baseline.
+    const result = runNode([DRIFT_SCRIPT]);
+    assert.strictEqual(result.outcome, 'exited');
+    assert.strictEqual(result.exitCode, 0);
+  });
+
+  test('a --root scan leaves the real gsd-core/workflows directory untouched', (t) => {
+    const realWorkflows = path.join(REPO_ROOT, 'gsd-core', 'workflows');
+    const before = fs.readdirSync(realWorkflows).sort();
+    const root = makeRoot('gsd-planning-prompt-drift-untouched-');
+    t.after(() => cleanup(root));
+    fs.writeFileSync(
+      path.join(root, 'gsd-core', 'workflows', 'zzz-e5-drift-fixture.md'),
+      'FIXTURE_COUNT=$(ls .planning/phases/zzz/*-PLAN.md 2>/dev/null | wc -l)\n',
+    );
+
+    const result = runNode([DRIFT_SCRIPT, '--root', root]);
+    assert.strictEqual(result.outcome, 'exited');
+    assert.strictEqual(result.exitCode, 1);
+    // The #3640 acceptance criterion, as behavior: the E5 scenario's fixture
+    // never appears in the shared tree the parallel chunks observe.
+    assert.deepStrictEqual(fs.readdirSync(realWorkflows).sort(), before);
+  });
+
+  test('--root without a value fails closed with a usage error', () => {
+    const result = runNode([DRIFT_SCRIPT, '--root']);
+    assert.strictEqual(result.outcome, 'exited');
+    assert.strictEqual(result.exitCode, 1);
+    assert.match(result.stderr, /--root/);
+    assert.ok(!result.stderr.includes('TypeError'), 'must surface a usage error, not a raw path.resolve(undefined) throw');
+  });
+});
+
 // ─── E5 (test matrix): PROVE the guard, not just its pure functions, can
 // still FAIL — an empty baseline that is green only because nothing
 // exercises the fail path is exactly the "trusted on a green baseline it

--- a/tests/planning-prompt-drift.test.cjs
+++ b/tests/planning-prompt-drift.test.cjs
@@ -328,16 +328,16 @@ test('scanRepo(repoRoot) matches the baseline exactly: zero fresh AND zero stale
 
 // ─── CLI end-to-end against an ISOLATED --root tree (#3640) ─────────────────
 //
-// The E5 block below writes its fixture directly into the real, shared
-// gsd-core/workflows/ because main() hardcoded its scan root — and any
-// parallel consumer of the real tree can then observe the fixture
-// mid-lifecycle (the emitted-provenance install bakes it into all 19
-// manifests and later fails its existsSync pass once t.after() removes it;
-// the #3333 TOCTOU ENOENT crash in copyWithPathReplacement was the same
-// writer's first documented symptom). These rows drive the SAME real CLI,
-// through the same exit path, with an explicit --root override pointing at
-// an isolated temp tree — the guard's fail path is proven end-to-end with
-// zero writes into the shared source tree.
+// This block REPLACES the original E5 shape, which wrote its fixture
+// directly into the real, shared gsd-core/workflows/ because main() hardcoded
+// its scan root — and any parallel consumer of the real tree could then
+// observe the fixture mid-lifecycle (the emitted-provenance install baked it
+// into all 19 manifests and later failed its existsSync pass once t.after()
+// removed it; the #3333 TOCTOU ENOENT crash in copyWithPathReplacement was
+// the same writer's first documented symptom). These rows drive the SAME
+// real CLI, through the same exit path, with an explicit --root override
+// pointing at an isolated temp tree — the guard's fail path is proven
+// end-to-end with zero writes into the shared source tree.
 
 describe('CLI end-to-end: --root scan-root override (#3640)', () => {
   // A scan-root skeleton: the SCAN_DIR tree main() walks plus a valid empty
@@ -425,34 +425,3 @@ describe('CLI end-to-end: --root scan-root override (#3640)', () => {
   });
 });
 
-// ─── E5 (test matrix): PROVE the guard, not just its pure functions, can
-// still FAIL — an empty baseline that is green only because nothing
-// exercises the fail path is exactly the "trusted on a green baseline it
-// did not earn" failure this epic keeps recording. `main()` fixes its scan
-// root to the real repo (`path.join(__dirname, '..')`), so this drives the
-// actual CLI end-to-end against a real (temporary) file under a real
-// SCAN_DIR — not a synthetic tree passed to the pure `scanRepo` — cleaned
-// up in `t.after()` regardless of assertion outcome. ─────────────────────
-
-describe('CLI end-to-end: the guard fails on a deliberate unacknowledged fixture', () => {
-  test('a fresh, unacknowledged plan-count re-derivation exits 1 and names itself in stderr', (t) => {
-    const fixturePath = path.join(REPO_ROOT, 'gsd-core', 'workflows', 'zzz-e5-drift-fixture.md');
-    // helpers.cleanup() refuses any path outside the OS temp root; this
-    // fixture must live under a real SCAN_DIR (gsd-core/workflows/) because
-    // main() hardcodes its scan root to the real repo — see the file header
-    // above this describe block.
-    // eslint-disable-next-line local/no-raw-rmsync-in-tests -- fixture lives outside the temp root helpers.cleanup() requires (see comment above)
-    t.after(() => fs.rmSync(fixturePath, { force: true }));
-    fs.writeFileSync(
-      fixturePath,
-      'FIXTURE_COUNT=$(ls .planning/phases/zzz/*-PLAN.md 2>/dev/null | wc -l)\n',
-    );
-
-    const result = runNode([DRIFT_SCRIPT]);
-    assert.strictEqual(result.outcome, 'exited');
-    assert.strictEqual(result.exitCode, 1);
-    assert.match(result.stderr, /NEW plan\/summary count re-derivation/);
-    assert.match(result.stderr, /gsd-core\/workflows\/zzz-e5-drift-fixture\.md/);
-    assert.match(result.stderr, /FIXTURE_COUNT=/);
-  });
-});


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #3640

---

## What was broken

`tests/planning-prompt-drift.test.cjs`'s E5 CLI end-to-end block wrote `gsd-core/workflows/zzz-e5-drift-fixture.md` into the **real, shared source tree** (because the drift CLI hardcoded its scan root) and removed it in `t.after()`. Parallel test chunks can observe that transient fixture: `tests/emitted-provenance.test.cjs`'s `loadManifests()` runs a real install that copies `gsd-core/workflows/**` verbatim, baking the file into all 19 runtime manifests — then its "every attributed source exists in the repo" pass fails (21 rows) once the writer's cleanup deletes it. The issue reports this as a 1-in-3 full-suite CI flake; the same writer's first documented symptom was the #3333 TOCTOU ENOENT crash in `copyWithPathReplacement` (`tests/install-regressions.test.cjs` names this fixture verbatim).

## What this fix does

Gives `scripts/lint-planning-prompt-drift.cjs` a `--root <dir>` scan-root override and rewrites the E5 block to drive the **same real CLI fail path** (scan → load baseline → diff → exit 1 naming the violation) against an isolated temp tree. No test writes into the shared tree anymore. Default invocation (no flags) is byte-identical to before — `lint:ci` behavior is unchanged.

## Root cause

`main()` hardcoded `path.join(__dirname, '..')`, so the only way to prove the guard can FAIL end-to-end was to plant a fixture in the real tree — a fixture every parallel consumer of the tree can observe mid-lifecycle. The bug is the missing seam, not the observer: `emitted-provenance` correctly fails on a source that vanished.

Deterministic reproduction (both halves verified):
1. Fixture present during `loadManifests()` → present in **19/19** manifests (attributed via `gsd-core-verbatim`).
2. Fixture removed before the existsSync pass → **21 missing-source rows** naming `gsd-core/workflows/zzz-e5-drift-fixture.md`.

## Testing

### How I verified the fix

- **RED first**: committed the new rows at `2a776a73f`; `gsd-test` verdict `failed` with exactly the 4 new expected-exit-1 rows red (36,775 others green).
- **GREEN**: `gsd-test` verdict `passed` 36,780/36,780 at `3cc2f60e2` (pass marker recorded).
- Adversarial review caught a real hole in the first cut — `--root --update` resolved the *flag* into a cwd-relative path and `--update` would `mkdir -p` a stray baseline tree inside the source dir. Fixed: values starting with `-` and non-directory values are rejected; usage errors exit **2**, a code distinct from the guard's findings exit (1), so tests assert the typed code instead of parsing stderr.
- `npm run lint:ci` clean (exit 0) after `npm run build:lib` (the one red run was a stale local build — `gsd-core/bin/lib` predating recent merges, not the diff).

### Regression test added?

- [x] Yes — `CLI end-to-end: --root scan-root override (#3640)` describe: fail-path row (exit 1 + violation named), clean-fixture control, empty-tree boundary, default-invocation pin, real-tree-untouched row (the acceptance criterion as behavior), and four exit-2 usage rows.

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux

(Report paths flow through `toPosixRel` at the only seam — POSIX on every OS, pinned by the existing #3223 suite; gsd-test ran the linux-node24 lane.)

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #3640`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass (`gsd-test` 36,780/36,780)
- [x] `.changeset/` fragment not required for this diff shape (touches only `scripts/` + `tests/`; `changeset/lint.cjs` reports `ok_no_user_facing_changes`) — `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None. The drift CLI gains an optional flag; bare invocation is unchanged.
