### PR TITLE
fix(#3685): report phase-complete write flags from the transaction, not the filesystem

### DIFF
--- a/.changeset/brave-birds-travel.md
+++ b/.changeset/brave-birds-travel.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`phase complete` now reports `roadmap_updated` and `state_updated` honestly** — both flags read `fs.existsSync()`, so they were `true` for any project that had the file at all, and a rollup that silently wrote nothing was indistinguishable from one that landed. Each flag now reflects whether that file's content actually changed in the transaction, matching the contract `requirements_updated` already honored. (#3685)

--- a/.changeset/brave-birds-travel.md
+++ b/.changeset/brave-birds-travel.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 3826
 ---
 **`phase complete` now reports `roadmap_updated` and `state_updated` honestly** — both flags read `fs.existsSync()`, so they were `true` for any project that had the file at all, and a rollup that silently wrote nothing was indistinguishable from one that landed. Each flag now reflects whether that file's content actually changed in the transaction, matching the contract `requirements_updated` already honored. (#3685)

--- a/src/phase.cts
+++ b/src/phase.cts
@@ -2222,6 +2222,12 @@ function cmdPhaseComplete(cwd: string, phaseNum: string, raw: boolean): void {
     ? (phaseInfo['summaries'] as string[]).length
     : 0;
   let requirementsUpdated = false;
+  // #3685: mirror requirementsUpdated's diff-tracking contract at the
+  // writes.push({filePath, before, after}) sites below, rather than
+  // reporting via fs.existsSync (which is true whenever the file merely
+  // exists, not when the transaction actually wrote a change).
+  let roadmapUpdated = false;
+  let stateUpdated = false;
 
   const warnings: string[] = [];
   // ADR-3408 §8.5 / D2 (#3374): "liberal but visible" — when the write-seam
@@ -2632,6 +2638,7 @@ function cmdPhaseComplete(cwd: string, phaseNum: string, raw: boolean): void {
           before: originalRoadmapContent,
           after: roadmapContent,
         });
+        roadmapUpdated = roadmapContent !== originalRoadmapContent;
 
         const reqPath = path.join(planningDir(cwd), 'REQUIREMENTS.md');
         if (fs.existsSync(reqPath)) {
@@ -3205,6 +3212,7 @@ function cmdPhaseComplete(cwd: string, phaseNum: string, raw: boolean): void {
         }
 
         writes.push({ filePath: statePath, before: originalStateContent, after: stateContent });
+        stateUpdated = stateContent !== originalStateContent;
       }
 
       writePlanningFileSet(writes);
@@ -3271,8 +3279,8 @@ function cmdPhaseComplete(cwd: string, phaseNum: string, raw: boolean): void {
     next_phase_name: nextPhaseName,
     is_last_phase: isLastPhase,
     date: today,
-    roadmap_updated: fs.existsSync(roadmapPath),
-    state_updated: fs.existsSync(statePath),
+    roadmap_updated: roadmapUpdated,
+    state_updated: stateUpdated,
     requirements_updated: requirementsUpdated,
     auto_pruned: autoPruned,
     warnings,

--- a/tests/phase.test.cjs
+++ b/tests/phase.test.cjs
@@ -3334,7 +3334,7 @@ describe('phase complete canonical verification gate (#1522)', () => {
 // #3685: cmdPhaseComplete's roadmap_updated/state_updated flags were computed
 // via fs.existsSync(roadmapPath) / fs.existsSync(statePath) — true whenever
 // the file merely EXISTS, even when the transaction rewrote nothing. The
-// sibling requirements_updated (line ~2951 in src/phase.cts) already honours
+// sibling requirements_updated (line ~2951 in src/phase.cts) already honors
 // the correct contract: true only when that file's content actually changed
 // in the transaction. Clock is pinned (GSD_TEST_MODE + GSD_NOW_MS) because
 // syncStateFrontmatter stamps a millisecond-resolution `last_updated:` field
@@ -3395,6 +3395,7 @@ describe('phase complete write-flag content-change contract (#3685)', () => {
       parsed2.state_updated, false,
       'fs.existsSync() reported true here, masking the no-op (#3685)',
     );
+    const roadmapAfter2 = fs.readFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), 'utf-8');
 
     // Stability across repeats: the flag must not alternate true/false on
     // successive no-op runs — pin a THIRD call to the same behavior.
@@ -3402,7 +3403,6 @@ describe('phase complete write-flag content-change contract (#3685)', () => {
     assert.ok(run3.success, `third phase complete failed: ${run3.error}`);
     const stateAfter3 = fs.readFileSync(statePath, 'utf-8');
     const roadmapAfter3 = fs.readFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), 'utf-8');
-    const roadmapAfter2 = fs.readFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), 'utf-8');
     assert.equal(stateAfter3, stateAfter2, 'STATE.md must remain byte-identical on a third no-op run');
     assert.equal(roadmapAfter3, roadmapAfter2, 'ROADMAP.md must remain byte-identical on a third no-op run');
     const parsed3 = JSON.parse(run3.output);

--- a/tests/phase.test.cjs
+++ b/tests/phase.test.cjs
@@ -3181,6 +3181,7 @@ Plans:
       path.join(tmpDir, '.planning', 'STATE.md'),
       `---\ngsd_state_version: 1.0\ncurrent_phase: 1\nprogress:\n  total_phases: 2\n  completed_phases: 0\n  percent: 0\n---\n\n# State\n\nTotal Phases: 2\n`,
     );
