### PR TITLE
fix(#3796): write the audit report to the single-version filename every reader expects

### DIFF
--- a/.changeset/nimble-lynx-caper.md
+++ b/.changeset/nimble-lynx-caper.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 4007
 ---
 **The milestone audit report is written where its readers look for it** — `/gsd-audit-milestone` created the report at a doubled `.planning/v{version}-v{version}-MILESTONE-AUDIT.md` path while every downstream reference (Report pointers, the `cat`, the completion checklist) reads the single-version `v{version}-MILESTONE-AUDIT.md`, so the report silently landed unread. (#3796)

--- a/.changeset/nimble-lynx-caper.md
+++ b/.changeset/nimble-lynx-caper.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**The milestone audit report is written where its readers look for it** — `/gsd-audit-milestone` created the report at a doubled `.planning/v{version}-v{version}-MILESTONE-AUDIT.md` path while every downstream reference (Report pointers, the `cat`, the completion checklist) reads the single-version `v{version}-MILESTONE-AUDIT.md`, so the report silently landed unread. (#3796)

--- a/gsd-core/workflows/audit-milestone.md
+++ b/gsd-core/workflows/audit-milestone.md
@@ -183,7 +183,7 @@ Discovery only — never auto-calls `/gsd:validate-phase`.
 
 ## 6. Aggregate into v{version}-MILESTONE-AUDIT.md
 
-Create `.planning/v{version}-v{version}-MILESTONE-AUDIT.md` with:
+Create `.planning/v{version}-MILESTONE-AUDIT.md` with:
 
 ```yaml
 ---

--- a/scripts/lint-test-file-count.allowlist.json
+++ b/scripts/lint-test-file-count.allowlist.json
@@ -249,6 +249,14 @@
       ],
       "issue": "3873",
       "justification": "ADR-3473 \u00a78.8 makes docs/reference/state-md.md and its four locale siblings generated-and-committed and adds the repo's first locale-parity check (verified: no locale-parity lint precedent exists here). That check is a distinct concern from docs-update (content freshness) and docs-parity-live-registry (registry parity); folding it into either would place an unrelated subject inside them purely to satisfy a count. The section it guards is absent from all four translations today and documents the status enum behind #3853."
+    },
+    "audit": {
+      "files": [
+        "audit-command-cutover.test.cjs",
+        "audit-fix-command.test.cjs",
+        "audit-milestone-filename-guard.test.cjs"
+      ],
+      "issue": "#3796 \u2014 the third file is a structural guard over the shipped audit-milestone workflow text (writer/reader filename agreement), not a behavior suite of the audit module; consolidation into the CLI suites would put a source-text scan behind spawn-heavy fixtures."
     }
   }
 }

--- a/tests/audit-milestone-filename-guard.test.cjs
+++ b/tests/audit-milestone-filename-guard.test.cjs
@@ -1,0 +1,39 @@
+'use strict';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #3796 — the audit-milestone report writer and its readers must agree on
+// the report's filename.
+//
+// The single writer line created `.planning/v{version}-v{version}-MILESTONE
+// -AUDIT.md` (a doubled version segment) while every downstream reference —
+// the step's own heading, the Report pointers, the `cat`, and the completion
+// checklist — reads `v{version}-MILESTONE-AUDIT.md`. The report landed at a
+// path no reader ever looked at.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const AUDIT_MD = path.join(__dirname, '..', 'gsd-core', 'workflows', 'audit-milestone.md');
+
+// audit-milestone.md is shipped workflow text — the bytes ARE what the
+// runtime loads; a structural scan over it tests the deployed contract.
+test('#3796: the audit report writer and readers agree on the single-version filename', () => {
+  const md = fs.readFileSync(AUDIT_MD, 'utf-8');
+  assert.ok(
+    !md.includes('v{version}-v{version}'),
+    '#3796: no doubled version segment may appear anywhere in the workflow',
+  );
+  const writer = /^Create `\.planning\/v\{version\}-MILESTONE-AUDIT\.md` with:$/m;
+  assert.ok(
+    writer.test(md),
+    '#3796: the writer line must create exactly .planning/v{version}-MILESTONE-AUDIT.md',
+  );
+  const readers = md.match(/v\{version\}-MILESTONE-AUDIT\.md/g) || [];
+  assert.ok(
+    readers.length >= 5,
+    `the single-version readers (heading, Report pointers, cat, checklist) must remain; found ${readers.length}`,
+  );
+});


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3796

## What was broken

`audit-milestone.md`'s single writer line created `.planning/v{version}-v{version}-MILESTONE-AUDIT.md` — a doubled version segment — while every downstream reference (the step's own heading, the Report pointers at L243/266/328, the `cat` at L316, the completion checklist at L371) reads `v{version}-MILESTONE-AUDIT.md`. The report landed at a path no reader ever looked at. Carried from get-shit-done-cc 1.42.3.

## What this fix does

The issue's own one-token fix: the duplicated `v{version}-` segment is dropped from the writer line. A structural guard (`tests/audit-milestone-filename-guard.test.cjs`) bans any doubled version segment anywhere in the workflow, pins the writer's exact anchored filename, and floors the single-version readers at 5 — so a re-doubling or a writer/reader split fails loudly.

The isolated review verified: no other doubled-token shape exists in any shipped surface; every reader across commands, the milestone lib, templates, and `autonomous.md` already agrees on the single-version name; the edit shrinks the file (growth-only ratchet — no ack needed).

## Testing

- Failing-first (RED) proven on the bench at `e03304e9` — the guard failed against the shipped doubled filename.
- Full suite green at `7795b39e` (40477/40477, verdict `passed`, pass marker recorded). One intermediate run failed the test-file-count lint (third file under the `audit` prefix) — registered in the allowlist with the #3796 justification (a structural source-text guard; consolidation would hide it behind spawn-heavy CLI fixtures).

## Evidence

- Diagnosis artifact: `.gsd/bug/fix.3796-audit-milestone-doubled-filename/10-diagnosis.md` (working tree only).