### PR TITLE
fix(#3641): make v005/v004 see bracket-convention phase entries

### DIFF
--- a/.changeset/quick-dogs-munch.md
+++ b/.changeset/quick-dogs-munch.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`roadmap validate` and `roadmap milestone-scope` now see bracket-convention phase entries (`### [GSD.04] 01:`)** — with `phase_id_convention: "bracket"` set, a genuinely truncated milestone window warned as nothing (V005 could never fire) while V004 falsely reported "no recognizable phase entries". Both now resolve the convention (config.json, ROADMAP frontmatter fallback) and route V004 through the shared entry predicate, so validate and the milestone-scope probe agree. Bracket milestone headings (`[GSD.02] Name`, no digit token) never count as entries. (#3641)

--- a/.changeset/quick-dogs-munch.md
+++ b/.changeset/quick-dogs-munch.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 3723
 ---
 **`roadmap validate` and `roadmap milestone-scope` now see bracket-convention phase entries (`### [GSD.04] 01:`)** — with `phase_id_convention: "bracket"` set, a genuinely truncated milestone window warned as nothing (V005 could never fire) while V004 falsely reported "no recognizable phase entries". Both now resolve the convention (config.json, ROADMAP frontmatter fallback) and route V004 through the shared entry predicate, so validate and the milestone-scope probe agree. Bracket milestone headings (`[GSD.02] Name`, no digit token) never count as entries. (#3641)

--- a/src/roadmap-command-router.cts
+++ b/src/roadmap-command-router.cts
@@ -26,7 +26,7 @@ import cliExitMod = require('./cli-exit.cjs');
 const { ExitError } = cliExitMod;
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import roadmapParserMod = require('./roadmap-parser.cjs');
-const { extractCurrentMilestoneScoped } = roadmapParserMod;
+const { extractCurrentMilestoneScoped, hasPhaseEntries } = roadmapParserMod;
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import planningScopeMod = require('./planning-scope.cjs');
 const { SCOPE } = planningScopeMod;
@@ -188,42 +188,12 @@ function routeRoadmapCommand({ roadmap, args, cwd, raw, error }: RouteRoadmapCom
           }
         }
 
-        // No recognizable phase structure — at least one `### Phase N:` heading.
-        // Mirrors the phase-heading pattern used across roadmap-parser.cts.
-        const hasPhaseEntry = /^#{2,4}\s*Phase\s+\S/im.test(roadmapContent);
-        if (!hasPhaseEntry && !warnings.some((w) => w.code === 'V002')) {
-          warnings.push({ code: 'V004', message: 'ROADMAP.md contains no recognizable phase entries (no "### Phase N:" headings)' });
-        }
-
-        // #3263: a whole-document phase check (V004 above) is satisfied by a
-        // document whose phase entries live OUTSIDE the active milestone's
-        // resolved window — e.g. an intervening version-bearing heading closes
-        // the window before its own `### Phase N:` sections. That truncation
-        // is exactly what the #3184 scope discriminator classifies, so ask
-        // the single owner (never re-derive the window shape here —
-        // lint-milestone-window-drift bans local copies) and surface a
-        // non-COMPLETE-but-not-empty verdict. TRUNCATED only: a genuinely
-        // phase-less milestone classifies COMPLETE (V004 owns that case) and
-        // an unscoped/unreadable window is a different failure mode with a
-        // different remediation, deliberately not warned here.
-        try {
-          const scoped = extractCurrentMilestoneScoped(contentAfterBom, cwd);
-          if (scoped.scope === SCOPE.TRUNCATED) {
-            warnings.push({
-              code: 'V005',
-              message:
-                'Active milestone window is truncated: phase entries exist in ROADMAP.md but are excluded from the ' +
-                'active milestone\'s resolved window (check for a heading between the milestone heading and its "### Phase N:" sections)',
-            });
-          }
-        } catch {
-          // The classifier is best-effort here — a throw must not mask the
-          // structural warnings already collected above.
-        }
-
-        // W021 only fires when phase_id_convention is explicitly 'milestone-prefixed'.
-        // Authoritative source: .planning/config.json (set by the upgrade command).
-        // Fallback: ROADMAP.md frontmatter (for projects that set the field there directly).
+        // #3641: resolve phase_id_convention ONCE, ahead of every consumer in
+        // this validate pass — V004's entry check and V005's scope classifier
+        // below, and the W021 milestone-prefix check after them.
+        // Authoritative source: .planning/config.json (set by the upgrade
+        // command). Fallback: ROADMAP.md frontmatter (for projects that set
+        // the field there directly).
         let convention: string | undefined | null;
         try {
           const cfg = loadConfig(cwd);
@@ -244,6 +214,48 @@ function routeRoadmapCommand({ roadmap, args, cwd, raw, error }: RouteRoadmapCom
             }
           }
         }
+
+        // No recognizable phase structure. #3641: routed through the
+        // roadmap-parser owner (`hasPhaseEntries` — headings, #2199 bullets,
+        // #3577 table rows) instead of a private inline heading regex, so the
+        // document-level check and the V005 scope axis below can never
+        // disagree about what a phase entry is — and so a bracket-convention
+        // project's `### [GSD.04] 01:` entries are entries here too.
+        const hasPhaseEntry = hasPhaseEntries(roadmapContent, convention);
+        if (!hasPhaseEntry && !warnings.some((w) => w.code === 'V002')) {
+          warnings.push({ code: 'V004', message: 'ROADMAP.md contains no recognizable phase entries (no phase headings, bullet entries, or table rows)' });
+        }
+
+        // #3263: a whole-document phase check (V004 above) is satisfied by a
+        // document whose phase entries live OUTSIDE the active milestone's
+        // resolved window — e.g. an intervening version-bearing heading closes
+        // the window before its own `### Phase N:` sections. That truncation
+        // is exactly what the #3184 scope discriminator classifies, so ask
+        // the single owner (never re-derive the window shape here —
+        // lint-milestone-window-drift bans local copies) and surface a
+        // non-COMPLETE-but-not-empty verdict. TRUNCATED only: a genuinely
+        // phase-less milestone classifies COMPLETE (V004 owns that case) and
+        // an unscoped/unreadable window is a different failure mode with a
+        // different remediation, deliberately not warned here.
+        try {
+          // #3641: thread the resolved convention so the scope axis's
+          // hasPhaseEntries comparison recognizes bracket phase entries.
+          const scoped = extractCurrentMilestoneScoped(contentAfterBom, cwd, undefined, convention);
+          if (scoped.scope === SCOPE.TRUNCATED) {
+            warnings.push({
+              code: 'V005',
+              message:
+                'Active milestone window is truncated: phase entries exist in ROADMAP.md but are excluded from the ' +
+                'active milestone\'s resolved window (check for a heading between the milestone heading and its phase-entry sections)',
+            });
+          }
+        } catch {
+          // The classifier is best-effort here — a throw must not mask the
+          // structural warnings already collected above.
+        }
+
+        // W021 only fires when phase_id_convention is explicitly
+        // 'milestone-prefixed' — the same hoisted resolution above (#3641).
         if (convention === 'milestone-prefixed') {
           warnings.push(...checkW021(roadmapContent));
         }

--- a/src/roadmap-command-router.cts
+++ b/src/roadmap-command-router.cts
@@ -202,8 +202,11 @@ function routeRoadmapCommand({ roadmap, args, cwd, raw, error }: RouteRoadmapCom
           convention = undefined;
         }
         if (convention === undefined || convention === null) {
-          // Fallback: read from ROADMAP.md frontmatter
-          const fmMatch = roadmapContent.match(/^---\r?\n([\s\S]+?)\r?\n---/);
+          // Fallback: read from ROADMAP.md frontmatter. Bounded to match
+          // cmdRoadmapMilestoneScope's copy exactly (#3641 review NEW-1: an
+          // unbounded capture here read past 4KB frontmatters the probe's
+          // bounded copy could not, diverging validate from the probe).
+          const fmMatch = roadmapContent.match(/^---\r?\n([\s\S]{0,4000}?)\r?\n---/);
           if (fmMatch) {
             const kvMatch = fmMatch[1].match(/^phase_id_convention:\s*(.*)$/m);
             if (kvMatch) {

--- a/src/roadmap-parser.cts
+++ b/src/roadmap-parser.cts
@@ -32,6 +32,9 @@ const {
   roadmapPhaseLookupSources,
   extractPhaseToken,
   isSentinelPhaseId,
+  // #3641: the single-owner bracket heading-intro grammar — see
+  // BRACKET_PHASE_ENTRY_HEADING_RE below.
+  PHASE_HEADING_PREFIX_SRC,
 } = phaseIdModule;
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import planningWorkspace = require('./planning-workspace.cjs');
@@ -412,9 +415,31 @@ function sliceMilestoneWindow(content: string, version: string): string | null {
  * exist" — a window containing only sentinel phases still reached the
  * region and must read COMPLETE, not TRUNCATED.
  */
-function hasPhaseEntries(markdown: string): boolean {
+// #3641: the bracket-convention phase-ENTRY heading shape — the SAME intro
+// grammar phase-id.cts owns (PHASE_HEADING_PREFIX_SRC: a `[...]` bracket
+// optionally followed by a `Phase ` label, or a bare `Phase ` label), so
+// under 'bracket' the entry set admits `### [GSD.04] 01: Name` (bracket +
+// bare token — ADR-612: the bracket IS the intro; a bare number without one
+// is not) in addition to every shape the legacy pattern already recognized.
+// Built by interpolating the single-owner export — never a re-typed grammar
+// (the phase-id drift guard bans literal re-derivations) — and mirroring the
+// composition PR #2867 threads into the probe's phase-SET scan, so the entry
+// axis and the set axis cannot disagree on what a bracket phase heading is.
+const BRACKET_PHASE_ENTRY_HEADING_RE = new RegExp(
+  `^${PHASE_HEADING_PREFIX_SRC}[\\w][\\w.-]*(?:\\s*\\([^)\\n]{0,200}\\))?\\s*:`,
+  'i',
+);
+
+function hasPhaseEntries(markdown: string, phaseIdConvention?: string | null): boolean {
   // #1729: `(?:\s*\([^)\n]{0,200}\))?` tolerates a pre-colon ( ) tag (literal mirror of OPTIONAL_PHASE_TAG_SOURCE).
-  const phaseHeadingPattern = /^(?:\[[^\]]{1,200}\]\s*)?Phase\s+([\w][\w.-]*)(?:\s*\([^)\n]{0,200}\))?\s*:/i;
+  // #3641: the widened grammar engages ONLY when the resolved convention is
+  // 'bracket' — a project that has not opted in compiles the same legacy
+  // pattern it always did. The widened intro is a strict SUPERSET of the
+  // legacy one, so a mid-migration bracket ROADMAP keeps its legacy-labeled
+  // headings recognized too.
+  const phaseHeadingPattern = phaseIdConvention === 'bracket'
+    ? BRACKET_PHASE_ENTRY_HEADING_RE
+    : /^(?:\[[^\]]{1,200}\]\s*)?Phase\s+([\w][\w.-]*)(?:\s*\([^)\n]{0,200}\))?\s*:/i;
   for (const h of tokenizeHeadings(markdown)) {
     if (h.level < 2 || h.level > 4) continue;
     if (phaseHeadingPattern.test(h.text)) return true;
@@ -598,8 +623,18 @@ function classifyMilestoneWindow(input: {
  * symbols, 20 direct callers) means its signature and return type do not
  * change. This is the real owner; `extractCurrentMilestone` becomes a
  * one-line wrapper returning `.value` so every existing caller is untouched.
+ *
+ * @param phaseIdConvention - #3641: the RESOLVED `phase_id_convention`
+ *   config value, threaded to `hasPhaseEntries` so the scope axis's row-8
+ *   comparison recognizes bracket-convention phase entries
+ *   (`### [GSD.04] 01: Name`). Optional: absent, or any value other than
+ *   `'bracket'`, compiles the legacy entry grammar byte-identically — the
+ *   widening engages only for a project that resolved the convention
+ *   explicitly. `extractCurrentMilestone`'s wrapper deliberately does NOT
+ *   expose it (its 20 callers are not the scope-axis consumers; V005's
+ *   router site and `getMilestonePhaseFilter` resolve and thread it).
  */
-function extractCurrentMilestoneScoped(content: string, cwd?: string, ws?: string | null): { value: string; scope: Scope } {
+function extractCurrentMilestoneScoped(content: string, cwd?: string, ws?: string | null, phaseIdConvention?: string | null): { value: string; scope: Scope } {
   if (!cwd) {
     // Row 1: a deliberate unscoped read (no cwd supplied) is a real answer —
     // the caller asked for no scoping, so whole-document is COMPLETE.
@@ -640,13 +675,13 @@ function extractCurrentMilestoneScoped(content: string, cwd?: string, ws?: strin
         versionResolved,
         hasVersionedMilestones: versionedMilestonesPresent,
         headingFound: false,
-        windowHasPhaseEntries: hasPhaseEntries(value),
-        documentHasPhaseEntries: hasPhaseEntries(value),
+        windowHasPhaseEntries: hasPhaseEntries(value, phaseIdConvention),
+        documentHasPhaseEntries: hasPhaseEntries(value, phaseIdConvention),
       }),
     };
   }
 
-  const documentHasPhaseEntries = hasPhaseEntries(stripShippedMilestones(content));
+  const documentHasPhaseEntries = hasPhaseEntries(stripShippedMilestones(content), phaseIdConvention);
   const summaryPattern = new RegExp(
     `<summary[^>]*>([^<]*${escapeRegex(version)}[^<]*)<\\/summary>`,
     'i'
@@ -680,7 +715,7 @@ function extractCurrentMilestoneScoped(content: string, cwd?: string, ws?: strin
             versionResolved,
             hasVersionedMilestones: versionedMilestonesPresent,
             headingFound: true,
-            windowHasPhaseEntries: hasPhaseEntries(value),
+            windowHasPhaseEntries: hasPhaseEntries(value, phaseIdConvention),
             documentHasPhaseEntries,
           }),
         };
@@ -694,7 +729,7 @@ function extractCurrentMilestoneScoped(content: string, cwd?: string, ws?: strin
         versionResolved,
         hasVersionedMilestones: versionedMilestonesPresent,
         headingFound: false,
-        windowHasPhaseEntries: hasPhaseEntries(value),
+        windowHasPhaseEntries: hasPhaseEntries(value, phaseIdConvention),
         documentHasPhaseEntries,
       }),
     };
@@ -787,7 +822,7 @@ function extractCurrentMilestoneScoped(content: string, cwd?: string, ws?: strin
       versionResolved,
       hasVersionedMilestones: versionedMilestonesPresent,
       headingFound: true,
-      windowHasPhaseEntries: hasPhaseEntries(value),
+      windowHasPhaseEntries: hasPhaseEntries(value, phaseIdConvention),
       documentHasPhaseEntries,
     }),
   };
