### PR TITLE
test(#3936): tighten quick researcher regression coverage

### DIFF
--- a/tests/init.test.cjs
+++ b/tests/init.test.cjs
@@ -1951,18 +1951,6 @@ describe('cmdInitQuick', () => {
     cleanup(tmpDir);
   });
 
-  test('init quick emits researcher_model', () => {
-    // #3936: the quick research step (Step 4.75) dispatches gsd-phase-researcher,
-    // so init quick must resolve the researcher's own model tier — parity with
-    // init plan-phase (which emits researcher_model for the same agent).
-    const result = runGsdTools('init quick "Fix login bug"', tmpDir);
-    assert.ok(result.success, `Command failed: ${result.error}`);
-
-    const output = JSON.parse(result.output);
-    assert.ok('researcher_model' in output,
-      'init quick should emit researcher_model for the Step 4.75 research dispatch');
-  });
-
   test('init quick resolves researcher_model from model_overrides', () => {
     fs.writeFileSync(path.join(tmpDir, '.planning', 'config.json'), JSON.stringify({
       model_profile: 'balanced',
@@ -5030,4 +5018,3 @@ describe('init — GSD_PROJECT scoping (#3964)', () => {
     assert.equal(out['codebase_dir_exists'], true, 'unscoped probe of the root codebase dir');
   });
 });
-

--- a/tests/quick-research.test.cjs
+++ b/tests/quick-research.test.cjs
@@ -117,77 +117,43 @@ describe('quick workflow: research step', () => {
     );
   });
 
-  test('research step spawns gsd-phase-researcher', () => {
+  test('research Agent uses researcher role bindings end to end', () => {
     content = expandWorkflowSections(workflowPath);
-    const researchSection = content.substring(
-      content.indexOf('Step 4.75'),
-      content.indexOf('Step 5:')
-    );
-    assert.ok(
-      researchSection.includes('subagent_type="gsd-phase-researcher"'),
-      'research step should spawn gsd-phase-researcher agent'
-    );
-  });
+    const researchStart = content.indexOf('Step 4.75');
+    const plannerStart = content.indexOf('Step 5:', researchStart);
+    assert.ok(researchStart !== -1, 'Step 4.75 anchor should exist');
+    assert.ok(plannerStart > researchStart, 'Step 5 should follow Step 4.75');
 
-  test('research step injects the researcher persona, not the planner persona', () => {
-    // #3936: the dispatch targets gsd-phase-researcher, so the persona riding the
-    // prompt and the model tier must be the researcher's own — not the planner's.
-    content = expandWorkflowSections(workflowPath);
-    const researchSection = content.substring(
-      content.indexOf('Step 4.75'),
-      content.indexOf('Step 5:')
-    );
-    assert.ok(
-      researchSection.includes('${AGENT_SKILLS_RESEARCHER}'),
-      'research step should inject the gsd-phase-researcher persona'
-    );
-    assert.ok(
-      !researchSection.includes('${AGENT_SKILLS_PLANNER}'),
-      'research step must not inject the planner persona into a researcher dispatch'
-    );
-    assert.ok(
-      researchSection.includes('model="{researcher_model}"'),
-      'research step should pin the researcher model tier, not planner_model'
-    );
-  });
+    const researchSection = content.slice(researchStart, plannerStart);
+    const agentStart = researchSection.indexOf('Agent(');
+    const agentEnd = researchSection.indexOf('\n)', agentStart);
+    assert.ok(agentStart !== -1, 'research Agent call should exist');
+    assert.ok(agentEnd > agentStart, 'research Agent payload should be non-empty');
+    const researchAgent = researchSection.slice(agentStart, agentEnd);
 
-  test('quick workflow resolves the researcher persona', () => {
-    // #3936: AGENT_SKILLS_RESEARCHER must be resolved in quick.md's Step 2 block,
-    // the way plan-phase.md does, or the Step 4.75 interpolation expands empty.
-    const quickMd = fs.readFileSync(path.join(WORKFLOWS_DIR, 'quick.md'), 'utf8');
-    assert.ok(
-      quickMd.includes('AGENT_SKILLS_RESEARCHER=$(gsd_run query agent-skills gsd-phase-researcher)'),
-      'quick.md should resolve AGENT_SKILLS_RESEARCHER from agent-skills'
-    );
-  });
-
-  test('quick workflow parses researcher_model from init quick', () => {
-    const quickMd = fs.readFileSync(path.join(WORKFLOWS_DIR, 'quick.md'), 'utf8');
-    const parseList = quickMd.substring(
-      quickMd.indexOf('Parse JSON for:'),
-      quickMd.indexOf('```', quickMd.indexOf('Parse JSON for:'))
-    );
-    assert.ok(
-      parseList.includes('researcher_model'),
-      'quick.md parse list should include researcher_model'
-    );
-  });
-
-  test('planner and executor dispatches keep their own personas', () => {
-    // Negative space: #3936 touches only the research dispatch — the planner and
-    // executor spawns must keep their own personas and model tiers.
-    content = expandWorkflowSections(workflowPath);
-    const plannerSection = content.substring(
-      content.indexOf('Step 5: Spawn planner'),
-      content.indexOf('Step 5.5')
-    );
-    assert.ok(
-      plannerSection.includes('${AGENT_SKILLS_PLANNER}'),
-      'planner dispatch should still inject the planner persona'
-    );
-    assert.ok(
-      content.includes('${AGENT_SKILLS_EXECUTOR}'),
-      'executor dispatch should still inject the executor persona'
+    assert.deepStrictEqual(
+      {
+        hostSkillBinding: content.includes(
+          'AGENT_SKILLS_RESEARCHER=$(gsd_run query agent-skills gsd-phase-researcher)'
+        ),
+        modelParsed: content
+          .slice(content.indexOf('Parse JSON for:'), content.indexOf('\n', content.indexOf('Parse JSON for:')))
+          .includes('researcher_model'),
+        researcherPersona: researchAgent.includes('${AGENT_SKILLS_RESEARCHER}'),
+        researcherSubagent: researchAgent.includes('subagent_type="gsd-phase-researcher"'),
+        researcherModel: researchAgent.includes('model="{researcher_model}"'),
+        plannerPersona: researchAgent.includes('${AGENT_SKILLS_PLANNER}'),
+        plannerModel: researchAgent.includes('model="{planner_model}"'),
+      },
+      {
+        hostSkillBinding: true,
+        modelParsed: true,
+        researcherPersona: true,
+        researcherSubagent: true,
+        researcherModel: true,
+        plannerPersona: false,
+        plannerModel: false,
+      }
     );
   });
 


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3936

## What was broken

The quick workflow dispatched `gsd-phase-researcher` with planner persona and model bindings, so research could run under the wrong role contract.

## What this fix does

The production correction landed in #4158. This follow-up preserves the stronger regression guard from davdittrich/gsd-core#5: it scopes the assertions to the actual Step 4.75 `Agent(...)` payload, rejects planner bindings there, and removes redundant workflow-wide checks.

## Root cause

The researcher dispatch reused planner role bindings. The merged fix corrected the workflow; this PR tightens the regression test so the same mismatch cannot pass unnoticed.

## Testing

### How I verified the fix

- `node --test tests/init.test.cjs tests/quick-research.test.cjs` — 273/273 pass
- `npm run lint:ci` — pass
- Exact-SHA critical, Ponytail, Agy, and Claude reviews — pass
- `src/` and `gsd-core/` are byte-identical to `next`

### Regression test added?

- [x] Yes — the bounded Step 4.75 assertion verifies the researcher persona, subagent type, and model while rejecting planner bindings
- [ ] No — explain why:

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (test-only; no runtime implementation changes)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [ ] All existing tests pass (`npm test`) — PR CI is the authoritative full-suite gate
- [x] Test-only follow-up; changeset lint reports no user-facing change
- [x] No unnecessary dependencies added

## Breaking changes

None