### PR TITLE
fix(#4060): drive repo-baseline lint check in-process, not via a subprocess timeout race

### DIFF
--- a/scripts/lint-allow-test-rule-refs.cjs
+++ b/scripts/lint-allow-test-rule-refs.cjs
@@ -721,8 +721,19 @@ function classifySites(files) {
   };
 }
 
-async function main() {
-  const args = process.argv.slice(2);
+/**
+ * @param {string[]} [argv] - CLI-style argv (excluding the node binary and
+ *   script path). Defaults to `process.argv.slice(2)` ONLY when omitted
+ *   (`undefined`) — the sole change from the prior hardcoded read, so the
+ *   CLI entrypoint below (`runMain(main)`, which calls `main()` with no
+ *   args) is unaffected. Passing an explicit array (including `[]`) lets a
+ *   caller — notably `tests/lint-allow-test-rule-refs.test.cjs`'s
+ *   "repo baseline passes" row, #4060 — drive this function directly,
+ *   in-process, with no subprocess and thus no `spawnSync` `timeout` to
+ *   race against CI-load contention.
+ */
+async function main(argv = process.argv.slice(2)) {
+  const args = argv;
   const unknown = args.filter((a) => a !== '--help');
   if (unknown.length > 0) {
     throw new ExitError(2, `lint-allow-test-rule-refs: unknown argument(s): ${unknown.join(', ')}`);
@@ -853,6 +864,7 @@ module.exports = {
   classifyFile,
   classifySites,
   classifyCode,
+  main,
 };
 
 if (require.main === module) {

--- a/tests/lint-allow-test-rule-refs.test.cjs
+++ b/tests/lint-allow-test-rule-refs.test.cjs
@@ -42,15 +42,25 @@ const SCRIPT = path.join(ROOT, 'scripts', 'lint-allow-test-rule-refs.cjs');
 // sandbox override, so it drives ESLint's `Linter` over every real
 // marker-bearing file the script finds (~294 files after the #3464 perf
 // follow-up narrowed the Linter pass off the full ~1200-file glob walk).
-// That is a heavier class than `PROBE_TIMEOUT_MS` describes ("a single short
-// CLI query or `node -e` probe against a temp fixture") — measured ~2.3-3.3s
-// locally post-narrowing, down from ~7-12s pre-narrowing, which is what
-// previously died at exactly the `PROBE_TIMEOUT_MS=15000` bound under CI
-// load (empty stdout/stderr, exitCode null — SIGKILLed by the harness
-// timeout, not a real assertion failure). 30000ms is ~10x the measured local
-// runtime, leaving real headroom for slower CI runners without hand-waving
-// the bound back up to "whatever makes it pass this once."
-const REPO_BASELINE_LINT_TIMEOUT_MS = 30000;
+//
+// Unlike every other row, this one needs no per-test sandboxing or env-var
+// override (there is no synthetic fixture state to isolate — it targets the
+// real, shared repo tree), so it is the one row with no structural reason to
+// go through a subprocess at all. It previously did anyway
+// (`runNode([SCRIPT], { timeoutMs: ... })`), which raced the script's real
+// wall-clock completion against a FIXED `spawnSync` `timeout` bound under
+// variable, unbounded CI-load contention — a bound that was already raised
+// once before (`PROBE_TIMEOUT_MS=15000` -> a dedicated 30000ms constant)
+// after dying at the lower value under CI load (empty stdout/stderr, exit
+// code null — SIGKILLed by the harness timeout, not a real assertion
+// failure), and then died again at the raised value for the same reason
+// (#4060). A fixed timeout racing unbounded contention has no value that is
+// simultaneously tight enough to catch a real hang and loose enough to never
+// lose the race under load, so raising the number a third time would not fix
+// the mechanism, only its odds. Fixed by removing the subprocess boundary
+// for this one row: it now drives the script's own exported `main` directly,
+// in-process, exactly like the structural rows 13-15 already do for the
+// script's other exports — there is no `spawnSync` timeout to race at all.
 
 // Deliberately split so this file's OWN source never contains the contiguous
 // exemption-marker substring the script under test scans for — the script
@@ -239,12 +249,42 @@ describe('lint-allow-test-rule-refs', () => {
     assert.match(r.stderr, /--bogus/);
   });
 
-  test('repo baseline passes (real tests/ dir against real allowlist + ceilings)', () => {
-    const r = runNode([SCRIPT], { cwd: ROOT, timeoutMs: REPO_BASELINE_LINT_TIMEOUT_MS });
-    assert.strictEqual(r.exitCode, 0, `stderr: ${r.stderr}\nstdout: ${r.stdout}`);
-    assert.match(r.stdout, /effective exemptions:/);
-    assert.match(r.stdout, /unverified markers:/);
-    assert.match(r.stdout, /Known limit:/);
+  test('repo baseline passes (real tests/ dir against real allowlist + ceilings)', async () => {
+    // In-process: no subprocess, no spawnSync `timeout` to race against CI
+    // load (see the header comment above this describe block). Capture
+    // console.log the same way the CLI's own stdout is asserted on below,
+    // restored in `finally` regardless of outcome so a thrown/rejected call
+    // can never leak a patched console.log into a later test.
+    const originalLog = console.log;
+    let stdout = '';
+    console.log = (...args) => {
+      stdout += `${args.join(' ')}\n`;
+    };
+    try {
+      await scriptUnderTest.main([]);
+    } finally {
+      console.log = originalLog;
+    }
+    assert.match(stdout, /effective exemptions:/);
+    assert.match(stdout, /unverified markers:/);
+    assert.match(stdout, /Known limit:/);
+  });
+
+  test('repo baseline: main() still rejects unknown argv in-process (boundary on the new argv contract)', async () => {
+    // Pins that exporting/parameterizing `main` for in-process use did not
+    // loosen its existing CLI-argv validation — same contract the
+    // subprocess-based "unknown CLI arguments are rejected with exit code 2"
+    // row below already covers via the CLI entrypoint, exercised here
+    // directly against the exported function.
+    await assert.rejects(
+      () => scriptUnderTest.main(['--bogus']),
+      (err) => {
+        assert.strictEqual(err.code, 2);
+        assert.match(err.message, /unknown argument/);
+        assert.match(err.message, /--bogus/);
+        return true;
+      }
+    );
   });
 
   // ─── #3520 test-matrix rows 1-12 ────────────────────────────────────────

--- a/tests/lint-allow-test-rule-refs.test.cjs
+++ b/tests/lint-allow-test-rule-refs.test.cjs
@@ -251,23 +251,47 @@ describe('lint-allow-test-rule-refs', () => {
 
   test('repo baseline passes (real tests/ dir against real allowlist + ceilings)', async () => {
     // In-process: no subprocess, no spawnSync `timeout` to race against CI
-    // load (see the header comment above this describe block). Capture
-    // console.log the same way the CLI's own stdout is asserted on below,
-    // restored in `finally` regardless of outcome so a thrown/rejected call
-    // can never leak a patched console.log into a later test.
+    // load (see the header comment above this describe block). Capture BOTH
+    // console.log and process.stderr.write — main()'s only diagnostic output
+    // on a real failure is a bare `throw new ExitError(1)` with NO message
+    // (scripts/lint-allow-test-rule-refs.cjs:824-832); every actual detail
+    // (which files/violations) goes to process.stderr.write, not the thrown
+    // error. The old subprocess-based assertion embedded both r.stderr and
+    // r.stdout in its failure message; capturing only console.log here would
+    // silently regress that — a real failure would surface as an opaque,
+    // messageless ExitError with no clue which allowlist/ceiling tripped.
+    // Both patches are restored in `finally` regardless of outcome so a
+    // thrown/rejected call can never leak into a later test.
     const originalLog = console.log;
+    const originalStderrWrite = process.stderr.write;
     let stdout = '';
+    let stderr = '';
     console.log = (...args) => {
       stdout += `${args.join(' ')}\n`;
     };
+    process.stderr.write = (chunk, encoding, callback) => {
+      stderr += typeof chunk === 'string' ? chunk : chunk.toString(typeof encoding === 'string' ? encoding : 'utf8');
+      const cb = typeof encoding === 'function' ? encoding : callback;
+      if (typeof cb === 'function') cb();
+      return true;
+    };
     try {
       await scriptUnderTest.main([]);
+    } catch (err) {
+      // Re-throw with the captured streams attached so a real gate failure
+      // (allowlist/ceiling trip) is diagnosable from the test output alone,
+      // matching what the old subprocess assertion's message provided.
+      const wrapped = new Error(`${err.message}\nstderr: ${stderr}\nstdout: ${stdout}`);
+      wrapped.cause = err;
+      throw wrapped;
     } finally {
       console.log = originalLog;
+      process.stderr.write = originalStderrWrite;
     }
-    assert.match(stdout, /effective exemptions:/);
-    assert.match(stdout, /unverified markers:/);
-    assert.match(stdout, /Known limit:/);
+    const context = `stderr: ${stderr}\nstdout: ${stdout}`;
+    assert.match(stdout, /effective exemptions:/, context);
+    assert.match(stdout, /unverified markers:/, context);
+    assert.match(stdout, /Known limit:/, context);
   });
 
   test('repo baseline: main() still rejects unknown argv in-process (boundary on the new argv contract)', async () => {


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #4060

---

## What was broken

`tests/lint-allow-test-rule-refs.test.cjs`'s "repo baseline passes" subtest drove the real
`scripts/lint-allow-test-rule-refs.cjs` via a `spawnSync` subprocess with a fixed 30s timeout. Under
CI-load contention (6+ concurrent matrix shards post-merge), the subprocess occasionally lost the
race against that fixed wall-clock bound and got SIGKILLed by the harness — reported as a false
`AssertionError` (`null !== 0`), not a real script failure. This is the *second* occurrence of this
exact signature: the bound was already raised once before (`PROBE_TIMEOUT_MS=15000` → a dedicated
`REPO_BASELINE_LINT_TIMEOUT_MS=30000`) after dying the first time.

## What this fix does

Removes the subprocess (and its timeout race) entirely for this one subtest: it now drives the
script's own exported `main()` function directly, in-process — no `spawnSync`, no OS-scheduling-
dependent kill boundary to lose a race against. `main()` is refactored to accept an explicit `argv`
parameter (defaulting to `process.argv.slice(2)` only when omitted, so the CLI entrypoint is
byte-identical) and added to `module.exports`, matching how this same file already drives the
script's other exports directly (structural rows 13-15).

## Root cause

A fixed-timeout subprocess race against unbounded, variable CI-load contention has no value that is
simultaneously tight enough to catch a real hang and loose enough to never lose the race under load —
raising the bound a third time would repeat the same failed fix, not address the mechanism. This
subtest is the only row in the file with no structural need for subprocess isolation (no synthetic
fixture state to isolate — it targets the real, shared repo tree), so removing the subprocess
boundary eliminates the race precondition rather than just widening the window it can lose in.

## Testing

### How I verified the fix

Failing-first regression test committed and run via `gsd-test` (RED: `TypeError: scriptUnderTest.main
is not a function`, both new subtests). Fix applied, re-verified GREEN via `gsd-test`. Full matrix
(`linux-node24`) passing at the shipped sha: 40834/40834.

### Regression test added?

- [x] Yes — the rewritten "repo baseline passes" subtest itself is the regression coverage (it now
      has no subprocess/timeout to race), plus a new boundary test pinning that the exported `main`
      still rejects unknown argv in-process, and stderr/stdout capture (added after an isolated
      code-review finding) so a real future failure stays diagnosable.

### Platforms tested

- [x] Linux (via `gsd-test`'s remote matrix — this is a Node test-suite change, not platform-specific
      code; macOS/Windows are unaffected)
- [x] N/A (not platform-specific)

### Runtimes tested

- [x] N/A (not runtime-specific — internal test-suite infrastructure only)

---

## Checklist

- [x] Issue linked above with `Fixes #4060`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (failing-first, verified via `gsd-test`)
- [x] All existing tests pass (`gsd-test`, full matrix, 40834/40834)
- [ ] `.changeset/` fragment added if this is a user-facing fix — **not applicable**: this is an
      internal test-suite reliability fix with no change to any published package behavior, CLI
      command, or documented contract. `no-changelog` label applied instead, per
      `.changeset/README.md`'s own opt-out ("PRs that legitimately have no user-facing impact can add
      the `no-changelog` label").
- [x] No unnecessary dependencies added

## Breaking changes

None.

---

## Note for reviewers: pre-existing CI noise investigated, not part of this fix

While rebasing onto a fast-moving `next` (advanced 4 times during this PR's lifetime), `gsd-test`
twice reported `tests/emitted-attribution.test.cjs`'s "differential attribution over the real tree"
failing, claiming `complete-milestone.md` / `execute-phase.md` / `ship.md` grew without an
acknowledgment. Investigated and confirmed via `git cat-file -s <sha>:<path>` at each relevant commit
that this growth is real but was already correctly acknowledged in already-merged PRs #3774
(`472f585f7`) and #3648 (`8487f0ed4`) — the `gsd-test` bench was resolving `origin/next` to a stale
sha at the time. A subsequent rebase + re-verify resolved a fresh, correct base and confirmed no real
unacked growth exists relative to it. Not caused by, or fixed in, this PR (which never touches any
`gsd-core/workflows/*.md` file) — a tracking issue for the bench's stale-mirror behavior is being
filed separately.
