### PR TITLE
fix(#3704): rewrite fnm versioned node paths to the stable alias on macOS and Linux

### DIFF
--- a/.changeset/tidy-finches-dance.md
+++ b/.changeset/tidy-finches-dance.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**Managed hooks no longer bake a prunable fnm version path on macOS and Linux** — `normalizeNodePath` matched only fnm's shim, but Node resolves `process.execPath` through that symlink to the concrete `node-versions/<ver>/installation/bin/node` directory, so the branch never fired on POSIX and every managed hook was pinned to one Node version. `fnm uninstall` or fnm's own pruning then broke all of them. The versioned path now rewrites to the stable `aliases/default` path, matching how the Homebrew, mise and volta branches already behave. (#3704)

--- a/.changeset/tidy-finches-dance.md
+++ b/.changeset/tidy-finches-dance.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 3856
 ---
 **Managed hooks no longer bake a prunable fnm version path on macOS and Linux** — `normalizeNodePath` matched only fnm's shim, but Node resolves `process.execPath` through that symlink to the concrete `node-versions/<ver>/installation/bin/node` directory, so the branch never fired on POSIX and every managed hook was pinned to one Node version. `fnm uninstall` or fnm's own pruning then broke all of them. The versioned path now rewrites to the stable `aliases/default` path, matching how the Homebrew, mise and volta branches already behave. (#3704)

--- a/src/runtime-hooks-surface.cts
+++ b/src/runtime-hooks-surface.cts
@@ -390,6 +390,21 @@ interface NodeNormOpts {
   execPath?: string;
 }
 
+/**
+ * Normalize a directory that will be joined with `/…` — posix separators, no
+ * trailing slash. `FNM_DIR=/custom/fnm/` would otherwise bake
+ * `/custom/fnm//aliases/default/bin/node` (#3704 review). Cosmetic — `existsSync`
+ * resolves the doubled separator and every shell collapses it — but the value is
+ * written into a user's settings.json and read by humans.
+ *
+ * Shared by both fnm branches deliberately: they build the same alias paths from
+ * different roots, and a trim applied to only one is a difference with no reason
+ * behind it.
+ */
+function normalizeRootDir(dir: string): string {
+  return shellCmdProjection.posixNormalize(dir).replace(/\/+$/, '');
+}
+
 function normalizeNodePath(execPath: string, opts?: NodeNormOpts): string {
   if (!execPath) return execPath;
   const env = (opts && opts.env) || process.env;
@@ -404,11 +419,12 @@ function normalizeNodePath(execPath: string, opts?: NodeNormOpts): string {
   if (/\/fnm_multishells\/[0-9]+_[0-9]+\/(?:bin\/)?node(\.exe)?$/i.test(normalizedForMatch)) {
     const candidates: string[] = [];
     if (env.FNM_DIR) {
-      candidates.push(`${env.FNM_DIR}/aliases/default/node.exe`);
-      candidates.push(`${env.FNM_DIR}/aliases/default/bin/node`);
+      const fnmRoot = normalizeRootDir(env.FNM_DIR);
+      candidates.push(`${fnmRoot}/aliases/default/node.exe`);
+      candidates.push(`${fnmRoot}/aliases/default/bin/node`);
     }
     if (env.APPDATA) {
-      candidates.push(`${env.APPDATA}/fnm/aliases/default/node.exe`);
+      candidates.push(`${normalizeRootDir(env.APPDATA)}/fnm/aliases/default/node.exe`);
     }
     for (const candidate of candidates) {
       if (candidate && existsSync(candidate)) return candidate;
@@ -439,7 +455,7 @@ function normalizeNodePath(execPath: string, opts?: NodeNormOpts): string {
   if (fnmVersioned) {
     const isExe = Boolean(fnmVersioned[2]);
     const roots = [fnmVersioned[1]];
-    if (env.FNM_DIR) roots.push(shellCmdProjection.posixNormalize(env.FNM_DIR));
+    if (env.FNM_DIR) roots.push(normalizeRootDir(env.FNM_DIR));
     const fnmAliasCandidates: string[] = [];
     for (const root of roots) {
       // Probe the spelling matching the input first, then the other — a layout

--- a/src/runtime-hooks-surface.cts
+++ b/src/runtime-hooks-surface.cts
@@ -396,7 +396,12 @@ function normalizeNodePath(execPath: string, opts?: NodeNormOpts): string {
   const existsSync = (opts && opts.existsSync) || fs.existsSync;
 
   const normalizedForMatch = shellCmdProjection.posixNormalize(execPath);
-  if (/\/fnm_multishells\/[0-9]+_[0-9]+\/node(\.exe)?$/i.test(normalizedForMatch)) {
+  // #977: fnm's Windows shim IS `process.execPath` there — Windows does not
+  // realpath through it — so this branch stays. #3704 adds `(?:bin\/)?`: fnm's
+  // POSIX shim is `<multishell>/bin/node`, so the original pattern could not match
+  // it even when a caller hands one in explicitly (#3662's `execPath` option
+  // exists to do exactly that, normalizing a path from another environment).
+  if (/\/fnm_multishells\/[0-9]+_[0-9]+\/(?:bin\/)?node(\.exe)?$/i.test(normalizedForMatch)) {
     const candidates: string[] = [];
     if (env.FNM_DIR) {
       candidates.push(`${env.FNM_DIR}/aliases/default/node.exe`);
@@ -409,6 +414,42 @@ function normalizeNodePath(execPath: string, opts?: NodeNormOpts): string {
       if (candidate && existsSync(candidate)) return candidate;
     }
     return execPath;
+  }
+
+  // #3704: fnm pins a concrete version at
+  // <FNM_DIR>/node-versions/<ver>/installation/bin/node (Windows:
+  // .../installation/node.exe). On macOS/Linux this — not the shim above — is what
+  // `process.execPath` reports, because Node realpaths through
+  // `fnm_multishells`. So the shim branch above is unreachable on POSIX and the
+  // raw versioned path was baked into every managed hook: `fnm uninstall <ver>`,
+  // or fnm's own pruning, then 404s every hook — the ephemeral-path failure #977
+  // exists to prevent, and the same one #1619 (mise) and #2185 (Homebrew) fixed
+  // for their managers by matching the VERSIONED path rather than a shim.
+  //
+  // The stable alias is <FNM_DIR>/aliases/default/..., which fnm repoints on
+  // `fnm default`. Derive <FNM_DIR> from execPath first (#2185's rule — the path
+  // IS the install location, and FNM_DIR may be unset or point at a different
+  // install), keeping the env as a secondary candidate. Rewrite only when the
+  // alias exists; otherwise fall through to the raw execPath, exactly like the
+  // mise and volta branches, so a rewrite never turns a stale-but-working pin
+  // into an immediately broken one.
+  const fnmVersioned = normalizedForMatch.match(
+    /^(.*)\/node-versions\/[^/]+\/installation\/(?:bin\/)?node(\.exe)?$/i,
+  );
+  if (fnmVersioned) {
+    const isExe = Boolean(fnmVersioned[2]);
+    const roots = [fnmVersioned[1]];
+    if (env.FNM_DIR) roots.push(shellCmdProjection.posixNormalize(env.FNM_DIR));
+    const fnmAliasCandidates: string[] = [];
+    for (const root of roots) {
+      // Probe the spelling matching the input first, then the other — a layout
+      // is one or the other, and guessing wrong would skip a real alias.
+      const leaf = isExe ? ['node.exe', 'bin/node'] : ['bin/node', 'node.exe'];
+      for (const tail of leaf) fnmAliasCandidates.push(`${root}/aliases/default/${tail}`);
+    }
+    for (const candidate of fnmAliasCandidates) {
+      if (existsSync(candidate)) return candidate;
+    }
   }
 
   // Homebrew (macOS Intel /usr/local, Apple Silicon /opt/homebrew, Linuxbrew

--- a/tests/install.test.cjs
+++ b/tests/install.test.cjs
@@ -1925,6 +1925,136 @@ describe('normalizeNodePath — mise versioned path → sibling shim (#1619)', (
   });
 });
 
+// ─── normalizeNodePath — fnm versioned path → alias (#3704) ──────────────────
+//
+// Bug #3704: the POSIX half of #977. fnm's branch matched only the SHIM
+// (`<multishell>/node`), but on macOS/Linux `process.execPath` is never that —
+// Node realpaths through `fnm_multishells` to
+// `<FNM_DIR>/node-versions/<ver>/installation/bin/node`. Two independent reasons
+// the old pattern missed: the realpath above, and the `bin/` segment (fnm's POSIX
+// shim is `<multishell>/bin/node`, the pattern required `<multishell>/node`).
+//
+// Consequence: the raw versioned path was baked into every managed hook, so
+// `fnm uninstall <ver>` — or fnm's own pruning — 404s all of them. That is the
+// ephemeral-path failure #977 exists to prevent, already fixed for mise (#1619),
+// Homebrew (#2185) and volta (#2335) by matching the VERSIONED path.
+//
+// NOTE ON THE STUBS: each test grants existence to exactly ONE candidate, the one
+// its platform would really have. A stub that grants both `aliases/default/node.exe`
+// and `aliases/default/bin/node` does not test candidate ORDER, it hides it — no
+// real machine has both.
+describe('normalizeNodePath — fnm versioned path → alias (#3704)', () => {
+  const FNM = '/Users/u/.local/share/fnm';
+  const FNM_POSIX_PINNED = `${FNM}/node-versions/v22.22.0/installation/bin/node`;
+  const FNM_POSIX_ALIAS = `${FNM}/aliases/default/bin/node`;
+  const FNM_POSIX_SHIM = '/Users/u/.local/state/fnm_multishells/55303_1787205798690/bin/node';
+
+  const FNM_WIN = 'C:/Users/u/AppData/Roaming/fnm';
+  const FNM_WIN_PINNED = `${FNM_WIN}/node-versions/v22.22.0/installation/node.exe`;
+  const FNM_WIN_ALIAS = `${FNM_WIN}/aliases/default/node.exe`;
+  const FNM_WIN_SHIM = 'C:/Users/u/AppData/Local/fnm_multishells/1234_5678/node.exe';
+
+  test('POSIX versioned install path + alias exists → alias (the reported bug)', () => {
+    assert.equal(
+      normalizeNodePath(FNM_POSIX_PINNED, { env: {}, existsSync: p => p === FNM_POSIX_ALIAS }),
+      FNM_POSIX_ALIAS);
+  });
+
+  test('Windows versioned install path → aliases/default/node.exe (.exe preserved)', () => {
+    assert.equal(
+      normalizeNodePath(FNM_WIN_PINNED, { env: {}, existsSync: p => p === FNM_WIN_ALIAS }),
+      FNM_WIN_ALIAS);
+  });
+
+  test('backslash Windows path normalizes the same as forward-slash', () => {
+    assert.equal(
+      normalizeNodePath(FNM_WIN_PINNED.replace(/\//g, '\\'),
+        { env: {}, existsSync: p => p === FNM_WIN_ALIAS }),
+      FNM_WIN_ALIAS);
+  });
+
+  test('POSIX shim carries a bin/ segment and is now matched too', () => {
+    // Reason 2. This path never arrives as process.execPath on POSIX, but #3662's
+    // `execPath` option exists so a caller can normalize a path from another
+    // environment — and it could not match before.
+    assert.equal(
+      normalizeNodePath(FNM_POSIX_SHIM, { env: { FNM_DIR: FNM }, existsSync: p => p === FNM_POSIX_ALIAS }),
+      FNM_POSIX_ALIAS);
+  });
+
+  test('no regression (#977): the Windows shim still resolves through FNM_DIR', () => {
+    // The one fnm shape that already worked, and the one that is genuinely
+    // process.execPath on Windows — Windows does not realpath the shim away.
+    assert.equal(
+      normalizeNodePath(FNM_WIN_SHIM, { env: { FNM_DIR: FNM_WIN }, existsSync: p => p === FNM_WIN_ALIAS }),
+      FNM_WIN_ALIAS);
+  });
+
+  test('FNM_DIR unset → root derived from execPath (#2185 rule)', () => {
+    assert.equal(
+      normalizeNodePath(FNM_POSIX_PINNED, { env: {}, existsSync: p => p === FNM_POSIX_ALIAS }),
+      FNM_POSIX_ALIAS);
+  });
+
+  test('FNM_DIR pointing at a different install → the path-derived root wins', () => {
+    const other = '/opt/other-fnm';
+    assert.equal(
+      normalizeNodePath(FNM_POSIX_PINNED, {
+        env: { FNM_DIR: other },
+        // BOTH aliases exist; the one belonging to the path must be chosen.
+        existsSync: p => p === FNM_POSIX_ALIAS || p === `${other}/aliases/default/bin/node`,
+      }),
+      FNM_POSIX_ALIAS);
+  });
+
+  test('no regression: alias absent → falls back to raw execPath unchanged', () => {
+    // Rewriting to an alias that is not there would turn a stale-but-working pin
+    // into an immediately broken one — worse than the bug.
+    assert.equal(
+      normalizeNodePath(FNM_POSIX_PINNED, { env: {}, existsSync: () => false }),
+      FNM_POSIX_PINNED);
+    assert.equal(
+      normalizeNodePath(FNM_POSIX_SHIM, { env: { FNM_DIR: FNM }, existsSync: () => false }),
+      FNM_POSIX_SHIM);
+  });
+
+  test('a non-fnm path containing node-versions is left unchanged', () => {
+    for (const foreign of [
+      '/opt/custom/node-versions/v1/bin/node',
+      '/srv/node-versions/v22/installation-notes/bin/node', // `installation` must be a whole segment
+    ]) {
+      assert.equal(
+        normalizeNodePath(foreign, { env: {}, existsSync: () => true }),
+        foreign,
+        `${foreign} is not an fnm layout`);
+    }
+  });
+
+  test('sibling managers are untouched by the fnm branch', () => {
+    const cases = [
+      ['/Users/u/.local/share/mise/installs/node/22.1.0/bin/node', '/Users/u/.local/share/mise/shims/node'],
+      ['/Users/u/.volta/tools/image/node/22.1.0/bin/node', '/Users/u/.volta/bin/node'],
+      ['/opt/homebrew/Cellar/node/26.7.0/bin/node', '/opt/homebrew/bin/node'],
+    ];
+    for (const [input, expected] of cases) {
+      assert.equal(
+        normalizeNodePath(input, { env: { FNM_DIR: FNM }, existsSync: p => p === expected }),
+        expected,
+        `${input} must still resolve through its own manager's branch`);
+    }
+  });
+
+  test('the rewrite is always an absolute path, never a bare node (#3022/#3002)', () => {
+    const out = normalizeNodePath(FNM_POSIX_PINNED, { env: {}, existsSync: () => true });
+    assert.ok(out.includes('/'), `expected an absolute path, got ${out}`);
+    assert.notEqual(out, 'node');
+  });
+
+  test('empty execPath is returned unchanged without throwing', () => {
+    assert.equal(normalizeNodePath('', { env: {}, existsSync: () => true }), '');
+  });
+});
+
 // ─── normalizeNodePath — volta versioned image path → stable shim (#2335) ────
 //
 // Bug #2335: the volta analog of #977 (fnm) / #1619 (mise) / #2185 (Homebrew).

--- a/tests/install.test.cjs
+++ b/tests/install.test.cjs
@@ -2050,6 +2050,37 @@ describe('normalizeNodePath — fnm versioned path → alias (#3704)', () => {
     assert.notEqual(out, 'node');
   });
 
+  test('a trailing slash on FNM_DIR does not bake a doubled separator', () => {
+    // Review finding (minor). Cosmetic only — existsSync resolves `//` and shells
+    // collapse it — but the value is written into a user's settings.json.
+    const alias = `${FNM}/aliases/default/bin/node`;
+    assert.equal(
+      normalizeNodePath(FNM_POSIX_SHIM, {
+        env: { FNM_DIR: `${FNM}/` },
+        // Exact match, deliberately: a stub that collapses a doubled separator
+      // before comparing would pass whether or not the trim happened.
+      existsSync: p => p === alias,
+      }),
+      alias);
+  });
+
+  test('a trailing slash is trimmed on every fnm root, not just one branch', () => {
+    // One shared normalizeRootDir, three call sites — the versioned branch, the
+    // shim branch's FNM_DIR, and its APPDATA fallback.
+    const aliasBin = `${FNM}/aliases/default/bin/node`;
+    assert.equal(
+      normalizeNodePath('/nowhere/node-versions/v1/installation/bin/node',
+        { env: { FNM_DIR: `${FNM}//` }, existsSync: p => p === aliasBin }),
+      aliasBin,
+      'versioned branch');
+    const winAlias = 'C:/Users/u/AppData/Roaming/fnm/aliases/default/node.exe';
+    assert.equal(
+      normalizeNodePath('C:/x/fnm_multishells/1_2/node.exe',
+        { env: { APPDATA: 'C:/Users/u/AppData/Roaming/' }, existsSync: p => p === winAlias }),
+      winAlias,
+      'APPDATA fallback');
+  });
+
   test('empty execPath is returned unchanged without throwing', () => {
     assert.equal(normalizeNodePath('', { env: {}, existsSync: () => true }), '');
   });


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #3704

---

## What was broken

`normalizeNodePath()` decides which Node interpreter gets baked into every managed hook command. Its
fnm branch matched only the **shim**:

```js
/\/fnm_multishells\/[0-9]+_[0-9]+\/node(\.exe)?$/i
```

On macOS and Linux `process.execPath` is never that path — Node realpaths through the
`fnm_multishells` symlink to `<FNM_DIR>/node-versions/<ver>/installation/bin/node`. So the branch
could not fire, and the raw versioned path was baked into all 13 managed hooks.

`fnm uninstall <ver>`, or fnm's own pruning, then deletes that directory and every hook 404s — the
exact ephemeral-path failure #977 exists to prevent. It also silently defeats a Node upgrade: after
moving the fnm default to v24 the guards still ran on v22, while the package declares
`engines.node: >=24.0.0`. A re-run of the installer does not heal an already-baked `settings.json`.

## Root cause

Two independent reasons the pattern missed on POSIX:

1. **The realpath.** `which node` is `…/fnm_multishells/<pid>_<ts>/bin/node`, but `process.execPath`
   is `…/node-versions/<ver>/installation/bin/node`.
2. **The `bin/` segment.** fnm's POSIX shim is `<multishell>/bin/node`; the pattern required
   `<multishell>/node`.

The three sibling branches all match the **versioned install path** instead — Homebrew (#2185),
mise (#1619), volta (#2335) — and mise's own comment states the mechanism verbatim: *"Node realpaths
`process.execPath` to that versioned path, and `mise up` prunes old versions, so a baked hook command
404s after any node bump — the same ephemeral-path failure #977 fixed for fnm."* That is exactly what
the fnm branch did not do. #977 was scoped to Windows, where the shim genuinely *is* `execPath`, so
the POSIX form was never covered.

Driving the function directly showed the branch fires on **one of four** fnm shapes:

| Input | Before | After |
|---|---|---|
| `…/node-versions/<ver>/installation/bin/node` (what POSIX `execPath` really is) | unchanged | `…/aliases/default/bin/node` |
| `…/fnm_multishells/<pid>_<ts>/bin/node` (POSIX shim) | unchanged | `…/aliases/default/bin/node` |
| `…/node-versions/<ver>/installation/node.exe` (Windows versioned) | unchanged | `…/aliases/default/node.exe` |
| `…/fnm_multishells/<pid>_<ts>/node.exe` (Windows shim, #977) | rewritten ✅ | unchanged ✅ |
| mise / volta / Homebrew (controls) | rewritten ✅ | unchanged ✅ |

## What this fix does

Adds a versioned-path branch mirroring the mise/volta shape, and widens the shim pattern by
`(?:bin/)?` to close reason 2. The fnm root is derived **from the matched path first** (#2185's rule —
"the path IS the install location"), with `FNM_DIR` as a secondary candidate, and the rewrite happens
only when the alias exists — otherwise the raw `execPath` is returned unchanged, exactly as every
sibling branch does. Rewriting to an alias that is not there would turn a stale-but-working pin into
an immediately broken one.

The result is always an absolute alias path, never a bare `node` (#3022 / #3002).

## Testing

**Failing-first.** Tests committed alone at `b59acd52`: `outcome: "failed"`,
`38195 passed / 7 failed / 38202`. **Seven of the thirteen** fail against unmodified code — every case
that reaches the versioned path (POSIX, Windows, backslash-normalized, `FNM_DIR` unset, `FNM_DIR`
pointing elsewhere) plus the POSIX shim's `bin/` gap. The remaining six are controls that already
passed: #977's Windows shim, the three sibling managers, the alias-absent fallback, the non-fnm
paths, the never-bare-`node` assertion and the empty-input case.

**Green.** See the verdict recorded on the shipped commit.

Fifteen shapes covered, including the negative space that constrains the fix:

- **#977's Windows shim must not regress** — it is the one fnm shape that worked, and on Windows the
  shim really is `execPath`.
- **mise, volta and Homebrew untouched** — asserted explicitly, since the new branch is inserted
  before them.
- **Alias absent → raw `execPath`**, for both the versioned and shim paths.
- **`FNM_DIR` unset** still rewrites (root derived from the path); **`FNM_DIR` pointing at a different
  install** loses to the path-derived root.
- A non-fnm path containing `node-versions`, and `…/installation-notes/…`, are left alone —
  `installation` must be a whole segment.
- Backslash Windows paths normalize identically.

**A note recorded in the test block**, because the trap is easy to repeat: an existence stub that
grants *both* `aliases/default/node.exe` and `aliases/default/bin/node` does not test candidate order,
it hides it — no real machine has both. A first pass used such a stub and produced two false failures.
Each test now grants exactly the one candidate its platform would really have.

### Regression test added?

- [x] Yes

### Platforms tested

- [x] Linux (remote runner)
- [x] Windows layouts covered as **path-shape** cases (`node.exe`, backslash normalization) rather than
      by running on Windows — this function is pure string/predicate logic with both filesystem and
      env access injected, so the platform is an input rather than an environment
- [x] macOS — the reported environment; the POSIX shapes are the subject of the fix

### Runtimes tested

- [x] N/A (installer/hook-baking surface, not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #3704`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug
- [x] Regression test added
- [x] All existing tests pass (remote runner)
- [x] `.changeset/` fragment added
- [x] No unnecessary dependencies added

## Breaking changes

None. The change only affects fnm paths that previously fell through unrewritten, and only when the
alias target actually exists. Every other manager, and fnm's Windows shim, behave exactly as before —
each pinned by a test.
