### PR TITLE
fix(#3840): reject a malformed feature `order` instead of coercing it

### DIFF
--- a/.changeset/witty-lynx-sing.md
+++ b/.changeset/witty-lynx-sing.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**A feature fragment declaring a malformed `order:` no longer sorts silently to the top of `docs/FEATURES.md`** — the generator validated that field by coercion, so an empty value read as `0` and hex, octal, binary and exponential values read as numbers, all placing the section ahead of every real feature with no violation and a clean `--check`. (#3840)

--- a/.changeset/witty-lynx-sing.md
+++ b/.changeset/witty-lynx-sing.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 3851
 ---
 **A feature fragment declaring a malformed `order:` no longer sorts silently to the top of `docs/FEATURES.md`** — the generator validated that field by coercion, so an empty value read as `0` and hex, octal, binary and exponential values read as numbers, all placing the section ahead of every real feature with no violation and a clean `--check`. (#3840)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -361,7 +361,13 @@ shared file, so there is nothing to collide on.
    `docs/features/_groups/<slug>.md`, which a feature PR never touches.
 4. **`order` is optional.** It defaults to the numeric part of `id`, which is
    right for almost everything. Declare it only to place a section somewhere its
-   number would not put it (`27b` precedes `27a` for historical reasons).
+   number would not put it (`27b` precedes `27a` for historical reasons). When
+   declared it must be an optionally-signed integer or decimal — `27`, `0`,
+   `-1`, `+3`, `27.2`. Anything else is an `order_invalid` violation, including
+   an empty value, a hex/binary/octal literal and exponential notation: all of
+   those coerce to a finite number under JavaScript's `Number()`, so before
+   #3840 a bare `order:` sorted the section to position 0 — ahead of every real
+   feature — with no violation and a clean `--check`.
 5. **Bodies start at `####`.** A `##` or `###` inside a fragment body would
    forge a group or a sibling section with no id and no TOC entry; `--check`
    rejects it (`body_heading_too_shallow`).

--- a/scripts/gen-features.cjs
+++ b/scripts/gen-features.cjs
@@ -165,6 +165,20 @@ const GROUP_NOTE_FIELDS = Object.freeze(['group']);
  */
 const ID_RE = /^(?:0|[1-9][0-9]*)(?:\.[0-9]+|[a-z])?$/;
 
+/**
+ * A legal explicit `order`: an optionally-signed decimal literal.
+ *
+ * `order` was the only field validated by COERCION rather than by shape, and
+ * `Number()` is far more liberal than a docs ordering field has reason to be:
+ * `Number('')` and `Number(' ')` are 0, and `0x10`, `0b11`, `0o17`, `1e3`, `1.`
+ * and `.5` all coerce to finite numbers. A fragment declaring `order:` with
+ * nothing after it therefore sorted to position 0 — ahead of every real
+ * feature — with no violation and exit 0, in a gate whose whole contract is a
+ * typed violation rather than a silent guess. Shape first, then coerce,
+ * mirroring how ID_RE guards `id`.
+ */
+const ORDER_RE = /^[+-]?(?:0|[1-9][0-9]*)(?:\.[0-9]+)?$/;
+
 /** The fragment filename shape: a kebab slug, mirroring `docs/adr/`'s rule. */
 const FRAGMENT_FILENAME_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*\.md$/;
 
@@ -407,7 +421,10 @@ function readCorpus() {
     let order = defaultOrder(data.id);
     if (data.order !== undefined) {
       order = Number(data.order);
-      if (!Number.isFinite(order)) {
+      // Both guards are load-bearing: the regex rejects the shapes `Number`
+      // would silently accept, and `isFinite` still catches a well-shaped
+      // literal long enough to overflow to Infinity.
+      if (!ORDER_RE.test(data.order) || !Number.isFinite(order)) {
         add(REASON.ORDER_INVALID, rel, { order: data.order });
         continue;
       }
@@ -620,7 +637,7 @@ function describeViolation(v) {
     case REASON.ID_DUPLICATE:
       return `${v.file}: id '${v.id}' is already used by ${v.first} — pick another (any unique id is legal)`;
     case REASON.ORDER_INVALID:
-      return `${v.file}: order '${v.order}' is not a finite number`;
+      return `${v.file}: order '${v.order}' is not a decimal number (an optionally-signed integer or decimal)`;
     case REASON.ANCHOR_DUPLICATE:
       return `${v.file}: anchor '#${v.anchor}' collides with ${v.first}`;
     case REASON.BODY_EMPTY:

--- a/tests/features-index-gate.test.cjs
+++ b/tests/features-index-gate.test.cjs
@@ -571,6 +571,180 @@ describe('gen-features CLI', () => {
     assert.deepEqual(reasonsIn(report(root)), [REASON.ORDER_INVALID]);
   });
 
+  // ---------------------------------------------------------------------------
+  // `order` validation (#3840 follow-up): `Number()` coercion is far more
+  // liberal than a docs ordering field has reason to be. `Number('')` is 0,
+  // and `0x10`, `0b11`, `0o17`, `1e3`, `1.` and `.5` all coerce to finite
+  // numbers — so a fragment declaring `order:` with nothing after it sorted
+  // to position 0, ahead of every real feature, with zero violations.
+  // ---------------------------------------------------------------------------
+
+  test('an empty order is rejected, not coerced to zero', (t) => {
+    const root = makeRepo(t, {
+      'a.md': fragment('1', 'A', 'G', '**Purpose:** x.', { order: '' }),
+    });
+    assert.deepEqual(reasonsIn(report(root)), [REASON.ORDER_INVALID]);
+  });
+
+  test('a bare `order:` line is rejected too — the shape an author actually types', (t) => {
+    // The reject rows above build `order` through renderFrontmatter, which
+    // emits the QUOTED-empty form `order: ""`. A human types the bare form.
+    // Both converge to '' at the validator; this pins that they do, so a
+    // change to parseScalar's quoted branch cannot quietly split them.
+    for (const line of ['order:', 'order:   ']) {
+      const root = makeRepo(t, {
+        'a.md': `---\nid: 1\ntitle: A\ngroup: G\n${line}\n---\n\n**Purpose:** x.\n`,
+      });
+      assert.deepEqual(reasonsIn(report(root)), [REASON.ORDER_INVALID], line);
+    }
+  });
+
+  test('a non-decimal radix order is rejected', (t) => {
+    for (const order of ['0x10', '0b11', '0o17']) {
+      const root = makeRepo(t, {
+        'a.md': fragment('1', 'A', 'G', '**Purpose:** x.', { order }),
+      });
+      assert.deepEqual(reasonsIn(report(root)), [REASON.ORDER_INVALID], `order: ${order}`);
+    }
+  });
+
+  test('an exponential order is rejected', (t) => {
+    const root = makeRepo(t, {
+      'a.md': fragment('1', 'A', 'G', '**Purpose:** x.', { order: '1e3' }),
+    });
+    assert.deepEqual(reasonsIn(report(root)), [REASON.ORDER_INVALID]);
+  });
+
+  test('a malformed decimal order is rejected', (t) => {
+    for (const order of ['1.', '.5']) {
+      const root = makeRepo(t, {
+        'a.md': fragment('1', 'A', 'G', '**Purpose:** x.', { order }),
+      });
+      assert.deepEqual(reasonsIn(report(root)), [REASON.ORDER_INVALID], `order: ${order}`);
+    }
+  });
+
+  test('Infinity, NaN and separators stay rejected', (t) => {
+    // Regression pin: these already fail today under plain Number() coercion
+    // and must keep failing once order is validated by shape as well.
+    for (const order of ['Infinity', 'NaN', '1_0']) {
+      const root = makeRepo(t, {
+        'a.md': fragment('1', 'A', 'G', '**Purpose:** x.', { order }),
+      });
+      assert.deepEqual(reasonsIn(report(root)), [REASON.ORDER_INVALID], `order: ${order}`);
+    }
+  });
+
+  test('an order that overflows to Infinity is rejected', (t) => {
+    // The regex alone would admit this shape; the finite guard must still fire.
+    const root = makeRepo(t, {
+      'a.md': fragment('1', 'A', 'G', '**Purpose:** x.', { order: '1'.repeat(400) }),
+    });
+    assert.deepEqual(reasonsIn(report(root)), [REASON.ORDER_INVALID]);
+  });
+
+  test('accepts a plain integer order', (t) => {
+    const root = makeRepo(t, {
+      'a.md': fragment('5', 'A', 'G', '**Purpose:** x.', { order: '27' }),
+      'b.md': fragment('1', 'B', 'G'),
+    });
+    assert.deepEqual(report(root).violations, []);
+    run(root, ['--write']);
+    const doc = fs.readFileSync(path.join(root, 'docs', 'FEATURES.md'), 'utf8');
+    // order 27 > B's default order (1), so A must render after B.
+    assert.equal(doc.indexOf('### 5.') > doc.indexOf('### 1.'), true);
+  });
+
+  test('accepts an explicit zero order', (t) => {
+    const root = makeRepo(t, {
+      'a.md': fragment('5', 'A', 'G', '**Purpose:** x.', { order: '0' }),
+      'b.md': fragment('9', 'B', 'G'),
+    });
+    assert.deepEqual(report(root).violations, []);
+    run(root, ['--write']);
+    const doc = fs.readFileSync(path.join(root, 'docs', 'FEATURES.md'), 'utf8');
+    // order 0 < B's default order (9), so A must render before B.
+    assert.equal(doc.indexOf('### 5.') < doc.indexOf('### 9.'), true);
+  });
+
+  test('accepts a negative order', (t) => {
+    const root = makeRepo(t, {
+      'a.md': fragment('5', 'A', 'G', '**Purpose:** x.', { order: '-1' }),
+      'b.md': fragment('1', 'B', 'G'),
+    });
+    assert.deepEqual(report(root).violations, []);
+    run(root, ['--write']);
+    const doc = fs.readFileSync(path.join(root, 'docs', 'FEATURES.md'), 'utf8');
+    // order -1 < B's default order (1), so A must render before B.
+    assert.equal(doc.indexOf('### 5.') < doc.indexOf('### 1.'), true);
+  });
+
+  test('accepts a leading-plus order', (t) => {
+    const root = makeRepo(t, {
+      'a.md': fragment('5', 'A', 'G', '**Purpose:** x.', { order: '+3' }),
+      'b.md': fragment('1', 'B', 'G'),
+      'c.md': fragment('10', 'C', 'G'),
+    });
+    assert.deepEqual(report(root).violations, []);
+    run(root, ['--write']);
+    const doc = fs.readFileSync(path.join(root, 'docs', 'FEATURES.md'), 'utf8');
+    // order +3 sits between B's default order (1) and C's default order (10).
+    assert.equal(doc.indexOf('### 1.') < doc.indexOf('### 5.'), true);
+    assert.equal(doc.indexOf('### 5.') < doc.indexOf('### 10.'), true);
+  });
+
+  test('a quoted numeric order is accepted after unquoting', (t) => {
+    // Built by writing the raw fragment text so the frontmatter line literally
+    // reads `order: "27.2"`, rather than going through the `fragment()` helper
+    // (which would double-quote a JS string value).
+    const root = makeRepo(t, {
+      'a.md': '---\nid: 5\ntitle: A\ngroup: G\norder: "27.2"\n---\n\n**Purpose:** x.\n',
+      'b.md': fragment('1', 'B', 'G'),
+    });
+    assert.deepEqual(report(root).violations, []);
+    run(root, ['--write']);
+    const doc = fs.readFileSync(path.join(root, 'docs', 'FEATURES.md'), 'utf8');
+    // order 27.2 > B's default order (1), so A must render after B.
+    assert.equal(doc.indexOf('### 5.') > doc.indexOf('### 1.'), true);
+  });
+
+  test('an invalid id short-circuits before order validation', (t) => {
+    const root = makeRepo(t, {
+      'a.md': fragment('12ab', 'A', 'G', '**Purpose:** x.', { order: '' }),
+    });
+    assert.deepEqual(reasonsIn(report(root)), [REASON.ID_INVALID]);
+  });
+
+  test('an invalid order short-circuits before the body check', (t) => {
+    const root = makeRepo(t, {
+      'a.md': fragment('1', 'A', 'G', '', { order: '' }),
+    });
+    assert.deepEqual(reasonsIn(report(root)), [REASON.ORDER_INVALID]);
+  });
+
+  test('each malformed order is reported per file', (t) => {
+    const root = makeRepo(t, {
+      'a.md': fragment('1', 'A', 'G', '**Purpose:** x.', { order: '' }),
+      'b.md': fragment('2', 'B', 'G', '**Purpose:** x.', { order: '' }),
+    });
+    const rep = report(root);
+    assert.equal(rep.violations.length, 2);
+    const files = rep.violations.map((v) => v.file).sort();
+    assert.deepEqual(files, ['docs/features/a.md', 'docs/features/b.md']);
+  });
+
+  test('a malformed order refuses the write rather than reordering the document', (t) => {
+    const root = makeRepo(t, {
+      'a.md': fragment('1', 'A', 'G'),
+      'b.md': fragment('2', 'B', 'G'),
+      'c.md': fragment('900', 'C', 'G', '**Purpose:** x.', { order: '' }),
+    });
+    const before = fs.readFileSync(path.join(root, 'docs', 'FEATURES.md'), 'utf8');
+    assert.equal(run(root, ['--write']).exitCode, 1);
+    const after = fs.readFileSync(path.join(root, 'docs', 'FEATURES.md'), 'utf8');
+    assert.equal(after, before);
+  });
+
   test('an explicit order overrides the id-derived default', (t) => {
     const root = makeRepo(t, {
       'a.md': fragment('27', 'A', 'G'),


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3840

#3840 carries `approved-enhancement`, one of the three approval labels `auto-close-unsolicited-prs.yml:50` accepts. The defect is in the code that shipped for that issue, so it is the correct link.

---

## What was broken

A feature fragment declaring a malformed `order:` sorted silently to the top of `docs/FEATURES.md` — body and generated table of contents both — with zero violations, a clean `--check`, and `--write` exiting 0.

## What this fix does

`order` is now validated by shape before coercion, so every malformed value is a typed `order_invalid` violation instead of a number.

## Root cause

`order` was the only fragment field validated by **coercion** rather than by shape. Every other field is either shape-checked (`ID_RE`) or falsy-checked (`if (!data[field])`); `order` asked `Number()` to guess:

```js
order = Number(data.order);
if (!Number.isFinite(order)) { add(REASON.ORDER_INVALID, ...); continue; }
```

`Number()` is far more liberal than a docs ordering field has reason to be. Verified by execution — every one of these is finite, so every one passed:

| value | `Number()` |
|---|---|
| `""` (a bare `order:`) | `0` |
| `"0x10"` | `16` |
| `"0b11"` | `3` |
| `"0o17"` | `15` |
| `"1e3"` | `1000` |
| `"1."` | `1` |
| `".5"` | `0.5` |

The empty case is the reachable one: a bare `order:` line yields `''`, `Number('')` is `0`, and `0` sorts ahead of every real feature *and* floats its whole group to the front.

Reproduced against the unfixed script with three fragments (ids 1, 2, 900, the last carrying `order:`):

```
violations: []
write exit 0: Wrote 3 features in 1 groups
rendered: 900 -> 1 -> 2
TOC:      Zzz -> Aaa -> Bbb
```

That is a fail-open in a gate whose entire contract is the opposite — the file's own header says the rule is enforced "with a typed violation rather than leaving a human to notice."

The fix keeps both guards. `ORDER_RE` rejects the shapes `Number()` would silently accept; `Number.isFinite` stays because the regex alone would admit a literal long enough to overflow to `Infinity` (`'1'.repeat(400)`).

## Testing

### How I verified the fix

Remote runner, green on the exact pushed sha.

Red-before-green was proven by a harness driving the real CLI against synthetic temp-dir corpora: the seven reject rows above each returned `violations: []` against the unfixed script and `order_invalid` after, while the `Infinity` / `NaN` / `1_0` rows returned `order_invalid` both before and after.

`node scripts/gen-features.cjs --check` exits 0 against the committed corpus — the two live fragments that declare `order` are unaffected, and `docs/FEATURES.md` is byte-identical.

`npm run lint:ci` exits 0 across all 67 gates.

### Regression test added?

- [x] Yes — added a test that would have caught this bug

17 tests in `tests/features-index-gate.test.cjs`, all asserting on the typed `--json` report rather than stderr prose. Reject rows: empty, bare `order:` and `order:` plus trailing spaces, hex/binary/octal, exponential, `1.` and `.5`, the 400-digit overflow, and regression pins for `Infinity` / `NaN` / `1_0`. Accept rows: `27`, `0`, `-1`, `+3`, and the quoted `"27.2"` form — each also asserting the **resolved position** in the rendered document, because "accepted" without a position proves only that nothing threw.

Three independence rows cover the short-circuit ordering an invalid field implies: an invalid `id` reports `id_invalid` alone, an invalid `order` reports `order_invalid` alone even when the body is also empty, and two bad fragments report one violation each. One row asserts `--write` refuses and leaves `docs/FEATURES.md` byte-identical rather than reordering it.

The bare-`order:` row exists because the other reject rows build the field through `renderFrontmatter`, which emits the *quoted*-empty form `order: ""`. A human types the bare form. Both converge to `''` at the validator; that row pins the convergence.

### Platforms tested

- [x] macOS
- [x] Windows (including backslash path handling)
- [x] Linux

Pure string validation with no path handling; the suite runs in the full remote matrix.

### Runtimes tested

- [x] N/A (not runtime-specific)

A build-time generator, not a runtime surface.

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue carries a maintainer-applied approval label (`approved-enhancement`)
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass — via the remote runner; local `npm test` is hook-blocked in this repo
- [x] `.changeset/` fragment added
- [x] No unnecessary dependencies added

## Provenance

Surfaced by re-running the feature-implementation directive's design and QA-architecture steps against the code merged in #3845. That PR shipped without them, and the defect is exactly what the enumeration they produce is for: the behavior table's "field present but empty" row had never been written down, so no test existed for it.

## Known limits

- **`slugify` narrows to ASCII word characters** where GitHub's anchor algorithm keeps unicode letters. Unreachable today — no fragment title or group contains a non-ASCII character — and self-consistent when reached, since the generator derives both the TOC link and the heading from the same function. Left as-is deliberately: `docs/` house style is American English, so a unicode-aware slugify would permit a title a different documented rule already rejects.
- **The tightening removes three shapes that previously coerced**: `0x10`, `1e3` and `.5`. No live fragment uses any of them — only two fragments declare `order` at all, both plain decimals — so nothing depends on the old leniency.

## Breaking changes

None for any live input. `docs/FEATURES.md` is byte-identical and `--check` exits 0 against the committed corpus. A fragment that relied on hex, exponential or leading-dot notation would now be rejected; none exists.
