### PR TITLE
docs: fix broken star history charts

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -103,11 +103,11 @@ npx @opengsd/gsd-core@latest
 
 ## スター履歴
 
-<a href="https://star-history.com/#open-gsd/gsd-core&Date">
+<a href="https://star-history.dera.page/#open-gsd/gsd-core&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=open-gsd/gsd-core&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=open-gsd/gsd-core&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=open-gsd/gsd-core&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=open-gsd/gsd-core&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=open-gsd/gsd-core&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=open-gsd/gsd-core&type=Date" />
  </picture>
 </a>
 

--- a/README.ko-KR.md
+++ b/README.ko-KR.md
@@ -103,11 +103,11 @@ npx @opengsd/gsd-core@latest
 
 ## 스타 히스토리
 
-<a href="https://star-history.com/#open-gsd/gsd-core&Date">
+<a href="https://star-history.dera.page/#open-gsd/gsd-core&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=open-gsd/gsd-core&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=open-gsd/gsd-core&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=open-gsd/gsd-core&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=open-gsd/gsd-core&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=open-gsd/gsd-core&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=open-gsd/gsd-core&type=Date" />
  </picture>
 </a>
 

--- a/README.md
+++ b/README.md
@@ -105,11 +105,11 @@ Troubleshooting? See [docs/how-to/recover-and-troubleshoot.md](docs/how-to/recov
 
 ## Star History
 
-<a href="https://star-history.com/#open-gsd/gsd-core&Date">
+<a href="https://star-history.dera.page/#open-gsd/gsd-core&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=open-gsd/gsd-core&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=open-gsd/gsd-core&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=open-gsd/gsd-core&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=open-gsd/gsd-core&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=open-gsd/gsd-core&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=open-gsd/gsd-core&type=Date" />
  </picture>
 </a>
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -103,11 +103,11 @@ Problemas? Consulte [docs/pt-BR/how-to/recover-and-troubleshoot.md](docs/pt-BR/h
 
 ## Histórico de estrelas
 
-<a href="https://star-history.com/#open-gsd/gsd-core&Date">
+<a href="https://star-history.dera.page/#open-gsd/gsd-core&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=open-gsd/gsd-core&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=open-gsd/gsd-core&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=open-gsd/gsd-core&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=open-gsd/gsd-core&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=open-gsd/gsd-core&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=open-gsd/gsd-core&type=Date" />
  </picture>
 </a>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -103,11 +103,11 @@ npx @opengsd/gsd-core@latest
 
 ## Star History
 
-<a href="https://star-history.com/#open-gsd/gsd-core&Date">
+<a href="https://star-history.dera.page/#open-gsd/gsd-core&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=open-gsd/gsd-core&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=open-gsd/gsd-core&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=open-gsd/gsd-core&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=open-gsd/gsd-core&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=open-gsd/gsd-core&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=open-gsd/gsd-core&type=Date" />
  </picture>
 </a>
 


### PR DESCRIPTION
The current star history chart is broken and no longer renders reliably. Update the chart links in the main and localized README files so the repository's star history remains visible.