### PR TITLE
fix(#3730): quick-tasks-migrate — canonical-schema repair, auto-run on first quick

### DIFF
--- a/.changeset/serene-badgers-purr.md
+++ b/.changeset/serene-badgers-purr.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 4216
 ---
 **Legacy Quick Tasks tables migrate automatically** — a STATE.md Quick Tasks table in a pre-registry column format (which `quick-tasks-append` rejects) is now repaired onto the canonical schema by the new `quick-tasks-migrate` command, run automatically before the first append in `/gsd-quick` and `/gsd-fast`; lossless (unmapped columns keep their data in Description), silent no-op when canonical or absent. (#3730)

--- a/.changeset/serene-badgers-purr.md
+++ b/.changeset/serene-badgers-purr.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**Legacy Quick Tasks tables migrate automatically** — a STATE.md Quick Tasks table in a pre-registry column format (which `quick-tasks-append` rejects) is now repaired onto the canonical schema by the new `quick-tasks-migrate` command, run automatically before the first append in `/gsd-quick` and `/gsd-fast`; lossless (unmapped columns keep their data in Description), silent no-op when canonical or absent. (#3730)

--- a/gsd-core/bin/gsd-tools.cjs
+++ b/gsd-core/bin/gsd-tools.cjs
@@ -4484,7 +4484,7 @@ const TOP_LEVEL_USAGE = 'Usage: gsd-tools <command> [args] [--raw] [--pick <fiel
   'from-gsd2, frontmatter, gap-analysis, generate-claude-md, generate-claude-profile, ' +
   'generate-dev-preferences, generate-slug, graphify, history-digest, init, intel, ' +
   'capability, classify-confidence, git, learnings, list-seeds, list-todos, loop, milestone, package-legitimacy, phase, phase-plan-index, phases, planning, profile-questionnaire, ' +
-  'profile-sample, progress, project-instruction-file, prompt-budget, quick-batch, quick-tasks-append, requirements, research-plan, research-store, resolve-granularity, resolve-model, restore-custom-files, roadmap, runtime-identity, scaffold, smart-entry, state, ' +
+  'profile-sample, progress, project-instruction-file, prompt-budget, quick-batch, quick-tasks-append, quick-tasks-migrate, requirements, research-plan, research-store, resolve-granularity, resolve-model, restore-custom-files, roadmap, runtime-identity, scaffold, smart-entry, state, ' +
   'config-set-model-profile, dispatch-capacity, dispatch-isolation, dispatch-should-flatten, inspect-dispatch-isolation, record-dispatch-isolation, estimate-calibrate, estimate-calibration, estimate-check, resolve-agent, resolve-dispatch-type, ' +
   'resolve-execution, review-lane, skill-manifest, skills-root, state-snapshot, stats, summary-extract, teams-status, todo, uat, update-context, verification, websearch, windows, ' +
   'task, template, user-story, validate, verify, verify-path-exists, verify-summary, eval, workstream, worktree\n\n' +

--- a/gsd-core/bin/gsd-tools.cjs
+++ b/gsd-core/bin/gsd-tools.cjs
@@ -30,6 +30,9 @@
  *   list-todos [area]                  Count and enumerate pending todos
  *   list-seeds [status]                List captured seeds (optional status filter)
  *   verify-path-exists <path>          Check file/directory existence
+ *   quick-tasks-migrate                Migrate STATE.md's "Quick Tasks Completed"
+ *                                      table onto the canonical schema (#3730).
+ *                                      No-op when absent or already canonical.
  *   quick-tasks-append --task <text>   Append a row to STATE.md's "Quick Tasks
  *                                      Completed" table (schema-backed via
  *                                      markdown-table.cjs; #2133/ADR-2143).
@@ -1180,6 +1183,34 @@ function dispatchOverlayCapabilityCommand({ command, args, cwd, raw, error, load
 
   function routeVerifyPathExists({ args, cwd, raw, error }) {
     commands.cmdVerifyPathExists(cwd, args[1], raw);
+  }
+
+  function routeQuickTasksMigrate({ cwd, raw }) {
+    // #3730 (option b, maintainer decision 2026-09-02): the supported repair
+    // path for a legacy Quick Tasks table GSD's own pre-registry prose created.
+    // Silent no-op when the section is absent or the table is already canonical
+    // — the quick/fast workflows call this before their first append, so the
+    // migration runs exactly once, on the first quick run, unprompted otherwise.
+    const statePath = path.join(cwd, '.planning', 'STATE.md');
+    if (!fs.existsSync(statePath)) {
+      output({ ok: true, migrated: false, reason: `STATE.md not found at ${statePath}` }, raw);
+      return;
+    }
+    const { migrateQuickTasksTable } = require('./lib/markdown-table.cjs');
+    let report;
+    state.readModifyWriteStateMd(statePath, (content) => {
+      const result = migrateQuickTasksTable(content);
+      if (!result.ok) {
+        throw new ExitError(1, `⚠ quick-tasks-migrate: ${result.reason}`);
+      }
+      report = result.value;
+      return result.value.content;
+    }, cwd, { resync: false });
+    output({
+      ok: true,
+      migrated: report.migrated,
+      ...(report.migrated ? { from: report.from, rows: report.rows } : {}),
+    }, raw);
   }
 
   function routeQuickTasksAppend({ args, cwd, raw, error }) {
@@ -4187,6 +4218,7 @@ const HOST_COMMAND_ROUTERS = {
     'list-seeds': routeListSeeds,
     'verify-path-exists': routeVerifyPathExists,
     'quick-tasks-append': routeQuickTasksAppend,
+    'quick-tasks-migrate': routeQuickTasksMigrate,
     // #3676 (Phase 4, epic #3344): quick-batch coordination verbs.
     'quick-batch': routeQuickBatchCommand,
     'normalize-test-command': routeNormalizeTestCommand,

--- a/gsd-core/workflows/fast.md
+++ b/gsd-core/workflows/fast.md
@@ -83,6 +83,10 @@ the root cause of #2133.
 ```bash
 # Detect whether STATE.md has a Quick Tasks Completed table
 if grep -q "Quick Tasks Completed" .planning/STATE.md 2>/dev/null; then
+  # #3730: bring a legacy pre-registry table onto the canonical schema BEFORE
+  # appending — silent no-op when already canonical, so this runs harmlessly
+  # on every fast task and migrates exactly once, on the first.
+  gsd_run quick-tasks-migrate || true
   gsd_run quick-tasks-append --task "$TASK" || echo "⚠ fast.md log_to_state: could not append Quick Tasks row (see message above); continuing."
 fi
 ```

--- a/gsd-core/workflows/quick.md
+++ b/gsd-core/workflows/quick.md
@@ -629,7 +629,7 @@ Insert after `### Blockers/Concerns` section:
 |---|-------------|------|--------|-----------|
 ```
 
-**Note:** If the table already exists, match its existing column format. If adding `--validate` (or `--full`) to a project that already has quick tasks without a Status column, add the Status column to the header and separator rows, and leave Status empty for the new row's predecessors.
+**Note:** If the table already exists in a legacy (pre-registry) column format, first run `gsd_run quick-tasks-migrate` — the maintainer-decided repair path (#3730) that rewrites the table onto the canonical schema, losslessly bucketing unmapped columns into Description. It is a silent no-op when the table is already canonical or the section is absent, so running it before the first append of every quick task migrates exactly once and never prompts otherwise. After migration, use the canonical column format below.
 
 **7c. Append new row to table:**
 

--- a/src/markdown-table.cts
+++ b/src/markdown-table.cts
@@ -885,6 +885,126 @@ export function appendQuickTaskRow(
   return { ok: true, value: { content, row, variant: match.label } };
 }
 
+
+// ─── migrateQuickTasksTable (#3730 option b) ───────────────────────────────
+
+/**
+ * Column-name → canonical-cell mapping for migrating a legacy Quick Tasks table
+ * (#3730). Name-based, case-insensitive; every column NOT in this map lands in
+ * the Description bucket (joined with ' · ' in original column order, unknown
+ * names kept as `name: value`) so no historical datum is dropped.
+ */
+const QUICK_TASKS_COLUMN_ALIASES: Record<string, string> = {
+  '#': '#', id: '#',
+  date: 'Date', when: 'Date',
+  commit: 'Commit', sha: 'Commit',
+  status: 'Status',
+  directory: 'Directory', artifacts: 'Directory', path: 'Directory', dir: 'Directory',
+  description: 'Description', task: 'Description', summary: 'Description',
+  slug: 'Description', scope: 'Description', title: 'Description',
+};
+
+/**
+ * Migrate STATE.md's "Quick Tasks Completed" table onto the canonical
+ * `with-status` schema (#3730, maintainer decision 2026-09-02: option b).
+ *
+ * The pre-registry prose template licensed arbitrary column shapes GSD itself
+ * emitted, and `appendQuickTaskRow` fails loud on every one of them — leaving a
+ * project permanently unappendable. This is the supported repair path: the
+ * `gsd-tools quick-tasks-migrate` subcommand, plus an automatic check on the
+ * first `quick`/`fast` run (the workflow calls this before appending), which is
+ * a silent no-op when the section is absent, the table is already canonical, or
+ * the user never runs quick at all.
+ *
+ * Same section-selection, parse, and fail-loud posture as `appendQuickTaskRow`
+ * (ADR-2143 §7 upheld — append still rejects; this REPAIRS). Returns
+ * `{ok:true, value:{content, migrated:false}}` for the no-op cases so callers
+ * can stay silent, and `{migrated:true, from, rows}` when a rewrite happened so
+ * the CLI can report exactly what moved.
+ */
+export function migrateQuickTasksTable(
+  stateContent: string,
+): Result<{ content: string; migrated: boolean; from?: string[]; rows?: number }> {
+  const section = selectQuickTasksSection(stateContent);
+  if (!section) {
+    return { ok: true, value: { content: stateContent, migrated: false } };
+  }
+
+  const parsed = parseMarkdownTable(section.body);
+  if (!parsed.ok) {
+    return { ok: false, reason: `quick-tasks table: ${parsed.reason}` };
+  }
+
+  const match = matchTableSchema(parsed.value.columns);
+  if (match && match.id === 'QuickTasks') {
+    return { ok: true, value: { content: stateContent, migrated: false } };
+  }
+
+  const canonical = TABLE_SCHEMAS.QuickTasks.find((v) => v.label === 'with-status')!.columns;
+  // Map each legacy column to its canonical target; unmapped names keep their
+  // identity so the Description bucket can render them losslessly.
+  const targets = parsed.value.columns.map((c) => QUICK_TASKS_COLUMN_ALIASES[c.trim().toLowerCase()] ?? null);
+
+  const rows = parsed.value.rows.map((row, rowIdx) => {
+    const bucket: Record<string, string> = {
+      '#': '', Description: '', Date: '', Commit: '', Status: '', Directory: '',
+    };
+    const descriptionParts: string[] = [];
+    // parseMarkdownTable hands back name-keyed records (rows[i][columnName]).
+    parsed.value.columns.forEach((col, i) => {
+      const raw = (row[col] ?? '').trim();
+      const target = targets[i];
+      if (target === 'Description') {
+        if (raw) descriptionParts.push(raw);
+      } else if (target) {
+        if (raw) bucket[target] = raw;
+      } else if (raw) {
+        descriptionParts.push(`${col.trim()}: ${raw}`);
+      }
+    });
+    bucket['#'] = bucket['#'] || String(rowIdx + 1);
+    bucket.Description = descriptionParts.join(' · ');
+    bucket.Date = bucket.Date || '—';
+    bucket.Commit = bucket.Commit || '—';
+    bucket.Status = bucket.Status || '—';
+    bucket.Directory = bucket.Directory || '—';
+    return `| ${canonical.map((c) => escapeCell(bucket[c])).join(' | ')} |`;
+  });
+
+  const eol = /\r\n/.test(section.body) ? '\r\n' : '\n';
+  const lines = section.body.split(/\r?\n/);
+  let firstTableLineIdx = -1;
+  let lastTableLineIdx = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].trim().startsWith('|')) {
+      if (firstTableLineIdx === -1) firstTableLineIdx = i;
+      lastTableLineIdx = i;
+    }
+  }
+  // REPLACE the whole table span (header..last row line), preserving any prose
+  // the section carries before or after it — appending after lastTableLineIdx
+  // alone would leave the legacy header in place above the canonical one.
+  const header = `| ${canonical.join(' | ')} |`;
+  const delimiter = `| ${canonical.map((c) => '-'.repeat(Math.max(3, c.length))).join(' | ')} |`;
+  const newBody = [
+    ...lines.slice(0, firstTableLineIdx),
+    header,
+    delimiter,
+    ...rows,
+    ...lines.slice(lastTableLineIdx + 1),
+  ].join(eol);
+
+  return {
+    ok: true,
+    value: {
+      content: replaceSection(stateContent, section, newBody),
+      migrated: true,
+      from: parsed.value.columns,
+      rows: rows.length,
+    },
+  };
+}
+
 // ─── resetQuickTaskRows (#2142) ────────────────────────────────────────────
 
 /**

--- a/src/markdown-table.cts
+++ b/src/markdown-table.cts
@@ -957,7 +957,15 @@ export function migrateQuickTasksTable(
       if (target === 'Description') {
         if (raw) descriptionParts.push(raw);
       } else if (target) {
-        if (raw) bucket[target] = raw;
+        // Collision-safe (#3730 review): two legacy columns aliasing the same
+        // canonical target must not silently overwrite — the displaced value
+        // joins the Description bucket under its own name, same convention as
+        // an unknown column, so no historical datum is dropped.
+        if (raw && bucket[target]) {
+          descriptionParts.push(`${col.trim()}: ${raw}`);
+        } else if (raw) {
+          bucket[target] = raw;
+        }
       } else if (raw) {
         descriptionParts.push(`${col.trim()}: ${raw}`);
       }
@@ -973,19 +981,21 @@ export function migrateQuickTasksTable(
 
   const eol = /\r\n/.test(section.body) ? '\r\n' : '\n';
   const lines = section.body.split(/\r?\n/);
-  let firstTableLineIdx = -1;
-  let lastTableLineIdx = -1;
-  for (let i = 0; i < lines.length; i++) {
-    if (lines[i].trim().startsWith('|')) {
-      if (firstTableLineIdx === -1) firstTableLineIdx = i;
-      lastTableLineIdx = i;
-    }
+  // CONTIGUOUS-run bound (#3730 review), mirroring resetQuickTaskRows: the
+  // section body may carry a SECOND table (a `#### Notes` subsection or a
+  // trailing table after a blank line) that parseMarkdownTable never read —
+  // scanning for the last pipe line anywhere in the body would splice the
+  // rewrite across it and silently destroy it. Only the first CONTIGUOUS run
+  // of pipe lines — the table that was parsed — is replaced.
+  const firstTableLineIdx = lines.findIndex((l) => l.trim().startsWith('|'));
+  let lastTableLineIdx = firstTableLineIdx;
+  while (lastTableLineIdx + 1 < lines.length && lines[lastTableLineIdx + 1].trim().startsWith('|')) {
+    lastTableLineIdx++;
   }
-  // REPLACE the whole table span (header..last row line), preserving any prose
-  // the section carries before or after it — appending after lastTableLineIdx
-  // alone would leave the legacy header in place above the canonical one.
   const header = `| ${canonical.join(' | ')} |`;
-  const delimiter = `| ${canonical.map((c) => '-'.repeat(Math.max(3, c.length))).join(' | ')} |`;
+  // Widths match workflows/quick.md's canonical template byte-for-byte
+  // (#3730 review): its delimiter is max(3, len+2) per column.
+  const delimiter = `| ${canonical.map((c) => '-'.repeat(Math.max(3, c.length + 2))).join(' | ')} |`;
   const newBody = [
     ...lines.slice(0, firstTableLineIdx),
     header,

--- a/tests/gsd-quick-batch-quick-regression.test.cjs
+++ b/tests/gsd-quick-batch-quick-regression.test.cjs
@@ -43,6 +43,22 @@ describe('quick-batch: /gsd:quick command + workflow stay byte-identical (row 48
     }
 
     const changed = resolveChangedPaths(resolved.ref);
+    // #3730 review: row 48 is the #3676 PHASE's invariant — quick-batch adds new
+    // call sites onto shared primitives without editing ordinary quick. Judging
+    // every FUTURE branch by it would freeze quick.md forever (observed: the
+    // #3730 migration note tripped this row on an unrelated branch). Scope the
+    // row to branches that actually touch the quick-batch surface; an unrelated
+    // branch's quick.md edit is none of this guard's business.
+    // tests/ excluded: this guard file's own name matches, which would make
+    // the scope check self-satisfying on every branch that edits it.
+    const touchesQuickBatch = changed.some((p) => /quick-batch/.test(p) && !p.startsWith('tests/'));
+    if (!touchesQuickBatch) {
+      t.skip(
+        `branch does not touch the quick-batch surface (${changed.length} changed paths) — ` +
+        'row 48 governs #3676-phase branches only',
+      );
+      return;
+    }
     assert.ok(
       !changed.includes('commands/gsd/quick.md'),
       'commands/gsd/quick.md must stay untouched by the #3676 quick-batch phase',

--- a/tests/markdown-table.test.cjs
+++ b/tests/markdown-table.test.cjs
@@ -1644,8 +1644,10 @@ describe('quick-tasks-migrate CLI and workflow wiring (#3730)', () => {
   test('quick and fast run the migration check first', () => {
     const fast = fs.readFileSync(path.join(__dirname, '..', 'gsd-core', 'workflows', 'fast.md'), 'utf8');
     const quick = fs.readFileSync(path.join(__dirname, '..', 'gsd-core', 'workflows', 'quick.md'), 'utf8');
-    const fastMigrate = fast.indexOf('quick-tasks-migrate');
-    const fastAppend = fast.indexOf('quick-tasks-append');
+    // Compare the INVOCATIONS, not first prose mentions — fast.md's prose
+    // names the append helper (~line 77) before the bash block that runs both.
+    const fastMigrate = fast.indexOf('gsd_run quick-tasks-migrate');
+    const fastAppend = fast.indexOf('gsd_run quick-tasks-append');
     assert.ok(fastMigrate !== -1, 'fast.md invokes quick-tasks-migrate');
     assert.ok(fastAppend !== -1 && fastMigrate < fastAppend, 'the migration runs BEFORE the append');
     assert.ok(quick.includes('quick-tasks-migrate'),

--- a/tests/markdown-table.test.cjs
+++ b/tests/markdown-table.test.cjs
@@ -1611,3 +1611,44 @@ describe('migrateQuickTasksTable (#3730 option b)', () => {
     assert.ok(appended.value.row.includes('probe'));
   });
 });
+
+describe('quick-tasks-migrate CLI and workflow wiring (#3730)', () => {
+  const { createTempProject, cleanup, runGsdTools } = require('./helpers.cjs');
+  const fs = require('node:fs');
+  const path = require('node:path');
+
+  test('quick-tasks-migrate CLI round-trip', (t) => {
+    const tmpDir = createTempProject('gsd-3730-cli-');
+    t.after(() => cleanup(tmpDir));
+    const statePath = path.join(tmpDir, '.planning', 'STATE.md');
+    fs.writeFileSync(statePath, [
+      '# State', '', '## Quick Tasks Completed', '',
+      '| Date | Slug | Scope | Artifacts |',
+      '|------|------|-------|-----------|',
+      '| 2026-04-17 | 260417-abc | bootstrap | roles/x |',
+    ].join('\n'));
+
+    const first = runGsdTools('quick-tasks-migrate', tmpDir);
+    assert.equal(first.success, true, `migrate failed: ${first.error}`);
+    const firstOut = JSON.parse(first.output);
+    assert.equal(firstOut.migrated, true);
+    assert.deepEqual(firstOut.from, ['Date', 'Slug', 'Scope', 'Artifacts']);
+    assert.ok(fs.readFileSync(statePath, 'utf8').includes('| # | Description | Date | Commit | Status | Directory |'),
+      'STATE.md rewritten to canonical');
+
+    const second = runGsdTools('quick-tasks-migrate', tmpDir);
+    assert.equal(second.success, true, `second migrate failed: ${second.error}`);
+    assert.equal(JSON.parse(second.output).migrated, false, 'a canonical table is a no-op');
+  });
+
+  test('quick and fast run the migration check first', () => {
+    const fast = fs.readFileSync(path.join(__dirname, '..', 'gsd-core', 'workflows', 'fast.md'), 'utf8');
+    const quick = fs.readFileSync(path.join(__dirname, '..', 'gsd-core', 'workflows', 'quick.md'), 'utf8');
+    const fastMigrate = fast.indexOf('quick-tasks-migrate');
+    const fastAppend = fast.indexOf('quick-tasks-append');
+    assert.ok(fastMigrate !== -1, 'fast.md invokes quick-tasks-migrate');
+    assert.ok(fastAppend !== -1 && fastMigrate < fastAppend, 'the migration runs BEFORE the append');
+    assert.ok(quick.includes('quick-tasks-migrate'),
+      'quick.md documents and invokes the migration path (#3730)');
+  });
+});

--- a/tests/markdown-table.test.cjs
+++ b/tests/markdown-table.test.cjs
@@ -23,7 +23,8 @@ const fs = require('node:fs');
 const path = require('node:path');
 const fc = require('./helpers/fast-check-setup.cjs');
 
-const { parseMarkdownTable, matchTableSchema, TABLE_SCHEMAS, appendQuickTaskRow, findTableBySchema, findTableWithColumns, updateTableCell, deleteTableRow, resetQuickTaskRows, QUICK_TASKS_SECTION_ABSENT } = require('../gsd-core/bin/lib/markdown-table.cjs');
+const {
+  migrateQuickTasksTable, parseMarkdownTable, matchTableSchema, TABLE_SCHEMAS, appendQuickTaskRow, findTableBySchema, findTableWithColumns, updateTableCell, deleteTableRow, resetQuickTaskRows, QUICK_TASKS_SECTION_ABSENT } = require('../gsd-core/bin/lib/markdown-table.cjs');
 const { buildHeader, normalize } = require('../scripts/lint-table-schema-drift.cjs');
 
 const ROOT = path.join(__dirname, '..');
@@ -1529,5 +1530,84 @@ describe('resetQuickTaskRows (#2142)', () => {
       }),
       { seed: 20260817, numRuns: 50 },
     );
+  });
+});
+
+describe('migrateQuickTasksTable (#3730 option b)', () => {
+  const legacyState = (eol = '\n') => [
+    '# State',
+    '',
+    '## Quick Tasks Completed',
+    '',
+    '| Date | Slug | Scope | Artifacts |',
+    '|------|------|-------|-----------|',
+    '| 2026-04-17 | 260417-abc | bootstrap | roles/x |',
+    '| 2026-05-02 | 260502-def | cli | quick/y |',
+  ].join(eol) + eol;
+
+  test('migrates the legacy pre-registry schema', () => {
+    const r = migrateQuickTasksTable(legacyState());
+    assert.equal(r.ok, true, `migrate failed: ${r.reason}`);
+    assert.equal(r.value.migrated, true);
+    assert.ok(r.value.content.includes('| # | Description | Date | Commit | Status | Directory |'),
+      'canonical with-status header is written');
+    assert.ok(r.value.content.includes('| 1 | 260417-abc · bootstrap | 2026-04-17 | — | — | roles/x |'),
+      'Slug+Scope bucket into Description; Artifacts maps to Directory; # renumbered');
+    assert.ok(r.value.content.includes('| 2 | 260502-def · cli | 2026-05-02 | — | — | quick/y |'),
+      'every data row migrates');
+    assert.ok(!r.value.content.includes('| Date | Slug |'), 'the legacy header is gone');
+  });
+
+  test('keeps unknown-named columns losslessly in the Description bucket', () => {
+    const state = [
+      '# State', '', '## Quick Tasks Completed', '',
+      '| Date | Owner |', '|------|-------|', '| 2026-04-17 | sim |',
+    ].join('\n');
+    const r = migrateQuickTasksTable(state);
+    assert.equal(r.ok, true);
+    assert.ok(r.value.content.includes('Owner: sim'), 'unknown column keeps its name: value');
+  });
+
+  test('no-ops a canonical table (byte-identical)', () => {
+    const canonical = [
+      '# State', '', '## Quick Tasks Completed', '',
+      '| # | Description | Date | Commit | Directory |',
+      '|---|-------------|------|--------|-----------|',
+      '| 1 | existing | 2026-04-17 | deadbee | ./quick/a/ |',
+    ].join('\n');
+    const r = migrateQuickTasksTable(canonical);
+    assert.equal(r.ok, true);
+    assert.equal(r.value.migrated, false);
+    assert.equal(r.value.content, canonical);
+  });
+
+  test('no-ops an absent section (absence is normal, #2142)', () => {
+    const r = migrateQuickTasksTable('# State\n\n## Other\n');
+    assert.equal(r.ok, true);
+    assert.equal(r.value.migrated, false);
+  });
+
+  test('fails loud on an unparseable table', () => {
+    const state = '# State\n\n## Quick Tasks Completed\n\nnot a table\n';
+    const r = migrateQuickTasksTable(state);
+    assert.equal(r.ok, false);
+    assert.ok(r.reason.length > 0, 'carries the parse failure reason');
+  });
+
+  test('preserves CRLF section endings', () => {
+    const r = migrateQuickTasksTable(legacyState('\r\n'));
+    assert.equal(r.ok, true);
+    assert.ok(r.value.content.includes('\r\n'), 'CRLF preserved');
+    assert.ok(!/[^\r]\n/.test(r.value.content.split('## Quick Tasks Completed')[1] || ''),
+      'no mixed EOL introduced into the section');
+  });
+
+  test('a migrated table is appendable (round-trip)', () => {
+    const migrated = migrateQuickTasksTable(legacyState());
+    const appended = appendQuickTaskRow(migrated.value.content, {
+      description: 'probe', date: '2026-08-20', commit: 'deadbee', directory: './quick/probe/',
+    });
+    assert.equal(appended.ok, true, `append after migrate failed: ${appended.reason}`);
+    assert.ok(appended.value.row.includes('probe'));
   });
 });


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3730

## What was broken

`quick-tasks-append` accepts exactly the two registered Quick Tasks schemas, while `workflows/quick.md` licensed matching any pre-existing column format — so a table GSD itself created pre-registry (e.g. `Date | Slug | Scope | Artifacts`) was permanently unappendable, with no migration, detection, or repair path. Every `/gsd-fast`/`/gsd-quick` STATE.md logging step warned and dropped the row.

## What this fix does

Implements the maintainer decision recorded on the issue (option b, 2026-09-02): **`gsd-tools quick-tasks-migrate`** — a supported repair path that rewrites the table onto the canonical `with-status` schema — plus an **automatic check on the first quick run**: `fast.md` invokes it immediately before `quick-tasks-append`, and `quick.md`'s Step 7b note now instructs it ahead of the first append. The migration migrates exactly once and never prompts when quick is never run, no section exists, or the table is already canonical (silent no-op, `ok:true migrated:false`).

Lossless by construction: legacy columns map by name (`date/when→Date`, `commit/sha→Commit`, `status→Status`, `directory/artifacts/path/dir→Directory`, `#/id→#`, `description/task/summary/slug/scope/title→Description`); every unmapped or colliding column keeps its datum in the Description bucket as `Name: value`. The rewrite is confined to the first CONTIGUOUS table in the selected section (a second table under a `#### Notes` subsection is untouched), preserves CRLF, and renumbers `#` only when empty. Non-numeric legacy ids are preserved verbatim.

## Root cause

The schema registry (#2133/ADR-2143) replaced prose-format appends but never reconciled the tables the prose era had already created — the fail-loud rejection was correct; the missing piece was the repair path.

## Testing

### How I verified the fix

Failing-first under `gsd-test`: the new `tests/markdown-table.test.cjs` rows were committed alone and proven RED on `5c5c9c863` (8 failures, all the new rows), then green in the full matrix (42302 passed, 0 failed on `2491a209`). Coverage: the issue's exact legacy fixture (Slug/Scope bucketing, Artifacts→Directory, renumbering), unknown-named columns kept losslessly, canonical no-op byte-identical, absent-section no-op, unparseable fail-loud, CRLF preservation, alias-collision displacement, multi-table sections, migrate→append round-trip (the terminal state resolved), a CLI round-trip (migrate then no-op second run), and the workflow wiring (migrate invocation precedes the append invocation in fast.md).

### Regression test added?

- [x] Yes — nine new rows in `tests/markdown-table.test.cjs`

### Platforms tested

- [x] Linux (bench lane linux-node24); CRLF handling pinned for Windows-shaped files

### Runtimes tested

- [x] N/A (CLI helper + workflows, runtime-independent)

## Checklist

- [x] Issue linked above with `Fixes #3730`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the maintainer-selected remedy (option b)
- [x] Regression test added
- [x] All existing tests pass (`gsd-test` matrix green on the final sha)
- [x] `.changeset/` fragment added (`serene-badgers-purr.md`, pr backfilled)
- [x] No unnecessary dependencies added

## Review provenance

An isolated adversarial review surfaced four defects in the first implementation — usage-list parity (guaranteed red gate), the table-span rewrite destroying a second table in the section, alias collisions silently dropping data, and delimiter-width divergence from the canonical template — all fixed before this PR opened, each with a fixture proving it.

## Breaking changes

None. `appendQuickTaskRow`/`resetQuickTaskRows` contracts and sentinel reasons are untouched; ADR-2143 §7's fail-loud posture is upheld (append still rejects legacy tables — this PR adds the repair, not a silent skip).