@@ -1380,7 +1415,7 @@ function getMilestonePhaseFilter(cwd: string, versionOverride?: string | null, p
     const roadmapPath = path.join(planningDir(cwd, ws), 'ROADMAP.md');
     const roadmapContent = platformReadSync(roadmapPath);
     if (roadmapContent === null) throw new Error('missing');
-    const scopedResult = extractCurrentMilestoneScoped(roadmapContent, cwd, ws);
+    const scopedResult = extractCurrentMilestoneScoped(roadmapContent, cwd, ws, phaseIdConvention);
     let roadmap = scopedResult.value;
     // Default: the filter's window IS extractCurrentMilestoneScoped's own
     // window (reused verbatim, not re-derived — ADR-3180 Decision 4c).
@@ -1417,7 +1452,7 @@ function getMilestonePhaseFilter(cwd: string, versionOverride?: string | null, p
       // via `storedMilestone`).
       const sliced = sliceMilestoneWindow(roadmapContent, versionOverride);
 
-      const documentHasPhaseEntries = hasPhaseEntries(stripShippedMilestones(roadmapContent));
+      const documentHasPhaseEntries = hasPhaseEntries(stripShippedMilestones(roadmapContent), phaseIdConvention);
 
       if (sliced !== null) {
         versionScoped = true;
@@ -1441,7 +1476,7 @@ function getMilestonePhaseFilter(cwd: string, versionOverride?: string | null, p
         versionResolved: true,
         hasVersionedMilestones: hasVersionedMilestonesGlobal,
         headingFound: sliced !== null,
-        windowHasPhaseEntries: hasPhaseEntries(roadmap),
+        windowHasPhaseEntries: hasPhaseEntries(roadmap, phaseIdConvention),
         documentHasPhaseEntries,
       });
     }
@@ -1662,4 +1697,8 @@ export = {
   scanMilestonePhaseIds,
   collectTablePhaseRows,
   findMilestoneScopeHeadingLines,
+  // #3641: the scope axis's phase-ENTRY predicate, exported so roadmap
+  // validate's V004 document-level check routes through the same single
+  // owner (and its convention gate) instead of a private inline copy.
+  hasPhaseEntries,
 };

--- a/src/roadmap-parser.cts
+++ b/src/roadmap-parser.cts
@@ -32,9 +32,10 @@ const {
   roadmapPhaseLookupSources,
   extractPhaseToken,
   isSentinelPhaseId,
-  // #3641: the single-owner bracket heading-intro grammar — see
-  // BRACKET_PHASE_ENTRY_HEADING_RE below.
+  // #3641: the single-owner heading-intro and digit-token grammar sources —
+  // see BRACKET_PHASE_ENTRY_HEADING_RE below.
   PHASE_HEADING_PREFIX_SRC,
+  PHASE_NUMBER_TOKEN_SOURCE,
 } = phaseIdModule;
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import planningWorkspace = require('./planning-workspace.cjs');
@@ -415,34 +416,40 @@ function sliceMilestoneWindow(content: string, version: string): string | null {
  * exist" — a window containing only sentinel phases still reached the
  * region and must read COMPLETE, not TRUNCATED.
  */
-// #3641: the bracket-convention phase-ENTRY heading shape — the SAME intro
-// grammar phase-id.cts owns (PHASE_HEADING_PREFIX_SRC: a `[...]` bracket
-// optionally followed by a `Phase ` label, or a bare `Phase ` label), so
-// under 'bracket' the entry set admits `### [GSD.04] 01: Name` (bracket +
-// bare token — ADR-612: the bracket IS the intro; a bare number without one
-// is not) in addition to every shape the legacy pattern already recognized.
-// Built by interpolating the single-owner export — never a re-typed grammar
-// (the phase-id drift guard bans literal re-derivations) — and mirroring the
-// composition PR #2867 threads into the probe's phase-SET scan, so the entry
-// axis and the set axis cannot disagree on what a bracket phase heading is.
+// #3641: the bracket-convention phase-ENTRY heading shape — ADR-612 Decision
+// 1's own discriminator: a phase heading is a bracket followed by a
+// DIGIT-then-colon (`### [GSD.04] 01: Name`); a bracket followed by a NAME
+// is a milestone heading and must never count. Every fragment interpolates a
+// single-owner export from phase-id.cts — the heading intro
+// (PHASE_HEADING_PREFIX_SRC: a `[...]` bracket optionally followed by a
+// `Phase ` label, or a bare `Phase ` label), the digit-bearing token
+// (PHASE_NUMBER_TOKEN_SOURCE, which also covers the dotted sub-phase form
+// `[GSD.02] 05.03:`), and the optional pre-colon tag
+// (OPTIONAL_PHASE_TAG_SOURCE) — never a re-typed grammar. Tested IN
+// ADDITION to the legacy pattern below, so bracket mode is a strict
+// superset: mid-migration legacy-labeled headings (`Phase AUTH-101:`-style
+// custom ids included) keep their existing recognition. Review finding: an
+// earlier single-alternative form with a `[\\w]` token admitted
+// `[bracket] Word:` shapes — a colon-bearing MILESTONE heading inside the
+// window read as an entry (defeating V005 outright for that spelling) and a
+// decoy `### [GSD.04] Notes:` outside the window manufactured a false V005
+// while suppressing the correct V004. The digit anchor forecloses both.
 const BRACKET_PHASE_ENTRY_HEADING_RE = new RegExp(
-  `^${PHASE_HEADING_PREFIX_SRC}[\\w][\\w.-]*(?:\\s*\\([^)\\n]{0,200}\\))?\\s*:`,
+  `^${PHASE_HEADING_PREFIX_SRC}${PHASE_NUMBER_TOKEN_SOURCE}${OPTIONAL_PHASE_TAG_SOURCE}\\s*:`,
   'i',
 );
 
 function hasPhaseEntries(markdown: string, phaseIdConvention?: string | null): boolean {
   // #1729: `(?:\s*\([^)\n]{0,200}\))?` tolerates a pre-colon ( ) tag (literal mirror of OPTIONAL_PHASE_TAG_SOURCE).
   // #3641: the widened grammar engages ONLY when the resolved convention is
-  // 'bracket' — a project that has not opted in compiles the same legacy
-  // pattern it always did. The widened intro is a strict SUPERSET of the
-  // legacy one, so a mid-migration bracket ROADMAP keeps its legacy-labeled
-  // headings recognized too.
-  const phaseHeadingPattern = phaseIdConvention === 'bracket'
-    ? BRACKET_PHASE_ENTRY_HEADING_RE
-    : /^(?:\[[^\]]{1,200}\]\s*)?Phase\s+([\w][\w.-]*)(?:\s*\([^)\n]{0,200}\))?\s*:/i;
+  // 'bracket' — a project that has not opted in runs the legacy pattern
+  // alone, byte-identically.
+  const phaseHeadingPattern = /^(?:\[[^\]]{1,200}\]\s*)?Phase\s+([\w][\w.-]*)(?:\s*\([^)\n]{0,200}\))?\s*:/i;
+  const bracketMode = phaseIdConvention === 'bracket';
   for (const h of tokenizeHeadings(markdown)) {
     if (h.level < 2 || h.level > 4) continue;
     if (phaseHeadingPattern.test(h.text)) return true;
+    if (bracketMode && BRACKET_PHASE_ENTRY_HEADING_RE.test(h.text)) return true;
   }
   // #3184 review finding: the bullet fallback must be fence-aware too, or a
   // FENCED markdown EXAMPLE of the `- [ ] **Phase N — Name**` syntax (e.g. a

