### PR TITLE
fix(#4099): stop word-splitting an unquoted PLAN_IDS string (bash vs zsh diverge)

### DIFF
--- a/.changeset/witty-bears-caper.md
+++ b/.changeset/witty-bears-caper.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**Plan-coverage manifest now counts and lists plan ids correctly under zsh.** Reviews with 2+ plans were undercounting the manifest's plan total and merging all ids onto one bullet line under zsh (macOS's default shell), because the count and list were derived from re-splitting an unquoted string — bash word-splits that by default, zsh does not. (#4099)

--- a/.changeset/witty-bears-caper.md
+++ b/.changeset/witty-bears-caper.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 4102
 ---
 **Plan-coverage manifest miscounted multi-plan reviews under zsh** — the count and bullet list were derived by re-splitting an unquoted string, which bash word-splits by default but zsh does not, so reviews with 2+ plans collapsed onto one manifest entry. (#4099)

--- a/.changeset/witty-bears-caper.md
+++ b/.changeset/witty-bears-caper.md
@@ -2,4 +2,4 @@
 type: Fixed
 pr: 0
 ---
-**Plan-coverage manifest now counts and lists plan ids correctly under zsh.** Reviews with 2+ plans were undercounting the manifest's plan total and merging all ids onto one bullet line under zsh (macOS's default shell), because the count and list were derived from re-splitting an unquoted string — bash word-splits that by default, zsh does not. (#4099)
+**Plan-coverage manifest miscounted multi-plan reviews under zsh** — the count and bullet list were derived by re-splitting an unquoted string, which bash word-splits by default but zsh does not, so reviews with 2+ plans collapsed onto one manifest entry. (#4099)

--- a/gsd-core/workflows/review.md
+++ b/gsd-core/workflows/review.md
@@ -277,17 +277,23 @@ done
 # in-phase sequence number ("01") and can never reconstruct the phase-qualified
 # id reviewers need to cite. The filename is guaranteed present for every copied
 # plan, so no plan is ever dropped from the manifest for lacking a key.
-# A plain string accumulator, not an array: zsh and bash disagree on array
-# indexing and this block runs under both (see the nullglob/NULL_GLOB pairing
-# above).
-PLAN_IDS=""
+# Count and bullets are both derived directly from the glob loop below, never
+# from re-splitting an accumulated string: bash word-splits an unquoted `$VAR`
+# on IFS by default, but zsh does not (no `setopt SH_WORD_SPLIT` here), so a
+# prior `PLAN_IDS="$PLAN_IDS $id"` + `for x in $PLAN_IDS` round-trip silently
+# collapsed every id onto one iteration under zsh whenever there were 2+ plans
+# (gsd-core#4099). Direct glob iteration (`for f in "${PHASE_DIR}"/*-PLAN.md`,
+# same pattern as the copy loop above) is identical under both shells, so this
+# never needs word-splitting at all.
+PLAN_COUNT=0
+PLAN_ID_BULLETS=""
 for PLAN_FILE in "${PHASE_DIR}"/*-PLAN.md; do
   PLAN_BASENAME=$(basename "$PLAN_FILE")
-  PLAN_IDS="$PLAN_IDS ${PLAN_BASENAME%-PLAN.md}"
+  PLAN_ID="${PLAN_BASENAME%-PLAN.md}"
+  PLAN_COUNT=$((PLAN_COUNT + 1))
+  PLAN_ID_BULLETS="${PLAN_ID_BULLETS}- ${PLAN_ID}
+"
 done
-PLAN_IDS="${PLAN_IDS# }"
-PLAN_COUNT=0
-for _ in $PLAN_IDS; do PLAN_COUNT=$((PLAN_COUNT + 1)); done
 
 # Named to avoid BOTH existing RUN_DIR globs: `gsd-review-*.md` (reviewer
 # reports, invoke_reviewers) and `gsd-review-plan-*.md` (the plan copies just
@@ -300,9 +306,7 @@ for _ in $PLAN_IDS; do PLAN_COUNT=$((PLAN_COUNT + 1)); done
   echo "Total plans in this review: ${PLAN_COUNT}"
   echo ""
   echo "Plan ids (give each one its own \`##\`-level section, headed verbatim):"
-  for PLAN_ID in $PLAN_IDS; do
-    echo "- ${PLAN_ID}"
-  done
+  printf '%s' "$PLAN_ID_BULLETS"
 } > "${RUN_DIR}/.plans-manifest.md"
 
 # Optional section files (only if content was included in the combined prompt)


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #4099

---

## What was broken

`gsd-core/workflows/review.md`'s `build_prompt` step built the plan-coverage manifest (`#3301`) by accumulating plan ids into a space-separated string and re-splitting it with unquoted `for x in $PLAN_IDS`. Bash word-splits an unquoted scalar on IFS by default; zsh does not — so under zsh, any review with 2+ plans collapsed the count and bullet list onto a single iteration (`Total plans in this review: 1` instead of the real count, all ids merged onto one bullet). This was failing `origin/next`'s CI (`test.yml`'s `full test (macos-latest, 24, shard 3/3)` job) on every push to `next`.

## What this fix does

Derives `PLAN_COUNT` and the manifest's bullet list directly from the same `*-PLAN.md` glob loop already used elsewhere in the file for copying plan files, instead of round-tripping through a string that then needs re-splitting. Glob iteration is identical under bash and zsh, so the fix never depends on IFS word-splitting behavior at all.

## Root cause

Unquoted parameter expansion (`for x in $VAR`) is word-split on `IFS` by bash by default but not by zsh (no `setopt SH_WORD_SPLIT` was set). The original code was aware bash/zsh disagree on *array* indexing and deliberately avoided arrays for this reason — but the plain-string-accumulator workaround it chose has its own, different bash/zsh divergence (word-splitting), which is what actually broke.

---

## Testing

### How I verified the fix

- Reproduced the bug locally: extracted the block and ran it under `zsh` with two plan files (`12.6-01-PLAN.md`, `12.6-02-PLAN.md`) — reproduced the exact CI failure (`Total plans in this review: 1`, one merged bullet).
- Applied the fix, re-ran the same repro under both `bash` and `zsh` — both now report `Total plans in this review: 3` (with a third `01-PLAN.md` fixture) with three separate bullets, identical output.
- Ran the full suite via `gsd-test --base next --head <sha>` (required gate) — `outcome: "passed"`, 40942/40942, 0 failures. Pass marker recorded for the shipped sha.
- The pre-existing regression test `tests/review-plan-coverage-manifest.test.cjs`'s `[zsh] decimal-phase ids are preserved verbatim in the manifest` subtest (the one failing in CI) now passes.

### Regression test added?

- [x] No — explain why: the regression test already existed (`tests/review-plan-coverage-manifest.test.cjs:211-220`, added with `#3301`/PR #4084) and already encoded the correct expectation; it was the test that was failing. No new test needed — this PR makes an existing, correct test pass.

### Platforms tested

- [x] macOS (zsh — the shell that was failing)
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [x] N/A (not platform-specific beyond bash/zsh, both exercised)

### Runtimes tested

- [x] N/A (not runtime-specific — this is a workflow-script portability fix, not runtime-facing behavior)

---

## Checklist

- [x] Issue linked above with `Fixes #4099`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not) — pre-existing test now passes
- [x] All existing tests pass (`gsd-test`, 40942/40942)
- [x] `.changeset/` fragment added (`Fixed`, pr backfilled after PR creation)
- [x] No unnecessary dependencies added

## Breaking changes

None
