### PR TITLE
fix(#3959): give review-prompt plans citable path anchors

### DIFF
--- a/.changeset/clever-moles-rest.md
+++ b/.changeset/clever-moles-rest.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**/gsd-review no longer down-weights plan-grounded reviews for a citation shape the prompt made impossible** — each plan in the review prompt now carries a repo-relative #### path header, and the budget copies are named after their source plan id instead of a bare index, so source-grounded lanes can cite plans in a form the consensus step resolves. (#3959)

--- a/.changeset/clever-moles-rest.md
+++ b/.changeset/clever-moles-rest.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 4170
 ---
 **/gsd-review no longer down-weights plan-grounded reviews for a citation shape the prompt made impossible** — each plan in the review prompt now carries a repo-relative #### path header, and the budget copies are named after their source plan id instead of a bare index, so source-grounded lanes can cite plans in a form the consensus step resolves. (#3959)

--- a/gsd-core/workflows/review.md
+++ b/gsd-core/workflows/review.md
@@ -208,7 +208,8 @@ Provide structured feedback on plan quality, completeness, and risks.
 {research if present}
 
 ### Plans to Review
-{all PLAN.md contents}
+For each `*-PLAN.md` in the phase directory, in glob order, include its full content preceded by a `####` header carrying the plan's **repo-relative path** (e.g. `#### .planning/phases/<phase>/<NN>-PLAN.md`). The path header is the citable anchor for findings about the plan itself — cite it as `<repo-relative plan path>:<line>` (name the heading in prose beside the citation if it helps the reader); reserve `path:line` for repo files the plan references.
+{per-plan: `#### <repo-relative plan path>` + full plan contents}
 
 ## Review Instructions
 
@@ -261,12 +262,15 @@ RUN_DIR="{run_dir}"   # from gather_context
 cp "$INSTRUCTIONS_BLOCK_FILE" "${RUN_DIR}/gsd-review-instructions.md"
 cp "$ROADMAP_SECTION_FILE" "${RUN_DIR}/gsd-review-roadmap.md"
 
-# Plan files: copy each PLAN.md to a predictable numbered path
-PLAN_INDEX=0
+# Plan files: copy each PLAN.md to a predictable path named after its source
+# plan id (#3959: a bare padded index discards provenance — the budget tool's
+# per-plan `### <file>` header then renders a run-dir artifact name no reviewer
+# or consensus step can resolve. The plan id keeps the gsd-review-plan-*.md glob
+# prepare_trimmed_prompt_for_reviewer consumes.)
 for PLAN_FILE in "${PHASE_DIR}"/*-PLAN.md; do
-  PADDED_IDX=$(printf '%02d' "$PLAN_INDEX")
-  cp "$PLAN_FILE" "${RUN_DIR}/gsd-review-plan-${PADDED_IDX}.md"
-  PLAN_INDEX=$((PLAN_INDEX + 1))
+  PLAN_BASENAME=$(basename "$PLAN_FILE")
+  PLAN_ID="${PLAN_BASENAME%-PLAN.md}"
+  cp "$PLAN_FILE" "${RUN_DIR}/gsd-review-plan-${PLAN_ID}.md"
 done
 
 # #3301: plan coverage manifest — tell reviewers exactly which plan ids exist and

--- a/tests/review-build-prompt-optional-sections.test.cjs
+++ b/tests/review-build-prompt-optional-sections.test.cjs
@@ -227,8 +227,11 @@ describe('#3300 build_prompt optional-section guards under nullglob', () => {
         null,
         'gsd-review-research.md must NOT be created when no *-RESEARCH.md exists',
       );
-      // The always-on parts of the block still did their job.
-      assert.strictEqual(readIfPresent(path.join(fx.runDir, 'gsd-review-plan-00.md')), 'plan\n');
+      // The always-on parts of the block still did their job (#3959: the copy
+      // is named after the source plan id, not the bare padded index).
+      assert.strictEqual(readIfPresent(path.join(fx.runDir, 'gsd-review-plan-01.md')), 'plan\n');
+      assert.strictEqual(readIfPresent(path.join(fx.runDir, 'gsd-review-plan-00.md')), null,
+        'the bare-index copy name is gone (#3959)');
     });
 
     test(`[${shell.name}] present optional sources: output matches the source exactly`, (t) => {
@@ -288,6 +291,43 @@ describe('#3300 build_prompt optional-section guards under nullglob', () => {
         + '(#2962) an unmatched glob leaves ls operand-less: it lists the cwd and exits 0, '
         + 'so the guard is always true and the following cat runs operand-less and reads '
         + 'stdin (#3300). Guard on the glob expansion itself instead.',
+    );
+  });
+});
+
+// ─── #3959: plan copies carry source provenance, prompt carries path anchors ──
+
+describe('#3959 plan-copy provenance and path anchors', () => {
+  for (const shell of SHELLS) {
+    test(`[${shell.name}] plan copies are named after their source plan id, not a bare index`, (t) => {
+      const fx = buildFixture({
+        '01-PLAN.md': 'plan one\n',
+        '02-PLAN.md': 'plan two\n',
+      });
+      t.after(() => cleanup(fx.root));
+      const res = runBlock(shell, extractBuildPromptBlock(), fx);
+      assert.strictEqual(res.status, 0, `block exited ${res.status}: ${res.stderr}`);
+      // Source-named copies: reviewers and the budget tool's `### <file>`
+      // header (src/prompt-budget.cts) see a resolvable plan identity, and
+      // the prepare_trimmed_prompt_for_reviewer glob still matches.
+      assert.strictEqual(readIfPresent(path.join(fx.runDir, 'gsd-review-plan-01.md')), 'plan one\n');
+      assert.strictEqual(readIfPresent(path.join(fx.runDir, 'gsd-review-plan-02.md')), 'plan two\n');
+      assert.strictEqual(readIfPresent(path.join(fx.runDir, 'gsd-review-plan-00.md')), null,
+        'bare-index copy names must not survive (#3959)');
+    });
+  }
+
+  test('Plans to Review template carries per-plan repo-relative path headers', () => {
+    // source-text-is-the-product: the workflow markdown IS the assembled
+    // prompt's contract. #3959: plan bodies inlined with no path anchor leave
+    // a source-grounded lane nothing citable that SOURCE_CITATION_RE accepts.
+    const content = readWorkflowCombined(REVIEW_WORKFLOW);
+    const anchorIdx = content.indexOf('### Plans to Review');
+    assert.notEqual(anchorIdx, -1, '### Plans to Review section not found in review.md (+steps)');
+    const section = content.slice(anchorIdx, anchorIdx + 600);
+    assert.ok(
+      /####.*path/i.test(section) || section.includes('#### <repo-relative'),
+      `Plans to Review must instruct a #### path header per plan; got: ${section.slice(0, 200)}`,
     );
   });
 });


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3959

## What was broken

`/gsd-review` inlined each plan's content into the combined prompt but never its path, so a source-grounded lane reviewing plan text had no anchor `SOURCE_CITATION_RE` accepts — plan-line citations are rejected by design (#3194), so correct reviews were stamped `[reviewed-without-source-citations]` and down-weighted. The budget copies (`gsd-review-plan-00.md`, …) also discarded the source name.

## What this fix does

The issue's preferred remedy, both halves:

- The `### Plans to Review` prompt template now instructs a per-plan `####` header carrying the plan's **repo-relative path**, and tells reviewers to cite plan findings as `<repo-relative plan path>:<line>` — a form the consensus step and a human can both resolve and that satisfies `SOURCE_CITATION_RE`.
- The build_prompt copy loop names each budget copy after its source plan id (`gsd-review-plan-<NN>.md` → derived from the plan basename, e.g. `gsd-review-plan-12.6-01.md`), restoring provenance for `prompt-budget`'s per-plan `### <file>` headers while preserving the `gsd-review-plan-*.md` glob that `prepare_trimmed_prompt_for_reviewer` and the manifest-naming guard consume.

Inlining plan bodies is unchanged (the issue explicitly keeps it).

## Root cause

Two provenance drops in `review.md`'s prompt assembly: no path anchor in the template, and index-named copies. See `.gsd/bug/fix-3959-review-plan-path-anchors/10-diagnosis.md`.

## Testing

### How I verified the fix

- **RED** on test-only sha `f1f93e97a`: `gsd-test` verdict `failed` — 5 failures, exactly the new #3959 tests plus the corrected stale `-00` assertion.
- **GREEN** on fix sha `10c19dd03` (41896/41896) and again on the rebased head `c86193708` after next moved (42049/42049, marker recorded). The interim `settings-integrations.md` attribution failure was a moving-base artifact: the runner snapshotted a stale `origin/next` and billed next's own #4161 commit as this branch's growth; the fresh-base run is clean.
- Behavioral tests execute the REAL shipped build_prompt bash block under bash and zsh via the existing #3300 harness.

### Regression test added?

- [x] Yes — `tests/review-build-prompt-optional-sections.test.cjs`: source-named copies (multi-plan), no bare-index copy survives, and the `Plans to Review` template carries the per-plan path-header instruction.

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux (gsd-test linux-node24 full matrix)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [x] Other: runtime-agnostic workflow text + bash block (bash/zsh lanes)
- [ ] N/A (not runtime-specific)

## Checklist

- [x] Issue linked above with `Fixes #3959`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug
- [x] Regression test added
- [x] All existing tests pass (gsd-test full matrix on `c86193708`)
- [x] `.changeset/` fragment added (pr backfilled to this PR's number)
- [x] No unnecessary dependencies added

## Breaking changes

None — prompt template gains an instruction; copy filenames carry the plan id instead of a padded index; every consumer grebs the `gsd-review-plan-*.md` glob, which is preserved.

GSD_PR_GATES_OK=1
