### PR TITLE
fix(#3895): delete the mempalace-curator's model frontmatter pin — the fleet's only hardcoded model

### DIFF
--- a/.changeset/kind-eagles-rally.md
+++ b/.changeset/kind-eagles-rally.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+gsd-mempalace-curator no longer hardcodes model: sonnet in its frontmatter — the only pin in the 34-agent fleet; it intercepted the deliberate inherit case (agents inherit the orchestrator model when resolution is inherit) and operators could not durably remove it. Default profiles keep sonnet via the model catalog; model_overrides and inherit now work (#3895)

--- a/.changeset/kind-eagles-rally.md
+++ b/.changeset/kind-eagles-rally.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 4048
 ---
 gsd-mempalace-curator no longer hardcodes model: sonnet in its frontmatter — the only pin in the 34-agent fleet; it intercepted the deliberate inherit case (agents inherit the orchestrator model when resolution is inherit) and operators could not durably remove it. Default profiles keep sonnet via the model catalog; model_overrides and inherit now work (#3895)

--- a/agents/gsd-mempalace-curator.md
+++ b/agents/gsd-mempalace-curator.md
@@ -2,7 +2,6 @@
 name: gsd-mempalace-curator
 description: Ship-time MemPalace curation — writes the session diary, proposes/creates cross-project tunnels, mirrors extract-learnings into the temporal KG, and runs wing-scoped drawer pruning. Spawned at ship:post by the mempalace capability.
 tools: Read, Bash, Grep, Glob
-model: sonnet
 color: cyan
 ---
 

--- a/tests/agent-frontmatter.test.cjs
+++ b/tests/agent-frontmatter.test.cjs
@@ -246,6 +246,38 @@ describe('AGENT: required frontmatter fields', () => {
   }
 });
 
+// ─── Model resolution uniformity (#3895) ─────────────────────────────────────
+
+describe('MODEL: no agent hardcodes a model frontmatter pin', () => {
+  // Exactly one shipped agent (gsd-mempalace-curator) carried `model: sonnet`
+  // while the other 33 resolved through the model-profile system. The pin
+  // intercepted #2517's deliberate inherit case — the ship:post dispatch OMITS
+  // model= on inherit so the agent inherits the orchestrator's model, but the
+  // frontmatter pin silently forced sonnet there. The catalog entry
+  // (model-catalog.json: golden/balanced sonnet) preserves default-profile
+  // behavior; operators regain model_overrides + inherit authority.
+  test('no shipped agent frontmatter contains a model: pin', () => {
+    const offenders = [];
+    for (const agent of ALL_AGENTS) {
+      const content = fs.readFileSync(path.join(AGENTS_DIR, agent + '.md'), 'utf-8');
+      const frontmatter = content.split('---')[1] || '';
+      if (/^model:/m.test(frontmatter)) offenders.push(agent);
+    }
+    assert.deepEqual(
+      offenders, [],
+      `agents must resolve models via the model-profile system, not a frontmatter pin (#3895): ${offenders.join(', ')}`
+    );
+  });
+
+  test('the curator keeps its catalog entry (deleting the pin must not orphan the agent)', () => {
+    const catalog = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'gsd-core', 'bin', 'shared', 'model-catalog.json'), 'utf-8'));
+    const entry = catalog.agents && catalog.agents['gsd-mempalace-curator'];
+    assert.ok(entry, 'catalog entry for gsd-mempalace-curator must exist');
+    assert.equal(entry.golden, 'sonnet', 'golden profile preserves the pinned behavior');
+    assert.equal(entry.balanced, 'sonnet', 'balanced profile preserves the pinned behavior');
+  });
+});
+
 // ─── Color Value Validation ──────────────────────────────────────────────────
 
 const VALID_AGENT_COLORS = new Set(['red', 'blue', 'green', 'yellow', 'purple', 'orange', 'pink', 'cyan']);


### PR DESCRIPTION
## What

`agents/gsd-mempalace-curator.md`'s `model: sonnet` frontmatter line — the only hardcoded model pin in the 34-agent fleet — is deleted. Nothing else changes.

## Why (#3895)

Every other agent resolves its model at dispatch time through the model-profile system. The ship:post dispatch (#2684) resolves per-hook and deliberately omits `model=` on inherit (#2517) so the agent inherits the orchestrator's model — the pin intercepted that inherit case, silently forcing `sonnet` where all 33 siblings would inherit, and operators could not durably remove it because install rewrites live agent copies wholesale.

Default-profile behavior is preserved: the catalog entry (`model-catalog.json` → `agents.gsd-mempalace-curator`: `golden: sonnet`, `balanced: sonnet`, `budget: haiku`) is what resolves now — the same path the rest of the fleet uses. `model_overrides` and inherit authority are restored.

## Change

- One line deleted from `agents/gsd-mempalace-curator.md`.
- New guard in `tests/agent-frontmatter.test.cjs`: a fleet-wide scan asserting **no** shipped agent frontmatter carries a `model:` pin (same blanket-ban shape as the file's `permissionMode` ban), plus a catalog control pinning that the curator's entry exists with golden/balanced `sonnet` — so the deletion can never orphan the agent or silently change default profiles.

## Verification

- RED: commit `6c5f4591` (tests only) — the fleet scan failed with offender list `[gsd-mempalace-curator]`; the catalog control passed by design.
- GREEN: 2/2; agent-frontmatter 372/372; agent-descriptor-parity + install-validation 54/54; bench verdict recorded on the final sha.
- Review findings folded in — see `.gsd/bug/fix.3895-mempalace-curator-model-pin/60-review.json`.

Closes #3895
