### PR TITLE
fix(#3902): packaging guard resolves npm 12's pack --json shape — stays armed on Node 26

### DIFF
--- a/.changeset/serene-goats-sprint.md
+++ b/.changeset/serene-goats-sprint.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**The packaging guard stays armed on npm 12 (Node 26)** — npm 12 emits pack --json as an object keyed by package name, so parsed[0] was undefined, the before() hook threw, and all 6 packaging-guard tests (including both does-NOT-ship gates) went dark for Node 26 contributors (#3902)

--- a/.changeset/serene-goats-sprint.md
+++ b/.changeset/serene-goats-sprint.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 4064
 ---
 **The packaging guard stays armed on npm 12 (Node 26)** — npm 12 emits pack --json as an object keyed by package name, so parsed[0] was undefined, the before() hook threw, and all 6 packaging-guard tests (including both does-NOT-ship gates) went dark for Node 26 contributors (#3902)

--- a/tests/packaging-shipped-scripts-require-only-shipped.test.cjs
+++ b/tests/packaging-shipped-scripts-require-only-shipped.test.cjs
@@ -46,6 +46,14 @@ function resolveTarballFiles() {
     timeout: 120_000,
   });
   const parsed = JSON.parse(raw);
+  return packListToPathSet(parsed);
+}
+
+/**
+ * Pure projection from `npm pack --json` output to the tarball path set —
+ * extracted so the SHAPE contract is unit-testable without running npm.
+ */
+function packListToPathSet(parsed) {
   return new Set(parsed[0].files.map((f) => f.path.replace(/\\/g, '/')));
 }
 
@@ -196,5 +204,31 @@ describe('#2858 — shipped scripts require only shipped paths', () => {
     const classification = classifyRequire('./lib/cli-exit.cjs', 'scripts/gen-adr-index.cjs', shippedFiles);
     assert.strictEqual(classification, 'shipped',
       `a sibling require within scripts/ must classify as 'shipped'; got '${classification}'`);
+  });
+});
+
+
+// ─── #3902: npm 12's pack --json shape must resolve like npm <=11's ──────────
+
+describe('#3902 packListToPathSet resolves both npm pack --json shapes', () => {
+  const FILES = [{ path: 'gsd-core/bin/gsd-tools.cjs' }, { path: 'lib/Backslash\\Case.cjs' }];
+
+  test('npm <=11 array shape', () => {
+    const set = packListToPathSet([{ files: FILES }]);
+    assert.ok(set.has('gsd-core/bin/gsd-tools.cjs'));
+    assert.ok(set.has('lib/Backslash/Case.cjs'), 'windows separators normalized');
+  });
+
+  test('npm 12 (Node 26) object-keyed shape', () => {
+    // npm 12 emits { "<pkg-name>": { files: [...] } } — parsed[0] is undefined
+    // there, which used to throw in the before() hook and silently disable
+    // the whole packaging guard, including both `does NOT ship` assertions.
+    const set = packListToPathSet({ '@opengsd/gsd-core': { files: FILES } });
+    assert.ok(set.has('gsd-core/bin/gsd-tools.cjs'));
+    assert.ok(set.has('lib/Backslash/Case.cjs'));
+  });
+
+  test('an unrecognized shape fails loud, never silently-empty', () => {
+    assert.throws(() => packListToPathSet({ weird: true }));
   });
 });