+    const beforeState = fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
 
     const result = runGsdTools('phase remove 2', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
@@ -3188,6 +3189,9 @@ Plans:
     assert.strictEqual(out.state_updated, true, 'state_updated must be true when STATE.md content changed');
     // Body 'Total Phases:' must be decremented from 2 to 1.
     const afterState = fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
+    // #3685: earn the `true` above — assert the file's content actually
+    // differs from the pre-call snapshot, not merely that it exists.
+    assert.notEqual(afterState, beforeState, '#3685: STATE.md content must actually change when state_updated is true');
     const bodyMatch = afterState.match(/^Total Phases:\s*(\d+)/m);
     assert.ok(bodyMatch, 'body must have Total Phases field after remove');
     assert.strictEqual(bodyMatch[1], '1', `body 'Total Phases:' must be 1 after removing one of 2 phases; got ${bodyMatch[1]}`);
@@ -3324,6 +3328,132 @@ describe('phase complete canonical verification gate (#1522)', () => {
     assert.match(errorPayload.message, /\/gsd-verify-work 0?1/);
     assert.equal(fs.readFileSync(roadmapPath, 'utf-8'), beforeRoadmap);
     assert.equal(fs.readFileSync(statePath, 'utf-8'), beforeState);
+  });
+});
+
+// #3685: cmdPhaseComplete's roadmap_updated/state_updated flags were computed
+// via fs.existsSync(roadmapPath) / fs.existsSync(statePath) — true whenever
+// the file merely EXISTS, even when the transaction rewrote nothing. The
+// sibling requirements_updated (line ~2951 in src/phase.cts) already honours
+// the correct contract: true only when that file's content actually changed
+// in the transaction. Clock is pinned (GSD_TEST_MODE + GSD_NOW_MS) because
+// syncStateFrontmatter stamps a millisecond-resolution `last_updated:` field
+// on every STATE.md write pass — an unpinned second run would genuinely
+// differ by that timestamp alone, masking the no-op these tests need to
+// observe (see .gsd/bug/fix-3685-phase-complete-write-flags/repro-pinned.cjs
+// for the standalone reproduction).
+describe('phase complete write-flag content-change contract (#3685)', () => {
+  let tmpDir;
+  const PINNED_CLOCK_ENV = { GSD_TEST_MODE: '1', GSD_NOW_MS: '1750000000000' };
+
+  beforeEach(() => {
+    tmpDir = createTempProject();
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('roadmap_updated is false when the transaction rewrites nothing (#3685)', () => {
+    writePhaseCompleteVerificationGateFixture(tmpDir, 'passed');
+    const roadmapPath = path.join(tmpDir, '.planning', 'ROADMAP.md');
+
+    const run1 = runVerifiedPhaseComplete(['phase', 'complete', '1'], tmpDir, PINNED_CLOCK_ENV);
+    assert.ok(run1.success, `first phase complete failed: ${run1.error}`);
+    const roadmapAfter1 = fs.readFileSync(roadmapPath, 'utf-8');
+
+    // Second call: phase 1 is already complete, so this is a genuine no-op
+    // against ROADMAP.md. Re-write the passed marker first so the #1522
+    // verification gate does not itself refuse the second call.
+    const run2 = runVerifiedPhaseComplete(['phase', 'complete', '1'], tmpDir, PINNED_CLOCK_ENV);
+    assert.ok(run2.success, `second phase complete failed: ${run2.error}`);
+    const roadmapAfter2 = fs.readFileSync(roadmapPath, 'utf-8');
+
+    assert.equal(roadmapAfter2, roadmapAfter1, 'ROADMAP.md must be byte-identical across the no-op second run');
+    const parsed2 = JSON.parse(run2.output);
+    assert.strictEqual(
+      parsed2.roadmap_updated, false,
+      'fs.existsSync() reported true here, masking the no-op (#3685)',
+    );
+  });
+
+  test('state_updated is false when the transaction rewrites nothing (#3685)', () => {
+    writePhaseCompleteVerificationGateFixture(tmpDir, 'passed');
+    const statePath = path.join(tmpDir, '.planning', 'STATE.md');
+
+    const run1 = runVerifiedPhaseComplete(['phase', 'complete', '1'], tmpDir, PINNED_CLOCK_ENV);
+    assert.ok(run1.success, `first phase complete failed: ${run1.error}`);
+    const stateAfter1 = fs.readFileSync(statePath, 'utf-8');
+
+    const run2 = runVerifiedPhaseComplete(['phase', 'complete', '1'], tmpDir, PINNED_CLOCK_ENV);
+    assert.ok(run2.success, `second phase complete failed: ${run2.error}`);
+    const stateAfter2 = fs.readFileSync(statePath, 'utf-8');
+
+    assert.equal(stateAfter2, stateAfter1, 'STATE.md must be byte-identical across the no-op second run');
+    const parsed2 = JSON.parse(run2.output);
+    assert.strictEqual(
+      parsed2.state_updated, false,
+      'fs.existsSync() reported true here, masking the no-op (#3685)',
+    );
+
+    // Stability across repeats: the flag must not alternate true/false on
+    // successive no-op runs — pin a THIRD call to the same behavior.
+    const run3 = runVerifiedPhaseComplete(['phase', 'complete', '1'], tmpDir, PINNED_CLOCK_ENV);
+    assert.ok(run3.success, `third phase complete failed: ${run3.error}`);
+    const stateAfter3 = fs.readFileSync(statePath, 'utf-8');
+    const roadmapAfter3 = fs.readFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), 'utf-8');
+    const roadmapAfter2 = fs.readFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), 'utf-8');
+    assert.equal(stateAfter3, stateAfter2, 'STATE.md must remain byte-identical on a third no-op run');
+    assert.equal(roadmapAfter3, roadmapAfter2, 'ROADMAP.md must remain byte-identical on a third no-op run');
+    const parsed3 = JSON.parse(run3.output);
+    assert.strictEqual(parsed3.roadmap_updated, false, 'roadmap_updated must stay false, not alternate, on repeat no-ops (#3685)');
+    assert.strictEqual(parsed3.state_updated, false, 'state_updated must stay false, not alternate, on repeat no-ops (#3685)');
+  });
+
+  test('both write flags are true when the transaction genuinely rewrites (#3685)', () => {
+    writePhaseCompleteVerificationGateFixture(tmpDir, 'passed');
+    const roadmapPath = path.join(tmpDir, '.planning', 'ROADMAP.md');
+    const statePath = path.join(tmpDir, '.planning', 'STATE.md');
+    const roadmapBefore = fs.readFileSync(roadmapPath, 'utf-8');
+    const stateBefore = fs.readFileSync(statePath, 'utf-8');
+
+    const result = runGsdTools(['phase', 'complete', '1'], tmpDir, PINNED_CLOCK_ENV);
+    assert.ok(result.success, `phase complete failed: ${result.error}`);
+    const parsed = JSON.parse(result.output);
+
+    const roadmapAfter = fs.readFileSync(roadmapPath, 'utf-8');
+    const stateAfter = fs.readFileSync(statePath, 'utf-8');
+
+    assert.notEqual(roadmapAfter, roadmapBefore, 'precondition: ROADMAP.md content must actually change');
+    assert.strictEqual(parsed.roadmap_updated, true, 'roadmap_updated must be true for a genuine rewrite');
+    assert.notEqual(stateAfter, stateBefore, 'precondition: STATE.md content must actually change');
+    assert.strictEqual(parsed.state_updated, true, 'state_updated must be true for a genuine rewrite');
+  });
+
+  test('roadmap_updated stays false when ROADMAP.md is absent (#3685)', () => {
+    writePhaseCompleteVerificationGateFixture(tmpDir, 'passed');
+    // Deletes a single fixture FILE inside tmpDir (not the temp dir itself);
+    // helpers.cleanup() is a directory-removal helper and cannot be used here.
+    // eslint-disable-next-line local/no-raw-rmsync-in-tests -- single-file delete, not a directory
+    fs.rmSync(path.join(tmpDir, '.planning', 'ROADMAP.md'));
+
+    const result = runVerifiedPhaseComplete(['phase', 'complete', '1'], tmpDir, PINNED_CLOCK_ENV);
+    assert.ok(result.success, `phase complete failed without ROADMAP.md: ${result.error}`);
+    const parsed = JSON.parse(result.output);
+    assert.strictEqual(parsed.roadmap_updated, false, 'roadmap_updated must be false when ROADMAP.md does not exist (#3685)');
+  });
+
+  test('state_updated stays false when STATE.md is absent (#3685)', () => {
+    writePhaseCompleteVerificationGateFixture(tmpDir, 'passed');
+    // Deletes a single fixture FILE inside tmpDir (not the temp dir itself);
+    // helpers.cleanup() is a directory-removal helper and cannot be used here.
+    // eslint-disable-next-line local/no-raw-rmsync-in-tests -- single-file delete, not a directory
+    fs.rmSync(path.join(tmpDir, '.planning', 'STATE.md'));
+
+    const result = runVerifiedPhaseComplete(['phase', 'complete', '1'], tmpDir, PINNED_CLOCK_ENV);
+    assert.ok(result.success, `phase complete failed without STATE.md: ${result.error}`);
+    const parsed = JSON.parse(result.output);
+    assert.strictEqual(parsed.state_updated, false, 'state_updated must be false when STATE.md does not exist (#3685)');
   });
 });
 
