### PR TITLE
fix(#4055): don't resurrect a merged-and-deleted phase/milestone branch

### DIFF
--- a/.changeset/steady-yaks-swim.md
+++ b/.changeset/steady-yaks-swim.md
@@ -2,4 +2,4 @@
 type: Fixed
 pr: 4080
 ---
-Fix: `query commit` no longer resurrects a merged-and-deleted phase/milestone branch (silently re-creating it and committing on it) when a new commit resolves to the same branch name.
+**`query commit` no longer resurrects a merged-and-deleted phase/milestone branch** — a commit resolving to a phase/milestone branch name that was already merged (via `--no-ff`, squash, or rebase merge) and deleted now commits in place instead of silently re-creating the branch and landing the commit there.

--- a/.changeset/steady-yaks-swim.md
+++ b/.changeset/steady-yaks-swim.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 4080
+---
+Fix: `query commit` no longer resurrects a merged-and-deleted phase/milestone branch (silently re-creating it and committing on it) when a new commit resolves to the same branch name.

--- a/src/commands.cts
+++ b/src/commands.cts
@@ -1687,19 +1687,48 @@ function cmdCommit(cwd: string, message: string | undefined, files: string[] | u
         // not silent about where the work is landing (#3207 AC3).
         const verify = execGit(['rev-parse', '--verify', `refs/heads/${branchName}`], { cwd });
         if (verify.exitCode !== 0) {
-          // Branch does not exist — CREATE AND SWITCH (the #1278 first-commit
-          // case). checkout -b cannot resurrect anything: the branch was just
-          // verified absent, so it is created fresh at HEAD.
-          const create = execGit(['checkout', '-b', branchName], { cwd });
-          if (create.exitCode === 0) {
+          // #4055: "does not currently exist" is NOT the same as "never
+          // existed" — a phase/milestone branch that was merged and then
+          // deleted also fails this verify, but checkout -b would silently
+          // RESURRECT it: a fresh branch of the same name, created at HEAD,
+          // that looks identical to the #1278 first-commit case but is
+          // actually a stale name being reused. Distinguish the two by asking
+          // whether HEAD's own ancestry already contains a merge commit for
+          // this branch name — that only happens if the branch existed and
+          // was merged. `--merges` limits the search to actual merge commits
+          // (a squash commit has one parent and never matches, but so does a
+          // never-created branch, so this errs toward the #1278 create path
+          // when it can't tell); `--fixed-strings` keeps branch names with
+          // `.` or other regex metacharacters (e.g. decimal phase slugs) from
+          // being misread as patterns.
+          const resurrection = execGit(
+            ['log', '--merges', '--fixed-strings', `--grep=${branchName}`, '--oneline', '-1'],
+            { cwd }
+          );
+          if (resurrection.exitCode === 0 && resurrection.stdout.trim() !== '') {
+            // Branch was merged into this history and deleted — do NOT
+            // resurrect it. Commit in place, surfaced non-silently like the
+            // other two cases (#4055 AC3).
             process.stderr.write(
-              `${branchingStrategy} branch "${branchName}" created; switched to it for this commit.\n`
+              `Warning: resolved ${branchingStrategy} branch "${branchName}" was previously merged and deleted; ` +
+              `not recreating it — committing on the current branch "${currentBranch.stdout.trim()}" instead.\n`
             );
           } else {
-            process.stderr.write(
-              `Warning: could not create ${branchingStrategy} branch "${branchName}" ` +
-              `(${create.stderr.trim()}); committing on the current branch "${currentBranch.stdout.trim()}".\n`
-            );
+            // Branch never existed — CREATE AND SWITCH (the #1278 first-commit
+            // case). checkout -b cannot resurrect anything here: the branch
+            // was verified absent AND no merge record for it exists, so it is
+            // created fresh at HEAD.
+            const create = execGit(['checkout', '-b', branchName], { cwd });
+            if (create.exitCode === 0) {
+              process.stderr.write(
+                `${branchingStrategy} branch "${branchName}" created; switched to it for this commit.\n`
+              );
+            } else {
+              process.stderr.write(
+                `Warning: could not create ${branchingStrategy} branch "${branchName}" ` +
+                `(${create.stderr.trim()}); committing on the current branch "${currentBranch.stdout.trim()}".\n`
+              );
+            }
           }
         } else {
           // Branch already exists — do NOT switch, commit on current branch.

--- a/src/commands.cts
+++ b/src/commands.cts
@@ -1624,6 +1624,11 @@ function cmdCommit(cwd: string, message: string | undefined, files: string[] | u
   const branchingStrategy = config['branching_strategy'] as string | undefined;
   if (branchingStrategy && branchingStrategy !== 'none') {
     let branchName: string | null = null;
+    // #4055 v2: the directory whose historical presence on HEAD proves this
+    // phase/milestone's own work already landed there — see the resurrection
+    // check below. Set alongside `branchName` in each strategy arm because
+    // both are derived from the same phaseInfo/milestone lookup.
+    let anchorPath: string | null = null;
     if (branchingStrategy === 'phase') {
       // Determine which phase we're committing for from the file paths.
       // #2539: the extraction is anchored to the directory SEGMENT immediately
@@ -1648,6 +1653,7 @@ function cmdCommit(cwd: string, message: string | undefined, files: string[] | u
           branchName = (config['phase_branch_template'] as string)
             .replace('{phase}', normalizePhaseName(phaseInfo['phase_number']))
             .replace('{slug}', (phaseInfo['phase_slug'] as string) || 'phase');
+          anchorPath = (phaseInfo['directory'] as string) || null;
         }
       }
     } else if (branchingStrategy === 'milestone') {
@@ -1668,6 +1674,14 @@ function cmdCommit(cwd: string, message: string | undefined, files: string[] | u
         branchName = (config['milestone_branch_template'] as string)
           .replace('{milestone}', milestone.version)
           .replace('{slug}', generateSlugInternal(milestone.name) || 'milestone');
+        // The archived-phases directory milestone completion writes
+        // (archivePhaseDirectories, milestone.cts) — its presence in HEAD's
+        // history is the milestone-strategy analog of a phase's own
+        // directory: work that only lands there once the milestone branch
+        // has actually been integrated back.
+        anchorPath = toPosixPath(
+          path.relative(cwd, path.join(planningDir(cwd), 'milestones', `${milestone.version}-phases`))
+        );
       }
     }
     if (branchName) {
@@ -1687,24 +1701,37 @@ function cmdCommit(cwd: string, message: string | undefined, files: string[] | u
         // not silent about where the work is landing (#3207 AC3).
         const verify = execGit(['rev-parse', '--verify', `refs/heads/${branchName}`], { cwd });
         if (verify.exitCode !== 0) {
-          // #4055: "does not currently exist" is NOT the same as "never
+          // #4055 v2: "does not currently exist" is NOT the same as "never
           // existed" — a phase/milestone branch that was merged and then
           // deleted also fails this verify, but checkout -b would silently
           // RESURRECT it: a fresh branch of the same name, created at HEAD,
           // that looks identical to the #1278 first-commit case but is
-          // actually a stale name being reused. Distinguish the two by asking
-          // whether HEAD's own ancestry already contains a merge commit for
-          // this branch name — that only happens if the branch existed and
-          // was merged. `--merges` limits the search to actual merge commits
-          // (a squash commit has one parent and never matches, but so does a
-          // never-created branch, so this errs toward the #1278 create path
-          // when it can't tell); `--fixed-strings` keeps branch names with
-          // `.` or other regex metacharacters (e.g. decimal phase slugs) from
-          // being misread as patterns.
-          const resurrection = execGit(
-            ['log', '--merges', '--fixed-strings', `--grep=${branchName}`, '--oneline', '-1'],
-            { cwd }
-          );
+          // actually a stale name being reused.
+          //
+          // Distinguish the two by content, not by commit-message pattern:
+          // ask whether HEAD's own ancestry already contains a commit that
+          // touched this phase/milestone's own directory (`anchorPath` —
+          // the phase's `.planning/phases/<n>-<slug>/` directory, or the
+          // milestone's archived `.planning/milestones/<v>-phases/`
+          // directory). That only happens once the branch's own work has
+          // actually landed on this history, and it holds regardless of how
+          // the branch was integrated: a `--no-ff` merge, a squash merge, or
+          // a rebase merge all bring the directory's changes in identically,
+          // where the prior `--merges --grep=<branchName>` heuristic saw
+          // only the first (squash/rebase are single-parent, so `--merges`
+          // never matched — the exact gap #4080 review shipped with). Unlike
+          // a `--grep` message search, a pathspec match is also precise: git
+          // only reports a commit here if it actually changed a file under
+          // `anchorPath`, so an unrelated commit that merely mentions the
+          // branch name in its message (or an old directory name that
+          // happens to be a substring of a renamed one) cannot false-match.
+          //
+          // A brand-new phase/milestone has nothing under `anchorPath` yet at
+          // this point in the commit (files are staged further below), so
+          // this correctly resolves to the #1278 create-and-switch path.
+          // anchorPath is set alongside branchName in both strategy arms
+          // above, so it is always non-null here.
+          const resurrection = execGit(['log', '--format=%H', '-1', '--', anchorPath as string], { cwd });
           if (resurrection.exitCode === 0 && resurrection.stdout.trim() !== '') {
             // Branch was merged into this history and deleted — do NOT
             // resurrect it. Commit in place, surfaced non-silently like the

--- a/tests/commands.test.cjs
+++ b/tests/commands.test.cjs
@@ -2046,6 +2046,188 @@ describe('commit command', () => {
     );
   });
 
+  // #4055 v2 (PR #4080 review): the first fix only detected resurrection via
+  // `git log --merges --grep=<branchName>`, which requires a real two-parent
+  // merge commit. A squash merge is single-parent and never matches, so the
+  // branch was still resurrected after a squash close-out — reproduced by all
+  // three review passes against the PR's own head commit. The replacement
+  // check is content-based (does HEAD's history already contain a commit that
+  // touched the phase's own directory), which a squash merge satisfies
+  // identically to a `--no-ff` merge.
+  test('#4055 v2: does not resurrect a phase branch closed out via squash merge', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({
+        commit_docs: true,
+        branching_strategy: 'phase',
+        phase_branch_template: 'gsd/phase-{phase}-{slug}',
+      })
+    );
+    fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '01-setup'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      '# Roadmap\n\n## Phase 1: Setup\nGoal: Initial setup\n'
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'phases', '01-setup', '01-CONTEXT.md'), '# Context\n'
+    );
+
+    const { TOOLS_PATH } = require('./helpers.cjs');
+    const baseBranch = gitOrThrow(['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: tmpDir }).trim();
+
+    const first = runNode([
+      TOOLS_PATH, 'commit', 'docs(01): first',
+      '--files', '.planning/phases/01-setup/01-CONTEXT.md',
+    ], { cwd: tmpDir });
+    throwIfFailed(first, 'gsd-tools commit (#4055v2 squash first)');
+    assert.strictEqual(
+      gitOrThrow(['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: tmpDir }).trim(),
+      'gsd/phase-01-setup',
+      'first commit must switch onto the phase branch'
+    );
+
+    // Squash merge — single-parent, no merge commit, message need not mention
+    // the branch name at all (mirrors GitHub's "Squash and merge").
+    gitOrThrow(['checkout', baseBranch], { cwd: tmpDir });
+    gitOrThrow(['merge', '--squash', 'gsd/phase-01-setup'], { cwd: tmpDir });
+    gitOrThrow(['commit', '-m', 'Phase 01 (#1)'], { cwd: tmpDir });
+    gitOrThrow(['branch', '-D', 'gsd/phase-01-setup'], { cwd: tmpDir });
+
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'phases', '01-setup', '02-NOTES.md'), '# Notes\n'
+    );
+    const second = runNode([
+      TOOLS_PATH, 'commit', 'docs(01): second',
+      '--files', '.planning/phases/01-setup/02-NOTES.md',
+    ], { cwd: tmpDir });
+    throwIfFailed(second, 'gsd-tools commit (#4055v2 squash second)');
+
+    const afterBranch = gitOrThrow(['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: tmpDir }).trim();
+    assert.strictEqual(
+      afterBranch,
+      baseBranch,
+      `must not resurrect the squash-merged-and-deleted phase branch (expected to stay on "${baseBranch}", got "${afterBranch}")`
+    );
+    const stillDeleted = runGit(['rev-parse', '--verify', 'refs/heads/gsd/phase-01-setup'], { cwd: tmpDir });
+    assert.notStrictEqual(
+      stillDeleted.exitCode,
+      0,
+      'the deleted phase branch must not have been re-created'
+    );
+  });
+
+  // #4055 v2 (PR #4080 review): a rebase merge is also single-parent per
+  // replayed commit — no merge commit exists at all, so the message-grep
+  // heuristic could never have covered it either.
+  test('#4055 v2: does not resurrect a phase branch closed out via rebase merge', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({
+        commit_docs: true,
+        branching_strategy: 'phase',
+        phase_branch_template: 'gsd/phase-{phase}-{slug}',
+      })
+    );
+    fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '01-setup'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      '# Roadmap\n\n## Phase 1: Setup\nGoal: Initial setup\n'
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'phases', '01-setup', '01-CONTEXT.md'), '# Context\n'
+    );
+
+    const { TOOLS_PATH } = require('./helpers.cjs');
+    const baseBranch = gitOrThrow(['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: tmpDir }).trim();
+
+    const first = runNode([
+      TOOLS_PATH, 'commit', 'docs(01): first',
+      '--files', '.planning/phases/01-setup/01-CONTEXT.md',
+    ], { cwd: tmpDir });
+    throwIfFailed(first, 'gsd-tools commit (#4055v2 rebase first)');
+    assert.strictEqual(
+      gitOrThrow(['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: tmpDir }).trim(),
+      'gsd/phase-01-setup',
+      'first commit must switch onto the phase branch'
+    );
+
+    // Rebase merge — replays the phase branch's commits onto base as
+    // single-parent commits, then fast-forwards; no merge commit is created.
+    gitOrThrow(['rebase', baseBranch, 'gsd/phase-01-setup'], { cwd: tmpDir });
+    gitOrThrow(['checkout', baseBranch], { cwd: tmpDir });
+    gitOrThrow(['merge', '--ff-only', 'gsd/phase-01-setup'], { cwd: tmpDir });
+    gitOrThrow(['branch', '-D', 'gsd/phase-01-setup'], { cwd: tmpDir });
+
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'phases', '01-setup', '02-NOTES.md'), '# Notes\n'
+    );
+    const second = runNode([
+      TOOLS_PATH, 'commit', 'docs(01): second',
+      '--files', '.planning/phases/01-setup/02-NOTES.md',
+    ], { cwd: tmpDir });
+    throwIfFailed(second, 'gsd-tools commit (#4055v2 rebase second)');
+
+    const afterBranch = gitOrThrow(['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: tmpDir }).trim();
+    assert.strictEqual(
+      afterBranch,
+      baseBranch,
+      `must not resurrect the rebase-merged-and-deleted phase branch (expected to stay on "${baseBranch}", got "${afterBranch}")`
+    );
+    const stillDeleted = runGit(['rev-parse', '--verify', 'refs/heads/gsd/phase-01-setup'], { cwd: tmpDir });
+    assert.notStrictEqual(
+      stillDeleted.exitCode,
+      0,
+      'the deleted phase branch must not have been re-created'
+    );
+  });
+
+  // #4055 v2 (PR #4080 review, Minor): the prior `--grep=<branchName>` check
+  // was an unanchored substring match — a merge commit that merely MENTIONS
+  // a branch name in its message (without ever having merged that branch)
+  // would false-positively block create-and-switch for a branch that never
+  // existed. The content-based check only matches a commit that actually
+  // touched the phase's own directory, so this must still create-and-switch.
+  test('#4055 v2: a branch name merely mentioned in an unrelated commit message does not block create-and-switch', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({
+        commit_docs: true,
+        branching_strategy: 'phase',
+        phase_branch_template: 'gsd/phase-{phase}-{slug}',
+      })
+    );
+    fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '02-other'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      '# Roadmap\n\n## Phase 2: Other\nGoal: Unrelated work\n'
+    );
+
+    // An unrelated merge commit whose message happens to name a phase-02
+    // branch that has never existed as a ref.
+    fs.writeFileSync(path.join(tmpDir, 'unrelated.txt'), 'unrelated\n');
+    gitOrThrow(['add', 'unrelated.txt'], { cwd: tmpDir });
+    gitOrThrow(['commit', '-m', "docs: mention gsd/phase-02-other in migration guide"], { cwd: tmpDir });
+
+    const { TOOLS_PATH } = require('./helpers.cjs');
+    const baseBranch = gitOrThrow(['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: tmpDir }).trim();
+
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'phases', '02-other', '01-CONTEXT.md'), '# Context\n'
+    );
+    const result = runNode([
+      TOOLS_PATH, 'commit', 'docs(02): first',
+      '--files', '.planning/phases/02-other/01-CONTEXT.md',
+    ], { cwd: tmpDir });
+    throwIfFailed(result, 'gsd-tools commit (#4055v2 false-positive)');
+
+    const afterBranch = gitOrThrow(['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: tmpDir }).trim();
+    assert.strictEqual(
+      afterBranch,
+      'gsd/phase-02-other',
+      `a never-existed branch merely named in an unrelated commit message must still be created-and-switched-to (expected "gsd/phase-02-other", got "${afterBranch}")`
+    );
+  });
+
   // #3734 — the phase arm of `query commit` must not treat a backlog sentinel
   // phase id as a real phase. /gsd-capture --backlog commits the sentinel phase
   // directory via add-backlog.md; pre-fix each capture created AND switched to a

--- a/tests/commands.test.cjs
+++ b/tests/commands.test.cjs
@@ -17,7 +17,7 @@ const { runGsdTools, createTempProject, createTempDir, cleanup } = require('./he
 const { splitLines } = require('../gsd-core/bin/lib/text-lines.cjs');
 const fc = require('./helpers/fast-check-setup.cjs');
 const { gitOrThrow, throwIfFailed } = require('./helpers/git-fixture.cjs');
-const { runNode } = require('./helpers/process-seam.cjs');
+const { runNode, runGit } = require('./helpers/process-seam.cjs');
 
 describe('history-digest command', () => {
   let tmpDir;
@@ -1965,6 +1965,84 @@ describe('commit command', () => {
     assert.ok(
       !/already exists/i.test(secondStderr),
       `second commit must not re-warn once on the phase branch; got stderr=${secondStderr}`
+    );
+  });
+
+  // #4055 — a phase branch that existed, was merged into the base branch, and
+  // was then deleted must NOT be resurrected on the next phase-scoped commit.
+  // Pre-fix, `rev-parse --verify` can't distinguish "never existed" from
+  // "existed, merged, deleted" (both fail verify), so the create-and-switch
+  // path silently re-created the branch and committed the next phase's work
+  // onto it instead of the current (base) branch.
+  test('#4055: does not resurrect a merged-and-deleted phase branch', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({
+        commit_docs: true,
+        branching_strategy: 'phase',
+        phase_branch_template: 'gsd/phase-{phase}-{slug}',
+      })
+    );
+    fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '01-setup'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      '# Roadmap\n\n## Phase 1: Setup\nGoal: Initial setup\n'
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'phases', '01-setup', '01-CONTEXT.md'), '# Context\n'
+    );
+
+    const { TOOLS_PATH } = require('./helpers.cjs');
+    const baseBranch = gitOrThrow(['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: tmpDir }).trim();
+
+    // First commit — fresh create, switches onto gsd/phase-01-setup.
+    const first = runNode([
+      TOOLS_PATH, 'commit', 'docs(01): first',
+      '--files', '.planning/phases/01-setup/01-CONTEXT.md',
+    ], { cwd: tmpDir });
+    throwIfFailed(first, 'gsd-tools commit (#4055 first)');
+    assert.strictEqual(
+      gitOrThrow(['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: tmpDir }).trim(),
+      'gsd/phase-01-setup',
+      'first commit must switch onto the phase branch'
+    );
+
+    // Merge the phase branch back into the base branch (a real merge commit,
+    // as a completed phase's PR would produce) and delete it — the branch
+    // name no longer resolves to any ref, exactly like the never-existed case.
+    gitOrThrow(['checkout', baseBranch], { cwd: tmpDir });
+    gitOrThrow(['merge', '--no-ff', '-m', "Merge branch 'gsd/phase-01-setup'", 'gsd/phase-01-setup'], { cwd: tmpDir });
+    gitOrThrow(['branch', '-D', 'gsd/phase-01-setup'], { cwd: tmpDir });
+
+    // Next phase-scoped commit resolves to the SAME branch name (e.g. a second
+    // capture into phase 01, or a re-run after the phase's PR merged). It must
+    // commit on the base branch, not resurrect the deleted branch.
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'phases', '01-setup', '02-NOTES.md'), '# Notes\n'
+    );
+    const second = runNode([
+      TOOLS_PATH, 'commit', 'docs(01): second',
+      '--files', '.planning/phases/01-setup/02-NOTES.md',
+    ], { cwd: tmpDir });
+    throwIfFailed(second, 'gsd-tools commit (#4055 second)');
+
+    const afterBranch = gitOrThrow(['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: tmpDir }).trim();
+    assert.strictEqual(
+      afterBranch,
+      baseBranch,
+      `must not resurrect the merged-and-deleted phase branch (expected to stay on "${baseBranch}", got "${afterBranch}")`
+    );
+    const stillDeleted = runGit(['rev-parse', '--verify', 'refs/heads/gsd/phase-01-setup'], { cwd: tmpDir });
+    assert.notStrictEqual(
+      stillDeleted.exitCode,
+      0,
+      'the deleted phase branch must not have been re-created'
+    );
+
+    const secondStderr = second.stderr || '';
+    assert.ok(
+      /previously merged and deleted/i.test(secondStderr),
+      `expected a non-silent warning about the merged-and-deleted branch; got stderr=${secondStderr}`
     );
   });
 


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #4055

---

## What was broken

`cmdCommit`'s create-and-switch guard decided whether a resolved phase/milestone branch was new using only `rev-parse --verify refs/heads/<branchName>`. That check can't distinguish "never existed" from "existed, was merged into the current branch, and was deleted" — both fail verify identically — so a merged-and-deleted phase branch got silently re-created via `checkout -b` and the next commit landed on it instead of the current branch.

## What this fix does

Before falling back to create-and-switch, checks whether HEAD's own ancestry already contains a merge commit naming the branch (`git log --merges --fixed-strings --grep=<branchName>`). If one is found, the branch is treated as a resurrection candidate and the commit lands on the current branch instead — surfaced with a non-silent warning, same as the existing-branch case. If none is found, the original create-and-switch behavior (#1278/#3207) is unchanged.

## Root cause

Introduced by e7993d77b (#3363, fix for #3207): the create-and-switch guard's "a verified-absent ref can't be a resurrection target" premise is false — deleting a branch after merge also leaves it verify-absent.

## Testing

### How I verified the fix

Added `tests/commands.test.cjs` test `#4055: does not resurrect a merged-and-deleted phase branch` — creates a phase branch, commits on it, merges it back with `--no-ff`, deletes it, then makes a second phase-scoped commit and asserts it stays on the base branch (not a re-created `gsd/phase-01-setup`) and that a non-silent warning is written to stderr.

Ran the full `tests/commands.test.cjs` suite locally: 266/266 passing, including all pre-existing branch-resolution coverage (#3207, #2539, #3734) unaffected.

### Regression test added?

- [x] Yes — added a test that would have caught this bug

### Platforms tested

- [x] Windows (including backslash path handling)
- [ ] macOS
- [ ] Linux
- [x] N/A (logic is git-plumbing based, not path-based)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific — this is CLI/git logic shared by all runtimes)

---

## Checklist

- [x] Issue linked above with `Fixes #4055`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass (`npm test` — ran `tests/commands.test.cjs` directly: 266/266 pass; the full 15-chunk suite exceeded my local run budget, so I'm relying on CI for the remaining chunks)
- [x] `.changeset/` fragment added — `.changeset/steady-yaks-swim.md`
- [x] No unnecessary dependencies added

## Breaking changes

None
