### PR TITLE
docs(#3159): ADR — the dispatch predicate takes a kind and a survivability

### DIFF
--- a/docs/adr/3159-session-survivability-dispatch.md
+++ b/docs/adr/3159-session-survivability-dispatch.md
@@ -1,11 +1,11 @@
-# ADR-3159: Dispatch safety is host capability **and** session survivability [Proposed]
+# ADR-3159: The dispatch predicate takes a dispatch **kind** and a session **survivability**, not a host descriptor alone [Proposed]
 
 - **Status:** Proposed (Phase 0 — ADR only. Phases 1–3 are outstanding, so per the [corpus lifecycle rule](README.md#1-every-adr-declares-one-status-from-the-canonical-vocabulary) this stays `Proposed`; **nothing in this document is true of the tree until Phase 1 merges**.)
 - **Date:** 2026-08-22
-- **Issue:** [#3159](https://github.com/open-gsd/gsd-core/issues/3159) — `approved-feature`. The maintainer's approval names this ADR as a condition: *"This changes the dispatch predicate from 'is the tool available' to 'is the tool available and will this session outlive the turn', which is an architectural statement about what GSD assumes of a host, not a config toggle."*
-- **Builds on:** [ADR-1239](1239-gsd-embeddable-orchestration-engine.md) (**EoS**), which defines the negotiated host-capability axes this decision extends from the other side — the axes describe the *host binary*; this ADR adds the one property that describes the *deployment*.
+- **Issue:** [#3159](https://github.com/open-gsd/gsd-core/issues/3159) — `approved-feature`. The maintainer's approval names this ADR as a condition: *"This changes the dispatch predicate from 'is the tool available' to 'is the tool available and will this session outlive the turn', which is an architectural statement about what GSD assumes of a host, not a config toggle."* This ADR concludes that the approved statement is **half** of the correction; the other half is recorded in D1.
+- **Builds on:** [ADR-1239](1239-gsd-embeddable-orchestration-engine.md) (**EoS**), which defines the negotiated host-capability axes. The axes describe the *host binary*; this ADR adds the two things they cannot describe — what is being dispatched, and whether the caller will live to collect it.
 - **Relationship to prior work:** completes the graduation begun by [#853](https://github.com/open-gsd/gsd-core/issues/853) / [#1708](https://github.com/open-gsd/gsd-core/issues/1708) (`shouldFlattenDispatch` + the `dispatch-should-flatten` query, which replaced a `RUNTIME === 'codex'` prose rule) and [#2584](https://github.com/open-gsd/gsd-core/issues/2584) (`dispatch-isolation`). Related: [#922](https://github.com/open-gsd/gsd-core/issues/922) (the same predicate failing in the opposite direction), [#2939](https://github.com/open-gsd/gsd-core/issues/2939) (the depth-budget correction to the same predicate).
-- **Not superseded by, and does not supersede, anything.** Two adjacent items are deliberately *out* of this ADR and tracked separately: [#3178](https://github.com/open-gsd/gsd-core/issues/3178) (the shape-2 spike) and [#3177](https://github.com/open-gsd/gsd-core/issues/3177) (a stale doc line, since closed).
+- **Out of scope, tracked separately:** [#3178](https://github.com/open-gsd/gsd-core/issues/3178) (the shape-2 spike) and [#3177](https://github.com/open-gsd/gsd-core/issues/3177) (a stale doc line, since closed).
 
 > **Source anchors.** Line numbers below are as of `next` at `2f86278b` and this file is append-only, so they will drift. Where a symbol or section name exists, it is cited instead.
 
@@ -15,16 +15,14 @@
 
 Two prior decisions moved dispatch safety off prose and onto documentation-sourced capability data:
 
-- `shouldFlattenDispatch` (`src/host-integration.cts`) answers *may this host background a nesting-capable orchestrator, or must it run inline?* Its own docblock records the lineage: it *"graduates the #853 prose rule (originally `RUNTIME === 'codex'`, then extended to cursor) to a typed, documentation-sourced decision."* It is exposed to workflows as `gsd_run query dispatch-should-flatten` (`routeDispatchShouldFlatten`, `gsd-core/bin/gsd-tools.cjs`).
+- `shouldFlattenDispatch` (`src/host-integration.cts`) answers *may this host background a nesting-capable orchestrator, or must it run inline?* Its docblock records the lineage: it *"graduates the #853 prose rule (originally `RUNTIME === 'codex'`, then extended to cursor) to a typed, documentation-sourced decision."* It is exposed as `gsd_run query dispatch-should-flatten` (`routeDispatchShouldFlatten`, `gsd-core/bin/gsd-tools.cjs`).
 - `dispatch-isolation` (#2584) does the same for executor isolation, *"so the scheduler branches on a declared capability instead of on a runtime id."*
 
-Both are fail-closed by construction. `shouldFlattenDispatch` returns `true` (inline — the always-safe path) for a null, missing, `undocumented`, or insufficient descriptor; the isolation gate in `execute-phase/steps/executor-isolation-dispatch.md` refuses to dispatch at all rather than guess, on the stated principle that *"a guard that cannot verify must not answer 'safe'."*
+Both fail closed by construction. That posture is correct and this ADR preserves it.
 
-This is good architecture and this ADR does not disturb it.
+### The predicate answers one question; its callers ask two
 
-### The predicate's inputs are all properties of the host binary
-
-`shouldFlattenDispatch` reads exactly five fields, all from `runtime.hostIntegration.dispatch` in the capability registry:
+`shouldFlattenDispatch` reads five fields, all from `runtime.hostIntegration.dispatch`:
 
 | Field | Answers |
 |---|---|
@@ -33,90 +31,112 @@ This is good architecture and this ADR does not disturb it.
 | `nested`, `subagentToolkit` | Can it host a nesting orchestrator? |
 | `maxDepth` | Is there depth budget left for the delegated leaf? |
 
-Every one is sourced from vendor documentation with a cited quote — that is `docs/reference/host-integration-capability-matrix.md`'s entire evidentiary method. For `claude` the matrix cites Claude Code's own sub-agent docs for `dispatch.backgroundDispatch: false`.
+Four of those five are about **nesting**. That is correct for what the function was written for — `manager.md` and `autonomous.md` background an entire plan/execute *stage*, which must itself spawn a planner, a plan-checker, executors and a verifier.
 
-**None of the five answers the question that actually determines whether backgrounding is safe: will the orchestrator's own process still exist when the backgrounded work finishes?**
+It is wrong for what the rest of the codebase dispatches. **A wave executor spawns nothing.** Neither does a doc writer, a codebase mapper, or a planner — and this is not an inference, it is a property of the shipped agent definitions, which grant no `Agent`/`Task` tool at all:
 
-### The failure
+```
+agents/gsd-executor.md        tools: Read, Write, Edit, Bash, Grep, Glob, Skill, mcp__context7__*
+agents/gsd-doc-writer.md      tools: Read, Bash, Grep, Glob, Write, Edit, Skill
+agents/gsd-codebase-mapper.md tools: Read, Bash, Grep, Glob, Write, Skill
+agents/gsd-planner.md         tools: Read, Write, Edit, Bash, Glob, Grep, Skill, WebFetch, mcp__context7__*
+```
 
-A host may drive GSD as a non-interactive one-shot launch (`claude -p "<prompt>"`), one process per stage. In that mode `Agent` *is* available, the descriptor *is* accurate, and the predicate correctly answers "may background" — and then the turn ends and the process exits. A backgrounded executor's completion notification is delivered to a session that no longer exists.
+These are **leaf** dispatches. Asking them to satisfy `backgroundDispatch`/`nested`/`maxDepth > 1` asks them to prove a capability they will never exercise.
 
-Reported against a real run (#3159): 7 plans across 6 waves; wave 2 was the only multi-plan wave, took the `run_in_background: true` branch, and was the only wave that failed. Its two executors completed **5 commits** and neither wrote its `SUMMARY.md`, having been killed before that step.
+**This is measurable today, and it is why the unowned sites are unowned.** On `claude`, whose descriptor declares `background: true` but `backgroundDispatch: false` (`capabilities/claude/capability.json`; cited to Claude Code's own sub-agent docs at `docs/reference/host-integration-capability-matrix.md:87`):
 
-**Ownership, stated plainly:** the lost work is the *host's* fault. A wrapper chose a launch model that kills the session at turn end. GSD is not responsible for that, and this ADR does not make a one-shot host a supported posture. What GSD lacks — and what this ADR adds — is a way for such a host to *say so*, so GSD can take the path that is already known to be safe.
+```
+$ gsd_run query dispatch-should-flatten --json
+{ "runtime": "claude", "shouldFlatten": true, "dispatch": { …, "background": true, "backgroundDispatch": false, … } }
+```
 
-### The existing fallback cannot cover it, and says why itself
+The only available predicate says **inline** on the primary runtime. Every site that backgrounds a leaf therefore could not consult it without losing its parallelism, and each hardcoded `run_in_background: true` instead. The unconditional sites are not an oversight; they are what happens when the only predicate on offer answers the wrong question.
 
-`<runtime_compatibility>`'s fallback rule instructs the orchestrator to treat a silent agent as successful *"based on spot-checks"* and *"always verify via filesystem and git state."* That is the right instinct and is unreachable here: it presumes an orchestrator alive to spot-check. Under one-shot launch it is not. The same assumption is load-bearing in the safe-resume gate.
+### The failure this ADR was opened for
 
-### The finding that changes the scope: three notions of "should we background," one owner
+A host may drive GSD as a non-interactive one-shot launch (`claude -p "<prompt>"`), one process per stage. `Agent` is available, the descriptor is accurate, and the leaf dispatch is legitimate — then the turn ends and the process exits. A backgrounded executor's completion notification is delivered to a session that no longer exists.
 
-The reported failure is at one site. It is not the only site, and a fix scoped to it would leave the same defect standing elsewhere. Auditing every `run_in_background` in shipped content on `next` at `2f86278b`:
+Reported against a real run (#3159): 7 plans across 6 waves; wave 2 was the only multi-plan wave, took the `run_in_background: true` branch, and was the only wave that failed. Its two executors completed **5 commits** and neither wrote its `SUMMARY.md`.
 
-Counts below are **`Agent()` parameter sites**, not prose mentions — the two differ by roughly a factor of two in these files, and the distinction is the difference between a real dispatch and a sentence describing one.
+**Ownership, stated plainly:** the lost work is the *host's* fault. A wrapper chose a launch model that kills the session at turn end. This ADR does not make one-shot launch a supported posture. It gives such a host a way to *say so*.
 
-| Site | Backgrounds | Gated by |
-|---|---|---|
-| `manager.md` (2 resolutions → 2 dispatches), `autonomous.md` (2 → 2) | a whole plan/execute stage | **`dispatch-should-flatten`** — the typed predicate |
-| `execute-phase.md:682` | wave executors (2+ plans) | **nothing** — the `run_in_background: true` mandate is unconditional prose |
-| `docs-update.md` (9) | parallel doc writers, two waves | **nothing** — unconditional |
-| `plan-phase.md` (3), `plan-phase/steps/chunked-planning-mode.md` (2) | planners and plan chunks | **nothing** — unconditional |
-| `debug.md` (2) | — | pinned `false` deliberately (#2196), with a recorded reason |
+The existing fallback cannot cover it, and says why itself: `<runtime_compatibility>`'s rule instructs the orchestrator to treat a silent agent as successful *"based on spot-checks"* and to *"always verify via filesystem and git state."* That presumes an orchestrator alive to spot-check.
 
-Only the first row consults an owner. **Fourteen `Agent()` dispatch sites across three files, plus `execute-phase.md`'s prose mandate, each independently assert an answer to the same question.** The reported repro landed on `execute-phase.md:682`; `docs-update.md` and `plan-phase.md` background into the identical dying session and orphan their own work by the identical mechanism.
+### The audit: 20 unowned dispatch sites across 6 files
 
-(`plan-phase/steps/stall-detection-helpers.md` mentions `run_in_background=true` three times but carries no dispatch of its own — it documents the pattern its caller uses. It is named here only so a reader auditing the same way does not count it twice.)
+Counted as **`Agent()` parameter sites**, not prose mentions — the two differ by roughly a factor of two in these files.
 
-A config key wired into `execute-phase.md` alone would close the reported instance and leave the class open — and would do it by adding a *fourth* independent notion of "should we background," disagreeing with the typed one. [ADR-3180](3180-planning-semantic-model-single-owner.md) names that shape precisely: a derivation with more than one owner is fixed on one copy and missed on the siblings.
+| Site | Backgrounds | Kind | Gated by |
+|---|---|---|---|
+| `manager.md` (2), `autonomous.md` (2) | a whole plan/execute stage | orchestrator | **`dispatch-should-flatten`** |
+| `execute-phase.md:682` | wave executors | leaf | **nothing** — an unconditional prose mandate |
+| `docs-update.md` (9) | doc writers, two waves | leaf | **nothing** |
+| `docs-update/steps/dispatch-monorepo-packages.md` (1) | per-package doc writers | leaf | **nothing** |
+| `plan-phase.md` (3), `plan-phase/steps/chunked-planning-mode.md` (2) | planners and plan chunks | leaf | **nothing** |
+| `map-codebase.md` (4) | codebase mappers | leaf | **nothing** |
+| `autonomous/steps/converge-dispatch-bg.md` (1) | convergence pass | leaf | **nothing** |
+| `debug.md` (2) | — | — | pinned `false` deliberately (#2196) |
+| `commands/gsd/graphify.md`, `skills/gsd-graphify/SKILL.md` | — | — | prose **prohibitions** ("Do NOT pass `run_in_background: true`"), not dispatches |
+
+Four gated sites; **20 ungated ones across six files**, plus `execute-phase.md`'s prose mandate. [ADR-3180](3180-planning-semantic-model-single-owner.md) names this shape: a derivation with more than one owner is fixed on one copy and missed on the siblings.
+
+(`plan-phase/steps/stall-detection-helpers.md` mentions `run_in_background=true` three times but carries no dispatch of its own — it documents the pattern its caller uses. Named here so a reader auditing the same way does not double-count it.)
 
 ## Decision
 
-### D1 — The dispatch-safety predicate is a conjunction
+### D1 — The dispatch question has two axes, and neither was fully specified
 
-Backgrounding is safe only when **both** hold:
+Whether a dispatch may be backgrounded depends on:
 
-1. the **host** can background a nesting-capable orchestrator (today's five descriptor fields, unchanged), **and**
-2. the **session** will outlive the turn in which the dispatch is made.
+1. **Kind** — is the dispatched agent a *leaf* (spawns nothing) or an *orchestrator* (must itself delegate)? A leaf requires only `background === true`. An orchestrator additionally requires `backgroundDispatch`, `nested`, `subagentToolkit: 'full'`, and depth budget above 1 — today's rule, unchanged.
+2. **Survivability** — will the dispatching session outlive the turn to collect the result? Required by **both** kinds.
 
-Either one false ⇒ inline. This is the architectural statement the maintainer's approval asked this ADR to make: availability and survivability are different properties, and only one of them was being consulted.
+The approval framed this as adding a survivability conjunct. That is necessary and not sufficient: adding it to a predicate that already asks the wrong question of leaf callers would answer "inline" on Claude for every leaf site. **The predicate was under-parameterized in two dimensions; survivability is the second one.**
 
-### D2 — Survivability is operator-declared, not descriptor-declared
+### D2 — Kind is declared by the call site, and is checkable against the agent definition
 
-It does **not** become a sixth `dispatch.*` axis.
+The dispatching workflow declares what it is dispatching. It is not inferred from the descriptor, which describes the host and cannot know what GSD is about to spawn.
 
-The capability matrix's evidentiary model requires each axis to carry a vendor-documented citation. "Does this process survive past its turn" is not a property Claude Code's documentation asserts or denies — it is a property of how a *third-party wrapper invoked* Claude Code, and no vendor documents another party's invocation. Adding an uncitable axis to a matrix whose whole discipline is citation would corrode the discipline for one key.
+The declaration is **falsifiable**, which is what keeps it from rotting: an agent dispatched as `leaf` must grant no `Agent`/`Task` tool in `agents/<name>.md`. Phase 3 asserts this over every dispatch site, so a future agent that gains the tool without its call sites being reclassified fails the suite rather than silently backgrounding a nesting agent into a depth budget that cannot hold it — the #2939 failure, re-entered from the other side.
 
-The layering that results is clean and worth stating as the rule: **the descriptor says what the host *can* do; config says what this *deployment* is.**
+### D3 — Survivability is operator-declared, not descriptor-declared
 
-### D3 — One owner: it enters at the existing predicate
+It does **not** become a sixth `dispatch.*` axis. The capability matrix requires each axis to carry a vendor-documented citation, and "does this process survive past its turn" is a property of how a *third-party wrapper invoked* the host — no vendor documents another party's invocation. Adding an uncitable axis to a matrix whose discipline is citation would corrode that discipline for one key.
 
-The survivability input is consumed by `shouldFlattenDispatch` and surfaced through the existing `dispatch-should-flatten` query. It is **not** a new branch in workflow prose.
+The resulting layering: **the descriptor says what the host *can* do; the call site says what is being dispatched; config says what this *deployment* is.**
 
-Consequence, and the reason for this choice: every current consumer (`manager.md`, `autonomous.md`) inherits the fix without being edited, and no second predicate exists to drift from the first.
+### D4 — One owner, parameterized — not forked, and not naively conjoined
 
-### D4 — The unowned sites come under that owner
+`shouldFlattenDispatch` takes the dispatch kind and the survivability input alongside the descriptor. It is not split into `shouldFlattenOrchestrator`/`shouldFlattenExecutor`, and the second axis is not bolted onto the existing orchestrator-grade rule.
 
-`execute-phase.md`'s wave dispatch, `docs-update.md`'s writer waves, and `plan-phase.md` (with its `chunked-planning-mode` step) stop asserting `run_in_background: true` unconditionally and consult the owner instead. `debug.md` is untouched — its `false` is deliberate and already reasoned.
+The existing signature accepts only `dispatch` and is exported through the public SDK (`src/host-integration-sdk.cts`), so Phase 1 owns the compatibility question explicitly: the added parameters are optional, and an omitted kind defaults to `orchestrator` — the stricter of the two — so any caller not yet updated keeps today's exact verdict.
 
-**The `.git/config.lock` rationale is preserved, not traded away.** The existing instruction — dispatch one `Agent()` per message, never all in one message, because simultaneous `git worktree add` calls race on `.git/config.lock` — is orthogonal to the background flag and stays exactly as written. Serialized foreground dispatch is *strictly more* serialized than serialized background dispatch, so the race the rule exists to prevent cannot be reintroduced by this change.
+Rejecting a fork is not aesthetic. Two predicates would answer the same question — *may this be backgrounded* — from two bodies of code, which is the ADR-3180 shape this ADR is otherwise arguing against.
 
-### D5 — Fail closed, and report which input decided
+### D5 — The ungated sites come under the owner, declaring their kind
+
+The 20 sites in the audit consult the predicate and declare `leaf`. `manager.md` and `autonomous.md` continue to consult it and declare `orchestrator`. `debug.md` is untouched — its `false` is deliberate and already reasoned. The graphify prohibitions are untouched; they are not dispatches.
+
+**The `.git/config.lock` rationale is preserved, not traded away.** The existing instruction — dispatch one `Agent()` per message, never all in one message, because simultaneous `git worktree add` calls race on `.git/config.lock` — is orthogonal to the background flag and stays exactly as written. Serialized foreground dispatch is *strictly more* serialized than serialized background dispatch, so the race cannot be reintroduced.
+
+### D6 — Fail closed, and report which input decided
 
 Any unresolvable input yields inline, matching the predicate's existing posture.
 
-`dispatch-should-flatten --json` gains a provenance field distinguishing **`host-capability`** (the descriptor said no), **`session-declared`** (the operator said no), and **`fail-closed`** (something could not be resolved) — so a `shouldFlatten: true` can be explained without reading source. This follows [ADR-1411](1411-resolution-provenance.md): resolution must report its provenance rather than fall open silently. A flag that silently produces the same boolean as a descriptor limitation is undiagnosable in exactly the situation — an unattended one-shot host — where nobody is watching.
+`dispatch-should-flatten --json` gains a provenance field distinguishing **`host-capability`**, **`session-declared`**, and **`fail-closed`**, following [ADR-1411](1411-resolution-provenance.md). A flag that silently produces the same boolean as a descriptor limitation is undiagnosable in exactly the situation — an unattended one-shot host — where nobody is watching.
 
-### D6 — The key is `workflow.session_outlives_turn`, boolean, default `true`
+**This is an observable output-contract change.** The documented shape is `{ runtime, shouldFlatten, dispatch }` and tests pin it (`tests/command-routing-hub.test.cjs`). Phase 1 adds a field rather than altering one, updates those tests, and states that consumers may not assume the object is closed. The `--raw` form still prints exactly `true` or `false` and is unchanged.
 
-An opt-out. Default preserves today's behavior byte-for-byte on every currently-supported runtime.
+### D7 — The key is `workflow.session_outlives_turn`, boolean, default `true`
 
-**It is named for the property, not the mechanism, and that is load-bearing.** A mechanism name (`workflow.background_dispatch`, the name the earlier abandoned attempt on PR [#3214](https://github.com/open-gsd/gsd-core/pull/3214) used) collides conceptually with the descriptor's own `dispatch.background` and `dispatch.backgroundDispatch`, which are vendor-sourced and mean different things. Three similarly-named knobs across two layers, one of which silently overrides the others, is the confusion this ADR exists to remove. The key states the fact the operator knows; GSD decides what to do about it.
+An opt-out, **named for the property, not the mechanism.** A mechanism name (`workflow.background_dispatch`, used by the earlier abandoned attempt on PR [#3214](https://github.com/open-gsd/gsd-core/pull/3214)) collides conceptually with the descriptor's own `dispatch.background` and `dispatch.backgroundDispatch`, which are vendor-sourced and mean different things. The key states the fact the operator knows; GSD decides what to do about it.
 
-### D7 — The default is declared in the schema, **not** re-typed at each call site
+### D8 — The default is declared in the schema, and the value is validated
 
-The key is registered in the schema manifest's `validKeys`, in `SCHEMA_DEFAULTS` (`src/config.cts`), and as a `docs/CONFIGURATION.md` row.
+Registered in the schema manifest's `validKeys`, in `SCHEMA_DEFAULTS` (`src/config.cts`), and as a `docs/CONFIGURATION.md` row.
 
-**`workflow.use_worktrees` is this ADR's sizing precedent, and explicitly *not* its registration precedent.** That distinction is load-bearing, so it is recorded with the measurement behind it. Against an empty `.planning/config.json` on `next` at `2f86278b`:
+**`workflow.use_worktrees` is the sizing precedent, and explicitly not the registration precedent.** Measured against an empty `.planning/config.json` on `next` at `2f86278b`:
 
 | Key | Registered in | `config-get` result |
 |---|---|---|
@@ -124,50 +144,56 @@ The key is registered in the schema manifest's `validKeys`, in `SCHEMA_DEFAULTS`
 | `workflow.use_worktrees` | `validKeys` only | `Error: Key not found`, exit 1 |
 | an unregistered key | nothing | `Error: Key not found`, exit 1 |
 
-The last two rows are **output-identical**: `workflow.use_worktrees` is indistinguishable from a key nobody ever registered. Its "default `true`" exists only as a literal `|| echo "true"` repeated at each call site.
+The last two rows are **output-identical**: `use_worktrees` is indistinguishable from a key nobody registered, its default existing only as a repeated `|| echo "true"` at each bash call site.
 
-That pattern must not be copied here, for a reason specific to this key's direction:
+**A malformed value is the live hazard, and it fails open.** `config-set` performs no boolean validation for keys of this shape — `gsd_run query config-set workflow.use_worktrees garbage` succeeds and stores the string `"garbage"`. A `session_outlives_turn` set to `"fasle"` is *not* `false`, so a permissive consumer concludes the session survives and backgrounds — the precise orphaning D6 exists to prevent. Phase 1 therefore adds strict boolean validation at `config-set` **and** strict parsing at the consumer: anything that is not exactly boolean `false` (or the string `"false"`) is treated as unresolvable, which fails closed to inline rather than open to backgrounding.
 
-- `use_worktrees`'s caller-supplied fallback resolves to `true` — *toward* parallel isolation. A call site that forgets the fallback gets an empty string, which is falsy, and degrades to sequential: **fail-safe by luck of the polarity**.
-- `session_outlives_turn`'s safe direction is the opposite. A forgotten fallback yields an empty string, which is not `"false"`, so the predicate concludes the session survives and backgrounds — **failing open, into precisely the orphaning this ADR exists to prevent.**
-
-A safety predicate whose default is re-typed at every call site has as many chances to be wrong as it has callers. Declaring it once in `SCHEMA_DEFAULTS` gives `config-get` an exit-0 answer and removes the per-site literal entirely.
-
-**One further hazard, called out so it is a design constraint rather than a review finding.** `resolveSchemaDefault` resolves an absent key in two tiers — the hardcoded `SCHEMA_DEFAULTS` first, then the capability-registry `configSchema` default that `capability-activation.cts`'s resolver honors. A key registered in one tier and not the other lets `config-get` and capability activation disagree on the effective default. That is the class [#2256](https://github.com/open-gsd/gsd-core/issues/2256) fixed for existing keys, and a new key can reintroduce it.
+**One further hazard, called out so it is a design constraint rather than a review finding.** `resolveSchemaDefault` resolves an absent key in two tiers — `SCHEMA_DEFAULTS` first, then the capability-registry `configSchema` default that `capability-activation.cts`'s resolver honors (`src/capability-activation.cts`). A key registered in one tier and not the other lets `config-get` and capability activation disagree on the effective default. That is the class [#2256](https://github.com/open-gsd/gsd-core/issues/2256) fixed for existing keys. Phase 1 registers both tiers and tests the resolution path the predicate actually uses, not only `config-get`.
 
 ## Consequences
 
-**Positive.** A host that knows its own launch model can state it, and gets the path already proven safe. The fix reaches every backgrounding site through one predicate instead of one site through a new branch. Three unowned assertions of a safety-relevant decision collapse onto the owner that already exists for it. The default is unchanged, so no currently-supported runtime is affected.
+**The default is preserved, and here is the evaluation rather than the assertion.** On `claude` (`background: true`, `backgroundDispatch: false`) with the key at its default `true`:
 
-**Negative.** Declaring `false` costs wave parallelism — that is the trade, and it is real: a phase with multi-plan waves runs strictly slower. GSD acquires a config axis that can be set wrongly in a direction it cannot detect (see Known limits). Bringing the unowned sites under the predicate means four workflow files must read a query they do not read today, which is added surface in high-churn files.
+| Call site | Kind | Today | After |
+|---|---|---|---|
+| `manager.md`, `autonomous.md` | orchestrator | `shouldFlatten: true` → inline | `shouldFlatten: true` → inline |
+| the 20 ungated sites | leaf | hardcoded background | `background: true` ∧ survivable → background |
 
-**Expected breakage on landing.** Editing shipped `gsd-core/workflows/*.md` moves emitted-artifact hashes, so the differential attribution check (`tests/emitted-attribution.test.cjs`, [ADR-2719](2719-emitted-artifact-attribution.md)) will fire — correctly. Any ripple not attributable to the diff needs a per-PR fragment under `tests/emitted-drift-acks/`. Growth in those files is separately reported against the size-budget ratchet ([ADR-1610](1610-workflow-agent-size-budget-ratchet.md)), and **`execute-phase.md` has little room**: it is XL-tier against a 96 KiB hard cap and measures 92,356 bytes on `next` at `2f86278b` — under 6 KB of headroom for a file that is also the most-edited in the tree. Phase 2 should reach the predicate through the shortest possible addition there (a resolution plus a conditional), and may need to land the explanatory prose in a `steps/` fragment rather than inline.
+Both rows are unchanged. The earlier draft of this ADR routed leaf sites through the orchestrator-grade rule and would have forced every one of them inline on the primary runtime; that is recorded as rejected Alternative 3.
 
-**Verification standard.** Phase 3's regression must prove the predicate flips on the *session* input with the *host* input held constant, and vice versa — a test that only exercises the default path passes identically before and after the change it exists to prove.
+**Positive.** A host that knows its own launch model can state it. Twenty independent assertions of a safety-relevant decision collapse onto one owner. The predicate stops asking leaf dispatches to prove they can nest, which removes the reason the ungated sites were ungated. The kind declaration is machine-checkable against the agent definitions.
+
+**Negative.** Declaring `false` costs parallelism at every leaf site — that is the trade, and it is real. GSD acquires a config axis that can be set wrongly in a direction it cannot detect. Six workflow files must read a query they do not read today. The predicate takes three inputs where it took one, and a caller that omits the kind gets the strict answer, which is safe but can silently under-parallelize if a site is added without one.
+
+**Expected breakage on landing.** Editing shipped `gsd-core/workflows/*.md` moves emitted-artifact hashes, so the differential attribution check (`tests/emitted-attribution.test.cjs`, [ADR-2719](2719-emitted-artifact-attribution.md)) will fire — correctly. Ripples not attributable to the diff need a per-PR fragment under `tests/emitted-drift-acks/`. Growth is separately reported against the size-budget ratchet ([ADR-1610](1610-workflow-agent-size-budget-ratchet.md)), and **`execute-phase.md` has little room**: XL-tier against a 96 KiB hard cap, measuring 92,356 bytes on `next` at `2f86278b` — under 6 KB of headroom in the most-edited file in the tree. Phase 2 should reach the predicate through the shortest possible addition there and may need to land explanatory prose in a `steps/` fragment.
+
+**Verification standard.** Phase 3's regression must move the verdict on each axis with the others held constant — kind alone, survivability alone, descriptor alone. A test that exercises only the default path passes identically before and after the change it exists to prove.
 
 ## Alternatives considered
 
-1. **A sixth `dispatch.*` descriptor axis (`sessionSurvivesTurn`).** Rejected — D2. No vendor citation can exist for it, and the matrix's method is citation. This is the philosophically tidier home and it structurally does not fit; recorded here so a later reader does not re-propose it without the reason.
-2. **Name it for the mechanism (`workflow.background_dispatch`).** Rejected — D6. It is the name the earlier attempt used, and it collides with two existing descriptor fields that mean something else.
-3. **Branch only in `execute-phase.md`.** Rejected — this is the smallest change that closes the reported repro, and it creates a fourth owner while leaving `docs-update.md` and the stall helper broken against the same host. The narrow fix is what the audit in Context argues against.
-4. **A new `execution.*` namespace** (`execution.session_outlives_turn`, the maintainer's own illustrative spelling in the approval). **Deferred to review, not rejected on merit.** `workflow.*` is chosen because it is the established namespace holding every dispatch-shaping toggle (`use_worktrees`, `worktree_skip_hooks`, `agent_hint_routing`) and matches the `workflow.use_worktrees` sizing precedent the approval named; `execution.*` would exist for one key. If the maintainer prefers the new namespace the change is mechanical — the name is the reviewable half of D6, the property-not-mechanism principle is not.
-5. **Auto-detect the one-shot posture.** Rejected — there is no reliable signal, and a wrong guess in the permissive direction reproduces the bug while claiming to have fixed it. A predicate that cannot verify must not answer "safe."
-6. **Shape 2 — serialize worktree creation, then dispatch synchronously.** *Deferred, not rejected on merit,* and tracked as [#3178](https://github.com/open-gsd/gsd-core/issues/3178). If concurrent foreground `Agent()` dispatch genuinely parallelizes under Claude Code, this removes the *need* for the flag rather than complementing it — a strictly better outcome. It rests on an unestablished premise, touches the highest-churn dispatch path, and would change behavior for every install rather than only affected ones. It is not a substitute for closing this issue, and this ADR is written so that if #3178's premise holds, D1's second conjunct becomes vestigial rather than wrong.
-7. **Shape 3 — orchestrator-owned `SUMMARY.md`.** Complementary hardening, not adopted here, per the maintainer's approval. It addresses recoverability after the orphaning; this ADR addresses not orphaning.
-8. **`parallelization: false` (today's workaround).** Rejected as the answer. It serializes within a wave so the 2+ branch is never reached, but it is a different property being used as a proxy, it costs parallelism unconditionally, and it does not touch the sites that background regardless of wave width.
+1. **A sixth `dispatch.*` descriptor axis (`sessionSurvivesTurn`).** Rejected — D3. No vendor citation can exist for it, and the matrix's method is citation.
+2. **Name it for the mechanism (`workflow.background_dispatch`).** Rejected — D7. Collides with two existing descriptor fields that mean something else.
+3. **Add survivability as a conjunct to the existing predicate, leaving it otherwise unchanged.** **Rejected on measured evidence, and this was the earlier draft of this ADR.** `dispatch-should-flatten` returns `shouldFlatten: true` for `claude` today, because Claude declares `backgroundDispatch: false`. Routing leaf sites through that rule would have disabled wave parallelism on the primary runtime by default — a silent, severe regression presented as a no-op opt-out. The error was conflating "may GSD background an orchestrator that must itself delegate" with "may this orchestrator background a leaf and stay alive."
+4. **Fork into `shouldFlattenOrchestrator` / `shouldFlattenExecutor`.** Rejected — D4. It fixes the semantics and reintroduces the two-owner shape.
+5. **Branch only in `execute-phase.md`.** Rejected — the smallest change that closes the reported repro, and it leaves nineteen sites broken against the same host while adding another owner.
+6. **A new `execution.*` namespace** (`execution.session_outlives_turn`, the approval's illustrative spelling). **Deferred to review, not rejected on merit.** `workflow.*` holds every dispatch-shaping toggle (`use_worktrees`, `worktree_skip_hooks`, `agent_hint_routing`) and matches the sizing precedent the approval named; `execution.*` would exist for one key. Mechanical to change; the property-not-mechanism principle in D7 is not.
+7. **Auto-detect the one-shot posture.** Rejected — no reliable signal, and a wrong guess in the permissive direction reproduces the bug while claiming to have fixed it.
+8. **Shape 2 — serialize worktree creation, then dispatch synchronously.** *Deferred, not rejected on merit,* tracked as [#3178](https://github.com/open-gsd/gsd-core/issues/3178). If concurrent foreground `Agent()` dispatch genuinely parallelizes, it removes the *need* for the survivability axis rather than complementing it. It rests on an unestablished premise and would change behavior for every install. This ADR is written so that if #3178's premise holds, D1's second axis becomes vestigial rather than wrong — the kind axis stands regardless.
+9. **Shape 3 — orchestrator-owned `SUMMARY.md`.** Complementary hardening, not adopted here, per the approval. It addresses recoverability after orphaning; this ADR addresses not orphaning.
+10. **`parallelization: false` (today's workaround).** Rejected as the answer. A different property used as a proxy, costing parallelism unconditionally, and it does not touch the sites that background regardless of wave width.
 
 ## Scope boundary
 
-**In scope:** the dispatch-safety predicate, its second input, the config key that supplies it, provenance reporting on the query, and bringing the unconditional `run_in_background: true` sites under that predicate.
+**In scope:** the dispatch predicate's two missing parameters, the config key supplying one of them, provenance reporting, and bringing the ungated sites under the predicate.
 
 **Out of scope:**
 
 - **Whether concurrent foreground `Agent()` dispatch parallelizes** — [#3178](https://github.com/open-gsd/gsd-core/issues/3178).
-- **Making one-shot launch a supported posture.** This ADR makes the property *expressible*; it does not add a runtime, a certification, or a support claim. `docs/` says nothing about orchestrator session lifetime today and this ADR does not change that.
-- **The `.git/config.lock` serialization rule.** Preserved verbatim (D4).
+- **Making one-shot launch a supported posture.** This ADR makes the property *expressible*. `docs/` asserts nothing about orchestrator session lifetime today and this ADR does not change that.
+- **The `.git/config.lock` serialization rule.** Preserved verbatim (D5).
 - **Recovery after an orphaned wave.** The safe-resume gate and shape 3 own that.
-- **`debug.md`'s pinned foreground dispatch.** Already reasoned (#2196), untouched.
-- **Every other capability axis and runtime.** No descriptor changes.
+- **`debug.md`'s pinned foreground dispatch** (#2196) and the graphify prohibitions. Untouched.
+- **Every capability descriptor and runtime.** No descriptor changes.
 
 ## Phases
 
@@ -176,19 +202,22 @@ Each phase is one sub-issue and one PR, per the corpus convention.
 | Phase | Owns | Deliverable |
 |---|---|---|
 | 0 | this ADR | ADR + `node scripts/gen-adr-index.cjs --write` |
-| 1 | D1, D2, D5, D6, D7 | the second conjunct in `shouldFlattenDispatch`; the key registered across manifest / `SCHEMA_DEFAULTS` / `docs/CONFIGURATION.md`; provenance on `dispatch-should-flatten --json`; a behavioral `config-set`/`config-get` test; changeset fragment (`Added`) |
-| 2 | D3, D4 | `execute-phase.md`, `docs-update.md`, `plan-phase.md` and its `chunked-planning-mode` step consult the owner; emitted-drift-ack fragment if the attribution check requires one |
-| 3 | verification | regression proving both conjuncts move the verdict independently, and that a declared non-surviving session takes the inline path at every site from Phase 2 |
+| 1 | D1–D4, D6–D8 | the kind + survivability parameters on `shouldFlattenDispatch` (optional, defaulting to `orchestrator`); the key registered across manifest / `SCHEMA_DEFAULTS` / registry `configSchema` / `docs/CONFIGURATION.md`; strict boolean validation at `config-set` and strict parsing at the consumer; provenance on `--json` with its pinned tests updated; changeset fragment (`Added`) |
+| 2 | D5 | the six ungated files declare `leaf`; `manager.md` / `autonomous.md` declare `orchestrator`; emitted-drift-ack fragment if the attribution check requires one |
+| 3 | verification | per-axis regressions; the D2 assertion that every site declared `leaf` dispatches an agent granting no `Agent`/`Task` tool; a declared non-surviving session takes the inline path at every site |
 
-Phase 1 ships a real but unreached capability — the key resolves and the predicate honors it, while the three unconditional sites still ignore it until Phase 2. That ordering is deliberate (the config surface is reviewable on its own), and it is the reason **this ADR must not be read as describing the tree until Phase 2 merges**.
+Phase 1 ships a real but unreached capability — the predicate honors both new inputs while the ungated sites still ignore it until Phase 2. That ordering is deliberate, and it is why **this ADR must not be read as describing the tree until Phase 2 merges**.
 
 ## Known limits
-
-Gathered here so a later reader does not have to assemble them from Consequences and Scope boundary:
 
 - **The flag is a declaration, and GSD cannot check it.** A host that sets it wrongly — or never sets it — orphans work exactly as today. This ADR makes the property expressible, not detectable.
 - **It does not make one-shot launch supported.** It makes it survivable when declared.
 - **The cost is parallelism, unconditionally, for anyone who declares it.** There is no partial mode.
-- **It does not address a session that dies for other reasons** — a quota kill, an interrupt, a crash. Those are the safe-resume gate's, and the failure shape is the same even though the cause is not.
-- **If [#3178](https://github.com/open-gsd/gsd-core/issues/3178)'s premise holds, D1's second conjunct becomes redundant** for the wave-dispatch case. It would remain correct, and would remain load-bearing for the non-wave sites; it is not written to be thrown away, but it is written to be superseded gracefully.
+- **The kind declaration can be forgotten.** A new dispatch site with no kind gets `orchestrator` and may under-parallelize. That is the safe direction, and Phase 3's assertion catches the inverse error, but neither catches a site that simply omits the query.
+- **It does not address a session that dies for other reasons** — a quota kill, an interrupt, a crash. Those are the safe-resume gate's, though the failure shape is the same.
+- **If [#3178](https://github.com/open-gsd/gsd-core/issues/3178)'s premise holds, the survivability axis becomes redundant** for the wave-dispatch case. The kind axis stands either way.
 - **Nothing here is true of the tree until Phases 1–2 merge.** `Proposed` locks nothing.
+
+## Provenance
+
+The first draft of this ADR proposed Alternative 3 — survivability as a conjunct on the unmodified predicate — and asserted that the default was preserved. Two independent adversarial reviews (codex; antigravity/Gemini 3.1 Pro) each ran `dispatch-should-flatten` against the live registry, found `shouldFlatten: true` for `claude`, and identified the regression. The leaf/orchestrator decomposition in D1 and the machine-checkable kind declaration in D2 are the result. Recorded because the rejected design is the one a reader is most likely to re-propose, and because the evidence that killed it — one query invocation — is cheaper than the argument.

--- a/docs/adr/3159-session-survivability-dispatch.md
+++ b/docs/adr/3159-session-survivability-dispatch.md
@@ -1,0 +1,173 @@
+# ADR-3159: Dispatch safety is host capability **and** session survivability [Proposed]
+
+- **Status:** Proposed (Phase 0 — ADR only. Phases 1–3 are outstanding, so per the [corpus lifecycle rule](README.md#1-every-adr-declares-one-status-from-the-canonical-vocabulary) this stays `Proposed`; **nothing in this document is true of the tree until Phase 1 merges**.)
+- **Date:** 2026-08-22
+- **Issue:** [#3159](https://github.com/open-gsd/gsd-core/issues/3159) — `approved-feature`. The maintainer's approval names this ADR as a condition: *"This changes the dispatch predicate from 'is the tool available' to 'is the tool available and will this session outlive the turn', which is an architectural statement about what GSD assumes of a host, not a config toggle."*
+- **Builds on:** [ADR-1239](1239-gsd-embeddable-orchestration-engine.md) (**EoS**), which defines the negotiated host-capability axes this decision extends from the other side — the axes describe the *host binary*; this ADR adds the one property that describes the *deployment*.
+- **Relationship to prior work:** completes the graduation begun by [#853](https://github.com/open-gsd/gsd-core/issues/853) / [#1708](https://github.com/open-gsd/gsd-core/issues/1708) (`shouldFlattenDispatch` + the `dispatch-should-flatten` query, which replaced a `RUNTIME === 'codex'` prose rule) and [#2584](https://github.com/open-gsd/gsd-core/issues/2584) (`dispatch-isolation`). Related: [#922](https://github.com/open-gsd/gsd-core/issues/922) (the same predicate failing in the opposite direction), [#2939](https://github.com/open-gsd/gsd-core/issues/2939) (the depth-budget correction to the same predicate).
+- **Not superseded by, and does not supersede, anything.** Two adjacent items are deliberately *out* of this ADR and tracked separately: [#3178](https://github.com/open-gsd/gsd-core/issues/3178) (the shape-2 spike) and [#3177](https://github.com/open-gsd/gsd-core/issues/3177) (a stale doc line, since closed).
+
+> **Source anchors.** Line numbers below are as of `next` at `2f86278b` and this file is append-only, so they will drift. Where a symbol or section name exists, it is cited instead.
+
+## Context
+
+### GSD already replaced runtime-name guessing with a typed predicate
+
+Two prior decisions moved dispatch safety off prose and onto documentation-sourced capability data:
+
+- `shouldFlattenDispatch` (`src/host-integration.cts`) answers *may this host background a nesting-capable orchestrator, or must it run inline?* Its own docblock records the lineage: it *"graduates the #853 prose rule (originally `RUNTIME === 'codex'`, then extended to cursor) to a typed, documentation-sourced decision."* It is exposed to workflows as `gsd_run query dispatch-should-flatten` (`routeDispatchShouldFlatten`, `gsd-core/bin/gsd-tools.cjs`).
+- `dispatch-isolation` (#2584) does the same for executor isolation, *"so the scheduler branches on a declared capability instead of on a runtime id."*
+
+Both are fail-closed by construction. `shouldFlattenDispatch` returns `true` (inline — the always-safe path) for a null, missing, `undocumented`, or insufficient descriptor; the isolation gate in `execute-phase/steps/executor-isolation-dispatch.md` refuses to dispatch at all rather than guess, on the stated principle that *"a guard that cannot verify must not answer 'safe'."*
+
+This is good architecture and this ADR does not disturb it.
+
+### The predicate's inputs are all properties of the host binary
+
+`shouldFlattenDispatch` reads exactly five fields, all from `runtime.hostIntegration.dispatch` in the capability registry:
+
+| Field | Answers |
+|---|---|
+| `background` | Can this host background a sub-agent at all? |
+| `backgroundDispatch` | Can a *backgrounded* sub-agent itself spawn further sub-agents? (the #853 discriminator) |
+| `nested`, `subagentToolkit` | Can it host a nesting orchestrator? |
+| `maxDepth` | Is there depth budget left for the delegated leaf? |
+
+Every one is sourced from vendor documentation with a cited quote — that is `docs/reference/host-integration-capability-matrix.md`'s entire evidentiary method. For `claude` the matrix cites Claude Code's own sub-agent docs for `dispatch.backgroundDispatch: false`.
+
+**None of the five answers the question that actually determines whether backgrounding is safe: will the orchestrator's own process still exist when the backgrounded work finishes?**
+
+### The failure
+
+A host may drive GSD as a non-interactive one-shot launch (`claude -p "<prompt>"`), one process per stage. In that mode `Agent` *is* available, the descriptor *is* accurate, and the predicate correctly answers "may background" — and then the turn ends and the process exits. A backgrounded executor's completion notification is delivered to a session that no longer exists.
+
+Reported against a real run (#3159): 7 plans across 6 waves; wave 2 was the only multi-plan wave, took the `run_in_background: true` branch, and was the only wave that failed. Its two executors completed **5 commits** and neither wrote its `SUMMARY.md`, having been killed before that step.
+
+**Ownership, stated plainly:** the lost work is the *host's* fault. A wrapper chose a launch model that kills the session at turn end. GSD is not responsible for that, and this ADR does not make a one-shot host a supported posture. What GSD lacks — and what this ADR adds — is a way for such a host to *say so*, so GSD can take the path that is already known to be safe.
+
+### The existing fallback cannot cover it, and says why itself
+
+`<runtime_compatibility>`'s fallback rule instructs the orchestrator to treat a silent agent as successful *"based on spot-checks"* and *"always verify via filesystem and git state."* That is the right instinct and is unreachable here: it presumes an orchestrator alive to spot-check. Under one-shot launch it is not. The same assumption is load-bearing in the safe-resume gate.
+
+### The finding that changes the scope: three notions of "should we background," one owner
+
+The reported failure is at one site. It is not the only site, and a fix scoped to it would leave the same defect standing elsewhere. Auditing every `run_in_background` in shipped content on `next` at `2f86278b`:
+
+| Site | Backgrounds | Gated by |
+|---|---|---|
+| `manager.md` (×2), `autonomous.md` (×2 dispatches, ×3 resolutions) | a whole plan/execute stage | **`dispatch-should-flatten`** — the typed predicate |
+| `execute-phase.md:682` | wave executors (2+ plans) | **nothing** — `run_in_background: true` is unconditional |
+| `docs-update.md` (6 sites) | parallel doc writers | **nothing** — unconditional |
+| `plan-phase/steps/stall-detection-helpers.md` | the planner, for stall detection | **nothing** — unconditional |
+| `debug.md` (×2) | — | pinned `false` deliberately (#2196), with a recorded reason |
+
+Only the first row consults an owner. The rest each independently assert an answer to the same question. The reported repro landed on `execute-phase.md:682`; `docs-update.md` and the stall helper background into the identical dying session and orphan their own work by the identical mechanism.
+
+A config key wired into `execute-phase.md` alone would close the reported instance and leave the class open — and would do it by adding a *fourth* independent notion of "should we background," disagreeing with the typed one. [ADR-3180](3180-planning-semantic-model-single-owner.md) names that shape precisely: a derivation with more than one owner is fixed on one copy and missed on the siblings.
+
+## Decision
+
+### D1 — The dispatch-safety predicate is a conjunction
+
+Backgrounding is safe only when **both** hold:
+
+1. the **host** can background a nesting-capable orchestrator (today's five descriptor fields, unchanged), **and**
+2. the **session** will outlive the turn in which the dispatch is made.
+
+Either one false ⇒ inline. This is the architectural statement the maintainer's approval asked this ADR to make: availability and survivability are different properties, and only one of them was being consulted.
+
+### D2 — Survivability is operator-declared, not descriptor-declared
+
+It does **not** become a sixth `dispatch.*` axis.
+
+The capability matrix's evidentiary model requires each axis to carry a vendor-documented citation. "Does this process survive past its turn" is not a property Claude Code's documentation asserts or denies — it is a property of how a *third-party wrapper invoked* Claude Code, and no vendor documents another party's invocation. Adding an uncitable axis to a matrix whose whole discipline is citation would corrode the discipline for one key.
+
+The layering that results is clean and worth stating as the rule: **the descriptor says what the host *can* do; config says what this *deployment* is.**
+
+### D3 — One owner: it enters at the existing predicate
+
+The survivability input is consumed by `shouldFlattenDispatch` and surfaced through the existing `dispatch-should-flatten` query. It is **not** a new branch in workflow prose.
+
+Consequence, and the reason for this choice: every current consumer (`manager.md`, `autonomous.md`) inherits the fix without being edited, and no second predicate exists to drift from the first.
+
+### D4 — The unowned sites come under that owner
+
+`execute-phase.md`'s wave dispatch, `docs-update.md`'s writer waves, and `plan-phase`'s stall-detection helper stop asserting `run_in_background: true` unconditionally and consult the owner instead. `debug.md` is untouched — its `false` is deliberate and already reasoned.
+
+**The `.git/config.lock` rationale is preserved, not traded away.** The existing instruction — dispatch one `Agent()` per message, never all in one message, because simultaneous `git worktree add` calls race on `.git/config.lock` — is orthogonal to the background flag and stays exactly as written. Serialized foreground dispatch is *strictly more* serialized than serialized background dispatch, so the race the rule exists to prevent cannot be reintroduced by this change.
+
+### D5 — Fail closed, and report which input decided
+
+Any unresolvable input yields inline, matching the predicate's existing posture.
+
+`dispatch-should-flatten --json` gains a provenance field distinguishing **`host-capability`** (the descriptor said no), **`session-declared`** (the operator said no), and **`fail-closed`** (something could not be resolved) — so a `shouldFlatten: true` can be explained without reading source. This follows [ADR-1411](1411-resolution-provenance.md): resolution must report its provenance rather than fall open silently. A flag that silently produces the same boolean as a descriptor limitation is undiagnosable in exactly the situation — an unattended one-shot host — where nobody is watching.
+
+### D6 — The key is `workflow.session_outlives_turn`, boolean, default `true`
+
+An opt-out. Default preserves today's behavior byte-for-byte on every currently-supported runtime.
+
+**It is named for the property, not the mechanism, and that is load-bearing.** A mechanism name (`workflow.background_dispatch`, the name the earlier abandoned attempt on PR [#3214](https://github.com/open-gsd/gsd-core/pull/3214) used) collides conceptually with the descriptor's own `dispatch.background` and `dispatch.backgroundDispatch`, which are vendor-sourced and mean different things. Three similarly-named knobs across two layers, one of which silently overrides the others, is the confusion this ADR exists to remove. The key states the fact the operator knows; GSD decides what to do about it.
+
+### D7 — Registration ripple
+
+The key is registered on every seam a config key must reach: the schema manifest's `validKeys`, `SCHEMA_DEFAULTS` (`src/config.cts`), and a `docs/CONFIGURATION.md` row matching the `workflow.use_worktrees` precedent.
+
+**One hazard is called out so it is a design constraint rather than a review finding.** `resolveSchemaDefault` resolves an absent key in two tiers — the hardcoded `SCHEMA_DEFAULTS` first, then the capability-registry `configSchema` default that `capability-activation.cts`'s resolver honors. A key registered in one tier and not the other lets `config-get` and capability activation disagree on the effective default. That is the class [#2256](https://github.com/open-gsd/gsd-core/issues/2256) fixed for existing keys, and a new key can reintroduce it.
+
+## Consequences
+
+**Positive.** A host that knows its own launch model can state it, and gets the path already proven safe. The fix reaches every backgrounding site through one predicate instead of one site through a new branch. Three unowned assertions of a safety-relevant decision collapse onto the owner that already exists for it. The default is unchanged, so no currently-supported runtime is affected.
+
+**Negative.** Declaring `false` costs wave parallelism — that is the trade, and it is real: a phase with multi-plan waves runs strictly slower. GSD acquires a config axis that can be set wrongly in a direction it cannot detect (see Known limits). Bringing three sites under the predicate means three workflow files must read a query they do not read today, which is added surface in high-churn files.
+
+**Expected breakage on landing.** Editing shipped `gsd-core/workflows/*.md` moves emitted-artifact hashes, so the differential attribution check (`tests/emitted-attribution.test.cjs`, [ADR-2719](2719-emitted-artifact-attribution.md)) will fire — correctly. Any ripple not attributable to the diff needs a per-PR fragment under `tests/emitted-drift-acks/`. Growth in those files is separately reported against the size-budget ratchet ([ADR-1610](1610-workflow-agent-size-budget-ratchet.md)); the phases below are expected to keep the added prose minimal for that reason, and `execute-phase.md` is already near its tier.
+
+**Verification standard.** Phase 3's regression must prove the predicate flips on the *session* input with the *host* input held constant, and vice versa — a test that only exercises the default path passes identically before and after the change it exists to prove.
+
+## Alternatives considered
+
+1. **A sixth `dispatch.*` descriptor axis (`sessionSurvivesTurn`).** Rejected — D2. No vendor citation can exist for it, and the matrix's method is citation. This is the philosophically tidier home and it structurally does not fit; recorded here so a later reader does not re-propose it without the reason.
+2. **Name it for the mechanism (`workflow.background_dispatch`).** Rejected — D6. It is the name the earlier attempt used, and it collides with two existing descriptor fields that mean something else.
+3. **Branch only in `execute-phase.md`.** Rejected — this is the smallest change that closes the reported repro, and it creates a fourth owner while leaving `docs-update.md` and the stall helper broken against the same host. The narrow fix is what the audit in Context argues against.
+4. **A new `execution.*` namespace** (`execution.session_outlives_turn`, the maintainer's own illustrative spelling in the approval). **Deferred to review, not rejected on merit.** `workflow.*` is chosen because it is the established namespace holding every dispatch-shaping toggle (`use_worktrees`, `worktree_skip_hooks`, `agent_hint_routing`) and matches the `workflow.use_worktrees` sizing precedent the approval named; `execution.*` would exist for one key. If the maintainer prefers the new namespace the change is mechanical — the name is the reviewable half of D6, the property-not-mechanism principle is not.
+5. **Auto-detect the one-shot posture.** Rejected — there is no reliable signal, and a wrong guess in the permissive direction reproduces the bug while claiming to have fixed it. A predicate that cannot verify must not answer "safe."
+6. **Shape 2 — serialize worktree creation, then dispatch synchronously.** *Deferred, not rejected on merit,* and tracked as [#3178](https://github.com/open-gsd/gsd-core/issues/3178). If concurrent foreground `Agent()` dispatch genuinely parallelizes under Claude Code, this removes the *need* for the flag rather than complementing it — a strictly better outcome. It rests on an unestablished premise, touches the highest-churn dispatch path, and would change behavior for every install rather than only affected ones. It is not a substitute for closing this issue, and this ADR is written so that if #3178's premise holds, D1's second conjunct becomes vestigial rather than wrong.
+7. **Shape 3 — orchestrator-owned `SUMMARY.md`.** Complementary hardening, not adopted here, per the maintainer's approval. It addresses recoverability after the orphaning; this ADR addresses not orphaning.
+8. **`parallelization: false` (today's workaround).** Rejected as the answer. It serializes within a wave so the 2+ branch is never reached, but it is a different property being used as a proxy, it costs parallelism unconditionally, and it does not touch the sites that background regardless of wave width.
+
+## Scope boundary
+
+**In scope:** the dispatch-safety predicate, its second input, the config key that supplies it, provenance reporting on the query, and bringing the unconditional `run_in_background: true` sites under that predicate.
+
+**Out of scope:**
+
+- **Whether concurrent foreground `Agent()` dispatch parallelizes** — [#3178](https://github.com/open-gsd/gsd-core/issues/3178).
+- **Making one-shot launch a supported posture.** This ADR makes the property *expressible*; it does not add a runtime, a certification, or a support claim. `docs/` says nothing about orchestrator session lifetime today and this ADR does not change that.
+- **The `.git/config.lock` serialization rule.** Preserved verbatim (D4).
+- **Recovery after an orphaned wave.** The safe-resume gate and shape 3 own that.
+- **`debug.md`'s pinned foreground dispatch.** Already reasoned (#2196), untouched.
+- **Every other capability axis and runtime.** No descriptor changes.
+
+## Phases
+
+Each phase is one sub-issue and one PR, per the corpus convention.
+
+| Phase | Owns | Deliverable |
+|---|---|---|
+| 0 | this ADR | ADR + `node scripts/gen-adr-index.cjs --write` |
+| 1 | D1, D2, D5, D6, D7 | the second conjunct in `shouldFlattenDispatch`; the key registered across manifest / `SCHEMA_DEFAULTS` / `docs/CONFIGURATION.md`; provenance on `dispatch-should-flatten --json`; a behavioral `config-set`/`config-get` test; changeset fragment (`Added`) |
+| 2 | D3, D4 | `execute-phase.md`, `docs-update.md`, and `plan-phase/steps/stall-detection-helpers.md` consult the owner; emitted-drift-ack fragment if the attribution check requires one |
+| 3 | verification | regression proving both conjuncts move the verdict independently, and that a declared non-surviving session takes the inline path at every site from Phase 2 |
+
+Phase 1 ships a real but unreached capability — the key resolves and the predicate honors it, while the three unconditional sites still ignore it until Phase 2. That ordering is deliberate (the config surface is reviewable on its own), and it is the reason **this ADR must not be read as describing the tree until Phase 2 merges**.
+
+## Known limits
+
+Gathered here so a later reader does not have to assemble them from Consequences and Scope boundary:
+
+- **The flag is a declaration, and GSD cannot check it.** A host that sets it wrongly — or never sets it — orphans work exactly as today. This ADR makes the property expressible, not detectable.
+- **It does not make one-shot launch supported.** It makes it survivable when declared.
+- **The cost is parallelism, unconditionally, for anyone who declares it.** There is no partial mode.
+- **It does not address a session that dies for other reasons** — a quota kill, an interrupt, a crash. Those are the safe-resume gate's, and the failure shape is the same even though the cause is not.
+- **If [#3178](https://github.com/open-gsd/gsd-core/issues/3178)'s premise holds, D1's second conjunct becomes redundant** for the wave-dispatch case. It would remain correct, and would remain load-bearing for the non-wave sites; it is not written to be thrown away, but it is written to be superseded gracefully.
+- **Nothing here is true of the tree until Phases 1–2 merge.** `Proposed` locks nothing.

--- a/docs/adr/3159-session-survivability-dispatch.md
+++ b/docs/adr/3159-session-survivability-dispatch.md
@@ -165,7 +165,14 @@ Both rows are unchanged. The earlier draft of this ADR routed leaf sites through
 
 **Negative.** Declaring `false` costs parallelism at every leaf site — that is the trade, and it is real. GSD acquires a config axis that can be set wrongly in a direction it cannot detect. Six workflow files must read a query they do not read today. The predicate takes three inputs where it took one, and a caller that omits the kind gets the strict answer, which is safe but can silently under-parallelize if a site is added without one.
 
-**Expected breakage on landing.** Editing shipped `gsd-core/workflows/*.md` moves emitted-artifact hashes, so the differential attribution check (`tests/emitted-attribution.test.cjs`, [ADR-2719](2719-emitted-artifact-attribution.md)) will fire — correctly. Ripples not attributable to the diff need a per-PR fragment under `tests/emitted-drift-acks/`. Growth is separately reported against the size-budget ratchet ([ADR-1610](1610-workflow-agent-size-budget-ratchet.md)), and **`execute-phase.md` has little room**: XL-tier against a 96 KiB hard cap, measuring 92,356 bytes on `next` at `2f86278b` — under 6 KB of headroom in the most-edited file in the tree. Phase 2 should reach the predicate through the shortest possible addition there and may need to land explanatory prose in a `steps/` fragment.
+**Expected breakage on landing.** Editing shipped `gsd-core/workflows/*.md` moves emitted-artifact hashes, so the differential attribution check (`tests/emitted-attribution.test.cjs`, [ADR-2719](2719-emitted-artifact-attribution.md)) will fire — correctly. Ripples not attributable to the diff need a per-PR fragment under `tests/emitted-drift-acks/`. Growth is separately reported against the size-budget ratchet ([ADR-1610](1610-workflow-agent-size-budget-ratchet.md)), and **the two files Phase 2 must edit are the two with the least room in the tree.** The operative bound is the per-file *margin ceiling*, which is far tighter than the XL tier's 96 KiB hard cap:
+
+| File | Size on `next` @ `2f86278b` | Margin budget | Headroom |
+|---|---|---|---|
+| `execute-phase.md` | 92,356 B | 93,400 B | **1,044 B** |
+| `plan-phase.md` | 94,431 B | 94,519 B | **88 B** |
+
+Eighty-eight bytes will not hold a query invocation and a conditional, let alone an explanation. Phase 2 therefore **cannot** add its prose inline in `plan-phase.md`, and very likely not in `execute-phase.md` either: both must reach the predicate through a `steps/` fragment, or land alongside a compensating reduction. This is a hard planning constraint on Phase 2, not a caution.
 
 **Verification standard.** Phase 3's regression must move the verdict on each axis with the others held constant — kind alone, survivability alone, descriptor alone. A test that exercises only the default path passes identically before and after the change it exists to prove.
 

--- a/docs/adr/3159-session-survivability-dispatch.md
+++ b/docs/adr/3159-session-survivability-dispatch.md
@@ -53,15 +53,19 @@ Reported against a real run (#3159): 7 plans across 6 waves; wave 2 was the only
 
 The reported failure is at one site. It is not the only site, and a fix scoped to it would leave the same defect standing elsewhere. Auditing every `run_in_background` in shipped content on `next` at `2f86278b`:
 
+Counts below are **`Agent()` parameter sites**, not prose mentions — the two differ by roughly a factor of two in these files, and the distinction is the difference between a real dispatch and a sentence describing one.
+
 | Site | Backgrounds | Gated by |
 |---|---|---|
-| `manager.md` (×2), `autonomous.md` (×2 dispatches, ×3 resolutions) | a whole plan/execute stage | **`dispatch-should-flatten`** — the typed predicate |
-| `execute-phase.md:682` | wave executors (2+ plans) | **nothing** — `run_in_background: true` is unconditional |
-| `docs-update.md` (6 sites) | parallel doc writers | **nothing** — unconditional |
-| `plan-phase/steps/stall-detection-helpers.md` | the planner, for stall detection | **nothing** — unconditional |
-| `debug.md` (×2) | — | pinned `false` deliberately (#2196), with a recorded reason |
+| `manager.md` (2 resolutions → 2 dispatches), `autonomous.md` (2 → 2) | a whole plan/execute stage | **`dispatch-should-flatten`** — the typed predicate |
+| `execute-phase.md:682` | wave executors (2+ plans) | **nothing** — the `run_in_background: true` mandate is unconditional prose |
+| `docs-update.md` (9) | parallel doc writers, two waves | **nothing** — unconditional |
+| `plan-phase.md` (3), `plan-phase/steps/chunked-planning-mode.md` (2) | planners and plan chunks | **nothing** — unconditional |
+| `debug.md` (2) | — | pinned `false` deliberately (#2196), with a recorded reason |
 
-Only the first row consults an owner. The rest each independently assert an answer to the same question. The reported repro landed on `execute-phase.md:682`; `docs-update.md` and the stall helper background into the identical dying session and orphan their own work by the identical mechanism.
+Only the first row consults an owner. **Fourteen `Agent()` dispatch sites across three files, plus `execute-phase.md`'s prose mandate, each independently assert an answer to the same question.** The reported repro landed on `execute-phase.md:682`; `docs-update.md` and `plan-phase.md` background into the identical dying session and orphan their own work by the identical mechanism.
+
+(`plan-phase/steps/stall-detection-helpers.md` mentions `run_in_background=true` three times but carries no dispatch of its own — it documents the pattern its caller uses. It is named here only so a reader auditing the same way does not count it twice.)
 
 A config key wired into `execute-phase.md` alone would close the reported instance and leave the class open — and would do it by adding a *fourth* independent notion of "should we background," disagreeing with the typed one. [ADR-3180](3180-planning-semantic-model-single-owner.md) names that shape precisely: a derivation with more than one owner is fixed on one copy and missed on the siblings.
 
@@ -92,7 +96,7 @@ Consequence, and the reason for this choice: every current consumer (`manager.md
 
 ### D4 — The unowned sites come under that owner
 
-`execute-phase.md`'s wave dispatch, `docs-update.md`'s writer waves, and `plan-phase`'s stall-detection helper stop asserting `run_in_background: true` unconditionally and consult the owner instead. `debug.md` is untouched — its `false` is deliberate and already reasoned.
+`execute-phase.md`'s wave dispatch, `docs-update.md`'s writer waves, and `plan-phase.md` (with its `chunked-planning-mode` step) stop asserting `run_in_background: true` unconditionally and consult the owner instead. `debug.md` is untouched — its `false` is deliberate and already reasoned.
 
 **The `.git/config.lock` rationale is preserved, not traded away.** The existing instruction — dispatch one `Agent()` per message, never all in one message, because simultaneous `git worktree add` calls race on `.git/config.lock` — is orthogonal to the background flag and stays exactly as written. Serialized foreground dispatch is *strictly more* serialized than serialized background dispatch, so the race the rule exists to prevent cannot be reintroduced by this change.
 
@@ -118,9 +122,9 @@ The key is registered on every seam a config key must reach: the schema manifest
 
 **Positive.** A host that knows its own launch model can state it, and gets the path already proven safe. The fix reaches every backgrounding site through one predicate instead of one site through a new branch. Three unowned assertions of a safety-relevant decision collapse onto the owner that already exists for it. The default is unchanged, so no currently-supported runtime is affected.
 
-**Negative.** Declaring `false` costs wave parallelism — that is the trade, and it is real: a phase with multi-plan waves runs strictly slower. GSD acquires a config axis that can be set wrongly in a direction it cannot detect (see Known limits). Bringing three sites under the predicate means three workflow files must read a query they do not read today, which is added surface in high-churn files.
+**Negative.** Declaring `false` costs wave parallelism — that is the trade, and it is real: a phase with multi-plan waves runs strictly slower. GSD acquires a config axis that can be set wrongly in a direction it cannot detect (see Known limits). Bringing the unowned sites under the predicate means four workflow files must read a query they do not read today, which is added surface in high-churn files.
 
-**Expected breakage on landing.** Editing shipped `gsd-core/workflows/*.md` moves emitted-artifact hashes, so the differential attribution check (`tests/emitted-attribution.test.cjs`, [ADR-2719](2719-emitted-artifact-attribution.md)) will fire — correctly. Any ripple not attributable to the diff needs a per-PR fragment under `tests/emitted-drift-acks/`. Growth in those files is separately reported against the size-budget ratchet ([ADR-1610](1610-workflow-agent-size-budget-ratchet.md)); the phases below are expected to keep the added prose minimal for that reason, and `execute-phase.md` is already near its tier.
+**Expected breakage on landing.** Editing shipped `gsd-core/workflows/*.md` moves emitted-artifact hashes, so the differential attribution check (`tests/emitted-attribution.test.cjs`, [ADR-2719](2719-emitted-artifact-attribution.md)) will fire — correctly. Any ripple not attributable to the diff needs a per-PR fragment under `tests/emitted-drift-acks/`. Growth in those files is separately reported against the size-budget ratchet ([ADR-1610](1610-workflow-agent-size-budget-ratchet.md)), and **`execute-phase.md` has little room**: it is XL-tier against a 96 KiB hard cap and measures 92,356 bytes on `next` at `2f86278b` — under 6 KB of headroom for a file that is also the most-edited in the tree. Phase 2 should reach the predicate through the shortest possible addition there (a resolution plus a conditional), and may need to land the explanatory prose in a `steps/` fragment rather than inline.
 
 **Verification standard.** Phase 3's regression must prove the predicate flips on the *session* input with the *host* input held constant, and vice versa — a test that only exercises the default path passes identically before and after the change it exists to prove.
 
@@ -156,7 +160,7 @@ Each phase is one sub-issue and one PR, per the corpus convention.
 |---|---|---|
 | 0 | this ADR | ADR + `node scripts/gen-adr-index.cjs --write` |
 | 1 | D1, D2, D5, D6, D7 | the second conjunct in `shouldFlattenDispatch`; the key registered across manifest / `SCHEMA_DEFAULTS` / `docs/CONFIGURATION.md`; provenance on `dispatch-should-flatten --json`; a behavioral `config-set`/`config-get` test; changeset fragment (`Added`) |
-| 2 | D3, D4 | `execute-phase.md`, `docs-update.md`, and `plan-phase/steps/stall-detection-helpers.md` consult the owner; emitted-drift-ack fragment if the attribution check requires one |
+| 2 | D3, D4 | `execute-phase.md`, `docs-update.md`, `plan-phase.md` and its `chunked-planning-mode` step consult the owner; emitted-drift-ack fragment if the attribution check requires one |
 | 3 | verification | regression proving both conjuncts move the verdict independently, and that a declared non-surviving session takes the inline path at every site from Phase 2 |
 
 Phase 1 ships a real but unreached capability — the key resolves and the predicate honors it, while the three unconditional sites still ignore it until Phase 2. That ordering is deliberate (the config surface is reviewable on its own), and it is the reason **this ADR must not be read as describing the tree until Phase 2 merges**.

--- a/docs/adr/3159-session-survivability-dispatch.md
+++ b/docs/adr/3159-session-survivability-dispatch.md
@@ -112,11 +112,28 @@ An opt-out. Default preserves today's behavior byte-for-byte on every currently-
 
 **It is named for the property, not the mechanism, and that is load-bearing.** A mechanism name (`workflow.background_dispatch`, the name the earlier abandoned attempt on PR [#3214](https://github.com/open-gsd/gsd-core/pull/3214) used) collides conceptually with the descriptor's own `dispatch.background` and `dispatch.backgroundDispatch`, which are vendor-sourced and mean different things. Three similarly-named knobs across two layers, one of which silently overrides the others, is the confusion this ADR exists to remove. The key states the fact the operator knows; GSD decides what to do about it.
 
-### D7 — Registration ripple
+### D7 — The default is declared in the schema, **not** re-typed at each call site
 
-The key is registered on every seam a config key must reach: the schema manifest's `validKeys`, `SCHEMA_DEFAULTS` (`src/config.cts`), and a `docs/CONFIGURATION.md` row matching the `workflow.use_worktrees` precedent.
+The key is registered in the schema manifest's `validKeys`, in `SCHEMA_DEFAULTS` (`src/config.cts`), and as a `docs/CONFIGURATION.md` row.
 
-**One hazard is called out so it is a design constraint rather than a review finding.** `resolveSchemaDefault` resolves an absent key in two tiers — the hardcoded `SCHEMA_DEFAULTS` first, then the capability-registry `configSchema` default that `capability-activation.cts`'s resolver honors. A key registered in one tier and not the other lets `config-get` and capability activation disagree on the effective default. That is the class [#2256](https://github.com/open-gsd/gsd-core/issues/2256) fixed for existing keys, and a new key can reintroduce it.
+**`workflow.use_worktrees` is this ADR's sizing precedent, and explicitly *not* its registration precedent.** That distinction is load-bearing, so it is recorded with the measurement behind it. Against an empty `.planning/config.json` on `next` at `2f86278b`:
+
+| Key | Registered in | `config-get` result |
+|---|---|---|
+| `git.create_tag` | `validKeys` + `SCHEMA_DEFAULTS` | `true`, exit 0 |
+| `workflow.use_worktrees` | `validKeys` only | `Error: Key not found`, exit 1 |
+| an unregistered key | nothing | `Error: Key not found`, exit 1 |
+
+The last two rows are **output-identical**: `workflow.use_worktrees` is indistinguishable from a key nobody ever registered. Its "default `true`" exists only as a literal `|| echo "true"` repeated at each call site.
+
+That pattern must not be copied here, for a reason specific to this key's direction:
+
+- `use_worktrees`'s caller-supplied fallback resolves to `true` — *toward* parallel isolation. A call site that forgets the fallback gets an empty string, which is falsy, and degrades to sequential: **fail-safe by luck of the polarity**.
+- `session_outlives_turn`'s safe direction is the opposite. A forgotten fallback yields an empty string, which is not `"false"`, so the predicate concludes the session survives and backgrounds — **failing open, into precisely the orphaning this ADR exists to prevent.**
+
+A safety predicate whose default is re-typed at every call site has as many chances to be wrong as it has callers. Declaring it once in `SCHEMA_DEFAULTS` gives `config-get` an exit-0 answer and removes the per-site literal entirely.
+
+**One further hazard, called out so it is a design constraint rather than a review finding.** `resolveSchemaDefault` resolves an absent key in two tiers — the hardcoded `SCHEMA_DEFAULTS` first, then the capability-registry `configSchema` default that `capability-activation.cts`'s resolver honors. A key registered in one tier and not the other lets `config-get` and capability activation disagree on the effective default. That is the class [#2256](https://github.com/open-gsd/gsd-core/issues/2256) fixed for existing keys, and a new key can reintroduce it.
 
 ## Consequences
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -274,7 +274,7 @@ Decided in principle, not yet ratified. Do not cite as settled architecture.
 | [ADR-1671](1671-dynamic-context-management-platform.md) | Dynamic context management platform | Proposed | — |
 | [ADR-1953](1953-complexity-triggered-refactor.md) | Complexity-triggered refactor — the loop measures the entropy it just added | Proposed | — |
 | [ADR-3128](3128-adaptive-runtime-evidence.md) | Adaptive runtime evidence for GSD Debug | Proposed | — |
-| [ADR-3159](3159-session-survivability-dispatch.md) | Dispatch safety is host capability **and** session survivability | Proposed | — |
+| [ADR-3159](3159-session-survivability-dispatch.md) | The dispatch predicate takes a dispatch **kind** and a session **survivability**, not a host descriptor alone | Proposed | — |
 
 ### Superseded, Retired, and Legacy
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -274,6 +274,7 @@ Decided in principle, not yet ratified. Do not cite as settled architecture.
 | [ADR-1671](1671-dynamic-context-management-platform.md) | Dynamic context management platform | Proposed | — |
 | [ADR-1953](1953-complexity-triggered-refactor.md) | Complexity-triggered refactor — the loop measures the entropy it just added | Proposed | — |
 | [ADR-3128](3128-adaptive-runtime-evidence.md) | Adaptive runtime evidence for GSD Debug | Proposed | — |
+| [ADR-3159](3159-session-survivability-dispatch.md) | Dispatch safety is host capability **and** session survivability | Proposed | — |
 
 ### Superseded, Retired, and Legacy
 


### PR DESCRIPTION
## ADR-only PR (Phase 0 of #3159)

Refs #3159

This PR adds **one file** — `docs/adr/3159-session-survivability-dispatch.md` — plus the
generated ADR index row. **No production code, no behavior change.**

It deliberately uses `Refs`, not `Closes`: #3159's feature is not delivered by this PR
(Phases 1–3 remain), and the diff is docs-only, which CONTRIBUTING's non-closing-reference
rule permits. Note also that none of the four PR templates fits an ADR-only submission —
happy to re-file under a Phase-0 sub-issue if you'd prefer the ADR-2313 / #3240 pattern.

## Why this ADR exists

Your approval of #3159 required it:

> This changes the dispatch predicate from "is the tool available" to "is the tool available
> **and** will this session outlive the turn", which is an architectural statement about what
> GSD assumes of a host, not a config toggle.

## The finding that changed the design

The approved framing is **half** the correction, and implementing only that half would have
shipped a silent regression on the primary runtime.

`shouldFlattenDispatch` requires `backgroundDispatch`, `nested`, `subagentToolkit: 'full'`
and depth budget > 1 — four axes about **nesting**. Correct for `manager.md`/`autonomous.md`,
which background a whole stage that must itself delegate. Wrong for everything else GSD
backgrounds. `claude` declares `backgroundDispatch: false`, so:

```
$ gsd_run query dispatch-should-flatten --json
{ "runtime": "claude", "shouldFlatten": true, ... }
```

The repo's own suite already documents this at `tests/command-routing-hub.test.cjs:1704`.
Adding survivability as a conjunct to that rule and routing leaf sites through it would have
forced **inline execution on Claude by default**, disabling wave parallelism — while the ADR
claimed the default was preserved. That draft is recorded as rejected Alternative 3.

Root cause: two different questions were sharing one predicate.

- *May GSD background an orchestrator that must itself delegate?* → needs the nesting axes.
- *May this orchestrator background a **leaf** and stay alive?* → needs only `background`
  plus survivability.

Executors, doc writers, mappers and planners grant **no `Agent`/`Task` tool** in their agent
definitions — they cannot nest, structurally. Requiring them to prove they can is why all 20
leaf sites hardcode `run_in_background: true` instead of consulting the predicate.

## What the ADR decides

The predicate takes a **dispatch kind** alongside **survivability**, keeping one owner rather
than forking. Added parameters are optional and default to `orchestrator` (the stricter arm),
so any un-updated caller keeps today's exact verdict. The kind declaration is machine-checkable:
a site declaring `leaf` must dispatch an agent granting no `Agent`/`Task` tool, asserted in
Phase 3.

Default behavior is preserved on every path — the ADR shows the evaluation rather than
asserting it.

## Audit

20 ungated `Agent()` dispatch sites across 6 files (not the 3 the first draft claimed);
`debug.md`'s pinned foreground dispatch and the graphify prose prohibitions are correctly
excluded.

## Verification

- `node scripts/gen-adr-index.cjs --check` — clean, index regenerated. Verified with a
  negative control (an injected broken link is caught and named).
- `changeset/lint.cjs` → `ok_no_user_facing_changes`; `lint-docs-required.cjs` →
  `ok_no_triggering_fragments`; `check-glossary-refs.cjs` → current.
- Every factual claim was checked against the tree at `2f86278b`; the ADR pins that SHA
  because line numbers drift.

## Provenance

The design error above was found by two independent adversarial reviews (codex;
antigravity/Gemini 3.1 Pro), each of which ran the shipped query rather than reasoning about
it. The ADR records this in a `Provenance` section, because the rejected design is the one a
reader is most likely to re-propose.
