### PR TITLE
fix(#3780): serialize the ledger read-modify-write so concurrent appends cannot be lost

### DIFF
--- a/src/broken-windows.cts
+++ b/src/broken-windows.cts
@@ -70,6 +70,8 @@ export const REASON = Object.freeze({
   WINDOWS_INVALID_ID: 'windows_invalid_id',
   WINDOWS_APPEND_MISSING_FIELD: 'windows_append_missing_field',
   WINDOWS_USAGE: 'windows_usage',
+  WINDOWS_LEDGER_LOCKED: 'windows_ledger_locked',
+  WINDOWS_WRITE_LOST: 'windows_write_lost',
 });
 
 /** Allowed window kinds. Aligned with the issue's enumerated sources. */
@@ -795,6 +797,100 @@ function renameWithRetry(tmp: string, target: string): void {
   throw lastErr;
 }
 
+/**
+ * Ledger mutation lock (issue #3780).
+ *
+ * `writeLedgerAtomic` makes each individual rewrite all-or-nothing, but the
+ * command paths do read -> compute -> rewrite as three uncoordinated steps.
+ * Two concurrent writers each hold the same snapshot, each render a complete
+ * ledger missing the other's entry, and the second rename silently discards
+ * the first — the loser cannot know it lost. The original acceptance of that
+ * race (review L2 on #1950) was explicitly conditioned on a single executor
+ * writing per phase, with the trigger "document if the executor ever gains
+ * parallel wave-level append". That condition no longer holds.
+ *
+ * The lock serializes the whole critical section so every append lands, rather
+ * than making losers fail. Held across read+compute+write, never across an
+ * `emit`. Lock acquisition is `wx` open, which is atomic on POSIX and Windows.
+ *
+ * Kept deliberately dumb: a sync busy-wait in the same style as
+ * `renameWithRetry`, because this is a synchronous CLI path with no event loop
+ * to yield to. A crashed holder is recovered via the staleness sweep so a dead
+ * process can never wedge the ledger permanently.
+ */
+const LOCK_MAX_WAIT_MS = 5000;
+const LOCK_POLL_MS = 20;
+const LOCK_STALE_MS = 30_000;
+
+function lockPath(cwd: string): string {
+  return `${ledgerPath(cwd)}.lock`;
+}
+
+/** Remove a lock whose holder is gone or which is older than LOCK_STALE_MS. */
+function clearStaleLock(lock: string): void {
+  let st: fs.Stats;
+  try {
+    st = fs.statSync(lock);
+  } catch {
+    return; // Released while we looked — nothing to clear.
+  }
+  if (Date.now() - st.mtimeMs < LOCK_STALE_MS) return;
+  // Best-effort: if another process wins the unlink race, its lock stands and
+  // we simply keep waiting.
+  try { fs.unlinkSync(lock); } catch { /* best-effort */ }
+}
+
+function acquireLedgerLock(cwd: string): string {
+  ensurePlanningDir(cwd);
+  const lock = lockPath(cwd);
+  const deadline = Date.now() + LOCK_MAX_WAIT_MS;
+
+  for (;;) {
+    try {
+      const fd = fs.openSync(lock, 'wx');
+      try {
+        fs.writeFileSync(fd, `${process.pid}\n${new Date().toISOString()}\n`, 'utf8');
+      } finally {
+        fs.closeSync(fd);
+      }
+      return lock;
+    } catch (err: unknown) {
+      const code = (err && typeof err === 'object' && 'code' in err)
+        ? String((err as { code?: unknown }).code)
+        : '';
+      if (code !== 'EEXIST') throw err;
+
+      clearStaleLock(lock);
+      if (Date.now() >= deadline) {
+        throw new WindowsError(
+          REASON.WINDOWS_LEDGER_LOCKED,
+          `Could not acquire the ledger lock at ${lock} within ${LOCK_MAX_WAIT_MS}ms. `
+          + 'Another windows command is mutating the ledger. Retry; if this persists, '
+          + 'no process holds it and the file can be removed by hand.',
+        );
+      }
+      const until = Date.now() + LOCK_POLL_MS;
+      while (Date.now() < until) {
+        // Busy-wait — synchronous CLI path, same rationale as renameWithRetry.
+      }
+    }
+  }
+}
+
+function releaseLedgerLock(lock: string): void {
+  try { fs.unlinkSync(lock); } catch { /* best-effort: already gone */ }
+}
+
+/** Run `fn` with the ledger mutation lock held. Always releases. */
+function withLedgerLock<T>(cwd: string, fn: () => T): T {
+  const lock = acquireLedgerLock(cwd);
+  try {
+    return fn();
+  } finally {
+    releaseLedgerLock(lock);
+  }
+}
+
 function writeLedgerAtomic(cwd: string, ledger: Ledger): void {
   ensurePlanningDir(cwd);
   const p = ledgerPath(cwd);
@@ -873,27 +969,62 @@ export function cmdWindowsAppend(
     required: ['--kind', '--phase', '--description'],
   });
 
-  let ledger: Ledger;
-  try {
-    ledger = readLedgerOrNull(cwd) ?? emptyLedger(nowIso());
-  } catch (e) {
-    if (e instanceof WindowsError) throw e;
-    throw new WindowsError(REASON.WINDOWS_LEDGER_MALFORMED, (e as Error).message);
-  }
+  // #3780: read -> compute -> write is one critical section. `emit` stays
+  // outside it so no lock is held across process output.
+  const result = withLedgerLock(cwd, () => {
+    let ledger: Ledger;
+    try {
+      ledger = readLedgerOrNull(cwd) ?? emptyLedger(nowIso());
+    } catch (e) {
+      if (e instanceof WindowsError) throw e;
+      throw new WindowsError(REASON.WINDOWS_LEDGER_MALFORMED, (e as Error).message);
+    }
 
-  const result = appendWindow(
-    ledger,
-    {
-      kind: parsed.values['--kind'] as WindowKind,
-      phase: parsed.values['--phase'] ?? '',
-      file: parsed.values['--file'] ?? '',
-      line: parsed.values['--line'] == null ? null : Number(parsed.values['--line']),
-      description: parsed.values['--description'] ?? '',
-    },
-    { now: nowIso() },
-  );
-  writeLedgerAtomic(cwd, result.ledger);
+    const appended = appendWindow(
+      ledger,
+      {
+        kind: parsed.values['--kind'] as WindowKind,
+        phase: parsed.values['--phase'] ?? '',
+        file: parsed.values['--file'] ?? '',
+        line: parsed.values['--line'] == null ? null : Number(parsed.values['--line']),
+        description: parsed.values['--description'] ?? '',
+      },
+      { now: nowIso() },
+    );
+    writeLedgerAtomic(cwd, appended.ledger);
+    assertEntryLanded(cwd, appended.entry.id);
+    return appended;
+  });
   emit({ ok: true, ledger: result.ledger, entry: result.entry });
+}
+
+/**
+ * Re-read the ledger and confirm `id` is present (#3780).
+ *
+ * The lock is what prevents lost writes; this is the belt to its braces. The
+ * contract this enforces is the one the issue names: an append either lands
+ * durably or reports failure — never a success response for an entry absent
+ * from the ledger it claims to have written. If a future change weakens the
+ * serialization, callers get a structured error instead of a false green, and
+ * the ship gate stops trusting an undercounted ledger.
+ */
+function assertEntryLanded(cwd: string, id: number): void {
+  let persisted: Ledger | null;
+  try {
+    persisted = readLedgerOrNull(cwd);
+  } catch (e) {
+    throw new WindowsError(
+      REASON.WINDOWS_WRITE_LOST,
+      `Wrote window ${id} but could not re-read the ledger to confirm it: ${(e as Error).message}.`,
+    );
+  }
+  if (!persisted || !persisted.entries.some((e) => e.id === id)) {
+    throw new WindowsError(
+      REASON.WINDOWS_WRITE_LOST,
+      `Wrote window ${id} but it is absent from the ledger on re-read — the write was lost. `
+      + 'Retry the append; do not treat this run as recorded.',
+    );
+  }
 }
 
 /** `gsd-tools windows waive <id> "<reason>"`. */
