### PR TITLE
test(#3761): replace vacuous wave/files_modified gate with an anchored one

### DIFF
--- a/tests/parallel-dependent-plans.test.cjs
+++ b/tests/parallel-dependent-plans.test.cjs
@@ -15,6 +15,7 @@
 
 const { test, describe } = require('node:test');
 const assert = require('node:assert/strict');
+const fc = require('fast-check');
 const fs = require('fs');
 const path = require('path');
 
@@ -26,6 +27,121 @@ const EXECUTE_PHASE_PATH = path.join(
   'workflows',
   'execute-phase.md'
 );
+
+// ---------------------------------------------------------------------------
+// Anchored same-wave overlap gate (#3761)
+//
+// The test this replaces accepted six whole-file substrings, five of which have
+// never appeared in agents/gsd-planner.md (`validate_waves`, `wave_validation`,
+// `same wave` — the last killing the entire quality-gate arm, since the file has
+// no quality_gate block at all). The sixth, `files_modified overlap`, matched one
+// incidental pseudocode comment, so deleting the whole gate left the suite green.
+// RULESET.TESTS.delete-bad-tests (CONTEXT.md:595): a vacuous-truth test is DELETED
+// and replaced, not patched.
+//
+// The replacement anchors on the step's normative `**Rule:**` paragraph — the
+// deliberate, documented declaration of the gate — scoped to the
+// <step name="assign_waves"> block rather than to the document as a whole.
+// ---------------------------------------------------------------------------
+
+/**
+ * Slice out the body of a named `<step name="…">` block.
+ *
+ * Index-based rather than regex-based: no backtracking surface over
+ * caller-supplied document content, so no `local/no-unbounded-quantifier`
+ * suppression is needed.
+ *
+ * @param {string} content Full agent `.md` document.
+ * @param {string} stepName Value of the step's `name` attribute.
+ * @returns {string|null} The body, or `null` when the block is absent or unterminated.
+ */
+function extractStepBody(content, stepName) {
+  const open = `<step name="${stepName}">`;
+  const start = content.indexOf(open);
+  if (start === -1) return null;
+  const bodyStart = start + open.length;
+  const end = content.indexOf('</step>', bodyStart);
+  if (end === -1) return null;
+  return content.slice(bodyStart, end);
+}
+
+/**
+ * The normative `**Rule:**` paragraph of a step body: the marker line plus every
+ * continuation line up to the next blank line, joined into one string. CRLF-safe.
+ *
+ * @param {string} stepBody
+ * @returns {string|null}
+ */
+function ruleParagraph(stepBody) {
+  const lines = stepBody.split(/\r?\n/);
+  const first = lines.findIndex((line) => line.trimStart().startsWith('**Rule:**'));
+  if (first === -1) return null;
+  const paragraph = [];
+  for (let i = first; i < lines.length && lines[i].trim() !== ''; i += 1) {
+    paragraph.push(lines[i].trim());
+  }
+  return paragraph.join(' ');
+}
+
+/** Split a rule paragraph into sentences on `.` / `;` boundaries. */
+function ruleSentences(paragraph) {
+  return paragraph.split(/(?<=[.;])\s+/).filter((sentence) => sentence.trim() !== '');
+}
+
+/**
+ * The four clauses that together make the rule a same-wave file-overlap GATE
+ * rather than incidental prose. Liberal in spelling so that rewording under the
+ * agent file's size-cap pressure does not red the suite; strict about all four
+ * being present, so that gutting the gate does.
+ */
+const SAME_WAVE_RULE_CLAUSES = [
+  { name: 'wave scope', pattern: /\bwave\b/i },
+  { name: 'files_modified subject', pattern: /files_modified/ },
+  { name: 'prohibition', pattern: /\b(?:zero|no|not|never)\b/i },
+  { name: 'overlap predicate', pattern: /overlap|shar(?:e|es|ing)|conflict|touch(?:es|ing)?/i },
+];
+
+/**
+ * @param {string|null} stepBody Output of {@link extractStepBody}.
+ * @returns {string[]} Names of the required clauses the step's rule fails to
+ *   satisfy. `[]` means the gate is declared.
+ *
+ * All four clauses must hold in ONE sentence. Four clauses scattered across a
+ * paragraph are co-occurrence, not a rule — that is #3761's defect in miniature,
+ * one level down, and it is what a whole-paragraph conjunction would let through.
+ */
+function missingSameWaveRuleClauses(stepBody) {
+  if (stepBody === null) return ['<step name="assign_waves"> block'];
+  const paragraph = ruleParagraph(stepBody);
+  if (paragraph === null) return ['**Rule:** paragraph'];
+  // Report the closest sentence's shortfall: it names what the rule is actually
+  // missing rather than the union of every sentence's gaps.
+  let closest = SAME_WAVE_RULE_CLAUSES.map((clause) => clause.name);
+  for (const sentence of ruleSentences(paragraph)) {
+    const missing = SAME_WAVE_RULE_CLAUSES.filter(
+      (clause) => !clause.pattern.test(sentence)
+    ).map((clause) => clause.name);
+    if (missing.length < closest.length) closest = missing;
+    if (closest.length === 0) break;
+  }
+  return closest;
+}
+
+/** Wrap a body in a named step block. */
+function namedStep(name, body, eol = '\n') {
+  return [`<step name="${name}">`, body, '</step>'].join(eol);
+}
+
+/** Wrap a body in an `assign_waves` step block. */
+function assignWavesStep(body, eol = '\n') {
+  return namedStep('assign_waves', body, eol);
+}
+
+/** The rule sentence as `agents/gsd-planner.md` currently declares it. */
+const CANONICAL_RULE =
+  '**Rule:** Same-wave plans must have zero `files_modified`/`files_deleted` overlap. ' +
+  'After assigning waves, scan each wave; if any file appears in 2+ plans, bump the ' +
+  'later plan to the next wave and repeat.';
 
 // ---------------------------------------------------------------------------
 // gsd-planner.md — wave assignment must account for files_modified overlap
@@ -87,18 +203,254 @@ describe('gsd-planner agent: files_modified wave ordering', () => {
     );
   });
 
