### PR TITLE
fix(#3981): give blocking guards a host-stall-proof timeout budget

### DIFF
--- a/.changeset/brave-eagles-greet.md
+++ b/.changeset/brave-eagles-greet.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**Blocking guards no longer silently disable themselves when the host stalls** — the six blocking PreToolUse guards are registered (and migrated on existing installs) with a 120 s timeout instead of 5 s; Claude Code treats a timed-out hook as non-blocking, so the old budget dropped the gate exactly under load. (#3981)

--- a/.changeset/brave-eagles-greet.md
+++ b/.changeset/brave-eagles-greet.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 4175
 ---
 **Blocking guards no longer silently disable themselves when the host stalls** — the six blocking PreToolUse guards are registered (and migrated on existing installs) with a 120 s timeout instead of 5 s; Claude Code treats a timed-out hook as non-blocking, so the old budget dropped the gate exactly under load. (#3981)

--- a/src/runtime-hooks-surface.cts
+++ b/src/runtime-hooks-surface.cts
@@ -664,6 +664,7 @@ function resolveBashRunner(opts?: BashRunnerOpts): string | null {
 interface HookEntry {
   command?: string;
   args?: unknown[];
+  timeout?: number;
 }
 
 interface HookGroup {
@@ -2048,6 +2049,37 @@ function applySettingsJsonHooks(settings: any, opts: ApplySettingsJsonHooksOpts)
       settings.hooks.SessionStart = [];
     }
 
+    // #3981: Claude Code treats a timed-out hook as NON-blocking — the tool
+    // call continues through the normal permission flow. The blocking
+    // PreToolUse guards therefore need a budget a host stall cannot exceed,
+    // not one sized to the hook's own ~0.1 s runtime. Observed stalls reached
+    // 84.3 s; 120 s is the top of the issue's prescribed 60–120 range and
+    // returns every observed verdict. Registration below uses this constant,
+    // and the migration pass right here raises existing managed entries.
+    const BLOCKING_GUARD_TIMEOUT_S = 120;
+    const blockingGuardNames = [
+      'gsd-prompt-guard',
+      'gsd-workflow-guard',
+      'gsd-worktree-path-guard',
+      'gsd-agent-isolation-guard',
+      'gsd-write-guard',
+      'gsd-validate-commit',
+    ];
+    for (const entries of Object.values(settings.hooks as Record<string, HookGroup[]>)) {
+      if (!Array.isArray(entries)) continue;
+      for (const entry of entries) {
+        if (!entry || !Array.isArray(entry.hooks)) continue;
+        for (const h of entry.hooks) {
+          if (
+            blockingGuardNames.some((name) => referencesHook(h as Record<string, unknown>, name)) &&
+            h.timeout === 5
+          ) {
+            h.timeout = BLOCKING_GUARD_TIMEOUT_S;
+          }
+        }
+      }
+    }
+
     const hasGsdUpdateHook = settings.hooks.SessionStart.some((entry: HookGroup) =>
       entry.hooks && entry.hooks.some((h: HookEntry) => referencesHook(h as Record<string, unknown>, 'gsd-check-update'))
     );
@@ -2138,7 +2170,7 @@ function applySettingsJsonHooks(settings: any, opts: ApplySettingsJsonHooksOpts)
           {
             type: 'command',
             command: promptGuardCommand,
-            timeout: 5
+            timeout: BLOCKING_GUARD_TIMEOUT_S
           }
         ]
       });
@@ -2224,7 +2256,7 @@ function applySettingsJsonHooks(settings: any, opts: ApplySettingsJsonHooksOpts)
           {
             type: 'command',
             command: workflowGuardCommand,
-            timeout: 5
+            timeout: BLOCKING_GUARD_TIMEOUT_S
           }
         ]
       });
@@ -2251,7 +2283,7 @@ function applySettingsJsonHooks(settings: any, opts: ApplySettingsJsonHooksOpts)
           {
             type: 'command',
             command: worktreePathGuardCommand,
-            timeout: 5
+            timeout: BLOCKING_GUARD_TIMEOUT_S
           }
         ]
       });
@@ -2283,7 +2315,7 @@ function applySettingsJsonHooks(settings: any, opts: ApplySettingsJsonHooksOpts)
           {
             type: 'command',
             command: agentIsolationGuardCommand,
-            timeout: 5
+            timeout: BLOCKING_GUARD_TIMEOUT_S
           }
         ]
       });
@@ -2312,7 +2344,7 @@ function applySettingsJsonHooks(settings: any, opts: ApplySettingsJsonHooksOpts)
           {
             type: 'command',
             command: writeGuardCommand,
-            timeout: 5
+            timeout: BLOCKING_GUARD_TIMEOUT_S
           }
         ]
       });
@@ -2339,7 +2371,7 @@ function applySettingsJsonHooks(settings: any, opts: ApplySettingsJsonHooksOpts)
           {
             type: 'command',
             command: validateCommitCommand,
-            timeout: 5
+            timeout: BLOCKING_GUARD_TIMEOUT_S
           }
         ]
       });