@@ -909,16 +1040,21 @@ export function cmdWindowsWaive(
 
   const id = parseIdOrThrow(idStr);
 
-  let ledger: Ledger;
-  try {
-    ledger = readLedgerOrNull(cwd) ?? emptyLedger(nowIso());
-  } catch (e) {
-    if (e instanceof WindowsError) throw e;
-    throw new WindowsError(REASON.WINDOWS_LEDGER_MALFORMED, (e as Error).message);
-  }
+  // #3780: waive shares append's read-modify-write shape and the same writer,
+  // so it takes the same lock — otherwise a concurrent append would still lose.
+  const updated = withLedgerLock(cwd, () => {
+    let ledger: Ledger;
+    try {
+      ledger = readLedgerOrNull(cwd) ?? emptyLedger(nowIso());
+    } catch (e) {
+      if (e instanceof WindowsError) throw e;
+      throw new WindowsError(REASON.WINDOWS_LEDGER_MALFORMED, (e as Error).message);
+    }
 
-  const updated = markWaived(ledger, id, reason ?? '', { now: nowIso() });
-  writeLedgerAtomic(cwd, updated);
+    const next = markWaived(ledger, id, reason ?? '', { now: nowIso() });
+    writeLedgerAtomic(cwd, next);
+    return next;
+  });
   emit({ ok: true, ledger: updated });
 }
 
