### PR TITLE
fix(#4196): bump fast-uri past GHSA-jqff-g426-hqxp (transitive, advisory reddened next)

### DIFF
--- a/.changeset/clever-ibex-glide.md
+++ b/.changeset/clever-ibex-glide.md
@@ -1,5 +1,5 @@
 ---
 type: Security
-pr: 0
+pr: 4199
 ---
 **Cleared a high-severity transitive advisory in `fast-uri`** — bumped past GHSA-jqff-g426-hqxp so `next`'s production dependency tree stays clean of disclosed CVEs. (#4196)

--- a/.changeset/clever-ibex-glide.md
+++ b/.changeset/clever-ibex-glide.md
@@ -1,0 +1,5 @@
+---
+type: Security
+pr: 0
+---
+**Cleared a high-severity transitive advisory in `fast-uri`** — bumped past GHSA-jqff-g426-hqxp so `next`'s production dependency tree stays clean of disclosed CVEs. (#4196)

--- a/package-lock.json
+++ b/package-lock.json
@@ -3240,9 +3240,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #4196

---

## What was broken

`next` (tip `dce40eeb6e`) is red: `fast-uri@3.1.5` carries **GHSA-jqff-g426-hqxp** (high), tripping the `#3588: npm audit --omit=dev reports zero advisories` gate in `tests/npm-integrity-gate.test.cjs`. The advisory was disclosed *after* PR #4188's own pre-merge CI ran (which passed the same gate on all 3 OSes), so the identical commit flipped from green to red ~15 minutes later on the post-merge `push` run.

## What this fix does

Bumps `fast-uri` to the patched `3.1.7` in `package-lock.json`. Zero source changes — pure transitive dependency bump.

## Root cause

`tests/npm-integrity-gate.test.cjs`'s `auditProductionVulns()` shells out to live `npm audit --omit=dev --json` with no snapshot pinning, wired as a required check on both `pull_request` and `push` to `next`. Because the npm/GHSA advisory database updates continuously and independently of repo state, a commit's dependency tree can be judged clean at PR-check time and vulnerable minutes later at merge time — through no fault of the PR. Full RCA is in #4196.

## Testing

### How I verified the fix

- Confirmed the break: `npm audit --omit=dev --json` against the pre-fix lockfile reports 1 high (fast-uri/GHSA-jqff-g426-hqxp), matching the CI failure (run [33654228326](https://github.com/open-gsd/gsd-core/actions/runs/33654228326)) exactly.
- Applied the bump, re-ran: `npm audit --omit=dev --json` → `{"info":0,"low":0,"moderate":0,"high":0,"critical":0,"total":0}`.
- `gsd-test --base next --head c3953e8451a0b8a1cce46d237ca679e0133eec10`: **passed**, 42199/42199, 0 failures.

### Regression test added?

- [x] No — explain why: the regression coverage already exists (`tests/npm-integrity-gate.test.cjs`, `#3588` suite) and is what caught this; it was RED for the right reason before this fix and is GREEN after. No new test needed for a pure lockfile bump.

### Platforms tested

- [x] Linux (gsd-test full matrix)
- [ ] macOS
- [ ] Windows (including backslash path handling)

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`gsd-test`)
- [x] `.changeset/` fragment added
- [x] No unnecessary dependencies added

## Breaking changes

None