--- a/tests/install-minimal-hooks.test.cjs
+++ b/tests/install-minimal-hooks.test.cjs
@@ -3019,3 +3019,138 @@ describe('#3023 pi shared-hooks bundle avoids the host-reserved hooks/ directory
     });
   }
 });
+
+// ─── #3981: blocking PreToolUse guards must not fail open on a host stall ────
+
+describe('bug #3981: blocking-guard timeout budget + migration', () => {
+  let targetDir;
+  beforeEach(() => { targetDir = createTempDir('gsd-3981-'); });
+  afterEach(() => { cleanup(targetDir); });
+
+  // Local to this describe: the #1754 helpers above are scoped to their own
+  // describe, so re-require the seam and rebuild the runner here.
+  const { applySettingsJsonHooks } = require('../gsd-core/bin/lib/runtime-hooks-surface.cjs');
+  const { captureConsole } = require('./helpers.cjs');
+  function runApplySettingsJsonHooks(dir, presentHooks) {
+    fs.mkdirSync(path.join(dir, 'hooks'), { recursive: true });
+    for (const hook of presentHooks) {
+      fs.writeFileSync(path.join(dir, 'hooks', hook), '// stub\n');
+    }
+    const settings = {};
+    const localCmd = (hookFile) => `node ${path.join(dir, 'hooks', hookFile)}`;
+    const localShellCmd = (hookFile) => `bash ${path.join(dir, 'hooks', hookFile)}`;
+    captureConsole(() => {
+      applySettingsJsonHooks(settings, {
+        runtime: 'claude',
+        isGlobal: false,
+        targetDir: dir,
+        postToolEvent: 'PostToolUse',
+        hookEvents: 'claude',
+        extendedHookEvents: [],
+        hooksSurface: 'settings-json',
+        updateCheckCommand: localCmd('gsd-check-update.js'),
+        contextMonitorCommand: localCmd('gsd-context-monitor.js'),
+        promptGuardCommand: localCmd('gsd-prompt-guard.js'),
+        readGuardCommand: localCmd('gsd-read-guard.js'),
+        readInjectionScannerCommand: localCmd('gsd-read-injection-scanner.js'),
+        configReloadCommand: null,
+        hookOpts: { portableHooks: false, runtime: 'claude' },
+        localCmd,
+        localShellCmd,
+      });
+    });
+    return { settings };
+  }
+
+  const BLOCKING_GUARDS = [
+    'gsd-prompt-guard.js',
+    'gsd-workflow-guard.js',
+    'gsd-worktree-path-guard.js',
+    'gsd-agent-isolation-guard.js',
+    'gsd-write-guard.js',
+    'gsd-validate-commit.sh',
+  ];
+
+  test('blocking PreToolUse guards register with a host-stall-proof timeout (#3981)', () => {
+    const { settings } = runApplySettingsJsonHooks(targetDir, ['gsd-prompt-guard.js']);
+    const entry = (settings.hooks.PreToolUse || []).find((e) =>
+      (e.hooks || []).some((h) => h.command && h.command.includes('gsd-prompt-guard.js')));
+    assert.ok(entry, 'prompt guard should be registered on a fresh install');
+    const h = entry.hooks.find((x) => x.command.includes('gsd-prompt-guard.js'));
+    assert.equal(h.timeout, 120,
+      `Claude Code treats a timed-out hook as non-blocking, so a 5 s budget silently disables the gate under host stalls; expected 120, got ${h.timeout}`);
+  });
+
+  test('managed timeout:5 blocking-guard entries are migrated to 120 (#3981)', () => {
+    // Same shape as the context-monitor backfill: raising the source constant
+    // alone never reaches an existing settings.json, because registration
+    // skips entries whose command is already referenced.
+    for (const guard of BLOCKING_GUARDS) {
+      const settings = {
+        hooks: {
+          PreToolUse: [{
+            matcher: 'Write|Edit',
+            hooks: [{ type: 'command', command: `node ${path.join(targetDir, 'hooks', guard)}`, timeout: 5 }],
+          }],
+        },
+      };
+      const localCmd = (hookFile) => `node ${path.join(targetDir, 'hooks', hookFile)}`;
+      captureConsole(() => {
+        applySettingsJsonHooks(settings, {
+          runtime: 'claude',
+          isGlobal: false,
+          targetDir,
+          postToolEvent: 'PostToolUse',
+          hookEvents: 'claude',
+          extendedHookEvents: [],
+          hooksSurface: 'settings-json',
+          updateCheckCommand: null,
+          contextMonitorCommand: null,
+          promptGuardCommand: null,
+          readGuardCommand: null,
+          readInjectionScannerCommand: null,
+          configReloadCommand: null,
+          hookOpts: { portableHooks: false, runtime: 'claude' },
+          localCmd,
+          localShellCmd: localCmd,
+        });
+      });
+      const h = settings.hooks.PreToolUse[0].hooks[0];
+      assert.equal(h.timeout, 120,
+        `existing managed ${guard} entry at timeout:5 must be migrated to 120, got ${h.timeout}`);
+    }
+  });
+
+  test('non-managed timeout:5 entries are left alone (#3981)', () => {
+    const mine = { type: 'command', command: 'node /usr/local/bin/my-own-hook.js', timeout: 5 };
+    const settings = { hooks: { PreToolUse: [{ matcher: 'Write', hooks: [mine] }] } };
+    const localCmd = (hookFile) => `node ${path.join(targetDir, 'hooks', hookFile)}`;
+    captureConsole(() => {
+      applySettingsJsonHooks(settings, {
+        runtime: 'claude', isGlobal: false, targetDir,
+        postToolEvent: 'PostToolUse', hookEvents: 'claude', extendedHookEvents: [],
+        hooksSurface: 'settings-json', updateCheckCommand: null, contextMonitorCommand: null,
+        promptGuardCommand: null, readGuardCommand: null, readInjectionScannerCommand: null,
+        configReloadCommand: null, hookOpts: { portableHooks: false, runtime: 'claude' },
+        localCmd, localShellCmd: localCmd,
+      });
+    });
+    assert.equal(mine.timeout, 5, 'the migration must only touch entries referencing managed GSD guards');
+  });
+
+  test('advisory hook budgets are unchanged (#3981)', () => {
+    const { settings } = runApplySettingsJsonHooks(targetDir, ['gsd-read-guard.js', 'gsd-context-monitor.js']);
+    const events = Object.values(settings.hooks).flat();
+    const findTimeout = (basename) => {
+      for (const entry of events) {
+        if (!Array.isArray(entry.hooks)) continue;
+        for (const h of entry.hooks) {
+          if (h.command && h.command.includes(basename)) return h.timeout;
+        }
+      }
+      return undefined;
+    };
+    assert.equal(findTimeout('gsd-read-guard.js'), 5, 'advisory read guard keeps its 5 s budget');
+    assert.equal(findTimeout('gsd-context-monitor.js'), 10, 'context monitor keeps its 10 s budget');
+  });
+});


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3981