@@ -932,16 +1068,20 @@ export function cmdWindowsMarkFixed(
   const { positionals } = parseArgs(args, { flags: [], required: [], positionals: 1 });
   const id = parseIdOrThrow(positionals[0]);
 
-  let ledger: Ledger;
-  try {
-    ledger = readLedgerOrNull(cwd) ?? emptyLedger(nowIso());
-  } catch (e) {
-    if (e instanceof WindowsError) throw e;
-    throw new WindowsError(REASON.WINDOWS_LEDGER_MALFORMED, (e as Error).message);
-  }
+  // #3780: same read-modify-write shape and writer as append/waive.
+  const updated = withLedgerLock(cwd, () => {
+    let ledger: Ledger;
+    try {
+      ledger = readLedgerOrNull(cwd) ?? emptyLedger(nowIso());
+    } catch (e) {
+      if (e instanceof WindowsError) throw e;
+      throw new WindowsError(REASON.WINDOWS_LEDGER_MALFORMED, (e as Error).message);
+    }
 
-  const updated = markFixed(ledger, id, { now: nowIso() });
-  writeLedgerAtomic(cwd, updated);
+    const next = markFixed(ledger, id, { now: nowIso() });
+    writeLedgerAtomic(cwd, next);
+    return next;
+  });
   emit({ ok: true, ledger: updated });
 }
 

