### PR TITLE
fix(#3900): overlay walker skips non-regular files — a repo-root socket no longer fails 32 tests

### DIFF
--- a/.changeset/vivid-lynx-zip.md
+++ b/.changeset/vivid-lynx-zip.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 4062
 ---
 local test runs no longer fail when a daemon keeps a unix socket under the repo root — the overlay builder classified every non-directory entry as a file, so copyFileSync threw ENXIO and 32 tests failed in their before() hooks with no connection to the code under test (#3900)

--- a/.changeset/vivid-lynx-zip.md
+++ b/.changeset/vivid-lynx-zip.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+local test runs no longer fail when a daemon keeps a unix socket under the repo root — the overlay builder classified every non-directory entry as a file, so copyFileSync threw ENXIO and 32 tests failed in their before() hooks with no connection to the code under test (#3900)

--- a/tests/helpers/cold-runtime-lib-fixture.cjs
+++ b/tests/helpers/cold-runtime-lib-fixture.cjs
@@ -77,6 +77,10 @@ function buildColdInstallTree(opts = {}) {
   fs.mkdirSync(hooksDestDir, { recursive: true });
   for (const entry of fs.readdirSync(path.join(repoRoot, 'hooks'), { withFileTypes: true })) {
     if (!shouldCopyHookEntry(entry.name)) continue;
+    // #3900 (same-class guard, found in review): the live repo tree is walked
+    // here — a daemon's socket/FIFO inside hooks/ would reach cpSync and
+    // throw ENXIO (a FIFO would block). Dirent type check, not name-only.
+    if (!entry.isFile() && !entry.isDirectory()) continue;
     fs.cpSync(path.join(repoRoot, 'hooks', entry.name), path.join(hooksDestDir, entry.name), {
       recursive: true,
     });

--- a/tests/helpers/overlay-repo.cjs
+++ b/tests/helpers/overlay-repo.cjs
@@ -211,6 +211,10 @@ function linkOrCopyFile(src, dest) {
 function buildOverlayRepo(fileOverrides, opts = {}) {
   const mode = opts.mode || 'link';
   const warn = opts.warn || console.warn;
+  // #3900: test-only root override — the #3900 regression tests build the
+  // overlay from a tiny synthetic root instead of walking the whole repo
+  // (every existing caller uses the default and is unaffected).
+  const root = opts.root || REPO_ROOT;
   const tmpRepo = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-2930-overlay-'));
   const entries = Object.entries(fileOverrides).map(([relPath, content]) => ({
     parts: relPath.split('/'),
@@ -255,6 +259,13 @@ function buildOverlayRepo(fileOverrides, opts = {}) {
       }
       if (srcStat.isDirectory()) {
         place(srcPath, destPath, overridden || [], false);
+      } else if (!srcStat.isFile()) {
+        // #3900: sockets, FIFOs, device nodes are not repository content.
+        // Classifying them as files made copyFileSync throw ENXIO on a
+        // socket (a FIFO would block until a writer appears) — 32 local
+        // test failures from a daemon's working-tree socket, none about the
+        // code under test. Skip: the overlay mirrors files, not devices.
+        continue;
       } else if (mode === 'copy') {
         // Real independent inode — a write through this path in the overlay
         // can never alias back to REPO_ROOT's own tracked file (see
@@ -272,7 +283,7 @@ function buildOverlayRepo(fileOverrides, opts = {}) {
     }
   }
 
-  place(REPO_ROOT, tmpRepo, entries, true);
+  place(root, tmpRepo, entries, true);
 
   if (skipped.length > 0) {
     // Not thrown: a source that left the tree mid-walk is genuinely not part of

--- a/tests/helpers/overlay-repo.cjs
+++ b/tests/helpers/overlay-repo.cjs
@@ -211,9 +211,10 @@ function linkOrCopyFile(src, dest) {
 function buildOverlayRepo(fileOverrides, opts = {}) {
   const mode = opts.mode || 'link';
   const warn = opts.warn || console.warn;
-  // #3900: test-only root override — the #3900 regression tests build the
-  // overlay from a tiny synthetic root instead of walking the whole repo
-  // (every existing caller uses the default and is unaffected).
+  // #3900: test-only root override (mirrors cold-runtime-lib-fixture's
+  // repoRoot) — the #3900 regression tests build the overlay from a tiny
+  // synthetic root instead of walking the whole repo; every existing caller
+  // uses the default REPO_ROOT and is unaffected.
   const root = opts.root || REPO_ROOT;
   const tmpRepo = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-2930-overlay-'));
   const entries = Object.entries(fileOverrides).map(([relPath, content]) => ({

--- a/tests/overlay-repo-helpers.test.cjs
+++ b/tests/overlay-repo-helpers.test.cjs
@@ -707,46 +707,44 @@ describe('buildOverlayRepo: non-regular files are skipped (#3900)', () => {
   const isPosix = process.platform !== 'win32';
 
   test('a unix socket anywhere under the repo root does not break the overlay', { skip: !isPosix }, async () => {
+    // opts.root (also from this fix): a tiny synthetic root, so the test does
+    // not pay a full repo walk — the walker is the same either way.
     const net = require('node:net');
-    const probeDir = path.join(__dirname, '..', '.gsd-3900-probe');
-    fs.mkdirSync(probeDir, { recursive: true });
-    const sockPath = path.join(probeDir, 'daemon.sock');
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-3900-root-'));
     const server = net.createServer();
-    await new Promise((resolve) => server.listen(sockPath, resolve));
+    await new Promise((resolve) => server.listen(path.join(root, 'daemon.sock'), resolve));
     try {
-      let overlay;
+      fs.writeFileSync(path.join(root, 'real.txt'), 'x');
+      const overlay = buildOverlayRepo({}, { root });
       try {
-        overlay = buildOverlayRepo({});
-        // The socket must not be mirrored into the overlay.
         assert.equal(
-          fs.existsSync(path.join(overlay, '.gsd-3900-probe', 'daemon.sock')),
+          fs.existsSync(path.join(overlay, 'daemon.sock')),
           false,
           'the socket is not repository content — it must not be copied',
         );
-        // And the repository's own files still are.
-        assert.equal(fs.existsSync(path.join(overlay, 'package.json')), true);
-      } finally {
-        if (overlay) cleanup(overlay);
-      }
-    } finally {
-      server.close();
-      fs.rmSync(probeDir, { recursive: true, force: true });
-    }
-  });
-
-  test('regular files under the probe directory still copy (control)', () => {
-    const probeDir = path.join(__dirname, '..', '.gsd-3900-probe-ctrl');
-    fs.mkdirSync(probeDir, { recursive: true });
-    fs.writeFileSync(path.join(probeDir, 'note.txt'), 'x');
-    try {
-      const overlay = buildOverlayRepo({});
-      try {
-        assert.equal(fs.existsSync(path.join(overlay, '.gsd-3900-probe-ctrl', 'note.txt')), true);
+        assert.equal(fs.existsSync(path.join(overlay, 'real.txt')), true,
+          'regular files in the same tree still overlay');
       } finally {
         cleanup(overlay);
       }
     } finally {
-      fs.rmSync(probeDir, { recursive: true, force: true });
+      server.close();
+      cleanup(root);
+    }
+  });
+
+  test('regular files still copy (control, synthetic root)', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-3900-ctrl-'));
+    try {
+      fs.writeFileSync(path.join(root, 'note.txt'), 'x');
+      const overlay = buildOverlayRepo({}, { root });
+      try {
+        assert.equal(fs.existsSync(path.join(overlay, 'note.txt')), true);
+      } finally {
+        cleanup(overlay);
+      }
+    } finally {
+      cleanup(root);
     }
   });
 });

--- a/tests/overlay-repo-helpers.test.cjs
+++ b/tests/overlay-repo-helpers.test.cjs
@@ -692,3 +692,61 @@ describe('placeVanishableLeaf: property coverage', () => {
     );
   });
 });
+
+// ─── #3900: non-regular working-tree files are not repository content ────────
+
+describe('buildOverlayRepo: non-regular files are skipped (#3900)', () => {
+  // A unix socket under the repo root (an MCP server, a language-server
+  // daemon, a watcher) made every suite built on the overlay fail in its
+  // before() hook: the walker classified anything not-a-directory as a file,
+  // and copyFileSync on a socket throws ENXIO (a FIFO would block). The
+  // reporter measured 32 failures across 6 files — none about the code under
+  // test. Unix-domain sockets bind only on POSIX; the Windows lane keeps the
+  // equivalence via a FIFO-shaped skip is impractical, so it verifies only
+  // the regular-file path.
+  const isPosix = process.platform !== 'win32';
+
+  test('a unix socket anywhere under the repo root does not break the overlay', { skip: !isPosix }, async () => {
+    const net = require('node:net');
+    const probeDir = path.join(__dirname, '..', '.gsd-3900-probe');
+    fs.mkdirSync(probeDir, { recursive: true });
+    const sockPath = path.join(probeDir, 'daemon.sock');
+    const server = net.createServer();
+    await new Promise((resolve) => server.listen(sockPath, resolve));
+    try {
+      let overlay;
+      try {
+        overlay = buildOverlayRepo({});
+        // The socket must not be mirrored into the overlay.
+        assert.equal(
+          fs.existsSync(path.join(overlay, '.gsd-3900-probe', 'daemon.sock')),
+          false,
+          'the socket is not repository content — it must not be copied',
+        );
+        // And the repository's own files still are.
+        assert.equal(fs.existsSync(path.join(overlay, 'package.json')), true);
+      } finally {
+        if (overlay) cleanup(overlay);
+      }
+    } finally {
+      server.close();
+      fs.rmSync(probeDir, { recursive: true, force: true });
+    }
+  });
+
+  test('regular files under the probe directory still copy (control)', () => {
+    const probeDir = path.join(__dirname, '..', '.gsd-3900-probe-ctrl');
+    fs.mkdirSync(probeDir, { recursive: true });
+    fs.writeFileSync(path.join(probeDir, 'note.txt'), 'x');
+    try {
+      const overlay = buildOverlayRepo({});
+      try {
+        assert.equal(fs.existsSync(path.join(overlay, '.gsd-3900-probe-ctrl', 'note.txt')), true);
+      } finally {
+        cleanup(overlay);
+      }
+    } finally {
+      fs.rmSync(probeDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## What

The test-harness overlay builder (`tests/helpers/overlay-repo.cjs`) no longer treats a unix socket, FIFO, or device node as a repository file. A daemon keeping a socket anywhere under the repo root used to fail every suite built on `buildOverlayRepo` in its `before()` hook.

## Why (#3900)

The walker classified every not-a-directory entry as a file; `copyFileSync` on a socket throws `ENXIO` (a FIFO would block until a writer appeared). The reporter measured **32 failures across 6 files** — all infrastructure suites, none about the code under test. The hard-link path doesn't save it: the overlay lives under `os.tmpdir()` (tmpfs on typical Linux), so the link always fails `EXDEV` and falls through to the copy. CI never sees it because a fresh clone has no working-tree daemons — exactly why it eats local debugging time: the failures name the code under test, not the socket.

## Change

- One guard at the classification site: `srcStat.isFile()` before the copy/link branches — non-regular entries are skipped (they are not repository content).
- `opts.root` — a test-only root override (default `REPO_ROOT`, every existing caller unaffected) so the regression tests build the overlay from a tiny synthetic root in milliseconds instead of paying a full repo walk.
- Tests in `tests/overlay-repo-helpers.test.cjs`: a real bound unix socket in the synthetic root must not appear in the overlay while a sibling regular file still does (POSIX; the Windows lane keeps the regular-file control).

## Verification

- RED: bench verdict `failed` on `1cf3b23b` (the socket was mirrored).
- GREEN: bench verdict `passed` 40,763/40,763 on `88bb4ef4` (fold-ins included: a Dirent type guard on the sibling cold-runtime-lib-fixture's hooks/ walk — the same class — plus changeset format and opts.root doc).
- Review findings folded in — see `.gsd/bug/fix.3900-overlay-repo-nonregular-files/60-review.json`.

Closes #3900