-  test('planner has validation step or quality gate for wave/files_modified consistency', () => {
+  test('the real planner declares the same-wave zero-overlap rule inside assign_waves', () => {
     const content = fs.readFileSync(PLANNER_AGENT_PATH, 'utf-8');
-    // Either a validation step or the quality_gate checklist must assert no same-wave overlap
-    const hasValidationStep =
-      content.includes('validate_waves') ||
-      content.includes('wave_validation') ||
-      content.includes('files_modified overlap');
-    const hasQualityGateCheck =
-      content.includes('files_modified') && content.includes('same wave');
+    const stepBody = extractStepBody(content, 'assign_waves');
+    assert.notEqual(stepBody, null, 'assign_waves step should exist in gsd-planner.md');
+    assert.deepEqual(
+      missingSameWaveRuleClauses(stepBody),
+      [],
+      'the assign_waves step must carry a normative **Rule:** paragraph stating that ' +
+        'same-wave plans have zero files_modified overlap'
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The gate's own teeth (#3761)
+//
+// These drive the same predicate the test above uses, against planner content
+// the DELETED test wrongly accepted. Row 1 is the failing-first regression: it
+// is the exact shape PR #3758 produces — the pseudocode comment that carried
+// `files_modified overlap` is gone, an unrelated pointer line carries the same
+// substring, and the gate itself has been removed.
+// ---------------------------------------------------------------------------
+
+describe('gsd-planner agent: same-wave overlap gate has teeth', () => {
+  test('a gutted assign_waves step is rejected even when an incidental "files_modified overlap" phrase survives', () => {
+    const gutted = assignWavesStep(
+      [
+        '```',
+        'waves = {}',
+        'for each plan in plan_order:',
+        '  plan.wave = 1',
+        '```',
+        '',
+        'Beyond files_modified overlap: @~/.claude/gsd-core/references/planner-coupling.md',
+      ].join('\n')
+    );
+    assert.deepEqual(
+      missingSameWaveRuleClauses(extractStepBody(gutted, 'assign_waves')),
+      ['**Rule:** paragraph'],
+      'the wave-ordering gate was deleted; an incidental substring must not stand in for it'
+    );
+  });
+
+  test('a pseudocode comment is not the anchor — the normative Rule paragraph is', () => {
+    const commentOnly = assignWavesStep(
+      [
+        '```',
+        '# Implicit dependency: files_modified overlap forces a later wave.',
+        'waves = {}',
+        '```',
+      ].join('\n')
+    );
+    assert.deepEqual(
+      missingSameWaveRuleClauses(extractStepBody(commentOnly, 'assign_waves')),
+      ['**Rule:** paragraph'],
+      'a comment inside a fenced block is illustrative, not a declared gate'
+    );
+  });
+
+  test('the rule must live inside assign_waves — a whole-file match does not count', () => {
+    const misplaced = [
+      assignWavesStep(['```', 'waves = {}', '```'].join('\n')),
+      '',
+      CANONICAL_RULE,
+    ].join('\n');
     assert.ok(
-      hasValidationStep || hasQualityGateCheck,
-      'planner should validate that no two plans in the same wave share files_modified entries'
+      misplaced.includes('Same-wave plans must have zero'),
+      'precondition: the rule text IS present somewhere in the document'
+    );
+    assert.deepEqual(
+      missingSameWaveRuleClauses(extractStepBody(misplaced, 'assign_waves')),
+      ['**Rule:** paragraph'],
+      'the check is step-scoped; a rule stranded outside assign_waves is not the gate'
+    );
+  });
+
+  test('dropping any single required clause from the rule reds the gate', () => {
+    // limit-1: each variant satisfies exactly three of the four clauses.
+    const variants = [
+      {
+        missing: 'wave scope',
+        rule: '**Rule:** Plans must have zero `files_modified`/`files_deleted` overlap.',
+      },
+      {
+        missing: 'files_modified subject',
+        rule: '**Rule:** Same-wave plans must have zero file overlap.',
+      },
+      {
+        missing: 'prohibition',
+        rule: '**Rule:** Same-wave plans tolerate `files_modified` overlap.',
+      },
+      {
+        missing: 'overlap predicate',
+        rule: '**Rule:** Same-wave plans must have zero `files_modified` entries in common.',
+      },
+    ];
+    for (const variant of variants) {
+      assert.deepEqual(
+        missingSameWaveRuleClauses(extractStepBody(assignWavesStep(variant.rule), 'assign_waves')),
+        [variant.missing],
+        `dropping "${variant.missing}" must be reported by name`
+      );
+    }
+  });
+
+  test('equivalent rewordings still satisfy the gate', () => {
+    // limit: four clauses present in each, spelled differently. Between them these
+    // exercise every alternative in every clause pattern, so a mutant that drops one
+    // alternative from `prohibition` or `overlap predicate` is killed here rather than
+    // surviving as an untested branch.
+    const equivalents = [
+      '**Rule:** Same-wave plans must have zero `files_modified`/`files_deleted` overlap.',
+      '**Rule:** Same wave plans must never share `files_modified` or `files_deleted` entries.',
+      '**Rule:** No two same-wave plans may end up sharing `files_modified` entries.',
+      '**Rule:** Same-wave plans must not conflict on `files_modified` entries.',
+      '**Rule:** A same-wave plan never shares `files_modified` entries with a sibling.',
+      '**Rule:** No wave may contain two plans that touch the same `files_modified` path.',
+    ];
+    for (const rule of equivalents) {
+      assert.deepEqual(
+        missingSameWaveRuleClauses(extractStepBody(assignWavesStep(rule), 'assign_waves')),
+        [],
+        `rewording under the agent file size cap must not red the suite: ${rule}`
+      );
+    }
+  });
+
+  test('extra prose alongside the rule does not break the gate', () => {
+    // limit+1: the four clauses plus an unrelated continuation line.
+    const withExtra = assignWavesStep(
+      [CANONICAL_RULE, 'Ties break toward the lower plan id for determinism.'].join('\n')
+    );
+    assert.deepEqual(
+      missingSameWaveRuleClauses(extractStepBody(withExtra, 'assign_waves')),
+      [],
+      'a longer rule paragraph is still a rule paragraph'
+    );
+  });
+
+  test('CRLF line endings do not defeat the rule scan', () => {
+    const crlf = assignWavesStep(['```', 'waves = {}', '```', '', CANONICAL_RULE].join('\r\n'), '\r\n');
+    assert.deepEqual(
+      missingSameWaveRuleClauses(extractStepBody(crlf, 'assign_waves')),
+      [],
+      'a Windows checkout must read the gate the same way'
+    );
+  });
+
+  test('an empty step body is rejected', () => {
+    assert.deepEqual(
+      missingSameWaveRuleClauses(''),
+      ['**Rule:** paragraph'],
+      'the predicate must not be vacuously true on nothing'
+    );
+  });
+
+  test('a missing step is reported, not thrown', () => {
+    const doc = assignWavesStep(CANONICAL_RULE);
+    assert.equal(extractStepBody(doc, 'group_into_plans'), null);
+    assert.deepEqual(missingSameWaveRuleClauses(extractStepBody(doc, 'group_into_plans')), [
+      '<step name="assign_waves"> block',
+    ]);
+  });
+
+  test('an unterminated step block yields null', () => {
+    assert.equal(extractStepBody('<step name="assign_waves">\nwaves = {}\n', 'assign_waves'), null);
+  });
+
+  test('the right step is extracted when earlier steps precede it', () => {
+    // gsd-planner.md carries 22 step blocks; the terminator search must start at the
+    // TARGET step's body, not at the document head, or every step but the first
+    // resolves to an empty body.
+    const document = [
+      namedStep('build_dependency_graph', 'placeholder'),
+      '',
+      assignWavesStep(CANONICAL_RULE),
+      '',
+      namedStep('group_into_plans', 'placeholder'),
+    ].join('\n');
+    const body = extractStepBody(document, 'assign_waves');
+    assert.ok(body !== null && body.includes('**Rule:**'), 'assign_waves body should be found');
+    assert.ok(
+      !body.includes('placeholder'),
+      'extraction must not bleed into a neighbouring step block'
+    );
+    assert.deepEqual(missingSameWaveRuleClauses(body), []);
+  });
+
+  test('clauses scattered across separate sentences are not a rule', () => {
+    // The four clauses co-occurring in one paragraph is exactly the shape of the
+    // defect this suite replaced, one level down: nothing here states that same-wave
+    // plans must not share files_modified entries.
+    const soup =
+      '**Rule:** Same-wave plans never overlap in scope; see `files_modified` for details.';
+    assert.deepEqual(
+      missingSameWaveRuleClauses(extractStepBody(assignWavesStep(soup), 'assign_waves')),
+      ['files_modified subject'],
+      'the gate must hold within a single sentence, not across a paragraph'
+    );
+  });
+
+  test('a paragraph that explicitly disclaims the gate is rejected', () => {
+    // Adversarial: every required word is present, and the paragraph says the opposite
+    // of the rule. Sentence-scoping is what rejects it — a paragraph-wide conjunction
+    // would score this as "gate present".
+    const disclaimers = [
+      '**Rule:** In the same wave, plans should never overlap in scope of ambition. This ' +
+        'paragraph is not describing `files_modified` sharing as a problem; ' +
+        '`files_modified` conflict between sibling plans is fine and requires no action, ' +
+        'never mind resolution.',
+      '**Rule:** Same-wave plans are great. Never mind `files_modified` for now. No ' +
+        'overlap discussion needed here since this is just a scheduling nicety.',
+    ];
+    for (const paragraph of disclaimers) {
+      assert.notDeepEqual(
+        missingSameWaveRuleClauses(extractStepBody(assignWavesStep(paragraph), 'assign_waves')),
+        [],
+        `a paragraph that permits the thing the gate forbids must not pass: ${paragraph}`
+      );
+    }
+  });
+
+  test('a whitespace-only line ends the rule paragraph', () => {
+    // Otherwise a later, unrelated line is absorbed into the paragraph and can supply a
+    // clause the rule itself does not state — re-creating the #3761 defect one level down.
+    const body = [
+      '**Rule:** Same-wave plans must have zero `files_modified` entries in common.',
+      '   ',
+      'Plans that overlap are bumped by the executor instead.',
+    ].join('\n');
+    assert.deepEqual(
+      missingSameWaveRuleClauses(extractStepBody(assignWavesStep(body), 'assign_waves')),
+      ['overlap predicate'],
+      'a clause stated outside the rule paragraph must not satisfy the rule'
+    );
+  });
+
+  test('property: extractStepBody round-trips any rendered step block', () => {
+    const stepName = fc
+      .string({ minLength: 1, maxLength: 20 })
+      .filter((s) => !/["<>]/.test(s));
+    const stepBody = fc.string({ maxLength: 200 }).filter((s) => !s.includes('</step>'));
+    fc.assert(
+      fc.property(stepName, stepBody, (name, body) => {
+        const doc = `intro\n<step name="${name}">${body}</step>\noutro`;
+        return extractStepBody(doc, name) === body;
+      }),
+      { numRuns: 200, seed: 3761 }
     );
   });
 });


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #3761

---

## What was broken

`tests/parallel-dependent-plans.test.cjs` carried a test named
`planner has validation step or quality gate for wave/files_modified consistency` whose
assertion was a six-token disjunction over whole-file substrings — and five of the six
tokens have never appeared in `agents/gsd-planner.md`. The whole gate reduced to one
incidental pseudocode comment in a 49 KB prompt file, so deleting the wave-ordering
gate entirely left the suite green.

## What this fix does

Deletes that test and replaces it with one anchored on the step's normative `**Rule:**`
sentence, scoped to `<step name="assign_waves">` rather than to the whole document, plus
thirteen tests that prove the new predicate actually reds when the gate is gutted.
`agents/gsd-planner.md` is not modified.

## Root cause

Two compounding defects, both present since #1600 authored the test alongside the
feature:

- **Ungrounded tokens.** `validate_waves`, `wave_validation` and `same wave` each occur
  **0** times in `agents/gsd-planner.md`; there is no `quality_gate` block in that file
  at all. `hasQualityGateCheck` was therefore permanently `false` and two of the three
  `hasValidationStep` arms were dead. Only `includes('files_modified overlap')`
  survived, at **1** occurrence — line 748's pseudocode comment.
- **Unscoped match.** The surviving check ran against the whole document, so *any*
  occurrence anywhere satisfied it. The four sibling tests in the same describe block
  already extract the `assign_waves` step first; this one did not.

The combination is what makes it vacuous rather than merely weak: PR #3758 deletes line
748 and the test stays green only because an unrelated pointer line added in the same PR
happens to contain the same substring.

## Testing

### How I verified the fix

**Failing-first, on the remote runner.** A control commit
(`fa59723f0b958c98374e59a518be26ca57532015`) applied the replacement tests together with
a deliberate mutation of `agents/gsd-planner.md` that deletes the same-wave overlap gate
— the `**Rule:**` sentence and the pseudocode comment — while adding PR #3758's pointer
line so the incidental substring survives. On that commit:

- the new anchored test **failed**, and
- the sibling test `assign_waves step checks files_modified overlap`, which uses the
  identical whole-file `includes('files_modified overlap')` the deleted assertion relied
  on, stayed **green**.

That pairing is the proof the replacement has teeth the original lacked: the same input
that the old predicate accepts, the new one rejects. The planner mutation exists only in
that control commit and is not part of this PR's diff.

The teeth tests encode the same demonstration permanently, driven against synthetic step
bodies so they never depend on the prompt file's current wording:

| Coverage | Case |
|---|---|
| regression | gutted step + surviving incidental phrase (PR #3758's exact shape) → rejected |
| negative | pseudocode comment is not an anchor → rejected |
| independence | rule stranded outside `assign_waves` → rejected (whole-file match does not count) |
| boundary `n−1` | each of the four required clauses removed in turn → rejected, **by name** |
| boundary `n` | six semantically equivalent rewordings → all accepted |
| boundary `n+1` | rule plus extra prose → accepted |
| adversarial | a paragraph that explicitly *permits* same-wave sharing → rejected |
| adversarial | the four clauses scattered across separate sentences → rejected |
| portability | CRLF step body → accepted |
| vacuity guard | empty step body → rejected |
| parser negative | missing step / unterminated step → `null`, reported not thrown |
| parser negative | sibling steps before the target → target's own body, not the first block's |
| paragraph scope | a whitespace-only line ends the rule paragraph |
| property (`fast-check`) | `extractStepBody` round-trips any rendered step block |

All four clauses must hold **within one sentence**. A paragraph-wide conjunction would
accept co-occurring words that never compose into a prohibition — #3761's own defect one
level down — and both review passes independently produced inputs that exploited exactly
that; each is now a regression test above. Within the sentence the clauses are
deliberately liberal about spelling (`zero`/`no`/`not`/`never`,
`overlap`/`share`/`sharing`/`conflict`/`touch`) so rewording under the agent file's size
cap does not red the suite. The six rewordings between them exercise every alternative in
every clause pattern, so no alternative is an untested branch.

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [x] N/A (not platform-specific)

Executed via the remote runner's full `(OS × Node)` fan-out. The CRLF case covers the
Windows line-ending hazard in-test rather than relying on a Windows lane.

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (remote runner, full matrix)
- [x] `.changeset/` fragment added if this is a user-facing fix — **N/A**: the diff is
      confined to `tests/`, which `scripts/changeset/lint.cjs` does not gate
      (`CONTRIBUTING.md:214` lists `bin/`, `gsd-core/`, `src/`, `agents/`, `commands/`,
      `hooks/`, `sdk/src/`), and `CONTRIBUTING.md:222` names test refactors as
      explicitly non-user-facing. No changelog entry is warranted for a test-quality fix.
- [x] No unnecessary dependencies added — `fast-check` is already a devDependency
      (`^4.8.0`) and is required by `RULESET.TESTS.property-based-testing` for the parser
      helper.

## Design notes

`agents/gsd-planner.md` is intentionally **not** modified. Adding a machine-readable
anchor was considered and rejected: the file sits 19 characters below the 49,152-character
cap asserted by `tests/precondition-element.test.cjs` and four sibling suites, so any
insertion would need a compensating trim — letting a test dictate the prompt's wording
budget — and it would collide with PR #3758's edits to the same region. The normative
`**Rule:**` sentence already present in `assign_waves` is the deliberate, documented
anchor the issue asks for, and it survives #3758's head (`697e838e0`) unchanged.

## Breaking changes

None
