### PR TITLE
test(#3239): reroute package-legitimacy-gate table parsers onto the ADR-2143 seam

### DIFF
--- a/.changeset/quick-foxes-click.md
+++ b/.changeset/quick-foxes-click.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 3977
 ---
 **Package-legitimacy-gate tests no longer silently drop malformed table rows.** The test suite's markdown-table parsing now reuses the ADR-2143 seam instead of two hand-rolled copies, so a ragged row or an escaped-pipe cell fails loudly instead of being silently mis-parsed. (#3239)

--- a/.changeset/quick-foxes-click.md
+++ b/.changeset/quick-foxes-click.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**Package-legitimacy-gate tests no longer silently drop malformed table rows.** The test suite's markdown-table parsing now reuses the ADR-2143 seam instead of two hand-rolled copies, so a ragged row or an escaped-pipe cell fails loudly instead of being silently mis-parsed. (#3239)

--- a/tests/package-legitimacy-gate.test.cjs
+++ b/tests/package-legitimacy-gate.test.cjs
@@ -18,6 +18,14 @@ const assert = require('node:assert/strict');
 const fs = require('fs');
 const path = require('path');
 
+// ADR-2143 seam (#3239): both hand-rolled table parsers this file used to
+// carry have been rerouted onto the canonical parser. See parseAllMarkdownTables
+// below for the one piece that stays local (grouping contiguous `|`-line runs
+// into separate table fixtures) — grouping has no ADR-2143 equivalent and is
+// test-fixture-specific, not a GFM parsing concern; every actual PARSE is
+// delegated to the seam.
+const { parseMarkdownTable: parseTable } = require('../gsd-core/bin/lib/markdown-table.cjs');
+
 const AGENTS = path.join(__dirname, '..', 'agents');
 const RESEARCHER = path.join(AGENTS, 'gsd-phase-researcher.md');
 const PLANNER = path.join(AGENTS, 'gsd-planner.md');
@@ -152,31 +160,12 @@ function anyLineHasAll(lines, required) {
   return lines.some((line) => hasAllTokens(line, required));
 }
 
-function parseMarkdownTable(lines) {
-  const tableLines = lines.filter((line) => /^\s*\|/.test(line));
-  if (tableLines.length < 2) return null;
-
-  const toCells = (line) => line
-    .trim()
-    .replace(/^\|/, '')
-    .replace(/\|$/, '')
-    .split('|')
-    .map((cell) => cell.trim());
-
-  const headers = toCells(tableLines[0]);
-  const rows = tableLines
-    .slice(2)
-    .map(toCells)
-    .filter((cells) => cells.length === headers.length)
-    .map((cells) => ({
-      cells,
-      fields: Object.fromEntries(headers.map((h, i) => [h, cells[i]])),
-    }));
-
-  return { headers, rows };
-}
-
-function parseMarkdownTables(lines) {
+// Groups contiguous `|`-prefixed lines into separate table-fixture blocks and
+// delegates each group's actual parse to the ADR-2143 seam (parseMarkdownTable
+// above). A malformed group (ragged row, missing delimiter row, etc.) throws
+// loudly instead of being silently filtered out — the exact "silent drop"
+// failure mode #3239 closes.
+function parseAllMarkdownTables(lines) {
   const groups = [];
   let current = [];
 
@@ -192,10 +181,66 @@ function parseMarkdownTables(lines) {
   }
   if (current.length > 0) groups.push(current);
 
-  return groups
-    .map((group) => parseMarkdownTable(group))
-    .filter(Boolean);
+  return groups.map((group) => {
+    const result = parseTable(group.join('\n'));
+    if (!result.ok) {
+      throw new Error(`malformed markdown table in fixture: ${result.reason}`);
+    }
+    return result.value;
+  });
 }
+
+describe('markdown-table seam reroute (#3239) — ragged rows and escaped pipes', () => {
+  test('ragged data row surfaces as a typed parse error, not a silent drop', () => {
+    const text = [
+      '| Package | Verdict |',
+      '|---------|---------|',
+      '| left-pad | OK |',
+      '| too-many-cells | OK | EXTRA |',
+    ].join('\n');
+
+    const result = parseTable(text);
+    assert.equal(result.ok, false, 'a ragged row must fail loudly, not parse as a truncated table');
+    assert.match(result.reason, /row 2 has 3 cells, expected 2/);
+  });
+
+  test('a cell containing an escaped pipe parses as one cell with a literal |, not two cells', () => {
+    const text = [
+      '| Package | Notes |',
+      '|---------|-------|',
+      String.raw`| left-pad | a\|b |`,
+    ].join('\n');
+
+    const result = parseTable(text);
+    assert.ok(result.ok, 'well-formed table with an escaped-pipe cell must parse');
+    assert.equal(result.value.rows[0].Notes, 'a|b');
+  });
+
+  test('parseAllMarkdownTables delegates each group to the seam and groups by blank-line boundaries', () => {
+    const lines = [
+      '| A | B |',
+      '|---|---|',
+      '| 1 | 2 |',
+      '',
+      '| C | D |',
+      '|---|---|',
+      '| 3 | 4 |',
+    ];
+    const tables = parseAllMarkdownTables(lines);
+    assert.equal(tables.length, 2);
+    assert.deepEqual(tables[0].columns, ['A', 'B']);
+    assert.deepEqual(tables[1].columns, ['C', 'D']);
+  });
+
+  test('parseAllMarkdownTables throws loudly when a group contains a ragged row', () => {
+    const lines = [
+      '| A | B |',
+      '|---|---|',
+      '| 1 | 2 | 3 |',
+    ];
+    assert.throws(() => parseAllMarkdownTables(lines), /malformed markdown table/);
+  });
+});
 
 function lineIndexes(lines, predicate) {
   const indexes = [];
@@ -282,13 +327,13 @@ describe('gsd-phase-researcher.md — Package Legitimacy Audit section in templa
     const section = templateSections.find((s) => s.heading === 'Package Legitimacy Audit');
     assert.ok(section, 'Package Legitimacy Audit section must exist');
 
-    const table = parseMarkdownTable(section.body);
-    assert.ok(table, 'Package Legitimacy Audit section must include a markdown table');
+    const result = parseTable(section.body.join('\n'));
+    assert.ok(result.ok, 'Package Legitimacy Audit section must include a valid markdown table');
 
     // 'slopcheck' column renamed to 'Verdict' to reflect the code seam (gsd-tools query package-legitimacy)
     const expected = ['Package', 'Registry', 'Age', 'Downloads', 'Verdict', 'Disposition'];
     for (const column of expected) {
-      assert.ok(table.headers.includes(column), `audit table must have "${column}" column`);
+      assert.ok(result.value.columns.includes(column), `audit table must have "${column}" column`);
     }
   });
 
@@ -296,10 +341,10 @@ describe('gsd-phase-researcher.md — Package Legitimacy Audit section in templa
     const section = templateSections.find((s) => s.heading === 'Package Legitimacy Audit');
     assert.ok(section, 'Package Legitimacy Audit section must exist');
 
-    const table = parseMarkdownTable(section.body);
-    assert.ok(table, 'Package Legitimacy Audit section must include a markdown table');
+    const result = parseTable(section.body.join('\n'));
+    assert.ok(result.ok, 'Package Legitimacy Audit section must include a valid markdown table');
 
-    const rowTexts = table.rows.map((row) => row.cells.join(' '));
+    const rowTexts = result.value.rows.map((row) => Object.values(row).join(' '));
     const slop = rowTexts.some((value) => hasAllTokens(value, ['slop']));
     const sus = rowTexts.some((value) => hasAllTokens(value, ['sus']));
     const ok = rowTexts.some((value) => hasAllTokens(value, ['ok']));
@@ -419,16 +464,16 @@ describe('gsd-planner.md — supply-chain row in threat_model template', () => {
   });
 
   test('threat_model template includes supply-chain row with mitigate disposition', () => {
-    const tables = parseMarkdownTables(threatModelBlock.split(/\r?\n/));
-    const strideTable = tables.find((table) => table.headers.includes('Threat ID'));
+    const tables = parseAllMarkdownTables(threatModelBlock.split(/\r?\n/));
+    const strideTable = tables.find((table) => table.columns.includes('Threat ID'));
     assert.ok(strideTable, 'threat_model must include STRIDE threat register table');
 
-    const supplyChainRow = strideTable.rows.find((row) => hasAllTokens(row.cells[0] || '', ['t-{phase}-sc']));
+    const supplyChainRow = strideTable.rows.find((row) => hasAllTokens(row['Threat ID'] || '', ['t-{phase}-sc']));
     assert.ok(supplyChainRow, 'threat_model must include T-{phase}-SC supply-chain row');
 
-    const dispoIdx = strideTable.headers.findIndex((h) => /disposition/i.test(String(h)));
-    assert.ok(dispoIdx >= 0, 'STRIDE table must have a Disposition column');
-    const disposition = supplyChainRow.cells[dispoIdx] || '';
+    const dispositionCol = strideTable.columns.find((h) => /disposition/i.test(h));
+    assert.ok(dispositionCol, 'STRIDE table must have a Disposition column');
+    const disposition = supplyChainRow[dispositionCol] || '';
     assert.ok(hasAllTokens(disposition, ['mitigate']), 'supply-chain threat disposition must be mitigate');
   });
 });


### PR DESCRIPTION
<!-- pr-template-exempt: test-only tech-debt chore (type: chore) — not a bug fix (no broken production behavior, no `confirmed-bug` label) and not a community enhancement proposal requiring `approved-enhancement`. Rerouting two hand-rolled test-helper parsers onto an existing seam, per the issue's own "does not change user-facing behavior" checklist item. -->

## What

`tests/package-legitimacy-gate.test.cjs` hand-rolled two markdown-table parsers (`parseMarkdownTable`, `parseMarkdownTables`) that duplicated the canonical ADR-2143 seam (`src/markdown-table.cts`). Both call sites now delegate to the seam (via `gsd-core/bin/lib/markdown-table.cjs`), addressing cells by column name instead of positional array index. The multi-table grouping loop (no ADR-2143 equivalent — a test-fixture concern, not GFM parsing) stays local, but now delegates each group's actual parse to the seam and throws loudly on a malformed group instead of silently filtering it out.

Closes #3239

## Why

The local parsers diverged from the seam in exactly the two ways the issue names:

- `.split('|')` mis-splits a cell containing an escaped pipe (`\|`).
- `.filter(cells => cells.length === headers.length)` **silently dropped** a ragged row instead of failing loudly — in a *legitimacy gate's own test suite*, a parser that silently discards a row it cannot read can report a pass over unverified input.

## How it was implemented

- Deleted the two local parsers.
- Added `parseAllMarkdownTables(lines)`: groups contiguous `|`-prefixed lines into table-fixture blocks (unchanged grouping logic — no seam equivalent exists for this), then delegates each group's parse to the seam's `parseMarkdownTable`, throwing on any group that comes back `{ok:false}`.
- Updated the two existing test bodies (`Package Legitimacy Audit table has required columns`, `audit section documents [SLOP]/[SUS]/[OK] dispositions`, `threat_model ... supply-chain row`) to use the seam's `Result<{columns, rows}>` shape (`rows` keyed by column name) instead of the old `{headers, rows: [{cells}]}` shape. No assertion changed in intent — the tables they read (agent `.md` templates) are unchanged and still parse to the same content.
- Added 4 new tests locking the two named divergences directly: a ragged-row fixture now returns a typed `{ok:false, reason:"row N has X cells, expected Y"}` instead of being silently dropped, and an escaped-pipe-cell fixture now parses to one cell with the literal `|` instead of splitting into two. Plus two tests for the grouping helper's happy path and its fail-loud behavior on a malformed group.

**Fence question (issue proposed-work item 3):** already decided and shipped by #3951 Rung B — `local/no-adhoc-markdown-parsing` is registered as `'error'` on the `tests/**/*.cjs` glob in `eslint.config.mjs`, and the rule's own filename gate (`eslint-rules/no-adhoc-markdown-parsing.cjs`) matches `tests/.*\.cjs$`. `tests/` is enforced, not exempt — no further decision needed here.

**Known limit (disclosed):** the eslint rule's detection is a regex fingerprint (fence-strip / section-collect / table-regex / replace-mutation). It does not fire on a plain `.split('|')` call, which is how the two parsers this PR removes went undetected despite the rule already covering `tests/**`. Closing that detection gap is a separate, out-of-scope precision-review task — not part of "reroute the two parsers the issue names."

## Testing

### How I verified

- `npx eslint tests/` — clean (exit 0).
- `npm run lint:ci` — clean (exit 0), including `node scripts/lint-table-schema-drift.cjs` (the issue's named regression guard).
- `gsd-test --base next --head 2aecb46c2d5effefb0f5677cbefbdd762ba04a7b` — **passed**, 40123/40123, on the `plex2` bench (a first attempt on a contended bench (`holodeck`, measured cpu-PSI `some avg60=93%`) hit 4 timeout-shaped failures in two files this PR never touches — `tests/emitted-ack-trailer.test.cjs` and `tests/lint-allow-test-rule-refs.test.cjs`, both subprocess/timeout-bound tests; the clean re-run on an idle bench confirms bench contention, not this change, caused them).
- Manual check: `parseMarkdownTable` against the real `agents/gsd-phase-researcher.md` Package Legitimacy Audit table and `agents/gsd-planner.md` STRIDE table both parse to the expected columns/rows.

### Platforms tested

- [x] Linux (gsd-test remote matrix)
- [ ] macOS — N/A, remote matrix is Linux-only per repo convention
- [ ] Windows — N/A, remote matrix is Linux-only per repo convention
- [x] N/A beyond the above (test-file-only change, no platform-specific code)

## Must-Have Acceptance Checklist (from #3239 "Done when")

- [x] Characterization tests lock `package-legitimacy-gate`'s current verdicts, including ragged-row and escaped-pipe fixtures
- [x] `tests/package-legitimacy-gate.test.cjs` imports the seam; zero hand-rolled table regexes remain in it
- [x] Ragged rows surface as a typed error instead of being silently filtered out, and the gate fails loudly on them
- [x] `parseMarkdownTables`' grouping either lands in the seam or delegates per-group to `parseMarkdownTable` — delegates per-group (see How it was implemented)
- [x] The `tests/` scope of `local/no-adhoc-markdown-parsing` is either enforced or documented as a deliberate exemption — already enforced (#3951 Rung B); documented above
- [x] `npm run lint:ci` green; `scripts/lint-table-schema-drift.cjs` still green (regression guard)
- [x] Remote runner verdict `passed` on the shipped sha

## Changeset

`.changeset/quick-foxes-click.md` (type: `Fixed`, pr number to be backfilled after this PR is created).

## Breaking changes

None. Test-internal helper only; no user-facing command, output, or file-format change.
