### PR TITLE
fix(#3734): backlog sentinels no longer create phase branches in query commit

### DIFF
--- a/.changeset/kind-quails-travel.md
+++ b/.changeset/kind-quails-travel.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`/gsd-capture --backlog` no longer scatters backlog items across per-item branches** — `query commit`'s phase-branching arm now treats `999.x`/`0.x` backlog sentinels as non-phases, so a backlog capture commits on the current branch instead of silently creating and switching to a `gsd/phase-999.*` branch per item. (#3734)

--- a/.changeset/kind-quails-travel.md
+++ b/.changeset/kind-quails-travel.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 3933
 ---
 **`/gsd-capture --backlog` no longer scatters backlog items across per-item branches** — `query commit`'s phase-branching arm now treats `999.x`/`0.x` backlog sentinels as non-phases, so a backlog capture commits on the current branch instead of silently creating and switching to a `gsd/phase-999.*` branch per item. (#3734)

--- a/src/commands.cts
+++ b/src/commands.cts
@@ -1632,7 +1632,10 @@ function cmdCommit(cwd: string, message: string | undefined, files: string[] | u
       // — see #2528 for the parallel drift problem in phase-locator/phase),
       // so this is the canonical path-segment-bound read, not a fourth copy.
       const phaseNum = detectPhaseNumberFromFiles(files);
-      if (phaseNum) {
+      // #3734: a 999.x/0.x backlog sentinel is a parking-lot entry, not a real
+      // phase — the phase arm must never branch-mutate for it (isSentinelPhaseId
+      // is the invariant's single owner, src/phase-id.cts).
+      if (phaseNum && !isSentinelPhaseId(phaseNum)) {
         const phaseInfo = findPhaseInternal(cwd, phaseNum) as Record<string, unknown> | null;
         if (phaseInfo) {
           branchName = (config['phase_branch_template'] as string)

--- a/tests/commands.test.cjs
+++ b/tests/commands.test.cjs
@@ -1805,6 +1805,81 @@ describe('commit command', () => {
       `second commit must not re-warn once on the phase branch; got stderr=${secondStderr}`
     );
   });
+
+  // #3734 — the phase arm of `query commit` must not treat a backlog sentinel
+  // phase id as a real phase. /gsd-capture --backlog commits the sentinel phase
+  // directory via add-backlog.md; pre-fix each capture created AND switched to a
+  // gsd/phase-999.<n>-<slug> branch, scattering backlog items across branches
+  // and leaving the operator's branch at the base commit.
+  test('#3734: 999.x backlog sentinel commits on the current branch and creates no phase branch', () => {
+    const startBranch = gitOrThrow(['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: tmpDir }).trim();
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({
+        commit_docs: true,
+        branching_strategy: 'phase',
+        phase_branch_template: 'gsd/phase-{phase}-{slug}',
+      })
+    );
+    fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '999.42-first-idea'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'phases', '999.42-first-idea', '.gitkeep'), '# backlog marker\n'
+    );
+
+    const result = runGsdTools(
+      'commit "docs: add backlog item 999.42 — first idea" --files .planning/phases/999.42-first-idea/.gitkeep',
+      tmpDir
+    );
+    assert.ok(result.success, `Command failed: ${result.error}`);
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.committed, true, 'sentinel capture must still commit');
+
+    const endBranch = gitOrThrow(['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: tmpDir }).trim();
+    assert.strictEqual(endBranch, startBranch, '#3734: sentinel capture must not switch branches');
+    const sentinelBranches = gitOrThrow(
+      ['branch', '--list', 'gsd/phase-999*'], { cwd: tmpDir }
+    ).trim();
+    assert.strictEqual(sentinelBranches, '', '#3734: no gsd/phase-999.* branch may be created');
+    // The "lost work" mode from the issue: the commit must be reachable on the
+    // branch the operator was actually on. gitOrThrow throws if the path is
+    // absent from startBranch, so reaching the content assertion proves it.
+    const onStartBranch = gitOrThrow(
+      ['show', `${startBranch}:.planning/phases/999.42-first-idea/.gitkeep`], { cwd: tmpDir }
+    );
+    assert.ok(onStartBranch.includes('# backlog marker'), 'sentinel commit must land on the starting branch');
+  });
+
+  test('#3734: 0.x backlog sentinel also never creates a phase branch', () => {
+    const startBranch = gitOrThrow(['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: tmpDir }).trim();
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({
+        commit_docs: true,
+        branching_strategy: 'phase',
+        phase_branch_template: 'gsd/phase-{phase}-{slug}',
+      })
+    );
+    fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '0.3-icebox-idea'), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'phases', '0.3-icebox-idea', '.gitkeep'), '# icebox marker\n');
+
+    const result = runGsdTools(
+      'commit "docs: add backlog item 0.3 — icebox idea" --files .planning/phases/0.3-icebox-idea/.gitkeep',
+      tmpDir
+    );
+    assert.ok(result.success, `Command failed: ${result.error}`);
+    assert.strictEqual(JSON.parse(result.output).committed, true, '0.x capture must still commit');
+
+    const endBranch = gitOrThrow(['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: tmpDir }).trim();
+    assert.strictEqual(endBranch, startBranch, '#3734: 0.x sentinel must not switch branches');
+    const sentinelBranches = gitOrThrow(
+      ['branch', '--list', 'gsd/phase-0*'], { cwd: tmpDir }
+    ).trim();
+    assert.strictEqual(sentinelBranches, '', '#3734: no gsd/phase-0.* branch may be created');
+    const onStartBranch = gitOrThrow(
+      ['show', `${startBranch}:.planning/phases/0.3-icebox-idea/.gitkeep`], { cwd: tmpDir }
+    );
+    assert.ok(onStartBranch.includes('# icebox marker'), '0.x sentinel commit must land on the starting branch');
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3734

## What was broken

`query commit`'s `branching_strategy: "phase"` arm had no `isSentinelPhaseId` guard, so a `999.x` backlog sentinel resolved as a real phase: every `/gsd-capture --backlog` item silently created and switched to a new `gsd/phase-999.<n>-<slug>` branch, leaving the operator's actual branch at the base commit with none of the work.

## What this fix does

Gates the phase arm on the invariant's single owner: `if (phaseNum && !isSentinelPhaseId(phaseNum))` in `src/commands.cts`. A `999.x`/`0.x` backlog capture now commits on the current branch and creates no branch; real phases keep the #3207/#1278 create-and-switch behavior untouched.

## Root cause

The phase arm predates the sentinel-guard family (#3225, #3372, #2786, #3639, #3641) and never received it; `add-backlog.md` commits the sentinel phase directory via `--files`, which joined the two into a branch-mutating path. The fix reuses `isSentinelPhaseId` (`src/phase-id.cts`) rather than re-deriving a sentinel regex, per the #3473 one-owner-per-invariant rule.

## Testing

### How I verified the fix

- Failing-first (RED) proven on the bench at `393cddd7b` (run `aa4101ae`): the 999.x regression test failed pre-fix with `actual 'gsd/phase-999.42-first-idea', expected 'master'`.
- Full suite green on the fix commit `9596613dd` (run `3c704fc6`, 39749/39749 passed, verdict `passed`); the pass carries doc-only forward to the branch HEAD.
- Local behavioral repro before/after: pre-fix a sentinel commit switched branches; post-fix it stays on `main` while a real phase (`02-real`) still creates `gsd/phase-02-real`.

### Regression test added?

- [x] Yes — `#3734: 999.x backlog sentinel commits on the current branch and creates no phase branch` and `#3734: 0.x backlog sentinel also never creates a phase branch` in `tests/commands.test.cjs`, both asserting no-branch, no-switch, and commit reachability on the starting branch (the issue's lost-work mode).

## Evidence

- Diagnosis artifact: `.gsd/bug/fix.3734-commit-sentinel-phase-guard/10-diagnosis.md` (working tree only, not part of the diff).
