### PR TITLE
fix(#3864): smart-entry classify() matches the verif* status stem

### DIFF
--- a/.changeset/graceful-foxes-dart.md
+++ b/.changeset/graceful-foxes-dart.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 4052
 ---
 smart-entry classifies a STATE.md status of verified (or verification) as verify-pending instead of falling through to unknown — the classifier matched the exact word verify and missed the verif stem its own normalizeStateStatus uses (#3864)

--- a/.changeset/graceful-foxes-dart.md
+++ b/.changeset/graceful-foxes-dart.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+smart-entry classifies a STATE.md status of verified (or verification) as verify-pending instead of falling through to unknown — the classifier matched the exact word verify and missed the verif stem its own normalizeStateStatus uses (#3864)

--- a/src/smart-entry.cts
+++ b/src/smart-entry.cts
@@ -599,7 +599,13 @@ export function classify(s: SmartEntrySignals): Situation {
   if (isComplete(s)) return 'complete';
   if (/\bplanning|planned\b/i.test(s.status)) return 'planning';
   if (/\bexecut(e|ing)|active|in.progress|building\b/i.test(s.status)) return 'executing';
-  if (/\bverify|review|needs.review|pending.review\b/i.test(s.status)) return 'verify-pending';
+  // #3864: `verif` (not `verify`) — the same stem state-document's
+  // normalizeStateStatus matches. "verified" and "verification" contain no
+  // "verify" substring, so the exact word left them falling through to
+  // `unknown` (or idle-stranded on a clean unpushed tree — differently
+  // wrong). verify_failed is tested above, so a failed verification still
+  // wins over this branch.
+  if (/\bverif|review|needs.review|pending.review\b/i.test(s.status)) return 'verify-pending';
   if (isIdleStranded(s)) return 'idle-stranded';
   return 'unknown';
 }

--- a/tests/smart-entry.unit.test.cjs
+++ b/tests/smart-entry.unit.test.cjs
@@ -137,6 +137,23 @@ describe('smart-entry: situation coverage', () => {
     assert.equal(result.situation, 'complete');
   });
 
+  test('#3864: "Phase complete — ready for verification" at 5/5 stays complete (complete beats a verif-bearing status)', () => {
+    // A real handler-written Status default (state-document.cts). It carries
+    // the verif stem but names COMPLETION — isComplete must win over the
+    // verify-pending branch when the project is actually done.
+    const dir = track(makeProject({ state: state({ status: 'Phase complete — ready for verification', total_phases: 5, current_phase: 5 }), roadmap: true }));
+    const result = classifyProject(dir);
+    assert.equal(result.situation, 'complete');
+  });
+
+  test('#3864: "Phase complete — ready for verification" mid-project is verify-pending', () => {
+    // Same real status word, phases remaining: pre-fix this fell through to
+    // unknown/idle-stranded (no "verify" substring); the stem now routes it.
+    const dir = track(makeProject({ state: state({ status: 'Phase complete — ready for verification', total_phases: 5, current_phase: 2 }), roadmap: true }));
+    const result = classifyProject(dir);
+    assert.equal(result.situation, 'verify-pending');
+  });
+
   test('#3864: verify-failed still wins over the verify-pending stem (ordering pinned)', () => {
     const dir = track(makeProject({ state: state({ status: 'verify-failed', total_phases: 5, current_phase: 2 }), roadmap: true, verifyFail: true }));
     const result = classifyProject(dir);

--- a/tests/smart-entry.unit.test.cjs
+++ b/tests/smart-entry.unit.test.cjs
@@ -114,6 +114,35 @@ describe('smart-entry: situation coverage', () => {
     });
   }
 
+  // #3860-family guard is NOT wanted here; these are #3864's missing pins:
+  // the classifier's verify branch must match the same verif* stem that
+  // state-document's normalizeStateStatus matches, or a STATE.md declaring
+  // `status: verified` falls through to `unknown` (and, on a clean tree with
+  // unpushed commits, to idle-stranded — differently wrong).
+  test('#3864: status "verified" classifies as verify-pending', () => {
+    const dir = track(makeProject({ state: state({ status: 'verified', total_phases: 5, current_phase: 2 }), roadmap: true }));
+    const result = classifyProject(dir);
+    assert.equal(result.situation, 'verify-pending');
+  });
+
+  test('#3864: status "verification" classifies as verify-pending', () => {
+    const dir = track(makeProject({ state: state({ status: 'verification', total_phases: 5, current_phase: 2 }), roadmap: true }));
+    const result = classifyProject(dir);
+    assert.equal(result.situation, 'verify-pending');
+  });
+
+  test('#3864: the stem does not over-match — "completed" still reaches complete', () => {
+    const dir = track(makeProject({ state: state({ status: 'completed', total_phases: 5, current_phase: 5 }), roadmap: true }));
+    const result = classifyProject(dir);
+    assert.equal(result.situation, 'complete');
+  });
+
+  test('#3864: verify-failed still wins over the verify-pending stem (ordering pinned)', () => {
+    const dir = track(makeProject({ state: state({ status: 'verify-failed', total_phases: 5, current_phase: 2 }), roadmap: true, verifyFail: true }));
+    const result = classifyProject(dir);
+    assert.equal(result.situation, 'verify-failed');
+  });
+
   test('SITUATIONS constant lists all 11 (incl unknown) and is frozen', () => {
     assert.equal(SITUATIONS.length, 11);
     assert.ok(SITUATIONS.includes('unknown'));


### PR DESCRIPTION
## What

`smart-entry` now classifies a STATE.md `status: verified` (or `verification`) as `verify-pending` instead of falling through to `unknown` — and on a clean tree with unpushed commits, instead of the differently-wrong `idle-stranded`.

## Why (#3864)

`classify()`'s verify branch matched the exact word `verify`: `/verify|review|.../`. `"verified"` contains no `"verify"` substring (sixth letter `i`, not `y`), so the branch never fired. The tool already disagreed with itself — `state-document`'s `normalizeStateStatus` matches any `verif*` stem. The symptom varied with git state (unknown vs idle-stranded), which made it look intermittent.

## Change

One stem alignment in `src/smart-entry.cts`: `verify` → `verif`, matching `normalizeStateStatus`'s predicate, with a comment citing the invariant. `verify_failed` is tested earlier in `classify()`, so a failed verification still wins over the new stem.

Tests in `tests/smart-entry.unit.test.cjs`: `verified` → verify-pending, `verification` → verify-pending, `completed` still reaches `complete` (over-match control), `verify-failed` still wins (ordering pinned).

## Verification

- RED: commit `67e20565` (tests only) — 2/4 failed exactly on the two stem cases.
- GREEN: 92/92 across the suite after the fix; bench verdict recorded on the final sha.
- Review findings folded in — see `.gsd/bug/fix.3864-smart-entry-verified-status/60-review.json`.

Closes #3864
