### PR TITLE
fix(#3786): authorize mutable scope from live observation only in the quick planner

### DIFF
--- a/.changeset/rapid-wasps-sing.md
+++ b/.changeset/rapid-wasps-sing.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`/gsd-quick` no longer authorizes edit/verification scope from historical state** — when scope depends on mutable external state (a fresh merge index, PR diffs, the working tree), the planner must observe it live or keep the plan's scope conditional; cached PR-diff paths and stale recovery notes are investigation guidance only, so a merge-conflict task can no longer provisionally "authorize" 65 historical paths. (#3786)

--- a/.changeset/rapid-wasps-sing.md
+++ b/.changeset/rapid-wasps-sing.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 4005
 ---
 **`/gsd-quick` no longer authorizes edit/verification scope from historical state** — when scope depends on mutable external state (a fresh merge index, PR diffs, the working tree), the planner must observe it live or keep the plan's scope conditional; cached PR-diff paths and stale recovery notes are investigation guidance only, so a merge-conflict task can no longer provisionally "authorize" 65 historical paths. (#3786)

--- a/gsd-core/workflows/quick.md
+++ b/gsd-core/workflows/quick.md
@@ -315,6 +315,7 @@ ${AGENT_SKILLS_PLANNER}
 <constraints>
 - Create a SINGLE plan with 1-3 focused tasks
 - Quick tasks should be atomic and self-contained
+- MUTABLE-SCOPE AUTHORITY (#3786): when concrete edit or verification scope depends on mutable external state (a merge index, PR/base diffs, the working tree), authorize scope ONLY from a live observation made at planning time — for conflict resolution that is the fresh merge index via `git diff --name-only --diff-filter=U` — or keep `files`/`verify` CONDITIONAL on that observation. Historical STATE.md entries, recovery notes, and cached PR/base diff paths may guide investigation only; they are never edit or verification authority, and a plan must not enumerate them as authorized files "pending replacement".
 ${RESEARCH_MODE ? '- Research findings are available — use them to inform library/pattern choices' : '- No research phase'}
 ${VALIDATE_MODE ? '- Target ~40% context usage (structured for verification)' : '- Target ~30% context usage (simple, focused)'}
 ${VALIDATE_MODE ? '- MUST generate `must_haves` in plan frontmatter (truths, artifacts, key_links)' : ''}

--- a/tests/quick-planner-scope-guard.test.cjs
+++ b/tests/quick-planner-scope-guard.test.cjs
@@ -27,7 +27,13 @@ const QUICK_MD = path.join(__dirname, '..', 'gsd-core', 'workflows', 'quick.md')
 // .md reads).
 function plannerConstraints() {
   const md = fs.readFileSync(QUICK_MD, 'utf-8');
-  const start = md.indexOf('<constraints>');
+  // quick.md carries TWO <constraints> blocks (planner at ~315, executor at
+  // ~479). Anchor to the PLANNER's: the last block opening before its
+  // subagent_type declaration — step reordering can never silently redirect
+  // the guard to another agent's block.
+  const plannerDispatch = md.indexOf('subagent_type="gsd-planner"');
+  assert.ok(plannerDispatch > 0, 'quick.md must dispatch the gsd-planner agent');
+  const start = md.lastIndexOf('<constraints>', plannerDispatch);
   const end = md.indexOf('</constraints>', start);
   assert.ok(start > 0 && end > start, 'quick.md must contain the planner <constraints> block');
   return md.slice(start, end);
@@ -40,7 +46,7 @@ test('#3786: the quick planner constraints carry a mutable-scope authority rule'
     '#3786: scope derived from mutable external state must be live-observed or kept conditional',
   );
   assert.ok(
-    /investigation only/i.test(constraints) || /never.{0,20}authority/i.test(constraints),
+    /may guide investigation only/i.test(constraints),
     '#3786: historical STATE.md/recovery/cached-diff paths must be labeled investigation-only, never edit/verification authority',
   );
   assert.ok(

--- a/tests/quick-planner-scope-guard.test.cjs
+++ b/tests/quick-planner-scope-guard.test.cjs
@@ -1,0 +1,50 @@
+'use strict';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #3786 — the /gsd-quick planner constraints must carry a mutable-scope
+// AUTHORITY rule.
+//
+// A minimized planner probe committed HISTORICAL scope as authorized edit /
+// verification scope in 2 of 3 trials: for a merge-conflict task whose fresh
+// merge had not run, one trial provisionally authorized 65 cached PR-diff
+// paths, another broadened verification to the whole PR integration surface.
+// Adding one explicit requirement — authorized scope comes only from the
+// fresh merge index — reduced failures to 0 of 3. The rule lives in the
+// shipped planner prompt (quick.md's <constraints> block), so a structural
+// guard over that text pins it.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const QUICK_MD = path.join(__dirname, '..', 'gsd-core', 'workflows', 'quick.md');
+
+// quick.md is shipped workflow text — the bytes ARE what the runtime loads,
+// so a structural scan over it tests the deployed contract (same shape as
+// tests/config-get-raw-guard.test.cjs; no allow-test-rule marker needed for
+// .md reads).
+function plannerConstraints() {
+  const md = fs.readFileSync(QUICK_MD, 'utf-8');
+  const start = md.indexOf('<constraints>');
+  const end = md.indexOf('</constraints>', start);
+  assert.ok(start > 0 && end > start, 'quick.md must contain the planner <constraints> block');
+  return md.slice(start, end);
+}
+
+test('#3786: the quick planner constraints carry a mutable-scope authority rule', () => {
+  const constraints = plannerConstraints();
+  assert.ok(
+    /live observation/i.test(constraints) && /conditional/i.test(constraints),
+    '#3786: scope derived from mutable external state must be live-observed or kept conditional',
+  );
+  assert.ok(
+    /investigation only/i.test(constraints) || /never.{0,20}authority/i.test(constraints),
+    '#3786: historical STATE.md/recovery/cached-diff paths must be labeled investigation-only, never edit/verification authority',
+  );
+  assert.ok(
+    constraints.includes('git diff --name-only --diff-filter=U'),
+    '#3786: the conflict-resolution case must name the fresh-merge-index command the probe validated',
+  );
+});


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3786

## What was broken

`/gsd-quick`'s planner could commit HISTORICAL scope as authorized edit/verification scope before any live observation of the mutable state. The reporter's minimized probe: for a merge-conflict task whose fresh merge had not run, 2 of 3 trials used historical scope — one provisionally authorized 65 cached PR-diff paths "pending replacement", one broadened verification to the whole PR integration surface. Stale STATE.md recovery notes were a trigger, not the sole cause (one red trial had none).

## What this fix does

Adds ONE constraint to the planner's `<constraints>` block in `gsd-core/workflows/quick.md` — the exact shape the reporter's probe validated (2/3 → 0/3): when concrete edit or verification scope depends on mutable external state (a merge index, PR/base diffs, the working tree), the planner authorizes scope ONLY from a live observation made at planning time — for conflict resolution, the fresh merge index via `git diff --name-only --diff-filter=U` — or keeps `files`/`verify` CONDITIONAL on that observation. Historical STATE.md entries, recovery notes, and cached PR/base diff paths may guide investigation only; a plan must not enumerate them as authorized files "pending replacement".

The isolated review verified: placement is the planner's block (outside the mode ternaries, so both quick and quick-full get it); no refusal paradox (immutable-history tasks always have live observation available); no downstream consumer reads plan-declared `files` values (every guard and step operates on real files); the named command is read-only.

**Review fold-ins** (fixed in this PR per the fold-findings rule): the guard test now anchors to the planner's own `<constraints>` block via its `subagent_type` declaration (quick.md has two such blocks — the executor's sits later), and a dead fallback regex was replaced with the anchored assertion.

## Testing

- Failing-first (RED) proven on the bench at `64758f18` — the guard failed against the shipped quick.md.
- Full suite green at the fix HEAD (40332/40332, verdict `passed`, pass marker recorded); quick.md's +620 bytes acknowledged via the `Emitted-Drift-Ack-Growth` commit trailer.
- A structural guard (`tests/quick-planner-scope-guard.test.cjs`) pins the rule: live-observation-or-conditional, investigation-only labeling, and the probe-validated command must all stay in the planner's constraints block.

## Evidence

- Diagnosis artifact: `.gsd/bug/fix.3786-quick-planner-live-scope/10-diagnosis.md` (working tree only).