### PR TITLE
fix(#3945): require a non-empty denominator for milestone-complete

### DIFF
--- a/.changeset/gentle-tunas-rest.md
+++ b/.changeset/gentle-tunas-rest.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 4164
 ---
 **Statusline no longer shows milestone complete at 0 of 0 phases** — the 0-of-0 counters a freshly-roadmapped milestone carries no longer read as every-phase-done (string truthiness made the equality vacuous); both the full and compact renderers now require a non-zero denominator. (#3945)

--- a/.changeset/gentle-tunas-rest.md
+++ b/.changeset/gentle-tunas-rest.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**Statusline no longer shows milestone complete at 0 of 0 phases** — the 0-of-0 counters a freshly-roadmapped milestone carries no longer read as every-phase-done (string truthiness made the equality vacuous); both the full and compact renderers now require a non-zero denominator. (#3945)

--- a/hooks/gsd-statusline.js
+++ b/hooks/gsd-statusline.js
@@ -389,8 +389,12 @@ function formatGsdState(s) {
     // Scene 2: idle + a recommended next command is visible to the user.
     // Surfaces "what to run next" without the user opening STATE.md.
     parts.push(`next ${s.nextAction} ${phasesStr}`);
-  } else if (Number(s.percent) === 100 || (s.completedPhases && s.totalPhases && s.completedPhases === s.totalPhases)) {
-    // Scene 3: milestone complete (every phase done).
+  } else if (Number(s.percent) === 100 || (Number(s.totalPhases) > 0 && Number(s.completedPhases) === Number(s.totalPhases))) {
+    // Scene 3: milestone complete (every phase done). #3945: the counters are
+    // regex-captured STRINGS, so the old `cp && tp && cp === tp` guard fired on
+    // the empty set ('0' is truthy, '0' === '0') — "0% · milestone complete".
+    // Numeric coercion + a non-empty denominator makes "nothing to measure"
+    // stop meaning "everything is done".
     parts.push('milestone complete');
   } else {
     // Backward-compatible default — preserved EXACTLY for STATE.md files that
@@ -500,7 +504,7 @@ function formatGsdStateCompact(s) {
   // still completes) wins over milestone-complete (Scene 3), even if a
   // non-atomic STATE.md edit leaves percent=100 alongside a lifecycle phase.
   const done = !s.activePhase && (Number(s.percent) === 100 ||
-    (s.completedPhases && s.totalPhases && s.completedPhases === s.totalPhases));
+    (Number(s.totalPhases) > 0 && Number(s.completedPhases) === Number(s.totalPhases)));
 
   if (done) {
     parts.push('complete');

--- a/tests/gsd-statusline.test.cjs
+++ b/tests/gsd-statusline.test.cjs
@@ -1217,6 +1217,32 @@ describe('formatGsdState #2833 lifecycle scenes', () => {
     });
     assert.equal(out, 'v2.0 · milestone complete');
   });
+
+  // #3945: the counters arrive as regex-captured STRINGS, so '0' is truthy and
+  // '0' === '0' made the "every phase done" guard fire on the empty set —
+  // rendering "0% · milestone complete" for a freshly-roadmapped milestone.
+  test('Scene 3 — 0 of 0 counters does not render milestone complete (#3945)', () => {
+    const out = formatGsdState({
+      milestone: 'v1.15',
+      milestoneName: 'Design Refresh',
+      status: 'planning',
+      completedPhases: '0',
+      totalPhases: '0',
+      percent: '0',
+    });
+    assert.ok(!out.includes('milestone complete'),
+      `0 of 0 phases must not read as complete; got: ${out}`);
+    assert.ok(out.includes('planning'), `default path should render the status; got: ${out}`);
+  });
+
+  test('Scene 3 — boundary denominators: 1/1 completes, 0/1 and 1/0 do not (#3945)', () => {
+    assert.ok(formatGsdState({ milestone: 'v2.0', completedPhases: '1', totalPhases: '1' })
+      .includes('milestone complete'), '1 of 1 done is complete');
+    assert.ok(!formatGsdState({ milestone: 'v2.0', completedPhases: '0', totalPhases: '1' })
+      .includes('milestone complete'), '0 of 1 is not complete');
+    assert.ok(!formatGsdState({ milestone: 'v2.0', completedPhases: '1', totalPhases: '0' })
+      .includes('milestone complete'), '1 of 0 is not a complete milestone');
+  });
 });
 
 // ─── Backward compatibility — CRITICAL: existing STATE.md unchanged ─────────
@@ -1802,6 +1828,8 @@ test('config-set statusline.show_context_tokens yes → rejected', () => {
         { milestone: 'v2.0', completedPhases: '5', totalPhases: '5' },
         { milestone: 'v2.0', activePhase: '4.5', percent: '100', status: 'executing' },
         { milestone: 'v1.9', percent: '40', status: 'executing', phaseNum: '2', phaseTotal: '5' },
+        // #3945: the vacuous 0-of-0 shape must agree on NOT-complete too.
+        { milestone: 'v1.15', status: 'planning', completedPhases: '0', totalPhases: '0', percent: '0' },
       ];
       for (const s of cases) {
         const fullDone = formatGsdState(s).includes('milestone complete');
@@ -1810,6 +1838,18 @@ test('config-set statusline.show_context_tokens yes → rejected', () => {
           `completion parity diverged for ${JSON.stringify(s)}`);
       }
     });
+    test('compact — 0 of 0 counters does not render complete (#3945)', () => {
+      // Same vacuous-equality defect as the full renderer's Scene 3; the
+      // compact completion branch must also require a non-empty denominator.
+      const out = formatGsdStateCompact({
+        milestone: 'v1.15', status: 'planning',
+        completedPhases: '0', totalPhases: '0', percent: '0',
+      });
+      assert.ok(!/(^|\s)complete(\s|$)/.test(out),
+        `0 of 0 phases must not read as complete in compact; got: ${out}`);
+      assert.ok(out.includes('planning'), `compact should render the status; got: ${out}`);
+    });
+
     test('idle with queued next action renders "next <action> <phases>"', () => {
       const out = formatGsdStateCompact({
         milestone: 'v2.0', nextAction: 'execute-phase', nextPhases: ['4.5', '4.6'],


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3945

## What was broken

The statusline rendered `v1.15 Design Refresh [░░░░░░░░░░] 0% · milestone complete` for a milestone with 0 of 0 phases. The completion guards in both renderers compared the regex-captured STRING counters directly, so `'0' && '0' && '0' === '0'` fired Scene 3 on the empty set.

## What this fix does

Both completion guards (`formatGsdState` and the compact renderer) now use `Number(s.totalPhases) > 0 && Number(s.completedPhases) === Number(s.totalPhases)` — numeric coercion plus a non-empty denominator, exactly the shape the issue suggests. The two guards are token-identical, preserving the full/compact parity contract. Safe side-effects: non-numeric junk counters (e.g. `'unknown' === 'unknown'`) that wrongly fired complete before are now rejected; all non-zero and percent=100 shapes render byte-identically.

## Root cause

`completedPhases`/`totalPhases` are captured from STATE.md frontmatter by regex at `hooks/gsd-statusline.js:299-300` as strings; the `&&` pair meant to reject the empty case cannot because `'0'` is truthy. The 0/0 state is reachable and self-sustaining (every milestone between roadmapping and its first plan — see the issue's `state update-progress` #3233 analysis), so the window is wide.

## Testing

### How I verified the fix

- **RED** on test-only sha `e59f54b72`: `gsd-test` verdict `failed` — exactly the two new regression tests (+ describes), 5 failures.
- **GREEN** on fix sha `c15f0e5ea`: verdict `passed`, 41885/41885 on linux-node24, pass marker recorded.
- The isolated adversarial reviewer independently reproduced RED (hook reverted, tests fail) and GREEN.

### Regression test added?

- [x] Yes — `tests/gsd-statusline.test.cjs`: 0-of-0 not complete (full + compact renderers), boundary denominators (1/1, 0/1, 1/0), and the 0/0 case added to the full/compact parity loop.

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux (gsd-test matrix, linux-node24)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [x] Other: runtime-agnostic statusline hook (node)
- [ ] N/A (not runtime-specific)

## Checklist

- [x] Issue linked above with `Fixes #3945`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — presentation-layer guard only; the issue's "possibly related" `state update-progress` layer is deliberately untouched
- [x] Regression test added
- [x] All existing tests pass (gsd-test full matrix on `c15f0e5ea`)
- [x] `.changeset/` fragment added (pr backfilled to this PR's number)
- [x] No unnecessary dependencies added

## Breaking changes

None — every non-vacuous completion shape renders identically; only the 0-of-0 (and junk-string) shapes stop reading as complete.

GSD_PR_GATES_OK=1
