### PR TITLE
ci(#4196): auto-merge Dependabot patch/minor bumps once required checks pass

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,52 @@
+name: Dependabot Auto-Merge
+
+# #4196: Dependabot already opens a correct fix PR within minutes of a new
+# advisory landing (e.g. #4193 for GHSA-jqff-g426-hqxp), but nothing merged
+# it — it just sat until a human noticed `next` had gone red on the
+# `npm audit --omit=dev` gate and someone else's unrelated PR tripped over
+# it. This closes that gap: patch/minor Dependabot PRs are approved and
+# handed to GitHub's native auto-merge the moment they're opened, so they
+# land the instant required checks (including the audit gate) go green —
+# without waiting on a human to notice. Major-version bumps always need a
+# human; they're excluded below.
+
+on:
+  pull_request:
+    branches:
+      - next
+
+permissions:
+  pull-requests: write
+
+concurrency:
+  group: dependabot-auto-merge-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  auto-merge:
+    # Defense-in-depth: check both the triggering actor and the PR author.
+    # github.actor alone can't be forged to a different login, but pairing it
+    # with pull_request.user.login is GitHub's documented hardening pattern.
+    if: |
+      github.actor == 'dependabot[bot]' &&
+      github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98  # v3.1.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Approve and enable auto-merge (patch/minor only)
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
+        run: |
+          gh pr review --approve "$PR_URL" \
+            --body "Auto-approved: Dependabot $UPDATE_TYPE bump. Merges automatically once required checks pass."
+          gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #4196

---

## What was broken

`next` keeps going red from `npm audit` gate failures that no PR caused — a new advisory lands in the npm/GHSA registry, and the *next* commit to touch `next` inherits the failure. Dependabot already opens a correct fix PR fast (e.g. #4193, for the fast-uri advisory fixed in #4199), but nothing automatically merges it — the PR just sits until a human notices `next` is red and manually intervenes, sometimes hours later, and sometimes by bolting an unrelated dependency bump onto someone else's in-flight branch (see #4196 for the concrete example of that happening).

## What this fix does

Adds `.github/workflows/dependabot-auto-merge.yml`: on a Dependabot PR against `next`, it classifies the update type via `dependabot/fetch-metadata`, and for patch/minor bumps only, auto-approves the PR and enables GitHub's native auto-merge. The PR still has to pass every required check (including the `npm audit` gate itself) before it actually merges — this only removes the "wait for a human to notice and click merge" step. Major-version bumps are excluded and still require a human.

Also enabled `allow_auto_merge` on the repo (was `false`, which is why #4193 could never have auto-merged even if this workflow had existed).

## Root cause

See #4196 for the full RCA. In short: `next`'s dependency-vulnerability gate depends on live, externally-mutable state (the npm/GHSA advisory database), so it can't be made fully deterministic — but the remediation channel that already exists (Dependabot) can be made to close the gap automatically instead of waiting on a human.

## Testing

### How I verified the fix

- `gsd-test --base next --head 2ea59358641835f6b13ae9a6f9e16b90453b136e`: **passed**, 42206/42206, 0 failures.
- Verified the pinned `dependabot/fetch-metadata@25dd0e...` SHA against the live GitHub API matches the `v3.1.0` tag exactly.
- Two isolated review passes (correctness + security) each ran against this workflow file; both raised findings that are fixed in the pushed commit — least-privilege (dropped unused `contents: write`), script-injection hardening (moved `update-type` interpolation into `env:`), and defense-in-depth on the actor check (added `pull_request.user.login` alongside `github.actor`).

### Regression test added?

- [ ] No — explain why: this is a GitHub Actions workflow with no local execution path; it can only be exercised by an actual Dependabot PR hitting `next`. Behavior will be observable the next time Dependabot opens a patch/minor PR.

### Platforms tested

- [x] N/A (not platform-specific — runs on `ubuntu-latest` in Actions)

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`gsd-test`)
- [x] No unnecessary dependencies added

## Breaking changes

None. `allow_auto_merge` being enabled means any *future* PR (not just Dependabot's) could have auto-merge toggled on by someone with write access — this doesn't change who can approve/merge, only removes the need to be present when checks finally go green.