--- a/tests/broken-windows-concurrency.test.cjs
+++ b/tests/broken-windows-concurrency.test.cjs
@@ -1,0 +1,144 @@
+// Regression tests for issue #3780 — `windows append` lost writes under
+// concurrent writers.
+//
+// These must be real processes, not an in-process loop: the defect is a
+// read -> compute -> rewrite cycle that is not serialized ACROSS processes,
+// and any single-process simulation would prove nothing about the thing that
+// actually breaks. Each child performs one append; every append must survive.
+//
+// On the unfixed code the first test fails reliably — measured here at 3 of 8
+// appends surviving, and the maintainer's triage measured one entry lost in
+// 8 of 10 runs with only two concurrent writers.
+//
+// The concurrent leg uses async `spawn` deliberately rather than the sync
+// process-seam: `runNode` is spawnSync-based, which would serialize the
+// writers and make the test incapable of observing the race. The spawns are
+// still bounded — each carries its own kill timer.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawn } = require('node:child_process');
+const { cleanup } = require('./helpers.cjs');
+const { runNode } = require('./helpers/process-seam.cjs');
+
+const LIB = path.join(__dirname, '..', 'gsd-core', 'bin', 'lib', 'broken-windows.cjs');
+const WRITERS = 8;
+const CHILD_TIMEOUT_MS = 30_000;
+
+const APPEND_SRC = `
+  const bw = require(${JSON.stringify(LIB)});
+  bw.cmdWindowsAppend(process.argv[1], [
+    '--kind', 'todo',
+    '--phase', '1',
+    '--description', process.argv[2],
+  ]);
+`;
+
+function mkProject() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-windows-race-'));
+  fs.mkdirSync(path.join(dir, '.planning'), { recursive: true });
+  return dir;
+}
+
+/** Spawn one child that appends a single window and exits. Bounded by a kill timer. */
+function spawnAppend(cwd, description) {
+  return new Promise((resolve) => {
+    // stdio ignored: each child emits its own JSON, which we do not consume —
+    // the ledger on disk is the assertion surface.
+    const child = spawn(process.execPath, ['-e', APPEND_SRC, cwd, description], { stdio: 'ignore' });
+    const timer = setTimeout(() => child.kill('SIGKILL'), CHILD_TIMEOUT_MS);
+    const done = (code) => { clearTimeout(timer); resolve(code); };
+    child.on('exit', done);
+    child.on('error', () => done(-1));
+  });
+}
+
+function readEntries(cwd) {
+  const raw = fs.readFileSync(path.join(cwd, '.planning', 'WINDOWS.md'), 'utf8');
+  return require(LIB).parseLedger(raw).entries;
+}
+
+test('#3780: concurrent appends all land in the ledger', async () => {
+  const cwd = mkProject();
+  try {
+    const codes = await Promise.all(
+      Array.from({ length: WRITERS }, (_, i) => spawnAppend(cwd, `concurrent writer ${i}`)),
+    );
+
+    // Every writer must report success. A writer that legitimately could not
+    // get the lock exits non-zero — a loud failure is acceptable behavior, but
+    // it must not happen at this concurrency.
+    assert.deepStrictEqual(codes.filter((c) => c !== 0), [], 'every concurrent append should exit 0');
+
+    const entries = readEntries(cwd);
+    assert.strictEqual(
+      entries.length,
+      WRITERS,
+      `expected all ${WRITERS} appends to survive, found ${entries.length} — writes were lost`,
+    );
+
+    // Ids must be dense and unique: two writers computing the same nextId from
+    // the same snapshot is the mechanism behind the loss.
+    assert.deepStrictEqual(
+      entries.map((e) => e.id).sort((a, b) => a - b),
+      Array.from({ length: WRITERS }, (_, i) => i + 1),
+      'ids should be unique and dense',
+    );
+
+    // And no writer's payload may be silently dropped in favour of another's.
+    assert.strictEqual(
+      new Set(entries.map((e) => e.description)).size,
+      WRITERS,
+      "every writer's description should be present exactly once",
+    );
+  } finally {
+    cleanup(cwd);
+  }
+});
+
+test('#3780: the ledger stays parseable and the lock is released', async () => {
+  const cwd = mkProject();
+  try {
+    await Promise.all(
+      Array.from({ length: WRITERS }, (_, i) => spawnAppend(cwd, `racer ${i}`)),
+    );
+
+    // The atomic-rename writer's all-or-nothing property is a stated guard
+    // rail: the ledger must never be partial, even in the failing case. This
+    // leg passes with and without the fix — that is the point.
+    const entries = readEntries(cwd);
+    assert.ok(entries.length > 0, 'ledger should parse after concurrent writes');
+    for (const e of entries) {
+      assert.strictEqual(typeof e.id, 'number');
+      assert.strictEqual(e.status, 'open');
+    }
+
+    assert.strictEqual(
+      fs.existsSync(path.join(cwd, '.planning', 'WINDOWS.md.lock')),
+      false,
+      'lock should be released after every writer finishes',
+    );
+  } finally {
+    cleanup(cwd);
+  }
+});
+
+test('#3780: a single writer is unaffected — same ids, same shape', () => {
+  const cwd = mkProject();
+  try {
+    for (let i = 0; i < 3; i++) {
+      const r = runNode(['-e', APPEND_SRC, cwd, `sequential ${i}`], { timeoutMs: CHILD_TIMEOUT_MS });
+      assert.strictEqual(r.exitCode, 0, `sequential append ${i} should succeed: ${r.stderr}`);
+    }
+
+    const entries = readEntries(cwd);
+    assert.deepStrictEqual(entries.map((e) => e.id), [1, 2, 3], 'sequential id assignment is unchanged');
+    assert.strictEqual(entries[0].description, 'sequential 0');
+    assert.strictEqual(entries[0].status, 'open');
+  } finally {
+    cleanup(cwd);
+  }
+});


