### PR TITLE
feat(#3274): make reviewer-lane timeout configurable via timeoutConfigKey

### DIFF
--- a/.changeset/quick-finches-greet.md
+++ b/.changeset/quick-finches-greet.md
@@ -1,5 +1,5 @@
 ---
 type: Added
-pr: 0
+pr: 4083
 ---
-**Reviewer lane timeouts can now be configured per-lane** — declare `timeoutConfigKey` on a reviewer lane manifest (all 12 shipped lanes now do, via `review.timeouts.<slug>`) to override its frozen wall-clock timeout floor from `.planning/config.json`, instead of being stuck with a value that was right for one repository and wrong for another. For the antigravity lane, its native `agy --print-timeout` flag now derives from the same configured value instead of a second hardcoded literal. (#3274)
+**Reviewer lane timeouts can now be configured per-lane** — declare `timeoutConfigKey` on a reviewer lane manifest (nine of the twelve shipped lanes now do, via `review.timeouts.<slug>`) to override its frozen wall-clock timeout floor from `.planning/config.json`, instead of being stuck with a value that was right for one repository and wrong for another. For the antigravity lane, its native `agy --print-timeout` flag now derives from the same configured value instead of a second hardcoded literal. (#3274)

--- a/.changeset/quick-finches-greet.md
+++ b/.changeset/quick-finches-greet.md
@@ -1,0 +1,5 @@
+---
+type: Added
+pr: 0
+---
+**Reviewer lane timeouts can now be configured per-lane** — declare `timeoutConfigKey` on a reviewer lane manifest (all 12 shipped lanes now do, via `review.timeouts.<slug>`) to override its frozen wall-clock timeout floor from `.planning/config.json`, instead of being stuck with a value that was right for one repository and wrong for another. For the antigravity lane, its native `agy --print-timeout` flag now derives from the same configured value instead of a second hardcoded literal. (#3274)

--- a/capabilities/antigravity/capability.json
+++ b/capabilities/antigravity/capability.json
@@ -131,6 +131,7 @@
       "effortChannel": "none"
     },
     "timeoutFloorMs": 600000,
+    "timeoutConfigKey": "review.timeouts.antigravity",
     "emptyOutput": "handler-owned",
     "reviewsSection": "Antigravity",
     "evidenceClass": "source-grounded",
@@ -149,6 +150,11 @@
       "type": "number",
       "default": -1,
       "description": "Prompt-token budget for the Antigravity reviewer lane. Unset is -1, a sentinel: 0 is a legitimate value meaning \"do not trim this lane\", so it cannot double as \"not configured\". Keyed on the reviewer slug `antigravity`, not the `agy` binary alias used by review.models.agy."
+    },
+    "review.timeouts.antigravity": {
+      "type": "number",
+      "default": -1,
+      "description": "Outer wall-clock timeout override (seconds) for the Antigravity reviewer lane. Unset is -1, a sentinel: 0 or a negative number is also treated as unset (a timeout has no legitimate zero/negative value), so no second sentinel is needed. Falls back to the lane's built-in timeoutFloorMs when unset."
     }
   }
 }

--- a/capabilities/antigravity/capability.json
+++ b/capabilities/antigravity/capability.json
@@ -120,7 +120,7 @@
       "binary": "agy",
       "args": [
         "--print-timeout",
-        "540s",
+        "{{nativeTimeout}}",
         "{{model}}",
         "-p",
         "{{prompt}}"

--- a/capabilities/claude/capability.json
+++ b/capabilities/claude/capability.json
@@ -144,6 +144,7 @@
       }
     },
     "timeoutFloorMs": 1200000,
+    "timeoutConfigKey": "review.timeouts.claude",
     "emptyOutput": "stub-with-stderr",
     "reviewsSection": "Claude",
     "evidenceClass": "source-grounded",
@@ -162,6 +163,11 @@
       "type": "number",
       "default": -1,
       "description": "Prompt-token budget for the Claude reviewer lane. Unset is -1, a sentinel: 0 is a legitimate value meaning \"do not trim this lane\", so it cannot double as \"not configured\"."
+    },
+    "review.timeouts.claude": {
+      "type": "number",
+      "default": -1,
+      "description": "Outer wall-clock timeout override (seconds) for the Claude reviewer lane. Unset is -1, a sentinel: 0 or a negative number is also treated as unset (a timeout has no legitimate zero/negative value), so no second sentinel is needed. Falls back to the lane's built-in timeoutFloorMs when unset."
     }
   }
 }

--- a/capabilities/coderabbit/capability.json
+++ b/capabilities/coderabbit/capability.json
@@ -31,6 +31,7 @@
       "effortChannel": "none"
     },
     "timeoutFloorMs": 360000,
+    "timeoutConfigKey": "review.timeouts.coderabbit",
     "emptyOutput": "stub-with-stderr",
     "reviewsSection": "CodeRabbit",
     "evidenceClass": "diff-only",
@@ -44,6 +45,11 @@
       "type": "number",
       "default": -1,
       "description": "Prompt-token budget for the CodeRabbit reviewer lane. Unset is -1, a sentinel: 0 is a legitimate value meaning \"do not trim this lane\", so it cannot double as \"not configured\"."
+    },
+    "review.timeouts.coderabbit": {
+      "type": "number",
+      "default": -1,
+      "description": "Outer wall-clock timeout override (seconds) for the CodeRabbit reviewer lane. Unset is -1, a sentinel: 0 or a negative number is also treated as unset (a timeout has no legitimate zero/negative value), so no second sentinel is needed. Falls back to the lane's built-in timeoutFloorMs when unset."
     }
   }
 }

--- a/capabilities/coderabbit/capability.json
+++ b/capabilities/coderabbit/capability.json
@@ -31,7 +31,7 @@
       "effortChannel": "none"
     },
     "timeoutFloorMs": 360000,
-    "timeoutConfigKey": "review.timeouts.coderabbit",
+    "timeoutConfigKey": null,
     "emptyOutput": "stub-with-stderr",
     "reviewsSection": "CodeRabbit",
     "evidenceClass": "diff-only",
@@ -45,11 +45,6 @@
       "type": "number",
       "default": -1,
       "description": "Prompt-token budget for the CodeRabbit reviewer lane. Unset is -1, a sentinel: 0 is a legitimate value meaning \"do not trim this lane\", so it cannot double as \"not configured\"."
-    },
-    "review.timeouts.coderabbit": {
-      "type": "number",
-      "default": -1,
-      "description": "Outer wall-clock timeout override (seconds) for the CodeRabbit reviewer lane. Unset is -1, a sentinel: 0 or a negative number is also treated as unset (a timeout has no legitimate zero/negative value), so no second sentinel is needed. Falls back to the lane's built-in timeoutFloorMs when unset."
     }
   }
 }

--- a/capabilities/codex/capability.json
+++ b/capabilities/codex/capability.json
@@ -139,6 +139,7 @@
       "effortChannel": "argv"
     },
     "timeoutFloorMs": 1200000,
+    "timeoutConfigKey": "review.timeouts.codex",
     "emptyOutput": "stub-with-stderr",
     "reviewsSection": "Codex",
     "evidenceClass": "source-grounded",
@@ -157,6 +158,11 @@
       "type": "number",
       "default": -1,
       "description": "Prompt-token budget for the Codex reviewer lane. Unset is -1, a sentinel: 0 is a legitimate value meaning \"do not trim this lane\", so it cannot double as \"not configured\"."
+    },
+    "review.timeouts.codex": {
+      "type": "number",
+      "default": -1,
+      "description": "Outer wall-clock timeout override (seconds) for the Codex reviewer lane. Unset is -1, a sentinel: 0 or a negative number is also treated as unset (a timeout has no legitimate zero/negative value), so no second sentinel is needed. Falls back to the lane's built-in timeoutFloorMs when unset."
     }
   }
 }

--- a/capabilities/cursor/capability.json
+++ b/capabilities/cursor/capability.json
@@ -141,6 +141,7 @@
       "effortChannel": "none"
     },
     "timeoutFloorMs": 900000,
+    "timeoutConfigKey": "review.timeouts.cursor",
     "emptyOutput": "stub-with-stderr",
     "reviewsSection": "Cursor",
     "evidenceClass": "source-grounded",
@@ -154,6 +155,11 @@
       "type": "number",
       "default": -1,
       "description": "Prompt-token budget for the Cursor reviewer lane. Unset is -1, a sentinel: 0 is a legitimate value meaning \"do not trim this lane\", so it cannot double as \"not configured\"."
+    },
+    "review.timeouts.cursor": {
+      "type": "number",
+      "default": -1,
+      "description": "Outer wall-clock timeout override (seconds) for the Cursor reviewer lane. Unset is -1, a sentinel: 0 or a negative number is also treated as unset (a timeout has no legitimate zero/negative value), so no second sentinel is needed. Falls back to the lane's built-in timeoutFloorMs when unset."
     }
   }
 }

--- a/capabilities/cursor/capability.json
+++ b/capabilities/cursor/capability.json
@@ -141,7 +141,7 @@
       "effortChannel": "none"
     },
     "timeoutFloorMs": 900000,
-    "timeoutConfigKey": "review.timeouts.cursor",
+    "timeoutConfigKey": null,
     "emptyOutput": "stub-with-stderr",
     "reviewsSection": "Cursor",
     "evidenceClass": "source-grounded",
@@ -155,11 +155,6 @@
       "type": "number",
       "default": -1,
       "description": "Prompt-token budget for the Cursor reviewer lane. Unset is -1, a sentinel: 0 is a legitimate value meaning \"do not trim this lane\", so it cannot double as \"not configured\"."
-    },
-    "review.timeouts.cursor": {
-      "type": "number",
-      "default": -1,
-      "description": "Outer wall-clock timeout override (seconds) for the Cursor reviewer lane. Unset is -1, a sentinel: 0 or a negative number is also treated as unset (a timeout has no legitimate zero/negative value), so no second sentinel is needed. Falls back to the lane's built-in timeoutFloorMs when unset."
     }
   }
 }

--- a/capabilities/gemini/capability.json
+++ b/capabilities/gemini/capability.json
@@ -32,6 +32,7 @@
       "effortChannel": "none"
     },
     "timeoutFloorMs": 900000,
+    "timeoutConfigKey": "review.timeouts.gemini",
     "emptyOutput": "stub-with-stderr",
     "reviewsSection": "Gemini",
     "evidenceClass": "source-grounded",
@@ -50,6 +51,11 @@
       "type": "number",
       "default": -1,
       "description": "Prompt-token budget for the Gemini reviewer lane. Unset is -1, a sentinel: 0 is a legitimate value meaning \"do not trim this lane\", so it cannot double as \"not configured\"."
+    },
+    "review.timeouts.gemini": {
+      "type": "number",
+      "default": -1,
+      "description": "Outer wall-clock timeout override (seconds) for the Gemini reviewer lane. Unset is -1, a sentinel: 0 or a negative number is also treated as unset (a timeout has no legitimate zero/negative value), so no second sentinel is needed. Falls back to the lane's built-in timeoutFloorMs when unset."
     }
   }
 }

--- a/capabilities/kimi-code/capability.json
+++ b/capabilities/kimi-code/capability.json
@@ -135,6 +135,7 @@
       "effortChannel": "none"
     },
     "timeoutFloorMs": 900000,
+    "timeoutConfigKey": "review.timeouts.kimi-code",
     "emptyOutput": "stub-with-stderr",
     "reviewsSection": "Kimi Code",
     "evidenceClass": "source-grounded",
@@ -153,6 +154,11 @@
       "type": "number",
       "default": -1,
       "description": "Prompt-token budget for the Kimi Code reviewer lane. Unset is -1, a sentinel: 0 is a legitimate value meaning \"do not trim this lane\", so it cannot double as \"not configured\"."
+    },
+    "review.timeouts.kimi-code": {
+      "type": "number",
+      "default": -1,
+      "description": "Outer wall-clock timeout override (seconds) for the Kimi Code reviewer lane. Unset is -1, a sentinel: 0 or a negative number is also treated as unset (a timeout has no legitimate zero/negative value), so no second sentinel is needed. Falls back to the lane's built-in timeoutFloorMs when unset."
     }
   }
 }

--- a/capabilities/llama-cpp/capability.json
+++ b/capabilities/llama-cpp/capability.json
@@ -30,6 +30,7 @@
       "effortChannel": "none"
     },
     "timeoutFloorMs": 120000,
+    "timeoutConfigKey": "review.timeouts.llama_cpp",
     "emptyOutput": "stub-with-stderr",
     "reviewsSection": "llama.cpp",
     "evidenceClass": "source-grounded",
@@ -53,6 +54,11 @@
       "type": "number",
       "default": -1,
       "description": "Prompt-token budget for the llama.cpp reviewer lane. Unset is -1, a sentinel: 0 is a legitimate value meaning \"do not trim this lane\", so it cannot double as \"not configured\"."
+    },
+    "review.timeouts.llama_cpp": {
+      "type": "number",
+      "default": -1,
+      "description": "Outer wall-clock timeout override (seconds) for the llama.cpp reviewer lane. Unset is -1, a sentinel: 0 or a negative number is also treated as unset (a timeout has no legitimate zero/negative value), so no second sentinel is needed. Falls back to the lane's built-in timeoutFloorMs when unset."
     }
   }
 }

--- a/capabilities/lm-studio/capability.json
+++ b/capabilities/lm-studio/capability.json
@@ -30,6 +30,7 @@
       "effortChannel": "none"
     },
     "timeoutFloorMs": 120000,
+    "timeoutConfigKey": "review.timeouts.lm_studio",
     "emptyOutput": "stub-with-stderr",
     "reviewsSection": "LM Studio",
     "evidenceClass": "source-grounded",
@@ -53,6 +54,11 @@
       "type": "number",
       "default": -1,
       "description": "Prompt-token budget for the LM Studio reviewer lane. Unset is -1, a sentinel: 0 is a legitimate value meaning \"do not trim this lane\", so it cannot double as \"not configured\"."
+    },
+    "review.timeouts.lm_studio": {
+      "type": "number",
+      "default": -1,
+      "description": "Outer wall-clock timeout override (seconds) for the LM Studio reviewer lane. Unset is -1, a sentinel: 0 or a negative number is also treated as unset (a timeout has no legitimate zero/negative value), so no second sentinel is needed. Falls back to the lane's built-in timeoutFloorMs when unset."
     }
   }
 }

--- a/capabilities/ollama/capability.json
+++ b/capabilities/ollama/capability.json
@@ -30,6 +30,7 @@
       "effortChannel": "none"
     },
     "timeoutFloorMs": 120000,
+    "timeoutConfigKey": "review.timeouts.ollama",
     "emptyOutput": "stub-with-stderr",
     "reviewsSection": "Ollama",
     "evidenceClass": "source-grounded",
@@ -53,6 +54,11 @@
       "type": "number",
       "default": -1,
       "description": "Prompt-token budget for the Ollama reviewer lane. Unset is -1, a sentinel: 0 is a legitimate value meaning \"do not trim this lane\", so it cannot double as \"not configured\"."
+    },
+    "review.timeouts.ollama": {
+      "type": "number",
+      "default": -1,
+      "description": "Outer wall-clock timeout override (seconds) for the Ollama reviewer lane. Unset is -1, a sentinel: 0 or a negative number is also treated as unset (a timeout has no legitimate zero/negative value), so no second sentinel is needed. Falls back to the lane's built-in timeoutFloorMs when unset."
     }
   }
 }

--- a/capabilities/opencode/capability.json
+++ b/capabilities/opencode/capability.json
@@ -158,6 +158,7 @@
       "effortChannel": "argv"
     },
     "timeoutFloorMs": 660000,
+    "timeoutConfigKey": "review.timeouts.opencode",
     "emptyOutput": "stub-with-stderr",
     "reviewsSection": "OpenCode",
     "evidenceClass": "source-grounded",
@@ -176,6 +177,11 @@
       "type": "number",
       "default": -1,
       "description": "Prompt-token budget for the OpenCode reviewer lane. Unset is -1, a sentinel: 0 is a legitimate value meaning \"do not trim this lane\", so it cannot double as \"not configured\"."
+    },
+    "review.timeouts.opencode": {
+      "type": "number",
+      "default": -1,
+      "description": "Outer wall-clock timeout override (seconds) for the OpenCode reviewer lane. Unset is -1, a sentinel: 0 or a negative number is also treated as unset (a timeout has no legitimate zero/negative value), so no second sentinel is needed. Falls back to the lane's built-in timeoutFloorMs when unset."
     }
   }
 }

--- a/capabilities/qwen/capability.json
+++ b/capabilities/qwen/capability.json
@@ -128,6 +128,7 @@
       "effortChannel": "none"
     },
     "timeoutFloorMs": 900000,
