### PR TITLE
fix(#3740): ack writer searches the exact status-field shape the reader parses

### DIFF
--- a/.changeset/sunny-herons-hum.md
+++ b/.changeset/sunny-herons-hum.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 3940
 ---
 **`audit-open acknowledge` no longer reports success on an entry it did not clear** — acknowledging a deferred item whose status is written as a nested list line now records a status the reader actually parses, so acknowledged entries drop out of audit counts instead of resurfacing forever. (#3740)

--- a/.changeset/sunny-herons-hum.md
+++ b/.changeset/sunny-herons-hum.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`audit-open acknowledge` no longer reports success on an entry it did not clear** — acknowledging a deferred item whose status is written as a nested list line now records a status the reader actually parses, so acknowledged entries drop out of audit counts instead of resurfacing forever. (#3740)

--- a/src/uat.cts
+++ b/src/uat.cts
@@ -2038,8 +2038,19 @@ function acknowledgeDeferredItem(content: string, targetText: string): Acknowled
   }
 
   const matchIndexInContent = sectionOffset + start;
-  const statusFieldRe = /^\s*(?:-\s+)?(\*+status:\*+|status:)/i;
-  const statusLineIdx = matchedLines.findIndex((rawLine) => statusFieldRe.test(rawLine.replace(/\r$/, '')));
+  // #3740: the search must mirror the reader exactly. extractGapEntryFields
+  // strips a bullet marker on line 0 ALONE — a later `- ` line is a nested
+  // sub-list, never a field line — so a marker-prefixed match on any
+  // continuation line would rewrite a line no reader reads and report `ok`
+  // while the entry stays outstanding. Line 0 KEEPS the marker-optional
+  // form: the reader de-bullets it, so `- status: open` as the entry line is
+  // a real field there (and first-wins means the insert branch could not
+  // outrank it). Everything else falls through to the insert branch below,
+  // which the marker-free and no-status controls already round-trip.
+  const statusFieldRe = /^\s*(\*+status:\*+|status:)/i;
+  const statusFieldReLine0 = /^\s*(?:-\s+)?(\*+status:\*+|status:)/i;
+  const statusLineIdx = matchedLines.findIndex((rawLine, idx) =>
+    (idx === 0 ? statusFieldReLine0 : statusFieldRe).test(rawLine.replace(/\r$/, '')));
 
   // No CRLF-preservation branch here (WARNING 1, #3458 follow-up review):
   // every write goes through `platformWriteSync` → `normalizeContent`, which

--- a/tests/uat.test.cjs
+++ b/tests/uat.test.cjs
@@ -16,6 +16,8 @@ const {
   CHECKPOINT_LANGUAGE_ALIASES,
   resolveCheckpointFrame,
   parseDeferredItems,
+  parseDeferredItemsWithStatus,
+  acknowledgeDeferredItem,
   parseUatItems,
   parseUatItemsWithStats,
 } = require('../gsd-core/bin/lib/uat.cjs');
@@ -6570,5 +6572,54 @@ describe('parseUatItemsWithStats — result: line-scan boundary defects (#3078-C
     assert.ok(findAlphaBlocked(withSeparatorResult.items), `expected outstanding row 1/Alpha/blocked absent: ${describeAll()}`);
     assert.deepStrictEqual(withSeparatorResult.items, plainLfResult.items, `must match the plain-LF twin by identity: ${describeAll()}`);
     assert.strictEqual(withSeparatorResult.headingsSeen, plainLfResult.headingsSeen, describeAll());
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// #3740: acknowledgeDeferredItem must agree with the field extractor on
+// what a status-field line is. The writer's search regex was marker-optional
+// while the reader (extractGapEntryFields) deliberately strips a bullet
+// marker on line 0 ONLY — a later `- ` line is a nested sub-list, not a
+// field. Pre-fix, a nested `  - status: open` line was rewritten and `ok`
+// returned, but no reader ever saw the rewrite: the entry stayed outstanding
+// after a "successful" acknowledgement.
+// ────────────────────────────────────────────────────────────────────────
+describe('#3740: acknowledge round-trips through the reader (parse → acknowledge → parse)', () => {
+  function roundTrip(body) {
+    const content = '## Deferred Items\n\n' + body + '\n';
+    const before = parseDeferredItemsWithStatus(content);
+    assert.equal(before.length, 1, `fixture must parse to exactly one entry, got ${before.length}`);
+    const ack = acknowledgeDeferredItem(content, before[0].name);
+    const after = parseDeferredItemsWithStatus(ack.content);
+    assert.equal(after.length, 1, 'acknowledged file must still parse to one entry');
+    return { ack, before: before[0], after: after[0], content: ack.content };
+  }
+
+  test('nested-marker status line: ack returns ok and the entry is no longer outstanding', () => {
+    const r = roundTrip('- alpha\n  - status: open');
+    assert.equal(r.ack.status, 'ok');
+    assert.equal(r.after.status, 'acknowledged',
+      '#3740: a nested `- status:` line is not a field line to the reader; the ack must take the insert branch the reader parses');
+  });
+
+  test('nested-marker status line, CRLF variant: same outcome', () => {
+    const r = roundTrip('- alpha\r\n  - status: open');
+    assert.equal(r.ack.status, 'ok');
+    assert.equal(r.after.status, 'acknowledged');
+  });
+
+  test('control: marker-free status line is still rewritten in place, not duplicated', () => {
+    const r = roundTrip('- alpha\n  status: open');
+    assert.equal(r.ack.status, 'ok');
+    assert.equal(r.after.status, 'acknowledged');
+    const statusLines = r.content.split('\n').filter((l) => /status:\s*/.test(l));
+    assert.equal(statusLines.length, 1, `exactly one status line must remain, got ${JSON.stringify(statusLines)}`);
+    assert.match(statusLines[0], /status:\s*acknowledged/);
+  });
+
+  test('control: entry with no status line keeps the insert branch', () => {
+    const r = roundTrip('- alpha');
+    assert.equal(r.ack.status, 'ok');
+    assert.equal(r.after.status, 'acknowledged');
   });
 });

--- a/tests/uat.test.cjs
+++ b/tests/uat.test.cjs
@@ -6608,6 +6608,17 @@ describe('#3740: acknowledge round-trips through the reader (parse → acknowled
     assert.equal(r.after.status, 'acknowledged');
   });
 
+  test('line-0 entry-line status (`- status: open`) is still rewritten in place', () => {
+    // The reader de-bullets line 0, so a status field on the entry line IS a
+    // real field there — and first-wins means the insert branch could never
+    // outrank it. The search must keep matching this shape (#3740 review).
+    const r = roundTrip('- status: open\n  reason: flaky');
+    assert.equal(r.ack.status, 'ok');
+    assert.equal(r.after.status, 'acknowledged');
+    const statusLines = r.content.split('\n').filter((l) => /status:\s*/.test(l));
+    assert.equal(statusLines.length, 1, `exactly one status line must remain, got ${JSON.stringify(statusLines)}`);
+  });
+
   test('control: marker-free status line is still rewritten in place, not duplicated', () => {
     const r = roundTrip('- alpha\n  status: open');
     assert.equal(r.ack.status, 'ok');


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3740

## What was broken

`audit-open acknowledge` returned `ok` after rewriting a nested `  - status:` line in a deferred-items entry — but the field extractor deliberately treats a later `- ` line as a nested sub-list, never a field, so no reader ever saw the rewrite: the entry stayed outstanding after a "successful" acknowledgement, and a milestone-close ack loop could spin on it.

## What this fix does

Aligns the ack writer's status-field search with the reader exactly: the marker-optional form is kept **only for line 0** (where the reader de-bullets and first-wins makes the insert branch unable to outrank it); every continuation line is searched marker-free only. A nested-marker status now falls through to the existing insert branch — the path the issue's controls (B and C) show already round-trips.

Review-driven addition beyond the issue's literal prescription: the issue's suggested one-line narrowing (drop `(?:-\s+)?` everywhere) would have relocated the same failure mode to entries whose status sits on line 0 (`- status: open`) — the reader parses that as a real field, and first-wins would keep the stale `open` over the inserted `acknowledged`. Both independent reviewers caught this; the fix keeps the marker-optional match at idx 0 and adds a line-0 regression test.

## Root cause

Writer/reader drift: `acknowledgeDeferredItem`'s `statusFieldRe` accepted a marker-prefixed `status:` on any line, while `extractGapEntryFields` strips a bullet marker on line 0 only (stated three times in-file as the nested-sub-list invariant).

## Testing

### How I verified the fix

- Failing-first (RED) proven on the bench at `26edfd46e` (verdict failed: the round-trip describe + nested-marker test).
- Full suite green at `e3dde2be9` (39860/39860, verdict `passed`, pass marker recorded).
- Local lib round-trip of all four shapes: nested marker, marker-free, no-status, and line-0 — all end `acknowledged`; marker-free and line-0 shapes still rewrite in place with exactly one status line.

### Regression test added?

- [x] Yes — `tests/uat.test.cjs` describe `#3740: acknowledge round-trips through the reader`: nested-marker (+CRLF variant), line-0, and the two controls, asserting the parse → acknowledge → parse contract.

## Evidence

- Diagnosis artifact: `.gsd/bug/fix.3740-uat-ack-nested-status/10-diagnosis.md` (working tree only, not part of the diff).
- Known residue (per the issue): after the insert branch, the file keeps the stale nested bullet; the parser is unambiguous (first-wins). The issue flags reconcile-or-warn as a separate follow-up.