--- a/src/roadmap.cts
+++ b/src/roadmap.cts
@@ -34,6 +34,11 @@ import { platformWriteSync } from './shell-command-projection.cjs';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import planningWorkspace = require('./planning-workspace.cjs');
 const { planningPaths, withPlanningLock, findContextMdIn } = planningWorkspace;
+// #3641: milestone-scope's convention resolution reads the project config
+// (no cycle — config-loader does not import this module).
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import configLoaderForScope = require('./config-loader.cjs');
+const { loadConfig: loadConfigForScope } = configLoaderForScope;
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import scanPhasePlans = require('./plan-scan.cjs');
 // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -707,7 +712,35 @@ function cmdRoadmapMilestoneScope(cwd: string, raw: boolean): void {
   }
 
   const rawContent = fs.readFileSync(roadmapPath, 'utf-8');
-  const { value: window, scope } = extractCurrentMilestoneScoped(rawContent, cwd);
+  // #3641: resolve phase_id_convention and thread it into the scope axis, so
+  // this probe and `roadmap validate`'s V005 answer the SAME question the
+  // SAME way for a bracket-convention project — a window the classifier
+  // calls TRUNCATED in validate must never read COMPLETE here (the #3262
+  // capture/compare guard consumes this scope). Resolution mirrors the
+  // validate router's: .planning/config.json first, ROADMAP.md frontmatter
+  // as fallback.
+  let phaseIdConvention: string | undefined | null;
+  try {
+    const cfg = loadConfigForScope(cwd);
+    phaseIdConvention = cfg['phase_id_convention'] as string | undefined | null;
+  } catch {
+    phaseIdConvention = undefined;
+  }
+  if (phaseIdConvention === undefined || phaseIdConvention === null) {
+    // Bounded per local/no-unbounded-quantifier (#2128): frontmatter is a
+    // short header block — 4KB is orders of magnitude beyond any real one.
+    const fmMatch = rawContent.match(/^---\r?\n([\s\S]{0,4000}?)\r?\n---/);
+    if (fmMatch) {
+      const kvMatch = fmMatch[1].match(/^phase_id_convention:\s*(.*)$/m);
+      if (kvMatch) {
+        const val = kvMatch[1].trim();
+        if (val !== 'null' && val !== '') {
+          phaseIdConvention = val.replace(/^["']|["']$/g, '');
+        }
+      }
+    }
+  }
+  const { value: window, scope } = extractCurrentMilestoneScoped(rawContent, cwd, undefined, phaseIdConvention);
   // Document order (Set insertion order) — deterministic for a given document.
   const phases = [...scanMilestonePhaseIds(window)];
   output({ scope, phases, phase_count: phases.length }, raw, undefined);

--- a/tests/roadmap.test.cjs
+++ b/tests/roadmap.test.cjs
@@ -3851,3 +3851,230 @@ describe('bug #3263: roadmap validate warns on a truncated milestone window', ()
     } finally { cleanup(tmpDir); }
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #3641: hasPhaseEntries is convention-blind — V005 (and V004) cannot see
+// bracket-convention phase entries (`### [GSD.04] 01: Name`), so a genuinely
+// truncated bracket window classifies COMPLETE and validate stays silent
+// (while V004 falsely reports "no recognizable phase entries"). The fix
+// threads the resolved `phase_id_convention` into hasPhaseEntries and routes
+// V004 through the same owner. Mirrors the #3263 harness directly above.
+// Matrix: .gsd/bug/fix-3641-hasphaseentries-convention-v005/50-test-matrix.md
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('bug #3641: bracket-convention windows are visible to validate (V005/V004)', () => {
+  const ROADMAP_PARSER_LIB = path.join(__dirname, '..', 'gsd-core', 'bin', 'lib', 'roadmap-parser.cjs');
+
+  function writeFixture3641(tmpDir, roadmapContent, stateFields, conventionSource) {
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), roadmapContent);
+    if (stateFields) {
+      const lines = ['---'];
+      for (const [k, v] of Object.entries(stateFields)) lines.push(`${k}: ${v}`);
+      lines.push('---', '');
+      fs.writeFileSync(path.join(tmpDir, '.planning', 'STATE.md'), lines.join('\n'));
+    }
+    if (conventionSource && conventionSource.kind === 'config') {
+      fs.writeFileSync(
+        path.join(tmpDir, '.planning', 'config.json'),
+        JSON.stringify({ phase_id_convention: 'bracket' }, null, 2),
+      );
+    }
+    // kind === 'frontmatter': the roadmap content itself carries the frontmatter.
+  }
+
+  const BRACKET_TRUNCATED_ROADMAP = [
+    '# Roadmap',
+    '',
+    '## v3.0 In Progress 🚧',
+    '',
+    'Some preamble notes. No phase headings here.',
+    '',
+    '## v4.0 Next',
+    '',
+    '### [GSD.04] 01: Foo',
+    '',
+    '### [GSD.04] 02: Bar',
+  ].join('\n');
+
+  test('bracket truncated window (config convention) → V005 fires, no false V004', () => {
+    const tmpDir = createTempProject('gsd-3641-bracket-truncated-');
+    try {
+      writeFixture3641(tmpDir, BRACKET_TRUNCATED_ROADMAP, { milestone: 'v3.0' }, { kind: 'config' });
+      const result = runGsdTools(['roadmap', 'validate', '--raw'], tmpDir);
+      assert.strictEqual(result.success, false, 'truncated bracket window must exit non-zero');
+      const payload = JSON.parse(result.output);
+      assert.ok(payload.warnings.some((w) => w.code === 'V005'),
+        `truncated bracket window must produce V005; got: ${JSON.stringify(payload)}`);
+      assert.ok(!payload.warnings.some((w) => w.code === 'V004'),
+        `the document HAS bracket phase entries — V004 must not fire; got: ${JSON.stringify(payload)}`);
+    } finally { cleanup(tmpDir); }
+  });
+
+  test('bracket complete window → no warnings, exit 0', () => {
+    const tmpDir = createTempProject('gsd-3641-bracket-complete-');
+    try {
+      writeFixture3641(tmpDir, [
+        '# Roadmap',
+        '',
+        '## v3.0 In Progress 🚧',
+        '',
+        '### [GSD.03] 01: Foo',
+        '',
+        '### [GSD.03] 02: Bar',
+        '',
+        '## v4.0 Next',
+        '',
+        'Later plans.',
+      ].join('\n'), { milestone: 'v3.0' }, { kind: 'config' });
+      const result = runGsdTools(['roadmap', 'validate', '--raw'], tmpDir);
+      assert.ok(result.success, `complete bracket window must exit 0; got: ${result.error}`);
+      const payload = JSON.parse(result.output);
+      assert.deepStrictEqual(payload.warnings, [], `complete bracket window must have no warnings; got: ${JSON.stringify(payload)}`);
+    } finally { cleanup(tmpDir); }
+  });
+
+  test('bracket truncated window (frontmatter convention) → V005 fires', () => {
+    const tmpDir = createTempProject('gsd-3641-bracket-fm-');
+    try {
+      const withFrontmatter = [
+        '---',
+        'phase_id_convention: bracket',
+        '---',
+        '',
+        BRACKET_TRUNCATED_ROADMAP,
+      ].join('\n');
+      writeFixture3641(tmpDir, withFrontmatter, { milestone: 'v3.0' }, { kind: 'frontmatter' });
+      const result = runGsdTools(['roadmap', 'validate', '--raw'], tmpDir);
+      assert.strictEqual(result.success, false, 'frontmatter-convention truncated window must exit non-zero');
+      const payload = JSON.parse(result.output);
+      assert.ok(payload.warnings.some((w) => w.code === 'V005'),
+        `frontmatter convention must resolve for V005; got: ${JSON.stringify(payload)}`);
+    } finally { cleanup(tmpDir); }
+  });
+
+  test('legacy truncated window without convention → V005 still fires (parity)', () => {
+    const tmpDir = createTempProject('gsd-3641-legacy-parity-');
+    try {
+      writeFixture3641(tmpDir, [
+        '# Roadmap',
+        '',
+        '## v3.0 In Progress 🚧',
+        '',
+        'Some preamble notes.',
+        '',
+        '## v4.0 Next',
+        '',
+        '### Phase 1: Foo',
+        '',
+        '### Phase 2: Bar',
+      ].join('\n'), { milestone: 'v3.0' }, null);
+      const result = runGsdTools(['roadmap', 'validate', '--raw'], tmpDir);
+      assert.strictEqual(result.success, false, 'legacy truncated window must still exit non-zero');
+      const payload = JSON.parse(result.output);
+      assert.ok(payload.warnings.some((w) => w.code === 'V005'),
+        `legacy V005 behavior must be unchanged; got: ${JSON.stringify(payload)}`);
+    } finally { cleanup(tmpDir); }
+  });
+
+  test('bracket-spelling roadmap without convention → not widened (V004 only)', () => {
+    const tmpDir = createTempProject('gsd-3641-no-convention-');
+    try {
+      writeFixture3641(tmpDir, BRACKET_TRUNCATED_ROADMAP, { milestone: 'v3.0' }, null);
+      const result = runGsdTools(['roadmap', 'validate', '--raw'], tmpDir);
+      assert.strictEqual(result.success, false, 'unrecognized entries must still exit non-zero');
+      const payload = JSON.parse(result.output);
+      assert.ok(payload.warnings.some((w) => w.code === 'V004'),
+        `a project that never opted in keeps the legacy reading (V004); got: ${JSON.stringify(payload)}`);
+      assert.ok(!payload.warnings.some((w) => w.code === 'V005'),
+        `no convention declared — the widened grammar must not engage; got: ${JSON.stringify(payload)}`);
+    } finally { cleanup(tmpDir); }
+  });
+
+  test('bracket phase-less roadmap with bracket milestone name headings → V004 only, no V005', () => {
+    const tmpDir = createTempProject('gsd-3641-bracket-phaseless-');
+    try {
+      writeFixture3641(tmpDir, [
+        '# Roadmap',
+        '',
+        '## [GSD.02] Foundation',
+        '',
+        'Nothing planned yet. A bracket MILESTONE heading is a bracket plus a',
+        'name — not a phase entry (no digit-then-colon tail).',
+      ].join('\n'), { milestone: 'v3.0' }, { kind: 'config' });
+      const result = runGsdTools(['roadmap', 'validate', '--raw'], tmpDir);
+      assert.strictEqual(result.success, false, 'genuinely phase-less bracket roadmap must exit non-zero');
+      const payload = JSON.parse(result.output);
+      assert.ok(payload.warnings.some((w) => w.code === 'V004'),
+        `V004 owns the phase-less case under bracket too; got: ${JSON.stringify(payload)}`);
+      assert.ok(!payload.warnings.some((w) => w.code === 'V005'),
+        `a phase-less window must never produce V005; got: ${JSON.stringify(payload)}`);
+    } finally { cleanup(tmpDir); }
+  });
+
+  test('fenced bracket heading example does not count as a phase entry', () => {
+    const tmpDir = createTempProject('gsd-3641-bracket-fence-');
+    try {
+      writeFixture3641(tmpDir, [
+        '# Roadmap',
+        '',
+        '## v3.0 In Progress 🚧',
+        '',
+        'Documentation example of the syntax:',
+        '',
+        '```markdown',
+        '### [GSD.03] 01: Documented example',
+        '```',
+        '',
+        'No real phase headings anywhere.',
+        '',
+        '## v4.0 Next',
+        '',
+        'Later plans.',
+      ].join('\n'), { milestone: 'v3.0' }, { kind: 'config' });
+      const result = runGsdTools(['roadmap', 'validate', '--raw'], tmpDir);
+      assert.strictEqual(result.success, false, 'fenced-example-only roadmap must exit non-zero');
+      const payload = JSON.parse(result.output);
+      assert.ok(payload.warnings.some((w) => w.code === 'V004'),
+        `a fenced example is not a real entry; got: ${JSON.stringify(payload)}`);
+      assert.ok(!payload.warnings.some((w) => w.code === 'V005'),
+        `fenced examples must not flip the scope axis; got: ${JSON.stringify(payload)}`);
+    } finally { cleanup(tmpDir); }
+  });
+
+  test('bracket+label mixed spelling still recognized under bracket convention', () => {
+    const tmpDir = createTempProject('gsd-3641-bracket-mixed-');
+    try {
+      writeFixture3641(tmpDir, [
+        '# Roadmap',
+        '',
+        '## v3.0 In Progress 🚧',
+        '',
+        '### [GSD.03] Phase 01: Foo',
+        '',
+        '## v4.0 Next',
+        '',
+        'Later plans.',
+      ].join('\n'), { milestone: 'v3.0' }, { kind: 'config' });
+      const result = runGsdTools(['roadmap', 'validate', '--raw'], tmpDir);
+      assert.ok(result.success, `mixed spelling is already-recognized — must exit 0; got: ${result.error}`);
+      const payload = JSON.parse(result.output);
+      assert.deepStrictEqual(payload.warnings, [], `mixed spelling must stay recognized; got: ${JSON.stringify(payload)}`);
+    } finally { cleanup(tmpDir); }
+  });
+
+  test('hasPhaseEntries gates the widened grammar on the bracket convention (unit seam)', () => {
+    // Direct rows on the exported predicate: the widened heading grammar
+    // engages ONLY when the resolved convention is 'bracket'.
+    const roadmapParser = require(ROADMAP_PARSER_LIB);
+    assert.strictEqual(typeof roadmapParser.hasPhaseEntries, 'function',
+      'hasPhaseEntries must be exported for the validate seam (#3641)');
+    const bracketHeading = '### [GSD.04] 01: Foo';
+    const legacyHeading = '### Phase 01: Foo';
+    assert.strictEqual(roadmapParser.hasPhaseEntries(bracketHeading, 'bracket'), true,
+      "bracket convention: '[GSD.04] 01:' is a phase entry");
+    assert.strictEqual(roadmapParser.hasPhaseEntries(bracketHeading, null), false,
+      'no convention: the bracket+bare-number spelling is not an entry');
+    assert.strictEqual(roadmapParser.hasPhaseEntries(legacyHeading, 'bracket'), true,
+      'bracket convention is a superset — the legacy label stays recognized');
+  });
+});

