### PR TITLE
fix(slug): decompose Latin diacritics instead of truncating words

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.84",
-        "re2js": "^2.8.6",
         "ws": "^8.21.0"
       },
       "bin": {
@@ -31,6 +30,7 @@
         "fast-check": "^4.8.0",
         "globals": "^16.5.0",
         "js-yaml": "^4.3.1",
+        "re2js": "^2.8.6",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.60.0"
       },
@@ -4536,6 +4536,7 @@
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/re2js/-/re2js-2.8.6.tgz",
       "integrity": "sha512-xLgQil4kIUCrAzVk9fRSkxkFNwmygLFjVxXrLc65aE1F0+Zsb8rxumFBy4XKyvgMCTL6kilDq3EZ0piE2dP/Dg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/src/commands.cts
+++ b/src/commands.cts
@@ -204,6 +204,7 @@ function cmdGenerateSlug(text: string | undefined, raw: boolean): void {
 
   const slug = (text as string)
     .toLowerCase()
+    .normalize('NFD').replace(/[\u0300-\u036f]/g, '')
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '')
     .substring(0, 60);

--- a/src/core-utils.cts
+++ b/src/core-utils.cts
@@ -160,7 +160,11 @@ function transliterateForSlug(text: string): string {
       ? CYRILLIC_TRANSLITERATION[ch]
       : ch;
   }
-  return out;
+  // Latin diacritics (e.g. "validação") otherwise fall to the caller's
+  // `[^a-z0-9]+` strip and truncate the word ("valida-o" instead of
+  // "validacao"). Decompose (NFD) and drop combining marks AFTER the Cyrillic
+  // map so its mappings (ё→e, й→y, …) are unchanged.
+  return out.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
 }
 
 // ─── Phase file helpers ──────────────────────────────────────────────────────

--- a/src/init.cts
+++ b/src/init.cts
@@ -175,7 +175,7 @@ function guardedGetRoadmapPhase(
 // below — factored out once so the slugification formula itself cannot drift.
 function slugifyPhaseName(phaseName: string | null): string | null {
   return phaseName
-    ? phaseName.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '')
+    ? phaseName.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '').replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '')
     : null;
 }
 
@@ -1932,7 +1932,7 @@ function cmdInitPhaseOp(cwd: string, phase: string, raw: boolean): void {
         phase_number: roadmapPhase['phase_number'],
         phase_name: phaseName,
         phase_slug: phaseName
-          ? phaseName.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '')
+          ? phaseName.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '').replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '')
           : null,
         plans: [],
         summaries: [],
@@ -1954,7 +1954,7 @@ function cmdInitPhaseOp(cwd: string, phase: string, raw: boolean): void {
         phase_number: roadmapPhase['phase_number'],
         phase_name: phaseName,
         phase_slug: phaseName
-          ? phaseName.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '')
+          ? phaseName.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '').replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '')
           : null,
         plans: [],
         summaries: [],
@@ -3106,7 +3106,7 @@ function cmdInitProgress(cwd: string, raw: boolean, options: Record<string, unkn
       const status = 'not_started';
       const phaseInfo: Record<string, unknown> = {
         number: num,
-        name: name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, ''),
+        name: name.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '').replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, ''),
         directory: null,
         status,
         plan_count: 0,

--- a/src/phase-id.cts
+++ b/src/phase-id.cts
@@ -227,7 +227,7 @@ function getPhaseDirFromPhaseId(phaseId: unknown, phaseName: string | null | und
   const subParts = m[2].split('-').map(p => String(parseInt(p, 10)).padStart(2, '0'));
   const sub = subParts.join('-');
   const slug = phaseName
-    ? phaseName.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '')
+    ? phaseName.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '').replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '')
     : '';
   const parts = [milestone, sub, slug].filter(Boolean);
   const base = parts.join('-');
@@ -377,7 +377,7 @@ function toDir(id: PhaseId, slug: string): string {
   const sub = id.subphase ? `.${id.subphase}` : '';
   // Slug guard: the slug becomes an on-disk path segment, so collapse it to a
   // safe lowercase token — never a path separator or `..` traversal.
-  const safeSlug = slug.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+  const safeSlug = slug.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '').replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
   // A slug that sanitizes to nothing (e.g. '!!!') would otherwise emit a
   // dangling trailing hyphen.
   if (!safeSlug) {

--- a/src/phase-locator.cts
+++ b/src/phase-locator.cts
@@ -266,7 +266,7 @@ function searchPhaseInDir(baseDir: string, relBase: string, normalized: string):
       directory: toPosixPath(path.join(relBase, match)),
       phase_number: phaseNumber,
       phase_name: phaseName,
-      phase_slug: phaseName ? phaseName.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') : null,
+      phase_slug: phaseName ? phaseName.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '').replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') : null,
       plans,
       summaries,
       incomplete_plans: incompletePlans,

--- a/tests/core-utils.test.cjs
+++ b/tests/core-utils.test.cjs
@@ -269,6 +269,16 @@ describe('generateSlugInternal', () => {
   // title's meaning is preserved as ASCII. Latin-script output is byte-for-byte
   // unchanged (negative control below).
 
+  test('Latin diacritics decompose instead of truncating the word', () => {
+    assert.strictEqual(coreUtils.generateSlugInternal('Validação de Dados'), 'validacao-de-dados');
+    assert.strictEqual(coreUtils.generateSlugInternal('Autenticação Pessoal'), 'autenticacao-pessoal');
+    assert.strictEqual(coreUtils.generateSlugInternal('Übersicht für Kunden'), 'ubersicht-fur-kunden');
+  });
+
+  test('NFD strip does not alter the Cyrillic transliteration map', () => {
+    assert.strictEqual(coreUtils.generateSlugInternal('Жёлтый край'), 'zheltyy-kray');
+  });
+
   test('#2848 row 1 — Cyrillic title produces a non-empty transliterated slug', () => {
     // Russian "Проверка гипотезы" → "proverka gipotezy" → slug.
     const result = coreUtils.generateSlugInternal('Проверка гипотезы');


### PR DESCRIPTION
## Problem

Phase names with accented Latin characters produce truncated slugs: **"Validação de Dados" → `valida-o-de-dados`** (real directory from a pt-BR project: `02-autentica-o-pessoal` from "Autenticação Pessoal"). The `[^a-z0-9]+` strip removes the accented character and merges its neighbors into a single hyphen, cutting the word in half.

This affects every project whose `response_language` (or the user's phase naming) uses Portuguese, Spanish, French, German, etc.

## Fix

NFD-normalize and drop combining marks (`U+0300–U+036F`) before the ASCII strip:

- `transliterateForSlug` (canonical, core-utils) — the NFD pass runs **after** the Cyrillic transliteration map, so the #2848 mappings (ё→e, й→y, …) are byte-for-byte unchanged.
- The inline slug copies in `init.cts`, `phase-id.cts`, `phase-locator.cts` and `cmdGenerateSlug` (`commands.cts`) get the same one-line normalize.

## Tests

- `generateSlugInternal('Validação de Dados') === 'validacao-de-dados'` (+ Autenticação, Übersicht für Kunden)
- Negative control: `'Жёлтый край' === 'zheltyy-kray'` — proves the Cyrillic map is untouched.
- Full `tests/core-utils.test.cjs`: 100/100 pass.

Existing phase directories created with truncated slugs remain locatable — lookup is by phase number prefix, and on-disk slugs are re-derived from the directory name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)