+    "timeoutConfigKey": "review.timeouts.qwen",
     "emptyOutput": "stub-with-stderr",
     "reviewsSection": "Qwen",
     "evidenceClass": "source-grounded",
@@ -141,6 +142,11 @@
       "type": "number",
       "default": -1,
       "description": "Prompt-token budget for the Qwen Code reviewer lane. Unset is -1, a sentinel: 0 is a legitimate value meaning \"do not trim this lane\", so it cannot double as \"not configured\"."
+    },
+    "review.timeouts.qwen": {
+      "type": "number",
+      "default": -1,
+      "description": "Outer wall-clock timeout override (seconds) for the Qwen Code reviewer lane. Unset is -1, a sentinel: 0 or a negative number is also treated as unset (a timeout has no legitimate zero/negative value), so no second sentinel is needed. Falls back to the lane's built-in timeoutFloorMs when unset."
     }
   }
 }

--- a/capabilities/qwen/capability.json
+++ b/capabilities/qwen/capability.json
@@ -128,7 +128,7 @@
       "effortChannel": "none"
     },
     "timeoutFloorMs": 900000,
-    "timeoutConfigKey": "review.timeouts.qwen",
+    "timeoutConfigKey": null,
     "emptyOutput": "stub-with-stderr",
     "reviewsSection": "Qwen",
     "evidenceClass": "source-grounded",
@@ -142,11 +142,6 @@
       "type": "number",
       "default": -1,
       "description": "Prompt-token budget for the Qwen Code reviewer lane. Unset is -1, a sentinel: 0 is a legitimate value meaning \"do not trim this lane\", so it cannot double as \"not configured\"."
-    },
-    "review.timeouts.qwen": {
-      "type": "number",
-      "default": -1,
-      "description": "Outer wall-clock timeout override (seconds) for the Qwen Code reviewer lane. Unset is -1, a sentinel: 0 or a negative number is also treated as unset (a timeout has no legitimate zero/negative value), so no second sentinel is needed. Falls back to the lane's built-in timeoutFloorMs when unset."
     }
   }
 }

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -278,17 +278,19 @@ across lanes rather than one lane's behavior, so they remain central and are una
 
 ### Reviewer lane timeouts (`review.timeouts.*`, #3274)
 
-Every declared reviewer lane accepts an outer wall-clock timeout override, federated per-lane
-exactly like `review.max_prompt_tokens_per_reviewer.<slug>` above — the key is owned by that
-lane's own capability manifest, not a central schema. Keys are seconds: `review.timeouts.gemini`,
-`review.timeouts.claude`, `review.timeouts.codex`, `review.timeouts.coderabbit`,
-`review.timeouts.opencode`, `review.timeouts.qwen`, `review.timeouts.cursor`,
+Nine of the twelve declared reviewer lanes accept an outer wall-clock timeout override, federated
+per-lane exactly like `review.max_prompt_tokens_per_reviewer.<slug>` above — the key is owned by
+that lane's own capability manifest, not a central schema. Keys are seconds: `review.timeouts.gemini`,
+`review.timeouts.claude`, `review.timeouts.codex`, `review.timeouts.opencode`,
 `review.timeouts.antigravity`, `review.timeouts.kimi-code`, `review.timeouts.ollama`,
 `review.timeouts.lm_studio`, `review.timeouts.llama_cpp`. Unset (or `0`/negative/non-numeric)
 falls back to that lane's built-in floor. For the `antigravity` lane specifically, this value also
 derives its native `agy --print-timeout` flag (roughly 60 seconds under the configured outer
 value), so raising `review.timeouts.antigravity` raises both bounds together — this is how to fix
 a reviewer lane being killed mid-run on a large plan set: `gsd config-set review.timeouts.antigravity 900`.
+Three lanes — `qwen`, `cursor`, and `coderabbit` — take neither a model flag nor a host and do not
+federate a timeout key either, matching the same narrow key-ownership invariant their
+`review.models.*`/host keys already follow (each owns only its own prompt-budget key).
 
 ### Reviewer defaults for `/gsd-review`
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -276,6 +276,20 @@ The same applies to `review.max_prompt_tokens_per_reviewer.<slug>`. `review.max_
 (the global default), `review.default_reviewers` and `review.reviewer_instances` describe policy
 across lanes rather than one lane's behavior, so they remain central and are unaffected.
 
+### Reviewer lane timeouts (`review.timeouts.*`, #3274)
+
+Every declared reviewer lane accepts an outer wall-clock timeout override, federated per-lane
+exactly like `review.max_prompt_tokens_per_reviewer.<slug>` above — the key is owned by that
+lane's own capability manifest, not a central schema. Keys are seconds: `review.timeouts.gemini`,
+`review.timeouts.claude`, `review.timeouts.codex`, `review.timeouts.coderabbit`,
+`review.timeouts.opencode`, `review.timeouts.qwen`, `review.timeouts.cursor`,
+`review.timeouts.antigravity`, `review.timeouts.kimi-code`, `review.timeouts.ollama`,
+`review.timeouts.lm_studio`, `review.timeouts.llama_cpp`. Unset (or `0`/negative/non-numeric)
+falls back to that lane's built-in floor. For the `antigravity` lane specifically, this value also
+derives its native `agy --print-timeout` flag (roughly 60 seconds under the configured outer
+value), so raising `review.timeouts.antigravity` raises both bounds together — this is how to fix
+a reviewer lane being killed mid-run on a large plan set: `gsd config-set review.timeouts.antigravity 900`.
+
 ### Reviewer defaults for `/gsd-review`
 
 Use `review.default_reviewers` to scope the no-flag `/gsd-review` run to a subset of detected reviewers.

--- a/docs/how-to/ship-a-reviewer-lane.md
+++ b/docs/how-to/ship-a-reviewer-lane.md
@@ -51,6 +51,7 @@ Most lanes are `transport: "spawn"` — GSD runs a binary and reads its output. 
       "effortChannel": "none"
     },
     "timeoutFloorMs": 900000,
+    "timeoutConfigKey": "review.timeouts.acme",
     "emptyOutput": "stub-with-stderr",
     "reviewsSection": "Acme",
     "evidenceClass": "source-grounded",
@@ -65,6 +66,11 @@ Most lanes are `transport: "spawn"` — GSD runs a binary and reads its output. 
       "type": "string",
       "default": "",
       "description": "Model passed to the Acme reviewer lane."
+    },
+    "review.timeouts.acme": {
+      "type": "number",
+      "default": -1,
+      "description": "Outer wall-clock timeout override (seconds) for the Acme reviewer lane."
     }
   }
 }
@@ -107,6 +113,7 @@ If your reviewer is a served model endpoint rather than a CLI, use `transport: "
     "effortChannel": "none"
   },
   "timeoutFloorMs": 120000,
+  "timeoutConfigKey": "review.timeouts.acme_local",
   "emptyOutput": "stub-with-stderr",
   "reviewsSection": "Acme Local",
   "evidenceClass": "source-grounded",
