### PR TITLE
fix(#3841): make the identity classifier and the launcher preamble agree

### DIFF
--- a/.changeset/sturdy-jaguars-munch.md
+++ b/.changeset/sturdy-jaguars-munch.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**The identity classifier now agrees with the launcher preamble about a tool that proves itself and then exits non-zero** — the two surfaces implement one decision and disagreed on exactly that input, so the announced hard-fail rollout would have refused an install the current warn phase verifies. (#3841)

--- a/.changeset/sturdy-jaguars-munch.md
+++ b/.changeset/sturdy-jaguars-munch.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 3855
 ---
 **The identity classifier and the launcher preamble now reach the same verdict for the same probe** — the two surfaces implement one decision and disagreed on two inputs, a tool that proves itself and then exits non-zero and a payload naming this package outside the anchored wire shape, so the announced hard-fail rollout would have refused installs the warn phase verifies and accepted ones it warns about. (#3841)

--- a/.changeset/sturdy-jaguars-munch.md
+++ b/.changeset/sturdy-jaguars-munch.md
@@ -2,4 +2,4 @@
 type: Fixed
 pr: 0
 ---
-**The identity classifier now agrees with the launcher preamble about a tool that proves itself and then exits non-zero** — the two surfaces implement one decision and disagreed on exactly that input, so the announced hard-fail rollout would have refused an install the current warn phase verifies. (#3841)
+**The identity classifier and the launcher preamble now reach the same verdict for the same probe** — the two surfaces implement one decision and disagreed on two inputs, a tool that proves itself and then exits non-zero and a payload naming this package outside the anchored wire shape, so the announced hard-fail rollout would have refused installs the warn phase verifies and accepted ones it warns about. (#3841)

--- a/src/runtime-identity.cts
+++ b/src/runtime-identity.cts
@@ -190,16 +190,22 @@ export function classifyIdentityProbe(
       const version = typeof record.version === 'string' ? record.version : undefined;
       if (actual !== expected) return { reason: 'identity_mismatch', expected, actual, version };
 
-      // ANCHOR PARITY (#3841). The shell preamble cannot parse JSON; it matches
-      // a `case` pattern anchored at the START of stdout, so `packageName` must
-      // serialize first. A structural parse alone would accept
-      // `{"note":"x","packageName":"<us>"}` — a shape this package never emits —
-      // while the shell rejected it, so the two surfaces would disagree in the
-      // FAIL-OPEN direction. Honoring the anchor here is also what the module
-      // already claims to do: IDENTITY_RAW_PREFIX is documented as "ANCHORED,
-      // never a substring search", and buildIdentityPayload inserts packageName
-      // first precisely so a genuine payload always satisfies it.
-      if (!probe.stdout.startsWith(IDENTITY_RAW_PREFIX)) {
+      // ANCHOR PARITY (#3841). The shell preamble cannot parse JSON: it matches
+      // a `case` pattern anchored at the START of stdout, so a payload only
+      // verifies there when it begins at the first byte and serializes
+      // `packageName` first. A purely structural parse would accept
+      // `{"note":"x","packageName":"<us>"}` and a leading-whitespace payload
+      // that the shell rejects -- a FAIL-OPEN disagreement between the two
+      // surfaces.
+      //
+      // Reproduce those two properties SEMANTICALLY rather than byte-matching
+      // IDENTITY_RAW_PREFIX. The prefix describes the `--raw` wire format, but
+      // this classifier is also handed the DEFAULT pretty serialization
+      // (`runtime-identity` with no `--raw`, which is two-space indented) --
+      // byte-matching the compact prefix rejected that, which the remote matrix
+      // caught. `startsWith('{')` and a first-key check hold for both.
+      const firstKey = Object.keys(record)[0];
+      if (!probe.stdout.startsWith('{') || firstKey !== 'packageName') {
         return {
           reason: 'unparseable',
           expected,

--- a/src/runtime-identity.cts
+++ b/src/runtime-identity.cts
@@ -30,6 +30,11 @@
  * close-enough would reproduce the exact silent success #3129 already produced.
  * Liberality is spent on visibility instead — distinct reason codes, each
  * naming what actually happened.
+ *
+ * The classifier and the shell preamble are held in agreement by a
+ * cross-surface parity test (#3841): both read stdout only and must reach the
+ * same verdict for the same payload, or the preamble's warning and this
+ * module's diagnostic would silently diverge on the same input.
  */
 
 import { packageName } from './package-identity.cjs';
@@ -124,6 +129,24 @@ function excerpt(text: string): string {
 }
 
 /**
+ * `stdout` as a plain JSON object, or `null` when it is not one.
+ *
+ * `JSON.parse` accepts `0`, `"str"`, `[]`, `null` and `true`; arrays and `null`
+ * are also `object` to `typeof`. All are rejected here so no downstream
+ * truthiness check can mistake `[]` for a verified identity.
+ */
+function parseIdentityRecord(stdout: string): Record<string, unknown> | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout) as unknown;
+  } catch {
+    return null;
+  }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+  return parsed as Record<string, unknown>;
+}
+
+/**
  * Pure classifier: probe result -> verdict. Total — never throws, for any input.
  *
  * Non-object JSON (`0`, `"str"`, `[]`, `null`, `true`) is `unparseable`, not
@@ -142,9 +165,37 @@ export function classifyIdentityProbe(
     };
   }
 
-  // A non-zero exit is what a binary without this verb does. The predecessor
-  // prints its usage screen and exits 1; treat that as "something else
-  // answered", never as a parse problem.
+  // PARSE BEFORE CONSULTING THE EXIT CODE (#3841).
+  //
+  // The exit-code rule below is right for its stated reason -- the predecessor
+  // prints a usage screen and exits 1, and that is "something else answered",
+  // not a parse problem -- but it used to run FIRST, so it also caught a tool
+  // that had already proved its identity and merely exited non-zero afterwards.
+  // The shell preamble this module speaks for reads stdout ONLY (its command
+  // substitution discards the status), so the two surfaces disagreed on exactly
+  // that input: shell `ok`, classifier `no_identity_verb`. Measured against the
+  // real snippet, not inferred. Since this classifier is the engine for the
+  // announced hard-fail phase, such an install would have flipped from verified
+  // to refused at rollout, in the phase where that stops the run.
+  //
+  // The predecessor defence is unaffected: a usage screen yields no usable
+  // payload, so it still falls through to the exit-code branch below.
+  const record = parseIdentityRecord(probe.stdout);
+  if (record !== null) {
+    const actual = record.packageName;
+    if (typeof actual === 'string' && actual.length > 0) {
+      // Unknown keys are ignored so a future payload addition cannot fail an
+      // older check. The shell anchor is deliberately open in the middle for the
+      // same reason, and the parity suite pins both halves of that (case P10).
+      const version = typeof record.version === 'string' ? record.version : undefined;
+      return actual === expected
+        ? { reason: 'ok', expected, actual, version }
+        : { reason: 'identity_mismatch', expected, actual, version };
+    }
+  }
+
+  // Nothing was proved. NOW the exit status is the discriminator: a non-zero
+  // exit means a binary that does not implement this verb answered.
   if (probe.exitCode !== 0) {
     return {
       reason: 'no_identity_verb',
@@ -153,31 +204,11 @@ export function classifyIdentityProbe(
     };
   }
 
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(probe.stdout) as unknown;
-  } catch {
-    return { reason: 'unparseable', expected, detail: excerpt(probe.stdout) };
-  }
-
-  // Arrays are objects to typeof; null is too. Both must be rejected.
-  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
-    return { reason: 'unparseable', expected, detail: excerpt(probe.stdout) };
-  }
-
-  const record = parsed as Record<string, unknown>;
-  const actual = record.packageName;
-  if (typeof actual !== 'string' || actual.length === 0) {
-    return { reason: 'unparseable', expected, detail: 'payload has no usable packageName' };
-  }
-
-  const version = typeof record.version === 'string' ? record.version : undefined;
-  if (actual !== expected) {
-    return { reason: 'identity_mismatch', expected, actual, version };
-  }
-
-  // Unknown keys are ignored so a future payload addition cannot fail an older check.
-  return { reason: 'ok', expected, actual, version };
+  return {
+    reason: 'unparseable',
+    expected,
+    detail: record === null ? excerpt(probe.stdout) : 'payload has no usable packageName',
+  };
 }
 
 /**

--- a/src/runtime-identity.cts
+++ b/src/runtime-identity.cts
@@ -188,9 +188,26 @@ export function classifyIdentityProbe(
       // older check. The shell anchor is deliberately open in the middle for the
       // same reason, and the parity suite pins both halves of that (case P10).
       const version = typeof record.version === 'string' ? record.version : undefined;
-      return actual === expected
-        ? { reason: 'ok', expected, actual, version }
-        : { reason: 'identity_mismatch', expected, actual, version };
+      if (actual !== expected) return { reason: 'identity_mismatch', expected, actual, version };
+
+      // ANCHOR PARITY (#3841). The shell preamble cannot parse JSON; it matches
+      // a `case` pattern anchored at the START of stdout, so `packageName` must
+      // serialize first. A structural parse alone would accept
+      // `{"note":"x","packageName":"<us>"}` — a shape this package never emits —
+      // while the shell rejected it, so the two surfaces would disagree in the
+      // FAIL-OPEN direction. Honoring the anchor here is also what the module
+      // already claims to do: IDENTITY_RAW_PREFIX is documented as "ANCHORED,
+      // never a substring search", and buildIdentityPayload inserts packageName
+      // first precisely so a genuine payload always satisfies it.
+      if (!probe.stdout.startsWith(IDENTITY_RAW_PREFIX)) {
+        return {
+          reason: 'unparseable',
+          expected,
+          detail: 'payload names this package but is not in the anchored wire shape',
+        };
+      }
+
+      return { reason: 'ok', expected, actual, version };
     }
   }
 

--- a/tests/runtime-identity.test.cjs
+++ b/tests/runtime-identity.test.cjs
@@ -190,6 +190,19 @@ describe('classifyIdentityProbe', () => {
     assert.equal(v.reason, 'unparseable');
   });
 
+  test('the default PRETTY serialization still verifies (not just --raw)', () => {
+    // The classifier is handed both serializations: the shell only ever sees
+    // `--raw`, but `runtime-identity` with no flag emits two-space-indented
+    // JSON. An anchor expressed as a compact byte prefix rejected this.
+    const pretty = JSON.stringify({ packageName: EXPECTED_PACKAGE_NAME, version: '9.9.9' }, null, 2);
+    assert.equal(classifyIdentityProbe({ stdout: `${pretty}\n`, exitCode: 0 }).reason, 'ok');
+  });
+
+  test('a pretty payload with packageName not first does not verify', () => {
+    const pretty = JSON.stringify({ note: 'x', packageName: EXPECTED_PACKAGE_NAME }, null, 2);
+    assert.equal(classifyIdentityProbe({ stdout: `${pretty}\n`, exitCode: 0 }).reason, 'unparseable');
+  });
+
   test('a foreign packageName is a mismatch wherever it appears in the object', () => {
     const stdout = '{"note":"x","packageName":"get-shit-done-cc"}';
     const v = classifyIdentityProbe({ stdout, exitCode: 0 });

--- a/tests/runtime-identity.test.cjs
+++ b/tests/runtime-identity.test.cjs
@@ -170,6 +170,59 @@ describe('classifyIdentityProbe', () => {
     const stdout = JSON.stringify({ packageName: 'get-shit-done-cc', note: EXPECTED_PACKAGE_NAME });
     assert.equal(classifyIdentityProbe({ stdout, exitCode: 0 }).reason, 'identity_mismatch');
   });
+
+  // ── Parse-before-exit-code (#3841) ──────────────────────────────────────
+  // The shell preamble reads stdout only — its command substitution discards
+  // the child's exit status entirely. So the classifier must reach the same
+  // verdict a tool that already proved its identity and then exited non-zero
+  // for an unrelated reason (a later verb failing, a warning exit, etc.).
+
+  test('a valid payload verifies even when the probe exits non-zero', () => {
+    const v = classifyIdentityProbe({ stdout: okStdout(), exitCode: 1 });
+    assert.equal(v.reason, 'ok');
+    assert.equal(v.actual, EXPECTED_PACKAGE_NAME);
+  });
+
+  test('a non-zero exit with a foreign payload is a mismatch, not a missing verb', () => {
+    const v = classifyIdentityProbe({
+      stdout: '{"packageName":"get-shit-done-cc","version":"1.0.0"}',
+      exitCode: 1,
+    });
+    assert.equal(v.reason, 'identity_mismatch');
+    assert.equal(v.actual, 'get-shit-done-cc');
+  });
+
+  // REGRESSION PIN: these pass today and must keep passing — the predecessor
+  // and any answer that proves nothing still fall through to no_identity_verb.
+  for (const stdout of [
+    'usage: gsd-tools ...',
+    '[]',
+    '0',
+    'null',
+    '{"version":"1"}',
+  ]) {
+    test(`a non-zero exit that proved nothing stays no_identity_verb (${JSON.stringify(stdout)})`, () => {
+      const v = classifyIdentityProbe({ stdout, exitCode: 1 });
+      assert.equal(v.reason, 'no_identity_verb');
+    });
+  }
+
+  test('a signal-killed probe that still proved identity verifies', () => {
+    const v = classifyIdentityProbe({ stdout: okStdout(), exitCode: null });
+    assert.equal(v.reason, 'ok');
+  });
+
+  test('an empty stdout is unparseable', () => {
+    const v = classifyIdentityProbe({ stdout: '', exitCode: 0 });
+    assert.equal(v.reason, 'unparseable');
+  });
+
+  test('spawn failure short-circuits ahead of the payload', () => {
+    const spawnFailed = classifyIdentityProbe({ stdout: okStdout(), exitCode: 0, spawnFailed: true });
+    assert.equal(spawnFailed.reason, 'probe_failed');
+    const timedOut = classifyIdentityProbe({ stdout: okStdout(), exitCode: 0, timedOut: true });
+    assert.equal(timedOut.reason, 'probe_failed');
+  });
 });
 
 describe('buildIdentityPayload', () => {
@@ -624,4 +677,94 @@ describe('launcher preamble: identity assertion on a path-based branch (#3841)',
 
     assert.equal(r.stdout.includes(`CHILD=${IDENTITY_STATUS.OK}`), true, r.stdout);
   });
+});
+
+describe('shell preamble and classifier agree (cross-surface parity, #3841)', () => {
+  let dir;
+  let binDir;
+  let toolsDir;
+
+  const installFakeTool = (identityBody) => {
+    fs.writeFileSync(
+      path.join(toolsDir, 'gsd-tools.cjs'),
+      '#!/usr/bin/env node\n' +
+        'const a = process.argv.slice(2);\n' +
+        "if (a[0] === 'runtime-identity') { " + identityBody + ' }\n' +
+        "process.stdout.write('RAN:' + a.join(',') + '\\n');\n",
+      { mode: 0o755 },
+    );
+  };
+
+  const sourceAndReport = () => {
+    const harness = path.join(dir, 'harness.sh');
+    fs.writeFileSync(
+      harness,
+      '#!/bin/sh\n' +
+        `. "${SNIPPET}"\n` +
+        "printf 'STATUS=%s\\n' \"$GSD_IDENTITY_STATUS\"\n",
+      { mode: 0o755 },
+    );
+    return runHook(harness, [], {
+      interpreter: '/bin/sh',
+      cwd: dir,
+      timeoutMs: PROBE_TIMEOUT_MS,
+      env: { PATH: binDir, HOME: dir, RUNTIME_DIR: dir },
+    });
+  };
+
+  const skipOnWindows = (t) => {
+    if (process.platform !== 'win32') return false;
+    t.skip('POSIX shell preamble is not executed on Windows runtimes');
+    return true;
+  };
+
+  beforeEach(() => {
+    dir = createTempDir('gsd-3841-parity-');
+    binDir = path.join(dir, 'bin');
+    toolsDir = path.join(dir, 'gsd-core', 'bin');
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.mkdirSync(toolsDir, { recursive: true });
+    fs.symlinkSync(process.execPath, path.join(binDir, 'node'));
+  });
+
+  afterEach(() => cleanup(dir));
+
+  const matching = (extra = '') => `${IDENTITY_RAW_PREFIX},"version":"1.0.0"${extra}}`;
+  const foreign = '{"packageName":"get-shit-done-cc","version":"1.0.0"}';
+
+  const CASES = [
+    ['P1 payload matches, exit 0', matching(), 0, true],
+    ['P2 payload matches, exit 1', matching(), 1, true],
+    ['P3 foreign payload, exit 0', foreign, 0, false],
+    ['P4 foreign payload, exit 1', foreign, 1, false],
+    ['P5 predecessor usage text, exit 1', 'usage: gsd-tools <command>', 1, false],
+    [
+      'P6 decoy embeds expected name in another field, exit 0',
+      JSON.stringify({ packageName: 'get-shit-done-cc', note: EXPECTED_PACKAGE_NAME }),
+      0,
+      false,
+    ],
+    ['P7 truncated payload (no closing brace), exit 0', matching().slice(0, -1), 0, false],
+    ['P8 payload followed by trailing garbage, exit 0', `${matching()}\nextra`, 0, false],
+    ['P9 empty stdout, exit 0', '', 0, false],
+    ['P10 additive unknown key, exit 0', matching(',"extra":true'), 0, true],
+  ];
+
+  for (const [label, stdout, exitCode, verified] of CASES) {
+    test(label, (t) => {
+      if (skipOnWindows(t)) return;
+
+      installFakeTool(`process.stdout.write(${JSON.stringify(stdout)} + '\\n'); process.exit(${exitCode});`);
+      const r = sourceAndReport();
+      const shellStatus = r.stdout.split('\n').find((l) => l.startsWith('STATUS='))?.slice('STATUS='.length);
+
+      const verdict = classifyIdentityProbe({ stdout: `${stdout}\n`, exitCode });
+      const jsStatus = statusForVerdict(verdict);
+
+      const expectedStatus = verified ? IDENTITY_STATUS.OK : IDENTITY_STATUS.UNVERIFIED;
+      assert.equal(jsStatus, shellStatus, `classifier/shell disagree for: ${label}`);
+      assert.equal(jsStatus, expectedStatus, `classifier status wrong for: ${label}`);
+      assert.equal(shellStatus, expectedStatus, `shell status wrong for: ${label}`);
+    });
+  }
 });

--- a/tests/runtime-identity.test.cjs
+++ b/tests/runtime-identity.test.cjs
@@ -74,6 +74,13 @@ describe('classifyIdentityProbe', () => {
     assert.equal(v.reason, 'unparseable');
   });
 
+  test('an empty-string packageName is unparseable, not a match', () => {
+    // Distinct path from "no packageName key at all": the key is present and is
+    // a string, so only the `.length > 0` guard rejects it.
+    const v = classifyIdentityProbe({ stdout: '{"packageName":"","version":"1.0.0"}', exitCode: 0 });
+    assert.equal(v.reason, 'unparseable');
+  });
+
   // JSON.parse accepts all of these. A naive truthiness check would let `[]`
   // through as a verified identity.
   for (const [label, raw] of [
@@ -169,6 +176,24 @@ describe('classifyIdentityProbe', () => {
   test('rejects a decoy that embeds the expected name in another field', () => {
     const stdout = JSON.stringify({ packageName: 'get-shit-done-cc', note: EXPECTED_PACKAGE_NAME });
     assert.equal(classifyIdentityProbe({ stdout, exitCode: 0 }).reason, 'identity_mismatch');
+  });
+
+  // ── Anchor parity on the classifier itself (#3841) ──────────────────────
+  test('a payload that names this package but is not anchored does not verify', () => {
+    const stdout = `{"note":"x","packageName":"${EXPECTED_PACKAGE_NAME}","version":"1.0.0"}`;
+    const v = classifyIdentityProbe({ stdout, exitCode: 0 });
+    assert.equal(v.reason, 'unparseable');
+  });
+
+  test('leading whitespace breaks the anchor', () => {
+    const v = classifyIdentityProbe({ stdout: `  ${okStdout()}`, exitCode: 0 });
+    assert.equal(v.reason, 'unparseable');
+  });
+
+  test('a foreign packageName is a mismatch wherever it appears in the object', () => {
+    const stdout = '{"note":"x","packageName":"get-shit-done-cc"}';
+    const v = classifyIdentityProbe({ stdout, exitCode: 0 });
+    assert.equal(v.reason, 'identity_mismatch');
   });
 
   // ── Parse-before-exit-code (#3841) ──────────────────────────────────────
@@ -470,10 +495,37 @@ describe('IDENTITY_RAW_PREFIX — the anchor the shell matches on', () => {
   });
 });
 
-describe('launcher preamble: identity assertion on a path-based branch (#3841)', () => {
+const skipOnWindows = (t) => {
+  if (process.platform !== 'win32') return false;
+  t.skip('POSIX shell preamble is not executed on Windows runtimes');
+  return true;
+};
+
+/**
+ * Per-describe fixture for driving the REAL launcher preamble against a fake
+ * `gsd-tools`. Shared by the two describes below rather than retyped: they need
+ * the same temp tree (a `bin/` holding only a `node` symlink, plus
+ * `gsd-core/bin/gsd-tools.cjs`) and the same restricted-PATH invocation, and a
+ * second copy is a place for the two to drift apart.
+ *
+ * Returns handles rather than installing its own beforeEach/afterEach, so each
+ * describe keeps its own fresh state and its own lifecycle hooks.
+ */
+function makeIdentityFixture() {
   let dir;
   let binDir;
   let toolsDir;
+
+  const setup = () => {
+    dir = createTempDir('gsd-3841-identity-');
+    binDir = path.join(dir, 'bin');
+    toolsDir = path.join(dir, 'gsd-core', 'bin');
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.mkdirSync(toolsDir, { recursive: true });
+    fs.symlinkSync(process.execPath, path.join(binDir, 'node'));
+  };
+
+  const teardown = () => cleanup(dir);
 
   // Resolution here goes through the RUNTIME_DIR-local branch — the branch
   // #3831 could NOT make safe structurally, and therefore the one this
@@ -512,22 +564,17 @@ describe('launcher preamble: identity assertion on a path-based branch (#3841)',
     });
   };
 
-  const skipOnWindows = (t) => {
-    if (process.platform !== 'win32') return false;
-    t.skip('POSIX shell preamble is not executed on Windows runtimes');
-    return true;
-  };
+  return { setup, teardown, installFakeTool, sourceAndReport };
+}
 
-  beforeEach(() => {
-    dir = createTempDir('gsd-3841-identity-');
-    binDir = path.join(dir, 'bin');
-    toolsDir = path.join(dir, 'gsd-core', 'bin');
-    fs.mkdirSync(binDir, { recursive: true });
-    fs.mkdirSync(toolsDir, { recursive: true });
-    fs.symlinkSync(process.execPath, path.join(binDir, 'node'));
-  });
+describe('launcher preamble: identity assertion on a path-based branch (#3841)', () => {
+  const fx = makeIdentityFixture();
 
-  afterEach(() => cleanup(dir));
+  beforeEach(() => fx.setup());
+  afterEach(() => fx.teardown());
+
+  const installFakeTool = (identityBody) => fx.installFakeTool(identityBody);
+  const sourceAndReport = (extra = '') => fx.sourceAndReport(extra);
 
   const emit = (json) => `process.stdout.write(${JSON.stringify(json)} + '\\n'); process.exit(0);`;
 
@@ -680,54 +727,13 @@ describe('launcher preamble: identity assertion on a path-based branch (#3841)',
 });
 
 describe('shell preamble and classifier agree (cross-surface parity, #3841)', () => {
-  let dir;
-  let binDir;
-  let toolsDir;
+  const fx = makeIdentityFixture();
 
-  const installFakeTool = (identityBody) => {
-    fs.writeFileSync(
-      path.join(toolsDir, 'gsd-tools.cjs'),
-      '#!/usr/bin/env node\n' +
-        'const a = process.argv.slice(2);\n' +
-        "if (a[0] === 'runtime-identity') { " + identityBody + ' }\n' +
-        "process.stdout.write('RAN:' + a.join(',') + '\\n');\n",
-      { mode: 0o755 },
-    );
-  };
+  beforeEach(() => fx.setup());
+  afterEach(() => fx.teardown());
 
-  const sourceAndReport = () => {
-    const harness = path.join(dir, 'harness.sh');
-    fs.writeFileSync(
-      harness,
-      '#!/bin/sh\n' +
-        `. "${SNIPPET}"\n` +
-        "printf 'STATUS=%s\\n' \"$GSD_IDENTITY_STATUS\"\n",
-      { mode: 0o755 },
-    );
-    return runHook(harness, [], {
-      interpreter: '/bin/sh',
-      cwd: dir,
-      timeoutMs: PROBE_TIMEOUT_MS,
-      env: { PATH: binDir, HOME: dir, RUNTIME_DIR: dir },
-    });
-  };
-
-  const skipOnWindows = (t) => {
-    if (process.platform !== 'win32') return false;
-    t.skip('POSIX shell preamble is not executed on Windows runtimes');
-    return true;
-  };
-
-  beforeEach(() => {
-    dir = createTempDir('gsd-3841-parity-');
-    binDir = path.join(dir, 'bin');
-    toolsDir = path.join(dir, 'gsd-core', 'bin');
-    fs.mkdirSync(binDir, { recursive: true });
-    fs.mkdirSync(toolsDir, { recursive: true });
-    fs.symlinkSync(process.execPath, path.join(binDir, 'node'));
-  });
-
-  afterEach(() => cleanup(dir));
+  const installFakeTool = (identityBody) => fx.installFakeTool(identityBody);
+  const sourceAndReport = () => fx.sourceAndReport();
 
   const matching = (extra = '') => `${IDENTITY_RAW_PREFIX},"version":"1.0.0"${extra}}`;
   const foreign = '{"packageName":"get-shit-done-cc","version":"1.0.0"}';
@@ -748,6 +754,9 @@ describe('shell preamble and classifier agree (cross-surface parity, #3841)', ()
     ['P8 payload followed by trailing garbage, exit 0', `${matching()}\nextra`, 0, false],
     ['P9 empty stdout, exit 0', '', 0, false],
     ['P10 additive unknown key, exit 0', matching(',"extra":true'), 0, true],
+    ['P11 packageName present but not first, exit 0', `{"note":"x","packageName":"${EXPECTED_PACKAGE_NAME}","version":"1.0.0"}`, 0, false],
+    ['P12 leading whitespace before the payload, exit 0', `  ${matching()}`, 0, false],
+    ['P13 foreign packageName not first, exit 0', `{"note":"x","packageName":"get-shit-done-cc"}`, 0, false],
   ];
 
   for (const [label, stdout, exitCode, verified] of CASES) {


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3841

#3841 carries `approved-enhancement`, one of the three approval labels `auto-close-unsolicited-prs.yml:50` accepts. The defect is in the code that shipped for that issue, so it is the correct link.

---

## What was broken

`src/runtime-identity.cts` and `gsd-core/workflows/_runtime-launcher.snippet.sh` implement the *same decision* — "did the resolved tool prove it is us?" — and disagreed on two inputs. The module presents them as one vocabulary: `IDENTITY_STATUS` is documented as "the two-valued status the launcher preamble exports", `statusForVerdict` as "the only bridge between them".

## What this fix does

Makes them agree, and adds the parity test that keeps them agreeing.

## Root cause

Two separate ordering bugs, both measured against the real snippet rather than inferred.

**1. Exit code consulted before the payload.** `classifyIdentityProbe` returned early on any non-zero exit, before it ever parsed stdout. The shell reads stdout *only* — its command substitution discards the status.

| probe behavior | shell | classifier | |
|---|---|---|---|
| valid payload, **exit 1** | `ok` | `no_identity_verb` | **disagree** |
| valid payload, exit 0 | `ok` | `ok` | agree |
| valid payload + trailing line | `unverified` | `unparseable` | agree |

**2. Anchor not honored by the classifier** — found by the isolated security review, not by the design. The classifier parses structurally and so accepted `packageName` at any key position; the shell's `case` is anchored at the *start* of stdout. For `{"note":"x","packageName":"@opengsd/gsd-core",…}` the classifier said `ok` and the shell said `unverified` — a **fail-open** disagreement. All ten of the original parity rows put `packageName` first, so none of them caught it.

### Why this mattered now rather than later

`classifyIdentityProbe` has **zero production callers** today. The only non-test references are the module's own generated compilation. `cmdRuntimeIdentity` *is* wired (`gsd-core/bin/gsd-tools.cjs:1089`); the classifier is not — it is the engine for the announced warn-then-**fail** rollout.

That is precisely what made the divergence dangerous rather than academic. An install verified by today's warn phase would have been refused the moment hard-fail landed, and one the warn phase warns about would have been silently accepted — in the phase where those outcomes stop the run instead of printing a line. Nothing recorded the difference and no test would have caught it.

### Which surface moved, and why

**The classifier. Not the shell.** Hyrum's Law decided it: the shell is the shipped path with observable dependents, the classifier has none. Changing the shell would have flipped live behavior for anyone whose tool prints a valid payload and exits non-zero — and would have spent bytes from the preamble budget that is #3841's own stated blocker. No shell change means none of the 113 inlined copies move and no frozen ceiling is touched.

The exit-code rule was right for its stated reason and merely mis-ordered: the predecessor prints a usage screen and exits 1, which yields no parseable payload, so it still falls through to that branch untouched. The anchor check is scoped to the `ok` arm only — a foreign `packageName` stays `identity_mismatch` wherever it appears, since both surfaces already call that unverified.

## Testing

### How I verified the fix

Remote runner, green on the exact pushed sha. `npm run lint:ci` exit 0 across all 67 gates.

Red-before-green was proven by harnesses driving the real snippet and the built classifier: rows 10/11/14 and parity P2 failed pre-fix in the first round; P11 measured as shell `unverified` / classifier `ok` pre-fix in the second.

### Note on the red matrix run

The first attempt at the anchor fix was **wrong, and the matrix caught it** — 2/38185 failed, both in this file, one reporting `+ 'unparseable' - 'ok'`.

I had implemented it as a byte-prefix match against `IDENTITY_RAW_PREFIX`. That constant describes the **`--raw`** wire format, but `cmdRuntimeIdentity` without that flag pretty-prints at indent 2, and the classifier is handed *both* serializations — only the shell is restricted to `--raw`. The pre-existing test that runs the real verb with no flag went red.

No local gate could have caught it: `build:lib`, `eslint` and `lint:ci` were green throughout, because none of them execute tests, and every harness I wrote for red/green constructed compact payloads — mirroring the shell's input set rather than the classifier's. That is the same mistake at the design level: the behavior table enumerated what the shell sends and assumed the classifier saw the same set.

The anchor now reproduces its two properties **semantically** — the payload begins at the first byte of stdout, and `packageName` serializes first — both of which hold for either serialization. `IDENTITY_RAW_PREFIX` stays exported with its own tests; it is the shell's wire contract, not a general classifier predicate, and conflating the two was the error. Two rows added for the default serialization.

### Regression test added?

- [x] Yes — added a test that would have caught this bug

**The durable half is a cross-surface parity suite** — the `<known_defect_gauntlet>` requirement for two surfaces implementing one decision, which did not exist. Thirteen probe behaviors run through *both* the real `_runtime-launcher.snippet.sh` (sourced, not copied) and `classifyIdentityProbe`, asserting the two **agree with each other** independently of which is right, so a future drift fails regardless of direction:

P1 matching/exit 0 · **P2 matching/exit 1** · P3–P4 foreign · P5 predecessor usage screen · P6 the decoy · P7 truncated · P8 trailing garbage · P9 empty · P10 additive unknown key · **P11 `packageName` not first** · **P12 leading whitespace** · P13 foreign not-first.

Plus classifier rows for: non-zero exit with a matching payload, non-zero exit with a foreign payload, a signal-killed probe that still proved identity, empty stdout, an empty-string `packageName`, spawn/timeout short-circuiting ahead of the payload, and a regression pin looping the five shapes that must *stay* `no_identity_verb`.

### Platforms tested

- [x] macOS
- [x] Windows (including backslash path handling)
- [x] Linux

The POSIX preamble is not executed on Windows runtimes, so the shell-driven rows declare `t.skip()` with a reason there; the classifier rows are platform-neutral and run in the full matrix.

### Runtimes tested

- [x] N/A (not runtime-specific)

The preamble is shared shell, identical across runtimes by construction, and is unchanged here.

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue carries a maintainer-applied approval label (`approved-enhancement`)
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass — via the remote runner; local `npm test` is hook-blocked in this repo
- [x] `.changeset/` fragment added
- [x] No unnecessary dependencies added

## Review

Three engines. The Memtrace graph pass returned 0 issues.

The **isolated security review** produced the anchor-parity finding above — the most valuable result of the run, since it caught a parity suite that would have certified an agreement that did not hold. It also verified, empirically rather than by assumption, that `JSON.parse('{"__proto__":{…}}')` creates an own data property rather than reassigning a prototype, so `record.packageName` reads `undefined` and no pollution vector exists.

**Code review** (both axes, isolated) found three more, all fixed: the test matrix marked the empty-string `packageName` row as already covered when no such test existed; the changeset described only the exit-code half of the diff; and ~45 lines of fixture helpers were duplicated verbatim between two describes, now one `makeIdentityFixture()`.

One process note: the first Standards dispatch died on an API error mid-response and was re-run; the re-run is what is recorded.

## Provenance

Surfaced by re-running the feature-implementation directive's design and QA-architecture steps against the code merged in #3848, which shipped without them.

## Known limits

- **Neither surface defends against a deliberate impersonator.** A hostile tool emitting our exact anchored payload verifies on both, by design. The check distinguishes "us" from "something else that happened to be resolved", not "us" from an attacker. The parity suite is not a security boundary.
- **A signal-killed probe is still classified by its payload.** `exitCode: null` with a proving payload yields `ok`. Arguably closer to `probe_failed`, but the classifier cannot distinguish a signal kill from a shell reporting null without a signal field, and inventing that distinction would be guessing. The payload is the stronger evidence and is what the shell already uses.
- **The probe remains unbounded in the shell.** Previously recorded and unchanged: `lint-portable-timeout` is right that stock macOS ships neither `timeout` nor `gtimeout`, so the available remedies are worse than the exposure.
- **`classifyIdentityProbe` still has no production caller.** That is the announced rollout state, not an oversight — it is the fail-phase engine. This PR makes it agree with the surface that *is* live, so wiring it later is not a behavior change.

## Breaking changes

None observable. The classifier has no production caller, so no shipped behavior moves. The launcher preamble is byte-identical, so all 113 inlined copies are untouched.