--- a/tests/packaging-shipped-scripts-require-only-shipped.test.cjs
+++ b/tests/packaging-shipped-scripts-require-only-shipped.test.cjs
@@ -54,7 +54,18 @@ function resolveTarballFiles() {
  * extracted so the SHAPE contract is unit-testable without running npm.
  */
 function packListToPathSet(parsed) {
-  return new Set(parsed[0].files.map((f) => f.path.replace(/\\/g, '/')));
+  // #3902: npm <=11 emits an ARRAY of pack results; npm 12 (bundled with
+  // Node 26) emits an OBJECT keyed by package name. parsed[0] is undefined on
+  // the object shape — which threw in this file's before() hook and silently
+  // disabled the whole packaging guard, including both `does NOT ship`
+  // assertions. Resolve either shape; anything else fails loud.
+  const entry = Array.isArray(parsed)
+    ? parsed[0]
+    : parsed[Object.keys(parsed)[0]];
+  if (!entry || !Array.isArray(entry.files)) {
+    throw new Error(`npm pack --json returned an unrecognized shape: ${Object.prototype.toString.call(parsed)}`);
+  }
+  return new Set(entry.files.map((f) => f.path.replace(/\\/g, '/')));
 }
 
 /**

--- a/tests/packaging-shipped-scripts-require-only-shipped.test.cjs
+++ b/tests/packaging-shipped-scripts-require-only-shipped.test.cjs
@@ -59,9 +59,20 @@ function packListToPathSet(parsed) {
   // the object shape — which threw in this file's before() hook and silently
   // disabled the whole packaging guard, including both `does NOT ship`
   // assertions. Resolve either shape; anything else fails loud.
-  const entry = Array.isArray(parsed)
-    ? parsed[0]
-    : parsed[Object.keys(parsed)[0]];
+  // Single-package assumption: this repo has no workspaces, so npm 12 emits
+  // exactly ONE key. If workspaces are ever adopted, first-key would silently
+  // validate only one package — recreate the silent-disarm this fix kills —
+  // so a multi-key object fails loud instead.
+  let entry;
+  if (Array.isArray(parsed)) {
+    entry = parsed[0];
+  } else {
+    const keys = Object.keys(parsed);
+    if (keys.length !== 1) {
+      throw new Error(`npm pack --json emitted ${keys.length} package keys; expected exactly 1 for this single-package repo`);
+    }
+    entry = parsed[keys[0]];
+  }
   if (!entry || !Array.isArray(entry.files)) {
     throw new Error(`npm pack --json returned an unrecognized shape: ${Object.prototype.toString.call(parsed)}`);
   }
@@ -241,5 +252,12 @@ describe('#3902 packListToPathSet resolves both npm pack --json shapes', () => {
 
   test('an unrecognized shape fails loud, never silently-empty', () => {
     assert.throws(() => packListToPathSet({ weird: true }));
+  });
+
+  test('a multi-key object (workspaces) fails loud — first-key would silently validate one package', () => {
+    assert.throws(() => packListToPathSet({
+      'pkg-a': { files: FILES },
+      'pkg-b': { files: FILES },
+    }), /exactly 1/);
   });
 });


### PR DESCRIPTION
## What

The packaging guard (`tests/packaging-shipped-scripts-require-only-shipped.test.cjs`) resolves `npm pack --json` output on **both** shapes — the array npm ≤11 emits and the object-keyed-by-package-name npm 12 (bundled with Node 26) emits — and fails loud on anything else.

## Why (#3902)

The file indexed `parsed[0].files`; on npm 12 `parsed[0]` is undefined, the `before()` hook threw, and all 6 tests in the guard went dark — including the two `does NOT ship` gates that stop repo-only CI tooling leaking into the published package. Exactly the assertions you least want silently absent, on exactly the contributors newest tooling. CONTRIBUTING pins Node 24 as the floor but requires Node 26 compatibility for code **and** tests — this was the test's parse, not the code.

## Change

- The projection is extracted into a pure `packListToPathSet(parsed)` so the shape contract is unit-testable without running npm — which matters because the bench's Node 24 npm cannot reproduce the defect natively; the object-shape unit case is the portable RED.
- Both shapes resolve; an unrecognized shape **throws** (a silently-empty set is the exact dark-guard failure mode this guard exists to prevent).
- Review fold-in: the single-package assumption is documented and **enforced** — a multi-key object (workspaces) throws rather than silently validating one package's file list.

## Verification

- RED: commit `0b7f4433` (extraction preserving the array-only logic + both-shape unit tests) — the npm-12 object-shape case fails; the array and unrecognized-shape cases pass by design.
- GREEN: bench verdicts `passed` 40,837/40,837 on `914d3f1a` and 40,838/40,838 on `476627cb` (fold-in); full file 8/8.
- Review findings folded in — see `.gsd/bug/fix.3902-npm12-pack-shape/60-review.json`.

Closes #3902