@@ -127,7 +134,7 @@ If your reviewer is a served model endpoint rather than a CLI, use `transport: "
 
 Declare the lane's keys in your own manifest `config` block, never in the central schema. A key present in both is a build failure, not a warning — federated ownership is exclusive.
 
-Name `modelConfigKey` and `promptBudgetKey` to match keys you actually declare. A lane pointing at a key nobody owns resolves to nothing, which reads to the user as "my model override is being ignored."
+Name `modelConfigKey`, `promptBudgetKey`, and `timeoutConfigKey` to match keys you actually declare. A lane pointing at a key nobody owns resolves to nothing, which reads to the user as "my model override is being ignored."
 
 Users then set them the ordinary way, in `.planning/config.json`:
 

--- a/docs/reference/capability-manifest.md
+++ b/docs/reference/capability-manifest.md
@@ -232,7 +232,7 @@ The shape is **hybrid**:
 
 Current role counts across `capabilities/`: `feature` 20, `runtime` 19, `reviewer` 5.
 
-All 12 shipped lane declarations carry all 13 fields below.
+All 12 shipped lane declarations carry all 14 fields below.
 
 | Field | Type | Notes |
 |---|---|---|
@@ -242,6 +242,7 @@ All 12 shipped lane declarations carry all 13 fields below.
 | `probe` | object | Availability check. `probe.kind` is a closed enum: `command-exists` \| `command-capability` \| `http-reachable`. `command-capability` additionally takes `binary`, `needle`, and a **required** `timeoutMs` — it exists because a bare binary name can be ambiguous (`kimi` is claimed by both the Kimi Code CLI and the legacy Python `kimi-cli`), and the timeout bound is mandatory because an unbounded `--help \| grep` probe is this repo's named Unbounded Subprocesses defect. |
 | `invoke` | object | Shape is selected by `transport`. For `spawn`: `binary`, `args[]`, `promptChannel` (`stdin` \| `argv` \| `argv-file-ref` \| `none`), `outputChannel` (`stdout` \| `file-arg`), `outputArg` (required when `outputChannel` is `file-arg`), `modelArg` (string or `null`), `effortChannel` (`none` \| `argv` \| `env`), `env` (optional; an object of environment name/value pairs, string values only, merged over the inherited environment for that one spawn — keys must match the portable environment-name grammar `[A-Za-z_][A-Za-z0-9_]*`, which is a portability policy rather than an OS limit, and `__proto__` is refused because it would be dropped before reaching the child). For `openai-http`: `hostConfigKey`, `defaultHost`, `path`, `modelDiscovery` (`none` \| `first-from-models-endpoint`), `fallbackModel`, `effortChannel`. `args` supports the `{{model}}`, `{{prompt}}`, `{{effort}}`, and `{{output}}` placeholders. **Every field in this object is disclosed at install and bound to the consent signature** — `env` and `defaultHost` by name in the consent prompt, the rest through a residual, so any change to a declared `invoke` field forces re-consent. `env` additionally **refuses execution-primitive names** — `PATH`, `NODE_OPTIONS`, `LD_PRELOAD`, `DYLD_INSERT_LIBRARIES`, `BASH_ENV`, `PYTHONPATH`, `PERL5OPT`, `RUBYOPT`, `GIT_SSH_COMMAND`, `JAVA_TOOL_OPTIONS` and siblings, matched case-insensitively (Windows environment lookup is). A lane needing a specific executable declares an absolute `binary` rather than reshaping the child's `PATH`. That denylist is defence in depth and not the boundary: it cannot be complete against an arbitrary child, and disclosure runs before validation, so install-time consent — which shows every declared pair and warns on execution-primitive names — is what actually gates them. |
 | `timeoutFloorMs` | number | Measured per-lane floor. Lane divergence here is real and correct — the descriptor's job is to declare divergence in one place, not to promise uniformity. |
+| `timeoutConfigKey` | string or `null` | Federated config key holding this lane's outer timeout override, in SECONDS, e.g. `review.timeouts.antigravity`. Falls back to `timeoutFloorMs` when unset or invalid (#3274). |
 | `emptyOutput` | closed enum | `stub-with-stderr` \| `handler-owned`. |
 | `reviewsSection` | string | The `REVIEWS.md` heading this lane renders under. Must be unique across the merged roster. |
 | `evidenceClass` | closed enum | `source-grounded` \| `diff-only` (diff-only findings are down-weighted in consensus). |
@@ -282,6 +283,7 @@ An unknown field inside a `reviewer` body is a **non-fatal warning on stderr, ne
       "effortChannel": "none"
     },
     "timeoutFloorMs": 360000,
+    "timeoutConfigKey": "review.timeouts.coderabbit",
     "emptyOutput": "stub-with-stderr",
     "reviewsSection": "CodeRabbit",
     "evidenceClass": "diff-only",

--- a/docs/reference/capability-manifest.md
+++ b/docs/reference/capability-manifest.md
@@ -283,7 +283,7 @@ An unknown field inside a `reviewer` body is a **non-fatal warning on stderr, ne
       "effortChannel": "none"
     },
     "timeoutFloorMs": 360000,
-    "timeoutConfigKey": "review.timeouts.coderabbit",
+    "timeoutConfigKey": null,
     "emptyOutput": "stub-with-stderr",
     "reviewsSection": "CodeRabbit",
     "evidenceClass": "diff-only",

--- a/gsd-core/bin/lib/capability-registry.cjs
+++ b/gsd-core/bin/lib/capability-registry.cjs
@@ -225,6 +225,7 @@ const capabilities = {
         "effortChannel": "none"
       },
       "timeoutFloorMs": 600000,
+      "timeoutConfigKey": "review.timeouts.antigravity",
       "emptyOutput": "handler-owned",
       "reviewsSection": "Antigravity",
       "evidenceClass": "source-grounded",
@@ -243,6 +244,11 @@ const capabilities = {
         "type": "number",
         "default": -1,
         "description": "Prompt-token budget for the Antigravity reviewer lane. Unset is -1, a sentinel: 0 is a legitimate value meaning \"do not trim this lane\", so it cannot double as \"not configured\". Keyed on the reviewer slug `antigravity`, not the `agy` binary alias used by review.models.agy."
+      },
+      "review.timeouts.antigravity": {
+        "type": "number",
+        "default": -1,
+        "description": "Outer wall-clock timeout override (seconds) for the Antigravity reviewer lane. Unset is -1, a sentinel: 0 or a negative number is also treated as unset (a timeout has no legitimate zero/negative value), so no second sentinel is needed. Falls back to the lane's built-in timeoutFloorMs when unset."
       }
     }
   },
@@ -634,6 +640,7 @@ const capabilities = {
         }
       },
       "timeoutFloorMs": 1200000,
+      "timeoutConfigKey": "review.timeouts.claude",
       "emptyOutput": "stub-with-stderr",
       "reviewsSection": "Claude",
       "evidenceClass": "source-grounded",
@@ -652,6 +659,11 @@ const capabilities = {
         "type": "number",
         "default": -1,
         "description": "Prompt-token budget for the Claude reviewer lane. Unset is -1, a sentinel: 0 is a legitimate value meaning \"do not trim this lane\", so it cannot double as \"not configured\"."
+      },
+      "review.timeouts.claude": {
+        "type": "number",
+        "default": -1,
+        "description": "Outer wall-clock timeout override (seconds) for the Claude reviewer lane. Unset is -1, a sentinel: 0 or a negative number is also treated as unset (a timeout has no legitimate zero/negative value), so no second sentinel is needed. Falls back to the lane's built-in timeoutFloorMs when unset."
       }
     }
   },
@@ -1046,6 +1058,7 @@ const capabilities = {
         "effortChannel": "none"
       },
       "timeoutFloorMs": 360000,
+      "timeoutConfigKey": "review.timeouts.coderabbit",
       "emptyOutput": "stub-with-stderr",
       "reviewsSection": "CodeRabbit",
       "evidenceClass": "diff-only",
@@ -1059,6 +1072,11 @@ const capabilities = {
         "type": "number",
         "default": -1,
         "description": "Prompt-token budget for the CodeRabbit reviewer lane. Unset is -1, a sentinel: 0 is a legitimate value meaning \"do not trim this lane\", so it cannot double as \"not configured\"."
+      },
+      "review.timeouts.coderabbit": {
+        "type": "number",
+        "default": -1,
+        "description": "Outer wall-clock timeout override (seconds) for the CodeRabbit reviewer lane. Unset is -1, a sentinel: 0 or a negative number is also treated as unset (a timeout has no legitimate zero/negative value), so no second sentinel is needed. Falls back to the lane's built-in timeoutFloorMs when unset."
       }
     }
   },
@@ -1203,6 +1221,7 @@ const capabilities = {
         "effortChannel": "argv"
       },
       "timeoutFloorMs": 1200000,
+      "timeoutConfigKey": "review.timeouts.codex",
       "emptyOutput": "stub-with-stderr",
       "reviewsSection": "Codex",
       "evidenceClass": "source-grounded",
@@ -1221,6 +1240,11 @@ const capabilities = {
         "type": "number",
         "default": -1,
         "description": "Prompt-token budget for the Codex reviewer lane. Unset is -1, a sentinel: 0 is a legitimate value meaning \"do not trim this lane\", so it cannot double as \"not configured\"."
+      },
+      "review.timeouts.codex": {
+        "type": "number",
+        "default": -1,
+        "description": "Outer wall-clock timeout override (seconds) for the Codex reviewer lane. Unset is -1, a sentinel: 0 or a negative number is also treated as unset (a timeout has no legitimate zero/negative value), so no second sentinel is needed. Falls back to the lane's built-in timeoutFloorMs when unset."
       }
     }
   },
@@ -1466,6 +1490,7 @@ const capabilities = {
         "effortChannel": "none"
       },
       "timeoutFloorMs": 900000,
+      "timeoutConfigKey": "review.timeouts.cursor",
       "emptyOutput": "stub-with-stderr",
       "reviewsSection": "Cursor",
       "evidenceClass": "source-grounded",
@@ -1479,6 +1504,11 @@ const capabilities = {
         "type": "number",
         "default": -1,
         "description": "Prompt-token budget for the Cursor reviewer lane. Unset is -1, a sentinel: 0 is a legitimate value meaning \"do not trim this lane\", so it cannot double as \"not configured\"."
+      },
+      "review.timeouts.cursor": {
+        "type": "number",
+        "default": -1,
+        "description": "Outer wall-clock timeout override (seconds) for the Cursor reviewer lane. Unset is -1, a sentinel: 0 or a negative number is also treated as unset (a timeout has no legitimate zero/negative value), so no second sentinel is needed. Falls back to the lane's built-in timeoutFloorMs when unset."
       }
     }
   },
@@ -1718,6 +1748,7 @@ const capabilities = {
         "effortChannel": "none"
       },
       "timeoutFloorMs": 900000,
+      "timeoutConfigKey": "review.timeouts.gemini",
       "emptyOutput": "stub-with-stderr",
       "reviewsSection": "Gemini",
       "evidenceClass": "source-grounded",
@@ -1736,6 +1767,11 @@ const capabilities = {
         "type": "number",
         "default": -1,
         "description": "Prompt-token budget for the Gemini reviewer lane. Unset is -1, a sentinel: 0 is a legitimate value meaning \"do not trim this lane\", so it cannot double as \"not configured\"."
+      },
+      "review.timeouts.gemini": {
+        "type": "number",
+        "default": -1,
+        "description": "Outer wall-clock timeout override (seconds) for the Gemini reviewer lane. Unset is -1, a sentinel: 0 or a negative number is also treated as unset (a timeout has no legitimate zero/negative value), so no second sentinel is needed. Falls back to the lane's built-in timeoutFloorMs when unset."
       }
     }
   },
@@ -2311,6 +2347,7 @@ const capabilities = {
         "effortChannel": "none"
       },
       "timeoutFloorMs": 900000,
+      "timeoutConfigKey": "review.timeouts.kimi-code",
       "emptyOutput": "stub-with-stderr",
       "reviewsSection": "Kimi Code",
       "evidenceClass": "source-grounded",
@@ -2329,6 +2366,11 @@ const capabilities = {
         "type": "number",
         "default": -1,
         "description": "Prompt-token budget for the Kimi Code reviewer lane. Unset is -1, a sentinel: 0 is a legitimate value meaning \"do not trim this lane\", so it cannot double as \"not configured\"."
+      },
+      "review.timeouts.kimi-code": {
+        "type": "number",
+        "default": -1,
+        "description": "Outer wall-clock timeout override (seconds) for the Kimi Code reviewer lane. Unset is -1, a sentinel: 0 or a negative number is also treated as unset (a timeout has no legitimate zero/negative value), so no second sentinel is needed. Falls back to the lane's built-in timeoutFloorMs when unset."
       }
     }
   },
@@ -2417,6 +2459,7 @@ const capabilities = {
         "effortChannel": "none"
       },
       "timeoutFloorMs": 120000,
+      "timeoutConfigKey": "review.timeouts.llama_cpp",
       "emptyOutput": "stub-with-stderr",
       "reviewsSection": "llama.cpp",
       "evidenceClass": "source-grounded",
@@ -2440,6 +2483,11 @@ const capabilities = {
         "type": "number",
         "default": -1,
         "description": "Prompt-token budget for the llama.cpp reviewer lane. Unset is -1, a sentinel: 0 is a legitimate value meaning \"do not trim this lane\", so it cannot double as \"not configured\"."
+      },
+      "review.timeouts.llama_cpp": {
+        "type": "number",
+        "default": -1,
+        "description": "Outer wall-clock timeout override (seconds) for the llama.cpp reviewer lane. Unset is -1, a sentinel: 0 or a negative number is also treated as unset (a timeout has no legitimate zero/negative value), so no second sentinel is needed. Falls back to the lane's built-in timeoutFloorMs when unset."
       }
     }
   },
@@ -2475,6 +2523,7 @@ const capabilities = {
         "effortChannel": "none"
       },
       "timeoutFloorMs": 120000,
+      "timeoutConfigKey": "review.timeouts.lm_studio",
       "emptyOutput": "stub-with-stderr",
       "reviewsSection": "LM Studio",
       "evidenceClass": "source-grounded",
@@ -2498,6 +2547,11 @@ const capabilities = {
         "type": "number",
         "default": -1,
         "description": "Prompt-token budget for the LM Studio reviewer lane. Unset is -1, a sentinel: 0 is a legitimate value meaning \"do not trim this lane\", so it cannot double as \"not configured\"."
+      },
+      "review.timeouts.lm_studio": {
+        "type": "number",
+        "default": -1,
+        "description": "Outer wall-clock timeout override (seconds) for the LM Studio reviewer lane. Unset is -1, a sentinel: 0 or a negative number is also treated as unset (a timeout has no legitimate zero/negative value), so no second sentinel is needed. Falls back to the lane's built-in timeoutFloorMs when unset."
       }
     }
   },
@@ -2757,6 +2811,7 @@ const capabilities = {
         "effortChannel": "none"
       },
       "timeoutFloorMs": 120000,
+      "timeoutConfigKey": "review.timeouts.ollama",
       "emptyOutput": "stub-with-stderr",
       "reviewsSection": "Ollama",
       "evidenceClass": "source-grounded",
@@ -2780,6 +2835,11 @@ const capabilities = {
         "type": "number",
         "default": -1,
         "description": "Prompt-token budget for the Ollama reviewer lane. Unset is -1, a sentinel: 0 is a legitimate value meaning \"do not trim this lane\", so it cannot double as \"not configured\"."
+      },
+      "review.timeouts.ollama": {
+        "type": "number",
+        "default": -1,
+        "description": "Outer wall-clock timeout override (seconds) for the Ollama reviewer lane. Unset is -1, a sentinel: 0 or a negative number is also treated as unset (a timeout has no legitimate zero/negative value), so no second sentinel is needed. Falls back to the lane's built-in timeoutFloorMs when unset."
       }
     }
   },
@@ -2943,6 +3003,7 @@ const capabilities = {
         "effortChannel": "argv"
       },
       "timeoutFloorMs": 660000,
+      "timeoutConfigKey": "review.timeouts.opencode",
       "emptyOutput": "stub-with-stderr",
       "reviewsSection": "OpenCode",
       "evidenceClass": "source-grounded",
@@ -2961,6 +3022,11 @@ const capabilities = {
         "type": "number",
         "default": -1,
         "description": "Prompt-token budget for the OpenCode reviewer lane. Unset is -1, a sentinel: 0 is a legitimate value meaning \"do not trim this lane\", so it cannot double as \"not configured\"."
+      },
+      "review.timeouts.opencode": {
+        "type": "number",
+        "default": -1,
+        "description": "Outer wall-clock timeout override (seconds) for the OpenCode reviewer lane. Unset is -1, a sentinel: 0 or a negative number is also treated as unset (a timeout has no legitimate zero/negative value), so no second sentinel is needed. Falls back to the lane's built-in timeoutFloorMs when unset."
       }
     }
   },
@@ -3294,6 +3360,7 @@ const capabilities = {
         "effortChannel": "none"
       },
       "timeoutFloorMs": 900000,
+      "timeoutConfigKey": "review.timeouts.qwen",
       "emptyOutput": "stub-with-stderr",
       "reviewsSection": "Qwen",
       "evidenceClass": "source-grounded",
@@ -3307,6 +3374,11 @@ const capabilities = {
         "type": "number",
         "default": -1,
         "description": "Prompt-token budget for the Qwen Code reviewer lane. Unset is -1, a sentinel: 0 is a legitimate value meaning \"do not trim this lane\", so it cannot double as \"not configured\"."
+      },
+      "review.timeouts.qwen": {
+        "type": "number",
+        "default": -1,
+        "description": "Outer wall-clock timeout override (seconds) for the Qwen Code reviewer lane. Unset is -1, a sentinel: 0 or a negative number is also treated as unset (a timeout has no legitimate zero/negative value), so no second sentinel is needed. Falls back to the lane's built-in timeoutFloorMs when unset."
       }
     }
   },
@@ -4709,19 +4781,24 @@ const configKeys = {
   "workflow.api_coverage_gate": "ai-integration",
   "review.models.agy": "antigravity",
   "review.max_prompt_tokens_per_reviewer.antigravity": "antigravity",
+  "review.timeouts.antigravity": "antigravity",
   "workflow.assumption_delta": "assumption-delta",
   "workflow.windows_enforce": "broken-windows",
   "review.models.claude": "claude",
   "review.max_prompt_tokens_per_reviewer.claude": "claude",
+  "review.timeouts.claude": "claude",
   "claude_orchestration.enabled": "claude-orchestration",
   "claude_orchestration.execution_backend": "claude-orchestration",
   "claude_orchestration.min_agent_sdk_version": "claude-orchestration",
   "workflow.code_review": "code-review",
   "workflow.code_review_depth": "code-review",
   "review.max_prompt_tokens_per_reviewer.coderabbit": "coderabbit",
+  "review.timeouts.coderabbit": "coderabbit",
   "review.models.codex": "codex",
   "review.max_prompt_tokens_per_reviewer.codex": "codex",
+  "review.timeouts.codex": "codex",
   "review.max_prompt_tokens_per_reviewer.cursor": "cursor",
+  "review.timeouts.cursor": "cursor",
   "workflow.drift_threshold": "drift",
   "workflow.drift_action": "drift",
   "workflow.schema_drift_gate": "drift",
@@ -4734,17 +4811,21 @@ const configKeys = {
   "workflow.post_planning_gaps": "gap-analysis",
   "review.models.gemini": "gemini",
   "review.max_prompt_tokens_per_reviewer.gemini": "gemini",
+  "review.timeouts.gemini": "gemini",
   "graphify.enabled": "graphify",
   "intel.enabled": "intel",
   "review.models.kimi-code": "kimi-code",
   "review.max_prompt_tokens_per_reviewer.kimi-code": "kimi-code",
+  "review.timeouts.kimi-code": "kimi-code",
   "workflow.live_dom_uat": "live-dom-uat",
   "review.models.llama_cpp": "llama-cpp",
   "review.llama_cpp_host": "llama-cpp",
   "review.max_prompt_tokens_per_reviewer.llama_cpp": "llama-cpp",
+  "review.timeouts.llama_cpp": "llama-cpp",
   "review.models.lm_studio": "lm-studio",
   "review.lm_studio_host": "lm-studio",
   "review.max_prompt_tokens_per_reviewer.lm_studio": "lm-studio",
+  "review.timeouts.lm_studio": "lm-studio",
   "mempalace.enabled": "mempalace",
   "mempalace.memory_mode": "mempalace",
   "mempalace.wing": "mempalace",
@@ -4759,11 +4840,14 @@ const configKeys = {
   "review.models.ollama": "ollama",
   "review.ollama_host": "ollama",
   "review.max_prompt_tokens_per_reviewer.ollama": "ollama",
+  "review.timeouts.ollama": "ollama",
   "review.models.opencode": "opencode",
   "review.max_prompt_tokens_per_reviewer.opencode": "opencode",
+  "review.timeouts.opencode": "opencode",
   "workflow.pattern_mapper": "pattern-mapper",
   "profile-pipeline.enabled": "profile-pipeline",
   "review.max_prompt_tokens_per_reviewer.qwen": "qwen",
+  "review.timeouts.qwen": "qwen",
   "refactor.trigger_enabled": "refactor-trigger",
   "refactor.complexity_threshold": "refactor-trigger",
   "refactor.complexity_jump_delta": "refactor-trigger",
@@ -4804,6 +4888,12 @@ const configSchema = {
     "default": -1,
     "description": "Prompt-token budget for the Antigravity reviewer lane. Unset is -1, a sentinel: 0 is a legitimate value meaning \"do not trim this lane\", so it cannot double as \"not configured\". Keyed on the reviewer slug `antigravity`, not the `agy` binary alias used by review.models.agy."
   },
+  "review.timeouts.antigravity": {
+    "owner": "antigravity",
+    "type": "number",
+    "default": -1,
+    "description": "Outer wall-clock timeout override (seconds) for the Antigravity reviewer lane. Unset is -1, a sentinel: 0 or a negative number is also treated as unset (a timeout has no legitimate zero/negative value), so no second sentinel is needed. Falls back to the lane's built-in timeoutFloorMs when unset."
+  },
   "workflow.assumption_delta": {
     "owner": "assumption-delta",
     "type": "boolean",
@@ -4827,6 +4917,12 @@ const configSchema = {
     "type": "number",
     "default": -1,
     "description": "Prompt-token budget for the Claude reviewer lane. Unset is -1, a sentinel: 0 is a legitimate value meaning \"do not trim this lane\", so it cannot double as \"not configured\"."
+  },
+  "review.timeouts.claude": {
+    "owner": "claude",
+    "type": "number",
+    "default": -1,
+    "description": "Outer wall-clock timeout override (seconds) for the Claude reviewer lane. Unset is -1, a sentinel: 0 or a negative number is also treated as unset (a timeout has no legitimate zero/negative value), so no second sentinel is needed. Falls back to the lane's built-in timeoutFloorMs when unset."
   },
   "claude_orchestration.enabled": {
     "owner": "claude-orchestration",
@@ -4874,6 +4970,12 @@ const configSchema = {
     "default": -1,
     "description": "Prompt-token budget for the CodeRabbit reviewer lane. Unset is -1, a sentinel: 0 is a legitimate value meaning \"do not trim this lane\", so it cannot double as \"not configured\"."
   },
+  "review.timeouts.coderabbit": {
+    "owner": "coderabbit",
+    "type": "number",
+    "default": -1,
+    "description": "Outer wall-clock timeout override (seconds) for the CodeRabbit reviewer lane. Unset is -1, a sentinel: 0 or a negative number is also treated as unset (a timeout has no legitimate zero/negative value), so no second sentinel is needed. Falls back to the lane's built-in timeoutFloorMs when unset."
+  },
   "review.models.codex": {
     "owner": "codex",
     "type": "string",
@@ -4886,11 +4988,23 @@ const configSchema = {
     "default": -1,
     "description": "Prompt-token budget for the Codex reviewer lane. Unset is -1, a sentinel: 0 is a legitimate value meaning \"do not trim this lane\", so it cannot double as \"not configured\"."
   },
+  "review.timeouts.codex": {
+    "owner": "codex",
+    "type": "number",
+    "default": -1,
+    "description": "Outer wall-clock timeout override (seconds) for the Codex reviewer lane. Unset is -1, a sentinel: 0 or a negative number is also treated as unset (a timeout has no legitimate zero/negative value), so no second sentinel is needed. Falls back to the lane's built-in timeoutFloorMs when unset."
+  },
   "review.max_prompt_tokens_per_reviewer.cursor": {
     "owner": "cursor",
     "type": "number",
     "default": -1,
     "description": "Prompt-token budget for the Cursor reviewer lane. Unset is -1, a sentinel: 0 is a legitimate value meaning \"do not trim this lane\", so it cannot double as \"not configured\"."
+  },
+  "review.timeouts.cursor": {
+    "owner": "cursor",
+    "type": "number",
+    "default": -1,
+    "description": "Outer wall-clock timeout override (seconds) for the Cursor reviewer lane. Unset is -1, a sentinel: 0 or a negative number is also treated as unset (a timeout has no legitimate zero/negative value), so no second sentinel is needed. Falls back to the lane's built-in timeoutFloorMs when unset."
   },
   "workflow.drift_threshold": {
     "owner": "drift",
@@ -4971,6 +5085,12 @@ const configSchema = {
     "default": -1,
     "description": "Prompt-token budget for the Gemini reviewer lane. Unset is -1, a sentinel: 0 is a legitimate value meaning \"do not trim this lane\", so it cannot double as \"not configured\"."
   },
+  "review.timeouts.gemini": {
+    "owner": "gemini",
+    "type": "number",
+    "default": -1,
+    "description": "Outer wall-clock timeout override (seconds) for the Gemini reviewer lane. Unset is -1, a sentinel: 0 or a negative number is also treated as unset (a timeout has no legitimate zero/negative value), so no second sentinel is needed. Falls back to the lane's built-in timeoutFloorMs when unset."
+  },
   "graphify.enabled": {
     "owner": "graphify",
     "type": "boolean",
@@ -4994,6 +5114,12 @@ const configSchema = {
     "type": "number",
     "default": -1,
     "description": "Prompt-token budget for the Kimi Code reviewer lane. Unset is -1, a sentinel: 0 is a legitimate value meaning \"do not trim this lane\", so it cannot double as \"not configured\"."
+  },
+  "review.timeouts.kimi-code": {
+    "owner": "kimi-code",
+    "type": "number",
+    "default": -1,
+    "description": "Outer wall-clock timeout override (seconds) for the Kimi Code reviewer lane. Unset is -1, a sentinel: 0 or a negative number is also treated as unset (a timeout has no legitimate zero/negative value), so no second sentinel is needed. Falls back to the lane's built-in timeoutFloorMs when unset."
   },
   "workflow.live_dom_uat": {
     "owner": "live-dom-uat",
@@ -5019,6 +5145,12 @@ const configSchema = {
     "default": -1,
     "description": "Prompt-token budget for the llama.cpp reviewer lane. Unset is -1, a sentinel: 0 is a legitimate value meaning \"do not trim this lane\", so it cannot double as \"not configured\"."
   },
+  "review.timeouts.llama_cpp": {
+    "owner": "llama-cpp",
+    "type": "number",
+    "default": -1,
+    "description": "Outer wall-clock timeout override (seconds) for the llama.cpp reviewer lane. Unset is -1, a sentinel: 0 or a negative number is also treated as unset (a timeout has no legitimate zero/negative value), so no second sentinel is needed. Falls back to the lane's built-in timeoutFloorMs when unset."
+  },
   "review.models.lm_studio": {
     "owner": "lm-studio",
     "type": "string",
@@ -5036,6 +5168,12 @@ const configSchema = {
     "type": "number",
     "default": -1,
     "description": "Prompt-token budget for the LM Studio reviewer lane. Unset is -1, a sentinel: 0 is a legitimate value meaning \"do not trim this lane\", so it cannot double as \"not configured\"."
+  },
+  "review.timeouts.lm_studio": {
+    "owner": "lm-studio",
+    "type": "number",
+    "default": -1,
+    "description": "Outer wall-clock timeout override (seconds) for the LM Studio reviewer lane. Unset is -1, a sentinel: 0 or a negative number is also treated as unset (a timeout has no legitimate zero/negative value), so no second sentinel is needed. Falls back to the lane's built-in timeoutFloorMs when unset."
   },
   "mempalace.enabled": {
     "owner": "mempalace",
@@ -5126,6 +5264,12 @@ const configSchema = {
     "default": -1,
     "description": "Prompt-token budget for the Ollama reviewer lane. Unset is -1, a sentinel: 0 is a legitimate value meaning \"do not trim this lane\", so it cannot double as \"not configured\"."
   },
+  "review.timeouts.ollama": {
+    "owner": "ollama",
+    "type": "number",
+    "default": -1,
+    "description": "Outer wall-clock timeout override (seconds) for the Ollama reviewer lane. Unset is -1, a sentinel: 0 or a negative number is also treated as unset (a timeout has no legitimate zero/negative value), so no second sentinel is needed. Falls back to the lane's built-in timeoutFloorMs when unset."
+  },
   "review.models.opencode": {
     "owner": "opencode",
     "type": "string",
@@ -5137,6 +5281,12 @@ const configSchema = {
     "type": "number",
     "default": -1,
     "description": "Prompt-token budget for the OpenCode reviewer lane. Unset is -1, a sentinel: 0 is a legitimate value meaning \"do not trim this lane\", so it cannot double as \"not configured\"."
+  },
+  "review.timeouts.opencode": {
+    "owner": "opencode",
+    "type": "number",
+    "default": -1,
+    "description": "Outer wall-clock timeout override (seconds) for the OpenCode reviewer lane. Unset is -1, a sentinel: 0 or a negative number is also treated as unset (a timeout has no legitimate zero/negative value), so no second sentinel is needed. Falls back to the lane's built-in timeoutFloorMs when unset."
   },
   "workflow.pattern_mapper": {
     "owner": "pattern-mapper",
@@ -5155,6 +5305,12 @@ const configSchema = {
     "type": "number",
     "default": -1,
     "description": "Prompt-token budget for the Qwen Code reviewer lane. Unset is -1, a sentinel: 0 is a legitimate value meaning \"do not trim this lane\", so it cannot double as \"not configured\"."
+  },
+  "review.timeouts.qwen": {
+    "owner": "qwen",
+    "type": "number",
+    "default": -1,
+    "description": "Outer wall-clock timeout override (seconds) for the Qwen Code reviewer lane. Unset is -1, a sentinel: 0 or a negative number is also treated as unset (a timeout has no legitimate zero/negative value), so no second sentinel is needed. Falls back to the lane's built-in timeoutFloorMs when unset."
   },
   "refactor.trigger_enabled": {
     "owner": "refactor-trigger",
@@ -5377,6 +5533,7 @@ const runtimes = {
         "effortChannel": "none"
       },
       "timeoutFloorMs": 600000,
+      "timeoutConfigKey": "review.timeouts.antigravity",
       "emptyOutput": "handler-owned",
       "reviewsSection": "Antigravity",
       "evidenceClass": "source-grounded",
@@ -5395,6 +5552,11 @@ const runtimes = {
         "type": "number",
         "default": -1,
         "description": "Prompt-token budget for the Antigravity reviewer lane. Unset is -1, a sentinel: 0 is a legitimate value meaning \"do not trim this lane\", so it cannot double as \"not configured\". Keyed on the reviewer slug `antigravity`, not the `agy` binary alias used by review.models.agy."
+      },
+      "review.timeouts.antigravity": {
+        "type": "number",
+        "default": -1,
+        "description": "Outer wall-clock timeout override (seconds) for the Antigravity reviewer lane. Unset is -1, a sentinel: 0 or a negative number is also treated as unset (a timeout has no legitimate zero/negative value), so no second sentinel is needed. Falls back to the lane's built-in timeoutFloorMs when unset."
       }
     }
   },
@@ -5657,6 +5819,7 @@ const runtimes = {
         }
       },
       "timeoutFloorMs": 1200000,
+      "timeoutConfigKey": "review.timeouts.claude",
       "emptyOutput": "stub-with-stderr",
       "reviewsSection": "Claude",
       "evidenceClass": "source-grounded",
@@ -5675,6 +5838,11 @@ const runtimes = {
         "type": "number",
         "default": -1,
         "description": "Prompt-token budget for the Claude reviewer lane. Unset is -1, a sentinel: 0 is a legitimate value meaning \"do not trim this lane\", so it cannot double as \"not configured\"."
+      },
+      "review.timeouts.claude": {
+        "type": "number",
+        "default": -1,
+        "description": "Outer wall-clock timeout override (seconds) for the Claude reviewer lane. Unset is -1, a sentinel: 0 or a negative number is also treated as unset (a timeout has no legitimate zero/negative value), so no second sentinel is needed. Falls back to the lane's built-in timeoutFloorMs when unset."
       }
     }
   },
@@ -6028,6 +6196,7 @@ const runtimes = {
         "effortChannel": "argv"
       },
       "timeoutFloorMs": 1200000,
+      "timeoutConfigKey": "review.timeouts.codex",
       "emptyOutput": "stub-with-stderr",
       "reviewsSection": "Codex",
       "evidenceClass": "source-grounded",
@@ -6046,6 +6215,11 @@ const runtimes = {
         "type": "number",
         "default": -1,
         "description": "Prompt-token budget for the Codex reviewer lane. Unset is -1, a sentinel: 0 is a legitimate value meaning \"do not trim this lane\", so it cannot double as \"not configured\"."
+      },
+      "review.timeouts.codex": {
+        "type": "number",
+        "default": -1,
+        "description": "Outer wall-clock timeout override (seconds) for the Codex reviewer lane. Unset is -1, a sentinel: 0 or a negative number is also treated as unset (a timeout has no legitimate zero/negative value), so no second sentinel is needed. Falls back to the lane's built-in timeoutFloorMs when unset."
       }
     }
   },
@@ -6291,6 +6465,7 @@ const runtimes = {
         "effortChannel": "none"
       },
       "timeoutFloorMs": 900000,
+      "timeoutConfigKey": "review.timeouts.cursor",
       "emptyOutput": "stub-with-stderr",
       "reviewsSection": "Cursor",
       "evidenceClass": "source-grounded",
@@ -6304,6 +6479,11 @@ const runtimes = {
         "type": "number",
         "default": -1,
         "description": "Prompt-token budget for the Cursor reviewer lane. Unset is -1, a sentinel: 0 is a legitimate value meaning \"do not trim this lane\", so it cannot double as \"not configured\"."
+      },
+      "review.timeouts.cursor": {
+        "type": "number",
+        "default": -1,
+        "description": "Outer wall-clock timeout override (seconds) for the Cursor reviewer lane. Unset is -1, a sentinel: 0 or a negative number is also treated as unset (a timeout has no legitimate zero/negative value), so no second sentinel is needed. Falls back to the lane's built-in timeoutFloorMs when unset."
       }
     }
   },
@@ -6786,6 +6966,7 @@ const runtimes = {
         "effortChannel": "none"
       },
       "timeoutFloorMs": 900000,
+      "timeoutConfigKey": "review.timeouts.kimi-code",
       "emptyOutput": "stub-with-stderr",
       "reviewsSection": "Kimi Code",
       "evidenceClass": "source-grounded",
@@ -6804,6 +6985,11 @@ const runtimes = {
         "type": "number",
         "default": -1,
         "description": "Prompt-token budget for the Kimi Code reviewer lane. Unset is -1, a sentinel: 0 is a legitimate value meaning \"do not trim this lane\", so it cannot double as \"not configured\"."
+      },
+      "review.timeouts.kimi-code": {
+        "type": "number",
+        "default": -1,
+        "description": "Outer wall-clock timeout override (seconds) for the Kimi Code reviewer lane. Unset is -1, a sentinel: 0 or a negative number is also treated as unset (a timeout has no legitimate zero/negative value), so no second sentinel is needed. Falls back to the lane's built-in timeoutFloorMs when unset."
       }
     }
   },
@@ -6967,6 +7153,7 @@ const runtimes = {
         "effortChannel": "argv"
       },
       "timeoutFloorMs": 660000,
+      "timeoutConfigKey": "review.timeouts.opencode",
       "emptyOutput": "stub-with-stderr",
       "reviewsSection": "OpenCode",
       "evidenceClass": "source-grounded",
@@ -6985,6 +7172,11 @@ const runtimes = {
         "type": "number",
         "default": -1,
         "description": "Prompt-token budget for the OpenCode reviewer lane. Unset is -1, a sentinel: 0 is a legitimate value meaning \"do not trim this lane\", so it cannot double as \"not configured\"."
+      },
+      "review.timeouts.opencode": {
+        "type": "number",
+        "default": -1,
+        "description": "Outer wall-clock timeout override (seconds) for the OpenCode reviewer lane. Unset is -1, a sentinel: 0 or a negative number is also treated as unset (a timeout has no legitimate zero/negative value), so no second sentinel is needed. Falls back to the lane's built-in timeoutFloorMs when unset."
       }
     }
   },
@@ -7187,6 +7379,7 @@ const runtimes = {
         "effortChannel": "none"
       },
       "timeoutFloorMs": 900000,
+      "timeoutConfigKey": "review.timeouts.qwen",
       "emptyOutput": "stub-with-stderr",
       "reviewsSection": "Qwen",
       "evidenceClass": "source-grounded",
@@ -7200,6 +7393,11 @@ const runtimes = {
         "type": "number",
         "default": -1,
         "description": "Prompt-token budget for the Qwen Code reviewer lane. Unset is -1, a sentinel: 0 is a legitimate value meaning \"do not trim this lane\", so it cannot double as \"not configured\"."
+      },
+      "review.timeouts.qwen": {
+        "type": "number",
+        "default": -1,
+        "description": "Outer wall-clock timeout override (seconds) for the Qwen Code reviewer lane. Unset is -1, a sentinel: 0 or a negative number is also treated as unset (a timeout has no legitimate zero/negative value), so no second sentinel is needed. Falls back to the lane's built-in timeoutFloorMs when unset."
       }
     }
   },

--- a/gsd-core/bin/lib/capability-registry.cjs
+++ b/gsd-core/bin/lib/capability-registry.cjs
@@ -214,7 +214,7 @@ const capabilities = {
         "binary": "agy",
         "args": [
           "--print-timeout",
-          "540s",
+          "{{nativeTimeout}}",
           "{{model}}",
           "-p",
           "{{prompt}}"
@@ -1058,7 +1058,7 @@ const capabilities = {
         "effortChannel": "none"
       },
       "timeoutFloorMs": 360000,
-      "timeoutConfigKey": "review.timeouts.coderabbit",
+      "timeoutConfigKey": null,
       "emptyOutput": "stub-with-stderr",
       "reviewsSection": "CodeRabbit",
       "evidenceClass": "diff-only",
@@ -1072,11 +1072,6 @@ const capabilities = {
         "type": "number",
         "default": -1,
         "description": "Prompt-token budget for the CodeRabbit reviewer lane. Unset is -1, a sentinel: 0 is a legitimate value meaning \"do not trim this lane\", so it cannot double as \"not configured\"."
-      },
-      "review.timeouts.coderabbit": {
-        "type": "number",
-        "default": -1,
-        "description": "Outer wall-clock timeout override (seconds) for the CodeRabbit reviewer lane. Unset is -1, a sentinel: 0 or a negative number is also treated as unset (a timeout has no legitimate zero/negative value), so no second sentinel is needed. Falls back to the lane's built-in timeoutFloorMs when unset."
       }
     }
   },
@@ -1490,7 +1485,7 @@ const capabilities = {
         "effortChannel": "none"
       },
       "timeoutFloorMs": 900000,
-      "timeoutConfigKey": "review.timeouts.cursor",
+      "timeoutConfigKey": null,
       "emptyOutput": "stub-with-stderr",
       "reviewsSection": "Cursor",
       "evidenceClass": "source-grounded",
@@ -1504,11 +1499,6 @@ const capabilities = {
         "type": "number",
         "default": -1,
         "description": "Prompt-token budget for the Cursor reviewer lane. Unset is -1, a sentinel: 0 is a legitimate value meaning \"do not trim this lane\", so it cannot double as \"not configured\"."
-      },
-      "review.timeouts.cursor": {
-        "type": "number",
-        "default": -1,
-        "description": "Outer wall-clock timeout override (seconds) for the Cursor reviewer lane. Unset is -1, a sentinel: 0 or a negative number is also treated as unset (a timeout has no legitimate zero/negative value), so no second sentinel is needed. Falls back to the lane's built-in timeoutFloorMs when unset."
       }
     }
   },
@@ -3360,7 +3350,7 @@ const capabilities = {
         "effortChannel": "none"
       },
       "timeoutFloorMs": 900000,
-      "timeoutConfigKey": "review.timeouts.qwen",
+      "timeoutConfigKey": null,
       "emptyOutput": "stub-with-stderr",
       "reviewsSection": "Qwen",
       "evidenceClass": "source-grounded",
@@ -3374,11 +3364,6 @@ const capabilities = {
         "type": "number",
         "default": -1,
         "description": "Prompt-token budget for the Qwen Code reviewer lane. Unset is -1, a sentinel: 0 is a legitimate value meaning \"do not trim this lane\", so it cannot double as \"not configured\"."
-      },
-      "review.timeouts.qwen": {
-        "type": "number",
-        "default": -1,
-        "description": "Outer wall-clock timeout override (seconds) for the Qwen Code reviewer lane. Unset is -1, a sentinel: 0 or a negative number is also treated as unset (a timeout has no legitimate zero/negative value), so no second sentinel is needed. Falls back to the lane's built-in timeoutFloorMs when unset."
       }
     }
   },
@@ -4793,12 +4778,10 @@ const configKeys = {
   "workflow.code_review": "code-review",
   "workflow.code_review_depth": "code-review",
   "review.max_prompt_tokens_per_reviewer.coderabbit": "coderabbit",
-  "review.timeouts.coderabbit": "coderabbit",
   "review.models.codex": "codex",
   "review.max_prompt_tokens_per_reviewer.codex": "codex",
   "review.timeouts.codex": "codex",
   "review.max_prompt_tokens_per_reviewer.cursor": "cursor",
-  "review.timeouts.cursor": "cursor",
   "workflow.drift_threshold": "drift",
   "workflow.drift_action": "drift",
   "workflow.schema_drift_gate": "drift",
@@ -4847,7 +4830,6 @@ const configKeys = {
   "workflow.pattern_mapper": "pattern-mapper",
   "profile-pipeline.enabled": "profile-pipeline",
   "review.max_prompt_tokens_per_reviewer.qwen": "qwen",
-  "review.timeouts.qwen": "qwen",
   "refactor.trigger_enabled": "refactor-trigger",
   "refactor.complexity_threshold": "refactor-trigger",
   "refactor.complexity_jump_delta": "refactor-trigger",
@@ -4970,12 +4952,6 @@ const configSchema = {
     "default": -1,
     "description": "Prompt-token budget for the CodeRabbit reviewer lane. Unset is -1, a sentinel: 0 is a legitimate value meaning \"do not trim this lane\", so it cannot double as \"not configured\"."
   },
-  "review.timeouts.coderabbit": {
-    "owner": "coderabbit",
-    "type": "number",
-    "default": -1,
-    "description": "Outer wall-clock timeout override (seconds) for the CodeRabbit reviewer lane. Unset is -1, a sentinel: 0 or a negative number is also treated as unset (a timeout has no legitimate zero/negative value), so no second sentinel is needed. Falls back to the lane's built-in timeoutFloorMs when unset."
-  },
   "review.models.codex": {
     "owner": "codex",
     "type": "string",
@@ -4999,12 +4975,6 @@ const configSchema = {
     "type": "number",
     "default": -1,
     "description": "Prompt-token budget for the Cursor reviewer lane. Unset is -1, a sentinel: 0 is a legitimate value meaning \"do not trim this lane\", so it cannot double as \"not configured\"."
-  },
-  "review.timeouts.cursor": {
-    "owner": "cursor",
-    "type": "number",
-    "default": -1,
-    "description": "Outer wall-clock timeout override (seconds) for the Cursor reviewer lane. Unset is -1, a sentinel: 0 or a negative number is also treated as unset (a timeout has no legitimate zero/negative value), so no second sentinel is needed. Falls back to the lane's built-in timeoutFloorMs when unset."
   },
   "workflow.drift_threshold": {
     "owner": "drift",
@@ -5306,12 +5276,6 @@ const configSchema = {
     "default": -1,
     "description": "Prompt-token budget for the Qwen Code reviewer lane. Unset is -1, a sentinel: 0 is a legitimate value meaning \"do not trim this lane\", so it cannot double as \"not configured\"."
   },
-  "review.timeouts.qwen": {
-    "owner": "qwen",
-    "type": "number",
-    "default": -1,
-    "description": "Outer wall-clock timeout override (seconds) for the Qwen Code reviewer lane. Unset is -1, a sentinel: 0 or a negative number is also treated as unset (a timeout has no legitimate zero/negative value), so no second sentinel is needed. Falls back to the lane's built-in timeoutFloorMs when unset."
-  },
   "refactor.trigger_enabled": {
     "owner": "refactor-trigger",
     "type": "boolean",
@@ -5522,7 +5486,7 @@ const runtimes = {
         "binary": "agy",
         "args": [
           "--print-timeout",
-          "540s",
+          "{{nativeTimeout}}",
           "{{model}}",
           "-p",
           "{{prompt}}"
@@ -6465,7 +6429,7 @@ const runtimes = {
         "effortChannel": "none"
       },
       "timeoutFloorMs": 900000,
-      "timeoutConfigKey": "review.timeouts.cursor",
+      "timeoutConfigKey": null,
       "emptyOutput": "stub-with-stderr",
       "reviewsSection": "Cursor",
       "evidenceClass": "source-grounded",
@@ -6479,11 +6443,6 @@ const runtimes = {
         "type": "number",
         "default": -1,
         "description": "Prompt-token budget for the Cursor reviewer lane. Unset is -1, a sentinel: 0 is a legitimate value meaning \"do not trim this lane\", so it cannot double as \"not configured\"."
-      },
-      "review.timeouts.cursor": {
-        "type": "number",
-        "default": -1,
-        "description": "Outer wall-clock timeout override (seconds) for the Cursor reviewer lane. Unset is -1, a sentinel: 0 or a negative number is also treated as unset (a timeout has no legitimate zero/negative value), so no second sentinel is needed. Falls back to the lane's built-in timeoutFloorMs when unset."
       }
     }
   },
@@ -7379,7 +7338,7 @@ const runtimes = {
         "effortChannel": "none"
       },
       "timeoutFloorMs": 900000,
-      "timeoutConfigKey": "review.timeouts.qwen",
+      "timeoutConfigKey": null,
       "emptyOutput": "stub-with-stderr",
       "reviewsSection": "Qwen",
       "evidenceClass": "source-grounded",
@@ -7393,11 +7352,6 @@ const runtimes = {
         "type": "number",
         "default": -1,
         "description": "Prompt-token budget for the Qwen Code reviewer lane. Unset is -1, a sentinel: 0 is a legitimate value meaning \"do not trim this lane\", so it cannot double as \"not configured\"."
-      },
-      "review.timeouts.qwen": {
-        "type": "number",
-        "default": -1,
-        "description": "Outer wall-clock timeout override (seconds) for the Qwen Code reviewer lane. Unset is -1, a sentinel: 0 or a negative number is also treated as unset (a timeout has no legitimate zero/negative value), so no second sentinel is needed. Falls back to the lane's built-in timeoutFloorMs when unset."
       }
     }
   },

--- a/gsd-core/bin/lib/capability-validator.cjs
+++ b/gsd-core/bin/lib/capability-validator.cjs
@@ -1824,6 +1824,9 @@ const KNOWN_REVIEWER_FIELDS = new Set([
   // missed a configured model and silently disabled the pinned-model escape hatch
   // #2073 added. A convention one shipped lane already violates is not a contract.
   'modelConfigKey',
+  // `timeoutConfigKey` added by #3274, same optional/backward-compatible shape as
+  // `modelConfigKey` above: a manifest authored before this field existed must keep validating.
+  'timeoutConfigKey',
   'handler',
 ]);
 
@@ -2368,6 +2371,17 @@ function validateReviewerBodyFields(cap) {
     errors.push(
       ctx + ' reviewer.modelConfigKey must be a dotted config key or null ' +
       '(got: ' + describeValue(r.modelConfigKey) + ')',
+    );
+  }
+
+  // OPTIONAL, mirroring modelConfigKey's D4 forward/backward-compat treatment (#3274): a manifest
+  // authored before this field existed must keep validating. Absent/null means "no override for
+  // this lane, use timeoutFloorMs". An empty string is neither absent nor a key, and is rejected.
+  if (r.timeoutConfigKey !== undefined && r.timeoutConfigKey !== null &&
+      (typeof r.timeoutConfigKey !== 'string' || r.timeoutConfigKey.length === 0)) {
+    errors.push(
+      ctx + ' reviewer.timeoutConfigKey must be a dotted config key or null ' +
+      '(got: ' + describeValue(r.timeoutConfigKey) + ')',
     );
   }
 

--- a/src/review-lane-descriptor.cts
+++ b/src/review-lane-descriptor.cts
@@ -44,6 +44,9 @@
  *   4. `flags: string[]` — Antigravity is selected by BOTH `--antigravity` and
  *      `--agy`, which a single-valued field cannot express. This also flattens
  *      D8's uniqueness invariant across every lane's flags.
+ *   5. `NATIVE_TIMEOUT` — a lane whose CLI takes its own native inner timeout flag (today only
+ *      antigravity's `--print-timeout`) declares where the resolved value goes; `resolveLanePlan`
+ *      computes what it is from the same resolved outer `timeoutMs` (#3274).
  *
  * Phase 2 (#2795) implements the manifest validator against the amended
  * vocabulary, which is the point of amending rather than leaving it to be
@@ -110,7 +113,7 @@ export type LaneProbe =
  * and vanishes when it has nothing to contribute (no model configured, no effort channel, prompt on
  * stdin), which is what lets one template serve the configured and unconfigured cases.
  *
- * This is a closed four-member vocabulary with no expressions, no nesting and no conditionals — a
+ * This is a closed five-member vocabulary with no expressions, no nesting and no conditionals — a
  * placeholder set, deliberately not a template language. The moment it needs a conditional, the
  * lane wants a `handler` instead (D6).
  */
@@ -123,6 +126,9 @@ export const ARGV_PLACEHOLDER = Object.freeze({
   OUTPUT: '{{output}}',
   /** The argv-borne prompt, or nothing unless `promptChannel` is `argv`/`argv-file-ref`. */
   PROMPT: '{{prompt}}',
+  /** A lane's own CLI-native inner timeout duration, derived from the resolved outer `timeoutMs`
+   * (never independently configured) — see `resolveLanePlan`'s expansion of this token. */
+  NATIVE_TIMEOUT: '{{nativeTimeout}}',
 } as const);
 
 export interface SpawnInvoke {
@@ -187,8 +193,12 @@ interface ReviewerLaneCommon {
    * user's repository and model, not of the lane — a cap right for a three-plan phase is wrong
    * for a fifteen-plan one. Resolved at invocation time (`resolveLanePlan`); an unset key, or a
    * config value that is not a positive finite number, falls back to `timeoutFloorMs` unchanged.
-   * For a lane whose handler ALSO bakes a native tool-side timeout into argv (antigravity's
-   * `--print-timeout`), the resolved value feeds both levels — see `antigravityArgv`.
+   * For a lane whose `args` template ALSO carries a native tool-side timeout (antigravity's
+   * `--print-timeout`, via the `{{nativeTimeout}}` ARGV_PLACEHOLDER), the resolved value feeds both
+   * levels — see `resolveLanePlan`'s expansion of that token. Three lanes — `qwen`, `cursor`,
+   * `coderabbit` — accept neither a model flag nor a host and own no `review.timeouts.<slug>` key
+   * either, matching the same narrow key-ownership invariant `modelConfigKey` already follows for
+   * them (#3691 narrows #2797).
    */
   timeoutConfigKey: string | null;
   emptyOutput: EmptyOutputPolicy;
@@ -350,7 +360,7 @@ export const REVIEWER_LANES: ReadonlyArray<ReviewerLane> = Object.freeze([
       effortChannel: 'none',
     },
     timeoutFloorMs: 360_000,
-    timeoutConfigKey: 'review.timeouts.coderabbit',
+    timeoutConfigKey: null,
     emptyOutput: 'stub-with-stderr',
     reviewsSection: 'CodeRabbit',
     evidenceClass: 'diff-only',
@@ -402,7 +412,7 @@ export const REVIEWER_LANES: ReadonlyArray<ReviewerLane> = Object.freeze([
       effortChannel: 'none',
     },
     timeoutFloorMs: 900_000,
-    timeoutConfigKey: 'review.timeouts.qwen',
+    timeoutConfigKey: null,
     emptyOutput: 'stub-with-stderr',
     reviewsSection: 'Qwen',
     evidenceClass: 'source-grounded',
@@ -428,7 +438,7 @@ export const REVIEWER_LANES: ReadonlyArray<ReviewerLane> = Object.freeze([
       effortChannel: 'none',
     },
     timeoutFloorMs: 900_000,
-    timeoutConfigKey: 'review.timeouts.cursor',
+    timeoutConfigKey: null,
     emptyOutput: 'stub-with-stderr',
     reviewsSection: 'Cursor',
     evidenceClass: 'source-grounded',
@@ -448,12 +458,11 @@ export const REVIEWER_LANES: ReadonlyArray<ReviewerLane> = Object.freeze([
     probe: { kind: 'command-exists', binary: 'agy' },
     invoke: {
       binary: 'agy',
-      // '{{nativeTimeout}}' is NOT one of the four generic ARGV_PLACEHOLDER tokens above — it is a
-      // handler-owned marker (ADR-2782 D6) that `antigravityArgv` (review-lane-runner.cts)
-      // substitutes with a value DERIVED from the resolved outer timeoutMs (#3274), so the native
-      // `--print-timeout` and the outer wall-clock cap can never drift apart. The generic resolver
-      // in review-lane-invocation.cts passes any token it doesn't recognize through unchanged, so
-      // this is safe there too — it only means something to the antigravity handler.
+      // `{{nativeTimeout}}` is the fifth ARGV_PLACEHOLDER member (#3274) — `resolveLanePlan`
+      // (review-lane-invocation.cts) expands it to a value DERIVED from this same lane's resolved
+      // outer `timeoutMs`, so the native `--print-timeout` and the outer wall-clock cap can never
+      // drift apart. No other shipped lane's `args` template contains this token, so the expansion
+      // is inert everywhere else.
       args: ['--print-timeout', '{{nativeTimeout}}', '{{model}}', '-p', '{{prompt}}'],
       promptChannel: 'argv-file-ref',
       outputChannel: 'stdout',

--- a/src/review-lane-descriptor.cts
+++ b/src/review-lane-descriptor.cts
@@ -178,6 +178,19 @@ interface ReviewerLaneCommon {
   probe: LaneProbe;
   /** Outer wall-clock bound. An inner tool-native timeout lives in the handler (D6). */
   timeoutFloorMs: number;
+  /**
+   * Dotted config key holding this lane's outer timeout override, in SECONDS, or null when the
+   * lane accepts none.
+   *
+   * Added by #3274 in the same spirit as `promptBudgetKey`/`modelConfigKey`: the frozen
+   * `timeoutFloorMs` table has no reachable override, and a review duration is a property of the
+   * user's repository and model, not of the lane — a cap right for a three-plan phase is wrong
+   * for a fifteen-plan one. Resolved at invocation time (`resolveLanePlan`); an unset key, or a
+   * config value that is not a positive finite number, falls back to `timeoutFloorMs` unchanged.
+   * For a lane whose handler ALSO bakes a native tool-side timeout into argv (antigravity's
+   * `--print-timeout`), the resolved value feeds both levels — see `antigravityArgv`.
+   */
+  timeoutConfigKey: string | null;
   emptyOutput: EmptyOutputPolicy;
   /** The `## <reviewsSection> Review` heading in write_reviews. Unique (D8). */
   reviewsSection: string;