### PR DESCRIPTION
Closes #3780.

## What this fixes

`windows append` could report success for an entry that never reached the ledger. Every mutating command does read → compute → rewrite as three uncoordinated steps; `writeLedgerAtomic` makes each individual rewrite all-or-nothing but nothing serializes the cycle. Two writers holding the same snapshot each render a complete ledger missing the other's entry, and the second rename silently discards the first. Both processes exit zero, and the loser cannot know it lost.

The escalating factor from the issue: the ship gate reads the ledger's open count, so a silently dropped entry undercounts and the gate can pass while a recorded defect is missing.

## Approach

**`withLedgerLock`** — an `O_EXCL` advisory lock held across the entire critical section, released in a `finally`.

Applied to **append, waive and fixed**. Locking only append would not be enough: all three share the writer and the same read-modify-write shape, so a concurrent waive would still clobber an append. A lock older than `LOCK_STALE_MS` is treated as abandoned, so a crashed writer cannot wedge the ledger permanently. `emit` deliberately stays outside the lock — nothing is held across process output.

**`assertEntryLanded`** — after writing, append re-reads the ledger and throws `WINDOWS_WRITE_LOST` if its entry is absent. The lock is what prevents loss; this enforces the contract the Agent Brief names — *an append must either land durably or report failure, never a success response for an entry absent from the ledger it claims to have written.* If a future change weakens the serialization, callers get a structured error instead of a false green.

Two new codes: `WINDOWS_LEDGER_LOCKED`, `WINDOWS_WRITE_LOST`.

I chose serialization over fail-the-loser because the brief allows either and serialization is the one that keeps recorded defects recorded — a retry loop in every caller would be the alternative.

## Guard rails from triage — all held

| Guard rail | How it is held |
|---|---|
| Single-writer path behaves exactly as before | Same dense id assignment, same output shape, same best-effort on a missing ledger. A test asserts this and **passes identically with and without the fix**. |
| Ledger always parseable, never partial | The atomic-rename writer is untouched. A test asserts parseability after a raced run — also passes both ways, by design. |
| waive/fixed unchanged for single writers, compatible with the serialization | Both take the same lock; neither changes behavior when uncontended. |

## Verification

- `node --test tests/broken-windows*.test.cjs` — **57 pass, 0 fail** (54 pre-existing + 3 new)
- `npx eslint src/broken-windows.cts tests/broken-windows-concurrency.test.cjs` — clean
- `npm run build:lib` — clean

**Failing-first, verified by reverting only the source fix and rebuilding:**

```
✖ #3780: concurrent appends all land in the ledger
  AssertionError: expected all 8 appends to survive, found 3 — writes were lost
```

Three of eight survived. With the fix, 8/8. The other two legs stayed green in both runs, which is the point — they pin the guard rails rather than the bug.

## Note on the tests

They spawn **real competing processes**. The defect is a cross-process race, so an in-process simulation would prove nothing about the thing that actually breaks. The concurrent leg uses async `spawn` rather than the sync process-seam on purpose: `runNode` is `spawnSync`-based and would serialize the writers, making the test incapable of observing the race. Each spawn still carries its own kill timer, so nothing is unbounded. The sequential leg uses `runNode` normally.

---
🤖 Written with Claude Code. Happy to adjust the lock's wait/stale budgets, or to switch to fail-the-loser semantics if you would rather callers retry explicitly.