### PR TITLE
fix(#2845): stop the dimension parity guard counting a back-reference

### DIFF
--- a/tests/ui-spec-inventory-provenance.test.cjs
+++ b/tests/ui-spec-inventory-provenance.test.cjs
@@ -137,18 +137,44 @@ const WORD_NUMERAL = Object.freeze({
   여섯: 6, 일곱: 7, 여덟: 8,
 });
 
-/** Every numeric "N dimensions" claim in `text`, in any of the three shipped languages.
- *  Returns plain numbers — the typed IR the parity function consumes. */
-function parseDeclaredCounts(text) {
+/** A numeral introduced by "other" or "remaining" is a BACK-REFERENCE to the rest of a set
+ *  — "the same as the other six dimensions" — never a claim about the set's SIZE. Counting
+ *  one turned `next` red on dacae9273 against entirely correct documentation, and a drift
+ *  guard that fires on accurate prose is a false positive, which is how guards end up
+ *  disabled.
+ *
+ *  Declared once and shared by both English scans so the two can never drift apart — the
+ *  same divergence class this whole suite exists to catch. `\b` anchors it to the whole
+ *  word, so "another six dimensions" (a real claim about a second set) still counts, and
+ *  both scans apply it case-insensitively: a sentence-initial "Other six dimensions…" is
+ *  the same back-reference as a mid-sentence one.
+ *
+ *  Known limits: the exclusion is English-only — the ja/zh/ko/pt patterns have no
+ *  equivalent, because translated docs here are CORRECTED to match English rather than
+ *  authored, so there is no instance to model the grammar on. And it cannot tell a
+ *  back-reference from a genuine total that happens to open with the same word ("Other 6
+ *  dimensions were added"); prose alone does not disambiguate those, and the false-negative
+ *  is the safer side of that trade for a guard whose failure mode is being switched off. */
+const NOT_A_BACK_REFERENCE = String.raw`(?<!\b(?:other|remaining)\s)`;
+
+/** Every numeric "N dimensions" claim in `text`, in any of the shipped languages.
+ *  Returns plain numbers — the typed IR the parity function consumes.
+ *
+ *  `excludeBackReferences: false` reproduces the pre-fix behavior. It exists so a test can
+ *  prove, against the real shipped files, that the exclusion is load-bearing rather than
+ *  decorative — see the dacae9273 regression block. */
+function parseDeclaredCounts(text, { excludeBackReferences = true } = {}) {
   const body = lf(text);
   const found = [];
   const push = (v) => { if (Number.isInteger(v)) found.push(v); };
   const scan = (re, take) => { for (const m of body.matchAll(re)) take(m); };
+  const guard = excludeBackReferences ? NOT_A_BACK_REFERENCE : '';
 
   // "6 dimensions", "6 design quality dimensions", "6 Validation Dimensions"
-  scan(/(\d+)\s+(?:[A-Za-z][A-Za-z-]*\s+){0,3}?[Dd]imensions?\b/g, (m) => push(Number(m[1])));
+  scan(new RegExp(`${guard}(\\d+)\\s+(?:[A-Za-z][A-Za-z-]*\\s+){0,3}?[Dd]imensions?\\b`, 'gi'),
+    (m) => push(Number(m[1])));
   // "six dimensions", "six quality dimensions"
-  scan(/\b(five|six|seven|eight|nine|ten)\s+(?:[A-Za-z][A-Za-z-]*\s+){0,3}?dimensions\b/gi,
+  scan(new RegExp(`${guard}\\b(five|six|seven|eight|nine|ten)\\s+(?:[A-Za-z][A-Za-z-]*\\s+){0,3}?dimensions\\b`, 'gi'),
     (m) => push(WORD_NUMERAL[m[1].toLowerCase()]));
   // "Dimensions: 6/6 passed"
   scan(/Dimensions:\s*(\d+)\/(\d+)/g, (m) => { push(Number(m[1])); push(Number(m[2])); });
@@ -452,6 +478,63 @@ describe('#2845 — parsers are total and newline-agnostic', () => {
       assert.deepEqual(parseYamlExampleBlocks(input), []);
       assert.equal(sectionContaining(input, 'REQ-UI-03'), '');
     }
+  });
+});
+
+describe('#2845 — a back-reference is not a count claim (regression: `next` red on dacae9273)', () => {
+  // The how-to gained "Dimension 7 is a rule gsd-ui-checker follows, the same as the
+  // other six dimensions" — correct prose — and the guard read "six dimensions" as that
+  // document claiming the checker has six. `next` went red on documentation that was
+  // right.
+  //
+  // Worth recording WHY it reached `next`: the docs PR was green. A doc-only diff
+  // inert-skips the test matrix in the PR lane, so the guard that reads docs never ran
+  // against the docs change that broke it. It fired on push to `next` — after merge.
+
+  test('"the other N dimensions" / "the remaining N dimensions" are not counted', () => {
+    for (const phrase of [
+      'Dimension 7 is a rule the checker follows, the same as the other six dimensions.',
+      'the same as the other 6 dimensions',
+      'the remaining six dimensions are unchanged',
+      'the remaining 6 dimensions are unchanged',
+      // Sentence-initial: the digit scan was case-SENSITIVE while the word scan was not,
+      // so these two slipped through the first version of this fix.
+      'Other six dimensions apply.',
+      'Other 6 dimensions apply.',
+      'Remaining six dimensions are unaffected.',
+      'Remaining 6 dimensions are unaffected.',
+    ]) {
+      assert.deepEqual(parseDeclaredCounts(phrase), [], `counted a back-reference: ${phrase}`);
+    }
+  });
+
+  test('a real count claim is still counted — the fix must not blind the guard', () => {
+    assert.deepEqual(parseDeclaredCounts('validates the spec across six dimensions'), [6]);
+    assert.deepEqual(parseDeclaredCounts('System MUST validate against 7 dimensions'), [7]);
+    assert.deepEqual(parseDeclaredCounts('All 7 dimensions evaluated'), [7]);
+    assert.deepEqual(parseDeclaredCounts('**7 Validation Dimensions:**'), [7]);
+    assert.deepEqual(parseDeclaredCounts('gsd-ui-checker seven quality dimensions'), [7]);
+  });
+
+  test('the exclusion is anchored to the whole word, not a substring', () => {
+    // "another" contains "other" but has no word boundary before it, so a genuine claim
+    // about a second set must survive.
+    assert.deepEqual(parseDeclaredCounts('another six dimensions'), [6]);
+  });
+
+  test('the exclusion is load-bearing on the real shipped how-to, not just on fixtures', () => {
+    // Typed proof rather than a substring match on prose: run the matcher over the real
+    // file with the exclusion OFF and then ON. Off, it must report a 6 — that 6 is the
+    // back-reference, and is literally what turned `next` red. On, only 7s survive.
+    // If the docs prose is ever reworded away, the first assertion fails loudly rather
+    // than this guard quietly ceasing to exercise the path it exists for.
+    const howto = readShipped(SURFACE.HOWTO);
+    const withoutExclusion = [...new Set(parseDeclaredCounts(howto, { excludeBackReferences: false }))].sort();
+    const withExclusion = [...new Set(parseDeclaredCounts(howto))].sort();
+
+    assert.deepEqual(withoutExclusion, [6, 7],
+      'vacuous unless the how-to still carries the back-reference this guard exists for');
+    assert.deepEqual(withExclusion, [7]);
   });
 });
 


### PR DESCRIPTION
## Fix PR

## Linked Issue

Refs #2845

> Non-closing reference. This unbreaks `next`, which went red on `dacae9273` — the docs
> follow-up to #2845 (merged as #3746). #2845 is already closed and there is no separate open
> issue for this; per [CONTRIBUTING.md](../../CONTRIBUTING.md#pull-request-guidelines) a closing
> keyword against an already-closed issue "closes nothing, and it trains readers to treat closing
> keywords as decorative."

---

## What was broken

**`next` is red.** `test (ubuntu-latest, 24, shard 2/3)`, plus the macOS and Windows `full test`
shard-2 lanes and the `Required tests` rollup, on `dacae9273`:

```
✖ no shipped surface still declares a stale dimension count
  [{ kind: "count-mismatch", surface: "docs/how-to/design-a-ui-phase.md", found: 6, expected: 7 }]
```

The guard fired on documentation that was **correct**. `docs/how-to/design-a-ui-phase.md:159`
reads *"Dimension 7 is a rule `gsd-ui-checker` follows, the same as the other six dimensions."*
There are seven dimensions, and six of them are the others — the sentence is right.

## What this fix does

`parseDeclaredCounts` treated any `<numeral> … dimensions` collocation in a scanned file as a
claim about the dimension **total**. It could not distinguish a claim about the size of the set
from a back-reference to the rest of it.

A negative lookbehind now excludes a numeral introduced by `other` or `remaining`. The docs prose
is left exactly as it was — see Testing for why that is deliberate.

## Root cause

Three layers, and the third is the one worth reading:

1. **Proximate:** prose containing "the other six dimensions" in a file the guard scans.
2. **The actual defect:** an over-broad matcher. A drift guard that fires on accurate prose is a
   false positive, and false positives are how guards get switched off — worse than a miss.
3. **Systemic:** the PR that introduced it was **green**. A doc-only diff inert-skips the test
   matrix in the PR lane, and doc-only pushes are exempt from the local gate — so the guard whose
   entire job is reading `docs/` never ran against the `docs/` change that broke it. It fired on
   push to `next`, after merge. **Any docs-reading guard in this repo has that blind spot.**

## Testing

### How I verified the fix

Failing-first. RED was established at two levels before anything was touched: CI already showed
the real-tree assertion failing, and the pre-fix matcher returns `["six"]` for the back-reference
fixture where the new test demands `[]`.

Verified green on the remote runner at this HEAD: `36896/36896`, zero failures.

An isolated reviewer confirmed by execution — not by reading — that the fix does not blind the
guard: all 13 count surfaces still yield only 7s with **none** going empty (an empty count list is
itself a violation, `no-count-found`, by design), and a real 7→6 mutation across four different
claim shapes (`validates against N dimensions`, `**N Validation Dimensions:**`,
`All N dimensions evaluated`, `N quality dimensions`) is still caught.

**The docs prose is deliberately unchanged.** Line 159 is the only instance of the pattern in the
tree. Keeping it means the real-tree assertion exercises the path this fix exists for, rather than
the fix being proven only against synthetic fixtures. Rewording would have turned `next` green
while leaving the trap armed for the next person who writes that sentence.

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

Both polarities, in `tests/ui-spec-inventory-provenance.test.cjs`:

- eight back-reference shapes that must **not** count, including all four sentence-initial cases
- five real count claims that must still count
- `another six dimensions` — the word-boundary case, a genuine claim about a second set
- the shipped how-to itself, asserted as a typed before/after: with the exclusion off the file
  reports `[6, 7]`, with it on `[7]`. That proves the exclusion is load-bearing on the real file,
  and fails loudly if the prose is ever reworded away rather than quietly ceasing to test anything.

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [x] N/A (not platform-specific)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [x] N/A (not runtime-specific)

---

## Review findings, and what they changed

An isolated reviewer found two majors. Both were real and both are fixed here:

1. **The fix contained the bug it was fixing.** The digit-form scan was `/g` while the word-form
   was `/gi`, so `Other six dimensions` was excluded but `Other 6 dimensions` — sentence-initial,
   digit form — still counted. One grammatical variant of the failure class left open, and none of
   the original regression phrases used a capitalized back-reference, so nothing caught it. Both
   scans are now case-insensitive and all four sentence-initial shapes are pinned.
2. **The non-vacuity test used a raw substring match** on shipped prose, which this suite's own
   header forbids outside three documented exceptions. Replaced with the typed before/after
   described above, via a new `excludeBackReferences` opt-out on `parseDeclaredCounts`.

Two minors also taken: the lookbehind is now a single shared `NOT_A_BACK_REFERENCE` constant
instead of being written at two sites — the same two-surface divergence class this suite exists to
catch — and the second known limit is documented rather than silently accepted.

## Known limits

- **The exclusion is English-only.** The ja/zh/ko/pt patterns get no equivalent, because
  translated docs here are *corrected* to match English rather than authored, so there is no
  back-reference instance to model the grammar on. Verified: no translated surface currently
  contains a back-reference-shaped phrase.
- **It cannot distinguish a back-reference from a genuine total that opens with the same word** —
  "Other 6 dimensions were added" would be missed. Prose alone does not disambiguate those, and
  for a guard whose failure mode is being switched off, the false negative is the safer side of
  that trade. Recorded in the code, not just here.

## Checklist

- [x] Issue linked above (non-closing `Refs`, per the already-closed-issue rule)
- [x] Fix is scoped to the reported breakage — no unrelated changes
- [x] Regression test added
- [x] All existing tests pass — 36896/36896 on the remote runner at this HEAD
- [x] `.changeset/` fragment — **not required**: `scripts/changeset/lint.cjs` fires on `bin/`,
      `gsd-core/`, `src/`, `agents/`, `commands/`, `hooks/`, `sdk/src/`; this diff touches only
      `tests/`
- [x] No unnecessary dependencies added

## Breaking changes

None. Test-only; no shipped artifact changes.