@@ -249,6 +262,7 @@ export const REVIEWER_LANES: ReadonlyArray<ReviewerLane> = Object.freeze([
       effortChannel: 'none',
     },
     timeoutFloorMs: 900_000,
+    timeoutConfigKey: 'review.timeouts.gemini',
     emptyOutput: 'stub-with-stderr',
     reviewsSection: 'Gemini',
     evidenceClass: 'source-grounded',
@@ -281,6 +295,7 @@ export const REVIEWER_LANES: ReadonlyArray<ReviewerLane> = Object.freeze([
       env: { CLAUDE_CODE_DISABLE_CLAUDE_MDS: '1', CLAUDE_CODE_DISABLE_AUTO_MEMORY: '1' },
     },
     timeoutFloorMs: 1_200_000,
+    timeoutConfigKey: 'review.timeouts.claude',
     emptyOutput: 'stub-with-stderr',
     reviewsSection: 'Claude',
     evidenceClass: 'source-grounded',
@@ -309,6 +324,7 @@ export const REVIEWER_LANES: ReadonlyArray<ReviewerLane> = Object.freeze([
       effortChannel: 'argv',
     },
     timeoutFloorMs: 1_200_000,
+    timeoutConfigKey: 'review.timeouts.codex',
     emptyOutput: 'stub-with-stderr',
     reviewsSection: 'Codex',
     evidenceClass: 'source-grounded',
@@ -334,6 +350,7 @@ export const REVIEWER_LANES: ReadonlyArray<ReviewerLane> = Object.freeze([
       effortChannel: 'none',
     },
     timeoutFloorMs: 360_000,
+    timeoutConfigKey: 'review.timeouts.coderabbit',
     emptyOutput: 'stub-with-stderr',
     reviewsSection: 'CodeRabbit',
     evidenceClass: 'diff-only',
@@ -359,6 +376,7 @@ export const REVIEWER_LANES: ReadonlyArray<ReviewerLane> = Object.freeze([
       effortChannel: 'argv',
     },
     timeoutFloorMs: 660_000,
+    timeoutConfigKey: 'review.timeouts.opencode',
     emptyOutput: 'stub-with-stderr',
     reviewsSection: 'OpenCode',
     evidenceClass: 'source-grounded',
@@ -384,6 +402,7 @@ export const REVIEWER_LANES: ReadonlyArray<ReviewerLane> = Object.freeze([
       effortChannel: 'none',
     },
     timeoutFloorMs: 900_000,
+    timeoutConfigKey: 'review.timeouts.qwen',
     emptyOutput: 'stub-with-stderr',
     reviewsSection: 'Qwen',
     evidenceClass: 'source-grounded',
@@ -409,6 +428,7 @@ export const REVIEWER_LANES: ReadonlyArray<ReviewerLane> = Object.freeze([
       effortChannel: 'none',
     },
     timeoutFloorMs: 900_000,
+    timeoutConfigKey: 'review.timeouts.cursor',
     emptyOutput: 'stub-with-stderr',
     reviewsSection: 'Cursor',
     evidenceClass: 'source-grounded',
@@ -428,13 +448,20 @@ export const REVIEWER_LANES: ReadonlyArray<ReviewerLane> = Object.freeze([
     probe: { kind: 'command-exists', binary: 'agy' },
     invoke: {
       binary: 'agy',
-      args: ['--print-timeout', '540s', '{{model}}', '-p', '{{prompt}}'],
+      // '{{nativeTimeout}}' is NOT one of the four generic ARGV_PLACEHOLDER tokens above — it is a
+      // handler-owned marker (ADR-2782 D6) that `antigravityArgv` (review-lane-runner.cts)
+      // substitutes with a value DERIVED from the resolved outer timeoutMs (#3274), so the native
+      // `--print-timeout` and the outer wall-clock cap can never drift apart. The generic resolver
+      // in review-lane-invocation.cts passes any token it doesn't recognize through unchanged, so
+      // this is safe there too — it only means something to the antigravity handler.
+      args: ['--print-timeout', '{{nativeTimeout}}', '{{model}}', '-p', '{{prompt}}'],
       promptChannel: 'argv-file-ref',
       outputChannel: 'stdout',
       modelArg: '--model',
       effortChannel: 'none',
     },
     timeoutFloorMs: 600_000,
+    timeoutConfigKey: 'review.timeouts.antigravity',
     emptyOutput: 'handler-owned',
     reviewsSection: 'Antigravity',
     evidenceClass: 'source-grounded',
@@ -465,6 +492,7 @@ export const REVIEWER_LANES: ReadonlyArray<ReviewerLane> = Object.freeze([
       effortChannel: 'none',
     },
     timeoutFloorMs: 120_000,
+    timeoutConfigKey: 'review.timeouts.ollama',
     emptyOutput: 'stub-with-stderr',
     reviewsSection: 'Ollama',
     evidenceClass: 'source-grounded',
@@ -494,6 +522,7 @@ export const REVIEWER_LANES: ReadonlyArray<ReviewerLane> = Object.freeze([
       effortChannel: 'none',
     },
     timeoutFloorMs: 120_000,
+    timeoutConfigKey: 'review.timeouts.lm_studio',
     emptyOutput: 'stub-with-stderr',
     reviewsSection: 'LM Studio',
     evidenceClass: 'source-grounded',
@@ -521,6 +550,7 @@ export const REVIEWER_LANES: ReadonlyArray<ReviewerLane> = Object.freeze([
       effortChannel: 'none',
     },
     timeoutFloorMs: 120_000,
+    timeoutConfigKey: 'review.timeouts.llama_cpp',
     emptyOutput: 'stub-with-stderr',
     reviewsSection: 'llama.cpp',
     evidenceClass: 'source-grounded',
@@ -566,6 +596,7 @@ export const REVIEWER_LANES: ReadonlyArray<ReviewerLane> = Object.freeze([
       effortChannel: 'none',
     },
     timeoutFloorMs: 900_000,
+    timeoutConfigKey: 'review.timeouts.kimi-code',
     emptyOutput: 'stub-with-stderr',
     reviewsSection: 'Kimi Code',
     evidenceClass: 'source-grounded',

--- a/src/review-lane-invocation.cts
+++ b/src/review-lane-invocation.cts
@@ -362,10 +362,25 @@ export function resolveLanePlan(input: ResolveInput): ResolveResult {
   }
 
   const { promptPath, reviewPath, errPath } = artifactPaths(input.runDir, slug);
-  const timeoutMs =
+  const floorMs =
     typeof lane.timeoutFloorMs === 'number' && Number.isFinite(lane.timeoutFloorMs) && lane.timeoutFloorMs > 0
       ? lane.timeoutFloorMs
       : 900_000;
+  // #3274: `timeoutConfigKey` resolves in SECONDS (the user-facing convention this repo already
+  // uses for timeout-shaped config keys — workflow.cross_ai_timeout, graphify.build_timeout — vs.
+  // the internal millisecond unit `timeoutFloorMs` carries). Anything that is not a positive finite
+  // number is treated as unset and falls back to `floorMs`, never coerced: a wrong-typed config
+  // value silently becoming a wrong-but-plausible timeout is worse than falling back cleanly. `0`
+  // and negative values are deliberately treated as unset too — a timeout has no legitimate zero or
+  // negative value, so no second sentinel (unlike the prompt-budget keys, which use -1) is needed.
+  const configuredTimeoutSeconds =
+    typeof lane.timeoutConfigKey === 'string' ? input.configGet(lane.timeoutConfigKey) : undefined;
+  const timeoutMs =
+    typeof configuredTimeoutSeconds === 'number' &&
+    Number.isFinite(configuredTimeoutSeconds) &&
+    configuredTimeoutSeconds > 0
+      ? configuredTimeoutSeconds * 1000
+      : floorMs;
   const emptyOutput: EmptyOutputPolicy = lane.emptyOutput === 'handler-owned' ? 'handler-owned' : 'stub-with-stderr';
   // #3194: only an EXACT 'diff-only' declaration exempts a lane from evidence verification.
   // Anything else — including a missing or garbage value on a third-party overlay body —

--- a/src/review-lane-invocation.cts
+++ b/src/review-lane-invocation.cts
@@ -276,6 +276,22 @@ export function resolveTimeoutMs(
     : floorMs;
 }
 
+/** Buffer (seconds) a lane's native inner timeout sits under its resolved outer wall-clock cap
+ * (#3274). Matches the shipped 600s outer / 540s native relationship exactly when unconfigured:
+ * floor(600000/1000) - 60 = 540. */
+const NATIVE_TIMEOUT_BUFFER_SECONDS = 60;
+
+/**
+ * Render the `{{nativeTimeout}}` argv placeholder from a lane's resolved outer timeout (#3274).
+ *
+ * Clamped to a 1-second floor so a very small configured (or, today, only-ever-default) outer
+ * timeout never produces a zero or negative duration string a CLI would reject or misinterpret.
+ */
+export function nativeTimeoutToken(timeoutMs: number): string {
+  const seconds = Math.max(1, Math.floor(timeoutMs / 1000) - NATIVE_TIMEOUT_BUFFER_SECONDS);
+  return `${seconds}s`;
+}
+
 /**
  * Classify a lane's output as a review or as empty.
  *
@@ -526,6 +542,7 @@ export function resolveLanePlan(input: ResolveInput): ResolveResult {
     '{{effort}}': effortExpansion,
     '{{output}}': outputExpansion,
     '{{prompt}}': promptExpansion,
+    '{{nativeTimeout}}': [nativeTimeoutToken(timeoutMs)],
   };
   const template = Array.isArray(inv.args)
     ? inv.args.filter((a): a is string => typeof a === 'string')

--- a/src/review-lane-invocation.cts
+++ b/src/review-lane-invocation.cts
@@ -255,6 +255,28 @@ export function normalizeHost(raw: string): string {
 }
 
 /**
+ * Resolve a lane's outer wall-clock timeout in milliseconds (#3274).
+ *
+ * `timeoutConfigKey` resolves in SECONDS — the user-facing convention this repo already uses for
+ * timeout-shaped config keys (`workflow.cross_ai_timeout`, `graphify.build_timeout`), distinct from
+ * the internal millisecond unit `timeoutFloorMs` carries. Anything that is not a positive finite
+ * number is treated as unset and falls back to `floorMs`, never coerced: a wrong-typed config value
+ * silently becoming a wrong-but-plausible timeout is worse than falling back cleanly. `0` and
+ * negative values are deliberately treated as unset too — a timeout has no legitimate zero or
+ * negative value, so no second sentinel (unlike the prompt-budget keys, which use -1) is needed.
+ */
+export function resolveTimeoutMs(
+  timeoutConfigKey: string | null | undefined,
+  floorMs: number,
+  configGet: (key: string) => unknown,
+): number {
+  const configuredSeconds = typeof timeoutConfigKey === 'string' ? configGet(timeoutConfigKey) : undefined;
+  return typeof configuredSeconds === 'number' && Number.isFinite(configuredSeconds) && configuredSeconds > 0
+    ? configuredSeconds * 1000
+    : floorMs;
+}
+
+/**
  * Classify a lane's output as a review or as empty.
  *
  * WHITESPACE-ONLY COUNTS AS EMPTY, for every lane. The bash tested `[ ! -s file ]`, which counts
@@ -366,21 +388,7 @@ export function resolveLanePlan(input: ResolveInput): ResolveResult {
     typeof lane.timeoutFloorMs === 'number' && Number.isFinite(lane.timeoutFloorMs) && lane.timeoutFloorMs > 0
       ? lane.timeoutFloorMs
       : 900_000;
-  // #3274: `timeoutConfigKey` resolves in SECONDS (the user-facing convention this repo already
-  // uses for timeout-shaped config keys — workflow.cross_ai_timeout, graphify.build_timeout — vs.
-  // the internal millisecond unit `timeoutFloorMs` carries). Anything that is not a positive finite
-  // number is treated as unset and falls back to `floorMs`, never coerced: a wrong-typed config
-  // value silently becoming a wrong-but-plausible timeout is worse than falling back cleanly. `0`
-  // and negative values are deliberately treated as unset too — a timeout has no legitimate zero or
-  // negative value, so no second sentinel (unlike the prompt-budget keys, which use -1) is needed.
-  const configuredTimeoutSeconds =
-    typeof lane.timeoutConfigKey === 'string' ? input.configGet(lane.timeoutConfigKey) : undefined;
-  const timeoutMs =
-    typeof configuredTimeoutSeconds === 'number' &&
-    Number.isFinite(configuredTimeoutSeconds) &&
-    configuredTimeoutSeconds > 0
-      ? configuredTimeoutSeconds * 1000
-      : floorMs;
+  const timeoutMs = resolveTimeoutMs(lane.timeoutConfigKey, floorMs, input.configGet);
   const emptyOutput: EmptyOutputPolicy = lane.emptyOutput === 'handler-owned' ? 'handler-owned' : 'stub-with-stderr';
   // #3194: only an EXACT 'diff-only' declaration exempts a lane from evidence verification.
   // Anything else — including a missing or garbage value on a third-party overlay body —

--- a/src/review-lane-runner.cts
+++ b/src/review-lane-runner.cts
@@ -807,8 +807,25 @@ export function antigravityPrompt(promptPath: string, repoRoot: string): string 
   );
 }
 
+/** Buffer (seconds) agy's native `--print-timeout` sits under the resolved outer wall-clock cap
+ * (#3274). Matches the shipped 600s outer / 540s native relationship exactly when no
+ * `review.timeouts.antigravity` override is configured (floor(600000/1000) - 60 = 540). */
+const ANTIGRAVITY_NATIVE_TIMEOUT_BUFFER_SECONDS = 60;
+
 /**
- * Antigravity's argv adjustments — the two things data cannot express for this lane.
+ * Derive agy's native `--print-timeout` duration string from the resolved outer timeout (#3274).
+ *
+ * Clamped to a 1-second floor: a configured outer timeout smaller than the buffer would otherwise
+ * produce a zero or negative duration, which agy would reject or misinterpret rather than the
+ * intended "give this reviewer almost no time."
+ */
+function antigravityNativeTimeout(timeoutMs: number): string {
+  const seconds = Math.max(1, Math.floor(timeoutMs / 1000) - ANTIGRAVITY_NATIVE_TIMEOUT_BUFFER_SECONDS);
+  return `${seconds}s`;
+}
+
+/**
+ * Antigravity's argv adjustments — the three things data cannot express for this lane.
  *
  * 1. `--add-dir <repo>`, CAPABILITY-PROBED. Without it agy's permission context never receives the
  *    cwd repo: the agent anchors on its own `~/.gemini/antigravity-cli/scratch` dir and reviews the
@@ -816,19 +833,31 @@ export function antigravityPrompt(promptPath: string, repoRoot: string): string 
  *    probed rather than assumed because older agy builds reject the unknown flag outright, and a
  *    lane that fails to start is worse than one that runs on the prompt anchor alone.
  * 2. The self-report prompt variant above, swapped in for the standard file-ref text.
+ * 3. The native `--print-timeout` VALUE (#3274), derived from the resolved outer `timeoutMs` so it
+ *    can never drift out of sync with the outer wall-clock cap the runner's `spawn` call enforces.
+ *    The descriptor declares WHERE the value goes (a `'{{nativeTimeout}}'` marker in `invoke.args`);
+ *    this handler decides WHAT it is — computing a derived, formatted value is exactly the kind of
+ *    expression the closed `ARGV_PLACEHOLDER` vocabulary deliberately excludes (see its docstring).
  *
- * Both are argv shape, so they belong here rather than in the descriptor: expressing "add this flag
- * only if the binary's --help mentions it" as data would need a conditional, which is precisely
- * what the named-handler seam exists to absorb (ADR-2782 D6).
+ * All three are argv shape, so they belong here rather than in the descriptor: expressing "add this
+ * flag only if the binary's --help mentions it", or "compute this value from that one", as data
+ * would need a conditional or an expression, which is precisely what the named-handler seam exists
+ * to absorb (ADR-2782 D6).
  */
 export function antigravityArgv(
   argv: readonly string[],
   promptPath: string,
   repoRoot: string,
+  timeoutMs: number,
   deps: RunnerDeps,
 ): string[] {
   const standard = fileRefPromptText(promptPath, repoRoot);
-  const out = argv.map((a) => (a === standard ? antigravityPrompt(promptPath, repoRoot) : a));
+  const nativeTimeout = antigravityNativeTimeout(timeoutMs);
+  const out = argv.map((a) => {
+    if (a === standard) return antigravityPrompt(promptPath, repoRoot);
+    if (a === '{{nativeTimeout}}') return nativeTimeout;
+    return a;
+  });
 
   let supportsAddDir = false;
   try {
@@ -1070,7 +1099,7 @@ function runSpawnLane(plan: SpawnPlan, deps: RunnerDeps, repoRoot: string): Lane
 
   const argv =
     plan.handler === 'antigravity'
-      ? antigravityArgv(plan.argv, plan.promptPath, repoRoot, deps)
+      ? antigravityArgv(plan.argv, plan.promptPath, repoRoot, plan.timeoutMs, deps)
       : plan.argv;
 
   const out = deps.spawn(plan.binary, argv, {

--- a/src/review-lane-runner.cts
+++ b/src/review-lane-runner.cts
@@ -807,25 +807,8 @@ export function antigravityPrompt(promptPath: string, repoRoot: string): string 
   );
 }
 
-/** Buffer (seconds) agy's native `--print-timeout` sits under the resolved outer wall-clock cap
- * (#3274). Matches the shipped 600s outer / 540s native relationship exactly when no
- * `review.timeouts.antigravity` override is configured (floor(600000/1000) - 60 = 540). */
-const ANTIGRAVITY_NATIVE_TIMEOUT_BUFFER_SECONDS = 60;
-
 /**
- * Derive agy's native `--print-timeout` duration string from the resolved outer timeout (#3274).
- *
- * Clamped to a 1-second floor: a configured outer timeout smaller than the buffer would otherwise
- * produce a zero or negative duration, which agy would reject or misinterpret rather than the
- * intended "give this reviewer almost no time."
- */
-function antigravityNativeTimeout(timeoutMs: number): string {
-  const seconds = Math.max(1, Math.floor(timeoutMs / 1000) - ANTIGRAVITY_NATIVE_TIMEOUT_BUFFER_SECONDS);
-  return `${seconds}s`;
-}
-
-/**
- * Antigravity's argv adjustments — the three things data cannot express for this lane.
+ * Antigravity's argv adjustments — the two things data cannot express for this lane.
  *
  * 1. `--add-dir <repo>`, CAPABILITY-PROBED. Without it agy's permission context never receives the
  *    cwd repo: the agent anchors on its own `~/.gemini/antigravity-cli/scratch` dir and reviews the
@@ -833,31 +816,23 @@ function antigravityNativeTimeout(timeoutMs: number): string {
  *    probed rather than assumed because older agy builds reject the unknown flag outright, and a
  *    lane that fails to start is worse than one that runs on the prompt anchor alone.
  * 2. The self-report prompt variant above, swapped in for the standard file-ref text.
- * 3. The native `--print-timeout` VALUE (#3274), derived from the resolved outer `timeoutMs` so it
- *    can never drift out of sync with the outer wall-clock cap the runner's `spawn` call enforces.
- *    The descriptor declares WHERE the value goes (a `'{{nativeTimeout}}'` marker in `invoke.args`);
- *    this handler decides WHAT it is — computing a derived, formatted value is exactly the kind of
- *    expression the closed `ARGV_PLACEHOLDER` vocabulary deliberately excludes (see its docstring).
  *
- * All three are argv shape, so they belong here rather than in the descriptor: expressing "add this
- * flag only if the binary's --help mentions it", or "compute this value from that one", as data
- * would need a conditional or an expression, which is precisely what the named-handler seam exists
- * to absorb (ADR-2782 D6).
+ * Both are argv shape, so they belong here rather than in the descriptor: expressing "add this
+ * flag only if the binary's --help mentions it" as data would need a conditional, which is
+ * precisely what the named-handler seam exists to absorb (ADR-2782 D6). The native
+ * `--print-timeout` VALUE (#3274) is NOT this handler's job — `resolveLanePlan`
+ * (review-lane-invocation.cts) resolves the `{{nativeTimeout}}` ARGV_PLACEHOLDER itself, exactly
+ * like `{{model}}`/`{{effort}}`/`{{output}}`/`{{prompt}}`, so `plan.argv` arrives here already fully
+ * resolved.
  */
 export function antigravityArgv(
   argv: readonly string[],
   promptPath: string,
   repoRoot: string,
-  timeoutMs: number,
   deps: RunnerDeps,
 ): string[] {
   const standard = fileRefPromptText(promptPath, repoRoot);
-  const nativeTimeout = antigravityNativeTimeout(timeoutMs);
-  const out = argv.map((a) => {
-    if (a === standard) return antigravityPrompt(promptPath, repoRoot);
-    if (a === '{{nativeTimeout}}') return nativeTimeout;
-    return a;
-  });
+  const out = argv.map((a) => (a === standard ? antigravityPrompt(promptPath, repoRoot) : a));
 
   let supportsAddDir = false;
   try {
@@ -1099,7 +1074,7 @@ function runSpawnLane(plan: SpawnPlan, deps: RunnerDeps, repoRoot: string): Lane
 
   const argv =
     plan.handler === 'antigravity'
-      ? antigravityArgv(plan.argv, plan.promptPath, repoRoot, plan.timeoutMs, deps)
+      ? antigravityArgv(plan.argv, plan.promptPath, repoRoot, deps)
       : plan.argv;
 
   const out = deps.spawn(plan.binary, argv, {

--- a/tests/antigravity-repo-grounding.test.cjs
+++ b/tests/antigravity-repo-grounding.test.cjs
@@ -40,7 +40,7 @@ const helpSaying = (text) => ({ spawn: () => ({ status: 0, stdout: text, stderr:
 describe('#2176 — agy receives the repo under review', () => {
   test('--add-dir is passed with the repo root when the binary supports it', () => {
     const p = planFor('antigravity');
-    const argv = antigravityArgv(p.argv, p.promptPath, ROOT, helpSaying('--add-dir  --model'));
+    const argv = antigravityArgv(p.argv, p.promptPath, ROOT, 600_000, helpSaying('--add-dir  --model'));
     const i = argv.indexOf('--add-dir');
     assert.ok(i !== -1, '--add-dir must be passed when supported');
     assert.equal(argv[i + 1], ROOT);
@@ -50,14 +50,14 @@ describe('#2176 — agy receives the repo under review', () => {
     // An older agy rejects an unknown flag outright. A lane that fails to start is worse than one
     // running on the prompt anchor alone, so support is probed rather than presumed.
     const p = planFor('antigravity');
-    const argv = antigravityArgv(p.argv, p.promptPath, ROOT, helpSaying('no such flag here'));
+    const argv = antigravityArgv(p.argv, p.promptPath, ROOT, 600_000, helpSaying('no such flag here'));
     assert.ok(!argv.includes('--add-dir'));
   });
 
   test('the probe is bounded', () => {
     const p = planFor('antigravity');
     const calls = [];
-    antigravityArgv(p.argv, p.promptPath, ROOT, {
+    antigravityArgv(p.argv, p.promptPath, ROOT, 600_000, {
       spawn: (b, a, o) => { calls.push(o); return { status: 0, stdout: '', stderr: '' }; },
     });
     assert.ok(calls.every((c) => c.timeoutMs > 0), 'every process-starting probe must be bounded');
@@ -65,14 +65,14 @@ describe('#2176 — agy receives the repo under review', () => {
 
   test('adding --add-dir keeps the prompt last', () => {
     const p = planFor('antigravity');
-    const argv = antigravityArgv(p.argv, p.promptPath, ROOT, helpSaying('--add-dir'));
+    const argv = antigravityArgv(p.argv, p.promptPath, ROOT, 600_000, helpSaying('--add-dir'));
     assert.equal(argv[argv.length - 2], '-p');
     assert.ok(argv[argv.length - 1].includes(RUN));
   });
 
   test('a probe that throws degrades to no flag rather than failing the lane', () => {
     const p = planFor('antigravity');
-    const argv = antigravityArgv(p.argv, p.promptPath, ROOT, {
+    const argv = antigravityArgv(p.argv, p.promptPath, ROOT, 600_000, {
       spawn: () => { throw new Error('spawn failed'); },
     });
     assert.ok(!argv.includes('--add-dir'));
@@ -95,7 +95,7 @@ describe('#2176 — the prompt is anchored and demands a self-report', () => {
 
   test('the self-report variant actually reaches argv', () => {
     const p = planFor('antigravity');
-    const argv = antigravityArgv(p.argv, p.promptPath, ROOT, helpSaying(''));
+    const argv = antigravityArgv(p.argv, p.promptPath, ROOT, 600_000, helpSaying(''));
     assert.ok(argv[argv.length - 1].includes('REVIEWED-WITHOUT-REPO-ACCESS'));
   });
 
@@ -136,5 +136,38 @@ describe('#2176 — blind-review marking', () => {
 
   test('an empty review is left alone', () => {
     assert.equal(stampBlindReview(''), '');
+  });
+});
+
+describe('#3274 — the native --print-timeout flag derives from the resolved outer timeout', () => {
+  test('an unconfigured (default) timeout produces the original 540s native flag (row 9, regression)', () => {
+    const p = planFor('antigravity');
+    const argv = antigravityArgv(p.argv, p.promptPath, ROOT, p.timeoutMs, helpSaying(''));
+    assert.ok(argv.includes('540s'), `expected 540s in ${JSON.stringify(argv)}`);
+    assert.ok(!argv.some((a) => a === '{{nativeTimeout}}'), 'the marker token must never reach real argv');
+  });
+
+  test('a 900000ms outer timeout derives an 840s native flag (row 10)', () => {
+    const p = planFor('antigravity');
+    const argv = antigravityArgv(p.argv, p.promptPath, ROOT, 900_000, helpSaying(''));
+    assert.ok(argv.includes('840s'), `expected 840s in ${JSON.stringify(argv)}`);
+  });
+
+  test('a native timeout below the 60s buffer clamps to 1s, never 0 or negative (row 11)', () => {
+    const p = planFor('antigravity');
+    const argv = antigravityArgv(p.argv, p.promptPath, ROOT, 30_000, helpSaying(''));
+    assert.ok(argv.includes('1s'), `expected clamped 1s in ${JSON.stringify(argv)}`);
+  });
+
+  test('boundary around the 60-second native buffer (row 12)', () => {
+    const p = planFor('antigravity');
+    // 59s outer: floor(59)-60 = -1 -> clamped to 1s
+    assert.ok(antigravityArgv(p.argv, p.promptPath, ROOT, 59_000, helpSaying('')).includes('1s'));
+    // 60s outer: floor(60)-60 = 0 -> clamped to 1s
+    assert.ok(antigravityArgv(p.argv, p.promptPath, ROOT, 60_000, helpSaying('')).includes('1s'));
+    // 61s outer: floor(61)-60 = 1 -> 1s (not clamped, real arithmetic)
+    assert.ok(antigravityArgv(p.argv, p.promptPath, ROOT, 61_000, helpSaying('')).includes('1s'));
+    // 121s outer: floor(121)-60 = 61 -> 61s
+    assert.ok(antigravityArgv(p.argv, p.promptPath, ROOT, 121_000, helpSaying('')).includes('61s'));
   });
 });

--- a/tests/antigravity-repo-grounding.test.cjs
+++ b/tests/antigravity-repo-grounding.test.cjs
@@ -40,7 +40,7 @@ const helpSaying = (text) => ({ spawn: () => ({ status: 0, stdout: text, stderr:
 describe('#2176 — agy receives the repo under review', () => {
   test('--add-dir is passed with the repo root when the binary supports it', () => {
     const p = planFor('antigravity');
-    const argv = antigravityArgv(p.argv, p.promptPath, ROOT, 600_000, helpSaying('--add-dir  --model'));
+    const argv = antigravityArgv(p.argv, p.promptPath, ROOT, helpSaying('--add-dir  --model'));
     const i = argv.indexOf('--add-dir');
     assert.ok(i !== -1, '--add-dir must be passed when supported');
     assert.equal(argv[i + 1], ROOT);
@@ -50,14 +50,14 @@ describe('#2176 — agy receives the repo under review', () => {
     // An older agy rejects an unknown flag outright. A lane that fails to start is worse than one
     // running on the prompt anchor alone, so support is probed rather than presumed.
     const p = planFor('antigravity');
-    const argv = antigravityArgv(p.argv, p.promptPath, ROOT, 600_000, helpSaying('no such flag here'));
+    const argv = antigravityArgv(p.argv, p.promptPath, ROOT, helpSaying('no such flag here'));
     assert.ok(!argv.includes('--add-dir'));
   });
 
   test('the probe is bounded', () => {
     const p = planFor('antigravity');
     const calls = [];
-    antigravityArgv(p.argv, p.promptPath, ROOT, 600_000, {
+    antigravityArgv(p.argv, p.promptPath, ROOT, {
       spawn: (b, a, o) => { calls.push(o); return { status: 0, stdout: '', stderr: '' }; },
     });
     assert.ok(calls.every((c) => c.timeoutMs > 0), 'every process-starting probe must be bounded');
@@ -65,14 +65,14 @@ describe('#2176 — agy receives the repo under review', () => {
 
   test('adding --add-dir keeps the prompt last', () => {
     const p = planFor('antigravity');
-    const argv = antigravityArgv(p.argv, p.promptPath, ROOT, 600_000, helpSaying('--add-dir'));
+    const argv = antigravityArgv(p.argv, p.promptPath, ROOT, helpSaying('--add-dir'));
     assert.equal(argv[argv.length - 2], '-p');
     assert.ok(argv[argv.length - 1].includes(RUN));
   });
 
   test('a probe that throws degrades to no flag rather than failing the lane', () => {
     const p = planFor('antigravity');
-    const argv = antigravityArgv(p.argv, p.promptPath, ROOT, 600_000, {
+    const argv = antigravityArgv(p.argv, p.promptPath, ROOT, {
       spawn: () => { throw new Error('spawn failed'); },
     });
     assert.ok(!argv.includes('--add-dir'));
@@ -95,7 +95,7 @@ describe('#2176 — the prompt is anchored and demands a self-report', () => {
 
   test('the self-report variant actually reaches argv', () => {
     const p = planFor('antigravity');
-    const argv = antigravityArgv(p.argv, p.promptPath, ROOT, 600_000, helpSaying(''));
+    const argv = antigravityArgv(p.argv, p.promptPath, ROOT, helpSaying(''));
     assert.ok(argv[argv.length - 1].includes('REVIEWED-WITHOUT-REPO-ACCESS'));
   });
 
@@ -136,38 +136,5 @@ describe('#2176 — blind-review marking', () => {
 
   test('an empty review is left alone', () => {
     assert.equal(stampBlindReview(''), '');
-  });
-});
-
-describe('#3274 — the native --print-timeout flag derives from the resolved outer timeout', () => {
-  test('an unconfigured (default) timeout produces the original 540s native flag (row 9, regression)', () => {
-    const p = planFor('antigravity');
-    const argv = antigravityArgv(p.argv, p.promptPath, ROOT, p.timeoutMs, helpSaying(''));
-    assert.ok(argv.includes('540s'), `expected 540s in ${JSON.stringify(argv)}`);
-    assert.ok(!argv.some((a) => a === '{{nativeTimeout}}'), 'the marker token must never reach real argv');
-  });
-
-  test('a 900000ms outer timeout derives an 840s native flag (row 10)', () => {
-    const p = planFor('antigravity');
-    const argv = antigravityArgv(p.argv, p.promptPath, ROOT, 900_000, helpSaying(''));
-    assert.ok(argv.includes('840s'), `expected 840s in ${JSON.stringify(argv)}`);
-  });
-
-  test('a native timeout below the 60s buffer clamps to 1s, never 0 or negative (row 11)', () => {
-    const p = planFor('antigravity');
-    const argv = antigravityArgv(p.argv, p.promptPath, ROOT, 30_000, helpSaying(''));
-    assert.ok(argv.includes('1s'), `expected clamped 1s in ${JSON.stringify(argv)}`);
-  });
-
-  test('boundary around the 60-second native buffer (row 12)', () => {
-    const p = planFor('antigravity');
-    // 59s outer: floor(59)-60 = -1 -> clamped to 1s
-    assert.ok(antigravityArgv(p.argv, p.promptPath, ROOT, 59_000, helpSaying('')).includes('1s'));
-    // 60s outer: floor(60)-60 = 0 -> clamped to 1s
-    assert.ok(antigravityArgv(p.argv, p.promptPath, ROOT, 60_000, helpSaying('')).includes('1s'));
-    // 61s outer: floor(61)-60 = 1 -> 1s (not clamped, real arithmetic)
-    assert.ok(antigravityArgv(p.argv, p.promptPath, ROOT, 61_000, helpSaying('')).includes('1s'));
-    // 121s outer: floor(121)-60 = 61 -> 61s
-    assert.ok(antigravityArgv(p.argv, p.promptPath, ROOT, 121_000, helpSaying('')).includes('61s'));
   });
 });

--- a/tests/review-lane-invocation.test.cjs
+++ b/tests/review-lane-invocation.test.cjs
@@ -85,7 +85,8 @@ const GOLDEN = [
   { slug: 'opencode', binary: 'opencode', argv: ['run', '--model', 'O', '--effort', 'high', '--format', 'json', '-'], stdin: true, out: 'stdout', timeout: 660000 },
   { slug: 'qwen', binary: 'qwen', argv: ['-'], stdin: true, out: 'stdout', timeout: 900000 },
   { slug: 'cursor', binary: 'cursor-agent', argv: ['-p', '--mode', 'ask', '--trust', '--output-format', 'text', FILE_REF], stdin: false, out: 'stdout', timeout: 900000 },
-  { slug: 'antigravity', binary: 'agy', argv: ['--print-timeout', '540s', '--model', 'A', '-p', FILE_REF], stdin: false, out: 'stdout', timeout: 600000 },
+  // '{{nativeTimeout}}' is a handler-owned marker (#3274) resolveLanePlan does not expand — see antigravityArgv tests for the derived value.
+  { slug: 'antigravity', binary: 'agy', argv: ['--print-timeout', '{{nativeTimeout}}', '--model', 'A', '-p', FILE_REF], stdin: false, out: 'stdout', timeout: 600000 },
   { slug: 'kimi-code', binary: 'kimi', argv: ['-m', 'K', '-p', FILE_REF], stdin: false, out: 'stdout', timeout: 900000 },
 ];
 
@@ -134,6 +135,97 @@ describe('reviewer lane invocation — golden plans (the strangler-fig contract)
     for (const lane of REVIEWER_LANES) {
       assert.equal(resolve(lane.slug).ok, true, `${lane.slug} failed to resolve`);
     }
+  });
+});
+
+describe('#3274 — timeoutConfigKey resolves the outer wall-clock cap', () => {
+  const AGY_FLOOR = REVIEWER_LANES.find((l) => l.slug === 'antigravity').timeoutFloorMs;
+  const AGY_KEY = REVIEWER_LANES.find((l) => l.slug === 'antigravity').timeoutConfigKey;
+
+  test('an absent config key falls back to timeoutFloorMs (row 1)', () => {
+    const r = resolve('antigravity', { config: {} });
+    assert.equal(r.plan.timeoutMs, AGY_FLOOR);
+  });
+
+  test('a configured positive number overrides timeoutFloorMs, seconds -> ms (row 2)', () => {
+    const r = resolve('antigravity', { config: { [AGY_KEY]: 900 } });
+    assert.equal(r.plan.timeoutMs, 900_000);
+  });
+
+  test('0 is treated as unset, not a zero-length timeout (row 3)', () => {
+    const r = resolve('antigravity', { config: { [AGY_KEY]: 0 } });
+    assert.equal(r.plan.timeoutMs, AGY_FLOOR);
+  });
+
+  test('a negative configured timeout is treated as unset (row 4)', () => {
+    const r = resolve('antigravity', { config: { [AGY_KEY]: -5 } });
+    assert.equal(r.plan.timeoutMs, AGY_FLOOR);
+  });
+
+  test('NaN and Infinity are treated as unset (row 5)', () => {
+    assert.equal(resolve('antigravity', { config: { [AGY_KEY]: NaN } }).plan.timeoutMs, AGY_FLOOR);
+    assert.equal(resolve('antigravity', { config: { [AGY_KEY]: Infinity } }).plan.timeoutMs, AGY_FLOOR);
+  });
+
+  test('a non-number configured value is never coerced, falls back (row 6)', () => {
+    for (const bad of ['900', true, {}, [], 'null']) {
+      const r = resolve('antigravity', { config: { [AGY_KEY]: bad } });
+      assert.equal(r.plan.timeoutMs, AGY_FLOOR, `value ${JSON.stringify(bad)} must not resolve to a timeout`);
+    }
+  });
+
+  test('a lane with no timeoutConfigKey field falls back like an unset key (row 7)', () => {
+    const lane = { ...REVIEWER_LANES.find((l) => l.slug === 'gemini') };
+    delete lane.timeoutConfigKey;
+    const r = resolveLanePlan({ lane, configGet: () => 900, runDir: RUN, repoRoot: ROOT });
+    assert.equal(r.ok, true);
+    assert.equal(r.plan.timeoutMs, lane.timeoutFloorMs);
+  });
+
+  test('boundary: 0 vs 1 vs a fractional second (row 8)', () => {
+    assert.equal(resolve('antigravity', { config: { [AGY_KEY]: 0 } }).plan.timeoutMs, AGY_FLOOR);
+    assert.equal(resolve('antigravity', { config: { [AGY_KEY]: 1 } }).plan.timeoutMs, 1000);
+    assert.equal(resolve('antigravity', { config: { [AGY_KEY]: 0.5 } }).plan.timeoutMs, 500);
+  });
+
+  test("a non-antigravity lane's configured timeout does not touch argv (row 13)", () => {
+    const key = REVIEWER_LANES.find((l) => l.slug === 'gemini').timeoutConfigKey;
+    const unset = resolve('gemini', { config: {} });
+    const configured = resolve('gemini', { config: { [key]: 300 } });
+    assert.deepStrictEqual(configured.plan.argv, unset.plan.argv);
+    assert.notEqual(configured.plan.timeoutMs, unset.plan.timeoutMs);
+  });
+
+  test('property: any positive-second config resolves to exactly seconds * 1000 ms (row 20)', () => {
+    fc.assert(
+      fc.property(fc.integer({ min: 1, max: 1_000_000 }), (seconds) => {
+        const r = resolve('antigravity', { config: { [AGY_KEY]: seconds } });
+        assert.equal(r.plan.timeoutMs, seconds * 1000);
+      }),
+      FC,
+    );
+  });
+
+  test('property: any hostile config value degrades to timeoutFloorMs, never throws (row 21)', () => {
+    const hostile = fc.oneof(
+      fc.string(),
+      fc.boolean(),
+      fc.object(),
+      fc.array(fc.anything()),
+      fc.constant(0),
+      fc.integer({ max: 0 }),
+      fc.constant(NaN),
+      fc.constant(Infinity),
+      fc.constant(-Infinity),
+    );
+    fc.assert(
+      fc.property(hostile, (value) => {
+        const r = resolve('antigravity', { config: { [AGY_KEY]: value } });
+        assert.equal(r.ok, true);
+        assert.equal(r.plan.timeoutMs, AGY_FLOOR);
+      }),
+      FC,
+    );
   });
 });
 

--- a/tests/review-lane-invocation.test.cjs
+++ b/tests/review-lane-invocation.test.cjs
@@ -26,6 +26,7 @@ const {
 } = require('../gsd-core/bin/lib/review-lane-descriptor.cjs');
 const {
   resolveLanePlan,
+  resolveTimeoutMs,
   isEmptyReview,
   normalizeHost,
   fileRefPrompt,
@@ -180,6 +181,15 @@ describe('#3274 — timeoutConfigKey resolves the outer wall-clock cap', () => {
     const r = resolveLanePlan({ lane, configGet: () => 900, runDir: RUN, repoRoot: ROOT });
     assert.equal(r.ok, true);
     assert.equal(r.plan.timeoutMs, lane.timeoutFloorMs);
+  });
+
+  test('resolveTimeoutMs: direct unit — unset falls back to floorMs', () => {
+    assert.equal(resolveTimeoutMs(null, 5000, () => undefined), 5000);
+    assert.equal(resolveTimeoutMs('some.key', 5000, () => undefined), 5000);
+  });
+
+  test('resolveTimeoutMs: direct unit — configured value overrides, seconds -> ms', () => {
+    assert.equal(resolveTimeoutMs('some.key', 5000, (k) => (k === 'some.key' ? 30 : undefined)), 30000);
   });
 
   test('boundary: 0 vs 1 vs a fractional second (row 8)', () => {

--- a/tests/review-lane-invocation.test.cjs
+++ b/tests/review-lane-invocation.test.cjs
@@ -86,8 +86,9 @@ const GOLDEN = [
   { slug: 'opencode', binary: 'opencode', argv: ['run', '--model', 'O', '--effort', 'high', '--format', 'json', '-'], stdin: true, out: 'stdout', timeout: 660000 },
   { slug: 'qwen', binary: 'qwen', argv: ['-'], stdin: true, out: 'stdout', timeout: 900000 },
   { slug: 'cursor', binary: 'cursor-agent', argv: ['-p', '--mode', 'ask', '--trust', '--output-format', 'text', FILE_REF], stdin: false, out: 'stdout', timeout: 900000 },
-  // '{{nativeTimeout}}' is a handler-owned marker (#3274) resolveLanePlan does not expand — see antigravityArgv tests for the derived value.
-  { slug: 'antigravity', binary: 'agy', argv: ['--print-timeout', '{{nativeTimeout}}', '--model', 'A', '-p', FILE_REF], stdin: false, out: 'stdout', timeout: 600000 },
+  // resolveLanePlan fully resolves {{nativeTimeout}} itself (#3274) — this row proves the
+  // unconfigured default reproduces the original literal exactly.
+  { slug: 'antigravity', binary: 'agy', argv: ['--print-timeout', '540s', '--model', 'A', '-p', FILE_REF], stdin: false, out: 'stdout', timeout: 600000 },
   { slug: 'kimi-code', binary: 'kimi', argv: ['-m', 'K', '-p', FILE_REF], stdin: false, out: 'stdout', timeout: 900000 },
 ];
 
@@ -236,6 +237,30 @@ describe('#3274 — timeoutConfigKey resolves the outer wall-clock cap', () => {
       }),
       FC,
     );
+  });
+
+  test('a configured antigravity timeout derives both the outer cap and the native flag (row 10)', () => {
+    const r = resolve('antigravity', { config: { [AGY_KEY]: 900 } });
+    assert.equal(r.plan.timeoutMs, 900_000);
+    const i = r.plan.argv.indexOf('--print-timeout');
+    assert.equal(r.plan.argv[i + 1], '840s');
+  });
+
+  test('a native timeout below the 60s buffer clamps to 1s, never 0 or negative (row 11)', () => {
+    const r = resolve('antigravity', { config: { [AGY_KEY]: 30 } });
+    const i = r.plan.argv.indexOf('--print-timeout');
+    assert.equal(r.plan.argv[i + 1], '1s');
+  });
+
+  test('boundary around the 60-second native buffer (row 12)', () => {
+    const nativeFor = (seconds) => {
+      const r = resolve('antigravity', { config: { [AGY_KEY]: seconds } });
+      return r.plan.argv[r.plan.argv.indexOf('--print-timeout') + 1];
+    };
+    assert.equal(nativeFor(59), '1s');   // floor(59)-60 = -1 -> clamped
+    assert.equal(nativeFor(60), '1s');   // floor(60)-60 = 0 -> clamped
+    assert.equal(nativeFor(61), '1s');   // floor(61)-60 = 1
+    assert.equal(nativeFor(121), '61s'); // floor(121)-60 = 61
   });
 });
 

--- a/tests/reviewer-manifest-body.test.cjs
+++ b/tests/reviewer-manifest-body.test.cjs
@@ -1178,6 +1178,49 @@ describe('F. Lane scalars', () => {
   });
 });
 
+// ─── F2. timeoutConfigKey (#3274) — mirrors modelConfigKey's D4 forward/backward-compat shape ──
+
+describe('F2. timeoutConfigKey (#3274)', () => {
+  test('reviewer.timeoutConfigKey is optional — absent is valid (row 14)', () => {
+    const lane = laneOverride(() => {});
+    assert.equal(lane.timeoutConfigKey, undefined, 'fixture must not declare timeoutConfigKey');
+    const errs = validateReviewerBody({ id: 'x', reviewer: lane });
+    assert.deepEqual(errs, [], `expected no errors, got: ${JSON.stringify(errs)}`);
+  });
+
+  test('reviewer.timeoutConfigKey: null is valid (row 15)', () => {
+    const lane = laneOverride((l) => { l.timeoutConfigKey = null; });
+    const errs = validateReviewerBody({ id: 'x', reviewer: lane });
+    assert.deepEqual(errs, [], `expected no errors, got: ${JSON.stringify(errs)}`);
+  });
+
+  test('reviewer.timeoutConfigKey: a dotted string is valid (row 16)', () => {
+    const lane = laneOverride((l) => { l.timeoutConfigKey = 'review.timeouts.acme'; });
+    const errs = validateReviewerBody({ id: 'x', reviewer: lane });
+    assert.deepEqual(errs, [], `expected no errors, got: ${JSON.stringify(errs)}`);
+  });
+
+  test('reviewer.timeoutConfigKey: empty string is rejected (row 17)', () => {
+    const lane = laneOverride((l) => { l.timeoutConfigKey = ''; });
+    const errs = validateReviewerBody({ id: 'x', reviewer: lane });
+    assert.ok(
+      errs.some((e) => e.includes('reviewer.timeoutConfigKey must be a dotted config key or null') && e.includes('(got: "")')),
+      `expected an empty-string-is-not-none error, got: ${JSON.stringify(errs)}`,
+    );
+  });
+
+  test('reviewer.timeoutConfigKey: non-string, non-null is rejected (row 18)', () => {
+    for (const bad of [42, {}, []]) {
+      const lane = laneOverride((l) => { l.timeoutConfigKey = bad; });
+      const errs = validateReviewerBody({ id: 'x', reviewer: lane });
+      assert.ok(
+        errs.some((e) => e.includes('reviewer.timeoutConfigKey must be a dotted config key or null')),
+        `timeoutConfigKey=${JSON.stringify(bad)}: expected a type-rejection error, got: ${JSON.stringify(errs)}`,
+      );
+    }
+  });
+});
+
 // ─── G. Uniqueness (D8) — validateCrossCapability(Map, Set) ────────────────
 
 describe('G. Uniqueness (D8) — validateCrossCapability(Map, Set)', () => {


### PR DESCRIPTION
## Enhancement PR

---

## Linked Issue

Closes #3274

---

## What this enhancement improves

Cross-AI reviewer lane timeouts (`/gsd-review`). Adds an optional `timeoutConfigKey` field to the reviewer lane descriptor (`src/review-lane-descriptor.cts`) and every shipped lane's `capability.json` manifest, resolved by `resolveLanePlan` (`src/review-lane-invocation.cts`) into the lane's outer wall-clock timeout, falling back to the frozen `timeoutFloorMs` when unset.

## Before / After

**Before:** Every reviewer lane's `timeoutFloorMs` (and, for `antigravity`, its native `agy --print-timeout 540s` flag) was a frozen literal with no configuration path. A grounded multi-plan `antigravity` review taking ~13 minutes exceeded both the 540s native timeout and the 600s outer cap; the lane was killed mid-run and, because it declares `emptyOutput: 'handler-owned'`, the kill surfaced as a diagnostic stub indistinguishable from a genuinely empty response — the reviewer silently dropped out of the consensus.

**After:** Nine of the twelve lanes (every lane that takes a model flag or a host — `gemini`, `claude`, `codex`, `opencode`, `antigravity`, `ollama`, `lm_studio`, `llama_cpp`, `kimi-code`) declare `review.timeouts.<slug>`, settable via `.planning/config.json` or `gsd config-set review.timeouts.antigravity 900`. For `antigravity`, the same resolved value now also derives its native `--print-timeout` flag (roughly 60s under the outer cap), so raising the config key raises both bounds together instead of the native flag staying a second, independent hardcoded literal. `qwen`, `cursor`, and `coderabbit` — which take neither a model flag nor a host — do not own a timeout key, matching the existing narrow key-ownership invariant their `modelConfigKey` already follows (`tests/reviewer-config-federation.test.cjs`, #3691 narrows #2797).

The `antigravity` default (`timeoutFloorMs: 600_000`) is unchanged — the maintainer's disposition on the linked issue approved the config path only, not raising the default; users now raise it themselves via the new key.

## How it was implemented

- `src/review-lane-descriptor.cts` — `timeoutConfigKey: string | null` added to `ReviewerLaneCommon`; a fifth `ARGV_PLACEHOLDER` member, `NATIVE_TIMEOUT: '{{nativeTimeout}}'`, added to the closed argv-template vocabulary (disclosed widening, matching the module's existing practice for its four prior ones).
- `src/review-lane-invocation.cts` — `resolveTimeoutMs(timeoutConfigKey, floorMs, configGet)` resolves the outer timeout (config value is SECONDS, matching this repo's other user-facing timeout keys — `workflow.cross_ai_timeout`, `graphify.build_timeout`); `nativeTimeoutToken(timeoutMs)` derives the antigravity native flag value (60s buffer, 1s floor) and is wired into `resolveLanePlan`'s existing argv-expansion map alongside `{{model}}`/`{{effort}}`/`{{output}}`/`{{prompt}}`, so `plan.argv` is fully resolved on return — no change to `review-lane-runner.cts`'s `antigravityArgv`, which keeps its original two-thing responsibility (`--add-dir` probing, self-report prompt swap).
- `gsd-core/bin/lib/capability-validator.cjs` — `timeoutConfigKey` accepted as an optional reviewer field (string-or-null, same shape as the existing `modelConfigKey` check).
- All 12 `capabilities/<lane>/capability.json` manifests mirror the descriptor; `gsd-core/bin/lib/capability-registry.cjs` regenerated (`npm run gen:capability-registry`).
- Docs: `docs/CONFIGURATION.md` (new `review.timeouts.*` section), `docs/reference/capability-manifest.md` (field table + example), `docs/how-to/ship-a-reviewer-lane.md` (both example manifests).

## Testing

### How I verified the enhancement works

- New unit tests in `tests/review-lane-invocation.test.cjs`: `resolveTimeoutMs` direct-unit tests; a `#3274` describe block covering unset/configured/zero/negative/NaN/Infinity/non-number/no-field/boundary inputs, two seeded `fast-check` property tests (any positive-second config resolves to exactly `seconds * 1000`; any hostile input degrades to the floor, never throws), and the antigravity native-flag derivation (900s → 840s, a sub-buffer value clamps to 1s, boundary around the 60s buffer).
- New tests in `tests/reviewer-manifest-body.test.cjs` for `capability-validator.cjs`'s `timeoutConfigKey` validation (absent/null/valid-string valid; empty-string/wrong-type rejected).
- The GOLDEN invocation table in `tests/review-lane-invocation.test.cjs` (one row per shipped lane, asserting the exact resolved invocation) passes **unmodified in its unconfigured form** for all 12 lanes — proof the change is behaviorally inert when unconfigured.
- Full `gsd-test` remote matrix: **40900/40900 passed** on the exact pushed commit (`1de7cc145`) — this includes several pre-existing tests I discovered only by running the suite (`tests/antigravity-reviewer.test.cjs`, `tests/review-default-reviewers-workflow.test.cjs`, `tests/reviewer-config-federation.test.cjs`, `tests/reviewer-lane-declarations.test.cjs`) whose existing invariants (fully-resolved `plan.argv`; the qwen/cursor/coderabbit key-ownership narrowing) shaped the final design — see commit `1de7cc145` for the correction those failures drove.
- Local gates: `npm run build:lib`, `npm run lint`, `npm run lint:ci`, `npm run lint:generated-sync`, `GITHUB_BASE_REF=next npm run lint:changeset` all clean.

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

`gsd-test`'s remote matrix is Linux-only in this environment; the change touches no path-separator or platform-conditional code (pure config-value resolution and string formatting).

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

This is a `/gsd-review` reviewer-lane config surface, not a runtime-install surface.

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue — no additions or removals
- [x] If scope changed during implementation, I updated the issue and got re-approval before continuing

---

## Documentation

- [x] Updated the relevant file(s) under `docs/` to reflect this change
  - Configuration / schema change → `docs/CONFIGURATION.md`
- [x] All `docs/` content added in this PR is written in English
- [ ] If genuinely no user-facing docs impact (infrastructure / internal refactor / test-only), apply the `no-docs` label **or** add `<!-- docs-exempt: <reason> -->`

## Checklist

- [x] Issue linked above with `Closes #3274`
- [x] Linked issue has the `approved-enhancement` label
- [x] Changes are scoped to the approved enhancement — nothing extra included
- [x] All existing tests pass (`gsd-test` — 40900/40900)
- [x] New or updated tests cover the enhanced behavior
- [x] `.changeset/` fragment added (`npm run changeset -- --type Added --pr <NNN> --body "..."`)
- [x] No unnecessary dependencies added

## Breaking changes

None. `timeoutConfigKey` is optional and every lane's default effective timeout is unchanged when the new config key is unset — proven by the unmodified GOLDEN invocation table passing for all 12 lanes.
