### PR TITLE
fix(#4053): quote decimal-shaped frontmatter scalars for spec YAML readers

### DIFF
--- a/src/frontmatter.cts
+++ b/src/frontmatter.cts
@@ -822,6 +822,40 @@ function agentScalarNeedsDoubleQuoting(s: string): boolean {
   return false;
 }
 
+/**
+ * #4053 — Does this GENERAL frontmatter scalar need quoting to survive a
+ * YAML-SPEC reader, over and above `scalarNeedsDoubleQuoting`'s "can it open a
+ * plain scalar" test?
+ *
+ * The bug: a decimal-shaped phase identifier (`current_phase: 22.10`) opens a
+ * plain scalar fine, so it was emitted BARE — and a spec reader (js-yaml, the
+ * statusline, any external tool) then reloads it as the float 22.1, colliding
+ * with `22.1` and dropping the trailing zero. gsd's own tolerant line-scanner
+ * (`extractFrontmatter`) round-trips the raw text and so hid this; a spec
+ * reader does not.
+ *
+ * This is deliberately NARROWER than `agentScalarNeedsDoubleQuoting`, which
+ * quotes EVERY numeric (and word, and non-alphanumeric-first) value because an
+ * agent `model:`/`variant:` must round-trip string-typed. STATE.md is not like
+ * that: the state-rebuild idempotency baseline pins integer counts and phase
+ * numbers UNQUOTED (`current_phase: 3`, `completed_phases: 2`, `percent: 40`),
+ * and the fixtures also carry leading-zero phase ids bare (`current_phase: 02`).
+ * Blanket-quoting all numerics would churn every state writer's output. So the
+ * line is drawn precisely at the non-integer numeric FORMS a phase id takes when
+ * it collides: decimals like `22.10`, plus exponents, sexagesimal and
+ * hex/oct/bin. EVERY all-digit string (`3`, `10`, `02`) stays bare, because a
+ * plain integer round-trips harmlessly and a decimal is the only shape observed
+ * to collide (#4053).
+ */
+function generalScalarNeedsNumericQuoting(s: string): boolean {
+  if (!YAML_NUMERIC_RE.test(s)) return false;
+  // Every all-digit string (`3`, `10`, and leading-zero fixtures like `02`)
+  // stays bare — the state corpus pins those unquoted. Only non-integer numeric
+  // FORMS (decimals, exponents, sexagesimal, hex/oct/bin) — the shapes a phase
+  // id takes when it collides (#4053) — are quoted.
+  return !/^\d+$/.test(s);
+}
+
 function reconstructFrontmatter(obj: Frontmatter): string {
   const lines: string[] = [];
   // #3257: read the full-line-comment channel (set by parseGuardedYamlRegion when comments
@@ -887,12 +921,12 @@ function reconstructFrontmatter(obj: Frontmatter): string {
         } else {
           // eslint-disable-next-line @typescript-eslint/no-base-to-string
           const sv = String(subval);
-          lines.push(`  ${subkey}: ${sv.includes(':') || sv.includes('#') || scalarNeedsDoubleQuoting(sv) ? `"${escapeDoubleQuotedScalar(sv)}"` : sv}`);
+          lines.push(`  ${subkey}: ${sv.includes(':') || sv.includes('#') || scalarNeedsDoubleQuoting(sv) || generalScalarNeedsNumericQuoting(sv) ? `"${escapeDoubleQuotedScalar(sv)}"` : sv}`);
         }
       }
     } else {
       const sv = String(value);
-      if (sv.includes(':') || sv.includes('#') || sv.startsWith('[') || sv.startsWith('{') || scalarNeedsDoubleQuoting(sv)) {
+      if (sv.includes(':') || sv.includes('#') || sv.startsWith('[') || sv.startsWith('{') || scalarNeedsDoubleQuoting(sv) || generalScalarNeedsNumericQuoting(sv)) {
         lines.push(`${key}: "${escapeDoubleQuotedScalar(sv)}"`);
       } else {
         lines.push(`${key}: ${sv}`);

--- a/tests/frontmatter.test.cjs
+++ b/tests/frontmatter.test.cjs
@@ -249,6 +249,60 @@ describe('reconstructFrontmatter', () => {
     assert.ok(hashResult.includes('"value # note"'), 'should quote value with hash');
   });
 
+  // #4053 — A decimal-shaped identifier (e.g. a phase id like `22.10`) was
+  // emitted BARE, because scalarNeedsDoubleQuoting only asks "can this OPEN a
+  // plain scalar", which `22.10` can. But a YAML-SPEC reader (js-yaml, the
+  // statusline, any external tooling) then reloads bare `22.10` as the float
+  // 22.1 — colliding with `22.1` and dropping the trailing zero. gsd's own
+  // tolerant line-scanner hides this; a spec reader does not. The fix quotes
+  // numeric-looking scalars that are not plain integers, so they reload as the
+  // exact string, while leaving integer counts/phase numbers bare (the
+  // state-rebuild idempotency baseline pins those unquoted).
+  describe('#4053 — decimal-shaped numeric scalars survive a spec YAML reader', () => {
+    const yaml = require('js-yaml');
+    const lineFor = (obj, key) =>
+      reconstructFrontmatter(obj).split('\n').find((l) => l.startsWith(`${key}:`));
+
+    test('a decimal phase id is quoted so js-yaml keeps it a string', () => {
+      assert.strictEqual(lineFor({ current_phase: '22.1' }, 'current_phase'), 'current_phase: "22.1"');
+      assert.strictEqual(lineFor({ current_phase: '22.10' }, 'current_phase'), 'current_phase: "22.10"');
+      assert.strictEqual(lineFor({ current_phase: '22.0' }, 'current_phase'), 'current_phase: "22.0"');
+    });
+
+    test('"22.1" and "22.10" no longer collide under js-yaml', () => {
+      const load = (v) => yaml.load(reconstructFrontmatter({ current_phase: v })).current_phase;
+      const a = load('22.1');
+      const b = load('22.10');
+      assert.strictEqual(a, '22.1');
+      assert.strictEqual(b, '22.10'); // was the float 22.1 before the fix
+      assert.notStrictEqual(a, b);
+      assert.strictEqual(typeof b, 'string'); // was 'number' before the fix
+    });
+
+    test('a nested decimal value is also quoted', () => {
+      assert.strictEqual(
+        reconstructFrontmatter({ progress: { ratio: '1.10' } }),
+        'progress:\n  ratio: "1.10"',
+      );
+    });
+
+    test('plain integer phase ids and counts stay bare — no idempotency churn', () => {
+      assert.strictEqual(lineFor({ current_phase: '3' }, 'current_phase'), 'current_phase: 3');
+      assert.strictEqual(lineFor({ current_phase: '10' }, 'current_phase'), 'current_phase: 10');
+      assert.strictEqual(
+        reconstructFrontmatter({ progress: { completed_phases: '2', percent: '40' } }),
+        'progress:\n  completed_phases: 2\n  percent: 40',
+      );
+    });
+
+    test('free-text with no YAML-special characters stays unquoted — no blanket quoting', () => {
+      assert.strictEqual(
+        lineFor({ current_phase_name: 'Test Phase' }, 'current_phase_name'),
+        'current_phase_name: Test Phase',
+      );
+    });
+  });
+
   test('serializes nested objects with proper indentation', () => {
     const result = reconstructFrontmatter({ tech: { added: 'prisma', patterns: 'repo' } });
     assert.ok(result.includes('tech:'), 'should have parent key');
@@ -311,8 +365,11 @@ describe('reconstructFrontmatter', () => {
       reconstructed.includes('# NOTE: current_phase is hand-maintained here'),
       `comment should survive reconstruct; got:\n${reconstructed}`,
     );
-    // data identity preserved alongside the comment.
-    assert.ok(reconstructed.includes('gsd_state_version: 1.0'));
+    // data identity preserved alongside the comment. #4053: the version value
+    // `1.0` is numeric-looking and non-integer, so it is now quoted on write
+    // (matching the authoritative STATE.md template, which emits it quoted) so a
+    // spec YAML reader keeps it the string "1.0" rather than the float 1.
+    assert.ok(reconstructed.includes('gsd_state_version: "1.0"'));
     assert.ok(reconstructed.includes('current_phase: 3'));
     assert.ok(reconstructed.includes('status: executing'));
     // the reconstructed output re-parses to the same data (idempotent round-trip).

--- a/tests/state-transition.test.cjs
+++ b/tests/state-transition.test.cjs
@@ -1879,7 +1879,10 @@ describe('ADR-1769 Phase 4: milestoneSwitch transition — milestone reset', () 
 
   test('gsd_state_version is preserved across the reset', () => {
     const result = transitionCore(milestoneBody(), { kind: 'milestoneSwitch', version: 'v2.0', name: 'New Milestone' }, deps);
-    assert.ok(/gsd_state_version:\s*1\.0/.test(result.content), 'gsd_state_version must be preserved');
+    // #4053: the version value may be quoted on write ("1.0") now that
+    // non-integer numeric scalars are quoted; this test asserts preservation of
+    // the value, not its quoting, so accept an optional quote.
+    assert.ok(/gsd_state_version:\s*"?1\.0"?/.test(result.content), 'gsd_state_version must be preserved');
   });
 
   test('Current Position section is reset to "Not started (defining requirements)"', () => {

--- a/tests/state.test.cjs
+++ b/tests/state.test.cjs
@@ -857,7 +857,7 @@ describe('STATE.md frontmatter sync', () => {
 
     const content = fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
     assert.ok(content.startsWith('---\n'), 'should start with frontmatter delimiter');
-    assert.ok(content.includes('gsd_state_version: 1.0'), 'should have version field');
+    assert.ok(content.includes('gsd_state_version: "1.0"'), 'should have version field'); // #4053: non-integer numeric now quoted
     assert.ok(content.includes('current_phase: 02'), 'frontmatter should have current phase');
     assert.ok(content.includes('**Current Phase:** 02'), 'body field should be preserved');
     assert.ok(content.includes('**Status:** Executing Plan 1'), 'updated field in body');
@@ -6999,7 +6999,9 @@ describe('ADR-3408 §8.5 Matrix (#3471): stale-but-present, and the report resid
       }), tmp);
 
       const expected = [
-        '---', 'gsd_state_version: 1.0', 'status: unknown', 'last_updated: "2023-11-14T22:13:20.000Z"',
+        // #4053: gsd_state_version `1.0` (non-integer numeric) is now quoted so a
+        // spec YAML reader keeps it the string "1.0"; integer current_phase 5 stays bare.
+        '---', 'gsd_state_version: "1.0"', 'status: unknown', 'last_updated: "2023-11-14T22:13:20.000Z"',
         'stopped_at: Phase 5, curated stop', 'paused_at: Phase 5, curated pause',
         'current_phase: 5', 'current_phase_name: Curated Name', 'current_plan: 05-02-plan',
         'last_activity_desc: curated activity desc',


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #4053

> The linked issue carries the `confirmed-bug` label.

---

## What was broken

`reconstructFrontmatter` wrote a decimal-shaped phase identifier (e.g. `current_phase: 22.10`) **bare**. A YAML-spec reader (js-yaml, the statusline, external tooling) then reloads bare `22.10` as the float `22.1` — colliding with `22.1` and dropping the trailing zero. gsd's own tolerant line-scanner (`extractFrontmatter`) round-trips the raw text and so hid this; a spec reader does not.

## What this fix does

The general scalar path in `reconstructFrontmatter` now also quotes numeric-looking strings that are **not plain all-digit integers** (decimals, exponents, sexagesimal, hex/oct/bin), via a new `generalScalarNeedsNumericQuoting` reusing the existing `YAML_NUMERIC_RE`. Quoted values reload as the exact string under any reader; every all-digit value stays bare.

## Root cause

`scalarNeedsDoubleQuoting` only answers "can this value **open** a plain scalar" — which `22.10` can. It has no notion of a value that opens fine but **resolves to the wrong type**. `agentScalarNeedsDoubleQuoting` already handles that for agent `model:`/`variant:` fields, but the general STATE.md path never got the equivalent, so `current_phase` flowed through unquoted.

**Scope decision — why not blanket-quote every numeric.** The existing corpus draws a hard line: the state-rebuild idempotency baseline pins integer counts and phase numbers bare (`current_phase: 3`, `completed_phases: 2`, `percent: 40`), and fixtures carry leading-zero phase ids bare (`current_phase: 02`). Those all-digit values reload harmlessly, so the predicate leaves every all-digit string bare and quotes only the non-integer numeric *forms* a phase id takes when it actually collides — keeping the idempotency baseline and wider state corpus byte-stable. One deliberate collateral change: `gsd_state_version: 1.0` is a non-integer numeric, so it is now quoted → `gsd_state_version: "1.0"` (same latent bug; matches the authoritative STATE.md template, which already emits it quoted in `src/state.cts`). Four existing expected-output assertions were updated to the quoted form — happy to narrow this if you'd prefer `gsd_state_version` untouched. The change is applied to the two general scalar emission sites (top-level and nested); list-item scalars are left as-is since no state field is a numeric list.

## Testing

### How I verified the fix

New regression block in `tests/frontmatter.test.cjs` (`#4053 — decimal-shaped numeric scalars survive a spec YAML reader`) drives the real write path and loads the output with **js-yaml** (the spec reader where the bug bites): `22.1` / `22.10` / `22.0` are quoted on write; under js-yaml they read back as the distinct strings `"22.1"` and `"22.10"` (no collision, string-typed — both were the float `22.1` before); plain integer phase ids and counts stay bare; a free-text field with no YAML-special characters stays unquoted. Full gate green: `npm test` → 34,536 passing. (Three unrelated failures — `helpers-cleanup`, `pause-work-context-detection`, `graphify-visualization` — reproduce identically on a pristine `next` checkout; they are environmental, from running under a tmpdir root without graphviz, not from this change.)

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific — pure serializer logic)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added (`quote-decimal-frontmatter-scalars.md`, type Fixed)
- [x] No unnecessary dependencies added

## Breaking changes

Output-format only: numeric-looking non-integer scalar values in STATE.md frontmatter are now double-quoted (most visibly `gsd_state_version: "1.0"`). Both forms parse to the same value via gsd's own reader; the quoted form additionally survives a spec YAML reader unchanged. No API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
