### PR TITLE
fix(#4112): drop redundant $(( subshell wrapping in pause-work.md Context Detection

### DIFF
--- a/.changeset/sunny-voles-snooze.md
+++ b/.changeset/sunny-voles-snooze.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`/gsd-pause-work` no longer fails on its first step** — the Context Detection step's phase/spike/sketch lookups used a $(( construct that POSIX `sh`/dash rejects as a hard syntax error (bash/zsh happened to tolerate it via an undocumented fallback). (#4112)

--- a/.changeset/sunny-voles-snooze.md
+++ b/.changeset/sunny-voles-snooze.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 4140
 ---
 **`/gsd-pause-work` no longer fails on its first step** — the Context Detection step's phase/spike/sketch lookups used a $(( construct that POSIX `sh`/dash rejects as a hard syntax error (bash/zsh happened to tolerate it via an undocumented fallback). (#4112)

--- a/gsd-core/workflows/pause-work.md
+++ b/gsd-core/workflows/pause-work.md
@@ -15,13 +15,13 @@ Determine what kind of work is being paused and set the handoff destination acco
 
 ```bash
 # Check for active phase
-phase=$(( ls -lt .planning/phases/*/PLAN.md 2>/dev/null || true ) | head -1 | grep -oP 'phases/\K[^/]+' || true)
+phase=$(ls -lt .planning/phases/*/PLAN.md 2>/dev/null | head -1 | grep -oP 'phases/\K[^/]+' || true)
 
 # Check for active spike
-spike=$(( ls -lt .planning/spikes/*/SPIKE.md .planning/spikes/*/DESIGN.md .planning/spikes/*/README.md 2>/dev/null || true ) | head -1 | grep -oP 'spikes/\K[^/]+' || true)
+spike=$(ls -lt .planning/spikes/*/SPIKE.md .planning/spikes/*/DESIGN.md .planning/spikes/*/README.md 2>/dev/null | head -1 | grep -oP 'spikes/\K[^/]+' || true)
 
 # Check for active sketch
-sketch=$(( ls -lt .planning/sketches/*/README.md .planning/sketches/*/index.html 2>/dev/null || true ) | head -1 | grep -oP 'sketches/\K[^/]+' || true)
+sketch=$(ls -lt .planning/sketches/*/README.md .planning/sketches/*/index.html 2>/dev/null | head -1 | grep -oP 'sketches/\K[^/]+' || true)
 
 # Check for active deliberation
 deliberation=$(ls .planning/deliberations/*.md 2>/dev/null | head -1 || true)

--- a/scripts/lint-workflow-shellcheck-baseline.json
+++ b/scripts/lint-workflow-shellcheck-baseline.json
@@ -491,33 +491,18 @@
   },
   {
     "file": "gsd-core/workflows/pause-work.md",
-    "code": "1102",
-    "message": "Shells disambiguate $(( differently or not at all. For $(command substitution), add space after $( . For $((arithmetics)), fix parsing errors."
+    "code": "2012",
+    "message": "Use find instead of ls to better handle non-alphanumeric filenames."
   },
   {
     "file": "gsd-core/workflows/pause-work.md",
-    "code": "1102",
-    "message": "Shells disambiguate $(( differently or not at all. For $(command substitution), add space after $( . For $((arithmetics)), fix parsing errors."
+    "code": "2012",
+    "message": "Use find instead of ls to better handle non-alphanumeric filenames."
   },
   {
     "file": "gsd-core/workflows/pause-work.md",
-    "code": "1102",
-    "message": "Shells disambiguate $(( differently or not at all. For $(command substitution), add space after $( . For $((arithmetics)), fix parsing errors."
-  },
-  {
-    "file": "gsd-core/workflows/pause-work.md",
-    "code": "1106",
-    "message": "In arithmetic contexts, use < instead of -lt"
-  },
-  {
-    "file": "gsd-core/workflows/pause-work.md",
-    "code": "1106",
-    "message": "In arithmetic contexts, use < instead of -lt"
-  },
-  {
-    "file": "gsd-core/workflows/pause-work.md",
-    "code": "1106",
-    "message": "In arithmetic contexts, use < instead of -lt"
+    "code": "2012",
+    "message": "Use find instead of ls to better handle non-alphanumeric filenames."
   },
   {
     "file": "gsd-core/workflows/pause-work.md",
@@ -528,21 +513,6 @@
     "file": "gsd-core/workflows/pause-work.md",
     "code": "2102",
     "message": "Ranges can only match single chars (mentioned due to duplicates)."
-  },
-  {
-    "file": "gsd-core/workflows/pause-work.md",
-    "code": "2205",
-    "message": "(..) is a subshell. Did you mean [ .. ], a test expression?"
-  },
-  {
-    "file": "gsd-core/workflows/pause-work.md",
-    "code": "2205",
-    "message": "(..) is a subshell. Did you mean [ .. ], a test expression?"
-  },
-  {
-    "file": "gsd-core/workflows/pause-work.md",
-    "code": "2205",
-    "message": "(..) is a subshell. Did you mean [ .. ], a test expression?"
   },
   {
     "file": "gsd-core/workflows/plan-phase.md",

--- a/tests/pause-work-context-detection.test.cjs
+++ b/tests/pause-work-context-detection.test.cjs
@@ -54,22 +54,53 @@ function extractBashBlockAfterHeading(markdown, heading) {
 }
 
 /**
+ * A code review of this test (2026-09-01) found a real gap: falling back to
+ * plain `sh` when `dash` is unavailable can silently produce a
+ * non-discriminating test. If the resolved shell is actually bash-compatible
+ * (macOS `/bin/sh`, for example), it implements the same permissive `$((`
+ * fallback as bash — it will never throw on the broken construct either, so
+ * the "regression" test would pass identically whether the bug were present
+ * or not. That is the exact false-green failure class this file's header
+ * comment already documents being rewritten away from once; the fix here is
+ * to verify discrimination explicitly instead of trusting the shell name.
+ */
+const KNOWN_AMBIGUOUS_ARITHMETIC_SNIPPET =
+  'x=$(( ls -lt /tmp 2>/dev/null || true ) | head -1 || true)';
+
+/**
+ * True if `shell` rejects the known-ambiguous `$((` construct above (i.e. it
+ * does NOT implement bash's permissive arithmetic-expansion-or-subshell
+ * fallback, so it can actually tell broken from fixed for this bug).
+ */
+function shellRejectsAmbiguousArithmetic(shell) {
+  try {
+    execFileSync(shell, ['-c', KNOWN_AMBIGUOUS_ARITHMETIC_SNIPPET], { encoding: 'utf8' });
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+/**
  * Resolve a POSIX shell binary that does NOT implement bash's permissive
  * `$((` -> command-substitution fallback, so it can actually distinguish
  * broken from fixed. Plain `/bin/sh` is unreliable for this: on macOS it is
  * bash-compatible and does not reproduce the defect. Prefer `dash` (the
  * default `/bin/sh` on Debian/Ubuntu, including this repo's gsd-test Linux
- * bench); fall back to `sh` only if `dash` is not on PATH.
+ * bench); fall back to `sh` only if `dash` is not on PATH — and even then,
+ * only if `sh` actually discriminates the two cases (verified below, not
+ * assumed from the binary name).
  */
 function resolvePosixShell() {
   for (const candidate of ['dash', 'sh']) {
     try {
       execFileSync(candidate, ['-c', 'true'], { encoding: 'utf8' });
-      return candidate;
     } catch (err) {
       if (err.code === 'ENOENT') continue;
-      return candidate;
+      // Present but errored on a trivial command; fall through and still
+      // check discrimination below rather than assuming it is unusable.
     }
+    if (shellRejectsAmbiguousArithmetic(candidate)) return candidate;
   }
   return null;
 }
@@ -106,7 +137,9 @@ function runBlock(setup) {
 describe('regression #4112: pause-work.md Context Detection block', () => {
   test('does not throw a "Missing \'))\'" syntax error under POSIX sh/dash', (t) => {
     if (!posixShell) {
-      t.skip('neither dash nor sh is available on this host');
+      t.skip('no POSIX shell on this host actually rejects the ambiguous $(( construct ' +
+        '(dash unavailable and the resolved /bin/sh is bash-compatible) — cannot prove the ' +
+        'regression here; this is still proven on the gsd-test Linux bench, where /bin/sh is dash');
       return;
     }
     assert.doesNotThrow(() => {

--- a/tests/pause-work-context-detection.test.cjs
+++ b/tests/pause-work-context-detection.test.cjs
@@ -1,0 +1,120 @@
+'use strict';
+
+/**
+ * pause-work-context-detection.test.cjs — regression coverage for #4112.
+ *
+ * gsd-core/workflows/pause-work.md's "Context Detection" step opened its
+ * phase/spike/sketch assignments with `$((`, which bash/zsh parse as
+ * ARITHMETIC expansion, not the intended command-substitution-wrapping-a-
+ * subshell. That is a hard shell syntax error, not a warning, and it fires
+ * on every `/gsd:pause-work` invocation (this is that workflow's first step).
+ *
+ * These tests execute the real fenced bash block extracted from the shipped
+ * workflow file against real temp-directory filesystem states — not a mock,
+ * not a source-text grep of the fix. Extracting the fence by locating its
+ * markers in the .md prose is not `local/no-source-grep` territory: that
+ * ESLint rule targets readFileSync of .cjs/.cts/.js/.mjs/.mts/.ts SOURCE
+ * files followed by a text-search method; this reads workflow markdown and
+ * then actually runs the extracted shell as a subprocess.
+ */
+
+const { test, describe, before } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+const REPO_ROOT = path.join(__dirname, '..');
+const WORKFLOW_PATH = path.join(REPO_ROOT, 'gsd-core', 'workflows', 'pause-work.md');
+
+/** Extract the fenced ```bash block that immediately follows the given heading. */
+function extractBashBlockAfterHeading(markdown, heading) {
+  const headingIdx = markdown.indexOf(heading);
+  assert.ok(headingIdx !== -1, `heading "${heading}" not found in ${WORKFLOW_PATH}`);
+  const rest = markdown.slice(headingIdx);
+  const fenceMatch = rest.match(/```bash\n([\s\S]*?)```/);
+  assert.ok(fenceMatch, `no \`\`\`bash fence found after heading "${heading}"`);
+  return fenceMatch[1];
+}
+
+let contextDetectionBlock;
+
+before(() => {
+  const markdown = fs.readFileSync(WORKFLOW_PATH, 'utf8');
+  contextDetectionBlock = extractBashBlockAfterHeading(markdown, '## Context Detection');
+});
+
+/** Run the block in a fresh temp cwd, returning parsed var assignments. */
+function runBlock(setup) {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pause-work-context-'));
+  try {
+    if (setup) setup(tmpDir);
+    const probe = `${contextDetectionBlock}\n` +
+      'printf \'phase=%s\\nspike=%s\\nsketch=%s\\ndeliberation=%s\\n\' ' +
+      '"$phase" "$spike" "$sketch" "$deliberation"\n';
+    const stdout = execFileSync('bash', ['-c', probe], { cwd: tmpDir, encoding: 'utf8' });
+    const out = {};
+    for (const line of stdout.trim().split('\n')) {
+      const eq = line.indexOf('=');
+      out[line.slice(0, eq)] = line.slice(eq + 1);
+    }
+    return out;
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+describe('regression #4112: pause-work.md Context Detection block', () => {
+  test('is syntactically valid bash (bash -n) — the arithmetic-context misparse is gone', () => {
+    // A bare `bash -n` on the fragment alone is enough to prove parse validity
+    // without touching the filesystem at all.
+    assert.doesNotThrow(() => {
+      execFileSync('bash', ['-n', '-c', contextDetectionBlock], { encoding: 'utf8' });
+    }, /syntax error/);
+  });
+
+  test('no active phase/spike/sketch/deliberation resolves all four vars to empty string, no abort', () => {
+    const result = runBlock();
+    assert.equal(result.phase, '');
+    assert.equal(result.spike, '');
+    assert.equal(result.sketch, '');
+    assert.equal(result.deliberation, '');
+  });
+
+  test('single active phase resolves phase to its directory name', () => {
+    const result = runBlock((tmpDir) => {
+      const dir = path.join(tmpDir, '.planning', 'phases', '03-foo');
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, 'PLAN.md'), '# plan\n');
+    });
+    assert.equal(result.phase, '03-foo');
+    assert.equal(result.spike, '');
+    assert.equal(result.sketch, '');
+  });
+
+  test('spike/sketch resolution is independent of phase (no active phase present)', () => {
+    const result = runBlock((tmpDir) => {
+      const spikeDir = path.join(tmpDir, '.planning', 'spikes', 'SPIKE-002');
+      fs.mkdirSync(spikeDir, { recursive: true });
+      fs.writeFileSync(path.join(spikeDir, 'SPIKE.md'), '# spike\n');
+
+      const sketchDir = path.join(tmpDir, '.planning', 'sketches', 'my-sketch');
+      fs.mkdirSync(sketchDir, { recursive: true });
+      fs.writeFileSync(path.join(sketchDir, 'README.md'), '# sketch\n');
+    });
+    assert.equal(result.phase, '');
+    assert.equal(result.spike, 'SPIKE-002');
+    assert.equal(result.sketch, 'my-sketch');
+  });
+
+  test('deliberation (the already-correct pattern on line 27) is unaffected by the fix', () => {
+    const result = runBlock((tmpDir) => {
+      const delibDir = path.join(tmpDir, '.planning', 'deliberations');
+      fs.mkdirSync(delibDir, { recursive: true });
+      fs.writeFileSync(path.join(delibDir, 'topic.md'), '# deliberation\n');
+    });
+    assert.equal(result.phase, '');
+    assert.match(result.deliberation, /\.planning\/deliberations\/topic\.md$/);
+  });
+});

--- a/tests/pause-work-context-detection.test.cjs
+++ b/tests/pause-work-context-detection.test.cjs
@@ -3,11 +3,26 @@
 /**
  * pause-work-context-detection.test.cjs — regression coverage for #4112.
  *
- * gsd-core/workflows/pause-work.md's "Context Detection" step opened its
- * phase/spike/sketch assignments with `$((`, which bash/zsh parse as
- * ARITHMETIC expansion, not the intended command-substitution-wrapping-a-
- * subshell. That is a hard shell syntax error, not a warning, and it fires
- * on every `/gsd:pause-work` invocation (this is that workflow's first step).
+ * gsd-core/workflows/pause-work.md's "Context Detection" step opens its
+ * phase/spike/sketch assignments with `$((`. That is genuinely ambiguous in
+ * POSIX-family shell grammar between arithmetic expansion and a command
+ * substitution wrapping a subshell. bash and zsh silently fall back to the
+ * command-substitution reading when the arithmetic parse fails (undocumented
+ * but real — verified empirically), so this construct does NOT throw under
+ * bash/zsh. It DOES throw a hard "Syntax error: Missing '))'" under POSIX
+ * `sh` (dash), which does not implement that fallback and is the default
+ * `/bin/sh` on Debian/Ubuntu (including the CI/bench hosts this repo tests
+ * on, and a common default shell for `child_process.exec()`-style spawns
+ * with no explicit `shell:` override).
+ *
+ * An earlier version of this test asserted `bash -n` syntax validity and
+ * wrapped a plain `bash -c` execution in assert.doesNotThrow(). Both were
+ * wrong: `bash -n` never evaluates arithmetic-context content at parse time,
+ * and bash's runtime fallback means a bare `bash -c` execution never throws
+ * either. That version passed a full `gsd-test` run (41594/41594, 0
+ * failures) against the UNFIXED file — a false green. This version fixes
+ * that by asserting on the real, verified failure mode: execution under
+ * `dash`/`sh`.
  *
  * These tests execute the real fenced bash block extracted from the shipped
  * workflow file against real temp-directory filesystem states — not a mock,
@@ -38,14 +53,37 @@ function extractBashBlockAfterHeading(markdown, heading) {
   return fenceMatch[1];
 }
 
+/**
+ * Resolve a POSIX shell binary that does NOT implement bash's permissive
+ * `$((` -> command-substitution fallback, so it can actually distinguish
+ * broken from fixed. Plain `/bin/sh` is unreliable for this: on macOS it is
+ * bash-compatible and does not reproduce the defect. Prefer `dash` (the
+ * default `/bin/sh` on Debian/Ubuntu, including this repo's gsd-test Linux
+ * bench); fall back to `sh` only if `dash` is not on PATH.
+ */
+function resolvePosixShell() {
+  for (const candidate of ['dash', 'sh']) {
+    try {
+      execFileSync(candidate, ['-c', 'true'], { encoding: 'utf8' });
+      return candidate;
+    } catch (err) {
+      if (err.code === 'ENOENT') continue;
+      return candidate;
+    }
+  }
+  return null;
+}
+
 let contextDetectionBlock;
+let posixShell;
 
 before(() => {
   const markdown = fs.readFileSync(WORKFLOW_PATH, 'utf8');
   contextDetectionBlock = extractBashBlockAfterHeading(markdown, '## Context Detection');
+  posixShell = resolvePosixShell();
 });
 
-/** Run the block in a fresh temp cwd, returning parsed var assignments. */
+/** Run the block in a fresh temp cwd under bash, returning parsed var assignments. */
 function runBlock(setup) {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pause-work-context-'));
   try {
@@ -66,12 +104,14 @@ function runBlock(setup) {
 }
 
 describe('regression #4112: pause-work.md Context Detection block', () => {
-  test('is syntactically valid bash (bash -n) — the arithmetic-context misparse is gone', () => {
-    // A bare `bash -n` on the fragment alone is enough to prove parse validity
-    // without touching the filesystem at all.
+  test('does not throw a "Missing \'))\'" syntax error under POSIX sh/dash', (t) => {
+    if (!posixShell) {
+      t.skip('neither dash nor sh is available on this host');
+      return;
+    }
     assert.doesNotThrow(() => {
-      execFileSync('bash', ['-n', '-c', contextDetectionBlock], { encoding: 'utf8' });
-    }, /syntax error/);
+      execFileSync(posixShell, ['-c', contextDetectionBlock], { encoding: 'utf8' });
+    });
   });
 
   test('no active phase/spike/sketch/deliberation resolves all four vars to empty string, no abort', () => {
@@ -118,3 +158,5 @@ describe('regression #4112: pause-work.md Context Detection block', () => {
     assert.match(result.deliberation, /\.planning\/deliberations\/topic\.md$/);
   });
 });
+</content>
+</invoke>

--- a/tests/pause-work-context-detection.test.cjs
+++ b/tests/pause-work-context-detection.test.cjs
@@ -24,13 +24,23 @@
  * that by asserting on the real, verified failure mode: execution under
  * `dash`/`sh`.
  *
+ * A code review of an intermediate version also found that falling back
+ * from `dash` to plain `sh` without verifying discrimination could silently
+ * produce a non-discriminating test on a host where `/bin/sh` is
+ * bash-compatible (macOS, for example) — `resolvePosixShell` below verifies
+ * each shell candidate actually rejects a known-ambiguous `$((` snippet
+ * before trusting it, rather than assuming that from the binary name.
+ *
  * These tests execute the real fenced bash block extracted from the shipped
  * workflow file against real temp-directory filesystem states — not a mock,
- * not a source-text grep of the fix. Extracting the fence by locating its
- * markers in the .md prose is not `local/no-source-grep` territory: that
- * ESLint rule targets readFileSync of .cjs/.cts/.js/.mjs/.mts/.ts SOURCE
- * files followed by a text-search method; this reads workflow markdown and
- * then actually runs the extracted shell as a subprocess.
+ * not a source-text grep of the fix. Extracting the fence line-by-line (not
+ * a single fence-spanning regex — matches this repo's established
+ * extraction idiom, e.g. tests/no-hardcoded-home-gsd-tools.test.cjs) reads
+ * workflow markdown, not source code; `local/no-source-grep` targets
+ * readFileSync of .cjs/.cts/.js/.mjs/.mts/.ts SOURCE files, which this is
+ * not. All subprocess calls route through tests/helpers/process-seam.cjs
+ * (bounded by construction, never a hand-rolled execFileSync/spawnSync);
+ * temp-directory removal goes through tests/helpers.cjs's `cleanup()`.
  */
 
 const { test, describe, before } = require('node:test');
@@ -38,34 +48,45 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
-const { execFileSync } = require('node:child_process');
+const { runHook, OUTCOME } = require('./helpers/process-seam.cjs');
+const { cleanup } = require('./helpers.cjs');
+const { splitLines } = require('../gsd-core/bin/lib/text-lines.cjs');
 
 const REPO_ROOT = path.join(__dirname, '..');
 const WORKFLOW_PATH = path.join(REPO_ROOT, 'gsd-core', 'workflows', 'pause-work.md');
 
-/** Extract the fenced ```bash block that immediately follows the given heading. */
+/**
+ * Extract the fenced ```bash block that immediately follows the given
+ * heading, scanning line-by-line rather than matching a single
+ * fence-spanning regex (the shape `local/no-adhoc-markdown-parsing` flags).
+ */
 function extractBashBlockAfterHeading(markdown, heading) {
   const headingIdx = markdown.indexOf(heading);
   assert.ok(headingIdx !== -1, `heading "${heading}" not found in ${WORKFLOW_PATH}`);
-  const rest = markdown.slice(headingIdx);
-  const fenceMatch = rest.match(/```bash\n([\s\S]*?)```/);
-  assert.ok(fenceMatch, `no \`\`\`bash fence found after heading "${heading}"`);
-  return fenceMatch[1];
+  const lines = splitLines(markdown.slice(headingIdx));
+  const blockLines = [];
+  let inBash = false;
+  for (const line of lines) {
+    if (!inBash) {
+      if (/^```bash\s*$/.test(line)) inBash = true;
+    } else if (/^```\s*$/.test(line)) {
+      break;
+    } else {
+      blockLines.push(line);
+    }
+  }
+  assert.ok(blockLines.length > 0, `no \`\`\`bash fence found after heading "${heading}"`);
+  return `${blockLines.join('\n')}\n`;
 }
 
-/**
- * A code review of this test (2026-09-01) found a real gap: falling back to
- * plain `sh` when `dash` is unavailable can silently produce a
- * non-discriminating test. If the resolved shell is actually bash-compatible
- * (macOS `/bin/sh`, for example), it implements the same permissive `$((`
- * fallback as bash — it will never throw on the broken construct either, so
- * the "regression" test would pass identically whether the bug were present
- * or not. That is the exact false-green failure class this file's header
- * comment already documents being rewritten away from once; the fix here is
- * to verify discrimination explicitly instead of trusting the shell name.
- */
 const KNOWN_AMBIGUOUS_ARITHMETIC_SNIPPET =
   'x=$(( ls -lt /tmp 2>/dev/null || true ) | head -1 || true)';
+
+/** True if `shell` is present and spawnable at all (independent of exit code). */
+function shellIsUsable(shell) {
+  const result = runHook('-c', ['true'], { interpreter: shell });
+  return result.outcome === OUTCOME.EXITED;
+}
 
 /**
  * True if `shell` rejects the known-ambiguous `$((` construct above (i.e. it
@@ -73,12 +94,8 @@ const KNOWN_AMBIGUOUS_ARITHMETIC_SNIPPET =
  * fallback, so it can actually tell broken from fixed for this bug).
  */
 function shellRejectsAmbiguousArithmetic(shell) {
-  try {
-    execFileSync(shell, ['-c', KNOWN_AMBIGUOUS_ARITHMETIC_SNIPPET], { encoding: 'utf8' });
-    return false;
-  } catch {
-    return true;
-  }
+  const result = runHook('-c', [KNOWN_AMBIGUOUS_ARITHMETIC_SNIPPET], { interpreter: shell });
+  return result.outcome !== OUTCOME.EXITED || result.exitCode !== 0;
 }
 
 /**
@@ -88,18 +105,12 @@ function shellRejectsAmbiguousArithmetic(shell) {
  * bash-compatible and does not reproduce the defect. Prefer `dash` (the
  * default `/bin/sh` on Debian/Ubuntu, including this repo's gsd-test Linux
  * bench); fall back to `sh` only if `dash` is not on PATH — and even then,
- * only if `sh` actually discriminates the two cases (verified below, not
- * assumed from the binary name).
+ * only if `sh` actually discriminates the two cases (verified, not assumed
+ * from the binary name).
  */
 function resolvePosixShell() {
   for (const candidate of ['dash', 'sh']) {
-    try {
-      execFileSync(candidate, ['-c', 'true'], { encoding: 'utf8' });
-    } catch (err) {
-      if (err.code === 'ENOENT') continue;
-      // Present but errored on a trivial command; fall through and still
-      // check discrimination below rather than assuming it is unusable.
-    }
+    if (!shellIsUsable(candidate)) continue;
     if (shellRejectsAmbiguousArithmetic(candidate)) return candidate;
   }
   return null;
@@ -122,15 +133,17 @@ function runBlock(setup) {
     const probe = `${contextDetectionBlock}\n` +
       'printf \'phase=%s\\nspike=%s\\nsketch=%s\\ndeliberation=%s\\n\' ' +
       '"$phase" "$spike" "$sketch" "$deliberation"\n';
-    const stdout = execFileSync('bash', ['-c', probe], { cwd: tmpDir, encoding: 'utf8' });
+    const result = runHook('-c', [probe], { interpreter: 'bash', cwd: tmpDir });
+    assert.equal(result.outcome, OUTCOME.EXITED, `bash exited abnormally: ${result.stderr}`);
+    assert.equal(result.exitCode, 0, `bash exited ${result.exitCode}: ${result.stderr}`);
     const out = {};
-    for (const line of stdout.trim().split('\n')) {
+    for (const line of result.stdout.trim().split('\n')) {
       const eq = line.indexOf('=');
       out[line.slice(0, eq)] = line.slice(eq + 1);
     }
     return out;
   } finally {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    cleanup(tmpDir);
   }
 }
 
@@ -142,9 +155,9 @@ describe('regression #4112: pause-work.md Context Detection block', () => {
         'regression here; this is still proven on the gsd-test Linux bench, where /bin/sh is dash');
       return;
     }
-    assert.doesNotThrow(() => {
-      execFileSync(posixShell, ['-c', contextDetectionBlock], { encoding: 'utf8' });
-    });
+    const result = runHook('-c', [contextDetectionBlock], { interpreter: posixShell });
+    assert.equal(result.outcome, OUTCOME.EXITED, `${posixShell} exited abnormally: ${result.stderr}`);
+    assert.equal(result.exitCode, 0, `${posixShell} rejected the fixed block: ${result.stderr}`);
   });
 
   test('no active phase/spike/sketch/deliberation resolves all four vars to empty string, no abort', () => {

--- a/tests/pause-work-context-detection.test.cjs
+++ b/tests/pause-work-context-detection.test.cjs
@@ -158,5 +158,3 @@ describe('regression #4112: pause-work.md Context Detection block', () => {
     assert.match(result.deliberation, /\.planning\/deliberations\/topic\.md$/);
   });
 });
-</content>
-</invoke>


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #4112

---

## What was broken

`gsd-core/workflows/pause-work.md`'s Context Detection step opened three variable assignments
(`phase=`, `spike=`, `sketch=`) with `$((`, which is ambiguous shell grammar between arithmetic
expansion and a command substitution wrapping a subshell. POSIX `sh`/`dash` rejects it outright with
a hard `Syntax error: Missing '))'` — this is `/gsd:pause-work`'s very first step, so any execution
path that resolves the fenced block through a shell without bash's undocumented `$((` fallback fails
immediately. (bash/zsh happen to silently retry the construct as command substitution when the
arithmetic parse fails, which is why a plain interactive `bash -c` test — including the reproduction
in the issue itself — does not show the failure; verified directly, not just asserted.)

## What this fix does

Drops the redundant inner grouping parens so each assignment becomes a plain `$(...)` command
substitution, exactly matching the file's own pre-existing correct pattern three lines below
(`deliberation=$(ls .planning/deliberations/*.md 2>/dev/null | head -1 || true)`). No behavior
change: the fallback-to-empty-string result on no match is byte-identical before and after, verified
by the regression test's boundary/independence rows.

## Root cause

`$((` is a single indivisible arithmetic-expansion opener in POSIX/bash grammar. The author's
evident intent was `$( ( ls -lt ... || true ) | head -1 | grep ... || true )` — command substitution
wrapping a subshell — but wrote `$((` instead of `$( (`. bash and zsh resolve the resulting parse
failure permissively (an undocumented fallback to the command-substitution reading); POSIX `sh`
(`dash`, the default `/bin/sh` on Debian/Ubuntu, including this repo's own CI/bench hosts) does not,
and raises a hard syntax error at parse time.

## Testing

### How I verified the fix

Manual, direct execution (not just the automated suite):

```
$ dash -c 'phase=$(( ls -lt .planning/phases/*/PLAN.md 2>/dev/null || true ) | head -1 | grep -oE "phases/[^/]+" || true)'
dash: 1: Syntax error: Missing '))'
$ echo $?
2
```
against the fixed line:
```
$ dash -c 'phase=$(ls -lt .planning/phases/*/PLAN.md 2>/dev/null | head -1 | grep -oE "phases/[^/]+" || true); echo "ok:[$phase]"'
ok:[]
```
Full `gsd-test` remote matrix (Linux/Node 24): **41594/41594 passed** on the shipped sha.

### Regression test added?

- [x] Yes — `tests/pause-work-context-detection.test.cjs` extracts the real fenced bash block from
      the shipped workflow file and executes it under `dash`/`sh` (the shell that actually
      discriminates broken from fixed — `bash -n` and plain `bash -c` do not, and an earlier
      iteration of this test that used them was itself a false green against the unfixed file,
      caught by a full `gsd-test` run). It verifies the resolved shell actually rejects a
      known-ambiguous `$((` snippet before trusting it, rather than assuming that from the binary
      name. Additional rows cover the no-match fallback, single-match resolution, spike/sketch
      independence, and the untouched `deliberation=` line, all under bash.

### Platforms tested

- [x] Linux (gsd-test remote bench, Node 24)
- [x] macOS (manual local verification, bash 3.2.57 and dash)
- [ ] Windows (N/A — POSIX shell script, not exercised on Windows by this workflow)
- [ ] N/A (not platform-specific)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #4112`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included (the accompanying
      `scripts/lint-workflow-shellcheck-baseline.json` edit only reflects newly-visible pre-existing
      ShellCheck findings the parse failure previously masked; see below)
- [x] Regression test added
- [x] All existing tests pass (`gsd-test`: 41594/41594)
- [x] `.changeset/` fragment added (`Fixed`, PR number backfilled after opening)
- [x] No unnecessary dependencies added

## Breaking changes

None.

---

## Note on the accompanying `scripts/lint-workflow-shellcheck-baseline.json` change

Once the parse error is fixed, ShellCheck can newly analyze code it previously couldn't see past the
`$((` failure, surfacing 3 more instances of an already-baselined, unrelated SC2012 ("use find
instead of ls") suggestion for the file's pre-existing (unchanged) `ls -lt` calls. The baseline is
updated to reflect the true current count (1 → 4 for that finding) rather than switching `ls` to
`find`, which is a separate, out-of-scope style question this issue does not ask for.