@@ -6612,12 +6742,17 @@ describe('bug-3287 — init plan-phase exposes expected_phase_dir with project_c
     test('full consistency check: all STATE.md fields are coherent after phase.complete', () => {
       setupPhase3517Project(tmpDir);
       const statePath = path.join(tmpDir, '.planning', 'STATE.md');
+      const stateBefore = fs.readFileSync(statePath, 'utf8');
 
       const r = runSdkQuery(['phase.complete', '5'], tmpDir);
       assert.ok(r.success, `call failed: ${r.error}`);
       assert.equal(r.data?.state_updated, true, 'state_updated must be true');
 
       const state = fs.readFileSync(statePath, 'utf8');
+      // #3685: earn the `true` above — assert STATE.md's content actually
+      // changed, not merely that it exists (which is all the pre-fix
+      // existsSync-based flag proved).
+      assert.notEqual(state, stateBefore, '#3685: STATE.md content must actually change when state_updated is true');
 
       const fm = extractFrontmatter(state);
       assert.equal(
@@ -11132,10 +11267,15 @@ describe('#2572: phase complete warns when a SUMMARY claims files that never lan
   test('#2572-2: the advisory is ADVISORY — completion still succeeds and reports the phase complete', () => {
     const { tmpDir } = build2572SummaryArtifactFixture();
     try {
+      const stateBefore = fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
       const { output } = runVerifiedPhaseComplete(['phase', 'complete', '1'], tmpDir);
       const parsed = JSON.parse(output);
       assert.strictEqual(parsed.completed_phase, '1', '#2572-2 FAILED: completion must not be blocked by the advisory');
       assert.strictEqual(parsed.state_updated, true, '#2572-2 FAILED: STATE.md must still be written');
+      // #3685: earn the `true` above — assert STATE.md's content actually
+      // differs from the pre-call snapshot.
+      const stateAfter = fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
+      assert.notEqual(stateAfter, stateBefore, '#3685: STATE.md content must actually change when state_updated is true');
     } finally {
       cleanup(tmpDir);
     }
@@ -11879,11 +12019,15 @@ describe('bug #3572: phase remove must not corrupt STATE.md into two frontmatter
     // targetDir !== null, and the body lacks Total Phases/of-N — the trigger.
     let r = runGsdTools('phase insert 1 "Inserted probe"', tmpDir);
     assert.ok(r.success, `phase insert failed: ${r.error}`);
+    const stateBeforeRemove = fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
     r = runGsdTools('phase remove 1.1', tmpDir);
     assert.ok(r.success, `phase remove failed: ${r.error}`);
     assert.strictEqual(JSON.parse(r.output).state_updated, true, 'the #2640 resync must still happen');
 
     const after = fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
+    // #3685: earn the `true` above — assert STATE.md's content actually
+    // differs from the snapshot taken immediately before the remove call.
+    assert.notEqual(after, stateBeforeRemove, '#3685: STATE.md content must actually change when state_updated is true');
     assert.ok(after.startsWith('---\n') || after.startsWith('---\r\n'), 'file must still OPEN with the frontmatter fence');
     assert.strictEqual(fenceLineCount(after), 2, `exactly one frontmatter block (2 fence lines); got ${fenceLineCount(after)}:\n${after.slice(0, 400)}`);
     assert.strictEqual((after.match(/gsd_state_version/g) || []).length, 1, 'exactly one gsd_state_version — no second derived block');


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #3685

---

## What was broken

`phase complete` reported `roadmap_updated` and `state_updated` as `fs.existsSync(path)`, so both read `true` for any project that had the file at all — including a run that rewrote nothing. Those flags are the only signal a caller has that the rollup landed, so a silently-skipped write was indistinguishable from a successful one.

## What this fix does

Both flags now reflect whether that file's content actually changed in the transaction, computed at the existing `writes.push({filePath, before, after})` sites. Nothing about what gets written changes; only what gets reported.

## Root cause

The transaction already held both pre-images — `originalRoadmapContent` (`src/phase.cts:2463`) and `originalStateContent` (`:3101`) — and threw them away. Both are block-scoped inside the `runPhaseCompleteTransaction` closure, so they were out of scope at the result site, and the payload reached for `existsSync` instead.

The sibling `requirements_updated` has done this correctly since #2316-3 (`src/phase.cts:2951`), and its comment at `:2945-2950` asserts the ROADMAP write already uses the same diff-tracking. It did not — that claim was the bug. #2012 (PR #2032) fixed the *skip* this flag was masking and recorded the flag itself as still unfixed (`CHANGELOG.md:632`). The identical defect on a sibling command was fixed by #2640 / #2974 for `phase remove` (`CHANGELOG.md:346`); this is the same correction, finally applied here.

The fix hoists two `let` declarations beside `requirementsUpdated` and assigns each from a `before !== after` comparison. Two declarations, two assignments, two swapped object keys.

## Testing

### How I verified the fix

Failing-first, on the remote runner, against the exact commits:

- **RED** — `eac15d8c2da46061f4b8d11bd7cd85bf3ee38606` (tests only, no fix): `outcome:"failed"`, 37495/37498, **3 failures — all of them the two intended regressions and their parent describe block**, with the expected message `fs.existsSync() reported true here, masking the no-op (#3685)`. Nothing else broke, which also proves the four strengthened pre-existing assertions still hold.
- **GREEN** — `75333548c8ae05718eb9b652a790d610a411235e` (fix applied): recorded pass on the exact shipped sha.

The reproduction is a standalone harness that completes a phase twice and compares the files byte-for-byte. Before the fix it printed `run2 roadmap_updated= true  state_updated= true` while reporting `run2 ROADMAP byte-identical: true  STATE byte-identical: true`; after the fix both flags read `false` with the files still byte-identical.

The STATE.md half of that is only observable with the clock pinned (`GSD_TEST_MODE=1` + `GSD_NOW_MS`, honored by `realClock` at `src/clock.cts:43-70`), because `syncStateFrontmatter` stamps a millisecond-resolution `last_updated:` on every write — an unpinned second run genuinely differs by that timestamp alone. The tests pin it the same way. This is a clock seam, not an elapsed-time assertion: nothing asserts on wall-clock time, only on byte equality.

### Regression test added?

- [x] Yes — added a test that would have caught this bug

Five tests in `tests/phase.test.cjs`, folded into the existing suite rather than a new file (the per-module test-file cap forbids one):

| what it pins | direction |
|---|---|
| `roadmap_updated` is `false` when the transaction rewrites nothing | the bug (RED) |
| `state_updated` is `false` when the transaction rewrites nothing, and still `false` on a third consecutive run | the bug + stability (RED) |
| both flags are `true` when the transaction genuinely rewrites, each paired with a content-changed assertion | so the fix cannot be tightened into always-false |
| each flag stays `false` when its own file is absent | negative space; these also kill the flag-swap mutant, since the two flags are provably non-equal in both |

Also strengthens four pre-existing `=== true` assertions on these fields that passed vacuously — `existsSync` was `true` in those fixtures regardless of whether anything was written, so none of them could have caught this. Each now pairs its flag assertion with a content-changed assertion against a snapshot captured *before* the command under test, so the `true` is earned. No existing assertion was deleted; the `tests/` diff is 144 insertions, 0 deletions.

### Platforms tested

- [x] Linux
- [ ] macOS
- [ ] Windows (including backslash path handling)
- [ ] N/A (not platform-specific)

Linux is the remote runner's matrix. The change is platform-neutral — two string comparisons over content already held in memory, no paths constructed, no separators, no mode bits.

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass — verified on the remote runner at the shipped sha, not locally
- [x] `.changeset/` fragment added (`type: Fixed`)
- [x] No unnecessary dependencies added

## Breaking changes

**Observable output change, no consumer affected.** `roadmap_updated` and `state_updated` can now report `false` where they previously always reported `true` for any project with the file present. The direction only ever changes `true → false`, and only when nothing was written — which is precisely the case a caller could not have been relying on for correctness.

A repo-wide sweep for consumers of these two fields on `phase.complete` found none: no workflow, agent, reference, command, doc, or shipped code reads them. The only prose hit is `gsd-core/workflows/remove-phase.md:100`, which extracts `phase remove`'s payload — a different command, and one whose flags #2640/#2974 already made content-based without reported fallout.
