### PR TITLE
fix(#3784): read the hybrid `Current Plan: N of M` shape, keep zero-padding, and name the accepted shapes on failure

### DIFF
--- a/src/state-transition.cts
+++ b/src/state-transition.cts
@@ -1079,7 +1079,13 @@ function advancePlanCore(content: string, deps: StateTransitionDeps): StateTrans
   const newPlan = currentPlan + 1;
   let planDisplayValue: string;
   if (useCompoundFormat) {
-    planDisplayValue = (planRawValue as string).replace(/^\d+/, String(newPlan));
+    // Preserve the written zero-padding: "04 of 06" advances to "05 of 06",
+    // not "5 of 06". Only the leading half was being rewritten, so a padded
+    // file drifted into a lopsided one, which is the kind of untidiness that
+    // invites the next writer to "fix" the line into a shape nothing parses.
+    // padStart never truncates, so 09 -> 10 widens correctly.
+    planDisplayValue = (planRawValue as string).replace(/^\d+/, (digits) =>
+      String(newPlan).padStart(digits.length, '0'));
     body = stateReplaceField(body, planSourceField, planDisplayValue) || body;
   } else {
     planDisplayValue = `${newPlan} of ${totalPlans}`;

--- a/src/state-transition.cts
+++ b/src/state-transition.cts
@@ -1086,7 +1086,18 @@ function advancePlanCore(content: string, deps: StateTransitionDeps): StateTrans
     // padStart never truncates, so 09 -> 10 widens correctly.
     planDisplayValue = (planRawValue as string).replace(/^\d+/, (digits) =>
       String(newPlan).padStart(digits.length, '0'));
-    body = stateReplaceField(body, planSourceField, planDisplayValue) || body;
+    // Dispatch on the discriminator but pass a Title-Case LITERAL field name,
+    // never the variable. ADR-3408 §8.3(b): a literal cannot collide with a
+    // lowercase/snake_case frontmatter key, so it is safe regardless of how
+    // the content argument was derived. `body` here is in fact
+    // `stripFrontmatter(content)`, but the write-path drift guard does not do
+    // dataflow tracking (by design), and satisfying its invariant by
+    // construction is better than asking a reader to re-derive that it holds.
+    if (planSourceField === 'Current Plan') {
+      body = stateReplaceField(body, 'Current Plan', planDisplayValue) || body;
+    } else {
+      body = stateReplaceField(body, 'Plan', planDisplayValue) || body;
+    }
   } else {
     planDisplayValue = `${newPlan} of ${totalPlans}`;
     body = stateReplaceField(body, 'Current Plan', String(newPlan)) || body;

--- a/src/state-transition.cts
+++ b/src/state-transition.cts
@@ -977,8 +977,10 @@ function mutateCurrentPositionForAdvance(
 /**
  * Apply an `advancePlan` transition to STATE.md content.
  *
- * Parses Current Plan / Total Plans (legacy separate fields or compound
- * "Plan: X of Y" format), increments the plan number, updates body fields
+ * Parses Current Plan / Total Plans in any of three shapes — the legacy
+ * separate fields, the compound "Plan: X of Y", or the hybrid
+ * "Current Plan: X of Y" (legacy name, compound value, no Total Plans
+ * sibling) — increments the plan number, updates body fields
  * and the ## Current Position section. When currentPlan >= totalPlans,
  * takes the phase-complete branch (sets Status to "Phase complete — ready
  * for verification") instead of advancing.
@@ -1004,7 +1006,12 @@ function advancePlanCore(content: string, deps: StateTransitionDeps): StateTrans
       ? `---\n${reconstructFrontmatter(existingFm as unknown as Frontmatter)}\n---\n\n${b}`
       : b;
 
-  // Parse plan number — legacy first, then compound.
+  // Parse plan number — legacy pair first, then the hybrid, then compound.
+  //
+  // Field NAME and value FORMAT are independent, so track them separately:
+  // `planSourceField` is where the value is written back, `planRawValue` is
+  // the compound string whose leading digits get incremented. Deriving the
+  // format from the name alone is what made the hybrid below unreadable.
   const legacyPlan = stateExtractField(content, 'Current Plan');
   const legacyTotal = stateExtractField(content, 'Total Plans in Phase');
   const planField = stateExtractField(content, 'Plan');
@@ -1012,15 +1019,31 @@ function advancePlanCore(content: string, deps: StateTransitionDeps): StateTrans
   let currentPlan: number;
   let totalPlans: number;
   let useCompoundFormat = false;
+  let planSourceField = 'Plan';
+  let planRawValue: string | null = null;
+
+  const legacyOfMatch = legacyPlan ? legacyPlan.match(/of\s+(\d+)/) : null;
 
   if (legacyPlan && legacyTotal) {
+    // Legacy pair wins whenever both fields are present, even if the Current
+    // Plan value also carries an "of N" — the explicit field is the intent.
     currentPlan = parseInt(legacyPlan, 10);
     totalPlans = parseInt(legacyTotal, 10);
+  } else if (legacyPlan && legacyOfMatch) {
+    // Hybrid: legacy field name, compound value, no Total Plans sibling.
+    // Written by hand (and by agents) often enough to be worth reading.
+    currentPlan = parseInt(legacyPlan, 10);
+    totalPlans = parseInt(legacyOfMatch[1], 10);
+    useCompoundFormat = true;
+    planSourceField = 'Current Plan';
+    planRawValue = legacyPlan;
   } else if (planField) {
     currentPlan = parseInt(planField, 10);
     const ofMatch = planField.match(/of\s+(\d+)/);
     totalPlans = ofMatch ? parseInt(ofMatch[1], 10) : NaN;
     useCompoundFormat = true;
+    planSourceField = 'Plan';
+    planRawValue = planField;
   } else {
     currentPlan = NaN;
     totalPlans = NaN;
@@ -1056,8 +1079,8 @@ function advancePlanCore(content: string, deps: StateTransitionDeps): StateTrans
   const newPlan = currentPlan + 1;
   let planDisplayValue: string;
   if (useCompoundFormat) {
-    planDisplayValue = (planField as string).replace(/^\d+/, String(newPlan));
-    body = stateReplaceField(body, 'Plan', planDisplayValue) || body;
+    planDisplayValue = (planRawValue as string).replace(/^\d+/, String(newPlan));
+    body = stateReplaceField(body, planSourceField, planDisplayValue) || body;
   } else {
     planDisplayValue = `${newPlan} of ${totalPlans}`;
     body = stateReplaceField(body, 'Current Plan', String(newPlan)) || body;

--- a/src/state.cts
+++ b/src/state.cts
@@ -700,7 +700,19 @@ function cmdStateAdvancePlan(cwd: string, raw: boolean): void {
   }, cwd, { divergedFields });
 
   if (!resultData || resultData['error']) {
-    output({ error: 'Cannot parse Current Plan or Total Plans in Phase from STATE.md' }, raw, undefined);
+    // Say which of the two things went wrong. This used to report a parse
+    // failure for ANY transition error, which sends a reader hunting the plan
+    // fields when the fields were never the problem.
+    if (!resultData) {
+      output({ error: 'advance-plan produced no result from STATE.md' }, raw, undefined);
+      return;
+    }
+    output({
+      error:
+        'Cannot read the plan position from STATE.md. Expected one of: ' +
+        '`Current Plan: N` with `Total Plans in Phase: M`, `Plan: N of M`, ' +
+        'or `Current Plan: N of M`.',
+    }, raw, undefined);
     return;
   }
 

--- a/tests/state-transition.test.cjs
+++ b/tests/state-transition.test.cjs
@@ -523,6 +523,45 @@ describe('ADR-1769 Phase 2: advancePlan transition', () => {
     assert.strictEqual(result.data && result.data.reason, 'last_plan');
   });
 
+  test('compound format preserves zero-padding on both halves', () => {
+    const input = [
+      '# Project State',
+      '',
+      '**Plan:** 04 of 06',
+      '**Status:** Executing Phase 7',
+      '**Last Activity:** 2026-06-26',
+      '',
+    ].join('\n');
+    const result = transitionCore(input, { kind: 'advancePlan' }, deps);
+    assert.strictEqual(stateExtractField(result.content, 'Plan'), '05 of 06');
+  });
+
+  test('padding widens rather than truncates when the plan number grows', () => {
+    const input = [
+      '# Project State',
+      '',
+      '**Plan:** 09 of 12',
+      '**Status:** Executing Phase 7',
+      '**Last Activity:** 2026-06-26',
+      '',
+    ].join('\n');
+    const result = transitionCore(input, { kind: 'advancePlan' }, deps);
+    assert.strictEqual(stateExtractField(result.content, 'Plan'), '10 of 12');
+  });
+
+  test('unpadded compound stays unpadded', () => {
+    const input = [
+      '# Project State',
+      '',
+      '**Plan:** 2 of 6',
+      '**Status:** Executing Phase 7',
+      '**Last Activity:** 2026-06-26',
+      '',
+    ].join('\n');
+    const result = transitionCore(input, { kind: 'advancePlan' }, deps);
+    assert.strictEqual(stateExtractField(result.content, 'Plan'), '3 of 6');
+  });
+
   // The legacy pair must keep winning when both are present: a stray "of N"
   // inside the Current Plan value must not override an explicit Total Plans.
   test('legacy pair still takes precedence over an "of N" in Current Plan', () => {

--- a/tests/state-transition.test.cjs
+++ b/tests/state-transition.test.cjs
@@ -476,6 +476,70 @@ describe('ADR-1769 Phase 2: advancePlan transition', () => {
     assert.deepStrictEqual(result.updated, []);
   });
 
+  // Hybrid shape: the legacy field NAME carrying the compound VALUE, with no
+  // `Total Plans in Phase` sibling. Neither documented branch handled it —
+  // `legacyTotal` is null so the legacy branch fell through, and the compound
+  // branch reads the `Plan` field through a `^Plan:` line-anchored pattern
+  // that never matches `Current Plan:`. Both produced NaN, and the caller
+  // reported a parse failure against a file whose plan numbers are plainly
+  // readable.
+  //
+  // Not hypothetical: an agent wrote this exact shape unprompted, believing
+  // it was the parseable form, and every later run inherited it.
+  test('hybrid format: "Current Plan: 4 of 6" with no Total Plans sibling', () => {
+    const input = [
+      '# Project State',
+      '',
+      '**Status:** Executing Phase 7',
+      '**Last Activity:** 2026-06-26',
+      '',
+      '## Current Position',
+      '',
+      'Current Plan: 4 of 6',
+      'Status: Executing Phase 7',
+      '',
+    ].join('\n');
+    const result = transitionCore(input, { kind: 'advancePlan' }, deps);
+    assert.strictEqual(result.data && result.data.error, undefined);
+    assert.strictEqual(result.data && result.data.advanced, true);
+    assert.strictEqual(result.data && result.data.current_plan, 5);
+    assert.strictEqual(result.data && result.data.total_plans, 6);
+  });
+
+  test('hybrid format: phase-complete branch still fires on the last plan', () => {
+    const input = [
+      '# Project State',
+      '',
+      '**Status:** Executing Phase 7',
+      '**Last Activity:** 2026-06-26',
+      '',
+      '## Current Position',
+      '',
+      'Current Plan: 6 of 6',
+      '',
+    ].join('\n');
+    const result = transitionCore(input, { kind: 'advancePlan' }, deps);
+    assert.strictEqual(result.data && result.data.advanced, false);
+    assert.strictEqual(result.data && result.data.reason, 'last_plan');
+  });
+
+  // The legacy pair must keep winning when both are present: a stray "of N"
+  // inside the Current Plan value must not override an explicit Total Plans.
+  test('legacy pair still takes precedence over an "of N" in Current Plan', () => {
+    const input = [
+      '# Project State',
+      '',
+      '**Current Plan:** 2 of 99',
+      '**Total Plans in Phase:** 5',
+      '**Status:** Executing Phase 3',
+      '**Last Activity:** 2026-06-26',
+      '',
+    ].join('\n');
+    const result = transitionCore(input, { kind: 'advancePlan' }, deps);
+    assert.strictEqual(result.data && result.data.advanced, true);
+    assert.strictEqual(result.data && result.data.total_plans, 5);
+  });
+
   test('compound format: "Plan: 2 of 6" preserves compound shape', () => {
     const input = [
       '# Project State',

--- a/tests/state.test.cjs
+++ b/tests/state.test.cjs
@@ -1602,7 +1602,20 @@ describe('cmdStateAdvancePlan (state advance-plan)', () => {
 
     const output = JSON.parse(result.output);
     assert.ok(output.error !== undefined, 'output should have error field');
-    assert.ok(output.error.toLowerCase().includes('cannot parse'), 'error should mention Cannot parse');
+    // Assert on what makes the message actionable, not on one literal phrase:
+    // it must say the plan position could not be read AND name the shapes that
+    // would work. The previous assertion only checked for "cannot parse", which
+    // a message can satisfy while leaving the reader no idea what to write.
+    assert.ok(
+      /cannot read the plan position/i.test(output.error),
+      `error should say the plan position could not be read; got: ${output.error}`,
+    );
+    for (const shape of ['Total Plans in Phase', 'Plan: N of M', 'Current Plan: N of M']) {
+      assert.ok(
+        output.error.includes(shape),
+        `error should name the accepted shape ${JSON.stringify(shape)}; got: ${output.error}`,
+      );
+    }
   });
 
   test('advances plan in compound "Plan: X of Y" format', () => {


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3784

---

## What was broken

`state.advance-plan` rejected a STATE.md whose plan position was plainly readable
(`Current Plan: 04 of 06`) with `Cannot parse Current Plan or Total Plans in Phase`, then —
once the shape did parse — wrote the advanced value back lopsided as `5 of 06`.

## What this fix does

Teaches `advancePlanCore` (STATE.md Transition Module, `advancePlan` intent) to read the
hybrid shape, write it back to the field it came from, and preserve the written zero-padding.
Replaces the caller's catch-all error with one that distinguishes the two failure modes and
names all three accepted shapes.

## Root cause

`advancePlanCore` derived the value FORMAT from the field NAME. It handled the legacy pair
(`Current Plan` + `Total Plans in Phase`) and the compound `Plan: N of M`, but not the hybrid
of the two — the legacy field name carrying a compound value with no `Total Plans` sibling.
`legacyTotal` is `null` so the legacy branch fell through, and the compound branch reads the
`Plan` field through the STATE.md Document Module's `stateExtractField`, whose plain pattern
is `^Plan:` (line-anchored, `m`) and so never matches `Current Plan:`. Both produced `NaN`.

The fix separates the two axes the old code conflated: `planSourceField` (where the value is
written back) and `planRawValue` (the string whose leading digits are incremented). The legacy
pair still takes precedence when both fields are present, so a stray `of N` inside
`Current Plan` cannot override an explicit `Total Plans` — covered by its own test.

Padding is the same defect seen from the write side: only the leading half of `N of M` was
rewritten, so `04 of 06` advanced to `5 of 06`. `padStart` never truncates, so a value that
outgrows its padding widens correctly (`09 of 12` → `10 of 12`) and unpadded values are
untouched (`2 of 6` → `3 of 6`).

**On scope:** the issue reports three defects and this PR fixes all three, because they are one
loop rather than three independent bugs — lopsided padding is what invites the hand-tidy that
produces the unreadable hybrid, and the catch-all error is why four separate runs hit the hybrid
without anyone identifying it. Happy to split into separate PRs if you would rather review them
apart; say the word and I will.

**Standards:** no new Module, seam, or Interface is introduced, so `CONTEXT.md` needs no entry;
the two new identifiers are function-local. ADR-1769 defines the Transition Module but does not
fix the accepted STATE.md plan-value formats, so this revisits no ADR decision. Edited
`src/state-transition.cts` (the source of truth named in CONTEXT.md), not the generated
`gsd-core/bin/lib/state-transition.cjs`.

## Testing

### How I verified the fix

Both hybrid tests fail on `next` and pass after the change — confirmed by running them before
writing the fix, not after. The padding tests likewise.

End-to-end through the CLI on the STATE.md that produced the original report:

```
before: Current Plan: 04 of 06
after:  Current Plan: 05 of 06        # parses, advances, keeps its field and its padding
```

and on the compound shape:

```
before: Plan: 04 of 06
after:  Plan: 05 of 06
```

Full suite green after `npm ci`. Note for anyone reproducing: a stale `node_modules` fails the
`js-yaml` dependency-audit test (`npm ls js-yaml` exits 1 with `js-yaml@4.3.0` against a
`^4.3.1` requirement) — unrelated to this change, and `npm ci` clears it.

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

Six tests in `tests/state-transition.test.cjs`: hybrid advance, hybrid phase-complete branch,
legacy-pair precedence over a stray `of N`, padding preserved, padding widening at `09 → 10`,
and unpadded values staying unpadded. `tests/state.test.cjs`'s existing error-message test
asserted the literal `cannot parse`; it now asserts the message says the plan position could not
be read **and** names all three accepted shapes — the property that makes it actionable, rather
than a phrase a useless message could still satisfy.

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

Not platform-sensitive in substance — the change is string parsing with no path handling — but
only macOS was actually exercised, so the other boxes stay unticked.

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [ ] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix
- [x] No unnecessary dependencies added

`confirmed-bug` is unticked because it is a maintainer action — the issue is filed with a
reproduction and awaits triage. Please close this PR rather than let it sit if the bug is not
confirmed.

## Breaking changes

None. All three shapes that parsed before still parse and still write back in their original
form; the hybrid is added, not substituted. The only behavioural change to an already-working
path is that a zero-padded compound value now keeps its padding on write-back — visible in
STATE.md, consumed by nothing that parses width.
