### PR TITLE
enhance(#4039): share POSIX shell quoting helper

### DIFF
--- a/src/capability-lifecycle.cts
+++ b/src/capability-lifecycle.cts
@@ -83,9 +83,10 @@ const lockMod = require('./capability-lock.cjs') as {
   _setLockProbes: (probes: Partial<{ isPidAlive: (pid: number) => boolean; getProcessStartTime: (pid: number) => string | null }>) => void;
   _resetLockProbes: () => void;
 };
-const { platformWriteSync, retryRenameSync } = require('./shell-command-projection.cjs') as {
+const { platformWriteSync, retryRenameSync, shellSingleQuote } = require('./shell-command-projection.cjs') as {
   platformWriteSync: (filePath: string, content: string) => void;
   retryRenameSync: (fromPath: string, toPath: string) => void;
+  shellSingleQuote: (value: string) => string;
 };
 // #1463: numeric major.minor.patch comparison for the outdated check (the SAME compare the resolver
 // and capability list use). -1 (a<b), 0 (equal), 1 (a>b).
@@ -450,18 +451,6 @@ function isSafeHookScriptPath(script: string): boolean {
   if (PYCACHE_SEGMENT_RE.test(script)) return false;
   if (PYCACHE_SUFFIX_RE.test(path.basename(script))) return false;
   return true;
-}
-
-/**
- * #1460 (R) HIGH: POSIX single-quote an arbitrary string for safe inclusion in a shell command.
- * The emitted hook `command` is the ABSOLUTE confined script path, which begins with the
- * (non-manifest) install-prefix — commonly a home dir containing spaces/special chars (e.g.
- * "/Users/Bob Smith/.claude/..."). Written unquoted it would word-split (and, with a hostile
- * prefix, could inject). Wrapping in single quotes — with each embedded `'` escaped as `'\''` —
- * makes the whole path a single shell token that no metacharacter inside it can break.
- */
-function shellSingleQuote(value: string): string {
-  return "'" + value.replace(/'/g, "'\\''") + "'";
 }
 
 /**

--- a/src/shell-command-projection.cts
+++ b/src/shell-command-projection.cts
@@ -56,6 +56,11 @@ export function posixNormalize(p: string): string {
   return p.replace(/\\/g, '/');
 }
 
+/** #1460: Quote an arbitrary value as one POSIX shell token. */
+export function shellSingleQuote(value: string): string {
+  return "'" + value.replace(/'/g, "'\\''") + "'";
+}
+
 /**
  * #3663 — comparison key for a path that must equal another path regardless
  * of spelling: separator form (forward slashes via posixNormalize), relative


### PR DESCRIPTION
## Enhancement PR

## Linked Issue

Closes #4039

## What this enhancement improves

The existing POSIX shell single-quote behavior is reusable infrastructure, but its implementation is private to capability lifecycle code.

## Before / After

**Before:** `shellSingleQuote` was duplicated privately in `src/capability-lifecycle.cts`.

**After:** The helper is exported from `src/shell-command-projection.cts` and capability lifecycle reuses that single implementation. Runtime behavior is unchanged.

## How it was implemented

Moved the helper to the shared shell-command projection module and updated the lifecycle import. No dependencies or user-facing behavior changed.

## Testing

### How I verified the enhancement works

- `npm run build:lib`
- `node --test tests/capability-lifecycle.test.cjs tests/shell-command-projection.test.cjs` (129 passed)
- `npm run lint`
- `npm run check:contract-drift`

### Platforms tested

- [x] N/A (not platform-specific)

### Runtimes tested

- [x] N/A (not runtime-specific)

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue — no additions or removals

## Documentation

- [x] No user-facing docs impact; this is an internal refactor.

<!-- docs-exempt: internal refactor with no user-facing behavior or documentation change -->

## Checklist

- [x] Issue linked above with `Closes #4039`
- [x] Linked issue has the `approved-enhancement` label
- [x] Changes are scoped to the approved enhancement
- [x] New or updated tests cover the enhanced behavior
- [x] No unnecessary dependencies added

## Breaking changes

None.