### PR TITLE
fix(#3748): drop the partitive count that reads as a stale total

### DIFF
--- a/docs/how-to/design-a-ui-phase.md
+++ b/docs/how-to/design-a-ui-phase.md
@@ -156,7 +156,7 @@ Worth knowing before you rely on it, because the check is narrower than it looks
   `<package>@<version>` is for: compare it against what is installed now. A spec reused after an
   upgrade looks exactly like a fresh one apart from that string.
 - **Enforcement is applied by an agent, not by a parser.** Dimension 7 is a rule `gsd-ui-checker`
-  follows, the same as the other six dimensions. It is not a schema check that runs over your
+  follows, the same as every other dimension. It is not a schema check that runs over your
   spec, so treat a PASS as "the reviewer found a provenance line", not as a machine guarantee.
 - **"The checker never runs the recorded command" is an instruction, not a sandbox.** See
   [Security model → Trade-offs and limits](../explanation/security-model.md#trade-offs-and-limits)


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #3748.

> **Note on the label gate.** #3748 is still `needs-triage` — I filed it a few hours ago and cannot apply labels as an external contributor. Opening anyway because `next` is red and this is the minimal unblock; happy for it to sit until the bug is confirmed, or to close it if you would rather fix this your own way.

---

## What was broken

`next` has been red since `dacae9273` (#3746). `#2845 — cross-surface dimension-count parity` fails with `docs/how-to/design-a-ui-phase.md` declaring 6 dimensions against a canonical roster of 7:

```
AssertionError [ERR_ASSERTION]: [
  { "kind": "count-mismatch", "surface": "docs/how-to/design-a-ui-phase.md", "found": 6, "expected": 7 }
]
```

## What this fix does

Rewords one sentence so it carries no count. One line, docs only.

## Root cause

`docs/how-to/design-a-ui-phase.md:159` reads:

> Dimension 7 is a rule `gsd-ui-checker` follows, **the same as the other six dimensions**.

That is correct English — Inventory Provenance is the 7th, so the *other* six are the rest. But the count scanner added by #3745 (`tests/ui-spec-inventory-provenance.test.cjs:150-151`) treats any `<number-word> … dimensions` as a declaration of the total:

```js
scan(/\b(five|six|seven|eight|nine|ten)\s+(?:[A-Za-z][A-Za-z-]*\s+){0,3}?dimensions\b/gi, ...)
```

```
"the same as the other six dimensions"  ->  [ 'six' ]     <-- read as a total
"its seven dimensions"                  ->  [ 'seven' ]
```

So the same file declares both 7 (line 57, correct) and 6 (line 159, a partitive), and the parity check reports the second as stale. The guard is doing its job in spirit — it exists to catch a surface left behind at a stale count — but a partitive "the other N" is not a stale total.

## Why the prose and not the scanner

The scanner change is the durable half: the prose here is natural English, and the next author who writes a partitive hits this again. I measured it too — a negative lookbehind for `other|remaining|following` turns the check green **and stays non-weakening** (mutating line 57's "its seven dimensions" to "six" still reds it with `count-mismatch`). Details and the diff are [on the issue](https://github.com/open-gsd/gsd-core/issues/3748#issuecomment-5377295618).

I deliberately did **not** bundle it. It edits the gate #3745 landed hours ago, and that call belongs to its author. This PR is the minimal unblock and leaves the gate untouched; say the word and I will send the scanner half as a separate PR, or fold it in here.

---

## Testing

### How I verified the fix

Measured against `next` @ `dacae9273`, with `TMPDIR` unset so the environment matches the runners:

| | result |
|---|---|
| baseline (`dacae9273`, untouched) | 32 pass / **1 fail** |
| with this change | **33 pass / 0 fail** |

`lint:ci` green.

The failing row reproduces on a clean detached worktree of `upstream/next`, so it is in the base rather than in any one branch. It is currently the only failing test on three open PRs of mine (#3725, #3627, #3390) — confirmed by reading each job log, not inferred from the shard number — across `test (ubuntu-latest, 24, shard 2/3)`, `full test (macos-latest, 24, shard 2/3)` and `full test (windows-latest, 24, shard 2/3)`.

### Regression test added?

- [ ] Yes — added a test that would have caught this bug
- [x] No — explain why: the test that catches it already exists and is the one that failed. #3745's parity check is exactly the guard here; this PR makes the shipped surface satisfy it. A new test would assert that a specific sentence does not contain a number word, which pins prose rather than behavior. The scanner-side fix discussed above is where a new row would belong — it needs a non-weakening test, which I have already written and measured on the issue.

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [x] N/A (not platform-specific)

A one-word prose edit checked by a pure-text scan; no path handling involved. The failure reproduces identically on all three platforms in CI.

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [ ] Linked issue has the `confirmed-bug` label — **it does not yet**; #3748 is `needs-triage` and I cannot apply labels. Flagging rather than claiming it.
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`) — the previously-failing file is now 33/0; `lint:ci` green
- [x] `.changeset/` fragment added if this is a user-facing fix — **not applicable**: `docs/` is outside the changeset-lint trigger set (`bin/`, `gsd-core/`, `src/`, `agents/`, `commands/`, `hooks/`, `sdk/src/`), and no user-facing behavior changes
- [x] No unnecessary dependencies added

## Breaking changes

None. One sentence in a how-to doc, no behavior change.
