### PR TITLE
fix(#3651): prescribe only writes config-set accepts in integrations flow

### DIFF
--- a/.changeset/graceful-rams-dance.md
+++ b/.changeset/graceful-rams-dance.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`/gsd-config --integrations` no longer prescribes writes that fail** — the review-models section states the real rule (only reviewer lanes whose capability declares a modelConfigKey are settable; the nine settable lanes are enumerated; cursor/qwen/coderabbit named as keyless) instead of a validation pattern that never existed, and agent-skill lists are now written as JSON arrays instead of a comma-joined string that resolves as one broken skill path. (#3651)

--- a/.changeset/graceful-rams-dance.md
+++ b/.changeset/graceful-rams-dance.md
@@ -2,4 +2,4 @@
 type: Fixed
 pr: 0
 ---
-**`/gsd-config --integrations` no longer prescribes writes that fail** — the review-models section states the real rule (only reviewer lanes whose capability declares a modelConfigKey are settable; the nine settable lanes are enumerated; cursor/qwen/coderabbit named as keyless) instead of a validation pattern that never existed, and agent-skill lists are now written as JSON arrays instead of a comma-joined string that resolves as one broken skill path. (#3651)
+**`/gsd:config --integrations` no longer prescribes writes that fail** — the review-models section states the real rule (only reviewer lanes whose capability declares a modelConfigKey are settable; the nine settable lanes are enumerated; cursor/qwen/coderabbit named as keyless) instead of a validation pattern that never existed, and agent-skill lists are now written as JSON arrays instead of a comma-joined string that resolves as one broken skill path. (#3651)

--- a/.changeset/graceful-rams-dance.md
+++ b/.changeset/graceful-rams-dance.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 3732
 ---
 **`/gsd:config --integrations` no longer prescribes writes that fail** — the review-models section states the real rule (only reviewer lanes whose capability declares a modelConfigKey are settable; the nine settable lanes are enumerated; cursor/qwen/coderabbit named as keyless) instead of a validation pattern that never existed, and agent-skill lists are now written as JSON arrays instead of a comma-joined string that resolves as one broken skill path. (#3651)

--- a/gsd-core/workflows/settings-integrations.md
+++ b/gsd-core/workflows/settings-integrations.md
@@ -190,7 +190,7 @@ If "Configure CLI" is selected, ask:
 ```text
 AskUserQuestion([
   {
-    question: "Which reviewer lane do you want to configure? Other settable lanes: agy (Antigravity), kimi-code, llama_cpp, lm_studio, ollama — or type a slug",
+    question: "Which reviewer lane do you want to configure? (Common lanes below; any settable lane from the list above works — or type its slug)",
     header: "CLI",
     multiSelect: false,
     options: [
@@ -204,12 +204,11 @@ AskUserQuestion([
 ```
 
 For a slug received as free text, check it against the settable set above.
-If it is not one of the nine, print:
+If it is not one of the settable keys, print:
 
 ```text
-Rejected: review.models.<slug> is not settable. Only lanes whose capability
-declares a modelConfigKey can be configured here: agy, claude, codex, gemini,
-kimi-code, llama_cpp, lm_studio, ollama, opencode. (cursor, qwen, and
+Rejected: review.models.<slug> is not settable — only the reviewer lanes whose
+keys are enumerated above can be configured here. (cursor, qwen, and
 coderabbit have no per-lane model key.)
 ```
 

--- a/gsd-core/workflows/settings-integrations.md
+++ b/gsd-core/workflows/settings-integrations.md
@@ -26,10 +26,15 @@ log the plaintext value. The workflow follows these rules:
 - **`config-set` output is masked** for keys in the secret set
   (`brave_search`, `firecrawl`, `exa_search`) — see
   `gsd-core/bin/lib/secrets.cjs`.
-- **Agent-type and CLI slug validation.** `agent_skills.<agent-type>` and
-  `review.models.<cli>` keys are matched against `^[a-zA-Z0-9_-]+$`. Inputs
-  containing path separators (`/`, `\`, `..`), whitespace, or shell
-  metacharacters are rejected. This closes off skill-injection attacks.
+- **Agent-type and CLI slug validation.** Slug inputs for
+  `agent_skills.<agent-type>` and `review.models.<cli>` are checked against
+  `^[a-zA-Z0-9_-]+$` before any write; inputs containing path separators
+  (`/`, `\`, `..`), whitespace, or shell metacharacters are rejected. This
+  closes off skill-injection attacks. For `agent_skills` that check is the
+  gate on an open namespace (dynamic key pattern); for `review.models` it is
+  only a pre-check — the authoritative gate is the closed, registry-derived
+  settable set (see the review-models section below), because slug shape
+  alone never makes a `review.models.*` key writable.
 </security>
 
 <required_reading>
@@ -148,9 +153,23 @@ gsd_run query config-set brave_search null
 
 <step name="section_2_review_models">
 
-`review.models.<cli>` is a map that tells the code-review workflow which
-shell command to invoke for a given reviewer flavor. Supported flavors:
-`claude`, `codex`, `gemini`, `opencode`.
+`review.models.<cli>` is a closed, registry-derived map that tells the review
+workflow which model id a reviewer lane uses. It is not an open namespace: a
+`review.models.<cli>` key is settable only when that lane's capability
+declares a `modelConfigKey`, and `config-set` accepts exactly those keys
+(federated from the capability registry). No dynamic-key regex governs this
+namespace — any other slug fails with `Unknown config key`.
+
+Settable keys (the shipped registry's model-bearing lanes):
+
+`review.models.agy` (Antigravity), `review.models.claude`, `review.models.codex`,
+`review.models.gemini`, `review.models.kimi-code`, `review.models.llama_cpp`,
+`review.models.lm_studio`, `review.models.ollama`, `review.models.opencode`.
+
+Reviewer lanes `cursor`, `qwen`, and `coderabbit` declare no `modelConfigKey` —
+there is nothing to configure for them here (whether they should have a key is
+a separate, already-filed question). If the user asks for one of those, say
+exactly that and skip.
 
 ```text
 AskUserQuestion([
@@ -159,7 +178,7 @@ AskUserQuestion([
     header: "Review",
     multiSelect: false,
     options: [
-      { label: "Configure CLI", description: "Pick a reviewer flavor and set/clear its command" },
+      { label: "Configure CLI", description: "Pick a reviewer lane and set/clear its model id" },
       { label: "Done", description: "Finish this section" }
     ]
   }
@@ -171,7 +190,7 @@ If "Configure CLI" is selected, ask:
 ```text
 AskUserQuestion([
   {
-    question: "Which reviewer CLI do you want to configure?",
+    question: "Which reviewer lane do you want to configure? Other settable lanes: agy (Antigravity), kimi-code, llama_cpp, lm_studio, ollama — or type a slug",
     header: "CLI",
     multiSelect: false,
     options: [
@@ -184,7 +203,19 @@ AskUserQuestion([
 ])
 ```
 
-For the selected CLI, show the current value (or `(unset)`) and offer
+For a slug received as free text, check it against the settable set above.
+If it is not one of the nine, print:
+
+```text
+Rejected: review.models.<slug> is not settable. Only lanes whose capability
+declares a modelConfigKey can be configured here: agy, claude, codex, gemini,
+kimi-code, llama_cpp, lm_studio, ollama, opencode. (cursor, qwen, and
+coderabbit have no per-lane model key.)
+```
+
+and re-prompt.
+
+For the selected lane, show the current value (or `(unset)`) and offer
 Leave / Replace / Clear, followed by a text-input prompt for the model id
 string. Write via:
 
@@ -194,10 +225,6 @@ gsd_run query config-set review.models.<cli> "<model id>"
 
 After each update, return to the "Review model CLI mapping — what next?" question.
 Loop until the user selects "Done".
-
-The `review.models.<cli>` key is validated by the dynamic pattern
-`^review\.models\.[a-zA-Z0-9_-]+$`. Empty CLI slugs and path-containing slugs
-are rejected by `config-set` before any write.
 </step>
 
 <step name="section_3_agent_skills">
@@ -249,12 +276,22 @@ spaces, or shell metacharacters).
 
 and re-prompt.
 
-For a selected slug, prompt for the comma-separated skill list (text input).
-Show the current value if any, offer Leave / Replace / Clear. Write via:
+For a selected slug, prompt for the skill list (text input; a comma-separated
+reply is fine). Show the current value if any, offer Leave / Replace / Clear.
+
+Split the reply before writing: the resolver never splits strings, so a
+comma-joined string would be stored as ONE skill path that silently fails
+resolution at spawn time (#3651 — `references/planning-config.md`: "Paths
+cannot be comma-joined into one string; each path must be its own array
+element"). Split on commas, trim each entry, drop empty entries, and write
+the JSON array form:
 
 ```bash
-gsd_run query config-set agent_skills.<slug> "<skill-a,skill-b,skill-c>"
+gsd_run query config-set agent_skills.<slug> '["skills/alpha","skills/beta"]'
 ```
+
+A single skill may be written as one bare string or a one-element array —
+both resolve identically.
 
 After each update, return to the "Agent skills mapping — what next?" question.
 Loop until "Done".
@@ -278,12 +315,10 @@ Search Integrations
 | search_gitignored  | true | false      |
 
 Code Review CLI Routing
-| CLI         | Command                              |
+| Lane        | Model id                             |
 |-------------|--------------------------------------|
-| claude      | <value or (session model default)>   |
-| codex       | <value or (unset)>                   |
-| gemini      | <value or (unset)>                   |
-| opencode    | <value or (unset)>                   |
+| <lane>      | <value or (unset)>                   |
+| ...         | ... one row per lane the user set    |
 
 Agent Skills Injection
 | Agent Type       | Skills                    |
@@ -310,6 +345,6 @@ Quick commands:
 - [ ] User presented with three sections: Search Integrations, Review CLI Routing, Agent Skills Injection
 - [ ] API keys written plaintext only to `config.json`; never echoed, never logged, never displayed
 - [ ] Masked confirmation table uses `****<last-4>` for set keys and `(unset)` for null
-- [ ] `review.models.<cli>` and `agent_skills.<agent-type>` keys validated against `[a-zA-Z0-9_-]+` before write
+- [ ] `agent_skills.<agent-type>` slugs validated against `[a-zA-Z0-9_-]+` before write; `review.models.<cli>` slugs accepted only from the registry-derived settable set; skill lists written as JSON arrays (never comma-joined strings)
 - [ ] Config merge preserves all keys outside the three sections this workflow owns
 </success_criteria>

--- a/gsd-core/workflows/settings-integrations.md
+++ b/gsd-core/workflows/settings-integrations.md
@@ -26,15 +26,15 @@ log the plaintext value. The workflow follows these rules:
 - **`config-set` output is masked** for keys in the secret set
   (`brave_search`, `firecrawl`, `exa_search`) — see
   `gsd-core/bin/lib/secrets.cjs`.
-- **Agent-type and CLI slug validation.** Slug inputs for
-  `agent_skills.<agent-type>` and `review.models.<cli>` are checked against
-  `^[a-zA-Z0-9_-]+$` before any write; inputs containing path separators
-  (`/`, `\`, `..`), whitespace, or shell metacharacters are rejected. This
-  closes off skill-injection attacks. For `agent_skills` that check is the
-  gate on an open namespace (dynamic key pattern); for `review.models` it is
-  only a pre-check — the authoritative gate is the closed, registry-derived
-  settable set (see the review-models section below), because slug shape
-  alone never makes a `review.models.*` key writable.
+- **Agent-type and CLI slug validation.** `agent_skills.<agent-type>` slug
+  inputs are checked against `^[a-zA-Z0-9_-]+$` before any write; inputs
+  containing path separators (`/`, `\`, `..`), whitespace, or shell
+  metacharacters are rejected. This closes off skill-injection attacks on
+  that open namespace (dynamic key pattern). For `review.models.<cli>` no
+  slug-shape check is needed or performed: the gate is membership in the
+  closed, registry-derived settable set (see the review-models section
+  below), which subsumes slug shape — slug shape alone never makes a
+  `review.models.*` key writable.
 </security>
 
 <required_reading>
@@ -167,9 +167,9 @@ Settable keys (the shipped registry's model-bearing lanes):
 `review.models.lm_studio`, `review.models.ollama`, `review.models.opencode`.
 
 Reviewer lanes `cursor`, `qwen`, and `coderabbit` declare no `modelConfigKey` —
-there is nothing to configure for them here (whether they should have a key is
-a separate, already-filed question). If the user asks for one of those, say
-exactly that and skip.
+there is nothing to configure for them here (whether they should have a
+per-lane model key is a separate question, out of scope for this workflow).
+If the user asks for one of those, say exactly that and skip.
 
 ```text
 AskUserQuestion([
@@ -280,10 +280,11 @@ reply is fine). Show the current value if any, offer Leave / Replace / Clear.
 
 Split the reply before writing: the resolver never splits strings, so a
 comma-joined string would be stored as ONE skill path that silently fails
-resolution at spawn time (#3651 — `references/planning-config.md`: "Paths
-cannot be comma-joined into one string; each path must be its own array
-element"). Split on commas, trim each entry, drop empty entries, and write
-the JSON array form:
+resolution at spawn time (#3651 — `gsd-core/references/planning-config.md`:
+"Paths cannot be comma-joined into one string; each path must be its own
+array element"). Split on commas, trim each entry, drop empty entries, reject
+any entry containing a quote character (`'` or `"` — it cannot be written
+safely through the single-quoted form), and write the JSON array form:
 
 ```bash
 gsd_run query config-set agent_skills.<slug> '["skills/alpha","skills/beta"]'

--- a/tests/emitted-drift-acks/3651-settings-integrations-prescriptions.json
+++ b/tests/emitted-drift-acks/3651-settings-integrations-prescriptions.json
@@ -1,7 +1,7 @@
 {
-  "$comment": "Growth ack (#2914 fragment). Reason: #3651 corrects the two broken prescriptions in settings-integrations.md — the review.models section states the registry-derived settable rule (per-lane modelConfigKey, nine lanes enumerated once as full review.models.* keys, keyless lanes cursor/qwen/coderabbit named) instead of a nonexistent dynamic-key pattern claim, and the agent_skills section prescribes the JSON array write form plus the split-on-commas instruction. settings-integrations.md 16257 -> 18171 LF bytes (+1914, DEFAULT cap 40960). Pinned by the #3651 rows in tests/settings-integrations.test.cjs (workflow text must match the registry's settable set).",
+  "$comment": "Growth ack (#2914 fragment). Reason: #3651 corrects the two broken prescriptions in settings-integrations.md — the review.models section states the registry-derived settable rule (per-lane modelConfigKey, nine lanes enumerated once as full review.models.* keys, keyless lanes cursor/qwen/coderabbit named) instead of a nonexistent dynamic-key pattern claim, and the agent_skills section prescribes the JSON array write form plus the split-on-commas instruction (quote-bearing entries rejected). settings-integrations.md 16257 -> 18309 LF bytes (+2052, DEFAULT cap 40960). Pinned by the #3651 rows in tests/settings-integrations.test.cjs (workflow text must match the registry's settable set).",
   "version": 1,
   "paths": {
-    "settings-integrations.md": "gsd-core/workflows/settings-integrations.md +1914B: registry-derived review.models settable rule + agent_skills JSON-array prescription (#3651)"
+    "settings-integrations.md": "gsd-core/workflows/settings-integrations.md +2052B: registry-derived review.models settable rule + agent_skills JSON-array prescription (#3651)"
   }
 }

--- a/tests/emitted-drift-acks/3651-settings-integrations-prescriptions.json
+++ b/tests/emitted-drift-acks/3651-settings-integrations-prescriptions.json
@@ -1,0 +1,7 @@
+{
+  "$comment": "Growth ack (#2914 fragment). Reason: #3651 corrects the two broken prescriptions in settings-integrations.md — the review.models section states the registry-derived settable rule (per-lane modelConfigKey, nine lanes enumerated, keyless lanes cursor/qwen/coderabbit named) instead of a nonexistent dynamic-key pattern claim, and the agent_skills section prescribes the JSON array write form plus the split-on-commas instruction. settings-integrations.md 16257 -> 18249 LF bytes (+1992, DEFAULT cap 40960). Pinned by the #3651 rows in tests/settings-integrations.test.cjs (workflow text must match the registry's settable set).",
+  "version": 1,
+  "paths": {
+    "settings-integrations.md": "gsd-core/workflows/settings-integrations.md +1992B: registry-derived review.models settable rule + agent_skills JSON-array prescription (#3651)"
+  }
+}

--- a/tests/emitted-drift-acks/3651-settings-integrations-prescriptions.json
+++ b/tests/emitted-drift-acks/3651-settings-integrations-prescriptions.json
@@ -1,7 +1,7 @@
 {
-  "$comment": "Growth ack (#2914 fragment). Reason: #3651 corrects the two broken prescriptions in settings-integrations.md — the review.models section states the registry-derived settable rule (per-lane modelConfigKey, nine lanes enumerated, keyless lanes cursor/qwen/coderabbit named) instead of a nonexistent dynamic-key pattern claim, and the agent_skills section prescribes the JSON array write form plus the split-on-commas instruction. settings-integrations.md 16257 -> 18249 LF bytes (+1992, DEFAULT cap 40960). Pinned by the #3651 rows in tests/settings-integrations.test.cjs (workflow text must match the registry's settable set).",
+  "$comment": "Growth ack (#2914 fragment). Reason: #3651 corrects the two broken prescriptions in settings-integrations.md — the review.models section states the registry-derived settable rule (per-lane modelConfigKey, nine lanes enumerated once as full review.models.* keys, keyless lanes cursor/qwen/coderabbit named) instead of a nonexistent dynamic-key pattern claim, and the agent_skills section prescribes the JSON array write form plus the split-on-commas instruction. settings-integrations.md 16257 -> 18171 LF bytes (+1914, DEFAULT cap 40960). Pinned by the #3651 rows in tests/settings-integrations.test.cjs (workflow text must match the registry's settable set).",
   "version": 1,
   "paths": {
-    "settings-integrations.md": "gsd-core/workflows/settings-integrations.md +1992B: registry-derived review.models settable rule + agent_skills JSON-array prescription (#3651)"
+    "settings-integrations.md": "gsd-core/workflows/settings-integrations.md +1914B: registry-derived review.models settable rule + agent_skills JSON-array prescription (#3651)"
   }
 }

--- a/tests/settings-integrations.test.cjs
+++ b/tests/settings-integrations.test.cjs
@@ -12,6 +12,10 @@
  *   - Workflow references the four search API key fields
  *   - Workflow exposes review.models.{claude,codex,gemini,opencode} routing
  *   - Workflow exposes agent_skills.<agent-type> injection input
+ *   - #3651: workflow states the registry-derived review.models settable rule (no
+ *     dynamic-pattern claim) and enumerates exactly the registry's settable lanes
+ *   - #3651: workflow prescribes the JSON array agent_skills write form (never a
+ *     comma-joined string); behavioral pins for array/comma/single shapes
  *   - Masking convention (****last4) is documented in the workflow and the displayed
  *     confirmation pattern does not echo plaintext
  *   - config-set round-trips all integration keys through VALID_CONFIG_KEYS + dynamic patterns
@@ -106,7 +110,10 @@ describe('#2529 workflow — review.models routing', () => {
     }
   });
 
-  test('review.models.<cli> matches the dynamic pattern validator', () => {
+  test('review.models.<cli> keys validate via the federated capability registry', () => {
+    // #3651: these pass because the capability registry federates each lane's
+    // modelConfigKey into the valid-key set — NOT via a dynamicKeyPatterns regex
+    // (no such pattern exists; see the #3651 describe below).
     for (const cli of ['claude', 'codex', 'gemini', 'opencode']) {
       assert.ok(
         isValidConfigKey(`review.models.${cli}`),
@@ -133,6 +140,182 @@ describe('#2529 workflow — agent_skills injection', () => {
     assert.ok(isValidConfigKey('agent_skills.gsd-executor'));
     assert.ok(isValidConfigKey('agent_skills.gsd-planner'));
     assert.ok(isValidConfigKey('agent_skills.my_custom_agent'));
+  });
+});
+
+// ─── #3651: prescribed writes must match the real config-set contract ───────
+
+// Walk the shipped (frozen first-party) capability registry and collect the
+// reviewer-lane modelConfigKey slugs — the closed set `config-set` actually
+// accepts for review.models.* (federated via isCapabilityConfigKey).
+function collectReviewerModelConfigKeys() {
+  const registry = require('../gsd-core/bin/lib/capability-registry.cjs');
+  const keys = new Set();
+  const walk = (node) => {
+    if (!node || typeof node !== 'object') return;
+    if (Array.isArray(node)) { node.forEach(walk); return; }
+    if (
+      typeof node['modelConfigKey'] === 'string' &&
+      node['modelConfigKey'].startsWith('review.models.')
+    ) {
+      keys.add(node['modelConfigKey'].slice('review.models.'.length));
+    }
+    for (const value of Object.values(node)) walk(value);
+  };
+  walk(registry);
+  return keys;
+}
+
+describe('#3651 workflow — review.models settable-set rule', () => {
+  test('workflow states the registry-derived review.models rule, not a dynamic-pattern claim (#3651)', () => {
+    const src = fs.readFileSync(WORKFLOW_PATH, 'utf-8');
+    assert.ok(
+      !src.includes('^review\\.models\\.'),
+      'workflow must not claim a review.models dynamic-key pattern — dynamicKeyPatterns has no review.models entry'
+    );
+    assert.ok(
+      /modelConfigKey/.test(src),
+      'workflow must name the per-lane modelConfigKey rule'
+    );
+    assert.ok(
+      /capability registry/i.test(src),
+      'workflow must state that the settable set is derived from the capability registry'
+    );
+  });
+
+  test("workflow enumerates exactly the registry's settable review.models lanes (#3651)", () => {
+    const registryKeys = collectReviewerModelConfigKeys();
+    assert.ok(
+      registryKeys.size >= 9,
+      `expected the shipped nine-lane set from the registry, found ${registryKeys.size}`
+    );
+    const src = fs.readFileSync(WORKFLOW_PATH, 'utf-8');
+    const mentioned = new Set(
+      [...src.matchAll(/review\.models\.([a-zA-Z0-9_-]+)/g)].map((m) => m[1])
+    );
+    for (const key of registryKeys) {
+      assert.ok(
+        mentioned.has(key),
+        `workflow must enumerate settable lane review.models.${key} (registry truth)`
+      );
+    }
+    for (const slug of mentioned) {
+      assert.ok(
+        registryKeys.has(slug),
+        `workflow mentions review.models.${slug} but the registry declares no such settable key`
+      );
+    }
+  });
+
+  test('keyless reviewer lanes have no settable review.models key (#3651)', (t) => {
+    // Lanes whose capability declares modelConfigKey: null — the workflow used
+    // to walk users into writing these keys, and config-set rejects them.
+    for (const keyless of ['cursor', 'qwen', 'coderabbit']) {
+      assert.ok(
+        !isValidConfigKey(`review.models.${keyless}`),
+        `review.models.${keyless} must not validate (lane declares no modelConfigKey)`
+      );
+    }
+    for (const settable of collectReviewerModelConfigKeys()) {
+      assert.ok(
+        isValidConfigKey(`review.models.${settable}`),
+        `review.models.${settable} must validate`
+      );
+    }
+
+    const tmp = createTempProject();
+    t.after(() => cleanup(tmp));
+    runGsdTools(['config-ensure-section'], tmp);
+    const r = runGsdTools(['config-set', 'review.models.cursor', 'cursor-model'], tmp);
+    assert.ok(
+      !r.success,
+      'config-set must reject a keyless lane — the exact error the old workflow steered users into'
+    );
+  });
+});
+
+describe('#3651 workflow — agent_skills array-form write', () => {
+  test('workflow prescribes the JSON array agent_skills write, not a comma-joined string (#3651)', () => {
+    const src = fs.readFileSync(WORKFLOW_PATH, 'utf-8');
+    assert.ok(
+      !src.includes('"<skill-a,skill-b,skill-c>"'),
+      'the comma-joined string write prescription must be gone — the resolver never splits it'
+    );
+    assert.ok(
+      /config-set agent_skills\.<slug> '\["[^"]*"(?:,\s*"[^"]*")*\]'/.test(src),
+      'workflow must show the JSON array write form (config-set agent_skills.<slug> \'["…","…"]\')'
+    );
+    assert.ok(
+      /[Ss]plit/.test(src) && /comma/i.test(src),
+      'workflow must instruct the driving agent to split comma-separated input before the write'
+    );
+  });
+
+  test('JSON array agent_skills write round-trips and resolves per-element (#3651)', (t) => {
+    const tmp = createTempProject();
+    t.after(() => cleanup(tmp));
+    runGsdTools(['config-ensure-section'], tmp);
+
+    const r = runGsdTools(
+      ['config-set', 'agent_skills.gsd-planner', '["skills/alpha","skills/beta"]'],
+      tmp
+    );
+    assert.ok(r.success, `array-form set failed: ${r.error}`);
+
+    const cfg = JSON.parse(fs.readFileSync(path.join(tmp, '.planning', 'config.json'), 'utf-8'));
+    assert.deepStrictEqual(
+      cfg.agent_skills?.['gsd-planner'],
+      ['skills/alpha', 'skills/beta'],
+      'stored value must be the JSON array, element per skill'
+    );
+
+    const diag = runGsdTools(['agent-skills', 'gsd-planner', '--json'], tmp);
+    assert.ok(diag.success, `agent-skills failed: ${diag.error}`);
+    const parsed = JSON.parse(diag.output);
+    assert.strictEqual(
+      parsed.skills_count,
+      2,
+      `array form must resolve as 2 skill paths, got ${parsed.skills_count}`
+    );
+  });
+
+  test('comma-joined agent_skills value resolves as ONE path — the hazard the array form avoids (#3651)', (t) => {
+    const tmp = createTempProject();
+    t.after(() => cleanup(tmp));
+    runGsdTools(['config-ensure-section'], tmp);
+
+    const r = runGsdTools(
+      ['config-set', 'agent_skills.gsd-planner', 'skills/alpha,skills/beta'],
+      tmp
+    );
+    assert.ok(r.success, `comma-string set is accepted by config-set (shape is legal): ${r.error}`);
+
+    const diag = runGsdTools(['agent-skills', 'gsd-planner', '--json'], tmp);
+    assert.ok(diag.success, `agent-skills failed: ${diag.error}`);
+    const parsed = JSON.parse(diag.output);
+    assert.strictEqual(
+      parsed.skills_count,
+      1,
+      `a comma-joined string is ONE path (never split) — got ${parsed.skills_count}; if this changes, the workflow prescription and this pin must change together`
+    );
+  });
+
+  test('single bare-string agent_skills path keeps working (#3651)', (t) => {
+    const tmp = createTempProject();
+    t.after(() => cleanup(tmp));
+    runGsdTools(['config-ensure-section'], tmp);
+
+    const r = runGsdTools(
+      ['config-set', 'agent_skills.gsd-planner', 'skills/solo'],
+      tmp
+    );
+    assert.ok(r.success, `single-string set failed: ${r.error}`);
+
+    const diag = runGsdTools(['agent-skills', 'gsd-planner', '--json'], tmp);
+    assert.ok(diag.success, `agent-skills failed: ${diag.error}`);
+    const parsed = JSON.parse(diag.output);
+    assert.strictEqual(parsed.configured, true, 'a single string path is a configured entry');
+    assert.strictEqual(parsed.skills_count, 1, 'one string = one skill path');
   });
 });
 
@@ -214,21 +397,24 @@ describe('#2529 config-set round-trip', () => {
     assert.strictEqual(cfg.review?.models?.codex, 'codex exec --model gpt-5');
   });
 
-  test('config-set round-trips agent_skills.<agent-type>', (t) => {
+  test('config-set round-trips agent_skills.<agent-type> (array form — the shape the workflow prescribes, #3651)', (t) => {
     const tmp = createTempProject();
     t.after(() => cleanup(tmp));
     runGsdTools(['config-ensure-section'], tmp);
 
     const r = runGsdTools(
-      ['config-set', 'agent_skills.gsd-executor', 'skill-a,skill-b'],
+      ['config-set', 'agent_skills.gsd-executor', '["skill-a","skill-b"]'],
       tmp
     );
     assert.ok(r.success, `agent_skills.gsd-executor set failed: ${r.error}`);
     const cfg = JSON.parse(fs.readFileSync(path.join(tmp, '.planning', 'config.json'), 'utf-8'));
-    // Accept either array or string — validator accepts both shapes today.
-    const v = cfg.agent_skills?.['gsd-executor'];
-    assert.ok(v === 'skill-a,skill-b' || (Array.isArray(v) && v.join(',') === 'skill-a,skill-b'),
-      `expected agent_skills.gsd-executor to contain both skills, got ${JSON.stringify(v)}`);
+    // #3651: the prescribed write form must persist as a real JSON array — the
+    // either-shape acceptance this row used to allow hid the comma-string hazard.
+    assert.deepStrictEqual(
+      cfg.agent_skills?.['gsd-executor'],
+      ['skill-a', 'skill-b'],
+      `expected the array form to persist verbatim, got ${JSON.stringify(cfg.agent_skills?.['gsd-executor'])}`
+    );
   });
 });
 

--- a/tests/settings-integrations.test.cjs
+++ b/tests/settings-integrations.test.cjs
@@ -242,7 +242,7 @@ describe('#3651 workflow — agent_skills array-form write', () => {
       'the comma-joined string write prescription must be gone — the resolver never splits it'
     );
     assert.ok(
-      /config-set agent_skills\.<slug> '\["[^"]*"(?:,\s*"[^"]*")*\]'/.test(src),
+      /config-set agent_skills\.<slug> '\["[^"]{0,80}"(?:,\s*"[^"]{0,80}"){0,20}\]'/.test(src),
       'workflow must show the JSON array write form (config-set agent_skills.<slug> \'["…","…"]\')'
     );
     assert.ok(

--- a/tests/settings-integrations.test.cjs
+++ b/tests/settings-integrations.test.cjs
@@ -145,25 +145,25 @@ describe('#2529 workflow — agent_skills injection', () => {
 
 // ─── #3651: prescribed writes must match the real config-set contract ───────
 
-// Walk the shipped (frozen first-party) capability registry and collect the
-// reviewer-lane modelConfigKey slugs — the closed set `config-set` actually
-// accepts for review.models.* (federated via isCapabilityConfigKey).
+// The set `config-set` actually accepts for review.models.*: the frozen
+// first-party registry's configSchema — the exact map isCapabilityConfigKey
+// consults (hasOwnProperty), so this helper cannot drift from the validator.
 function collectReviewerModelConfigKeys() {
   const registry = require('../gsd-core/bin/lib/capability-registry.cjs');
-  const keys = new Set();
-  const walk = (node) => {
-    if (!node || typeof node !== 'object') return;
-    if (Array.isArray(node)) { node.forEach(walk); return; }
-    if (
-      typeof node['modelConfigKey'] === 'string' &&
-      node['modelConfigKey'].startsWith('review.models.')
-    ) {
-      keys.add(node['modelConfigKey'].slice('review.models.'.length));
-    }
-    for (const value of Object.values(node)) walk(value);
-  };
-  walk(registry);
-  return keys;
+  const schema = registry.configSchema || {};
+  return new Set(
+    Object.keys(schema)
+      .filter((k) => k.startsWith('review.models.'))
+      .map((k) => k.slice('review.models.'.length))
+  );
+}
+
+// Shared shape for the #3651 behavioral rows: write agent_skills for a slug,
+// then read back the resolver's structured diagnostic.
+function resolveSkillsCount(tmp, slug) {
+  const diag = runGsdTools(['agent-skills', slug, '--json'], tmp);
+  assert.ok(diag.success, `agent-skills failed: ${diag.error}`);
+  return JSON.parse(diag.output);
 }
 
 describe('#3651 workflow — review.models settable-set rule', () => {
@@ -187,7 +187,7 @@ describe('#3651 workflow — review.models settable-set rule', () => {
     const registryKeys = collectReviewerModelConfigKeys();
     assert.ok(
       registryKeys.size >= 9,
-      `expected the shipped nine-lane set from the registry, found ${registryKeys.size}`
+      `expected the shipped model-bearing lane set from the registry, found ${registryKeys.size}`
     );
     const src = fs.readFileSync(WORKFLOW_PATH, 'utf-8');
     const mentioned = new Set(
@@ -269,9 +269,7 @@ describe('#3651 workflow — agent_skills array-form write', () => {
       'stored value must be the JSON array, element per skill'
     );
 
-    const diag = runGsdTools(['agent-skills', 'gsd-planner', '--json'], tmp);
-    assert.ok(diag.success, `agent-skills failed: ${diag.error}`);
-    const parsed = JSON.parse(diag.output);
+    const parsed = resolveSkillsCount(tmp, 'gsd-planner');
     assert.strictEqual(
       parsed.skills_count,
       2,
@@ -290,9 +288,7 @@ describe('#3651 workflow — agent_skills array-form write', () => {
     );
     assert.ok(r.success, `comma-string set is accepted by config-set (shape is legal): ${r.error}`);
 
-    const diag = runGsdTools(['agent-skills', 'gsd-planner', '--json'], tmp);
-    assert.ok(diag.success, `agent-skills failed: ${diag.error}`);
-    const parsed = JSON.parse(diag.output);
+    const parsed = resolveSkillsCount(tmp, 'gsd-planner');
     assert.strictEqual(
       parsed.skills_count,
       1,
@@ -311,9 +307,7 @@ describe('#3651 workflow — agent_skills array-form write', () => {
     );
     assert.ok(r.success, `single-string set failed: ${r.error}`);
 
-    const diag = runGsdTools(['agent-skills', 'gsd-planner', '--json'], tmp);
-    assert.ok(diag.success, `agent-skills failed: ${diag.error}`);
-    const parsed = JSON.parse(diag.output);
+    const parsed = resolveSkillsCount(tmp, 'gsd-planner');
     assert.strictEqual(parsed.configured, true, 'a single string path is a configured entry');
     assert.strictEqual(parsed.skills_count, 1, 'one string = one skill path');
   });

--- a/tests/settings-integrations.test.cjs
+++ b/tests/settings-integrations.test.cjs
@@ -18,7 +18,8 @@
  *     comma-joined string); behavioral pins for array/comma/single shapes
  *   - Masking convention (****last4) is documented in the workflow and the displayed
  *     confirmation pattern does not echo plaintext
- *   - config-set round-trips all integration keys through VALID_CONFIG_KEYS + dynamic patterns
+ *   - config-set round-trips all integration keys through VALID_CONFIG_KEYS,
+ *     dynamic patterns, and the federated capability registry
  *   - Config merge preserves unrelated keys
  *   - /gsd:settings confirmation output mentions /gsd:settings-integrations
  *   - Negative: invalid agent-type name (path traversal / special char) is rejected
@@ -310,6 +311,29 @@ describe('#3651 workflow — agent_skills array-form write', () => {
     const parsed = resolveSkillsCount(tmp, 'gsd-planner');
     assert.strictEqual(parsed.configured, true, 'a single string path is a configured entry');
     assert.strictEqual(parsed.skills_count, 1, 'one string = one skill path');
+  });
+
+  test('one-element array agent_skills write resolves identically to the bare string (#3651)', (t) => {
+    const tmp = createTempProject();
+    t.after(() => cleanup(tmp));
+    runGsdTools(['config-ensure-section'], tmp);
+
+    const r = runGsdTools(
+      ['config-set', 'agent_skills.gsd-planner', '["skills/solo"]'],
+      tmp
+    );
+    assert.ok(r.success, `one-element-array set failed: ${r.error}`);
+
+    const cfg = JSON.parse(fs.readFileSync(path.join(tmp, '.planning', 'config.json'), 'utf-8'));
+    assert.deepStrictEqual(
+      cfg.agent_skills?.['gsd-planner'],
+      ['skills/solo'],
+      'one-element array must persist verbatim'
+    );
+
+    const parsed = resolveSkillsCount(tmp, 'gsd-planner');
+    assert.strictEqual(parsed.configured, true);
+    assert.strictEqual(parsed.skills_count, 1, 'one-element array = one skill path, same as the bare string');
   });
 });
 


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

> **Required.** This PR will be auto-closed if no valid issue link is found.

Fixes #3651

> The linked issue must have the `confirmed-bug` label. If it doesn't, ask a maintainer to confirm the bug before continuing.

---

## What was broken

`/gsd:config --integrations` (driven by `gsd-core/workflows/settings-integrations.md`) prescribed two writes that cannot work:

1. It claimed `review.models.<cli>` keys "are validated by the dynamic pattern `^review\.models\.[a-zA-Z0-9_-]+$`" — no such pattern exists anywhere in `dynamicKeyPatterns`. The namespace is a closed allowlist federated from the capability registry (only lanes whose capability declares a non-null `modelConfigKey`), so following the workflow into any non-settable slug (e.g. `cursor`, whose lane declares `modelConfigKey: null`) ends in `Error: Unknown config key` — after the workflow itself told the agent the namespace was open. The section also offered only 4 of the 9 settable lanes.
2. It prescribed writing comma-separated agent-skill values (`config-set agent_skills.<slug> "<skill-a,skill-b,skill-c>"`). Nothing splits on commas — `cmdAgentSkills` wraps a string as a single-element array — so the stored value becomes one broken skill path (`skills/alpha,skills/beta/SKILL.md`) that silently fails resolution at spawn time while the write reports success.

## What this fix does

- The review-models section now states the real rule: `review.models.<cli>` is settable only when the lane's capability declares a `modelConfigKey`; `config-set` accepts exactly the registry-federated keys and no dynamic-key regex governs the namespace. The nine settable keys are enumerated once (as full `review.models.*` keys), the keyless lanes (`cursor`, `qwen`, `coderabbit`) are named with an explicit "nothing to configure here" instruction, and free-text slugs are checked against the set with a rejection message.
- The agent-skills section now instructs the driving agent to split the comma-separated reply itself (trim, drop empties, reject quote-bearing entries) and write the JSON array form the resolver accepts: `config-set agent_skills.<slug> '["skills/alpha","skills/beta"]'`. Single-skill bare strings remain documented as valid.
- The `<security>` slug-validation bullet and `<success_criteria>` no longer assert a regex gate for `review.models`; the confirmation table shows one row per lane the user actually set.

## Root cause

Aspirational text shipped with the workflow's creation (220da8e487, 2026-04-22): both defective instructions predate the capability-registry federation (#2782/#2797) and the #3303 array-form documentation, and nothing tied the workflow's claims to the real seams. The parity is now enforced: a regression row derives the settable set from `registry.configSchema` (the exact map `isCapabilityConfigKey` consults) and requires the workflow's enumerated `review.models.*` mentions to match it exactly, so registry drift fails CI instead of silently restaling the workflow.

## Testing

### How I verified the fix

- Reproduced both defects on `next` HEAD with the issue's exact commands (config-set on a keyless lane → `Unknown config key` exit 1; comma-string write → `agent-skills --json` reports `skills_count: 1` for a two-skill value).
- TDD via `gsd-test`: RED proven on ba5f417f1 (36,813 tests, 5 failures = exactly the three new regression rows + their describes), then the fix turned them green. A cycle-2 run caught the #3576 bare-cite gate (new text cited `references/planning-config.md` non-canonically) — fixed to `gsd-core/references/planning-config.md`. Final green: gsd-test verdict `{"outcome":"passed"}` on 8a81809dce1261adbb81afa00e9e5b76e0bb6b01 (36,814/36,814, linux-node24).

### Regression test added?

- [x] Yes — added a test that would have caught this bug

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

(gsd-test bench matrix: linux-node24; the change is platform-neutral text + CLI rows.)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`) — via gsd-test (repo rule: no local runs)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None

---

### Ops notes

- Growth acknowledgment: `tests/emitted-drift-acks/3651-settings-integrations-prescriptions.json` (+2,052 LF bytes, DEFAULT cap 40,960).
- Existing either-shape round-trip row tightened to the prescribed array form (its old "accept array or string" assertion is the vacuity that hid the comma-string hazard).
- The issue's deferred question (whether `cursor`/`qwen` *should* have a model key) remains out of scope, as the issue itself specifies.