## What was broken

`applySettingsJsonHooks` registered every managed hook with `timeout: 5`, including the six blocking PreToolUse guards. Claude Code documents that a timed-out hook does **not** block — so any host stall over 5 s silently disabled the gates, exactly when the machine is under load (parallel executor waves, swap, Game Mode throttling). The issue's transcript archaeology: 117 `hook_cancelled` events in ~25 days, 23 of them on real blocking gates, max observed stall 84.3 s — while the hooks themselves run in ~0.1 s.

## What this fix does

- Registers the six blocking guards (`gsd-prompt-guard`, `gsd-workflow-guard`, `gsd-worktree-path-guard`, `gsd-agent-isolation-guard`, `gsd-write-guard`, `gsd-validate-commit`) with `timeout: 120` (top of the issue's prescribed 60–120 range; covers every observed stall).
- Adds a migration pass in the context-monitor-backfill shape: existing managed entries carrying `timeout: 5` for those six names are raised to 120 — raising the source constant alone never reaches an existing `settings.json`, since registration skips entries whose command is already referenced.
- Advisory budgets unchanged (read-guard 5, context-monitor 10, PostToolUse hooks 5); non-managed entries never touched; `async: true` deliberately not used (removes blocking ability).

## Root cause

The timeout constant was sized to the hook's own runtime rather than the host-stall fail-open semantics of Claude Code's hook timeout.

## Testing

### How I verified the fix

- **RED** on test-only sha `285e4ac50`: `gsd-test` verdict `failed` — exactly the two regression rows (fresh-registration timeout, 5→120 migration) plus their describe; the two negative-space guards passed, proving the harness discriminates.
- **GREEN** on fix sha `e5585adc7`: verdict `passed`, 42055/42055 on linux-node24, marker recorded.
- Tests drive the real exported `applySettingsJsonHooks` seam (same convention as the #1754 suite).

### Regression test added?

- [x] Yes — fresh registration carries 120; all six guard names migrate from 5; a non-managed `timeout:5` entry is left alone; advisory budgets stay 5/10.

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux (gsd-test linux-node24 full matrix)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [ ] N/A (not runtime-specific)

## Checklist

- [x] Issue linked above with `Fixes #3981`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — Claude settings.json surface only; kimi TOML deliberately untouched (its host's timeout semantics are not established by the issue)
- [x] Regression test added
- [x] All existing tests pass (gsd-test full matrix on `e5585adc7`)
- [x] `.changeset/` fragment added (pr backfilled to this PR's number)
- [x] No unnecessary dependencies added

## Breaking changes

None — a longer hook timeout only widens the window in which a guard can still return its verdict; hook code and matchers are unchanged.

GSD_PR_GATES_OK=1
