### PR TITLE
fix(#3842): recover ack paths from pull requests past the per-PR file cap

### DIFF
--- a/.changeset/tidy-hawks-roar.md
+++ b/.changeset/tidy-hawks-roar.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**A fully-spent ack fragment is no longer swept out from under an open pull request that changes more than 100 files** — `gh pr list --json files` truncates each PR file list at 100, so the fragment read as untouched and deleting it handed that PR the modify/delete conflict the staged sweep exists to prevent. (#3842)

--- a/.changeset/tidy-hawks-roar.md
+++ b/.changeset/tidy-hawks-roar.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 3857
 ---
 **A fully-spent ack fragment is no longer swept out from under an open pull request that changes more than 100 files** — `gh pr list --json files` truncates each PR file list at 100, so the fragment read as untouched and deleting it handed that PR the modify/delete conflict the staged sweep exists to prevent. (#3842)

--- a/scripts/lint-emitted-drift-ack.cjs
+++ b/scripts/lint-emitted-drift-ack.cjs
@@ -702,9 +702,14 @@ function fetchOpenPrTouchedAckPaths({ cwd = REPO_ROOT, execGh = execGhDefault, l
     // `>=`, never `>`: a PR with exactly MAX_PR_FILES files is byte-identical,
     // in this response, to one with four thousand truncated to MAX_PR_FILES.
     // The only safe reading of "at the cap" is "possibly incomplete".
-    const paths = files.length >= MAX_PR_FILES
-      ? fetchPrFiles(pr.number, { cwd, execGh })
-      : files.map((file) => (isPlainObject(file) ? file.path : file));
+    let paths;
+    if (files.length >= MAX_PR_FILES) {
+      // Second round trip, and the only one in this function. Deliberately not
+      // taken for the common case -- see this function's doc comment.
+      paths = fetchPrFiles(pr.number, { cwd, execGh });
+    } else {
+      paths = files.map((file) => (isPlainObject(file) ? file.path : file));
+    }
     for (const filePath of paths) {
       if (typeof filePath === 'string' && filePath.startsWith(`${ACK_DIR_REPO_PATH}/`)) {
         touched.add(filePath);

--- a/scripts/lint-emitted-drift-ack.cjs
+++ b/scripts/lint-emitted-drift-ack.cjs
@@ -573,6 +573,33 @@ const MAX_OPEN_PRS = 200;
 const GH_TIMEOUT_MS = 20_000;
 
 /**
+ * Upper bound on how many files `gh pr list --json files` reports for ANY ONE
+ * pull request. gh requests a single page of GitHub's file connection, so a PR
+ * touching more than this comes back SILENTLY TRUNCATED — the response carries
+ * no "there is more" flag.
+ *
+ * Measured against PR #3848 (2026-08-25): 124 files changed, 100 returned, and
+ * ZERO of the returned paths under `tests/`, because the list stops mid
+ * `gsd-core/workflows/` which sorts before it. Every ack fragment in that PR was
+ * invisible to the filter below — so the sweep would have deleted it and handed
+ * the PR a modify/delete conflict, the exact failure #3842 exists to prevent,
+ * one level down from the MAX_OPEN_PRS guard that already states this reasoning.
+ *
+ * Reachable rather than theoretical: the launcher preamble is inlined into 113
+ * shipped files, so every preamble change is a >100-file PR, and those are among
+ * the likeliest to carry an ack fragment.
+ */
+const MAX_PR_FILES = 100;
+
+/**
+ * GitHub will not enumerate more than this many files for one pull request on
+ * ANY route, paginated included. A PR past it cannot be answered completely, so
+ * it throws rather than returning a set quietly missing paths — the same rule,
+ * and the same reason, as MAX_OPEN_PRS.
+ */
+const GITHUB_MAX_PR_FILES = 3000;
+
+/**
  * Default `execGh` for `fetchOpenPrTouchedAckPaths` — a real `gh` invocation. Kept as a
  * separate, swappable function (rather than inlined) so tests can inject a stub instead
  * of shelling out to a real, authenticated `gh` — which is unavailable, and would be
@@ -589,6 +616,38 @@ function execGhDefault(args, { cwd = REPO_ROOT } = {}) {
 }
 
 /**
+ * Every changed path for ONE pull request, via the paginated REST endpoint.
+ *
+ * `gh pr list --json files` and `gh pr view --json files` both cap at
+ * MAX_PR_FILES; only `gh api … --paginate` walks the whole set. Verified against
+ * PR #3848: 124 paths, including the two under `tests/` that the capped route
+ * dropped. `{owner}` and `{repo}` are gh's own placeholders, resolved from the
+ * repository in `cwd`, so this needs no nwo plumbing.
+ *
+ * Throws on anything it cannot answer completely — the caller turns that into
+ * the `'unknown'` sentinel that holds every fragment, which is the whole
+ * fail-closed contract of this seam.
+ */
+function fetchPrFiles(number, { cwd = REPO_ROOT, execGh = execGhDefault } = {}) {
+  const stdout = execGh(
+    ['api', `repos/{owner}/{repo}/pulls/${number}/files`, '--paginate', '--jq', '.[].filename'],
+    { cwd },
+  );
+  const files = String(stdout)
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line !== '');
+  if (files.length >= GITHUB_MAX_PR_FILES) {
+    throw new Error(
+      `fetchPrFiles: pull request #${number} reported ${files.length} files, at or above `
+      + `GitHub's own per-PR ceiling of ${GITHUB_MAX_PR_FILES}. Refusing to reason about a list `
+      + 'that may still be incomplete.',
+    );
+  }
+  return files;
+}
+
+/**
  * The set of `tests/emitted-drift-acks/*.json` repo-relative paths touched by at least
  * one currently-OPEN pull request (#3842).
  *
@@ -596,7 +655,10 @@ function execGhDefault(args, { cwd = REPO_ROOT } = {}) {
  * list in a single round trip, never one call per PR — intersected against the fragment
  * directory prefix. This is the "one `gh` API call" the issue itself proposes: cheap
  * enough to run on every push to `next` without meaningfully growing the guard job's
- * budget.
+ * budget. A PR whose file list lands AT `MAX_PR_FILES` earns exactly one additional
+ * paginated `gh api` call to re-fetch its full list (#3842) — because `gh pr list`
+ * silently truncates there, "at the cap" and "truncated" are indistinguishable from
+ * this response alone, so every such PR must be re-checked rather than trusted.
  *
  * Throws (never degrades to an empty set) when: `gh` itself fails (auth, network, rate
  * limit), the output is not parseable JSON, is not an array, or reaches the `MAX_OPEN_PRS`
@@ -637,8 +699,13 @@ function fetchOpenPrTouchedAckPaths({ cwd = REPO_ROOT, execGh = execGhDefault, l
   const touched = new Set();
   for (const pr of prs) {
     const files = Array.isArray(pr?.files) ? pr.files : [];
-    for (const file of files) {
-      const filePath = isPlainObject(file) ? file.path : file;
+    // `>=`, never `>`: a PR with exactly MAX_PR_FILES files is byte-identical,
+    // in this response, to one with four thousand truncated to MAX_PR_FILES.
+    // The only safe reading of "at the cap" is "possibly incomplete".
+    const paths = files.length >= MAX_PR_FILES
+      ? fetchPrFiles(pr.number, { cwd, execGh })
+      : files.map((file) => (isPlainObject(file) ? file.path : file));
+    for (const filePath of paths) {
       if (typeof filePath === 'string' && filePath.startsWith(`${ACK_DIR_REPO_PATH}/`)) {
         touched.add(filePath);
       }
@@ -803,7 +870,10 @@ module.exports = {
   assertUsableBaseRef,
   GIT_TIMEOUT_MS,
   fetchOpenPrTouchedAckPaths,
+  fetchPrFiles,
   MAX_OPEN_PRS,
+  MAX_PR_FILES,
+  GITHUB_MAX_PR_FILES,
   GH_TIMEOUT_MS,
   runGuardNext,
 };

--- a/tests/emitted-attribution.test.cjs
+++ b/tests/emitted-attribution.test.cjs
@@ -88,6 +88,8 @@ const {
   assertUsableBaseRef,
   fetchOpenPrTouchedAckPaths,
   MAX_OPEN_PRS,
+  MAX_PR_FILES,
+  GITHUB_MAX_PR_FILES,
   runGuardNext,
 } = require('../scripts/lint-emitted-drift-ack.cjs');
 const {
@@ -4472,6 +4474,113 @@ describe('#3842: fetchOpenPrTouchedAckPaths', () => {
     assert.equal(paths.has(`${ACK_DIR_REPO_PATH}/x.json`), true);
     assert.equal(paths.size, 1);
   });
+
+  // `gh pr list --json files` truncates each PR's own file list at MAX_PR_FILES, silently
+  // (#3842, PR #3848: 124 files changed, 100 returned, none of the two ack paths among
+  // them because the list stops mid `gsd-core/workflows/`, which sorts before `tests/`).
+  // A PR AT the cap is answered with one additional paginated `gh api` call; below the
+  // cap, the single `gh pr list` call is trusted as-is.
+  const filler = (n) => Array.from(
+    { length: n },
+    (_, i) => ({ path: `gsd-core/workflows/w${String(i).padStart(4, '0')}.md` }),
+  );
+
+  test('a sub-cap PR is answered by the single list call', () => {
+    const files = filler(MAX_PR_FILES - 2).concat([{ path: `${ACK_DIR_REPO_PATH}/a.json` }]);
+    const stdout = JSON.stringify([{ number: 1, files }]);
+    let calls = 0;
+    const paths = fetchOpenPrTouchedAckPaths({ execGh: () => { calls += 1; return stdout; } });
+    assert.equal(calls, 1);
+    assert.equal(paths.has(`${ACK_DIR_REPO_PATH}/a.json`), true);
+  });
+
+  test('a PR at the file cap is re-fetched, because full and truncated look identical', () => {
+    const files = filler(MAX_PR_FILES);
+    const stdout = JSON.stringify([{ number: 77, files }]);
+    const paths = fetchOpenPrTouchedAckPaths({
+      execGh: (args) => (args[0] === 'pr' ? stdout : `${ACK_DIR_REPO_PATH}/a.json\n`),
+    });
+    assert.equal(paths.has(`${ACK_DIR_REPO_PATH}/a.json`), true);
+  });
+
+  test('a PR past the file cap has its ack path recovered by the re-fetch', () => {
+    const files = filler(MAX_PR_FILES + 1);
+    const stdout = JSON.stringify([{ number: 77, files }]);
+    const paths = fetchOpenPrTouchedAckPaths({
+      execGh: (args) => (args[0] === 'pr' ? stdout : `${ACK_DIR_REPO_PATH}/a.json\n`),
+    });
+    assert.equal(paths.has(`${ACK_DIR_REPO_PATH}/a.json`), true);
+  });
+
+  test('the re-fetch asks the paginated REST endpoint for that PR', () => {
+    const files = filler(MAX_PR_FILES);
+    const stdout = JSON.stringify([{ number: 77, files }]);
+    let capturedArgs;
+    fetchOpenPrTouchedAckPaths({
+      execGh: (args) => {
+        if (args[0] === 'pr') return stdout;
+        capturedArgs = args;
+        return '';
+      },
+    });
+    assert.ok(capturedArgs.includes('api'));
+    assert.ok(capturedArgs.includes('repos/{owner}/{repo}/pulls/77/files'));
+    assert.ok(capturedArgs.includes('--paginate'));
+  });
+
+  test('a failed re-fetch throws rather than trusting the truncated list', () => {
+    const files = filler(MAX_PR_FILES);
+    const stdout = JSON.stringify([{ number: 77, files }]);
+    assert.throws(() => fetchOpenPrTouchedAckPaths({
+      execGh: (args) => {
+        if (args[0] === 'pr') return stdout;
+        throw new Error('gh: rate limited');
+      },
+    }));
+  });
+
+  test("a PR beyond GitHub's own file ceiling throws rather than returning a partial set", () => {
+    const files = filler(MAX_PR_FILES);
+    const stdout = JSON.stringify([{ number: 77, files }]);
+    const apiOut = Array.from(
+      { length: GITHUB_MAX_PR_FILES },
+      (_, i) => `gsd-core/workflows/w${i}.md`,
+    ).join('\n');
+    assert.throws(() => fetchOpenPrTouchedAckPaths({
+      execGh: (args) => (args[0] === 'pr' ? stdout : apiOut),
+    }));
+  });
+
+  test('a re-fetched PR that touches no fragment contributes nothing', () => {
+    const files = filler(MAX_PR_FILES);
+    const stdout = JSON.stringify([{ number: 77, files }]);
+    const apiOut = filler(MAX_PR_FILES + 5).map((f) => f.path).join('\n');
+    const paths = fetchOpenPrTouchedAckPaths({
+      execGh: (args) => (args[0] === 'pr' ? stdout : apiOut),
+    });
+    assert.equal(paths.size, 0);
+  });
+
+  test('each capped PR is re-fetched independently', () => {
+    const cappedFiles = filler(MAX_PR_FILES);
+    const subCapFiles = filler(MAX_PR_FILES - 1);
+    const stdout = JSON.stringify([
+      { number: 1, files: cappedFiles },
+      { number: 2, files: cappedFiles },
+      { number: 3, files: subCapFiles },
+    ]);
+    let apiCalls = 0;
+    const paths = fetchOpenPrTouchedAckPaths({
+      execGh: (args) => {
+        if (args[0] === 'pr') return stdout;
+        apiCalls += 1;
+        const prNumber = args[1].match(/pulls\/(\d+)\/files/)[1];
+        return prNumber === '2' ? `${ACK_DIR_REPO_PATH}/a.json\n` : 'gsd-core/workflows/w0000.md\n';
+      },
+    });
+    assert.equal(apiCalls, 2);
+    assert.deepEqual([...paths], [`${ACK_DIR_REPO_PATH}/a.json`]);
+  });
 });
 
 describe('#3842: runGuardNext wires --defer-to-open-prs end to end against a real repo', () => {
@@ -4532,6 +4641,27 @@ describe('#3842: runGuardNext wires --defer-to-open-prs end to end against a rea
       });
       assert.ok(result.ok, 'an unverifiable open-PR set must hold rather than sweep');
       assert.ok(result.lines.some((l) => l.includes('gh: rate limited')));
+      assert.ok(result.lines.some((l) => l.includes('open-PR check unavailable')));
+    } finally {
+      cleanup(repo.dir);
+    }
+  });
+
+  test('a re-fetch failure degrades to the unknown sentinel, not to an empty set', () => {
+    const repo = makeGuardNextRepo();
+    try {
+      repo.writeFrag('a.json', { version: ACK_VERSION, paths: { 'x.md': { reason: 'why' } } });
+      const c2 = repo.commit('add fragment');
+      fs.writeFileSync(path.join(repo.dir, 'README.md'), 'unrelated\n');
+      repo.commit('unrelated change');
+
+      const result = runGuardNext({
+        argv: ['node', 'script', '--guard-next', '--base-ref', c2, '--defer-to-open-prs'],
+        cwd: repo.dir,
+        fetchOpenPrPaths: () => { throw new Error('fetchPrFiles: PR #77 re-fetch failed'); },
+      });
+      assert.ok(result.ok, 'an unverifiable open-PR set must hold rather than sweep');
+      assert.ok(result.lines.some((l) => l.includes('a.json') && l.includes('held')));
       assert.ok(result.lines.some((l) => l.includes('open-PR check unavailable')));
     } finally {
       cleanup(repo.dir);

--- a/tests/emitted-attribution.test.cjs
+++ b/tests/emitted-attribution.test.cjs
@@ -4551,6 +4551,38 @@ describe('#3842: fetchOpenPrTouchedAckPaths', () => {
     }));
   });
 
+  // Boundary coverage at GitHub's own file ceiling: limit-1, limit, limit+1.
+  // (limit is the test immediately above.)
+  test("boundary: a re-fetch just under GitHub's file ceiling is accepted", () => {
+    const files = filler(MAX_PR_FILES);
+    const stdout = JSON.stringify([{ number: 77, files }]);
+    const paths = Array.from(
+      { length: GITHUB_MAX_PR_FILES - 1 },
+      (_, i) => `gsd-core/workflows/w${i}.md`,
+    );
+    paths[0] = `${ACK_DIR_REPO_PATH}/a.json`;
+    const apiOut = paths.join('\n');
+    let result;
+    assert.doesNotThrow(() => {
+      result = fetchOpenPrTouchedAckPaths({
+        execGh: (args) => (args[0] === 'pr' ? stdout : apiOut),
+      });
+    });
+    assert.equal(result.has(`${ACK_DIR_REPO_PATH}/a.json`), true);
+  });
+
+  test('boundary: a re-fetch one past GitHub\'s file ceiling also throws', () => {
+    const files = filler(MAX_PR_FILES);
+    const stdout = JSON.stringify([{ number: 77, files }]);
+    const apiOut = Array.from(
+      { length: GITHUB_MAX_PR_FILES + 1 },
+      (_, i) => `gsd-core/workflows/w${i}.md`,
+    ).join('\n');
+    assert.throws(() => fetchOpenPrTouchedAckPaths({
+      execGh: (args) => (args[0] === 'pr' ? stdout : apiOut),
+    }));
+  });
+
   test('a re-fetched PR that touches no fragment contributes nothing', () => {
     const files = filler(MAX_PR_FILES);
     const stdout = JSON.stringify([{ number: 77, files }]);


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3842

#3842 carries `approved-enhancement`, one of the three approval labels `auto-close-unsolicited-prs.yml:50` accepts. The defect is in the code that shipped for that issue, so it is the correct link.

---

## What was broken

The staged sweep from #3847 held back any fully-spent ack fragment an open PR still touched — **except when that PR changed more than 100 files**, which is exactly the population it most needed to protect.

## What this fix does

Recovers the full file list for those PRs, so the fragment is seen as touched and held.

## Root cause

`fetchOpenPrTouchedAckPaths` learns which paths open PRs touch from one call:

```
gh pr list --state open --json number,files --limit N
```

**That call truncates every PR's file list at 100, with no flag on the response saying so.** Measured against PR #3848:

| | #3848 |
|---|---|
| files actually changed (`git show --stat`) | **124** |
| files returned by `gh pr list --json files` | **100** |
| `tests/` paths in the returned list | **0** |
| `tests/` paths actually changed | **2** |

The list stops mid-`gsd-core/workflows/`, which sorts alphabetically *before* `tests/`. Every `tests/emitted-drift-acks/*.json` path in that PR is invisible to the filter — so the fragment reads as untouched, is classified sweepable, and gets `git rm`'d, handing that PR a modify/delete conflict on its next merge attempt.

That is the exact failure #3842 was created to prevent, reintroduced one level down. The function already guards the *other* truncation at this seam, and says why:

> *"Refusing to reason about a possibly-truncated list — a fragment touched only by a PR past the cap would look untouched and be swept anyway."*

Correct, and applied to `prs.length >= limit`. It was never applied to `pr.files.length`. Same sentence, one level down.

**Reachable, not theoretical.** The launcher preamble is inlined into 113 shipped files, so *every* preamble change is a >100-file PR — #3848 is one. Those are also among the likeliest PRs to carry an ack fragment, because they are precisely what moves emitted artifacts.

## The fix

The single cheap call stays the common case. A PR whose returned list is **at or above** the cap earns one paginated `gh api repos/{owner}/{repo}/pulls/<n>/files --paginate`, verified to return all 124 paths for #3848 including both under `tests/`.

`>=`, not `>`: a PR with exactly 100 files is byte-identical, in that response, to one with four thousand truncated to 100. The only safe reading of "at the cap" is "possibly incomplete".

A failed re-fetch throws, reaching `runGuardNext`'s existing catch and becoming the `unknown` sentinel that holds every fragment — rather than falling back to the truncated list. Fail-closed, matching the `MAX_OPEN_PRS` precedent it is modelled on.

## Testing

### How I verified the fix

Remote runner, green on the exact pushed sha. `npm run lint:ci` exit 0 across all 67 gates. `node scripts/lint-emitted-drift-ack.cjs` (the plain lint lane) still exits 0.

Red-before-green proven by harnesses against the real module with injected `execGh` stubs: the at-cap and past-cap PRs' ack paths were absent from the returned Set, and no throw occurred on a failed or oversized re-fetch, because no re-fetch existed.

### Regression test added?

- [x] Yes — added a test that would have caught this bug

Eleven new tests. Both limits carry a full `limit-1 / limit / limit+1` set:

- **`MAX_PR_FILES`** — 99 files answered by the single call (asserting *exactly one* `execGh` invocation, which is how the "one cheap call" property is actually proven); exactly 100 triggers the re-fetch; 101+ recovers the ack path from it.
- **`GITHUB_MAX_PR_FILES`** — one under is accepted and recovers the path; at and one over both throw.

Plus: the re-fetch's argv (`api`, `repos/{owner}/{repo}/pulls/<n>/files`, `--paginate`); a failed re-fetch throws rather than trusting the truncated list; a re-fetched PR touching no fragment contributes nothing (the re-fetch must not invent a path); two capped PRs re-fetched independently alongside a sub-cap PR that triggers no second call; and a `runGuardNext` row proving a re-fetch failure degrades to the `unknown` sentinel and holds the fragment.

No test makes a real `gh` call — every one injects `execGh`. The real-world truncation evidence above was gathered out-of-band and lives in the design notes, not in a test.

### Platforms tested

- [x] macOS
- [x] Windows (including backslash path handling)
- [x] Linux

Pure list filtering with an injected exec seam; no path handling.

### Runtimes tested

- [x] N/A (not runtime-specific)

A CI guard, not a runtime surface.

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue carries a maintainer-applied approval label (`approved-enhancement`)
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass — via the remote runner; local `npm test` is hook-blocked in this repo
- [x] `.changeset/` fragment added
- [x] No unnecessary dependencies added

## Review

Three engines; the Memtrace graph pass returned 0 issues.

**Security review** (isolated) returned no findings, having specifically chased the argument-injection surface this change opens — `pr.number` is interpolated into a REST path. It established rather than assumed that the value is GitHub's own sequential integer arriving through `JSON.parse` as a JS number, so a `-`-prefixed value, a traversal segment or a query suffix cannot reach the template; and it contrasted this against `assertUsableBaseRef` in the same file, which exists because *its* input is caller-influenced text.

**Code review** (both axes, isolated) found three, all fixed. The important one was a **hard violation**: `GITHUB_MAX_PR_FILES` was tested only at the cap, and my own test matrix had explicitly exempted the other two points, arguing a 3001-entry stub "tests the constant, not the behavior". That argument was wrong — at-the-cap alone never proves the accepting side, so an implementation that threw on *every* re-fetch would have passed. Also fixed: the re-fetch dispatch was a ternary performing network I/O in an expression that read like a pure transform, now an explicit `if`; and a design row said "exceeding" the ceiling where the code correctly uses `>=`.

The standards pass also confirmed the new `gh` call is bounded — `fetchPrFiles` → `execGhDefault` → `timeout: GH_TIMEOUT_MS` (20s) — since an unbounded subprocess is a named defect class here.

## Provenance

Surfaced by re-running the feature-implementation directive's design and QA-architecture steps against the code merged in #3847, which shipped without them.

## Known limits

- **`GH_TIMEOUT_MS` is 20s and shared by both calls.** A very large paginated fetch could approach it. The outcome is fail-closed — the throw becomes the `unknown` sentinel and every fragment is held — so the risk is a deferred sweep, never a wrongly-deleted fragment. Left on shared policy rather than giving one caller its own bound.
- **A PR at or above GitHub's 3000-file ceiling** cannot be enumerated completely by any route and throws. An external hard limit, not a choice.
- **A filename containing a literal newline** could split across the `--jq '.[].filename'` output boundary. The security reviewer scored this below the reporting bar and I agree: the harmful direction requires one of *our own* ack fragment filenames to contain a newline, and those are generated as word triples. The other direction only holds a fragment longer than necessary, which is the safe way to be wrong.
- **The sweep is still not transactional.** A PR opened between the lookup and the `git rm` can be surprised. That race predates this change and is inherent to a push-triggered sweep; the deferral narrows the window rather than closing it.

## Breaking changes

None. The returned set only gains entries it should always have had, so strictly fewer fragments are swept — the conservative direction, and the function's stated purpose.