--- a/tests/roadmap.test.cjs
+++ b/tests/roadmap.test.cjs
@@ -3896,170 +3896,238 @@ describe('bug #3641: bracket-convention windows are visible to validate (V005/V0
     '### [GSD.04] 02: Bar',
   ].join('\n');
 
-  test('bracket truncated window (config convention) → V005 fires, no false V004', () => {
+  test('bracket truncated window (config convention) → V005 fires, no false V004', (t) => {
     const tmpDir = createTempProject('gsd-3641-bracket-truncated-');
-    try {
-      writeFixture3641(tmpDir, BRACKET_TRUNCATED_ROADMAP, { milestone: 'v3.0' }, { kind: 'config' });
-      const result = runGsdTools(['roadmap', 'validate', '--raw'], tmpDir);
-      assert.strictEqual(result.success, false, 'truncated bracket window must exit non-zero');
-      const payload = JSON.parse(result.output);
-      assert.ok(payload.warnings.some((w) => w.code === 'V005'),
-        `truncated bracket window must produce V005; got: ${JSON.stringify(payload)}`);
-      assert.ok(!payload.warnings.some((w) => w.code === 'V004'),
-        `the document HAS bracket phase entries — V004 must not fire; got: ${JSON.stringify(payload)}`);
-    } finally { cleanup(tmpDir); }
+    t.after(() => cleanup(tmpDir));
+  writeFixture3641(tmpDir, BRACKET_TRUNCATED_ROADMAP, { milestone: 'v3.0' }, { kind: 'config' });
+  const result = runGsdTools(['roadmap', 'validate', '--raw'], tmpDir);
+  assert.strictEqual(result.success, false, 'truncated bracket window must exit non-zero');
+  const payload = JSON.parse(result.output);
+  assert.ok(payload.warnings.some((w) => w.code === 'V005'),
+    `truncated bracket window must produce V005; got: ${JSON.stringify(payload)}`);
+  assert.ok(!payload.warnings.some((w) => w.code === 'V004'),
+    `the document HAS bracket phase entries — V004 must not fire; got: ${JSON.stringify(payload)}`);
   });
 
-  test('bracket complete window → no warnings, exit 0', () => {
+  test('bracket complete window → no warnings, exit 0', (t) => {
     const tmpDir = createTempProject('gsd-3641-bracket-complete-');
-    try {
-      writeFixture3641(tmpDir, [
-        '# Roadmap',
-        '',
-        '## v3.0 In Progress 🚧',
-        '',
-        '### [GSD.03] 01: Foo',
-        '',
-        '### [GSD.03] 02: Bar',
-        '',
-        '## v4.0 Next',
-        '',
-        'Later plans.',
-      ].join('\n'), { milestone: 'v3.0' }, { kind: 'config' });
-      const result = runGsdTools(['roadmap', 'validate', '--raw'], tmpDir);
-      assert.ok(result.success, `complete bracket window must exit 0; got: ${result.error}`);
-      const payload = JSON.parse(result.output);
-      assert.deepStrictEqual(payload.warnings, [], `complete bracket window must have no warnings; got: ${JSON.stringify(payload)}`);
-    } finally { cleanup(tmpDir); }
+    t.after(() => cleanup(tmpDir));
+  writeFixture3641(tmpDir, [
+    '# Roadmap',
+    '',
+    '## v3.0 In Progress 🚧',
+    '',
+    '### [GSD.03] 01: Foo',
+    '',
+    '### [GSD.03] 02: Bar',
+    '',
+    '## v4.0 Next',
+    '',
+    'Later plans.',
+  ].join('\n'), { milestone: 'v3.0' }, { kind: 'config' });
+  const result = runGsdTools(['roadmap', 'validate', '--raw'], tmpDir);
+  assert.ok(result.success, `complete bracket window must exit 0; got: ${result.error}`);
+  const payload = JSON.parse(result.output);
+  assert.deepStrictEqual(payload.warnings, [], `complete bracket window must have no warnings; got: ${JSON.stringify(payload)}`);
   });
 
-  test('bracket truncated window (frontmatter convention) → V005 fires', () => {
+  test('bracket truncated window (frontmatter convention) → V005 fires', (t) => {
     const tmpDir = createTempProject('gsd-3641-bracket-fm-');
-    try {
-      const withFrontmatter = [
-        '---',
-        'phase_id_convention: bracket',
-        '---',
-        '',
-        BRACKET_TRUNCATED_ROADMAP,
-      ].join('\n');
-      writeFixture3641(tmpDir, withFrontmatter, { milestone: 'v3.0' }, { kind: 'frontmatter' });
-      const result = runGsdTools(['roadmap', 'validate', '--raw'], tmpDir);
-      assert.strictEqual(result.success, false, 'frontmatter-convention truncated window must exit non-zero');
-      const payload = JSON.parse(result.output);
-      assert.ok(payload.warnings.some((w) => w.code === 'V005'),
-        `frontmatter convention must resolve for V005; got: ${JSON.stringify(payload)}`);
-    } finally { cleanup(tmpDir); }
+    t.after(() => cleanup(tmpDir));
+  const withFrontmatter = [
+    '---',
+    'phase_id_convention: bracket',
+    '---',
+    '',
+    BRACKET_TRUNCATED_ROADMAP,
+  ].join('\n');
+  writeFixture3641(tmpDir, withFrontmatter, { milestone: 'v3.0' }, { kind: 'frontmatter' });
+  const result = runGsdTools(['roadmap', 'validate', '--raw'], tmpDir);
+  assert.strictEqual(result.success, false, 'frontmatter-convention truncated window must exit non-zero');
+  const payload = JSON.parse(result.output);
+  assert.ok(payload.warnings.some((w) => w.code === 'V005'),
+    `frontmatter convention must resolve for V005; got: ${JSON.stringify(payload)}`);
   });
 
-  test('legacy truncated window without convention → V005 still fires (parity)', () => {
+  test('legacy truncated window without convention → V005 still fires (parity)', (t) => {
     const tmpDir = createTempProject('gsd-3641-legacy-parity-');
-    try {
-      writeFixture3641(tmpDir, [
-        '# Roadmap',
-        '',
-        '## v3.0 In Progress 🚧',
-        '',
-        'Some preamble notes.',
-        '',
-        '## v4.0 Next',
-        '',
-        '### Phase 1: Foo',
-        '',
-        '### Phase 2: Bar',
-      ].join('\n'), { milestone: 'v3.0' }, null);
-      const result = runGsdTools(['roadmap', 'validate', '--raw'], tmpDir);
-      assert.strictEqual(result.success, false, 'legacy truncated window must still exit non-zero');
-      const payload = JSON.parse(result.output);
-      assert.ok(payload.warnings.some((w) => w.code === 'V005'),
-        `legacy V005 behavior must be unchanged; got: ${JSON.stringify(payload)}`);
-    } finally { cleanup(tmpDir); }
+    t.after(() => cleanup(tmpDir));
+  writeFixture3641(tmpDir, [
+    '# Roadmap',
+    '',
+    '## v3.0 In Progress 🚧',
+    '',
+    'Some preamble notes.',
+    '',
+    '## v4.0 Next',
+    '',
+    '### Phase 1: Foo',
+    '',
+    '### Phase 2: Bar',
+  ].join('\n'), { milestone: 'v3.0' }, null);
+  const result = runGsdTools(['roadmap', 'validate', '--raw'], tmpDir);
+  assert.strictEqual(result.success, false, 'legacy truncated window must still exit non-zero');
+  const payload = JSON.parse(result.output);
+  assert.ok(payload.warnings.some((w) => w.code === 'V005'),
+    `legacy V005 behavior must be unchanged; got: ${JSON.stringify(payload)}`);
   });
 
-  test('bracket-spelling roadmap without convention → not widened (V004 only)', () => {
+  test('bracket-spelling roadmap without convention → not widened (V004 only)', (t) => {
     const tmpDir = createTempProject('gsd-3641-no-convention-');
-    try {
-      writeFixture3641(tmpDir, BRACKET_TRUNCATED_ROADMAP, { milestone: 'v3.0' }, null);
-      const result = runGsdTools(['roadmap', 'validate', '--raw'], tmpDir);
-      assert.strictEqual(result.success, false, 'unrecognized entries must still exit non-zero');
-      const payload = JSON.parse(result.output);
-      assert.ok(payload.warnings.some((w) => w.code === 'V004'),
-        `a project that never opted in keeps the legacy reading (V004); got: ${JSON.stringify(payload)}`);
-      assert.ok(!payload.warnings.some((w) => w.code === 'V005'),
-        `no convention declared — the widened grammar must not engage; got: ${JSON.stringify(payload)}`);
-    } finally { cleanup(tmpDir); }
+    t.after(() => cleanup(tmpDir));
+  writeFixture3641(tmpDir, BRACKET_TRUNCATED_ROADMAP, { milestone: 'v3.0' }, null);
+  const result = runGsdTools(['roadmap', 'validate', '--raw'], tmpDir);
+  assert.strictEqual(result.success, false, 'unrecognized entries must still exit non-zero');
+  const payload = JSON.parse(result.output);
+  assert.ok(payload.warnings.some((w) => w.code === 'V004'),
+    `a project that never opted in keeps the legacy reading (V004); got: ${JSON.stringify(payload)}`);
+  assert.ok(!payload.warnings.some((w) => w.code === 'V005'),
+    `no convention declared — the widened grammar must not engage; got: ${JSON.stringify(payload)}`);
   });
 
-  test('bracket phase-less roadmap with bracket milestone name headings → V004 only, no V005', () => {
+  test('bracket phase-less roadmap with bracket milestone name headings → V004 only, no V005', (t) => {
     const tmpDir = createTempProject('gsd-3641-bracket-phaseless-');
-    try {
-      writeFixture3641(tmpDir, [
-        '# Roadmap',
-        '',
-        '## [GSD.02] Foundation',
-        '',
-        'Nothing planned yet. A bracket MILESTONE heading is a bracket plus a',
-        'name — not a phase entry (no digit-then-colon tail).',
-      ].join('\n'), { milestone: 'v3.0' }, { kind: 'config' });
-      const result = runGsdTools(['roadmap', 'validate', '--raw'], tmpDir);
-      assert.strictEqual(result.success, false, 'genuinely phase-less bracket roadmap must exit non-zero');
-      const payload = JSON.parse(result.output);
-      assert.ok(payload.warnings.some((w) => w.code === 'V004'),
-        `V004 owns the phase-less case under bracket too; got: ${JSON.stringify(payload)}`);
-      assert.ok(!payload.warnings.some((w) => w.code === 'V005'),
-        `a phase-less window must never produce V005; got: ${JSON.stringify(payload)}`);
-    } finally { cleanup(tmpDir); }
+    t.after(() => cleanup(tmpDir));
+  writeFixture3641(tmpDir, [
+    '# Roadmap',
+    '',
+    '## [GSD.02] Foundation',
+    '',
+    'Nothing planned yet. A bracket MILESTONE heading is a bracket plus a',
+    'name — not a phase entry (no digit-then-colon tail).',
+  ].join('\n'), { milestone: 'v3.0' }, { kind: 'config' });
+  const result = runGsdTools(['roadmap', 'validate', '--raw'], tmpDir);
+  assert.strictEqual(result.success, false, 'genuinely phase-less bracket roadmap must exit non-zero');
+  const payload = JSON.parse(result.output);
+  assert.ok(payload.warnings.some((w) => w.code === 'V004'),
+    `V004 owns the phase-less case under bracket too; got: ${JSON.stringify(payload)}`);
+  assert.ok(!payload.warnings.some((w) => w.code === 'V005'),
+    `a phase-less window must never produce V005; got: ${JSON.stringify(payload)}`);
   });
 
-  test('fenced bracket heading example does not count as a phase entry', () => {
+  test('fenced bracket heading example does not count as a phase entry', (t) => {
     const tmpDir = createTempProject('gsd-3641-bracket-fence-');
-    try {
-      writeFixture3641(tmpDir, [
-        '# Roadmap',
-        '',
-        '## v3.0 In Progress 🚧',
-        '',
-        'Documentation example of the syntax:',
-        '',
-        '```markdown',
-        '### [GSD.03] 01: Documented example',
-        '```',
-        '',
-        'No real phase headings anywhere.',
-        '',
-        '## v4.0 Next',
-        '',
-        'Later plans.',
-      ].join('\n'), { milestone: 'v3.0' }, { kind: 'config' });
-      const result = runGsdTools(['roadmap', 'validate', '--raw'], tmpDir);
-      assert.strictEqual(result.success, false, 'fenced-example-only roadmap must exit non-zero');
-      const payload = JSON.parse(result.output);
-      assert.ok(payload.warnings.some((w) => w.code === 'V004'),
-        `a fenced example is not a real entry; got: ${JSON.stringify(payload)}`);
-      assert.ok(!payload.warnings.some((w) => w.code === 'V005'),
-        `fenced examples must not flip the scope axis; got: ${JSON.stringify(payload)}`);
-    } finally { cleanup(tmpDir); }
+    t.after(() => cleanup(tmpDir));
+  writeFixture3641(tmpDir, [
+    '# Roadmap',
+    '',
+    '## v3.0 In Progress 🚧',
+    '',
+    'Documentation example of the syntax:',
+    '',
+    '```markdown',
+    '### [GSD.03] 01: Documented example',
+    '```',
+    '',
+    'No real phase headings anywhere.',
+    '',
+    '## v4.0 Next',
+    '',
+    'Later plans.',
+  ].join('\n'), { milestone: 'v3.0' }, { kind: 'config' });
+  const result = runGsdTools(['roadmap', 'validate', '--raw'], tmpDir);
+  assert.strictEqual(result.success, false, 'fenced-example-only roadmap must exit non-zero');
+  const payload = JSON.parse(result.output);
+  assert.ok(payload.warnings.some((w) => w.code === 'V004'),
+    `a fenced example is not a real entry; got: ${JSON.stringify(payload)}`);
+  assert.ok(!payload.warnings.some((w) => w.code === 'V005'),
+    `fenced examples must not flip the scope axis; got: ${JSON.stringify(payload)}`);
   });
 
-  test('bracket+label mixed spelling still recognized under bracket convention', () => {
+  test('bracket+label mixed spelling still recognized under bracket convention', (t) => {
     const tmpDir = createTempProject('gsd-3641-bracket-mixed-');
-    try {
-      writeFixture3641(tmpDir, [
-        '# Roadmap',
-        '',
-        '## v3.0 In Progress 🚧',
-        '',
-        '### [GSD.03] Phase 01: Foo',
-        '',
-        '## v4.0 Next',
-        '',
-        'Later plans.',
-      ].join('\n'), { milestone: 'v3.0' }, { kind: 'config' });
-      const result = runGsdTools(['roadmap', 'validate', '--raw'], tmpDir);
-      assert.ok(result.success, `mixed spelling is already-recognized — must exit 0; got: ${result.error}`);
-      const payload = JSON.parse(result.output);
-      assert.deepStrictEqual(payload.warnings, [], `mixed spelling must stay recognized; got: ${JSON.stringify(payload)}`);
-    } finally { cleanup(tmpDir); }
+    t.after(() => cleanup(tmpDir));
+  writeFixture3641(tmpDir, [
+    '# Roadmap',
+    '',
+    '## v3.0 In Progress 🚧',
+    '',
+    '### [GSD.03] Phase 01: Foo',
+    '',
+    '## v4.0 Next',
+    '',
+    'Later plans.',
+  ].join('\n'), { milestone: 'v3.0' }, { kind: 'config' });
+  const result = runGsdTools(['roadmap', 'validate', '--raw'], tmpDir);
+  assert.ok(result.success, `mixed spelling is already-recognized — must exit 0; got: ${result.error}`);
+  const payload = JSON.parse(result.output);
+  assert.deepStrictEqual(payload.warnings, [], `mixed spelling must stay recognized; got: ${JSON.stringify(payload)}`);
+  });
+
+  test('colon-bearing bracket milestone heading in-window does not read as a phase entry (#3641 review HIGH)', (t) => {
+    const tmpDir = createTempProject('gsd-3641-bracket-colon-milestone-');
+    t.after(() => cleanup(tmpDir));
+    writeFixture3641(tmpDir, [
+      '# Roadmap',
+      '',
+      '## [GSD.03] v3.0: Current',
+      '',
+      'No phases under the active milestone — and its own heading carries a',
+      'colon, which must NOT make the window read as having phase entries.',
+      '',
+      '## [GSD.04] v4.0: Next',
+      '',
+      '### [GSD.04] 01: Foo',
+    ].join('\n'), { milestone: 'v3.0' }, { kind: 'config' });
+    const result = runGsdTools(['roadmap', 'validate', '--raw'], tmpDir);
+    assert.strictEqual(result.success, false, 'truncated bracket window (colon-bearing milestone heading) must exit non-zero');
+    const payload = JSON.parse(result.output);
+    assert.ok(payload.warnings.some((w) => w.code === 'V005'),
+      `ADR-612 discriminator: a bracket + NAME(:version) heading is a milestone, not an entry — the window is still truncated; got: ${JSON.stringify(payload)}`);
+    assert.ok(!payload.warnings.some((w) => w.code === 'V004'), `real bracket entries exist; got: ${JSON.stringify(payload)}`);
+  });
+
+  test('decoy bracket notes heading outside the window does not manufacture V005 (#3641 review MEDIUM)', (t) => {
+    const tmpDir = createTempProject('gsd-3641-bracket-decoy-');
+    t.after(() => cleanup(tmpDir));
+    writeFixture3641(tmpDir, [
+      '# Roadmap',
+      '',
+      '## v3.0 Current 🚧',
+      '',
+      'Nothing planned yet — a genuinely phase-less milestone.',
+      '',
+      '## v4.0 Next',
+      '',
+      '### [GSD.04] Notes: follow-ups',
+      '',
+      'Prose under a later milestone, not a phase entry.',
+    ].join('\n'), { milestone: 'v3.0' }, { kind: 'config' });
+    const result = runGsdTools(['roadmap', 'validate', '--raw'], tmpDir);
+    assert.strictEqual(result.success, false, 'phase-less bracket roadmap must exit non-zero');
+    const payload = JSON.parse(result.output);
+    assert.ok(payload.warnings.some((w) => w.code === 'V004'),
+      `no real entries — V004 owns the verdict; got: ${JSON.stringify(payload)}`);
+    assert.ok(!payload.warnings.some((w) => w.code === 'V005'),
+      `a decoy colon heading must never flip the scope axis to TRUNCATED; got: ${JSON.stringify(payload)}`);
+  });
+
+  test('milestone-scope probe agrees with validate on a truncated bracket window (#3641 review MEDIUM)', (t) => {
+    const tmpDir = createTempProject('gsd-3641-bracket-probe-');
+    t.after(() => cleanup(tmpDir));
+    writeFixture3641(tmpDir, BRACKET_TRUNCATED_ROADMAP, { milestone: 'v3.0' }, { kind: 'config' });
+    const result = runGsdTools(['roadmap', 'milestone-scope', '--raw'], tmpDir);
+    assert.ok(result.success, `probe must exit 0; got: ${result.error}`);
+    const payload = JSON.parse(result.output);
+    assert.strictEqual(payload.scope, 'truncated',
+      `the #3262 capture/compare signal must agree with validate's V005 classifier; got: ${JSON.stringify(payload)}`);
+  });
+
+  test('colon-less legacy phase heading alone still yields V004 (owner-entry definition pin)', (t) => {
+    const tmpDir = createTempProject('gsd-3641-colonless-');
+    t.after(() => cleanup(tmpDir));
+    writeFixture3641(tmpDir, [
+      '# Roadmap',
+      '',
+      '## v3.0 Current 🚧',
+      '',
+      '### Phase 1 — Foo',
+    ].join('\n'), { milestone: 'v3.0' }, null);
+    const result = runGsdTools(['roadmap', 'validate', '--raw'], tmpDir);
+    assert.strictEqual(result.success, false, 'colon-less-only roadmap must exit non-zero');
+    const payload = JSON.parse(result.output);
+    assert.ok(payload.warnings.some((w) => w.code === 'V004'),
+      `the canonical entry grammar is colon-terminated — a colon-less heading is not an entry for ANY reader; got: ${JSON.stringify(payload)}`);
   });
 
   test('hasPhaseEntries gates the widened grammar on the bracket convention (unit seam)', () => {


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #3641

---

## What was broken

`hasPhaseEntries` — the sole feeder of the milestone-window `scope` classifier's row-8 comparison — only recognized `Phase <id>:`-labeled headings. Under the bracket convention (`### [GSD.04] 01: Name`, where the bracket IS the heading intro), it returned false everywhere, so a genuinely **truncated** bracket window classified COMPLETE: **V005 could never fire on a bracket ROADMAP**, while V004 falsely reported "no recognizable phase entries" via its own inline copy of the same blindness. The `roadmap milestone-scope` probe (whose `scope` axis the issue names, and which the #3262 write-time guard consumes) had the same blind spot and could disagree with validate.

## What this fix does

- `hasPhaseEntries(markdown, phaseIdConvention?)` — under `'bracket'`, an additional heading test engages, composed entirely from phase-id.cts's single-owner exports (`PHASE_HEADING_PREFIX_SRC` + `PHASE_NUMBER_TOKEN_SOURCE` + `OPTIONAL_PHASE_TAG_SOURCE`): a bracket intro followed by a **digit**-then-colon token (ADR-612 Decision 1's own phase/milestone discriminator — a bracket followed by a *name* is a milestone heading and never counts). Tested **in addition to** the unchanged legacy pattern, so bracket mode is a strict superset and mid-migration legacy-labeled headings stay recognized. Any other convention value (or none) compiles the legacy behavior byte-identically.
- The resolved convention (`.planning/config.json`, ROADMAP frontmatter fallback) is threaded into `extractCurrentMilestoneScoped` (optional 4th param) — consumed by `roadmap validate`'s V005, `getMilestonePhaseFilter` (completing its existing param's contract), and the `roadmap milestone-scope` probe, which now agrees with validate.
- V004 routes through the same owner predicate instead of its private inline regex, so the document-level check and the scope axis can never disagree about what a phase entry is.

## Root cause

The convention-blind entry predicate: `hasPhaseEntries` was born convention-less with the #3184 scope discriminator; #612 PR-1 landed the bracket grammar sources but nothing threaded them into the scope axis (PR #2867 threads the phase-*set* axis only, and this issue is the deliberately-deferred entry-axis half).

**Review-driven hardening (cycle 2):** the first cut used a `[\w]`-token bracket tail mirroring #2867's set-scan shape; adversarial review proved it admitted `[bracket] Word:` shapes — a colon-bearing **milestone** heading inside the window made `windowHasPhaseEntries` always true (V005 unreachable for that spelling), and a decoy `### [GSD.04] Notes:` outside a phase-less window manufactured a false V005 while suppressing the correct V004. The digit anchor forecloses both; both shapes are pinned by regression rows that were proven RED before the fix.

## Testing

### How I verified the fix

- **RED first, twice**: cycle 1 at `58e4a7a8f` (6 failures = exactly the new rows), cycle 2 at `e15c89eed` (4 failures = the review rows). **GREEN**: `36794/36794` at `ed3908fa6` (pass marker recorded). Both reproduction fixtures re-verified on the real CLI.
- 13 new rows beside the #3263 suite: truncated bracket window (config + frontmatter convention) → V005; complete bracket window → clean; legacy parity; no-convention gate (not widened); bracket milestone name headings ≠ entries; fenced examples don't count; mixed bracket+label spelling; unit rows on the exported predicate; colon-bearing-milestone HIGH repro; decoy-notes MEDIUM repro; probe/validate parity; colon-less V004 pin.

### Regression test added?

- [x] Yes — see above; #3263's suite runs unchanged (legacy parity pinned).

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux

(Regex over ROADMAP text only; `tokenizeHeadings` handles CRLF; gsd-test ran the linux-node24 lane.)

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #3641`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — V004's fold-in is the same seam (its false positive fired on every bracket roadmap; leaving it was not an option); the probe threading is named by the issue's own What
- [x] Regression test added
- [x] All existing tests pass (`gsd-test` 36794/36794)
- [x] `.changeset/` fragment added (`Fixed`); `pr:` backfilled to this PR's number
- [x] No unnecessary dependencies added

## Breaking changes

None for projects that have not set `phase_id_convention: "bracket"` — the widened grammar engages only on that resolved value, pinned by test. For bracket projects (read-path opt-in per ADR-612) this is the correction the issue requests. Two deliberate alignments documented for reviewers: V004 now uses the shared entry definition (bullet- and table-house roadmaps no longer V004-warn; colon-less `Phase 1 — Foo` headings now do — matching the colon-terminated grammar every other reader uses), and both V004/V005 message texts were made convention-neutral.
