### PR TITLE
fix(#4176): gsd-ui-auditor screenshot path — honest probe, honest capture status, real port fallback

### DIFF
--- a/.changeset/clever-rams-hum.md
+++ b/.changeset/clever-rams-hum.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 4224
+---
+**`/gsd-ui-review` no longer claims screenshots it did not take, and no longer calls a live dev server absent** — the auditor's capture path now follows redirects and accepts any 2xx (a dev server whose `/` redirects was previously audited code-only), actually tries ports 3000, 5173 and 8080 as its own documentation promised, and derives the reported `Screenshots:` field from real exit statuses and files on disk, so it distinguishes full capture, partial capture (N/3) and failure-with-reason instead of printing success unconditionally. (#4176)

--- a/agents/gsd-ui-auditor.md
+++ b/agents/gsd-ui-auditor.md
@@ -109,37 +109,75 @@ This gate runs unconditionally on every audit. The .gitignore ensures screenshot
 ## Screenshot Capture (CLI only — no MCP, no persistent browser)
 
 ```bash
-# Check for running dev server
-DEV_STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:3000 2>/dev/null || echo "000")
+# Detect a running dev server across the documented ports. The probe follows
+# redirects, accepts any 2xx, and is time-bounded, so a root path that
+# redirects (Next.js middleware/i18n, trailing-slash normalization) or a port
+# that accepts but never answers is not misread as "no dev server". fetch()
+# rather than curl, for cross-platform parity with
+# gsd-core/references/checkpoints.md.
+DEV_URL=""
+DEV_GATED=""
+for PORT in 3000 5173 8080; do
+  # process.stdout.write(String(...)), never console.log(r.status): console.log
+  # of a NUMBER is colorized by node, so the probe would emit "\033[33m200\033[39m"
+  # and every 2xx would fall through to the no-dev-server branch.
+  PROBE=$(node -e 'fetch(process.argv[1],{redirect:"follow",signal:AbortSignal.timeout(5000)}).then(r=>process.stdout.write(String(r.status))).catch(()=>process.stdout.write("000"))' "http://localhost:$PORT" 2>/dev/null || echo "000")
+  PROBE=${PROBE:-000}
+  case "$PROBE" in
+    2??)     DEV_URL="http://localhost:$PORT"; break ;;
+    401|403) DEV_GATED="http://localhost:$PORT (HTTP $PROBE)" ;;
+  esac
+done
 
-if [ "$DEV_STATUS" = "200" ]; then
+if [ -n "$DEV_URL" ]; then
   SCREENSHOT_DIR=".planning/ui-reviews/${PADDED_PHASE}-$(date +%Y%m%d-%H%M%S)"
   mkdir -p "$SCREENSHOT_DIR"
 
-  # Desktop
-  npx playwright screenshot http://localhost:3000 \
-    "$SCREENSHOT_DIR/desktop.png" \
-    --viewport-size=1440,900 2>/dev/null
+  # Capture each viewport from the RESOLVED port, and believe only what the
+  # exit status and the file on disk actually say.
+  CAPTURED=0
+  FAILED_SHOTS=""
+  for SHOT in "desktop:1440,900" "mobile:375,812" "tablet:768,1024"; do
+    SHOT_NAME="${SHOT%%:*}"
+    SHOT_VIEWPORT="${SHOT##*:}"
+    if npx playwright screenshot "$DEV_URL" \
+         "$SCREENSHOT_DIR/$SHOT_NAME.png" \
+         --viewport-size="$SHOT_VIEWPORT" >/dev/null 2>&1 \
+       && [ -s "$SCREENSHOT_DIR/$SHOT_NAME.png" ]; then
+      CAPTURED=$((CAPTURED + 1))
+    else
+      FAILED_SHOTS="$FAILED_SHOTS $SHOT_NAME"
+    fi
+  done
 
-  # Mobile
-  npx playwright screenshot http://localhost:3000 \
-    "$SCREENSHOT_DIR/mobile.png" \
-    --viewport-size=375,812 2>/dev/null
-
-  # Tablet
-  npx playwright screenshot http://localhost:3000 \
-    "$SCREENSHOT_DIR/tablet.png" \
-    --viewport-size=768,1024 2>/dev/null
-
-  echo "Screenshots captured to $SCREENSHOT_DIR"
+  if [ "$CAPTURED" -eq 3 ]; then
+    CAPTURE_STATUS="captured"
+    echo "Screenshots captured to $SCREENSHOT_DIR (3/3) from $DEV_URL"
+  elif [ "$CAPTURED" -gt 0 ]; then
+    CAPTURE_STATUS="partially captured"
+    echo "Screenshots PARTIALLY captured to $SCREENSHOT_DIR ($CAPTURED/3) from $DEV_URL — failed:$FAILED_SHOTS"
+  else
+    CAPTURE_STATUS="not captured (capture failed)"
+    rmdir "$SCREENSHOT_DIR" 2>/dev/null
+    echo "Screenshot capture FAILED for all 3 viewports at $DEV_URL — code-only audit"
+  fi
+elif [ -n "$DEV_GATED" ]; then
+  CAPTURE_STATUS="not captured (dev server auth-gated)"
+  echo "Dev server at $DEV_GATED is auth-gated — code-only audit"
 else
-  echo "No dev server at localhost:3000 — code-only audit"
+  CAPTURE_STATUS="not captured (no dev server)"
+  echo "No dev server on ports 3000, 5173 or 8080 — code-only audit"
 fi
 ```
 
-If dev server not detected: audit runs on code review only (Tailwind class audit, string audit for generic labels, state handling check). Note in output that visual screenshots were not captured.
+Ports are tried in order — 3000, then 5173 (Vite default), then 8080 — and the
+first one that answers 2xx is the port every capture command uses.
 
-Try port 3000 first, then 5173 (Vite default), then 8080.
+`$CAPTURE_STATUS` is the single source of truth for the `**Screenshots:**` field
+of both the UI-REVIEW.md report and the structured return. Report what it holds
+— never assume capture succeeded because the block ran.
+
+If no dev server is detected, or capture fails: the audit runs on code review only (Tailwind class audit, string audit for generic labels, state handling check). Note in output that visual screenshots were not captured, and say why.
 
 </screenshot_approach>
 
@@ -299,7 +337,7 @@ Write to: `$PHASE_DIR/$PADDED_PHASE-UI-REVIEW.md`
 
 **Audited:** {date}
 **Baseline:** {UI-SPEC.md / abstract standards}
-**Screenshots:** {captured / not captured (no dev server)}
+**Screenshots:** {$CAPTURE_STATUS — captured / partially captured (N/3, list the failures) / not captured, with the reason}
 
 ---
 
@@ -366,7 +404,7 @@ Run the gitignore gate from `<gitignore_gate>`. This MUST happen before step 3.
 
 ## Step 3: Detect Dev Server and Capture Screenshots
 
-Run the screenshot approach from `<screenshot_approach>`. Record whether screenshots were captured.
+Run the screenshot approach from `<screenshot_approach>`. Carry `$CAPTURE_STATUS` forward and record it verbatim — full, partial, or none with its reason.
 
 ## Step 4: Scan Implemented Files
 
@@ -406,7 +444,7 @@ Use output format from `<output_format>`. If registry audit produced flags, add 
 
 **Phase:** {phase_number} - {phase_name}
 **Overall Score:** {total}/24
-**Screenshots:** {captured / not captured}
+**Screenshots:** {$CAPTURE_STATUS — captured / partially captured (N/3) / not captured, with the reason}
 
 ### Pillar Summary
 | Pillar | Score |
@@ -440,7 +478,7 @@ UI audit is complete when:
 - [ ] All `<required_reading>` loaded before any action
 - [ ] .gitignore gate executed before any screenshot capture
 - [ ] Dev server detection attempted
-- [ ] Screenshots captured (or noted as unavailable)
+- [ ] Capture outcome recorded from `$CAPTURE_STATUS` — full, partial, or none with its reason
 - [ ] All 6 pillars scored with evidence
 - [ ] Registry safety audit executed (if shadcn + third-party registries present)
 - [ ] Top 3 priority fixes identified with concrete solutions

--- a/agents/gsd-ui-auditor.md
+++ b/agents/gsd-ui-auditor.md
@@ -125,7 +125,10 @@ for PORT in 3000 5173 8080; do
   PROBE=${PROBE:-000}
   case "$PROBE" in
     2??)     DEV_URL="http://localhost:$PORT"; break ;;
-    401|403) DEV_GATED="http://localhost:$PORT (HTTP $PROBE)" ;;
+    # First gated port wins, matching the documented port PRECEDENCE below. An
+    # unguarded assignment here reports whichever gated port was tried LAST, so
+    # with 3000 and 8080 both auth-gated the reason would name 8080.
+    401|403) [ -n "$DEV_GATED" ] || DEV_GATED="http://localhost:$PORT (HTTP $PROBE)" ;;
   esac
 done
 

--- a/agents/gsd-ui-auditor.md
+++ b/agents/gsd-ui-auditor.md
@@ -119,8 +119,11 @@ DEV_URL=""
 DEV_GATED=""
 for PORT in 3000 5173 8080; do
   # process.stdout.write(String(...)), never console.log(r.status): console.log
-  # of a NUMBER is colorized by node, so the probe would emit "\033[33m200\033[39m"
-  # and every 2xx would fall through to the no-dev-server branch.
+  # CAN colorize a NUMBER — whenever node emits color, i.e. a TTY or FORCE_COLOR — so
+  # the probe would emit "\033[33m200\033[39m" and every 2xx would fall through to the
+  # no-dev-server branch. Measured: piped and uncoloured it prints "200\n"; with
+  # FORCE_COLOR=1 it prints the escapes. Writing the string is unconditional, which is
+  # why it is the fix rather than relying on the caller's colour state.
   PROBE=$(node -e 'fetch(process.argv[1],{redirect:"follow",signal:AbortSignal.timeout(5000)}).then(r=>process.stdout.write(String(r.status))).catch(()=>process.stdout.write("000"))' "http://localhost:$PORT" 2>/dev/null || echo "000")
   PROBE=${PROBE:-000}
   case "$PROBE" in

--- a/agents/gsd-ui-auditor.md
+++ b/agents/gsd-ui-auditor.md
@@ -137,7 +137,12 @@ for PORT in 3000 5173 8080; do
 done
 
 if [ -n "$DEV_URL" ]; then
-  SCREENSHOT_DIR=".planning/ui-reviews/${PADDED_PHASE}-$(date +%Y%m%d-%H%M%S)"
+  # The `-$$` is what makes this directory THIS audit's. Phase plus a whole-second
+  # timestamp is not unique: two audits of the same phase starting inside one second
+  # land in the same directory, and from there no cleanup rule can be safe, because
+  # both audits write exactly `desktop.png`, `mobile.png` and `tablet.png` — a
+  # filename cannot establish whose it is. Ownership has to come from the directory.
+  SCREENSHOT_DIR=".planning/ui-reviews/${PADDED_PHASE}-$(date +%Y%m%d-%H%M%S)-$$"
   mkdir -p "$SCREENSHOT_DIR"
 
   # Capture each viewport from the RESOLVED port, and believe only what the
@@ -165,9 +170,10 @@ if [ -n "$DEV_URL" ]; then
       # the review directory looking like evidence. Doing it here rather than in
       # the all-failed branch below is what makes the claim true of a PARTIAL
       # capture too — two good shots and one stray file was the gap.
-      # BY NAME, never a `*.png` glob: this directory is keyed to the phase and a
-      # whole second, so two audits of the same phase can share it, and a glob
-      # would delete the other one's captures.
+      # By name rather than a `*.png` glob. For this audit's own files the two are
+      # equivalent; the name form additionally leaves alone anything else that happens
+      # to be in the directory. What actually keeps a CONCURRENT audit's captures safe
+      # is the `-$$` in the directory above, never this line.
       rm -f "$SCREENSHOT_DIR/$SHOT_NAME.png"
       FAILED_SHOTS="$FAILED_SHOTS $SHOT_NAME"
     fi

--- a/agents/gsd-ui-auditor.md
+++ b/agents/gsd-ui-auditor.md
@@ -151,12 +151,12 @@ if [ -n "$DEV_URL" ]; then
   SCREENSHOT_DIR="$SCREENSHOT_BASE"
   SUFFIX=1
   until mkdir "$SCREENSHOT_DIR" 2>/dev/null; do
-    SCREENSHOT_DIR="$SCREENSHOT_BASE-$SUFFIX"
-    SUFFIX=$((SUFFIX + 1))
     if [ "$SUFFIX" -gt 99 ]; then
       SCREENSHOT_DIR=""
       break
     fi
+    SCREENSHOT_DIR="$SCREENSHOT_BASE-$SUFFIX"
+    SUFFIX=$((SUFFIX + 1))
   done
 
   if [ -z "$SCREENSHOT_DIR" ]; then
@@ -192,8 +192,8 @@ if [ -n "$DEV_URL" ]; then
         # capture too — two good shots and one stray file was the gap.
         # By name rather than a `*.png` glob. For this audit's own files the two are
         # equivalent; the name form additionally leaves alone anything else that happens
-        # to be in the directory. What actually keeps a CONCURRENT audit's captures safe
-        # is the `-$$` in the directory above, never this line.
+        # to be in the directory. What keeps a CONCURRENT audit's captures safe is the
+        # atomic allocation above, never this line.
         rm -f "$SCREENSHOT_DIR/$SHOT_NAME.png"
         FAILED_SHOTS="$FAILED_SHOTS $SHOT_NAME"
       fi

--- a/agents/gsd-ui-auditor.md
+++ b/agents/gsd-ui-auditor.md
@@ -122,10 +122,18 @@ This gate runs unconditionally on every audit. The .gitignore ensures screenshot
 # 503 (still compiling), or that accepted the connection and never answered,
 # is present. Reporting any of those as absent is #4176's own defect, one
 # status family over; the auditor cannot screenshot them, but it can say why.
+#
+# PRECONDITION: Node 18+, on the AUDITED project's PATH — this block runs on
+# whatever `node` that shell resolves, not on gsd-core's own runtime. fetch()
+# is global from 18; on an older Node the program below says so ("nofetch")
+# instead of throwing, because a thrown probe reads "000" on every port and
+# reports a present dev server as absent by yet another road. (`npx playwright`
+# below needs a current Node as well, so the bound is not new — only stated.)
 DEV_URL=""
 DEV_GATED=""
 DEV_OTHER=""
 DEV_TIMEOUT=""
+DEV_NOFETCH=""
 for PORT in 3000 5173 8080; do
   # process.stdout.write(String(...)), never console.log(r.status): console.log
   # CAN colorize a NUMBER — whenever node emits color, i.e. a TTY or FORCE_COLOR — so
@@ -137,10 +145,16 @@ for PORT in 3000 5173 8080; do
   # so an abort — TimeoutError on current Node, the older AbortError spelling on early
   # 18.x — can only be the 5s bound firing; every other rejection (refused, reset,
   # a redirect loop) still reads "000".
-  PROBE=$(node -e 'fetch(process.argv[1],{redirect:"follow",signal:AbortSignal.timeout(5000)}).then(r=>process.stdout.write(String(r.status))).catch(e=>process.stdout.write(e&&(e.name==="TimeoutError"||e.name==="AbortError")?"timeout":"000"))' "http://localhost:$PORT" 2>/dev/null || echo "000")
+  # No process.exit() after the nofetch write: stdout to a pipe is asynchronous on
+  # Windows, and an exit right behind the write can drop it. The process ends on
+  # its own once the write drains.
+  PROBE=$(node -e 'typeof fetch==="function"?fetch(process.argv[1],{redirect:"follow",signal:AbortSignal.timeout(5000)}).then(r=>process.stdout.write(String(r.status))).catch(e=>process.stdout.write(e&&(e.name==="TimeoutError"||e.name==="AbortError")?"timeout":"000")):process.stdout.write("nofetch "+process.version)' "http://localhost:$PORT" 2>/dev/null || echo "000")
   PROBE=${PROBE:-000}
   case "$PROBE" in
     2??)     DEV_URL="http://localhost:$PORT"; break ;;
+    # This node cannot probe at all, so no port can be classified: stop rather
+    # than record three "000"s and call the dev server absent.
+    nofetch*) DEV_NOFETCH="${PROBE#nofetch }"; break ;;
     # The WHOLE auth-required class, not just its two common members: 407 (proxy)
     # and 511 (captive portal) also mean a server ANSWERED and demanded credentials,
     # so leaving them out reports a present server as an absent one — which is
@@ -240,6 +254,11 @@ if [ -n "$DEV_URL" ]; then
       echo "Screenshot capture FAILED for all 3 viewports at $DEV_URL — code-only audit"
     fi
   fi
+elif [ -n "$DEV_NOFETCH" ]; then
+  # Above the answer classes deliberately: with no working probe there IS no
+  # answer to rank, and this is the one outcome that says nothing about the ports.
+  CAPTURE_STATUS="not captured (cannot probe: node $DEV_NOFETCH has no fetch(); Node 18+ required)"
+  echo "Cannot probe for a dev server: node $DEV_NOFETCH has no fetch() — Node 18+ is required — code-only audit"
 elif [ -n "$DEV_GATED" ]; then
   CAPTURE_STATUS="not captured (dev server auth-gated)"
   echo "Dev server at $DEV_GATED is auth-gated — code-only audit"

--- a/agents/gsd-ui-auditor.md
+++ b/agents/gsd-ui-auditor.md
@@ -125,10 +125,14 @@ for PORT in 3000 5173 8080; do
   PROBE=${PROBE:-000}
   case "$PROBE" in
     2??)     DEV_URL="http://localhost:$PORT"; break ;;
+    # The WHOLE auth-required class, not just its two common members: 407 (proxy)
+    # and 511 (captive portal) also mean a server ANSWERED and demanded credentials,
+    # so leaving them out reports a present server as an absent one — which is
+    # #4176's own defect, one status family over.
     # First gated port wins, matching the documented port PRECEDENCE below. An
     # unguarded assignment here reports whichever gated port was tried LAST, so
     # with 3000 and 8080 both auth-gated the reason would name 8080.
-    401|403) [ -n "$DEV_GATED" ] || DEV_GATED="http://localhost:$PORT (HTTP $PROBE)" ;;
+    401|403|407|511) [ -n "$DEV_GATED" ] || DEV_GATED="http://localhost:$PORT (HTTP $PROBE)" ;;
   esac
 done
 

--- a/agents/gsd-ui-auditor.md
+++ b/agents/gsd-ui-auditor.md
@@ -109,94 +109,51 @@ This gate runs unconditionally on every audit. The .gitignore ensures screenshot
 ## Screenshot Capture (CLI only — no MCP, no persistent browser)
 
 ```bash
-# Detect a running dev server across the documented ports. The probe follows
-# redirects, accepts any 2xx, and is time-bounded, so a root path that
-# redirects (Next.js middleware/i18n, trailing-slash normalization) is not
-# misread as "no dev server", and a port that accepts but never answers is
-# reported as exactly that instead of hanging the audit. fetch() rather than
-# curl, for cross-platform parity with gsd-core/references/checkpoints.md.
-#
-# EVERY answer is recorded, not only the two the capture can use. "No dev
-# server" is a claim about the PORT — nothing listening — and a server that
-# answered 404 (an API-only server on 3000), 500 (a dev server mid-crash) or
-# 503 (still compiling), or that accepted the connection and never answered,
-# is present. Reporting any of those as absent is #4176's own defect, one
-# status family over; the auditor cannot screenshot them, but it can say why.
-#
-# PRECONDITION: Node 18+, on the AUDITED project's PATH — this block runs on
-# whatever `node` that shell resolves, not on gsd-core's own runtime. fetch()
-# is global from 18; on an older Node the program below says so ("nofetch")
-# instead of throwing, because a thrown probe reads "000" on every port and
-# reports a present dev server as absent by yet another road. (`npx playwright`
-# below needs a current Node as well, so the bound is not new — only stated.)
+# Probe the documented ports. Follows redirects, accepts any 2xx, time-bounded; fetch()
+# for cross-platform parity with gsd-core/references/checkpoints.md.
+# EVERY answer is recorded: "no dev server" means nothing listened. A 404/500/503, or a
+# port that accepts and never answers, is a PRESENT server the auditor cannot use — say so.
+# PRECONDITION: Node 18+ on the AUDITED project's PATH (fetch is global from 18); an older
+# node prints "nofetch" rather than throwing, which would read as "000" on every port.
 DEV_URL=""
 DEV_GATED=""
 DEV_OTHER=""
 DEV_TIMEOUT=""
 DEV_NOFETCH=""
 for PORT in 3000 5173 8080; do
-  # process.stdout.write(String(...)), never console.log(r.status): console.log
-  # CAN colorize a NUMBER — whenever node emits color, i.e. a TTY or FORCE_COLOR — so
-  # the probe would emit "\033[33m200\033[39m" and every 2xx would fall through to the
-  # no-dev-server branch. Measured: piped and uncoloured it prints "200\n"; with
-  # FORCE_COLOR=1 it prints the escapes. Writing the string is unconditional, which is
-  # why it is the fix rather than relying on the caller's colour state.
-  # The timeout is named in the output. The program owns the ONLY AbortSignal in play,
-  # so an abort — TimeoutError on current Node, the older AbortError spelling on early
-  # 18.x — can only be the 5s bound firing; every other rejection (refused, reset,
-  # a redirect loop) still reads "000".
-  # No process.exit() after the nofetch write: stdout to a pipe is asynchronous on
-  # Windows, and an exit right behind the write can drop it. The process ends on
-  # its own once the write drains.
+  # process.stdout.write, never console.log: console.log colourises a NUMBER under a TTY
+  # or FORCE_COLOR, and "\033[33m200\033[39m" matches no arm. Measured.
+  # An abort can only be this program's own 5s signal (TimeoutError; AbortError on early
+  # 18.x), so it prints "timeout"; every other rejection prints "000". No process.exit()
+  # after the nofetch write: a pipe write is async on Windows and an exit can drop it.
   PROBE=$(node -e 'typeof fetch==="function"?fetch(process.argv[1],{redirect:"follow",signal:AbortSignal.timeout(5000)}).then(r=>process.stdout.write(String(r.status))).catch(e=>process.stdout.write(e&&(e.name==="TimeoutError"||e.name==="AbortError")?"timeout":"000")):process.stdout.write("nofetch "+process.version)' "http://localhost:$PORT" 2>/dev/null || echo "000")
   PROBE=${PROBE:-000}
   case "$PROBE" in
     2??)     DEV_URL="http://localhost:$PORT"; break ;;
-    # This node cannot probe at all, so no port can be classified: stop rather
-    # than record three "000"s and call the dev server absent.
+    # No working probe: nothing can be classified, so stop rather than record three 000s.
     nofetch*) DEV_NOFETCH="${PROBE#nofetch }"; break ;;
-    # The WHOLE auth-required class, not just its two common members: 407 (proxy)
-    # and 511 (captive portal) also mean a server ANSWERED and demanded credentials,
-    # so leaving them out reports a present server as an absent one — which is
-    # #4176's own defect, one status family over.
-    # First gated port wins, matching the documented port PRECEDENCE below. An
-    # unguarded assignment here reports whichever gated port was tried LAST, so
-    # with 3000 and 8080 both auth-gated the reason would name 8080.
+    # The WHOLE auth-required class (407 proxy, 511 captive portal too). First gated port
+    # wins — an unguarded assignment would name the LAST one tried.
     401|403|407|511) [ -n "$DEV_GATED" ] || DEV_GATED="http://localhost:$PORT (HTTP $PROBE)" ;;
-    # Any other status is a server that ANSWERED. The loop keeps going, because a
-    # later port may hold the real dev server (an API on 3000 answering 404, Vite
-    # on 5173), and a 2xx there still wins via the `break` above. First-wins, as
-    # the gated arm is, so the reported port follows the documented precedence.
+    # Any other status ANSWERED. Keep looping: a later port may hold the real 2xx server.
     [1-9]??) [ -n "$DEV_OTHER" ] || DEV_OTHER="http://localhost:$PORT (HTTP $PROBE)" ;;
-    # Accepted the connection, never answered within the bound: hung, mid-start,
-    # or stopped at a debugger — present, whichever it is.
+    # Accepted the connection, never answered within the bound: present, hung.
     timeout) [ -n "$DEV_TIMEOUT" ] || DEV_TIMEOUT="http://localhost:$PORT" ;;
   esac
 done
 
 if [ -n "$DEV_URL" ]; then
-  # ALLOCATE THE DIRECTORY ATOMICALLY. `mkdir` WITHOUT `-p` fails when the directory
-  # already exists, so exactly one caller can win it; `-p` succeeds for both and hands
-  # two audits the same directory. That matters because phase plus a whole-second
-  # timestamp is not unique — two audits of the same phase in one second collide, and
-  # so does the same shell running this block twice — and from a shared directory no
-  # cleanup can be safe, since both audits write exactly `desktop.png`, `mobile.png`
-  # and `tablet.png`. A filename can never establish whose it is; winning the mkdir can.
-  # A PID suffix does NOT solve this: `$$` names the shell, not the invocation, so it is
-  # identical across two runs in one shell and inside command substitution.
+  # ALLOCATE ATOMICALLY: `mkdir` without `-p` fails on an existing name, so exactly one
+  # audit wins it. Phase + whole-second timestamp is not unique, both audits write the
+  # same three filenames, and a PID suffix does not help ($$ is the shell, not the run).
   mkdir -p .planning/ui-reviews 2>/dev/null
   SCREENSHOT_BASE=".planning/ui-reviews/${PADDED_PHASE}-$(date +%Y%m%d-%H%M%S)"
   SCREENSHOT_DIR="$SCREENSHOT_BASE"
   SUFFIX=1
   ALLOC_FAILURE=""
   until mkdir "$SCREENSHOT_DIR" 2>/dev/null; do
-    # Retry ONLY a name collision. mkdir also fails when the parent is unwritable,
-    # missing, or a file, or the disk is full — and no suffix cures any of those.
-    # A candidate that failed and still does not exist failed for one of them, so
-    # stop at once instead of asking the same question 99 more times. (An audit
-    # that won this exact name and removed it again between the two calls would
-    # be read as structural too; the outcome on that race is a give-up, never a
-    # shared directory, and the window is two syscalls wide.)
+    # Retry ONLY a name collision. A candidate that failed and still does not exist failed
+    # structurally (parent unwritable/missing/a file, ENOSPC) — no suffix cures that.
     if [ ! -e "$SCREENSHOT_DIR" ]; then
       ALLOC_FAILURE="could not create a review directory under .planning/ui-reviews"
       SCREENSHOT_DIR=""
@@ -212,27 +169,19 @@ if [ -n "$DEV_URL" ]; then
   done
 
   if [ -z "$SCREENSHOT_DIR" ]; then
-    # The allocation loop above gave up. Never fall through: with SCREENSHOT_DIR empty
-    # the capture below would write to /desktop.png, outside the project entirely.
-    # Its own status, not "capture failed": no capture was attempted, and the two
-    # have different remedies (free a name or fix the directory, versus fix the
-    # browser). The report renders $CAPTURE_STATUS, so the distinction has to
-    # live in the VALUE — a detail carried only by this echo never reaches it.
+    # Never fall through: with SCREENSHOT_DIR empty the capture would write to /desktop.png.
+    # Its own status — no capture was attempted, and the remedy differs from "capture failed".
     CAPTURE_STATUS="not captured ($ALLOC_FAILURE)"
     echo "Could not allocate a review directory — $ALLOC_FAILURE — code-only audit"
   else
-    # Capture each viewport from the RESOLVED port, and believe only what the
-    # exit status and the file on disk actually say.
+    # Capture from the RESOLVED port; believe only the exit status and the file on disk.
     CAPTURED=0
     FAILED_SHOTS=""
     for SHOT in "desktop:1440,900" "mobile:375,812" "tablet:768,1024"; do
       SHOT_NAME="${SHOT%%:*}"
       SHOT_VIEWPORT="${SHOT##*:}"
-      # --timeout is not belt-and-braces here: `playwright screenshot` passes it to
-      # context.setDefaultTimeout() and defaults it to 0 — NO timeout — so this CLI path
-      # drops the 30s bound the Playwright library applies everywhere else. Without it a
-      # hung navigation blocks the audit forever, which is the same failure the probe's
-      # AbortSignal.timeout(5000) closes one step earlier.
+      # --timeout is load-bearing: this CLI defaults context.setDefaultTimeout() to 0 (none),
+      # so a hung navigation would block the audit forever.
       if npx playwright screenshot "$DEV_URL" \
            "$SCREENSHOT_DIR/$SHOT_NAME.png" \
            --viewport-size="$SHOT_VIEWPORT" \
@@ -240,26 +189,16 @@ if [ -n "$DEV_URL" ]; then
          && [ -s "$SCREENSHOT_DIR/$SHOT_NAME.png" ]; then
         CAPTURED=$((CAPTURED + 1))
       else
-        # Remove what THIS viewport may have written before scoring it a failure. A
-        # crashed browser commonly leaves a zero-byte or partial .png, which the
-        # `[ -s ]` above correctly refuses to count and which would otherwise sit in
-        # the review directory looking like evidence. Doing it here rather than in
-        # the all-failed branch below is what makes the claim true of a PARTIAL
-        # capture too — two good shots and one stray file was the gap.
-        # By name rather than a `*.png` glob. For this audit's own files the two are
-        # equivalent; the name form additionally leaves alone anything else that happens
-        # to be in the directory. What keeps a CONCURRENT audit's captures safe is the
-        # atomic allocation above, never this line.
+        # Remove what THIS viewport may have written (a crashed browser leaves a zero-byte or
+        # partial png), by name, here — so a PARTIAL capture leaves only real shots behind.
         rm -f "$SCREENSHOT_DIR/$SHOT_NAME.png"
         FAILED_SHOTS="$FAILED_SHOTS $SHOT_NAME"
       fi
     done
 
+    # The VALUE carries what the echo carries: the report template renders $CAPTURE_STATUS
+    # and nothing else.
     if [ "$CAPTURED" -eq 3 ]; then
-      # The VALUE carries what the echo carries — count, failed viewports, port and
-      # status — because the report template renders $CAPTURE_STATUS and nothing else.
-      # docs/AGENTS.md already described the field as naming the viewports that failed;
-      # until this line, only the transient echo did.
       CAPTURE_STATUS="captured (3/3 from $DEV_URL)"
       echo "Screenshots captured to $SCREENSHOT_DIR (3/3) from $DEV_URL"
     elif [ "$CAPTURED" -gt 0 ]; then
@@ -267,28 +206,21 @@ if [ -n "$DEV_URL" ]; then
       echo "Screenshots PARTIALLY captured to $SCREENSHOT_DIR ($CAPTURED/3) from $DEV_URL — failed:$FAILED_SHOTS"
     else
       CAPTURE_STATUS="not captured (capture failed for all 3 viewports at $DEV_URL)"
-      # `rm -rf`, not `rmdir`, and the atomic allocation above is what licenses it: this
-      # directory was won by this audit and shared with nobody, so removing it whole
-      # cannot destroy another audit's work. rmdir could not honour the claim — it fails
-      # on any file the capture command wrote under a name this block did not ask for,
-      # leaving both that file and the directory behind while the docs said otherwise.
+      # `rm -rf`, licensed by the atomic allocation: this directory is shared with nobody.
+      # rmdir cannot honour the claim — it fails on any file written under an unasked name.
       rm -rf "$SCREENSHOT_DIR"
       echo "Screenshot capture FAILED for all 3 viewports at $DEV_URL — code-only audit"
     fi
   fi
 elif [ -n "$DEV_NOFETCH" ]; then
-  # Above the answer classes deliberately: with no working probe there IS no
-  # answer to rank, and this is the one outcome that says nothing about the ports.
+  # Above the answer classes: with no working probe there is no answer to rank.
   CAPTURE_STATUS="not captured (cannot probe: node $DEV_NOFETCH has no fetch(); Node 18+ required)"
   echo "Cannot probe for a dev server: node $DEV_NOFETCH has no fetch() — Node 18+ is required — code-only audit"
 elif [ -n "$DEV_GATED" ]; then
   CAPTURE_STATUS="not captured (dev server auth-gated: $DEV_GATED)"
   echo "Dev server at $DEV_GATED is auth-gated — code-only audit"
 elif [ -n "$DEV_OTHER" ]; then
-  # Precedence among the present-but-unusable outcomes: gated, then any other
-  # answer, then a timeout. Each records its own FIRST port; across the three
-  # the more informative answer is reported, since "401" says what to do and
-  # "no answer in 5s" only says something is there.
+  # Precedence by CLASS: gated, then any other status, then timeout — each its own FIRST port.
   CAPTURE_STATUS="not captured (dev server answered, not 2xx: $DEV_OTHER)"
   echo "Dev server at $DEV_OTHER answered but is not serving a page — code-only audit"
 elif [ -n "$DEV_TIMEOUT" ]; then

--- a/agents/gsd-ui-auditor.md
+++ b/agents/gsd-ui-auditor.md
@@ -184,12 +184,26 @@ if [ -n "$DEV_URL" ]; then
   # and `tablet.png`. A filename can never establish whose it is; winning the mkdir can.
   # A PID suffix does NOT solve this: `$$` names the shell, not the invocation, so it is
   # identical across two runs in one shell and inside command substitution.
-  mkdir -p .planning/ui-reviews
+  mkdir -p .planning/ui-reviews 2>/dev/null
   SCREENSHOT_BASE=".planning/ui-reviews/${PADDED_PHASE}-$(date +%Y%m%d-%H%M%S)"
   SCREENSHOT_DIR="$SCREENSHOT_BASE"
   SUFFIX=1
+  ALLOC_FAILURE=""
   until mkdir "$SCREENSHOT_DIR" 2>/dev/null; do
+    # Retry ONLY a name collision. mkdir also fails when the parent is unwritable,
+    # missing, or a file, or the disk is full — and no suffix cures any of those.
+    # A candidate that failed and still does not exist failed for one of them, so
+    # stop at once instead of asking the same question 99 more times. (An audit
+    # that won this exact name and removed it again between the two calls would
+    # be read as structural too; the outcome on that race is a give-up, never a
+    # shared directory, and the window is two syscalls wide.)
+    if [ ! -e "$SCREENSHOT_DIR" ]; then
+      ALLOC_FAILURE="could not create a review directory under .planning/ui-reviews"
+      SCREENSHOT_DIR=""
+      break
+    fi
     if [ "$SUFFIX" -gt 99 ]; then
+      ALLOC_FAILURE="all 100 candidate names under $SCREENSHOT_BASE are taken"
       SCREENSHOT_DIR=""
       break
     fi
@@ -204,8 +218,8 @@ if [ -n "$DEV_URL" ]; then
     # have different remedies (free a name or fix the directory, versus fix the
     # browser). The report renders $CAPTURE_STATUS, so the distinction has to
     # live in the VALUE — a detail carried only by this echo never reaches it.
-    CAPTURE_STATUS="not captured (could not allocate a review directory under .planning/ui-reviews)"
-    echo "Could not allocate a review directory under .planning/ui-reviews — code-only audit"
+    CAPTURE_STATUS="not captured ($ALLOC_FAILURE)"
+    echo "Could not allocate a review directory — $ALLOC_FAILURE — code-only audit"
   else
     # Capture each viewport from the RESOLVED port, and believe only what the
     # exit status and the file on disk actually say.

--- a/agents/gsd-ui-auditor.md
+++ b/agents/gsd-ui-auditor.md
@@ -143,9 +143,15 @@ if [ -n "$DEV_URL" ]; then
   for SHOT in "desktop:1440,900" "mobile:375,812" "tablet:768,1024"; do
     SHOT_NAME="${SHOT%%:*}"
     SHOT_VIEWPORT="${SHOT##*:}"
+    # --timeout is not belt-and-braces here: `playwright screenshot` passes it to
+    # context.setDefaultTimeout() and defaults it to 0 — NO timeout — so this CLI path
+    # drops the 30s bound the Playwright library applies everywhere else. Without it a
+    # hung navigation blocks the audit forever, which is the same failure the probe's
+    # AbortSignal.timeout(5000) closes one step earlier.
     if npx playwright screenshot "$DEV_URL" \
          "$SCREENSHOT_DIR/$SHOT_NAME.png" \
-         --viewport-size="$SHOT_VIEWPORT" >/dev/null 2>&1 \
+         --viewport-size="$SHOT_VIEWPORT" \
+         --timeout=30000 >/dev/null 2>&1 \
        && [ -s "$SCREENSHOT_DIR/$SHOT_NAME.png" ]; then
       CAPTURED=$((CAPTURED + 1))
     else

--- a/agents/gsd-ui-auditor.md
+++ b/agents/gsd-ui-auditor.md
@@ -137,65 +137,84 @@ for PORT in 3000 5173 8080; do
 done
 
 if [ -n "$DEV_URL" ]; then
-  # The `-$$` is what makes this directory THIS audit's. Phase plus a whole-second
-  # timestamp is not unique: two audits of the same phase starting inside one second
-  # land in the same directory, and from there no cleanup rule can be safe, because
-  # both audits write exactly `desktop.png`, `mobile.png` and `tablet.png` — a
-  # filename cannot establish whose it is. Ownership has to come from the directory.
-  # PID-plus-timestamp rather than `mktemp -d`, matching gsd-code-fixer.md, which
-  # replaced mktemp's XXXXXX with the same `$$` + epoch suffix for a repo-relative
-  # path under #2647: on Windows/Git Bash `mktemp` produced an un-removable short
-  # `C:/mvwtNN` path to dodge MAX_PATH.
-  SCREENSHOT_DIR=".planning/ui-reviews/${PADDED_PHASE}-$(date +%Y%m%d-%H%M%S)-$$"
-  mkdir -p "$SCREENSHOT_DIR"
-
-  # Capture each viewport from the RESOLVED port, and believe only what the
-  # exit status and the file on disk actually say.
-  CAPTURED=0
-  FAILED_SHOTS=""
-  for SHOT in "desktop:1440,900" "mobile:375,812" "tablet:768,1024"; do
-    SHOT_NAME="${SHOT%%:*}"
-    SHOT_VIEWPORT="${SHOT##*:}"
-    # --timeout is not belt-and-braces here: `playwright screenshot` passes it to
-    # context.setDefaultTimeout() and defaults it to 0 — NO timeout — so this CLI path
-    # drops the 30s bound the Playwright library applies everywhere else. Without it a
-    # hung navigation blocks the audit forever, which is the same failure the probe's
-    # AbortSignal.timeout(5000) closes one step earlier.
-    if npx playwright screenshot "$DEV_URL" \
-         "$SCREENSHOT_DIR/$SHOT_NAME.png" \
-         --viewport-size="$SHOT_VIEWPORT" \
-         --timeout=30000 >/dev/null 2>&1 \
-       && [ -s "$SCREENSHOT_DIR/$SHOT_NAME.png" ]; then
-      CAPTURED=$((CAPTURED + 1))
-    else
-      # Remove what THIS viewport may have written before scoring it a failure. A
-      # crashed browser commonly leaves a zero-byte or partial .png, which the
-      # `[ -s ]` above correctly refuses to count and which would otherwise sit in
-      # the review directory looking like evidence. Doing it here rather than in
-      # the all-failed branch below is what makes the claim true of a PARTIAL
-      # capture too — two good shots and one stray file was the gap.
-      # By name rather than a `*.png` glob. For this audit's own files the two are
-      # equivalent; the name form additionally leaves alone anything else that happens
-      # to be in the directory. What actually keeps a CONCURRENT audit's captures safe
-      # is the `-$$` in the directory above, never this line.
-      rm -f "$SCREENSHOT_DIR/$SHOT_NAME.png"
-      FAILED_SHOTS="$FAILED_SHOTS $SHOT_NAME"
+  # ALLOCATE THE DIRECTORY ATOMICALLY. `mkdir` WITHOUT `-p` fails when the directory
+  # already exists, so exactly one caller can win it; `-p` succeeds for both and hands
+  # two audits the same directory. That matters because phase plus a whole-second
+  # timestamp is not unique — two audits of the same phase in one second collide, and
+  # so does the same shell running this block twice — and from a shared directory no
+  # cleanup can be safe, since both audits write exactly `desktop.png`, `mobile.png`
+  # and `tablet.png`. A filename can never establish whose it is; winning the mkdir can.
+  # A PID suffix does NOT solve this: `$$` names the shell, not the invocation, so it is
+  # identical across two runs in one shell and inside command substitution.
+  mkdir -p .planning/ui-reviews
+  SCREENSHOT_BASE=".planning/ui-reviews/${PADDED_PHASE}-$(date +%Y%m%d-%H%M%S)"
+  SCREENSHOT_DIR="$SCREENSHOT_BASE"
+  SUFFIX=1
+  until mkdir "$SCREENSHOT_DIR" 2>/dev/null; do
+    SCREENSHOT_DIR="$SCREENSHOT_BASE-$SUFFIX"
+    SUFFIX=$((SUFFIX + 1))
+    if [ "$SUFFIX" -gt 99 ]; then
+      SCREENSHOT_DIR=""
+      break
     fi
   done
 
-  if [ "$CAPTURED" -eq 3 ]; then
-    CAPTURE_STATUS="captured"
-    echo "Screenshots captured to $SCREENSHOT_DIR (3/3) from $DEV_URL"
-  elif [ "$CAPTURED" -gt 0 ]; then
-    CAPTURE_STATUS="partially captured"
-    echo "Screenshots PARTIALLY captured to $SCREENSHOT_DIR ($CAPTURED/3) from $DEV_URL — failed:$FAILED_SHOTS"
-  else
+  if [ -z "$SCREENSHOT_DIR" ]; then
+    # The allocation loop above gave up. Never fall through: with SCREENSHOT_DIR empty
+    # the capture below would write to /desktop.png, outside the project entirely.
     CAPTURE_STATUS="not captured (capture failed)"
-    # Every viewport already removed its own stray file in the loop above, so the
-    # directory is empty here unless something ELSE put a file in it — and in that
-    # case rmdir correctly fails and leaves that file alone.
-    rmdir "$SCREENSHOT_DIR" 2>/dev/null
-    echo "Screenshot capture FAILED for all 3 viewports at $DEV_URL — code-only audit"
+    echo "Could not allocate a review directory under .planning/ui-reviews — code-only audit"
+  else
+    # Capture each viewport from the RESOLVED port, and believe only what the
+    # exit status and the file on disk actually say.
+    CAPTURED=0
+    FAILED_SHOTS=""
+    for SHOT in "desktop:1440,900" "mobile:375,812" "tablet:768,1024"; do
+      SHOT_NAME="${SHOT%%:*}"
+      SHOT_VIEWPORT="${SHOT##*:}"
+      # --timeout is not belt-and-braces here: `playwright screenshot` passes it to
+      # context.setDefaultTimeout() and defaults it to 0 — NO timeout — so this CLI path
+      # drops the 30s bound the Playwright library applies everywhere else. Without it a
+      # hung navigation blocks the audit forever, which is the same failure the probe's
+      # AbortSignal.timeout(5000) closes one step earlier.
+      if npx playwright screenshot "$DEV_URL" \
+           "$SCREENSHOT_DIR/$SHOT_NAME.png" \
+           --viewport-size="$SHOT_VIEWPORT" \
+           --timeout=30000 >/dev/null 2>&1 \
+         && [ -s "$SCREENSHOT_DIR/$SHOT_NAME.png" ]; then
+        CAPTURED=$((CAPTURED + 1))
+      else
+        # Remove what THIS viewport may have written before scoring it a failure. A
+        # crashed browser commonly leaves a zero-byte or partial .png, which the
+        # `[ -s ]` above correctly refuses to count and which would otherwise sit in
+        # the review directory looking like evidence. Doing it here rather than in
+        # the all-failed branch below is what makes the claim true of a PARTIAL
+        # capture too — two good shots and one stray file was the gap.
+        # By name rather than a `*.png` glob. For this audit's own files the two are
+        # equivalent; the name form additionally leaves alone anything else that happens
+        # to be in the directory. What actually keeps a CONCURRENT audit's captures safe
+        # is the `-$$` in the directory above, never this line.
+        rm -f "$SCREENSHOT_DIR/$SHOT_NAME.png"
+        FAILED_SHOTS="$FAILED_SHOTS $SHOT_NAME"
+      fi
+    done
+
+    if [ "$CAPTURED" -eq 3 ]; then
+      CAPTURE_STATUS="captured"
+      echo "Screenshots captured to $SCREENSHOT_DIR (3/3) from $DEV_URL"
+    elif [ "$CAPTURED" -gt 0 ]; then
+      CAPTURE_STATUS="partially captured"
+      echo "Screenshots PARTIALLY captured to $SCREENSHOT_DIR ($CAPTURED/3) from $DEV_URL — failed:$FAILED_SHOTS"
+    else
+      CAPTURE_STATUS="not captured (capture failed)"
+      # `rm -rf`, not `rmdir`, and the atomic allocation above is what licenses it: this
+      # directory was won by this audit and shared with nobody, so removing it whole
+      # cannot destroy another audit's work. rmdir could not honour the claim — it fails
+      # on any file the capture command wrote under a name this block did not ask for,
+      # leaving both that file and the directory behind while the docs said otherwise.
+      rm -rf "$SCREENSHOT_DIR"
+      echo "Screenshot capture FAILED for all 3 viewports at $DEV_URL — code-only audit"
+    fi
   fi
 elif [ -n "$DEV_GATED" ]; then
   CAPTURE_STATUS="not captured (dev server auth-gated)"

--- a/agents/gsd-ui-auditor.md
+++ b/agents/gsd-ui-auditor.md
@@ -152,10 +152,15 @@ if [ -n "$DEV_URL" ]; then
   SUFFIX=1
   ALLOC_FAILURE=""
   until mkdir "$SCREENSHOT_DIR" 2>/dev/null; do
-    # Retry ONLY a name collision. A candidate that failed and still does not exist failed
-    # structurally (parent unwritable/missing/a file, ENOSPC) — no suffix cures that.
-    # -L as well as -e: a dangling symlink occupies the name but -e follows it and says no.
+    # Retry ONLY a name collision. A candidate that failed and is still absent (-L too: a
+    # dangling symlink occupies the name but -e follows it) either failed structurally —
+    # parent unwritable/missing/a file, ENOSPC — or lost a race to a name taken and freed
+    # between the two calls. One more attempt tells them apart: a race is won, structure
+    # fails again, and no suffix cures the latter.
     if [ ! -e "$SCREENSHOT_DIR" ] && [ ! -L "$SCREENSHOT_DIR" ]; then
+      if mkdir "$SCREENSHOT_DIR" 2>/dev/null; then
+        break
+      fi
       ALLOC_FAILURE="could not create a review directory under .planning/ui-reviews"
       SCREENSHOT_DIR=""
       break

--- a/agents/gsd-ui-auditor.md
+++ b/agents/gsd-ui-auditor.md
@@ -111,12 +111,21 @@ This gate runs unconditionally on every audit. The .gitignore ensures screenshot
 ```bash
 # Detect a running dev server across the documented ports. The probe follows
 # redirects, accepts any 2xx, and is time-bounded, so a root path that
-# redirects (Next.js middleware/i18n, trailing-slash normalization) or a port
-# that accepts but never answers is not misread as "no dev server". fetch()
-# rather than curl, for cross-platform parity with
-# gsd-core/references/checkpoints.md.
+# redirects (Next.js middleware/i18n, trailing-slash normalization) is not
+# misread as "no dev server", and a port that accepts but never answers is
+# reported as exactly that instead of hanging the audit. fetch() rather than
+# curl, for cross-platform parity with gsd-core/references/checkpoints.md.
+#
+# EVERY answer is recorded, not only the two the capture can use. "No dev
+# server" is a claim about the PORT — nothing listening — and a server that
+# answered 404 (an API-only server on 3000), 500 (a dev server mid-crash) or
+# 503 (still compiling), or that accepted the connection and never answered,
+# is present. Reporting any of those as absent is #4176's own defect, one
+# status family over; the auditor cannot screenshot them, but it can say why.
 DEV_URL=""
 DEV_GATED=""
+DEV_OTHER=""
+DEV_TIMEOUT=""
 for PORT in 3000 5173 8080; do
   # process.stdout.write(String(...)), never console.log(r.status): console.log
   # CAN colorize a NUMBER — whenever node emits color, i.e. a TTY or FORCE_COLOR — so
@@ -124,7 +133,11 @@ for PORT in 3000 5173 8080; do
   # no-dev-server branch. Measured: piped and uncoloured it prints "200\n"; with
   # FORCE_COLOR=1 it prints the escapes. Writing the string is unconditional, which is
   # why it is the fix rather than relying on the caller's colour state.
-  PROBE=$(node -e 'fetch(process.argv[1],{redirect:"follow",signal:AbortSignal.timeout(5000)}).then(r=>process.stdout.write(String(r.status))).catch(()=>process.stdout.write("000"))' "http://localhost:$PORT" 2>/dev/null || echo "000")
+  # The timeout is named in the output. The program owns the ONLY AbortSignal in play,
+  # so an abort — TimeoutError on current Node, the older AbortError spelling on early
+  # 18.x — can only be the 5s bound firing; every other rejection (refused, reset,
+  # a redirect loop) still reads "000".
+  PROBE=$(node -e 'fetch(process.argv[1],{redirect:"follow",signal:AbortSignal.timeout(5000)}).then(r=>process.stdout.write(String(r.status))).catch(e=>process.stdout.write(e&&(e.name==="TimeoutError"||e.name==="AbortError")?"timeout":"000"))' "http://localhost:$PORT" 2>/dev/null || echo "000")
   PROBE=${PROBE:-000}
   case "$PROBE" in
     2??)     DEV_URL="http://localhost:$PORT"; break ;;
@@ -136,6 +149,14 @@ for PORT in 3000 5173 8080; do
     # unguarded assignment here reports whichever gated port was tried LAST, so
     # with 3000 and 8080 both auth-gated the reason would name 8080.
     401|403|407|511) [ -n "$DEV_GATED" ] || DEV_GATED="http://localhost:$PORT (HTTP $PROBE)" ;;
+    # Any other status is a server that ANSWERED. The loop keeps going, because a
+    # later port may hold the real dev server (an API on 3000 answering 404, Vite
+    # on 5173), and a 2xx there still wins via the `break` above. First-wins, as
+    # the gated arm is, so the reported port follows the documented precedence.
+    [1-9]??) [ -n "$DEV_OTHER" ] || DEV_OTHER="http://localhost:$PORT (HTTP $PROBE)" ;;
+    # Accepted the connection, never answered within the bound: hung, mid-start,
+    # or stopped at a debugger — present, whichever it is.
+    timeout) [ -n "$DEV_TIMEOUT" ] || DEV_TIMEOUT="http://localhost:$PORT" ;;
   esac
 done
 
@@ -222,6 +243,16 @@ if [ -n "$DEV_URL" ]; then
 elif [ -n "$DEV_GATED" ]; then
   CAPTURE_STATUS="not captured (dev server auth-gated)"
   echo "Dev server at $DEV_GATED is auth-gated — code-only audit"
+elif [ -n "$DEV_OTHER" ]; then
+  # Precedence among the present-but-unusable outcomes: gated, then any other
+  # answer, then a timeout. Each records its own FIRST port; across the three
+  # the more informative answer is reported, since "401" says what to do and
+  # "no answer in 5s" only says something is there.
+  CAPTURE_STATUS="not captured (dev server answered, not 2xx)"
+  echo "Dev server at $DEV_OTHER answered but is not serving a page — code-only audit"
+elif [ -n "$DEV_TIMEOUT" ]; then
+  CAPTURE_STATUS="not captured (dev server accepted the connection, no answer in 5s)"
+  echo "Dev server at $DEV_TIMEOUT accepted the connection but did not answer within 5s — code-only audit"
 else
   CAPTURE_STATUS="not captured (no dev server)"
   echo "No dev server on ports 3000, 5173 or 8080 — code-only audit"

--- a/agents/gsd-ui-auditor.md
+++ b/agents/gsd-ui-auditor.md
@@ -200,7 +200,11 @@ if [ -n "$DEV_URL" ]; then
   if [ -z "$SCREENSHOT_DIR" ]; then
     # The allocation loop above gave up. Never fall through: with SCREENSHOT_DIR empty
     # the capture below would write to /desktop.png, outside the project entirely.
-    CAPTURE_STATUS="not captured (capture failed)"
+    # Its own status, not "capture failed": no capture was attempted, and the two
+    # have different remedies (free a name or fix the directory, versus fix the
+    # browser). The report renders $CAPTURE_STATUS, so the distinction has to
+    # live in the VALUE — a detail carried only by this echo never reaches it.
+    CAPTURE_STATUS="not captured (could not allocate a review directory under .planning/ui-reviews)"
     echo "Could not allocate a review directory under .planning/ui-reviews — code-only audit"
   else
     # Capture each viewport from the RESOLVED port, and believe only what the
@@ -238,13 +242,17 @@ if [ -n "$DEV_URL" ]; then
     done
 
     if [ "$CAPTURED" -eq 3 ]; then
-      CAPTURE_STATUS="captured"
+      # The VALUE carries what the echo carries — count, failed viewports, port and
+      # status — because the report template renders $CAPTURE_STATUS and nothing else.
+      # docs/AGENTS.md already described the field as naming the viewports that failed;
+      # until this line, only the transient echo did.
+      CAPTURE_STATUS="captured (3/3 from $DEV_URL)"
       echo "Screenshots captured to $SCREENSHOT_DIR (3/3) from $DEV_URL"
     elif [ "$CAPTURED" -gt 0 ]; then
-      CAPTURE_STATUS="partially captured"
+      CAPTURE_STATUS="partially captured ($CAPTURED/3 from $DEV_URL; failed:$FAILED_SHOTS)"
       echo "Screenshots PARTIALLY captured to $SCREENSHOT_DIR ($CAPTURED/3) from $DEV_URL — failed:$FAILED_SHOTS"
     else
-      CAPTURE_STATUS="not captured (capture failed)"
+      CAPTURE_STATUS="not captured (capture failed for all 3 viewports at $DEV_URL)"
       # `rm -rf`, not `rmdir`, and the atomic allocation above is what licenses it: this
       # directory was won by this audit and shared with nobody, so removing it whole
       # cannot destroy another audit's work. rmdir could not honour the claim — it fails
@@ -260,20 +268,20 @@ elif [ -n "$DEV_NOFETCH" ]; then
   CAPTURE_STATUS="not captured (cannot probe: node $DEV_NOFETCH has no fetch(); Node 18+ required)"
   echo "Cannot probe for a dev server: node $DEV_NOFETCH has no fetch() — Node 18+ is required — code-only audit"
 elif [ -n "$DEV_GATED" ]; then
-  CAPTURE_STATUS="not captured (dev server auth-gated)"
+  CAPTURE_STATUS="not captured (dev server auth-gated: $DEV_GATED)"
   echo "Dev server at $DEV_GATED is auth-gated — code-only audit"
 elif [ -n "$DEV_OTHER" ]; then
   # Precedence among the present-but-unusable outcomes: gated, then any other
   # answer, then a timeout. Each records its own FIRST port; across the three
   # the more informative answer is reported, since "401" says what to do and
   # "no answer in 5s" only says something is there.
-  CAPTURE_STATUS="not captured (dev server answered, not 2xx)"
+  CAPTURE_STATUS="not captured (dev server answered, not 2xx: $DEV_OTHER)"
   echo "Dev server at $DEV_OTHER answered but is not serving a page — code-only audit"
 elif [ -n "$DEV_TIMEOUT" ]; then
-  CAPTURE_STATUS="not captured (dev server accepted the connection, no answer in 5s)"
+  CAPTURE_STATUS="not captured (dev server at $DEV_TIMEOUT accepted the connection, no answer in 5s)"
   echo "Dev server at $DEV_TIMEOUT accepted the connection but did not answer within 5s — code-only audit"
 else
-  CAPTURE_STATUS="not captured (no dev server)"
+  CAPTURE_STATUS="not captured (no dev server on ports 3000, 5173 or 8080)"
   echo "No dev server on ports 3000, 5173 or 8080 — code-only audit"
 fi
 ```

--- a/agents/gsd-ui-auditor.md
+++ b/agents/gsd-ui-auditor.md
@@ -159,6 +159,16 @@ if [ -n "$DEV_URL" ]; then
        && [ -s "$SCREENSHOT_DIR/$SHOT_NAME.png" ]; then
       CAPTURED=$((CAPTURED + 1))
     else
+      # Remove what THIS viewport may have written before scoring it a failure. A
+      # crashed browser commonly leaves a zero-byte or partial .png, which the
+      # `[ -s ]` above correctly refuses to count and which would otherwise sit in
+      # the review directory looking like evidence. Doing it here rather than in
+      # the all-failed branch below is what makes the claim true of a PARTIAL
+      # capture too — two good shots and one stray file was the gap.
+      # BY NAME, never a `*.png` glob: this directory is keyed to the phase and a
+      # whole second, so two audits of the same phase can share it, and a glob
+      # would delete the other one's captures.
+      rm -f "$SCREENSHOT_DIR/$SHOT_NAME.png"
       FAILED_SHOTS="$FAILED_SHOTS $SHOT_NAME"
     fi
   done
@@ -171,13 +181,9 @@ if [ -n "$DEV_URL" ]; then
     echo "Screenshots PARTIALLY captured to $SCREENSHOT_DIR ($CAPTURED/3) from $DEV_URL — failed:$FAILED_SHOTS"
   else
     CAPTURE_STATUS="not captured (capture failed)"
-    # Remove what the failed captures WROTE before removing the directory. A crashed
-    # browser commonly leaves a zero-byte or partial .png behind; `[ -s ]` above
-    # correctly scores that as a failure, but rmdir then fails on the non-empty
-    # directory with its stderr discarded, so BOTH the stray file and the directory
-    # would survive. Scoped to the .png files in the timestamped directory this block
-    # created moments ago, and only on the all-three-failed path.
-    [ -n "$SCREENSHOT_DIR" ] && rm -f "$SCREENSHOT_DIR"/*.png
+    # Every viewport already removed its own stray file in the loop above, so the
+    # directory is empty here unless something ELSE put a file in it — and in that
+    # case rmdir correctly fails and leaves that file alone.
     rmdir "$SCREENSHOT_DIR" 2>/dev/null
     echo "Screenshot capture FAILED for all 3 viewports at $DEV_URL — code-only audit"
   fi

--- a/agents/gsd-ui-auditor.md
+++ b/agents/gsd-ui-auditor.md
@@ -123,8 +123,8 @@ DEV_NOFETCH=""
 for PORT in 3000 5173 8080; do
   # process.stdout.write, never console.log: console.log colourises a NUMBER under a TTY
   # or FORCE_COLOR, and "\033[33m200\033[39m" matches no arm. Measured.
-  # An abort can only be this program's own 5s signal (TimeoutError; AbortError on early
-  # 18.x), so it prints "timeout"; every other rejection prints "000". No process.exit()
+  # An abort can only be this program's own 5s signal (TimeoutError, or the generic
+  # AbortError older fetch builds raise), so it prints "timeout"; anything else is "000". No process.exit()
   # after the nofetch write: a pipe write is async on Windows and an exit can drop it.
   PROBE=$(node -e 'typeof fetch==="function"?fetch(process.argv[1],{redirect:"follow",signal:AbortSignal.timeout(5000)}).then(r=>process.stdout.write(String(r.status))).catch(e=>process.stdout.write(e&&(e.name==="TimeoutError"||e.name==="AbortError")?"timeout":"000")):process.stdout.write("nofetch "+process.version)' "http://localhost:$PORT" 2>/dev/null || echo "000")
   PROBE=${PROBE:-000}
@@ -154,7 +154,8 @@ if [ -n "$DEV_URL" ]; then
   until mkdir "$SCREENSHOT_DIR" 2>/dev/null; do
     # Retry ONLY a name collision. A candidate that failed and still does not exist failed
     # structurally (parent unwritable/missing/a file, ENOSPC) — no suffix cures that.
-    if [ ! -e "$SCREENSHOT_DIR" ]; then
+    # -L as well as -e: a dangling symlink occupies the name but -e follows it and says no.
+    if [ ! -e "$SCREENSHOT_DIR" ] && [ ! -L "$SCREENSHOT_DIR" ]; then
       ALLOC_FAILURE="could not create a review directory under .planning/ui-reviews"
       SCREENSHOT_DIR=""
       break

--- a/agents/gsd-ui-auditor.md
+++ b/agents/gsd-ui-auditor.md
@@ -142,6 +142,10 @@ if [ -n "$DEV_URL" ]; then
   # land in the same directory, and from there no cleanup rule can be safe, because
   # both audits write exactly `desktop.png`, `mobile.png` and `tablet.png` — a
   # filename cannot establish whose it is. Ownership has to come from the directory.
+  # PID-plus-timestamp rather than `mktemp -d`, matching gsd-code-fixer.md, which
+  # replaced mktemp's XXXXXX with the same `$$` + epoch suffix for a repo-relative
+  # path under #2647: on Windows/Git Bash `mktemp` produced an un-removable short
+  # `C:/mvwtNN` path to dodge MAX_PATH.
   SCREENSHOT_DIR=".planning/ui-reviews/${PADDED_PHASE}-$(date +%Y%m%d-%H%M%S)-$$"
   mkdir -p "$SCREENSHOT_DIR"
 

--- a/agents/gsd-ui-auditor.md
+++ b/agents/gsd-ui-auditor.md
@@ -161,6 +161,13 @@ if [ -n "$DEV_URL" ]; then
     echo "Screenshots PARTIALLY captured to $SCREENSHOT_DIR ($CAPTURED/3) from $DEV_URL — failed:$FAILED_SHOTS"
   else
     CAPTURE_STATUS="not captured (capture failed)"
+    # Remove what the failed captures WROTE before removing the directory. A crashed
+    # browser commonly leaves a zero-byte or partial .png behind; `[ -s ]` above
+    # correctly scores that as a failure, but rmdir then fails on the non-empty
+    # directory with its stderr discarded, so BOTH the stray file and the directory
+    # would survive. Scoped to the .png files in the timestamped directory this block
+    # created moments ago, and only on the all-three-failed path.
+    [ -n "$SCREENSHOT_DIR" ] && rm -f "$SCREENSHOT_DIR"/*.png
     rmdir "$SCREENSHOT_DIR" 2>/dev/null
     echo "Screenshot capture FAILED for all 3 viewports at $DEV_URL — code-only audit"
   fi

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -399,12 +399,13 @@ one, and takes its own artifacts with it: each viewport that fails has the
 partial or zero-byte file it may have written removed, so a partial capture
 leaves only the shots that actually succeeded, and a total failure removes the
 review directory outright. The directory is allocated atomically — `mkdir`
-without `-p`, retried under a fresh suffix when the name is taken — so it belongs
-to exactly one audit. That is what makes the cleanup safe to state without
-qualification: two audits of the same phase in the same second, or one shell
-running the audit twice, would otherwise share a directory and write the same
-three filenames, and no per-file rule could then tell whose capture it was
-deleting.
+without `-p`, retried under a fresh suffix when the name is taken — so exactly one
+audit wins a given name: two audits of the same phase in the same second, or one
+shell running the audit twice, would otherwise share a directory and write the
+same three filenames, and no per-file rule could then tell whose capture it was
+deleting. The guarantee is over creation, not over the pathname for all time —
+nothing here defends against another process substituting a parent directory
+mid-audit.
 
 ---
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -395,7 +395,10 @@ field is derived from the observed exit statuses and the files on disk, so it
 distinguishes three outcomes — captured (3/3), partially captured (N/3, naming
 the viewports that failed), and not captured with its reason (no dev server,
 auth-gated, or capture failure). A failed capture never reports as a successful
-one, and leaves no empty review directory behind.
+one, and takes its own artifacts with it — when all three viewports fail, the
+partial or zero-byte files a crashed capture wrote are removed along with the
+review directory, so a failed audit leaves nothing behind to be mistaken for
+evidence.
 
 ---
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -398,7 +398,10 @@ auth-gated, a server that answered something other than 2xx, a port that
 accepted the connection but never answered, or capture failure). "No dev
 server" means nothing was listening on any port: a server that answered 404 or
 500, or that hung, is reported as present, with its port and status, because
-the auditor could not use it — never as absent. A failed capture never reports as a successful
+the auditor could not use it — never as absent. The probe is `node -e` with
+`fetch()`, so it needs **Node 18+ on the audited project's PATH** — the
+project's runtime, not gsd-core's; an older Node is reported as its own outcome
+("cannot probe"), not as a missing server. A failed capture never reports as a successful
 one, and takes its own artifacts with it: each viewport that fails has the
 partial or zero-byte file it may have written removed, so a partial capture
 leaves only the shots that actually succeeded, and a total failure removes the

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -395,10 +395,13 @@ field is derived from the observed exit statuses and the files on disk, so it
 distinguishes three outcomes — captured (3/3), partially captured (N/3, naming
 the viewports that failed), and not captured with its reason (no dev server,
 auth-gated, or capture failure). A failed capture never reports as a successful
-one, and takes its own artifacts with it — when all three viewports fail, the
-partial or zero-byte files a crashed capture wrote are removed along with the
-review directory, so a failed audit leaves nothing behind to be mistaken for
-evidence.
+one, and takes its own artifacts with it: each viewport that fails has the
+partial or zero-byte file it may have written removed by name, so a partial
+capture leaves only the shots that actually succeeded and a total failure leaves
+the review directory empty, and therefore removed. Removal is by filename and
+never a wildcard — the directory is keyed to the phase and a whole second, so a
+concurrent audit sharing it keeps its own captures (and that directory then
+survives, which is the intended outcome rather than an exception to the claim).
 
 ---
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -396,12 +396,13 @@ distinguishes three outcomes — captured (3/3), partially captured (N/3, naming
 the viewports that failed), and not captured with its reason (no dev server,
 auth-gated, or capture failure). A failed capture never reports as a successful
 one, and takes its own artifacts with it: each viewport that fails has the
-partial or zero-byte file it may have written removed by name, so a partial
-capture leaves only the shots that actually succeeded and a total failure leaves
-the review directory empty, and therefore removed. Removal is by filename and
-never a wildcard — the directory is keyed to the phase and a whole second, so a
-concurrent audit sharing it keeps its own captures (and that directory then
-survives, which is the intended outcome rather than an exception to the claim).
+partial or zero-byte file it may have written removed, so a partial capture
+leaves only the shots that actually succeeded and a total failure leaves the
+review directory empty, and therefore removed. The directory is keyed to the
+phase, the second, and the audit's own process — two audits of the same phase
+starting in the same second do not share one, which is what makes that cleanup
+safe, since both would otherwise write the same three filenames and no per-file
+rule could tell them apart.
 
 ---
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -387,6 +387,16 @@ Three further dimensions carry no number: **Verify Command Format Sanity**,
 5. Spacing
 6. Experience Design
 
+**Screenshot capture.** Capture is CLI-only — the agent shells out to
+`npx playwright screenshot`, taking no MCP grant. It probes `localhost:3000`,
+then `5173`, then `8080`, following redirects and accepting any 2xx, and every
+capture runs against the port that answered. The reported `**Screenshots:**`
+field is derived from the observed exit statuses and the files on disk, so it
+distinguishes three outcomes — captured (3/3), partially captured (N/3, naming
+the viewports that failed), and not captured with its reason (no dev server,
+auth-gated, or capture failure). A failed capture never reports as a successful
+one, and leaves no empty review directory behind.
+
 ---
 
 ### gsd-dom-verifier

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -397,12 +397,14 @@ the viewports that failed), and not captured with its reason (no dev server,
 auth-gated, or capture failure). A failed capture never reports as a successful
 one, and takes its own artifacts with it: each viewport that fails has the
 partial or zero-byte file it may have written removed, so a partial capture
-leaves only the shots that actually succeeded and a total failure leaves the
-review directory empty, and therefore removed. The directory is keyed to the
-phase, the second, and the audit's own process — two audits of the same phase
-starting in the same second do not share one, which is what makes that cleanup
-safe, since both would otherwise write the same three filenames and no per-file
-rule could tell them apart.
+leaves only the shots that actually succeeded, and a total failure removes the
+review directory outright. The directory is allocated atomically — `mkdir`
+without `-p`, retried under a fresh suffix when the name is taken — so it belongs
+to exactly one audit. That is what makes the cleanup safe to state without
+qualification: two audits of the same phase in the same second, or one shell
+running the audit twice, would otherwise share a directory and write the same
+three filenames, and no per-file rule could then tell whose capture it was
+deleting.
 
 ---
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -394,7 +394,11 @@ capture runs against the port that answered. The reported `**Screenshots:**`
 field is derived from the observed exit statuses and the files on disk, so it
 distinguishes three outcomes — captured (3/3), partially captured (N/3, naming
 the viewports that failed), and not captured with its reason (no dev server,
-auth-gated, or capture failure). A failed capture never reports as a successful
+auth-gated, a server that answered something other than 2xx, a port that
+accepted the connection but never answered, or capture failure). "No dev
+server" means nothing was listening on any port: a server that answered 404 or
+500, or that hung, is reported as present, with its port and status, because
+the auditor could not use it — never as absent. A failed capture never reports as a successful
 one, and takes its own artifacts with it: each viewport that fails has the
 partial or zero-byte file it may have written removed, so a partial capture
 leaves only the shots that actually succeeded, and a total failure removes the

--- a/tests/playwright-ui-verify.test.cjs
+++ b/tests/playwright-ui-verify.test.cjs
@@ -160,8 +160,23 @@ function guardedLines(lines) {
 describe('#4176 — gsd-ui-auditor screenshot capture is honest', () => {
   test('dev-server probe follows redirects and is time-bounded', () => {
     const block = screenshotApproachBlock();
-    const followsRedirects = block.includes('curl -L') || block.includes('fetch(');
-    assert.ok(followsRedirects, 'probe must follow redirects (curl -L or fetch()) — a 307 dev server is not an absent one');
+    const usesCurlL = /curl[\t ]+(-[A-Za-z]{0,10}L|--location)\b/.test(block);
+    const usesFetch = /\bfetch\(/.test(block);
+    assert.ok(usesCurlL || usesFetch, 'probe must issue its request via curl or fetch()');
+    // Redirect-FOLLOWING is the property, and the bare presence of `fetch(` cannot
+    // express it: fetch's own default is already redirect:"follow", so a regression to
+    // redirect:"manual" — which reinstates the 307-read-as-absent bug #4176 is about —
+    // satisfies a `block.includes('fetch(')` check exactly as well as the fix does.
+    // Ban the non-following forms, and require the contract to be stated rather than
+    // inherited from a default a future runtime is free to change.
+    assert.ok(
+      !/redirect[\t ]*:[\t ]*["'](manual|error)["']/.test(block),
+      'probe must not disable redirect following — a redirecting dev server is not an absent one'
+    );
+    assert.ok(
+      usesCurlL || /redirect[\t ]*:[\t ]*["']follow["']/.test(block),
+      'a fetch()-based probe must state redirect:"follow" explicitly, so the redirect contract is pinned rather than inherited'
+    );
     const timeBounded = /--max-time|AbortSignal\.timeout|run-with-timeout|--connect-timeout/.test(block);
     assert.ok(timeBounded, 'probe must be time-bounded — an accepting-but-unresponsive port must not hang the audit');
   });
@@ -171,6 +186,19 @@ describe('#4176 — gsd-ui-auditor screenshot capture is honest', () => {
     assert.ok(
       !/=[\s]*"200"/.test(block),
       'probe must not exact-match "200" — that misreads redirects and other 2xx as no-server'
+    );
+    // Banning one literal idiom is not the same as requiring a range. `case "$PROBE" in
+    // 200) ... ;; esac` carries no `=` at all, so it reintroduces the same
+    // 2xx-but-not-200 misread while passing the ban above. Assert positively that a 2xx
+    // RANGE is what the probe accepts.
+    const acceptsRange =
+      /2\?\?\)/.test(block) ||               // case glob:  2??)
+      /2\[0-9\]\[0-9\]\)/.test(block) ||     // case class: 2[0-9][0-9])
+      /-ge[\t ]+200\b/.test(block) ||        // arithmetic lower bound
+      /\br\.ok\b/.test(block);               // fetch's own 2xx predicate
+    assert.ok(
+      acceptsRange,
+      'probe must accept a 2xx RANGE (a 2?? / 2[0-9][0-9] case glob, a >= 200 comparison, or r.ok) — not an enumerated status'
     );
   });
 
@@ -202,11 +230,27 @@ describe('#4176 — gsd-ui-auditor screenshot capture is honest', () => {
   });
 
   test('all three documented ports are tried in the control flow', () => {
-    const block = screenshotApproachBlock();
+    // Self-found, same class as finding 1: `block.includes(port)` is satisfied by a port
+    // named only in a comment. The pre-fix bug WAS a port documented in prose beside code
+    // that hard-coded 3000, so a whole-block substring check cannot distinguish the fix
+    // from the bug it replaced — it can only see that the digits exist somewhere. Read
+    // the iteration line itself.
+    // logicalLines, not guardedLines: a `for ... ; do` line OPENS a scope, so it is
+    // consumed by the guard walker and never appears among the governed lines.
+    const iteration = logicalLines(screenshotApproachLines())
+      .map((l) => l.trim())
+      .find((l) => /^for[\t ]+PORT[\t ]+in\b/i.test(l));
+    assert.ok(iteration, 'ports must be iterated, not hard-coded to one');
+    // And drop any trailing comment before reading it, or the check regresses to the
+    // whole-block substring form one line down: `for PORT in 3000; do # 5173, 8080 too`
+    // would otherwise satisfy it. (Measured — that mutation passed before this strip.)
+    const iterationCode = iteration.split(/[\t ]#/)[0];
     for (const port of ['3000', '5173', '8080']) {
-      assert.ok(block.includes(port), `port ${port} must appear in the capture control flow, not only in guidance prose`);
+      assert.ok(
+        iterationCode.includes(port),
+        `port ${port} must be in the port iteration itself, not only in guidance prose: ${iterationCode}`
+      );
     }
-    assert.ok(/for PORT in|for port in/.test(block), 'ports must be iterated, not hard-coded to one');
   });
 
   test('the resolved port — not a hard-coded 3000 — is what gets captured', () => {

--- a/tests/playwright-ui-verify.test.cjs
+++ b/tests/playwright-ui-verify.test.cjs
@@ -1050,32 +1050,47 @@ describe('#4176 — the capture fence, executed', { skip: BASH_OK ? false : 'no 
       'the failed viewport\u2019s zero-byte file must not survive alongside the real captures');
   });
 
-  test('two audits colliding on the same second get separate directories, and the first keeps its captures', () => {
-    // CONSTRUCTED, not hoped for. `date` is stubbed to a fixed value and both runs share
-    // one working directory, so the two audits genuinely contend for the same name — the
-    // case a wall-clock test can never reach, and the case that matters: both write
-    // exactly `desktop.png`, `mobile.png`, `tablet.png`, so no per-file rule can
-    // establish ownership, and a shared directory means the loser's total-failure
-    // cleanup destroys the winner's captures. Ownership must come from the directory.
+  test('audits colliding on the same second get separate directories, and none destroys another', () => {
+    // CONSTRUCTED, not hoped for. `date` is overridden to a fixed value and all three
+    // audits share one working directory, so they genuinely contend for the same base
+    // name — the case a wall-clock test can never reach, and the case that matters: every
+    // audit writes exactly `desktop.png`, `mobile.png`, `tablet.png`, so no per-file rule
+    // can establish ownership. Ownership must come from winning the directory.
+    //
+    // TWO SURVIVING AUDITS, not one. Reading the directory list after a single failing
+    // second run cannot see whether that run contended at all: its directory is removed
+    // either way, so freezing only the FIRST audit left the second on the real clock and
+    // the fixture still passed. Driven. Both successful audits must therefore be present,
+    // distinct, and both under the frozen base name.
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-4176-race-'));
     tmpDirs.push(dir);
     const fixed = { FIXED_DATE: '20300101-000000', PADDED_PHASE: '07' };
-    const first = ok(runFence({ ...fixed, PROBE_3000: '200' }, dir));
-    // PROVE THE CLOCK WAS FROZEN. If the override does not take, the two audits get
-    // different names from the timestamp alone, they never contend, and this test passes
-    // having constructed nothing — which is exactly what happened on windows-latest when
-    // the override was a file on PATH that Git Bash shadowed with /usr/bin/date.
-    assert.ok(first.shotDirs[0] && first.shotDirs[0].startsWith(`07-${fixed.FIXED_DATE}`),
-      `the date override did not take — this fixture cannot construct a collision: ${JSON.stringify(first.shotDirs)}`);
-    // The second audit fails every viewport, so its cleanup runs — under a shared
-    // directory that cleanup is what deleted the first audit's work.
-    const second = ok(runFence({ ...fixed, PROBE_3000: '200', SHOT_EXIT: 'desktop mobile tablet',
+    const base = `07-${fixed.FIXED_DATE}`;
+    ok(runFence({ ...fixed, PROBE_3000: '200' }, dir));
+    const second = ok(runFence({ ...fixed, PROBE_3000: '200' }, dir));
+    assert.strictEqual(second.shotDirs.length, 2,
+      `two contending audits must hold two directories: ${JSON.stringify(second.shotDirs)}`);
+    for (const d of second.shotDirs) {
+      assert.ok(d.startsWith(base),
+        `every audit must be on the frozen base name or they never contend: ${JSON.stringify(second.shotDirs)}`);
+    }
+    assert.notStrictEqual(second.shotDirs[0], second.shotDirs[1],
+      'a contended base name must not be handed to two audits');
+    for (const d of second.shotDirs) {
+      assert.deepStrictEqual(second.filesIn(d), ['desktop.png', 'mobile.png', 'tablet.png'],
+        `each audit keeps its own three captures: ${d}`);
+    }
+    // And a third audit that fails everything removes only its own directory — under a
+    // shared one, its cleanup is what destroyed the neighbours' identically-named files.
+    const third = ok(runFence({ ...fixed, PROBE_3000: '200', SHOT_EXIT: 'desktop mobile tablet',
       SHOT_WRITE: '', SHOT_EMPTY: 'desktop mobile tablet' }, dir));
-    assert.strictEqual(first.shotDirs.length, 1, 'the first audit must get a directory');
-    assert.strictEqual(second.shotDirs.length, 1,
-      `after the second audit cleaned up, exactly the first audit's directory must remain: ${JSON.stringify(second.shotDirs)}`);
-    assert.deepStrictEqual(second.filesIn(second.shotDirs[0]), ['desktop.png', 'mobile.png', 'tablet.png'],
-      'the second audit\u2019s failure cleanup must not touch the first audit\u2019s captures');
+    assert.match(third.stdout, /Screenshot capture FAILED for all 3 viewports/);
+    assert.strictEqual(third.shotDirs.length, 2,
+      `the failing audit must remove only its own directory: ${JSON.stringify(third.shotDirs)}`);
+    for (const d of third.shotDirs) {
+      assert.deepStrictEqual(third.filesIn(d), ['desktop.png', 'mobile.png', 'tablet.png'],
+        `a failing audit's cleanup must not touch another audit's captures: ${d}`);
+    }
   });
 
   test('an exhausted allocation is a capture failure, not a write outside the project', () => {
@@ -1097,12 +1112,38 @@ describe('#4176 — the capture fence, executed', { skip: BASH_OK ? false : 'no 
     // reason rather than for the reason it names.
     assert.doesNotMatch(r.stdout, /Screenshots captured/,
       'the date override did not take — the allocation was never exhausted');
+    // The MESSAGE, not just a generic failure. Dropping this line (it was lost when the
+    // vacuity guard above was added) let the fixture infer exhaustion from any capture
+    // failure with no invocations — an unfrozen clock plus a capture stub that fails
+    // early satisfied it while nothing was ever exhausted. Driven.
+    assert.match(r.stdout, /Could not allocate a review directory/,
+      'the exhaustion branch must be the one that ran, not merely some capture failure');
     assert.strictEqual(r.captureStatus, 'not captured (capture failed)');
     assert.doesNotMatch(r.stdout, /Screenshots captured/);
     assert.strictEqual(r.invocations.length, 0,
       'nothing may be captured when no directory was allocated — the path would be outside the project');
     assert.strictEqual(fs.readdirSync(reviews).length, 100,
       'the exhausted run must not have created a directory of its own');
+  });
+
+  test('the last candidate suffix is tried, not skipped', () => {
+    // The retry loop once incremented past the bound before forming the next candidate,
+    // so with the base and `-1`..`-98` taken it reported exhaustion while `-99` was free.
+    // That correction had no test of its own — reverting it passed the whole suite — and
+    // an off-by-one at the END of a bounded loop is exactly the shape a fixture that only
+    // exercises the empty and exhausted cases will never reach.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-4176-last-'));
+    tmpDirs.push(dir);
+    const reviews = path.join(dir, '.planning', 'ui-reviews');
+    fs.mkdirSync(reviews, { recursive: true });
+    fs.mkdirSync(path.join(reviews, '07-20300101-000000'));
+    for (let i = 1; i <= 98; i += 1) fs.mkdirSync(path.join(reviews, `07-20300101-000000-${i}`));
+    const r = ok(runFence({ FIXED_DATE: '20300101-000000', PADDED_PHASE: '07', PROBE_3000: '200' }, dir));
+    assert.doesNotMatch(r.stdout, /Could not allocate a review directory/,
+      'the last free candidate must be used, not skipped');
+    assert.match(r.stdout, /Screenshots captured/);
+    assert.ok(fs.existsSync(path.join(reviews, '07-20300101-000000-99')),
+      `the run must have allocated the one free suffix: ${JSON.stringify(fs.readdirSync(reviews).slice(-3))}`);
   });
 
   test('all three captures succeeding is the only path that claims "captured"', () => {

--- a/tests/playwright-ui-verify.test.cjs
+++ b/tests/playwright-ui-verify.test.cjs
@@ -560,3 +560,250 @@ describe('#4176 — gsd-ui-auditor screenshot capture is honest', () => {
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// EXECUTED, not read. Everything above asserts over the block's TEXT, and a
+// cross-model adversarial pass over the first version of this file broke eight of
+// those assertions with legal shell and legal JavaScript — a `fi # comment` that
+// desynchronised the scope walker, a `--timeout=0`, an exact-match `case` label
+// carrying a vacuous range test, a `redirect:"follow"` surviving only inside a JS
+// comment. Each is fixed above, and each fix is one more regex standing between a
+// claim and its evidence.
+//
+// The durable answer to "your test parses a language it does not lex" is to stop
+// parsing and start running. These two suites do that: the first executes the probe
+// program against real local HTTP servers (which is exactly how the reviewing
+// maintainer verified it by hand), the second executes the whole bash fence against
+// stub `node`/`npx` binaries and reads what it actually prints and leaves on disk.
+// A textual bypass cannot survive either one, because neither reads the text.
+// ---------------------------------------------------------------------------
+
+const http = require('http');
+const os = require('os');
+const { spawnSync, execFile } = require('child_process');
+
+// The probe is `node -e '<program>' "<url>"`. Take the program out verbatim.
+function probeProgram() {
+  const line = logicalLines(screenshotApproachLines().map(stripComment))
+    .find((l) => /\bnode\b[\t ]+-e[\t ]+'/.test(l));
+  assert.ok(line, 'expected the block to probe with `node -e`');
+  const open = line.indexOf("-e ") + 3;
+  assert.strictEqual(line[open], "'", 'expected the probe program in single quotes');
+  const close = line.indexOf("'", open + 1);
+  assert.ok(close > open, 'unterminated probe program');
+  return line.slice(open + 1, close);
+}
+
+function listen(handler) {
+  return new Promise((resolve) => {
+    const server = http.createServer(handler);
+    server.listen(0, '127.0.0.1', () => resolve(server));
+  });
+}
+const close = (server) => new Promise((resolve) => server.close(resolve));
+const urlOf = (server) => `http://127.0.0.1:${server.address().port}`;
+
+// ASYNC, and that is not a style choice. The servers above live in THIS process, so a
+// spawnSync here blocks the very event loop that has to answer the probe: every request
+// hung, the probe's own AbortSignal fired at 5s, and three tests failed with '000' against
+// live servers while the two that "passed" passed vacuously. Measured while writing this
+// suite — a self-inflicted instance of the false-clean class the rest of this file is about.
+function runProbe(url) {
+  return new Promise((resolve, reject) => {
+    execFile(process.execPath, ['-e', probeProgram(), url], { timeout: 30000 },
+      (err, stdout) => (err && !stdout ? reject(err) : resolve(String(stdout).trim())));
+  });
+}
+
+describe('#4176 — the probe program, executed against real servers', () => {
+  test('a redirecting dev server resolves to its final 2xx, not to "absent"', async () => {
+    // The originating bug: `curl` without -L against a root that 307s read as no server.
+    // A regression to redirect:"manual" or a deleted redirect key cannot pass this,
+    // whatever the block's comments say — the program is RUN.
+    const target = await listen((req, res) => { res.writeHead(200); res.end('ok'); });
+    const redirector = await listen((req, res) => {
+      res.writeHead(307, { Location: `${urlOf(target)}/` });
+      res.end();
+    });
+    try {
+      assert.strictEqual(await runProbe(urlOf(redirector)), '200',
+        'a 307 to a live 2xx must probe as 200 — following redirects is the #4176 fix');
+    } finally { await close(redirector); await close(target); }
+  });
+
+  test('a 2xx that is not 200 is still a dev server', async () => {
+    const server = await listen((req, res) => { res.writeHead(204); res.end(); });
+    try {
+      assert.strictEqual(await runProbe(urlOf(server)), '204');
+    } finally { await close(server); }
+  });
+
+  test('an auth-gated server reports its status, not absence', async () => {
+    const server = await listen((req, res) => { res.writeHead(401); res.end(); });
+    try {
+      assert.strictEqual(await runProbe(urlOf(server)), '401');
+    } finally { await close(server); }
+  });
+
+  test('nothing listening probes as 000', async () => {
+    const server = await listen((req, res) => { res.writeHead(200); res.end(); });
+    const dead = urlOf(server);
+    await close(server);
+    assert.strictEqual(await runProbe(dead), '000');
+  });
+
+  test('a port that accepts but never answers is time-bounded, not a hang', async () => {
+    // The issue's own third case. Without AbortSignal.timeout this never returns and the
+    // audit blocks forever; a presence check on the string "AbortSignal" cannot tell the
+    // difference between a bound that fires and one that does not.
+    const server = await listen(() => { /* accept, never respond */ });
+    try {
+      const started = Date.now();
+      assert.strictEqual(await runProbe(urlOf(server)), '000');
+      assert.ok(Date.now() - started < 20000,
+        'the probe must abort a non-answering port rather than hang');
+    } finally { await close(server); }
+  });
+});
+
+// The fence needs a POSIX shell. Windows CI has no bash on PATH by default, and the
+// repo's other fence-executing tests take the same platform gate.
+const BASH = process.platform === 'win32' ? null : 'bash';
+
+describe('#4176 — the capture fence, executed', { skip: BASH ? false : 'no bash on this platform' }, () => {
+  // Stub `node` and `npx` on PATH, run the fence, and read what it printed and left.
+  //  PROBE_<port>   the status the stubbed probe reports for that port
+  //  SHOT_FAIL      space-separated viewport names whose capture "fails"
+  //  SHOT_PARTIAL   viewport names whose failed capture still writes a zero-byte file
+  function runFence(env) {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-4176-'));
+    const bin = path.join(dir, 'bin');
+    fs.mkdirSync(bin);
+    fs.writeFileSync(path.join(bin, 'node'),
+      '#!/bin/sh\nfor a in "$@"; do case "$a" in http*) url="$a";; esac; done\n'
+      + 'port=${url##*:}\nport=${port%%/*}\neval "s=\\$PROBE_$port"\nprintf %s "${s:-000}"\n', { mode: 0o755 });
+    fs.writeFileSync(path.join(bin, 'npx'),
+      '#!/bin/sh\nout=""\nfor a in "$@"; do case "$a" in *.png) out="$a";; esac; done\n'
+      + 'name=$(basename "$out" .png)\n'
+      + 'printf "%s\\n" "$*" >> "$ARGV_LOG"\n'
+      + '[ -n "$PLANT_FOREIGN" ] && printf other > "$(dirname "$out")/other-audit.png"\n'
+      + 'case " $SHOT_FAIL " in *" $name "*)\n'
+      + '  case " $SHOT_PARTIAL " in *" $name "*) : > "$out";; esac\n'
+      + '  exit 1;; esac\n'
+      + 'printf "png" > "$out"\nexit 0\n', { mode: 0o755 });
+    const argvLog = path.join(dir, 'argv.log');
+    const script = path.join(dir, 'fence.sh');
+    fs.writeFileSync(script, `set -u\nPADDED_PHASE=07\n${screenshotApproachBlock()}\n`);
+    const r = spawnSync(BASH, [script], {
+      cwd: dir,
+      encoding: 'utf8',
+      timeout: 60000,
+      env: {
+        ...process.env,
+        PATH: `${bin}${path.delimiter}${process.env.PATH}`,
+        ARGV_LOG: argvLog,
+        SHOT_FAIL: '', SHOT_PARTIAL: '',
+        ...env,
+      },
+    });
+    const reviews = path.join(dir, '.planning', 'ui-reviews');
+    const shotDirs = fs.existsSync(reviews) ? fs.readdirSync(reviews) : [];
+    return {
+      stdout: r.stdout || '',
+      dir,
+      argv: fs.existsSync(argvLog) ? fs.readFileSync(argvLog, 'utf8') : '',
+      shotDirs,
+      files: shotDirs.length === 1 ? fs.readdirSync(path.join(reviews, shotDirs[0])).sort() : [],
+    };
+  }
+
+  test('no dev server on any port is reported as such, and nothing is created', () => {
+    const r = runFence({});
+    assert.match(r.stdout, /No dev server on ports 3000, 5173 or 8080/);
+    assert.deepStrictEqual(r.shotDirs, [], 'no review directory may be created without a dev server');
+  });
+
+  test('a total capture failure NEVER prints a success claim, and leaves nothing behind', () => {
+    // The #4176 defect itself, and the maintainer's Major finding, decided by execution:
+    // hoisting the success echo out of its branch makes this fail no matter how the block
+    // is punctuated, because the assertion is over what the block PRINTED.
+    const r = runFence({ PROBE_3000: '200', SHOT_FAIL: 'desktop mobile tablet', SHOT_PARTIAL: 'desktop mobile tablet' });
+    assert.doesNotMatch(r.stdout, /Screenshots captured/, 'a failed capture must never claim success');
+    assert.doesNotMatch(r.stdout, /PARTIALLY captured/);
+    assert.match(r.stdout, /Screenshot capture FAILED for all 3 viewports/);
+    assert.deepStrictEqual(r.shotDirs, [], 'the review directory must not survive a total failure');
+  });
+
+  test('a partial capture keeps the shots that worked and removes the stray files', () => {
+    // The review's finding 4, in the form the docs actually claim: the failed viewport's
+    // zero-byte file is gone while the two real captures remain.
+    const r = runFence({ PROBE_3000: '200', SHOT_FAIL: 'desktop', SHOT_PARTIAL: 'desktop' });
+    assert.match(r.stdout, /Screenshots PARTIALLY captured .*\(2\/3\).*failed: ?desktop/);
+    assert.deepStrictEqual(r.files, ['mobile.png', 'tablet.png'],
+      'the failed viewport\u2019s zero-byte file must not survive alongside the real captures');
+  });
+
+  test('a concurrent audit sharing the directory keeps its own captures', () => {
+    // Why the removal is BY NAME and not `rm -f "$DIR"/*.png`: the review directory is
+    // keyed to the phase and one whole second, so a second audit of the same phase can
+    // land in it. Under the glob, this audit's total failure deleted that one's captures.
+    // Here a foreign file is planted into the shared directory and every viewport then
+    // fails: our three stray files go, the neighbour's stays, and rmdir correctly declines
+    // to remove a directory that is no longer empty. The surviving directory is the
+    // intended outcome, not a leak — which is why the AGENTS.md capture paragraph says
+    // so explicitly rather than eliding it. (Named without its path: this file does not
+    // READ that document, and spelling the path would register it as a docs reader with
+    // the docs-guard lint, which is a claim about this test that is not true.)
+    const r = runFence({ PROBE_3000: '200', SHOT_FAIL: 'desktop mobile tablet',
+      SHOT_PARTIAL: 'desktop mobile tablet', PLANT_FOREIGN: '1' });
+    assert.match(r.stdout, /Screenshot capture FAILED for all 3 viewports/);
+    assert.strictEqual(r.shotDirs.length, 1, 'the shared directory must survive, since it is not ours alone');
+    assert.deepStrictEqual(r.files, ['other-audit.png'],
+      'cleanup must remove only the files this audit wrote, never the whole directory\u2019s .png files');
+  });
+
+  test('all three captures succeeding is the only path that prints "captured"', () => {
+    const r = runFence({ PROBE_3000: '200' });
+    assert.match(r.stdout, /Screenshots captured to .* \(3\/3\) from http:\/\/localhost:3000/);
+    assert.deepStrictEqual(r.files, ['desktop.png', 'mobile.png', 'tablet.png']);
+  });
+
+  test('the resolved port is the one captured, not a hard-coded 3000', () => {
+    const r = runFence({ PROBE_5173: '200' });
+    assert.match(r.stdout, /from http:\/\/localhost:5173/);
+    assert.ok(r.argv.includes('http://localhost:5173'), `capture argv: ${r.argv}`);
+    assert.ok(!r.argv.includes('http://localhost:3000'), `capture argv: ${r.argv}`);
+  });
+
+  test('a 2xx that is not 200 still resolves a dev server', () => {
+    const r = runFence({ PROBE_3000: '204' });
+    assert.match(r.stdout, /Screenshots captured/);
+  });
+
+  test('the FIRST auth-gated port is the one reported', () => {
+    // The review's finding 5, decided by behaviour: flipping the guard's operator makes
+    // DEV_GATED empty and this reports "no dev server", which fails here.
+    const r = runFence({ PROBE_3000: '401', PROBE_8080: '403' });
+    assert.match(r.stdout, /Dev server at http:\/\/localhost:3000 \(HTTP 401\) is auth-gated/);
+  });
+
+  test('the whole auth-required class is reported as gated, not as absent', () => {
+    for (const status of ['401', '403', '407', '511']) {
+      const r = runFence({ PROBE_3000: status });
+      assert.ok(
+        r.stdout.includes(`(HTTP ${status}) is auth-gated`),
+        `HTTP ${status} means the server answered and demanded credentials; it must not read as absent — got: ${r.stdout.trim()}`
+      );
+    }
+  });
+
+  test('every capture invocation carries a positive timeout', () => {
+    const r = runFence({ PROBE_3000: '200' });
+    const calls = r.argv.split('\n').filter((l) => l.includes('screenshot'));
+    assert.strictEqual(calls.length, 3, `expected 3 capture invocations: ${r.argv}`);
+    for (const call of calls) {
+      const m = /--timeout[= ]([0-9]+)\b/.exec(call);
+      assert.ok(m && Number(m[1]) > 0, `capture must pass a positive --timeout: ${call}`);
+    }
+  });
+});

--- a/tests/playwright-ui-verify.test.cjs
+++ b/tests/playwright-ui-verify.test.cjs
@@ -1012,7 +1012,7 @@ describe('#4176 — the capture fence, executed', { skip: BASH_OK ? false : 'no 
   test('no dev server on any port is reported as such, and nothing is created', () => {
     const r = ok(runFence({}));
     assert.match(r.stdout, /No dev server on ports 3000, 5173 or 8080/);
-    assert.strictEqual(r.captureStatus, 'not captured (no dev server)');
+    assert.strictEqual(r.captureStatus, 'not captured (no dev server on ports 3000, 5173 or 8080)');
     assert.deepStrictEqual(r.shotDirs, [], 'no review directory may be created without a dev server');
   });
 
@@ -1022,7 +1022,7 @@ describe('#4176 — the capture fence, executed', { skip: BASH_OK ? false : 'no 
     assert.doesNotMatch(r.stdout, /Screenshots captured/, 'a failed capture must never claim success');
     assert.doesNotMatch(r.stdout, /PARTIALLY captured/);
     assert.match(r.stdout, /Screenshot capture FAILED for all 3 viewports/);
-    assert.strictEqual(r.captureStatus, 'not captured (capture failed)',
+    assert.strictEqual(r.captureStatus, 'not captured (capture failed for all 3 viewports at http://localhost:3000)',
       'the report reads CAPTURE_STATUS, not the printed line — both have to be honest');
     assert.deepStrictEqual(r.shotDirs, [], 'the review directory must not survive a total failure');
   });
@@ -1032,7 +1032,7 @@ describe('#4176 — the capture fence, executed', { skip: BASH_OK ? false : 'no 
     // which exit status and file content agree — which is why they are separate knobs.
     const r = ok(runFence({ PROBE_3000: '200', SHOT_WRITE: '', SHOT_EXIT: '' }));
     assert.doesNotMatch(r.stdout, /Screenshots captured/);
-    assert.strictEqual(r.captureStatus, 'not captured (capture failed)');
+    assert.strictEqual(r.captureStatus, 'not captured (capture failed for all 3 viewports at http://localhost:3000)');
   });
 
   test('a capture that exits 0 leaving a ZERO-BYTE file is NOT a capture', () => {
@@ -1043,7 +1043,7 @@ describe('#4176 — the capture fence, executed', { skip: BASH_OK ? false : 'no 
     const r = ok(runFence({ PROBE_3000: '200', SHOT_WRITE: '', SHOT_EMPTY: 'desktop mobile tablet',
       SHOT_EXIT: '' }));
     assert.doesNotMatch(r.stdout, /Screenshots captured/);
-    assert.strictEqual(r.captureStatus, 'not captured (capture failed)');
+    assert.strictEqual(r.captureStatus, 'not captured (capture failed for all 3 viewports at http://localhost:3000)');
   });
 
   test('a capture that writes a real file but exits non-zero is NOT a capture, and its file goes', () => {
@@ -1059,7 +1059,8 @@ describe('#4176 — the capture fence, executed', { skip: BASH_OK ? false : 'no 
       const r = ok(runFence({ PROBE_3000: '200', SHOT_EXIT: failed,
         SHOT_WRITE: 'desktop mobile tablet' }));
       assert.match(r.stdout, new RegExp(`PARTIALLY captured .*\\(2/3\\).*failed: ?${failed}`));
-      assert.strictEqual(r.captureStatus, 'partially captured');
+      // THE VALUE names the count and the failed viewport, as docs/AGENTS.md said it did.
+      assert.strictEqual(r.captureStatus, `partially captured (2/3 from http://localhost:3000; failed: ${failed})`);
       // Restricting the cleanup to empty files only also passed every earlier fixture,
       // because none paired a failure with a non-empty artefact — a plausible-looking
       // png from a run that crashed after writing is the worst case to leave, not the least.
@@ -1072,7 +1073,7 @@ describe('#4176 — the capture fence, executed', { skip: BASH_OK ? false : 'no 
     const r = ok(runFence({ PROBE_3000: '200', SHOT_EXIT: 'desktop',
       SHOT_WRITE: 'mobile tablet', SHOT_EMPTY: 'desktop' }));
     assert.match(r.stdout, /Screenshots PARTIALLY captured .*\(2\/3\).*failed: ?desktop/);
-    assert.strictEqual(r.captureStatus, 'partially captured');
+    assert.strictEqual(r.captureStatus, 'partially captured (2/3 from http://localhost:3000; failed: desktop)');
     assert.deepStrictEqual(r.files, ['mobile.png', 'tablet.png'],
       'the failed viewport\u2019s zero-byte file must not survive alongside the real captures');
   });
@@ -1145,7 +1146,11 @@ describe('#4176 — the capture fence, executed', { skip: BASH_OK ? false : 'no 
     // early satisfied it while nothing was ever exhausted. Driven.
     assert.match(r.stdout, /Could not allocate a review directory/,
       'the exhaustion branch must be the one that ran, not merely some capture failure');
-    assert.strictEqual(r.captureStatus, 'not captured (capture failed)');
+    // Round-2 finding 4: this and "all three viewports failed" carried the SAME status
+    // string, while the block calls $CAPTURE_STATUS the single source of truth. The
+    // remedies differ (free a name or fix the directory, versus fix the browser), so the
+    // value has to.
+    assert.strictEqual(r.captureStatus, 'not captured (could not allocate a review directory under .planning/ui-reviews)');
     assert.doesNotMatch(r.stdout, /Screenshots captured/);
     assert.strictEqual(r.invocations.length, 0,
       'nothing may be captured when no directory was allocated — the path would be outside the project');
@@ -1176,7 +1181,7 @@ describe('#4176 — the capture fence, executed', { skip: BASH_OK ? false : 'no 
   test('all three captures succeeding is the only path that claims "captured"', () => {
     const r = ok(runFence({ PROBE_3000: '200' }));
     assert.match(r.stdout, /Screenshots captured to .* \(3\/3\) from http:\/\/localhost:3000/);
-    assert.strictEqual(r.captureStatus, 'captured');
+    assert.strictEqual(r.captureStatus, 'captured (3/3 from http://localhost:3000)');
     assert.deepStrictEqual(r.files, ['desktop.png', 'mobile.png', 'tablet.png']);
   });
 
@@ -1203,7 +1208,7 @@ describe('#4176 — the capture fence, executed', { skip: BASH_OK ? false : 'no 
   test('the FIRST auth-gated port is the one reported', () => {
     const r = ok(runFence({ PROBE_3000: '401', PROBE_8080: '403' }));
     assert.match(r.stdout, /Dev server at http:\/\/localhost:3000 \(HTTP 401\) is auth-gated/);
-    assert.strictEqual(r.captureStatus, 'not captured (dev server auth-gated)');
+    assert.strictEqual(r.captureStatus, 'not captured (dev server auth-gated: http://localhost:3000 (HTTP 401))');
   });
 
   test('the whole auth-required class is reported as gated, not as absent', () => {
@@ -1223,7 +1228,7 @@ describe('#4176 — the capture fence, executed', { skip: BASH_OK ? false : 'no 
       const r = ok(runFence({ PROBE_3000: status }));
       assert.doesNotMatch(r.stdout, /No dev server/, `HTTP ${status} is an answer, not an absence`);
       assert.match(r.stdout, new RegExp(`Dev server at http://localhost:3000 \\(HTTP ${status}\\) answered`));
-      assert.strictEqual(r.captureStatus, 'not captured (dev server answered, not 2xx)');
+      assert.strictEqual(r.captureStatus, `not captured (dev server answered, not 2xx: http://localhost:3000 (HTTP ${status}))`);
       assert.deepStrictEqual(r.shotDirs, [], 'nothing to capture from a server that is not serving a page');
     }
   });
@@ -1233,14 +1238,14 @@ describe('#4176 — the capture fence, executed', { skip: BASH_OK ? false : 'no 
     // beside Vite on 5173 is the everyday shape, and the capture belongs to 5173.
     const r = ok(runFence({ PROBE_3000: '404', PROBE_5173: '200' }));
     assert.match(r.stdout, /Screenshots captured .* from http:\/\/localhost:5173/);
-    assert.strictEqual(r.captureStatus, 'captured');
+    assert.strictEqual(r.captureStatus, 'captured (3/3 from http://localhost:5173)');
   });
 
   test('a port that accepts the connection but never answers is reported as present and hung, not absent', () => {
     const r = ok(runFence({ PROBE_3000: 'timeout' }));
     assert.doesNotMatch(r.stdout, /No dev server/);
     assert.match(r.stdout, /Dev server at http:\/\/localhost:3000 accepted the connection but did not answer within 5s/);
-    assert.strictEqual(r.captureStatus, 'not captured (dev server accepted the connection, no answer in 5s)');
+    assert.strictEqual(r.captureStatus, 'not captured (dev server at http://localhost:3000 accepted the connection, no answer in 5s)');
     assert.deepStrictEqual(r.shotDirs, []);
   });
 
@@ -1263,12 +1268,12 @@ describe('#4176 — the capture fence, executed', { skip: BASH_OK ? false : 'no 
     // reported. Both orderings of the ports are driven so the precedence is shown to be
     // by CLASS and not an accident of which port was probed first.
     const gatedFirst = ok(runFence({ PROBE_3000: '401', PROBE_5173: '500', PROBE_8080: 'timeout' }));
-    assert.strictEqual(gatedFirst.captureStatus, 'not captured (dev server auth-gated)');
+    assert.strictEqual(gatedFirst.captureStatus, 'not captured (dev server auth-gated: http://localhost:3000 (HTTP 401))');
     const gatedLast = ok(runFence({ PROBE_3000: 'timeout', PROBE_5173: '500', PROBE_8080: '403' }));
-    assert.strictEqual(gatedLast.captureStatus, 'not captured (dev server auth-gated)');
+    assert.strictEqual(gatedLast.captureStatus, 'not captured (dev server auth-gated: http://localhost:8080 (HTTP 403))');
     assert.match(gatedLast.stdout, /http:\/\/localhost:8080 \(HTTP 403\) is auth-gated/);
     const otherOverTimeout = ok(runFence({ PROBE_3000: 'timeout', PROBE_8080: '503' }));
-    assert.strictEqual(otherOverTimeout.captureStatus, 'not captured (dev server answered, not 2xx)');
+    assert.strictEqual(otherOverTimeout.captureStatus, 'not captured (dev server answered, not 2xx: http://localhost:8080 (HTTP 503))');
     assert.match(otherOverTimeout.stdout, /http:\/\/localhost:8080 \(HTTP 503\) answered/);
   });
 

--- a/tests/playwright-ui-verify.test.cjs
+++ b/tests/playwright-ui-verify.test.cjs
@@ -60,3 +60,79 @@ describe('Playwright-MCP UI verification integration', () => {
     assert.ok(hasConditional, 'Playwright integration must be conditional with manual fallback');
   });
 });
+
+// #4176: the auditor's sole screenshot path had three defects — a 200-only
+// probe that misread a redirecting dev server as absent, an unconditional
+// "Screenshots captured" echo that survived total capture failure, and a
+// documented 3000 -> 5173 -> 8080 fallback the control flow never attempted.
+// These assert against the <screenshot_approach> BASH BLOCK specifically, not
+// the whole file: the pre-fix bug was precisely that the fallback existed as
+// a guidance sentence while the code hard-coded one port, so a whole-file
+// grep for "5173" passed on the broken version.
+const AUDITOR_PATH = path.join(__dirname, '..', 'agents', 'gsd-ui-auditor.md');
+
+function screenshotApproachBlock() {
+  const content = fs.readFileSync(AUDITOR_PATH, 'utf-8');
+  const section = content.split('<screenshot_approach>')[1].split('</screenshot_approach>')[0];
+  const fence = section.match(/```bash\n([\s\S]*?)\n```/);
+  assert.ok(fence, '<screenshot_approach> must contain a bash fence');
+  return fence[1];
+}
+
+describe('#4176 — gsd-ui-auditor screenshot capture is honest', () => {
+  test('dev-server probe follows redirects and is time-bounded', () => {
+    const block = screenshotApproachBlock();
+    const followsRedirects = block.includes('curl -L') || block.includes('fetch(');
+    assert.ok(followsRedirects, 'probe must follow redirects (curl -L or fetch()) — a 307 dev server is not an absent one');
+    const timeBounded = /--max-time|AbortSignal\.timeout|run-with-timeout|--connect-timeout/.test(block);
+    assert.ok(timeBounded, 'probe must be time-bounded — an accepting-but-unresponsive port must not hang the audit');
+  });
+
+  test('probe accepts any 2xx rather than exact-matching 200', () => {
+    const block = screenshotApproachBlock();
+    assert.ok(
+      !/=[\s]*"200"/.test(block),
+      'probe must not exact-match "200" — that misreads redirects and other 2xx as no-server'
+    );
+  });
+
+  test('capture success is checked, not assumed', () => {
+    const block = screenshotApproachBlock();
+    const checksOutcome = /\[ -s "?\$SCREENSHOT_DIR|\[ -s |if npx |CAPTURED=|\$\?/.test(block);
+    assert.ok(checksOutcome, 'an exit-status or file-existence check must gate the captured/not-captured signal');
+    // The unconditional echo is the actual defect: a "captured" claim must not
+    // sit outside any conditional that could have observed a failure.
+    const unconditional = block
+      .split('\n')
+      .some((l) => /^\s*echo "Screenshots captured/.test(l) && !/CAPTURED|-eq|-s /.test(block.slice(0, block.indexOf(l))));
+    assert.ok(!unconditional, '"Screenshots captured" must never be echoed without an outcome check');
+  });
+
+  test('all three documented ports are tried in the control flow', () => {
+    const block = screenshotApproachBlock();
+    for (const port of ['3000', '5173', '8080']) {
+      assert.ok(block.includes(port), `port ${port} must appear in the capture control flow, not only in guidance prose`);
+    }
+    assert.ok(/for PORT in|for port in/.test(block), 'ports must be iterated, not hard-coded to one');
+  });
+
+  test('the resolved port — not a hard-coded 3000 — is what gets captured', () => {
+    const block = screenshotApproachBlock();
+    const captureLines = block.split('\n').filter((l) => l.includes('playwright screenshot'));
+    assert.ok(captureLines.length > 0, 'expected at least one capture invocation');
+    for (const line of captureLines) {
+      assert.ok(
+        !line.includes('localhost:3000'),
+        `capture must use the resolved port variable, not a literal localhost:3000: ${line.trim()}`
+      );
+    }
+  });
+
+  test('report surfaces can express partial capture', () => {
+    const content = fs.readFileSync(AUDITOR_PATH, 'utf-8');
+    assert.ok(
+      /partially captured/i.test(content),
+      'the Screenshots field must be able to say partial — full/none alone cannot describe 2 of 3'
+    );
+  });
+});

--- a/tests/playwright-ui-verify.test.cjs
+++ b/tests/playwright-ui-verify.test.cjs
@@ -323,6 +323,11 @@ function stripComment(line) {
     if (c === '\\' && i + 1 < line.length) { out += c + line[i + 1]; i += 1; continue; }
     if (c === '$' && line[i + 1] === "'") { out += c + line[i + 1]; i += 1; stack.push('ansi'); continue; }
     if (c === '$' && line[i + 1] === '(') { out += c + line[i + 1]; i += 1; stack.push('cmd'); continue; }
+    // Process substitution `<( )` / `>( )` and an extglob `@( )` `*( )` `+( )` `?( )` `!( )` are
+    // parenthesised INSIDE a word: their `)` ends the construct, not the word, so a `#` right
+    // after it is literal (`cat <(printf x)#c` prints `/dev/fd/63#c`). Same context as `$( )`.
+    // Round review, continuation 2.
+    if (/[<>@*+?!]/.test(c) && line[i + 1] === '(') { out += c + line[i + 1]; i += 1; stack.push('cmd'); continue; }
     // Nested parens inside `$( )`. A raw subshell — `$( (printf x); printf "%s" " # " )`
     // — closed the outer context at the INNER `)`, after which every quote was
     // misclassified and the trailing continuation was truncated away. Driven. Depth is
@@ -1449,6 +1454,13 @@ describe('#4176 — bash reader, units', () => {
     assert.strictEqual(stripComment('x=#y'), 'x=#y');
     assert.strictEqual(stripComment('echo ${x}#y'), 'echo ${x}#y');
     assert.strictEqual(stripComment('echo "a;" #b'), 'echo "a;"');
+    // A `)` that closes a construct INSIDE a word is not a word end: process substitution
+    // and extglob. Round review, continuation 2.
+    assert.strictEqual(stripComment('cat <(printf x)#c'), 'cat <(printf x)#c');
+    assert.strictEqual(stripComment('cat <(printf x) #c'), 'cat <(printf x)');
+    assert.strictEqual(stripComment('echo @(a)#c'), 'echo @(a)#c');
+    assert.strictEqual(stripComment('echo @(a) #c'), 'echo @(a)');
+    assert.strictEqual(stripComment('echo $(printf x)#c'), 'echo $(printf x)#c');
   });
 
   test('logicalLines joins only a backslash that is the LAST character of the line, in an odd run', () => {

--- a/tests/playwright-ui-verify.test.cjs
+++ b/tests/playwright-ui-verify.test.cjs
@@ -174,14 +174,21 @@ function hasControlKeyword(text) {
 function blankQuoted(text) {
   let out = '';
   let quote = null;
+  let ansi = false;        // inside $'...', where a backslash escapes the closing quote
   for (let i = 0; i < text.length; i += 1) {
     const c = text[i];
     if (quote) {
-      if (c === '\\' && quote === '"') { out += '  '; i += 1; continue; }
-      if (c === quote) { quote = null; out += ' '; continue; }
+      // ANSI-C quoting processes backslash escapes, so `$'x\''` is ONE string whose
+      // content is `x'`. Treating that escaped quote as the terminator ended the span
+      // early, and the real `then`/`fi`/`if` after it were then blanked by the NEXT
+      // apparent quote — a stale guard with no throw. Driven, and the same asymmetry
+      // stripComment already models.
+      if (c === '\\' && (quote === '"' || ansi)) { out += '  '; i += 1; continue; }
+      if (c === quote) { quote = null; ansi = false; out += ' '; continue; }
       out += ' ';
       continue;
     }
+    if (c === '$' && text[i + 1] === "'") { quote = "'"; ansi = true; out += '  '; i += 1; continue; }
     if (c === '\\') { out += '  '; i += 1; continue; }
     if (c === "'" || c === '"') { quote = c; out += ' '; continue; }
     out += c;

--- a/tests/playwright-ui-verify.test.cjs
+++ b/tests/playwright-ui-verify.test.cjs
@@ -829,17 +829,29 @@ describe('#4176 — the probe program, executed against real servers', () => {
       'a closed but valid port must probe as 000 through a real connection refusal');
   });
 
-  test('a port that accepts but never answers is time-bounded, not a hang', async () => {
+  test('a port that accepts but never answers is time-bounded, not a hang — and is named as a timeout', async () => {
     // The issue's own third case. Without AbortSignal.timeout this never returns and the
     // audit blocks forever; a presence check on the string "AbortSignal" cannot tell the
     // difference between a bound that fires and one that does not.
+    // AND IT IS NOT "000". A port that accepted the connection has something listening on
+    // it; printing the same token as a refused connection reported that server as absent
+    // — the defect this issue names, reached through the timeout instead of a status.
     const server = await listen(() => { /* accept, never respond */ });
     try {
       const started = Date.now();
-      assert.strictEqual(await runProbe(urlOf(server)), '000');
+      assert.strictEqual(await runProbe(urlOf(server)), 'timeout');
       assert.ok(Date.now() - started < 20000,
         'the probe must abort a non-answering port rather than hang');
     } finally { await close(server); }
+  });
+
+  test('a server that answers something other than 2xx or an auth status still reports that status', async () => {
+    for (const status of [404, 500, 503]) {
+      const server = await listen((req, res) => { res.writeHead(status); res.end(); });
+      try {
+        assert.strictEqual(await runProbe(urlOf(server)), String(status));
+      } finally { await close(server); }
+    }
   });
 });
 
@@ -1185,6 +1197,50 @@ describe('#4176 — the capture fence, executed', { skip: BASH_OK ? false : 'no 
       assert.ok(r.stdout.includes(`(HTTP ${status}) is auth-gated`),
         `HTTP ${status} means the server answered and demanded credentials; it must not read as absent — got: ${r.stdout.trim()}`);
     }
+  });
+
+  test('a server answering a status that is neither 2xx nor auth-gated is reported as PRESENT, with its port and status', () => {
+    // 404 from an API-only server, 500 from a dev server mid-crash, 503 while it compiles,
+    // 429 from a rate limiter: each ANSWERED. Before this fixture every one of them fell
+    // through the `case` and printed "No dev server", which is the claim #4176 exists to
+    // stop the auditor making about a server that is there.
+    for (const status of ['404', '429', '500', '503']) {
+      const r = ok(runFence({ PROBE_3000: status }));
+      assert.doesNotMatch(r.stdout, /No dev server/, `HTTP ${status} is an answer, not an absence`);
+      assert.match(r.stdout, new RegExp(`Dev server at http://localhost:3000 \\(HTTP ${status}\\) answered`));
+      assert.strictEqual(r.captureStatus, 'not captured (dev server answered, not 2xx)');
+      assert.deepStrictEqual(r.shotDirs, [], 'nothing to capture from a server that is not serving a page');
+    }
+  });
+
+  test('a later port holding a real dev server outranks an earlier port that answered non-2xx', () => {
+    // The loop must NOT stop at the first answer of any kind: an API on 3000 answering 404
+    // beside Vite on 5173 is the everyday shape, and the capture belongs to 5173.
+    const r = ok(runFence({ PROBE_3000: '404', PROBE_5173: '200' }));
+    assert.match(r.stdout, /Screenshots captured .* from http:\/\/localhost:5173/);
+    assert.strictEqual(r.captureStatus, 'captured');
+  });
+
+  test('a port that accepts the connection but never answers is reported as present and hung, not absent', () => {
+    const r = ok(runFence({ PROBE_3000: 'timeout' }));
+    assert.doesNotMatch(r.stdout, /No dev server/);
+    assert.match(r.stdout, /Dev server at http:\/\/localhost:3000 accepted the connection but did not answer within 5s/);
+    assert.strictEqual(r.captureStatus, 'not captured (dev server accepted the connection, no answer in 5s)');
+    assert.deepStrictEqual(r.shotDirs, []);
+  });
+
+  test('among present-but-unusable answers the precedence is gated, then any other status, then a timeout', () => {
+    // Each class records its own FIRST port; across classes the more actionable answer is
+    // reported. Both orderings of the ports are driven so the precedence is shown to be
+    // by CLASS and not an accident of which port was probed first.
+    const gatedFirst = ok(runFence({ PROBE_3000: '401', PROBE_5173: '500', PROBE_8080: 'timeout' }));
+    assert.strictEqual(gatedFirst.captureStatus, 'not captured (dev server auth-gated)');
+    const gatedLast = ok(runFence({ PROBE_3000: 'timeout', PROBE_5173: '500', PROBE_8080: '403' }));
+    assert.strictEqual(gatedLast.captureStatus, 'not captured (dev server auth-gated)');
+    assert.match(gatedLast.stdout, /http:\/\/localhost:8080 \(HTTP 403\) is auth-gated/);
+    const otherOverTimeout = ok(runFence({ PROBE_3000: 'timeout', PROBE_8080: '503' }));
+    assert.strictEqual(otherOverTimeout.captureStatus, 'not captured (dev server answered, not 2xx)');
+    assert.match(otherOverTimeout.stdout, /http:\/\/localhost:8080 \(HTTP 503\) answered/);
   });
 
   test('every capture invocation passes a positive timeout as its own argument', () => {

--- a/tests/playwright-ui-verify.test.cjs
+++ b/tests/playwright-ui-verify.test.cjs
@@ -172,8 +172,15 @@ function guardedLines(lines) {
 // the assertions over it pass on an empty selection. Filtering first makes that shape impossible
 // rather than merely unlikely. (A trailing comment on a real code line is still selected; that
 // direction over-fires, which is the safe one.)
+// Inline comments are stripped too, not just whole-line ones. `--timeout=30000` moved into a
+// trailing comment is an ordinary edit, not sabotage, and it would otherwise keep satisfying the
+// time-bound assertion while no longer being passed to the command. Strip from an unquoted ` #`
+// to end of line BEFORE joining, which also closes the splice via a trailing comment.
+function stripComment(line) {
+  return line.replace(/\s+#.*$/, '');
+}
 function captureInvocations(lines) {
-  return logicalLines(lines.filter((l) => !/^[\t ]*#/.test(l)))
+  return logicalLines(lines.map(stripComment).filter((l) => !/^[\t ]*#/.test(l) && l.trim() !== ''))
     .map((l) => l.trim())
     .filter((l) => l.includes('playwright screenshot'));
 }

--- a/tests/playwright-ui-verify.test.cjs
+++ b/tests/playwright-ui-verify.test.cjs
@@ -304,9 +304,15 @@ function stripComment(line) {
   const stack = [];
   const top = () => stack[stack.length - 1];
   let out = '';
+  // WORD START is tracked, not inferred from the previous character. `echo a \ # b` has a
+  // space before the `#`, but that space is ESCAPED — it belongs to the word ` #`, and bash
+  // prints `a  # b`. Reading `line[i - 1]` called it a comment. Driven by the round review.
+  let wordStart = true;
   for (let i = 0; i < line.length; i += 1) {
     const c = line[i];
     const ctx = top();
+    const wasWordStart = wordStart;
+    wordStart = stack.length === 0 && /[\t ]/.test(c);
     if (ctx === 'sq') { out += c; if (c === "'") stack.pop(); continue; }
     if (ctx === 'ansi') {                       // $'...' — backslash escapes ARE processed
       if (c === '\\' && i + 1 < line.length) { out += c + line[i + 1]; i += 1; continue; }
@@ -333,12 +339,12 @@ function stripComment(line) {
     if (c === '"' && ctx === 'dq') { out += c; stack.pop(); continue; }
     if (c === '"') { out += c; stack.push('dq'); continue; }
     if (c === "'" && ctx !== 'dq') { out += c; stack.push('sq'); continue; }
-    if (c === '#' && stack.length === 0 && (i === 0 || /[\t ]/.test(line[i - 1]))) {
-      // A `\` the removed text was hiding did NOT continue the line in bash, so this
-      // reader must not treat it as one. Driven: `echo one \ # x` followed by
-      // `--timeout=30000` runs the second line as its OWN command — bash never joins
-      // them, and keeping the backslash would make logicalLines() join what bash does not.
-      return out.replace(/[\t ]+$/, '').replace(/\\+$/, '');
+    if (c === '#' && stack.length === 0 && wasWordStart) {
+      // Trailing backslashes before the comment STAY. Reaching this branch means the space
+      // before `#` was unescaped, so any backslash run ahead of it was even — escaped
+      // backslashes, literal, never a continuation. (`echo one \ # x` no longer arrives
+      // here at all: its space is escaped, the `#` is literal, and bash prints it.)
+      return out.replace(/[\t ]+$/, '');
     }
     out += c;
   }
@@ -1346,6 +1352,10 @@ describe('#4176 — the capture fence, executed', { skip: BASH_OK ? false : 'no 
     const otherOverTimeout = ok(runFence({ PROBE_3000: 'timeout', PROBE_8080: '503' }));
     assert.strictEqual(otherOverTimeout.captureStatus, 'not captured (dev server answered, not 2xx: http://localhost:8080 (HTTP 503))');
     assert.match(otherOverTimeout.stdout, /http:\/\/localhost:8080 \(HTTP 503\) answered/);
+    // And the other order — the round review found this pair driven one way only, which
+    // is exactly the "by class, not by probe order" claim left unproven.
+    const otherFirst = ok(runFence({ PROBE_3000: '503', PROBE_8080: 'timeout' }));
+    assert.strictEqual(otherFirst.captureStatus, 'not captured (dev server answered, not 2xx: http://localhost:3000 (HTTP 503))');
   });
 
   test('every capture invocation passes a positive timeout as its own argument', () => {
@@ -1397,6 +1407,18 @@ describe('#4176 — bash reader, units', () => {
     for (const lab of [falsePass, falseFail, quotedSpace]) {
       for (const p of lab) assert.strictEqual(p.active.length, p.text.length, 'text and active must stay the same length');
     }
+  });
+
+  test('stripComment opens a comment only at a WORD start — an escaped space is not one', () => {
+    // bash: `#` starts a comment only where a word could start. After `\ ` the `#` is the
+    // second character of the word ` #`, so it is literal. After `\\ ` (escaped backslash,
+    // then a real space) it IS a comment. Found by the round review, driven against bash.
+    assert.strictEqual(stripComment('echo a \\ # b'), 'echo a \\ # b');
+    assert.strictEqual(stripComment('echo a \\\\ # b'), 'echo a \\\\');
+    assert.strictEqual(stripComment('echo a # b'), 'echo a');
+    assert.strictEqual(stripComment('echo a#b'), 'echo a#b');
+    assert.strictEqual(stripComment('# whole line'), '');
+    assert.strictEqual(stripComment('echo "a # b" # c'), 'echo "a # b"');
   });
 
   test('logicalLines joins only a backslash that is the LAST character of the line, in an odd run', () => {

--- a/tests/playwright-ui-verify.test.cjs
+++ b/tests/playwright-ui-verify.test.cjs
@@ -160,8 +160,33 @@ function logicalLines(lines) {
 // keyword list for the same reason: `else echo unparsed` reached neither the bare-`else`
 // branch nor this check. All three driven.
 function hasControlKeyword(text) {
-  const bare = text.replace(/'[^']*'/g, ' ').replace(/"(?:[^"\\]|\\.)*"/g, ' ');
-  return /(^|[\t ;&|(){}<>])(if|then|else|elif|fi|do|done|case|esac)([\t ;&|(){}<>]|$)/.test(bare);
+  return /(^|[\t ;&|(){}<>])(if|then|else|elif|fi|do|done|case|esac)([\t ;&|(){}<>]|$)/.test(blankQuoted(text));
+}
+
+// Replace the CONTENTS of quoted spans with spaces, walking the line once.
+//
+// Two independent regexes (`/'[^']*'/` then `/"..."/`) is not the same thing, and the
+// difference is a false PASS: an apostrophe inside a double-quoted string — legal, and
+// `test "'" = x` is the driven case — pairs with the next apostrophe several tokens
+// away, and the single-quote pass then erases the real `then`, `fi` and `if` between
+// them. The guard saw no control keyword and the walker kept a stale CAPTURED guard on a
+// hoisted success echo. Whichever regex runs first, the other one is wrong.
+function blankQuoted(text) {
+  let out = '';
+  let quote = null;
+  for (let i = 0; i < text.length; i += 1) {
+    const c = text[i];
+    if (quote) {
+      if (c === '\\' && quote === '"') { out += '  '; i += 1; continue; }
+      if (c === quote) { quote = null; out += ' '; continue; }
+      out += ' ';
+      continue;
+    }
+    if (c === '\\') { out += '  '; i += 1; continue; }
+    if (c === "'" || c === '"') { quote = c; out += ' '; continue; }
+    out += c;
+  }
+  return out;
 }
 
 function guardedLines(lines) {
@@ -275,6 +300,11 @@ function stripComment(line) {
     if (c === '\\' && i + 1 < line.length) { out += c + line[i + 1]; i += 1; continue; }
     if (c === '$' && line[i + 1] === "'") { out += c + line[i + 1]; i += 1; stack.push('ansi'); continue; }
     if (c === '$' && line[i + 1] === '(') { out += c + line[i + 1]; i += 1; stack.push('cmd'); continue; }
+    // Nested parens inside `$( )`. A raw subshell — `$( (printf x); printf "%s" " # " )`
+    // — closed the outer context at the INNER `)`, after which every quote was
+    // misclassified and the trailing continuation was truncated away. Driven. Depth is
+    // tracked on the stack itself: a bare `(` inside cmd pushes, its `)` pops.
+    if (c === '(' && ctx === 'cmd') { out += c; stack.push('cmd'); continue; }
     if (c === ')' && ctx === 'cmd') { out += c; stack.pop(); continue; }
     // `${var#pattern}` — the `#` there is a removal operator, not a comment, and the
     // scanner truncated `echo ${value# #}` mid-expansion. Driven.
@@ -310,43 +340,53 @@ function stripComment(line) {
 // up to the FIRST unquoted `)`; a quoted one is part of a pattern, not the terminator.
 function caseLabelOf(line) {
   const t = line.trim().replace(/^\(/, '');
-  // Walk once, tracking quotes, and split on `|` only OUTSIDE them. A blanket
-  // `split('|')` turned the single literal pattern `"401|403|407|511"` into four
-  // statuses (false PASS), while stripping quotes afterwards turned the literal
-  // `"2??"` into what looked like a range (false PASS on an arm that accepts only the
-  // statuses it enumerates). Both driven. So each pattern also records whether ANY of
-  // it was quoted: a quoted `?` is a literal question mark, not a wildcard.
+  // Walk once, tracking quotes, splitting on `|` only OUTSIDE them, and recording
+  // activity PER CHARACTER rather than per pattern.
+  //
+  // One boolean per pattern cannot express either direction, and both were driven:
+  // `2\?\?` escapes the wildcards so bash matches them literally — an exact-match arm
+  // that read as a range (false PASS) — while `"2"??` quotes only the digit and IS a
+  // range, which a whole-pattern flag called quoted (false FAIL). What decides whether a
+  // `?` is a wildcard is whether THAT `?` was quoted or escaped, so that is what is kept.
   const patterns = [];
   let cur = '';
-  let quoted = false;
+  let active = [];        // per character: is this an ACTIVE (unquoted, unescaped) glob metachar
   let quote = null;
   let end = -1;
+  const push = (c, isActive) => { cur += c; active.push(isActive); };
   for (let i = 0; i < t.length; i += 1) {
     const c = t[i];
     if (quote) {
-      if (c === '\\' && quote === '"') { cur += t[i + 1] ?? ''; i += 1; continue; }
+      if (c === '\\' && quote === '"') { push(t[i + 1] ?? '', false); i += 1; continue; }
       if (c === quote) { quote = null; continue; }
-      cur += c; quoted = true; continue;
+      push(c, false);
+      continue;
     }
-    if (c === '\\') { cur += t[i + 1] ?? ''; i += 1; continue; }   // `4\01` is 401
-    if (c === "'" || c === '"') { quote = c; quoted = true; continue; }
-    if (c === '|') { patterns.push({ text: cur.trim(), quoted }); cur = ''; quoted = false; continue; }
+    if (c === '\\') { push(t[i + 1] ?? '', false); i += 1; continue; }
+    if (c === "'" || c === '"') { quote = c; continue; }
+    if (c === '|') { patterns.push({ text: cur.trim(), active }); cur = ''; active = []; continue; }
     if (c === ')') { end = i; break; }
-    cur += c;
+    push(c, true);
   }
   if (end < 0) return null;
-  patterns.push({ text: cur.trim(), quoted });
+  patterns.push({ text: cur.trim(), active });
   // Whitespace only disqualifies an UNQUOTED pattern: `"x y"` is one legal pattern, and
   // rejecting the whole label for it false-FAILED an otherwise-valid arm. Driven.
   if (patterns.length === 0
-      || patterns.some((x) => x.text === '' || (!x.quoted && /[\t ]/.test(x.text)))) return null;
+      || patterns.some((x) => x.text === ''
+        || x.text.split('').some((ch, k) => /[\t ]/.test(ch) && x.active[k]))) return null;
   return patterns;
 }
+
 
 // A pattern that actually matches a RANGE of 2xx statuses. A quoted `"2??"` matches the
 // three literal characters `2??` and no status at all, so its wildcards do not count.
 function isTwoXxRange(pattern) {
-  return !pattern.quoted && /^2(\?\?|\[0-9\]\[0-9\]|\*)$/.test(pattern.text);
+  const { text, active } = pattern;
+  if (!/^2(\?\?|\[0-9\]\[0-9\]|\*)$/.test(text)) return false;
+  // Every metacharacter in the matched shape must be ACTIVE. `2\?\?` has the right text
+  // and no active wildcards, so it matches exactly the three characters `2??`.
+  return text.split('').every((ch, k) => !/[?*[\]]/.test(ch) || active[k]);
 }
 
 function captureInvocations(lines) {
@@ -596,16 +636,16 @@ describe('#4176 — gsd-ui-auditor screenshot capture is honest', () => {
     // The removal lives in the capture loop's FAILURE arm, not in the all-failed branch,
     // and that placement is the finding: scoped to the all-failed branch it left the
     // PARTIAL case — two good shots and one stray file — still overclaimed by the docs.
-    // It is also BY NAME rather than a `*.png` glob, because the review directory is
-    // keyed to the phase and a whole second, so a concurrent audit of the same phase can
-    // share it and a glob would delete that audit's captures.
+    // It is also BY NAME rather than a `*.png` glob. That is the narrower operation and
+    // leaves alone anything else in the directory; what keeps a CONCURRENT audit's
+    // captures safe is the atomic allocation, not this line.
     const rows = guardedLines(screenshotApproachLines());
     const removals = rows.filter((r) => /^rm -f\b/.test(r.line));
     assert.ok(removals.length > 0, 'expected the capture loop to remove a failed viewport\u2019s stray file');
     for (const row of removals) {
       assert.ok(
         !/\*/.test(row.line),
-        `stray-file removal must name the file, never glob the directory — a concurrent audit shares it: ${row.line}`
+        `stray-file removal must name the file, never glob the directory: ${row.line}`
       );
       assert.ok(
         /\$SHOT_NAME/.test(row.line),
@@ -645,7 +685,12 @@ describe('#4176 — gsd-ui-auditor screenshot capture is honest', () => {
     // outright, the block stays in the haystack, and the assertion is then satisfied by the
     // block's own text. That is a false clean, and CRLF-fragility is a class this repo lints
     // for (local/no-crlf-fragile-split). Assert on the Screenshots report field itself.
-    const surfaces = splitLines(fs.readFileSync(AUDITOR_PATH, 'utf-8'))
+    // HTML comments removed FIRST. Commenting out both real fields and adding a visible
+    // hard-coded `Screenshots: captured` line satisfied a scan of the raw source: the
+    // commented lines still matched, and the rendered text no longer carried the
+    // variable at all. Driven.
+    const rendered = fs.readFileSync(AUDITOR_PATH, 'utf-8').replace(/<!--[\s\S]*?-->/g, '');
+    const surfaces = splitLines(rendered)
       .filter((l) => /^\*\*Screenshots:\*\*/.test(l.trim()));
     assert.ok(surfaces.length > 0, 'expected a Screenshots report field in the agent output template');
     // The field's VALUE, not a mention on the line. `**Screenshots:** captured
@@ -709,11 +754,19 @@ const urlOf = (server) => `http://127.0.0.1:${server.address().port}`;
 function runProbe(url) {
   return new Promise((resolve, reject) => {
     execFile(process.execPath, ['-e', probeProgram(), url], { timeout: 30000 },
-      // Trim exactly what `$( )` trims — TRAILING NEWLINES — and nothing else. A blanket
-      // .trim() accepted a program emitting " 200", which the product's `case` rejects;
-      // no trimming at all rejected "200\n", which the product ACCEPTS, because command
-      // substitution strips it. Both directions were driven; this models the substitution.
-      (err, stdout) => (err && !stdout ? reject(err) : resolve(String(stdout).replace(/\n+$/, ''))));
+      // MODEL THE WHOLE SHELL EXPRESSION, not just the program. The fence runs
+      //   PROBE=$(node -e '…' "$url" 2>/dev/null || echo "000"); PROBE=${PROBE:-000}
+      // so a program that PRINTS 200 and then exits non-zero yields `200000` — which
+      // matches no arm and reads as absent. Ignoring the exit code here accepted exactly
+      // that mutant. `$( )` strips trailing newlines and nothing else: a blanket .trim()
+      // accepted " 200" (which the block's `case` rejects) and no trim at all rejected
+      // "200\n" (which it accepts). All three directions driven.
+      (err, stdout) => {
+        const code = err && typeof err.code === 'number' ? err.code : 0;
+        const raw = String(stdout) + (code !== 0 ? '000\n' : '');
+        const substituted = raw.replace(/\n+$/, '');
+        resolve(substituted === '' ? '000' : substituted);
+      });
   });
 }
 
@@ -825,7 +878,13 @@ describe('#4176 — the capture fence, executed', { skip: BASH_OK ? false : 'no 
     // them, which let `--user-agent="--timeout=30000"` satisfy the timeout assertion while
     // passing no timeout option at all.
     fs.writeFileSync(path.join(bin, 'npx'),
-      '#!/bin/sh\nout=""\nfor a in "$@"; do case "$a" in *.png) out="$a";; esac; done\n'
+      // VERIFY THE COMMAND SELECTION. A stub that manufactures screenshots for whatever
+      // it is handed accepts `npx --version playwright screenshot ...`, which the real
+      // offline npx answers by printing its version and capturing nothing. Driven: that
+      // mutant passed every assertion here and failed against the real binary.
+      '#!/bin/sh\n[ "$1" = "playwright" ] && [ "$2" = "screenshot" ] || '
+      + '{ echo "stub npx: not invoked as `playwright screenshot`: $1 $2" >&2; exit 66; }\n'
+      + 'out=""\nfor a in "$@"; do case "$a" in *.png) out="$a";; esac; done\n'
       + 'name=$(basename "$out" .png)\n'
       // NUL-DELIMITED. A newline-delimited log splits an argument that CONTAINS a
       // newline into two, so `--user-agent=$'audit\\n--timeout=30000'` — one argument
@@ -853,11 +912,18 @@ describe('#4176 — the capture fence, executed', { skip: BASH_OK ? false : 'no 
     // Capture the block's OWN status before the instrumentation runs: a trailing
     // `printf` resets `$?`, so appending `false` to the fence exited 0 and the
     // exit-status assertion passed on a fence that had failed. Driven.
+    // THE INSTRUMENTATION WRITES FILES, NOT STDOUT. Anything printed to stdout is
+    // forgeable by the block under test: a `CAPTURE_STATUS` whose VALUE contains a
+    // newline forged a second status line, and a `printf "FENCE_RC=0"` forged a clean
+    // exit — both passed a stdout-scraping reader, whether it took the first match or
+    // the last. A file the block never names cannot be forged by the block's own output.
+    const statusFile = path.join(dir, 'capture-status.out');
+    const rcFile = path.join(dir, 'fence-rc.out');
     fs.writeFileSync(script,
       `PADDED_PHASE=${env.PADDED_PHASE || '07'}\n${screenshotApproachBlock()}\n`
       + 'FENCE_RC=$?\n'
-      + 'printf "CAPTURE_STATUS=%s\\n" "$CAPTURE_STATUS"\n'
-      + 'printf "FENCE_RC=%s\\n" "$FENCE_RC"\n');
+      + `printf %s "$CAPTURE_STATUS" > ${JSON.stringify(statusFile)}\n`
+      + `printf %s "$FENCE_RC" > ${JSON.stringify(rcFile)}\n`);
     const r = spawnSync('bash', [script], {
       cwd: dir,
       encoding: 'utf8',
@@ -875,16 +941,14 @@ describe('#4176 — the capture fence, executed', { skip: BASH_OK ? false : 'no 
     const shotDirs = fs.existsSync(reviews) ? fs.readdirSync(reviews).sort() : [];
     const filesIn = (d) => fs.readdirSync(path.join(reviews, d)).sort();
     const argvRaw = fs.existsSync(argvLog) ? fs.readFileSync(argvLog, 'utf8') : '';
-    // The LAST occurrence. Reading the first accepted a fence that printed the honest
-    // value and then reassigned the variable — the report would render the second.
-    const statusAll = [...stdout.matchAll(/^CAPTURE_STATUS=(.*)$/gm)];
-    const status = statusAll.length ? statusAll[statusAll.length - 1] : null;
-    const rcLine = /^FENCE_RC=([0-9]+)$/m.exec(stdout);
+    const readOut = (f) => (fs.existsSync(f) ? fs.readFileSync(f, 'utf8') : null);
+    const status = readOut(statusFile);
+    const rcRead = readOut(rcFile);
     return {
       stdout,
-      exitCode: rcLine ? Number(rcLine[1]) : r.status,
+      exitCode: rcRead !== null && rcRead !== '' ? Number(rcRead) : r.status,
       stderr: r.stderr || '',
-      captureStatus: status ? status[1] : null,
+      captureStatus: status,
       dir,
       // Each invocation as an array of its arguments — boundaries preserved.
       invocations: argvRaw.split('--INVOCATION--\0').slice(1)
@@ -943,16 +1007,23 @@ describe('#4176 — the capture fence, executed', { skip: BASH_OK ? false : 'no 
   test('a capture that writes a real file but exits non-zero is NOT a capture, and its file goes', () => {
     // The exit-status half, isolated. Dropping it counts a crashed run that happened to
     // leave a plausible file.
-    const r = ok(runFence({ PROBE_3000: '200', SHOT_EXIT: 'desktop',
-      SHOT_WRITE: 'desktop mobile tablet' }));
-    assert.match(r.stdout, /PARTIALLY captured .*\(2\/3\).*failed: ?desktop/);
-    assert.strictEqual(r.captureStatus, 'partially captured');
-    // And the file is REMOVED. Restricting the cleanup to empty files only passed every
-    // fixture, because none of them paired a failure with a non-empty artefact — a
-    // plausible-looking png from a run that crashed after writing is the worst case to
-    // leave behind, not the least.
-    assert.deepStrictEqual(r.files, ['mobile.png', 'tablet.png'],
-      'a failed viewport\u2019s file must go whether or not it happens to be empty');
+    // EVERY viewport, not just the first. A cleanup skipping one specific name
+    // (`if [ "$SHOT_NAME" != mobile ]`) passed a fixture set that only ever failed
+    // `desktop`, and the total-failure fixtures conceal it because the directory is
+    // removed wholesale. Driven.
+    const others = { desktop: ['mobile.png', 'tablet.png'], mobile: ['desktop.png', 'tablet.png'],
+      tablet: ['desktop.png', 'mobile.png'] };
+    for (const [failed, survivors] of Object.entries(others)) {
+      const r = ok(runFence({ PROBE_3000: '200', SHOT_EXIT: failed,
+        SHOT_WRITE: 'desktop mobile tablet' }));
+      assert.match(r.stdout, new RegExp(`PARTIALLY captured .*\\(2/3\\).*failed: ?${failed}`));
+      assert.strictEqual(r.captureStatus, 'partially captured');
+      // Restricting the cleanup to empty files only also passed every earlier fixture,
+      // because none paired a failure with a non-empty artefact — a plausible-looking
+      // png from a run that crashed after writing is the worst case to leave, not the least.
+      assert.deepStrictEqual(r.files, survivors,
+        `a failed ${failed} capture must take its file with it, empty or not`);
+    }
   });
 
   test('a partial capture keeps the shots that worked and removes the stray file', () => {
@@ -984,6 +1055,28 @@ describe('#4176 — the capture fence, executed', { skip: BASH_OK ? false : 'no 
       `after the second audit cleaned up, exactly the first audit's directory must remain: ${JSON.stringify(second.shotDirs)}`);
     assert.deepStrictEqual(second.filesIn(second.shotDirs[0]), ['desktop.png', 'mobile.png', 'tablet.png'],
       'the second audit\u2019s failure cleanup must not touch the first audit\u2019s captures');
+  });
+
+  test('an exhausted allocation is a capture failure, not a write outside the project', () => {
+    // The safety branch had NO fixture: replacing its guard with `if false; then` passed
+    // every assertion. With SCREENSHOT_DIR empty the capture would write to /desktop.png
+    // — outside the project entirely — so the branch that prevents it is exactly the kind
+    // that must not be taken on trust.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-4176-full-'));
+    tmpDirs.push(dir);
+    const reviews = path.join(dir, '.planning', 'ui-reviews');
+    fs.mkdirSync(reviews, { recursive: true });
+    // Occupy the base name and every suffix the loop will try.
+    fs.mkdirSync(path.join(reviews, '07-20300101-000000'));
+    for (let i = 1; i <= 99; i += 1) fs.mkdirSync(path.join(reviews, `07-20300101-000000-${i}`));
+    const r = ok(runFence({ FIXED_DATE: '20300101-000000', PADDED_PHASE: '07', PROBE_3000: '200' }, dir));
+    assert.match(r.stdout, /Could not allocate a review directory/);
+    assert.strictEqual(r.captureStatus, 'not captured (capture failed)');
+    assert.doesNotMatch(r.stdout, /Screenshots captured/);
+    assert.strictEqual(r.invocations.length, 0,
+      'nothing may be captured when no directory was allocated — the path would be outside the project');
+    assert.strictEqual(fs.readdirSync(reviews).length, 100,
+      'the exhausted run must not have created a directory of its own');
   });
 
   test('all three captures succeeding is the only path that claims "captured"', () => {

--- a/tests/playwright-ui-verify.test.cjs
+++ b/tests/playwright-ui-verify.test.cjs
@@ -253,6 +253,22 @@ describe('#4176 — gsd-ui-auditor screenshot capture is honest', () => {
     }
   });
 
+  test('the auth-gated port is recorded first-wins, matching the documented precedence', () => {
+    // The ports carry a documented ORDER, and the reported reason should name the same
+    // port that order would have picked. An unguarded assignment inside the loop reports
+    // whichever gated port was tried last.
+    const assignments = logicalLines(screenshotApproachLines())
+      .map((l) => l.trim())
+      .filter((l) => /DEV_GATED=/.test(l) && !/^DEV_GATED=""$/.test(l));
+    assert.ok(assignments.length > 0, 'expected the port loop to record an auth-gated server');
+    for (const line of assignments) {
+      assert.ok(
+        /\[[\t ]+-[nz][\t ]+"?\$DEV_GATED"?[\t ]+\]/.test(line),
+        `the auth-gated port must be recorded first-wins, or the reason names the LAST gated port: ${line}`
+      );
+    }
+  });
+
   test('the resolved port — not a hard-coded 3000 — is what gets captured', () => {
     const block = screenshotApproachBlock();
     const captureLines = block.split('\n').filter((l) => l.includes('playwright screenshot'));

--- a/tests/playwright-ui-verify.test.cjs
+++ b/tests/playwright-ui-verify.test.cjs
@@ -2,7 +2,7 @@
 // Reads .md/.json/.yml product files whose deployed text IS what the
 // runtime loads — testing text content tests the deployed contract.
 
-const { test, describe } = require('node:test');
+const { test, describe, after } = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('fs');
 const path = require('path');
@@ -151,6 +151,19 @@ function logicalLines(lines) {
 // two-line `then` form is recognised, and ANY residual line still carrying a bare
 // control keyword this walker did not consume THROWS. A test that cannot parse the
 // block fails loudly; it never reports on a stack it has lost track of.
+// Does this text carry a shell control keyword the walker did not consume?
+//
+// QUOTED TEXT IS REMOVED FIRST — `echo "we do work"` threw on the `do` inside a string,
+// and a guard that false-fires is a guard that gets deleted. The boundary set includes
+// the redirection and grouping characters, because `fi>/dev/null` was accepted (and so
+// silently failed to pop the scope stack) purely for want of `>` in it. `else` is in the
+// keyword list for the same reason: `else echo unparsed` reached neither the bare-`else`
+// branch nor this check. All three driven.
+function hasControlKeyword(text) {
+  const bare = text.replace(/'[^']*'/g, ' ').replace(/"(?:[^"\\]|\\.)*"/g, ' ');
+  return /(^|[\t ;&|(){}<>])(if|then|else|elif|fi|do|done|case|esac)([\t ;&|(){}<>]|$)/.test(bare);
+}
+
 function guardedLines(lines) {
   const stack = [];
   const rows = [];
@@ -171,7 +184,19 @@ function guardedLines(lines) {
       throw new Error(`bash reader: '${pendingIf}' opened an if with no 'then' — got ${JSON.stringify(t)}`);
     }
     const ifMatch = /^if[\t ]+(.{1,4000}?)[\t ]*;[\t ]*then$/.exec(t);
-    if (ifMatch) { stack.push(ifMatch[1]); continue; }
+    if (ifMatch) {
+      // The lazy quantifier still spans `;`, so `if A; then :; fi; if true; then` matched
+      // as ONE header whose "condition" swallowed a complete if/fi and a second `if` —
+      // and the echo that followed inherited a guard mentioning CAPTURED that governed
+      // nothing. Driven: bash printed the success line with CAPTURED=0 while the
+      // structural assertion passed. A condition is not allowed to contain control
+      // keywords; if it does, this is a compound line the walker cannot model.
+      if (hasControlKeyword(ifMatch[1])) {
+        throw new Error(`bash reader: compound if header — ${JSON.stringify(t)}`);
+      }
+      stack.push(ifMatch[1]);
+      continue;
+    }
     const ifPending = /^if[\t ]+(.{1,4000}?)[\t ]*$/.exec(t);
     if (ifPending && !/;/.test(ifPending[1])) { pendingIf = ifPending[1]; continue; }
     const elifMatch = /^elif[\t ]+(.{1,4000}?)[\t ]*;[\t ]*then$/.exec(t);
@@ -187,7 +212,7 @@ function guardedLines(lines) {
     // uses a form it cannot model, and continuing would report guards it no longer knows.
     // Word-boundary matched so `elif`/`fi` inside a string or an identifier does not fire;
     // an over-fire here costs a loud test failure, an under-fire costs a false clean.
-    if (/(^|[\t ;&|(])(if|then|elif|fi|do|done|case|esac)([\t ;&|)]|$)/.test(t)) {
+    if (hasControlKeyword(t)) {
       throw new Error(`bash reader: unparsed control construct — ${JSON.stringify(t)}`);
     }
     rows.push({ line: t, guards: stack.slice() });
@@ -215,23 +240,34 @@ function guardedLines(lines) {
 // uses, and it is what the false PASS above needed. A `#` starts a comment only when it is
 // outside quotes AND at the start of a word — `foo#bar` is one word to bash, not a comment.
 function stripComment(line) {
+  // A STACK, not a single quote flag. Three constructs defeated the flat scanner, all
+  // driven: `$'x\' # quoted'` (ANSI-C quoting, where a backslash-escaped quote is NOT the
+  // terminator the flat scanner took it for), `"$(printf "%s" " # ")"` (a command
+  // substitution restarts quoting inside an already-open double quote), and their
+  // combinations. A `#` opens a comment only with the stack EMPTY and at a word start.
+  const stack = [];
+  const top = () => stack[stack.length - 1];
   let out = '';
-  let quote = null;       // null | "'" | '"'
   for (let i = 0; i < line.length; i += 1) {
     const c = line[i];
-    if (quote === "'") { out += c; if (c === "'") quote = null; continue; }
-    if (quote === '"') {
+    const ctx = top();
+    if (ctx === 'sq') { out += c; if (c === "'") stack.pop(); continue; }
+    if (ctx === 'ansi') {                       // $'...' — backslash escapes ARE processed
       if (c === '\\' && i + 1 < line.length) { out += c + line[i + 1]; i += 1; continue; }
-      out += c; if (c === '"') quote = null; continue;
+      out += c; if (c === "'") stack.pop(); continue;
     }
     if (c === '\\' && i + 1 < line.length) { out += c + line[i + 1]; i += 1; continue; }
-    if (c === "'" || c === '"') { out += c; quote = c; continue; }
-    if (c === '#' && (i === 0 || /[\t ]/.test(line[i - 1]))) {
-      // A `\` that the removed text was hiding did NOT continue the line in bash, so this
+    if (c === '$' && line[i + 1] === "'") { out += c + line[i + 1]; i += 1; stack.push('ansi'); continue; }
+    if (c === '$' && line[i + 1] === '(') { out += c + line[i + 1]; i += 1; stack.push('cmd'); continue; }
+    if (c === ')' && ctx === 'cmd') { out += c; stack.pop(); continue; }
+    if (c === '"' && ctx === 'dq') { out += c; stack.pop(); continue; }
+    if (c === '"') { out += c; stack.push('dq'); continue; }
+    if (c === "'" && ctx !== 'dq') { out += c; stack.push('sq'); continue; }
+    if (c === '#' && stack.length === 0 && (i === 0 || /[\t ]/.test(line[i - 1]))) {
+      // A `\` the removed text was hiding did NOT continue the line in bash, so this
       // reader must not treat it as one. Driven: `echo one \ # x` followed by
-      // `--timeout=30000` runs the second line as its OWN command — bash never joins them.
-      // Keeping the backslash would make logicalLines() join what bash does not, so a flag
-      // on the following line would satisfy an assertion the real command never receives.
+      // `--timeout=30000` runs the second line as its OWN command — bash never joins
+      // them, and keeping the backslash would make logicalLines() join what bash does not.
       return out.replace(/[\t ]+$/, '').replace(/\\+$/, '');
     }
     out += c;
@@ -253,17 +289,23 @@ function caseLabelOf(line) {
   let end = -1;
   for (let i = 0; i < t.length; i += 1) {
     const c = t[i];
+    // Escapes inside double quotes: `"a\")"` is ONE pattern, and reading its escaped
+    // quote as the terminator truncated the label and false-FAILED the arm. Driven.
+    if (quote === '"' && c === '\\') { i += 1; continue; }
     if (quote) { if (c === quote) quote = null; continue; }
     if (c === "'" || c === '"') { quote = c; continue; }
     if (c === '\\') { i += 1; continue; }
     if (c === ')') { end = i; break; }
   }
   if (end <= 0) return null;
-  const label = t.slice(0, end);
-  // A case label is patterns joined by `|`; anything with a space or `=` in it is a
-  // command line that merely happens to contain a `)`, not an arm.
-  if (/[\t =]/.test(label)) return null;
-  return label.split('|').map((x) => x.trim()).filter((x) => x !== '');
+  // Whitespace is legal before the arm terminator — `200 )` — and rejecting the label on
+  // any whitespace made caseLabelOf return null there, which silently downgraded the
+  // range check to the body test the case label had already made vacuous. Driven.
+  const patterns = t.slice(0, end).split('|').map((x) => x.trim());
+  if (patterns.length === 0 || patterns.some((x) => x === '' || /[\t =]/.test(x))) return null;
+  // Quotes are not part of the pattern: `"2"??` and `"401"` are the quoted spellings of
+  // `2??` and `401`, and returning them with quotes attached false-FAILED both.
+  return patterns.map((x) => x.replace(/['"]/g, ''));
 }
 
 function captureInvocations(lines) {
@@ -422,9 +464,12 @@ describe('#4176 — gsd-ui-auditor screenshot capture is honest', () => {
       // strictly worse than the last-wins bug this guards — and all 15 tests passed,
       // because a `-n` test was still textually present. Accept exactly the two forms
       // that mean "keep the first": `[ -n "$DEV_GATED" ] ||` and `[ -z "$DEV_GATED" ] &&`.
+      // The operator must gate THE ASSIGNMENT. `[ -n "$DEV_GATED" ] || :; DEV_GATED=...`
+      // satisfies a guard-anywhere-on-the-line regex and still reports the LAST gated
+      // port, because the `;` ends the conditional before the assignment runs. Driven.
       assert.ok(
-        /\[[\t ]+-n[\t ]+"?\$DEV_GATED"?[\t ]+\][\t ]*\|\|/.test(line)
-          || /\[[\t ]+-z[\t ]+"?\$DEV_GATED"?[\t ]+\][\t ]*&&/.test(line),
+        /\[[\t ]+-n[\t ]+"?\$DEV_GATED"?[\t ]+\][\t ]*\|\|[\t ]*DEV_GATED=/.test(line)
+          || /\[[\t ]+-z[\t ]+"?\$DEV_GATED"?[\t ]+\][\t ]*&&[\t ]*DEV_GATED=/.test(line),
         `the auth-gated port must be recorded first-wins — \`[ -n "$DEV_GATED" ] ||\` or \`[ -z "$DEV_GATED" ] &&\`; the operator is what makes it first-wins, not the test: ${line}`
       );
     }
@@ -488,11 +533,15 @@ describe('#4176 — gsd-ui-auditor screenshot capture is honest', () => {
       // timeout, so a presence check accepts the exact state this assertion exists to
       // forbid — driven against the previous version, which passed 15/15 with every
       // capture at `--timeout=0`.
-      const flag = /--timeout[= ]([0-9]+)\b/.exec(line);
-      assert.ok(flag, `capture must be time-bounded — playwright screenshot defaults to no timeout: ${line}`);
+      // THE LAST occurrence, because a repeated option is last-wins in the real command:
+      // `--timeout=30000 --timeout=0` passed a first-match read while passing no timeout
+      // at all. (The executed suite reads real argument boundaries and is the stronger
+      // check; this one keeps the source-level assertion honest.)
+      const found = [...line.matchAll(/--timeout[= ]([0-9]+)\b/g)];
+      assert.ok(found.length > 0, `capture must be time-bounded — playwright screenshot defaults to no timeout: ${line}`);
       assert.ok(
-        Number(flag[1]) > 0,
-        `--timeout=0 IS playwright's no-timeout setting — the bound must be positive: ${line}`
+        Number(found[found.length - 1][1]) > 0,
+        `--timeout=0 IS playwright's no-timeout setting — the effective bound must be positive: ${line}`
       );
     }
   });
@@ -611,7 +660,10 @@ const urlOf = (server) => `http://127.0.0.1:${server.address().port}`;
 function runProbe(url) {
   return new Promise((resolve, reject) => {
     execFile(process.execPath, ['-e', probeProgram(), url], { timeout: 30000 },
-      (err, stdout) => (err && !stdout ? reject(err) : resolve(String(stdout).trim())));
+      // NOT trimmed. The bash `case "$PROBE" in 2??)` matches the RAW captured value, so
+      // a program emitting " 200" resolves no dev server in the product while a trimmed
+      // comparison here would call it 200 and pass.
+      (err, stdout) => (err && !stdout ? reject(err) : resolve(String(stdout))));
   });
 }
 
@@ -646,10 +698,10 @@ describe('#4176 — the probe program, executed against real servers', () => {
   });
 
   test('nothing listening probes as 000', async () => {
-    const server = await listen((req, res) => { res.writeHead(200); res.end(); });
-    const dead = urlOf(server);
-    await close(server);
-    assert.strictEqual(await runProbe(dead), '000');
+    // Port 1 rather than a just-released ephemeral one: closing a server and probing its
+    // port is a race, and rebinding it inside that window was driven to return 200.
+    // Port 1 is privileged, so nothing in this test's world can be listening on it.
+    assert.strictEqual(await runProbe('http://127.0.0.1:1'), '000');
   });
 
   test('a port that accepts but never answers is time-bounded, not a hang', async () => {
@@ -668,33 +720,65 @@ describe('#4176 — the probe program, executed against real servers', () => {
 
 // The fence needs a POSIX shell. Windows CI has no bash on PATH by default, and the
 // repo's other fence-executing tests take the same platform gate.
-const BASH = process.platform === 'win32' ? null : 'bash';
+// The fence needs a POSIX shell. Gate on bash actually being RUNNABLE, not on the
+// platform: a `process.platform === 'win32'` gate also skips silently on any non-Windows
+// host without bash, and claims Windows has none when Git Bash is often present.
+const BASH_OK = (() => {
+  const r = spawnSync('bash', ['-c', 'exit 0'], { encoding: 'utf8', timeout: 15000 });
+  return r.status === 0;
+})();
 
-describe('#4176 — the capture fence, executed', { skip: BASH ? false : 'no bash on this platform' }, () => {
-  // Stub `node` and `npx` on PATH, run the fence, and read what it printed and left.
-  //  PROBE_<port>   the status the stubbed probe reports for that port
-  //  SHOT_FAIL      space-separated viewport names whose capture "fails"
-  //  SHOT_PARTIAL   viewport names whose failed capture still writes a zero-byte file
+describe('#4176 — the capture fence, executed', { skip: BASH_OK ? false : 'no runnable bash on this host' }, () => {
+  const tmpDirs = [];
+  after(() => { for (const d of tmpDirs) fs.rmSync(d, { recursive: true, force: true }); });
+
+  // Stub `node` and `npx` on PATH, run the fence, and read what it printed, what it left
+  // on disk, what it passed to the capture binary, and what CAPTURE_STATUS ended up as.
+  //
+  // EXIT STATUS AND FILE CONTENT ARE INDEPENDENT KNOBS, and that independence is the
+  // whole point of this harness. The first version derived both from one `SHOT_FAIL`
+  // list: success always wrote a non-empty file, failure never did. Two different
+  // regressions then passed every fixture — deleting the `[ -s ... ]` check, and
+  // ignoring the capture command's exit status — because with the two signals perfectly
+  // correlated, either one alone reproduces the correct answer. Both were driven.
+  //   SHOT_EXIT   viewports whose capture command exits non-zero
+  //   SHOT_WRITE  viewports that write a NON-EMPTY file (regardless of exit status)
+  //   SHOT_EMPTY  viewports that write a ZERO-BYTE file (the crashed-browser artefact)
   function runFence(env) {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-4176-'));
+    tmpDirs.push(dir);
     const bin = path.join(dir, 'bin');
     fs.mkdirSync(bin);
+    // node's own argv contract: `node -e <program> <arg1>` puts arg1 at $3. Selecting the
+    // last `http*` argument instead made the stub tolerate an inserted argument that real
+    // node would have handed to the program as argv[1], so a probe invocation that is
+    // wrong in the real world passed here.
     fs.writeFileSync(path.join(bin, 'node'),
-      '#!/bin/sh\nfor a in "$@"; do case "$a" in http*) url="$a";; esac; done\n'
+      '#!/bin/sh\n[ "$1" = "-e" ] || { echo "stub node: expected -e, got $1" >&2; exit 64; }\n'
+      + 'url="$3"\ncase "$url" in http*) ;; *) echo "stub node: argv[1] not a url: $url" >&2; exit 65;; esac\n'
       + 'port=${url##*:}\nport=${port%%/*}\neval "s=\\$PROBE_$port"\nprintf %s "${s:-000}"\n', { mode: 0o755 });
+    // One argument per line, so an assertion can read argument BOUNDARIES. `$*` collapsed
+    // them, which let `--user-agent="--timeout=30000"` satisfy the timeout assertion while
+    // passing no timeout option at all.
     fs.writeFileSync(path.join(bin, 'npx'),
       '#!/bin/sh\nout=""\nfor a in "$@"; do case "$a" in *.png) out="$a";; esac; done\n'
       + 'name=$(basename "$out" .png)\n'
-      + 'printf "%s\\n" "$*" >> "$ARGV_LOG"\n'
-      + '[ -n "$PLANT_FOREIGN" ] && printf other > "$(dirname "$out")/other-audit.png"\n'
-      + 'case " $SHOT_FAIL " in *" $name "*)\n'
-      + '  case " $SHOT_PARTIAL " in *" $name "*) : > "$out";; esac\n'
-      + '  exit 1;; esac\n'
-      + 'printf "png" > "$out"\nexit 0\n', { mode: 0o755 });
+      + '{ echo "--INVOCATION--"; for a in "$@"; do printf "%s\\n" "$a"; done; } >> "$ARGV_LOG"\n'
+      + 'case " $SHOT_WRITE " in *" $name "*) printf png > "$out";; esac\n'
+      + 'case " $SHOT_EMPTY " in *" $name "*) : > "$out";; esac\n'
+      + 'case " $SHOT_EXIT " in *" $name "*) exit 1;; esac\nexit 0\n', { mode: 0o755 });
     const argvLog = path.join(dir, 'argv.log');
     const script = path.join(dir, 'fence.sh');
-    fs.writeFileSync(script, `set -u\nPADDED_PHASE=07\n${screenshotApproachBlock()}\n`);
-    const r = spawnSync(BASH, [script], {
+    // No `set -u`: the agent does not run this block under it, and adding it changes the
+    // block's behaviour on an unset variable — a difference between the harness and the
+    // product is a finding the harness would then manufacture rather than detect.
+    // CAPTURE_STATUS is echoed because it, not the printed line, is what the report
+    // consumes: an unconditional `CAPTURE_STATUS="captured"` appended after the branches
+    // passed every assertion in the first version while making the final report lie.
+    fs.writeFileSync(script,
+      `PADDED_PHASE=${env.PADDED_PHASE || '07'}\n${screenshotApproachBlock()}\n`
+      + 'printf "CAPTURE_STATUS=%s\\n" "$CAPTURE_STATUS"\n');
+    const r = spawnSync('bash', [script], {
       cwd: dir,
       encoding: 'utf8',
       timeout: 60000,
@@ -702,108 +786,146 @@ describe('#4176 — the capture fence, executed', { skip: BASH ? false : 'no bas
         ...process.env,
         PATH: `${bin}${path.delimiter}${process.env.PATH}`,
         ARGV_LOG: argvLog,
-        SHOT_FAIL: '', SHOT_PARTIAL: '',
+        SHOT_EXIT: '', SHOT_WRITE: 'desktop mobile tablet', SHOT_EMPTY: '',
         ...env,
       },
     });
+    const stdout = r.stdout || '';
     const reviews = path.join(dir, '.planning', 'ui-reviews');
-    const shotDirs = fs.existsSync(reviews) ? fs.readdirSync(reviews) : [];
+    const shotDirs = fs.existsSync(reviews) ? fs.readdirSync(reviews).sort() : [];
+    const argvRaw = fs.existsSync(argvLog) ? fs.readFileSync(argvLog, 'utf8') : '';
+    const status = /CAPTURE_STATUS=(.*)/.exec(stdout);
     return {
-      stdout: r.stdout || '',
+      stdout,
+      exitCode: r.status,
+      stderr: r.stderr || '',
+      captureStatus: status ? status[1] : null,
       dir,
-      argv: fs.existsSync(argvLog) ? fs.readFileSync(argvLog, 'utf8') : '',
+      // Each invocation as an array of its arguments — boundaries preserved.
+      invocations: argvRaw.split('--INVOCATION--\n').slice(1)
+        .map((b) => b.split('\n').filter((x) => x !== '')),
       shotDirs,
       files: shotDirs.length === 1 ? fs.readdirSync(path.join(reviews, shotDirs[0])).sort() : [],
     };
   }
 
+  // The fence must not fail as a PROGRAM. Appending `exit 42` to it passed every
+  // assertion in the first version, because the runner discarded the exit status.
+  function ok(r) {
+    assert.strictEqual(r.exitCode, 0, `the fence must exit 0; stderr: ${r.stderr}`);
+    return r;
+  }
+
   test('no dev server on any port is reported as such, and nothing is created', () => {
-    const r = runFence({});
+    const r = ok(runFence({}));
     assert.match(r.stdout, /No dev server on ports 3000, 5173 or 8080/);
+    assert.strictEqual(r.captureStatus, 'not captured (no dev server)');
     assert.deepStrictEqual(r.shotDirs, [], 'no review directory may be created without a dev server');
   });
 
-  test('a total capture failure NEVER prints a success claim, and leaves nothing behind', () => {
-    // The #4176 defect itself, and the maintainer's Major finding, decided by execution:
-    // hoisting the success echo out of its branch makes this fail no matter how the block
-    // is punctuated, because the assertion is over what the block PRINTED.
-    const r = runFence({ PROBE_3000: '200', SHOT_FAIL: 'desktop mobile tablet', SHOT_PARTIAL: 'desktop mobile tablet' });
+  test('a total capture failure NEVER claims success, in the message OR in the status', () => {
+    const r = ok(runFence({ PROBE_3000: '200', SHOT_EXIT: 'desktop mobile tablet',
+      SHOT_WRITE: '', SHOT_EMPTY: 'desktop mobile tablet' }));
     assert.doesNotMatch(r.stdout, /Screenshots captured/, 'a failed capture must never claim success');
     assert.doesNotMatch(r.stdout, /PARTIALLY captured/);
     assert.match(r.stdout, /Screenshot capture FAILED for all 3 viewports/);
+    assert.strictEqual(r.captureStatus, 'not captured (capture failed)',
+      'the report reads CAPTURE_STATUS, not the printed line — both have to be honest');
     assert.deepStrictEqual(r.shotDirs, [], 'the review directory must not survive a total failure');
   });
 
-  test('a partial capture keeps the shots that worked and removes the stray files', () => {
-    // The review's finding 4, in the form the docs actually claim: the failed viewport's
-    // zero-byte file is gone while the two real captures remain.
-    const r = runFence({ PROBE_3000: '200', SHOT_FAIL: 'desktop', SHOT_PARTIAL: 'desktop' });
+  test('a capture that exits 0 without writing anything is NOT a capture', () => {
+    // The `[ -s ... ]` half of the check, isolated. Deleting it passes every fixture in
+    // which exit status and file content agree — which is why they are separate knobs.
+    const r = ok(runFence({ PROBE_3000: '200', SHOT_WRITE: '', SHOT_EXIT: '' }));
+    assert.doesNotMatch(r.stdout, /Screenshots captured/);
+    assert.strictEqual(r.captureStatus, 'not captured (capture failed)');
+  });
+
+  test('a capture that writes a real file but exits non-zero is NOT a capture', () => {
+    // The exit-status half, isolated. Dropping it counts a crashed run that happened to
+    // leave a plausible file.
+    const r = ok(runFence({ PROBE_3000: '200', SHOT_EXIT: 'desktop',
+      SHOT_WRITE: 'desktop mobile tablet' }));
+    assert.match(r.stdout, /PARTIALLY captured .*\(2\/3\).*failed: ?desktop/);
+    assert.strictEqual(r.captureStatus, 'partially captured');
+  });
+
+  test('a partial capture keeps the shots that worked and removes the stray file', () => {
+    const r = ok(runFence({ PROBE_3000: '200', SHOT_EXIT: 'desktop',
+      SHOT_WRITE: 'mobile tablet', SHOT_EMPTY: 'desktop' }));
     assert.match(r.stdout, /Screenshots PARTIALLY captured .*\(2\/3\).*failed: ?desktop/);
+    assert.strictEqual(r.captureStatus, 'partially captured');
     assert.deepStrictEqual(r.files, ['mobile.png', 'tablet.png'],
       'the failed viewport\u2019s zero-byte file must not survive alongside the real captures');
   });
 
-  test('a concurrent audit sharing the directory keeps its own captures', () => {
-    // Why the removal is BY NAME and not `rm -f "$DIR"/*.png`: the review directory is
-    // keyed to the phase and one whole second, so a second audit of the same phase can
-    // land in it. Under the glob, this audit's total failure deleted that one's captures.
-    // Here a foreign file is planted into the shared directory and every viewport then
-    // fails: our three stray files go, the neighbour's stays, and rmdir correctly declines
-    // to remove a directory that is no longer empty. The surviving directory is the
-    // intended outcome, not a leak — which is why the AGENTS.md capture paragraph says
-    // so explicitly rather than eliding it. (Named without its path: this file does not
-    // READ that document, and spelling the path would register it as a docs reader with
-    // the docs-guard lint, which is a claim about this test that is not true.)
-    const r = runFence({ PROBE_3000: '200', SHOT_FAIL: 'desktop mobile tablet',
-      SHOT_PARTIAL: 'desktop mobile tablet', PLANT_FOREIGN: '1' });
-    assert.match(r.stdout, /Screenshot capture FAILED for all 3 viewports/);
-    assert.strictEqual(r.shotDirs.length, 1, 'the shared directory must survive, since it is not ours alone');
-    assert.deepStrictEqual(r.files, ['other-audit.png'],
-      'cleanup must remove only the files this audit wrote, never the whole directory\u2019s .png files');
+  test('two audits of the same phase in the same second do not share a directory', () => {
+    // The ONLY thing that makes the cleanup safe. Both audits write `desktop.png`,
+    // `mobile.png`, `tablet.png`, so no per-file rule can establish ownership — a
+    // cross-model review drove exactly that: with a shared directory, this audit's
+    // cleanup deleted a neighbour's identically-named capture. Ownership therefore has
+    // to come from the directory name, and this asserts it does.
+    const a = ok(runFence({ PROBE_3000: '200', PADDED_PHASE: '07' }));
+    const b = ok(runFence({ PROBE_3000: '200', PADDED_PHASE: '07' }));
+    assert.strictEqual(a.shotDirs.length, 1);
+    assert.strictEqual(b.shotDirs.length, 1);
+    assert.notStrictEqual(a.shotDirs[0], b.shotDirs[0],
+      'a phase + whole-second directory name is not unique; the audit must add its own identity');
   });
 
-  test('all three captures succeeding is the only path that prints "captured"', () => {
-    const r = runFence({ PROBE_3000: '200' });
+  test('all three captures succeeding is the only path that claims "captured"', () => {
+    const r = ok(runFence({ PROBE_3000: '200' }));
     assert.match(r.stdout, /Screenshots captured to .* \(3\/3\) from http:\/\/localhost:3000/);
+    assert.strictEqual(r.captureStatus, 'captured');
     assert.deepStrictEqual(r.files, ['desktop.png', 'mobile.png', 'tablet.png']);
   });
 
   test('the resolved port is the one captured, not a hard-coded 3000', () => {
-    const r = runFence({ PROBE_5173: '200' });
+    const r = ok(runFence({ PROBE_5173: '200' }));
     assert.match(r.stdout, /from http:\/\/localhost:5173/);
-    assert.ok(r.argv.includes('http://localhost:5173'), `capture argv: ${r.argv}`);
-    assert.ok(!r.argv.includes('http://localhost:3000'), `capture argv: ${r.argv}`);
+    for (const call of r.invocations) {
+      assert.ok(call.includes('http://localhost:5173'), `capture argv: ${JSON.stringify(call)}`);
+      assert.ok(!call.includes('http://localhost:3000'), `capture argv: ${JSON.stringify(call)}`);
+    }
   });
 
   test('a 2xx that is not 200 still resolves a dev server', () => {
-    const r = runFence({ PROBE_3000: '204' });
-    assert.match(r.stdout, /Screenshots captured/);
+    assert.match(ok(runFence({ PROBE_3000: '204' })).stdout, /Screenshots captured/);
   });
 
   test('the FIRST auth-gated port is the one reported', () => {
-    // The review's finding 5, decided by behaviour: flipping the guard's operator makes
-    // DEV_GATED empty and this reports "no dev server", which fails here.
-    const r = runFence({ PROBE_3000: '401', PROBE_8080: '403' });
+    const r = ok(runFence({ PROBE_3000: '401', PROBE_8080: '403' }));
     assert.match(r.stdout, /Dev server at http:\/\/localhost:3000 \(HTTP 401\) is auth-gated/);
+    assert.strictEqual(r.captureStatus, 'not captured (dev server auth-gated)');
   });
 
   test('the whole auth-required class is reported as gated, not as absent', () => {
     for (const status of ['401', '403', '407', '511']) {
-      const r = runFence({ PROBE_3000: status });
-      assert.ok(
-        r.stdout.includes(`(HTTP ${status}) is auth-gated`),
-        `HTTP ${status} means the server answered and demanded credentials; it must not read as absent — got: ${r.stdout.trim()}`
-      );
+      const r = ok(runFence({ PROBE_3000: status }));
+      assert.ok(r.stdout.includes(`(HTTP ${status}) is auth-gated`),
+        `HTTP ${status} means the server answered and demanded credentials; it must not read as absent — got: ${r.stdout.trim()}`);
     }
   });
 
-  test('every capture invocation carries a positive timeout', () => {
-    const r = runFence({ PROBE_3000: '200' });
-    const calls = r.argv.split('\n').filter((l) => l.includes('screenshot'));
-    assert.strictEqual(calls.length, 3, `expected 3 capture invocations: ${r.argv}`);
-    for (const call of calls) {
-      const m = /--timeout[= ]([0-9]+)\b/.exec(call);
-      assert.ok(m && Number(m[1]) > 0, `capture must pass a positive --timeout: ${call}`);
+  test('every capture invocation passes a positive timeout as its own argument', () => {
+    // ARGUMENT BOUNDARIES, and the LAST occurrence. A text search over a collapsed
+    // command line accepted `--timeout=30000 --timeout=0` (bash keeps the last, i.e. no
+    // timeout) and `--user-agent="--timeout=30000"` (no timeout option at all). Both
+    // were driven against the first version of this assertion.
+    const r = ok(runFence({ PROBE_3000: '200' }));
+    assert.strictEqual(r.invocations.length, 3, `expected 3 capture invocations: ${JSON.stringify(r.invocations)}`);
+    for (const call of r.invocations) {
+      const values = [];
+      for (let i = 0; i < call.length; i += 1) {
+        const inline = /^--timeout=(.*)$/.exec(call[i]);
+        if (inline) { values.push(inline[1]); continue; }
+        if (call[i] === '--timeout') values.push(call[i + 1]);
+      }
+      assert.ok(values.length > 0, `capture must pass --timeout as its own argument: ${JSON.stringify(call)}`);
+      const effective = values[values.length - 1];   // a repeated option: the last wins
+      assert.ok(/^[0-9]+$/.test(effective) && Number(effective) > 0,
+        `the effective --timeout must be a positive integer (0 IS playwright's no-timeout): ${JSON.stringify(call)}`);
     }
   });
 });

--- a/tests/playwright-ui-verify.test.cjs
+++ b/tests/playwright-ui-verify.test.cjs
@@ -174,9 +174,17 @@ function guardedLines(lines) {
     if (pendingIf !== null) {
       // Only `then` may follow; anything else means we mis-read the `if` header.
       if (t === 'then' || t.startsWith('then ')) {
+        const tail = t === 'then' ? '' : t.slice(5).trim();
+        // The compound check belongs on EVERY path that opens a scope, not just the
+        // one-line `if`. `if COND` + `then :; fi; if true; then` reached this branch and
+        // pushed a condition whose tail closed the scope and opened another — bash
+        // printed the success line with CAPTURED=0 while the walker reported the echo
+        // as governed. Driven.
+        if (hasControlKeyword(tail)) {
+          throw new Error(`bash reader: compound then-clause — ${JSON.stringify(t)}`);
+        }
         stack.push(pendingIf);
         pendingIf = null;
-        const tail = t === 'then' ? '' : t.slice(5).trim();
         if (tail === '') continue;
         rows.push({ line: tail, guards: stack.slice() });
         continue;
@@ -200,7 +208,15 @@ function guardedLines(lines) {
     const ifPending = /^if[\t ]+(.{1,4000}?)[\t ]*$/.exec(t);
     if (ifPending && !/;/.test(ifPending[1])) { pendingIf = ifPending[1]; continue; }
     const elifMatch = /^elif[\t ]+(.{1,4000}?)[\t ]*;[\t ]*then$/.exec(t);
-    if (elifMatch) { if (stack.length) stack[stack.length - 1] = elifMatch[1]; continue; }
+    if (elifMatch) {
+      // Same omission as the `if` header carried, and the same false PASS: the lazy
+      // quantifier swallowed `:; fi; if true` into the stored condition.
+      if (hasControlKeyword(elifMatch[1])) {
+        throw new Error(`bash reader: compound elif header — ${JSON.stringify(t)}`);
+      }
+      if (stack.length) stack[stack.length - 1] = elifMatch[1];
+      continue;
+    }
     if (t === 'else') { if (stack.length) stack[stack.length - 1] = `!(${stack[stack.length - 1]})`; continue; }
     if (t === 'fi') { stack.pop(); continue; }
     if (/^(for|while|until)\b/.test(t) && /;[\t ]*do$/.test(t)) { stack.push(''); continue; }
@@ -260,6 +276,15 @@ function stripComment(line) {
     if (c === '$' && line[i + 1] === "'") { out += c + line[i + 1]; i += 1; stack.push('ansi'); continue; }
     if (c === '$' && line[i + 1] === '(') { out += c + line[i + 1]; i += 1; stack.push('cmd'); continue; }
     if (c === ')' && ctx === 'cmd') { out += c; stack.pop(); continue; }
+    // `${var#pattern}` — the `#` there is a removal operator, not a comment, and the
+    // scanner truncated `echo ${value# #}` mid-expansion. Driven.
+    if (c === '$' && line[i + 1] === '{') { out += c + line[i + 1]; i += 1; stack.push('param'); continue; }
+    if (c === '}' && ctx === 'param') { out += c; stack.pop(); continue; }
+    // Backticks are command substitution too, and they reopened the hidden-continuation
+    // bypass the `$( )` handling had closed: `--user-agent="$DEV_URL""`printf "%s" " # "`"`
+    // truncated the line and hid the continuation carrying a hard-coded port. Driven.
+    if (c === '`' && ctx === 'btick') { out += c; stack.pop(); continue; }
+    if (c === '`') { out += c; stack.push('btick'); continue; }
     if (c === '"' && ctx === 'dq') { out += c; stack.pop(); continue; }
     if (c === '"') { out += c; stack.push('dq'); continue; }
     if (c === "'" && ctx !== 'dq') { out += c; stack.push('sq'); continue; }
@@ -285,27 +310,43 @@ function stripComment(line) {
 // up to the FIRST unquoted `)`; a quoted one is part of a pattern, not the terminator.
 function caseLabelOf(line) {
   const t = line.trim().replace(/^\(/, '');
+  // Walk once, tracking quotes, and split on `|` only OUTSIDE them. A blanket
+  // `split('|')` turned the single literal pattern `"401|403|407|511"` into four
+  // statuses (false PASS), while stripping quotes afterwards turned the literal
+  // `"2??"` into what looked like a range (false PASS on an arm that accepts only the
+  // statuses it enumerates). Both driven. So each pattern also records whether ANY of
+  // it was quoted: a quoted `?` is a literal question mark, not a wildcard.
+  const patterns = [];
+  let cur = '';
+  let quoted = false;
   let quote = null;
   let end = -1;
   for (let i = 0; i < t.length; i += 1) {
     const c = t[i];
-    // Escapes inside double quotes: `"a\")"` is ONE pattern, and reading its escaped
-    // quote as the terminator truncated the label and false-FAILED the arm. Driven.
-    if (quote === '"' && c === '\\') { i += 1; continue; }
-    if (quote) { if (c === quote) quote = null; continue; }
-    if (c === "'" || c === '"') { quote = c; continue; }
-    if (c === '\\') { i += 1; continue; }
+    if (quote) {
+      if (c === '\\' && quote === '"') { cur += t[i + 1] ?? ''; i += 1; continue; }
+      if (c === quote) { quote = null; continue; }
+      cur += c; quoted = true; continue;
+    }
+    if (c === '\\') { cur += t[i + 1] ?? ''; i += 1; continue; }   // `4\01` is 401
+    if (c === "'" || c === '"') { quote = c; quoted = true; continue; }
+    if (c === '|') { patterns.push({ text: cur.trim(), quoted }); cur = ''; quoted = false; continue; }
     if (c === ')') { end = i; break; }
+    cur += c;
   }
-  if (end <= 0) return null;
-  // Whitespace is legal before the arm terminator — `200 )` — and rejecting the label on
-  // any whitespace made caseLabelOf return null there, which silently downgraded the
-  // range check to the body test the case label had already made vacuous. Driven.
-  const patterns = t.slice(0, end).split('|').map((x) => x.trim());
-  if (patterns.length === 0 || patterns.some((x) => x === '' || /[\t =]/.test(x))) return null;
-  // Quotes are not part of the pattern: `"2"??` and `"401"` are the quoted spellings of
-  // `2??` and `401`, and returning them with quotes attached false-FAILED both.
-  return patterns.map((x) => x.replace(/['"]/g, ''));
+  if (end < 0) return null;
+  patterns.push({ text: cur.trim(), quoted });
+  // Whitespace only disqualifies an UNQUOTED pattern: `"x y"` is one legal pattern, and
+  // rejecting the whole label for it false-FAILED an otherwise-valid arm. Driven.
+  if (patterns.length === 0
+      || patterns.some((x) => x.text === '' || (!x.quoted && /[\t ]/.test(x.text)))) return null;
+  return patterns;
+}
+
+// A pattern that actually matches a RANGE of 2xx statuses. A quoted `"2??"` matches the
+// three literal characters `2??` and no status at all, so its wildcards do not count.
+function isTwoXxRange(pattern) {
+  return !pattern.quoted && /^2(\?\?|\[0-9\]\[0-9\]|\*)$/.test(pattern.text);
 }
 
 function captureInvocations(lines) {
@@ -381,12 +422,12 @@ describe('#4176 — gsd-ui-auditor screenshot capture is honest', () => {
     // construction: a case-gated arm is judged on its LABEL, and only an arm with no case
     // label may earn acceptance from a comparison in its body.
     const acceptsRange = armLabel !== null
-      ? armLabel.some((pat) => /^2(\?\?|\[0-9\]\[0-9\]|\*)$/.test(pat))
+      ? armLabel.some(isTwoXxRange)
       : (/-ge[\t ]+200\b/.test(acceptArm) || /\br\.ok\b/.test(block));
     assert.ok(
       acceptsRange,
       armLabel !== null
-        ? `the case label that admits a status must be a 2xx RANGE (2?? / 2[0-9][0-9] / 2*), not an enumerated status — a range test inside an exact-match arm decides nothing: label was ${JSON.stringify(armLabel)}`
+        ? `the case label that admits a status must be an UNQUOTED 2xx range (2?? / 2[0-9][0-9] / 2*), not an enumerated status and not a quoted literal — a range test inside an exact-match arm decides nothing: label was ${JSON.stringify(armLabel)}`
         : `the arm that sets DEV_URL must accept a 2xx RANGE, not an enumerated status: ${acceptArm}`
     );
   });
@@ -489,7 +530,7 @@ describe('#4176 — gsd-ui-auditor screenshot capture is honest', () => {
       .map((l) => l.trim())
       .filter((l) => /DEV_GATED=/.test(l) && !/^DEV_GATED=""$/.test(l));
     assert.ok(gatedArms.length > 0, 'expected a case arm recording an auth-gated server');
-    const labels = gatedArms.map((l) => caseLabelOf(l) || []);
+    const labels = gatedArms.map((l) => (caseLabelOf(l) || []).map((x) => x.text));
     for (const status of ['401', '403', '407', '511']) {
       assert.ok(
         labels.some((lab) => lab.includes(status)),
@@ -571,8 +612,12 @@ describe('#4176 — gsd-ui-auditor screenshot capture is honest', () => {
         `stray-file removal must target the viewport that just failed: ${row.line}`
       );
     }
-    const removesDir = rows.filter((r) => /^rmdir\b/.test(r.line));
-    assert.ok(removesDir.length > 0, 'expected the all-failed branch to remove the review directory');
+    // The directory removal is `rm -rf`, not `rmdir`, and the atomic allocation is what
+    // licenses that: a directory won by this audit alone can be removed whole. `rmdir`
+    // could not honour the docs claim — it fails on any file the capture command wrote
+    // under a name this block never asked for, leaving both behind.
+    const removesDir = rows.filter((r) => /\brm -rf[\t ]+"?\$SCREENSHOT_DIR"?$/.test(r.line));
+    assert.ok(removesDir.length > 0, 'expected the all-failed branch to remove the review directory whole');
     for (const row of removesDir) {
       assert.ok(
         row.guards.some((cond) => /CAPTURED/.test(cond)),
@@ -603,9 +648,13 @@ describe('#4176 — gsd-ui-auditor screenshot capture is honest', () => {
     const surfaces = splitLines(fs.readFileSync(AUDITOR_PATH, 'utf-8'))
       .filter((l) => /^\*\*Screenshots:\*\*/.test(l.trim()));
     assert.ok(surfaces.length > 0, 'expected a Screenshots report field in the agent output template');
+    // The field's VALUE, not a mention on the line. `**Screenshots:** captured
+    // <!-- $CAPTURE_STATUS -->` renders a hard-coded word while satisfying an
+    // includes() check — the status is computed, carried, and then dropped at the one
+    // place a reader sees it. Driven.
     assert.ok(
-      surfaces.every((l) => l.includes('$CAPTURE_STATUS')),
-      'every Screenshots report field must render $CAPTURE_STATUS, or the status is computed and dropped'
+      surfaces.every((l) => /^\*\*Screenshots:\*\*[\t ]*\{?[\t ]*\$CAPTURE_STATUS\b/.test(l.trim())),
+      `every Screenshots report field must render $CAPTURE_STATUS as its value: ${JSON.stringify(surfaces)}`
     );
   });
 });
@@ -660,10 +709,11 @@ const urlOf = (server) => `http://127.0.0.1:${server.address().port}`;
 function runProbe(url) {
   return new Promise((resolve, reject) => {
     execFile(process.execPath, ['-e', probeProgram(), url], { timeout: 30000 },
-      // NOT trimmed. The bash `case "$PROBE" in 2??)` matches the RAW captured value, so
-      // a program emitting " 200" resolves no dev server in the product while a trimmed
-      // comparison here would call it 200 and pass.
-      (err, stdout) => (err && !stdout ? reject(err) : resolve(String(stdout))));
+      // Trim exactly what `$( )` trims — TRAILING NEWLINES — and nothing else. A blanket
+      // .trim() accepted a program emitting " 200", which the product's `case` rejects;
+      // no trimming at all rejected "200\n", which the product ACCEPTS, because command
+      // substitution strips it. Both directions were driven; this models the substitution.
+      (err, stdout) => (err && !stdout ? reject(err) : resolve(String(stdout).replace(/\n+$/, ''))));
   });
 }
 
@@ -698,10 +748,21 @@ describe('#4176 — the probe program, executed against real servers', () => {
   });
 
   test('nothing listening probes as 000', async () => {
-    // Port 1 rather than a just-released ephemeral one: closing a server and probing its
-    // port is a race, and rebinding it inside that window was driven to return 200.
-    // Port 1 is privileged, so nothing in this test's world can be listening on it.
-    assert.strictEqual(await runProbe('http://127.0.0.1:1'), '000');
+    // A port this test HELD and then released, not a well-known one: node's fetch
+    // rejects port 1 as a bad port before it ever attempts a connection, so probing it
+    // exercises URL validation rather than an absent listener — the wrong mechanism,
+    // reaching the right answer. Driven. Binding first also removes the guesswork about
+    // what else on the host might be listening; the residual is the window between the
+    // close and the probe, which is why a rebind is retried rather than asserted through.
+    let observed = null;
+    for (let attempt = 0; attempt < 3 && observed !== '000'; attempt += 1) {
+      const server = await listen((req, res) => { res.writeHead(200); res.end(); });
+      const dead = urlOf(server);
+      await close(server);
+      observed = await runProbe(dead);
+    }
+    assert.strictEqual(observed, '000',
+      'a closed but valid port must probe as 000 through a real connection refusal');
   });
 
   test('a port that accepts but never answers is time-bounded, not a hang', async () => {
@@ -744,18 +805,21 @@ describe('#4176 — the capture fence, executed', { skip: BASH_OK ? false : 'no 
   //   SHOT_EXIT   viewports whose capture command exits non-zero
   //   SHOT_WRITE  viewports that write a NON-EMPTY file (regardless of exit status)
   //   SHOT_EMPTY  viewports that write a ZERO-BYTE file (the crashed-browser artefact)
-  function runFence(env) {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-4176-'));
-    tmpDirs.push(dir);
+  function runFence(env, sharedDir) {
+    const dir = sharedDir || fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-4176-'));
+    if (!sharedDir) tmpDirs.push(dir);
     const bin = path.join(dir, 'bin');
-    fs.mkdirSync(bin);
+    fs.mkdirSync(bin, { recursive: true });
     // node's own argv contract: `node -e <program> <arg1>` puts arg1 at $3. Selecting the
     // last `http*` argument instead made the stub tolerate an inserted argument that real
     // node would have handed to the program as argv[1], so a probe invocation that is
     // wrong in the real world passed here.
     fs.writeFileSync(path.join(bin, 'node'),
       '#!/bin/sh\n[ "$1" = "-e" ] || { echo "stub node: expected -e, got $1" >&2; exit 64; }\n'
-      + 'url="$3"\ncase "$url" in http*) ;; *) echo "stub node: argv[1] not a url: $url" >&2; exit 65;; esac\n'
+      // Real node accepts `-e PROGRAM -- URL` and still hands URL to the program as
+      // argv[1]; a stub that stopped at `$3` reported absence and false-FAILED eleven
+      // fence tests on a legal invocation.
+      + 'shift 2\n[ "$1" = "--" ] && shift\nurl="$1"\ncase "$url" in http*) ;; *) echo "stub node: argv[1] not a url: $url" >&2; exit 65;; esac\n'
       + 'port=${url##*:}\nport=${port%%/*}\neval "s=\\$PROBE_$port"\nprintf %s "${s:-000}"\n', { mode: 0o755 });
     // One argument per line, so an assertion can read argument BOUNDARIES. `$*` collapsed
     // them, which let `--user-agent="--timeout=30000"` satisfy the timeout assertion while
@@ -763,10 +827,21 @@ describe('#4176 — the capture fence, executed', { skip: BASH_OK ? false : 'no 
     fs.writeFileSync(path.join(bin, 'npx'),
       '#!/bin/sh\nout=""\nfor a in "$@"; do case "$a" in *.png) out="$a";; esac; done\n'
       + 'name=$(basename "$out" .png)\n'
-      + '{ echo "--INVOCATION--"; for a in "$@"; do printf "%s\\n" "$a"; done; } >> "$ARGV_LOG"\n'
+      // NUL-DELIMITED. A newline-delimited log splits an argument that CONTAINS a
+      // newline into two, so `--user-agent=$'audit\\n--timeout=30000'` — one argument
+      // passing no timeout option at all — read as two arguments, the second of which
+      // satisfied the timeout assertion. Driven.
+      + '{ printf "%s\\0" "--INVOCATION--"; for a in "$@"; do printf "%s\\0" "$a"; done; } >> "$ARGV_LOG"\n'
       + 'case " $SHOT_WRITE " in *" $name "*) printf png > "$out";; esac\n'
       + 'case " $SHOT_EMPTY " in *" $name "*) : > "$out";; esac\n'
       + 'case " $SHOT_EXIT " in *" $name "*) exit 1;; esac\nexit 0\n', { mode: 0o755 });
+    // A `date` stub, so the collision case can actually be CONSTRUCTED. Without it the
+    // uniqueness test was vacuous: two runs a second apart get different names from the
+    // timestamp alone, so it passed with the uniqueness mechanism removed entirely.
+    // Driven — that is exactly how the first version of this test passed.
+    if (env.FIXED_DATE) {
+      fs.writeFileSync(path.join(bin, 'date'), `#!/bin/sh\nprintf %s "${env.FIXED_DATE}"\n`, { mode: 0o755 });
+    }
     const argvLog = path.join(dir, 'argv.log');
     const script = path.join(dir, 'fence.sh');
     // No `set -u`: the agent does not run this block under it, and adding it changes the
@@ -775,9 +850,14 @@ describe('#4176 — the capture fence, executed', { skip: BASH_OK ? false : 'no 
     // CAPTURE_STATUS is echoed because it, not the printed line, is what the report
     // consumes: an unconditional `CAPTURE_STATUS="captured"` appended after the branches
     // passed every assertion in the first version while making the final report lie.
+    // Capture the block's OWN status before the instrumentation runs: a trailing
+    // `printf` resets `$?`, so appending `false` to the fence exited 0 and the
+    // exit-status assertion passed on a fence that had failed. Driven.
     fs.writeFileSync(script,
       `PADDED_PHASE=${env.PADDED_PHASE || '07'}\n${screenshotApproachBlock()}\n`
-      + 'printf "CAPTURE_STATUS=%s\\n" "$CAPTURE_STATUS"\n');
+      + 'FENCE_RC=$?\n'
+      + 'printf "CAPTURE_STATUS=%s\\n" "$CAPTURE_STATUS"\n'
+      + 'printf "FENCE_RC=%s\\n" "$FENCE_RC"\n');
     const r = spawnSync('bash', [script], {
       cwd: dir,
       encoding: 'utf8',
@@ -793,19 +873,25 @@ describe('#4176 — the capture fence, executed', { skip: BASH_OK ? false : 'no 
     const stdout = r.stdout || '';
     const reviews = path.join(dir, '.planning', 'ui-reviews');
     const shotDirs = fs.existsSync(reviews) ? fs.readdirSync(reviews).sort() : [];
+    const filesIn = (d) => fs.readdirSync(path.join(reviews, d)).sort();
     const argvRaw = fs.existsSync(argvLog) ? fs.readFileSync(argvLog, 'utf8') : '';
-    const status = /CAPTURE_STATUS=(.*)/.exec(stdout);
+    // The LAST occurrence. Reading the first accepted a fence that printed the honest
+    // value and then reassigned the variable — the report would render the second.
+    const statusAll = [...stdout.matchAll(/^CAPTURE_STATUS=(.*)$/gm)];
+    const status = statusAll.length ? statusAll[statusAll.length - 1] : null;
+    const rcLine = /^FENCE_RC=([0-9]+)$/m.exec(stdout);
     return {
       stdout,
-      exitCode: r.status,
+      exitCode: rcLine ? Number(rcLine[1]) : r.status,
       stderr: r.stderr || '',
       captureStatus: status ? status[1] : null,
       dir,
       // Each invocation as an array of its arguments — boundaries preserved.
-      invocations: argvRaw.split('--INVOCATION--\n').slice(1)
-        .map((b) => b.split('\n').filter((x) => x !== '')),
+      invocations: argvRaw.split('--INVOCATION--\0').slice(1)
+        .map((b) => b.split('\0').filter((x) => x !== '')),
       shotDirs,
-      files: shotDirs.length === 1 ? fs.readdirSync(path.join(reviews, shotDirs[0])).sort() : [],
+      filesIn,
+      files: shotDirs.length === 1 ? filesIn(shotDirs[0]) : [],
     };
   }
 
@@ -813,6 +899,7 @@ describe('#4176 — the capture fence, executed', { skip: BASH_OK ? false : 'no 
   // assertion in the first version, because the runner discarded the exit status.
   function ok(r) {
     assert.strictEqual(r.exitCode, 0, `the fence must exit 0; stderr: ${r.stderr}`);
+    assert.ok(r.captureStatus !== null, 'the fence must leave CAPTURE_STATUS set');
     return r;
   }
 
@@ -842,13 +929,30 @@ describe('#4176 — the capture fence, executed', { skip: BASH_OK ? false : 'no 
     assert.strictEqual(r.captureStatus, 'not captured (capture failed)');
   });
 
-  test('a capture that writes a real file but exits non-zero is NOT a capture', () => {
+  test('a capture that exits 0 leaving a ZERO-BYTE file is NOT a capture', () => {
+    // The `-s` in `[ -s ... ]` doing its own work. Relaxing it to `[ -e ]` — the file
+    // merely EXISTS — passed every fixture until this one, because no scenario paired a
+    // clean exit with an empty file. A crashed browser writing a zero-byte png and
+    // exiting 0 is precisely the shape #4176 is about.
+    const r = ok(runFence({ PROBE_3000: '200', SHOT_WRITE: '', SHOT_EMPTY: 'desktop mobile tablet',
+      SHOT_EXIT: '' }));
+    assert.doesNotMatch(r.stdout, /Screenshots captured/);
+    assert.strictEqual(r.captureStatus, 'not captured (capture failed)');
+  });
+
+  test('a capture that writes a real file but exits non-zero is NOT a capture, and its file goes', () => {
     // The exit-status half, isolated. Dropping it counts a crashed run that happened to
     // leave a plausible file.
     const r = ok(runFence({ PROBE_3000: '200', SHOT_EXIT: 'desktop',
       SHOT_WRITE: 'desktop mobile tablet' }));
     assert.match(r.stdout, /PARTIALLY captured .*\(2\/3\).*failed: ?desktop/);
     assert.strictEqual(r.captureStatus, 'partially captured');
+    // And the file is REMOVED. Restricting the cleanup to empty files only passed every
+    // fixture, because none of them paired a failure with a non-empty artefact — a
+    // plausible-looking png from a run that crashed after writing is the worst case to
+    // leave behind, not the least.
+    assert.deepStrictEqual(r.files, ['mobile.png', 'tablet.png'],
+      'a failed viewport\u2019s file must go whether or not it happens to be empty');
   });
 
   test('a partial capture keeps the shots that worked and removes the stray file', () => {
@@ -860,18 +964,26 @@ describe('#4176 — the capture fence, executed', { skip: BASH_OK ? false : 'no 
       'the failed viewport\u2019s zero-byte file must not survive alongside the real captures');
   });
 
-  test('two audits of the same phase in the same second do not share a directory', () => {
-    // The ONLY thing that makes the cleanup safe. Both audits write `desktop.png`,
-    // `mobile.png`, `tablet.png`, so no per-file rule can establish ownership — a
-    // cross-model review drove exactly that: with a shared directory, this audit's
-    // cleanup deleted a neighbour's identically-named capture. Ownership therefore has
-    // to come from the directory name, and this asserts it does.
-    const a = ok(runFence({ PROBE_3000: '200', PADDED_PHASE: '07' }));
-    const b = ok(runFence({ PROBE_3000: '200', PADDED_PHASE: '07' }));
-    assert.strictEqual(a.shotDirs.length, 1);
-    assert.strictEqual(b.shotDirs.length, 1);
-    assert.notStrictEqual(a.shotDirs[0], b.shotDirs[0],
-      'a phase + whole-second directory name is not unique; the audit must add its own identity');
+  test('two audits colliding on the same second get separate directories, and the first keeps its captures', () => {
+    // CONSTRUCTED, not hoped for. `date` is stubbed to a fixed value and both runs share
+    // one working directory, so the two audits genuinely contend for the same name — the
+    // case a wall-clock test can never reach, and the case that matters: both write
+    // exactly `desktop.png`, `mobile.png`, `tablet.png`, so no per-file rule can
+    // establish ownership, and a shared directory means the loser's total-failure
+    // cleanup destroys the winner's captures. Ownership must come from the directory.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-4176-race-'));
+    tmpDirs.push(dir);
+    const fixed = { FIXED_DATE: '20300101-000000', PADDED_PHASE: '07' };
+    const first = ok(runFence({ ...fixed, PROBE_3000: '200' }, dir));
+    // The second audit fails every viewport, so its cleanup runs — under a shared
+    // directory that cleanup is what deleted the first audit's work.
+    const second = ok(runFence({ ...fixed, PROBE_3000: '200', SHOT_EXIT: 'desktop mobile tablet',
+      SHOT_WRITE: '', SHOT_EMPTY: 'desktop mobile tablet' }, dir));
+    assert.strictEqual(first.shotDirs.length, 1, 'the first audit must get a directory');
+    assert.strictEqual(second.shotDirs.length, 1,
+      `after the second audit cleaned up, exactly the first audit's directory must remain: ${JSON.stringify(second.shotDirs)}`);
+    assert.deepStrictEqual(second.filesIn(second.shotDirs[0]), ['desktop.png', 'mobile.png', 'tablet.png'],
+      'the second audit\u2019s failure cleanup must not touch the first audit\u2019s captures');
   });
 
   test('all three captures succeeding is the only path that claims "captured"', () => {
@@ -890,8 +1002,15 @@ describe('#4176 — the capture fence, executed', { skip: BASH_OK ? false : 'no 
     }
   });
 
-  test('a 2xx that is not 200 still resolves a dev server', () => {
-    assert.match(ok(runFence({ PROBE_3000: '204' })).stdout, /Screenshots captured/);
+  test('any 2xx resolves a dev server, not an enumerated few', () => {
+    // 299 is the point: a mutant that swaps the `2??` glob for an enumeration wide
+    // enough to cover the statuses a test happens to use — `200|204` — passes a fixture
+    // set built from plausible statuses. A status no enumeration would think to list is
+    // what makes this a RANGE test rather than a longer list.
+    for (const status of ['200', '201', '204', '206', '299']) {
+      assert.match(ok(runFence({ PROBE_3000: status })).stdout, /Screenshots captured/,
+        `HTTP ${status} is a 2xx and must resolve a dev server`);
+    }
   });
 
   test('the FIRST auth-gated port is the one reported', () => {
@@ -918,6 +1037,9 @@ describe('#4176 — the capture fence, executed', { skip: BASH_OK ? false : 'no 
     for (const call of r.invocations) {
       const values = [];
       for (let i = 0; i < call.length; i += 1) {
+        // `--` ends option parsing; everything after it is a positional, so
+        // `-- --timeout=30000` passes NO timeout option. Driven against the first version.
+        if (call[i] === '--') break;
         const inline = /^--timeout=(.*)$/.exec(call[i]);
         if (inline) { values.push(inline[1]); continue; }
         if (call[i] === '--timeout') values.push(call[i + 1]);

--- a/tests/playwright-ui-verify.test.cjs
+++ b/tests/playwright-ui-verify.test.cjs
@@ -114,10 +114,17 @@ function logicalLines(lines) {
   const joined = [];
   let buf = null;
   for (const raw of lines) {
-    const piece = buf === null ? raw : `${buf} ${raw.trim()}`;
-    const trimmedEnd = piece.replace(/[\t ]+$/, '');
-    if (trimmedEnd.endsWith('\\')) {
-      buf = trimmedEnd.slice(0, -1).replace(/[\t ]+$/, '');
+    // Leading whitespace only comes off a continuation line. A `.trim()` here also took
+    // its TRAILING whitespace, which is the very thing the test below has to see.
+    const piece = buf === null ? raw : `${buf} ${raw.replace(/^[\t ]+/, '')}`;
+    // A continuation is a backslash IMMEDIATELY before the newline. The first version
+    // trimmed trailing whitespace and then looked for the backslash, which is backwards
+    // from bash: in `echo a \ ` (backslash, space, newline) the backslash escapes the
+    // SPACE and the line ends there. And the run has to be ODD — `echo a \\` is an escaped
+    // backslash at the end of a complete line. Round-2 nit 7.
+    const run = /\\+$/.exec(piece);
+    if (run && run[0].length % 2 === 1) {
+      buf = piece.slice(0, -1).replace(/[\t ]+$/, '');
       continue;
     }
     buf = null;
@@ -726,33 +733,6 @@ describe('#4176 — gsd-ui-auditor screenshot capture is honest', () => {
       surfaces.every((l) => /^\*\*Screenshots:\*\*[\t ]*\{?[\t ]*\$CAPTURE_STATUS\b/.test(l.trim())),
       `every Screenshots report field must render $CAPTURE_STATUS as its value: ${JSON.stringify(surfaces)}`
     );
-  });
-});
-
-describe('#4176 — bash reader, units', () => {
-  test('caseLabelOf keeps text and active aligned when a pattern carries unquoted edge whitespace', () => {
-    // Both polarities of the desync, each on a legal label bash accepts.
-    // ` 2?\?` — the last `?` is ESCAPED, so this admits `2?` + a literal `?`, not a range.
-    // With the text trimmed and `active` not, the escaped slot was read one index early.
-    const falsePass = caseLabelOf(' 2?\\?) DEV_URL=x ;;');
-    assert.ok(falsePass !== null);
-    assert.deepStrictEqual(falsePass.map((x) => x.text), ['2??']);
-    assert.strictEqual(falsePass.some(isTwoXxRange), false, 'an escaped ? is not a wildcard, whatever precedes the pattern');
-    // ` "2"??` — the digit is quoted, both `?` are live wildcards: a range.
-    const falseFail = caseLabelOf(' "2"??) DEV_URL=x ;;');
-    assert.ok(falseFail !== null);
-    assert.strictEqual(falseFail.some(isTwoXxRange), true, 'a quoted digit followed by two live wildcards is a 2xx range');
-    // Trailing whitespace, and whitespace around a `|` separator.
-    assert.strictEqual(caseLabelOf('2?? ) x').some(isTwoXxRange), true);
-    assert.deepStrictEqual(caseLabelOf('401 | 403 |407) x').map((x) => x.text), ['401', '403', '407']);
-    // A QUOTED space is pattern content and survives — it is not separator whitespace.
-    const quotedSpace = caseLabelOf('" 2"??) x');
-    assert.deepStrictEqual(quotedSpace.map((x) => x.text), [' 2??']);
-    assert.strictEqual(quotedSpace.some(isTwoXxRange), false);
-    // And every returned pattern keeps the invariant the range test relies on.
-    for (const lab of [falsePass, falseFail, quotedSpace]) {
-      for (const p of lab) assert.strictEqual(p.active.length, p.text.length, 'text and active must stay the same length');
-    }
   });
 });
 
@@ -1373,5 +1353,54 @@ describe('#4176 — the capture fence, executed', { skip: BASH_OK ? false : 'no 
       assert.ok(/^[0-9]+$/.test(effective) && Number(effective) > 0,
         `the effective --timeout must be a positive integer (0 IS playwright's no-timeout): ${JSON.stringify(call)}`);
     }
+  });
+});
+
+describe('#4176 — bash reader, units', () => {
+  test('caseLabelOf keeps text and active aligned when a pattern carries unquoted edge whitespace', () => {
+    // Both polarities of the desync, each on a legal label bash accepts.
+    // ` 2?\?` — the last `?` is ESCAPED, so this admits `2?` + a literal `?`, not a range.
+    // With the text trimmed and `active` not, the escaped slot was read one index early.
+    const falsePass = caseLabelOf(' 2?\\?) DEV_URL=x ;;');
+    assert.ok(falsePass !== null);
+    assert.deepStrictEqual(falsePass.map((x) => x.text), ['2??']);
+    assert.strictEqual(falsePass.some(isTwoXxRange), false, 'an escaped ? is not a wildcard, whatever precedes the pattern');
+    // ` "2"??` — the digit is quoted, both `?` are live wildcards: a range.
+    const falseFail = caseLabelOf(' "2"??) DEV_URL=x ;;');
+    assert.ok(falseFail !== null);
+    assert.strictEqual(falseFail.some(isTwoXxRange), true, 'a quoted digit followed by two live wildcards is a 2xx range');
+    // Trailing whitespace, and whitespace around a `|` separator.
+    assert.strictEqual(caseLabelOf('2?? ) x').some(isTwoXxRange), true);
+    assert.deepStrictEqual(caseLabelOf('401 | 403 |407) x').map((x) => x.text), ['401', '403', '407']);
+    // A QUOTED space is pattern content and survives — it is not separator whitespace.
+    const quotedSpace = caseLabelOf('" 2"??) x');
+    assert.deepStrictEqual(quotedSpace.map((x) => x.text), [' 2??']);
+    assert.strictEqual(quotedSpace.some(isTwoXxRange), false);
+    // And every returned pattern keeps the invariant the range test relies on.
+    for (const lab of [falsePass, falseFail, quotedSpace]) {
+      for (const p of lab) assert.strictEqual(p.active.length, p.text.length, 'text and active must stay the same length');
+    }
+  });
+
+  test('logicalLines joins only a backslash that is the LAST character of the line, in an odd run', () => {
+    // bash: `\` escapes the next character. Before a newline it joins the lines; before
+    // a space it escapes the space and the line ends; doubled, it is a literal backslash.
+    assert.deepStrictEqual(logicalLines(['echo a \\', 'b']), ['echo a b'], 'backslash-newline continues');
+    assert.deepStrictEqual(logicalLines(['echo a \\ ', 'b']), ['echo a \\ ', 'b'], 'backslash-SPACE-newline does not');
+    assert.deepStrictEqual(logicalLines(['echo a \\\\', 'b']), ['echo a \\\\', 'b'], 'an escaped backslash does not');
+    assert.deepStrictEqual(logicalLines(['echo a \\\\\\', 'b']), ['echo a \\\\ b'], 'three: one escaped pair, then a continuation');
+    // The trailing whitespace has to survive on a CONTINUATION line too, or the second
+    // physical line of a joined command could never end a line by this rule.
+    assert.deepStrictEqual(logicalLines(['echo a \\', '  b \\ ', 'c']), ['echo a b \\ ', 'c']);
+  });
+
+  test('logicalLines agrees with bash on how many commands a continuation-bearing script runs',
+    { skip: BASH_OK ? false : 'no runnable bash on this host' }, () => {
+    const script = ['echo one \\ ', 'echo two', 'echo three \\\\', 'echo four \\', '  five'].join('\n');
+    const r = spawnSync('bash', ['-c', script], { encoding: 'utf8', timeout: 15000 });
+    const printed = splitLines(r.stdout).filter(Boolean);
+    const modelled = logicalLines(splitLines(script)).map((l) => l.trim());
+    assert.strictEqual(printed.length, modelled.length,
+      `bash ran ${printed.length} commands, the reader modelled ${modelled.length}: ${JSON.stringify(modelled)}`);
   });
 });

--- a/tests/playwright-ui-verify.test.cjs
+++ b/tests/playwright-ui-verify.test.cjs
@@ -362,6 +362,20 @@ function caseLabelOf(line) {
   let quote = null;
   let end = -1;
   const push = (c, isActive) => { cur += c; active.push(isActive); };
+  // Finish a pattern by trimming `cur` and `active` IN LOCKSTEP, and only UNQUOTED
+  // whitespace. They are parallel arrays, so `cur.trim()` alone shifts every later index
+  // of `active` by the number of characters it removed — driven: ` 2?\?` (leading space,
+  // last `?` escaped) read as a RANGE, because the escaped `?` at index 2 was looked up at
+  // index 1, the wildcard's slot; and ` "2"??` read as NOT a range for the mirror reason.
+  // A quoted space is part of the pattern, not the separator, so it stays. Round-2
+  // finding 2 (`map_key_unchecked`).
+  const finish = () => {
+    let s0 = 0;
+    let e0 = cur.length;
+    while (s0 < e0 && /[\t ]/.test(cur[s0]) && active[s0]) s0 += 1;
+    while (e0 > s0 && /[\t ]/.test(cur[e0 - 1]) && active[e0 - 1]) e0 -= 1;
+    patterns.push({ text: cur.slice(s0, e0), active: active.slice(s0, e0) });
+  };
   for (let i = 0; i < t.length; i += 1) {
     const c = t[i];
     if (quote) {
@@ -372,12 +386,12 @@ function caseLabelOf(line) {
     }
     if (c === '\\') { push(t[i + 1] ?? '', false); i += 1; continue; }
     if (c === "'" || c === '"') { quote = c; continue; }
-    if (c === '|') { patterns.push({ text: cur.trim(), active }); cur = ''; active = []; continue; }
+    if (c === '|') { finish(); cur = ''; active = []; continue; }
     if (c === ')') { end = i; break; }
     push(c, true);
   }
   if (end < 0) return null;
-  patterns.push({ text: cur.trim(), active });
+  finish();
   // Whitespace only disqualifies an UNQUOTED pattern: `"x y"` is one legal pattern, and
   // rejecting the whole label for it false-FAILED an otherwise-valid arm. Driven.
   if (patterns.length === 0
@@ -712,6 +726,33 @@ describe('#4176 — gsd-ui-auditor screenshot capture is honest', () => {
       surfaces.every((l) => /^\*\*Screenshots:\*\*[\t ]*\{?[\t ]*\$CAPTURE_STATUS\b/.test(l.trim())),
       `every Screenshots report field must render $CAPTURE_STATUS as its value: ${JSON.stringify(surfaces)}`
     );
+  });
+});
+
+describe('#4176 — bash reader, units', () => {
+  test('caseLabelOf keeps text and active aligned when a pattern carries unquoted edge whitespace', () => {
+    // Both polarities of the desync, each on a legal label bash accepts.
+    // ` 2?\?` — the last `?` is ESCAPED, so this admits `2?` + a literal `?`, not a range.
+    // With the text trimmed and `active` not, the escaped slot was read one index early.
+    const falsePass = caseLabelOf(' 2?\\?) DEV_URL=x ;;');
+    assert.ok(falsePass !== null);
+    assert.deepStrictEqual(falsePass.map((x) => x.text), ['2??']);
+    assert.strictEqual(falsePass.some(isTwoXxRange), false, 'an escaped ? is not a wildcard, whatever precedes the pattern');
+    // ` "2"??` — the digit is quoted, both `?` are live wildcards: a range.
+    const falseFail = caseLabelOf(' "2"??) DEV_URL=x ;;');
+    assert.ok(falseFail !== null);
+    assert.strictEqual(falseFail.some(isTwoXxRange), true, 'a quoted digit followed by two live wildcards is a 2xx range');
+    // Trailing whitespace, and whitespace around a `|` separator.
+    assert.strictEqual(caseLabelOf('2?? ) x').some(isTwoXxRange), true);
+    assert.deepStrictEqual(caseLabelOf('401 | 403 |407) x').map((x) => x.text), ['401', '403', '407']);
+    // A QUOTED space is pattern content and survives — it is not separator whitespace.
+    const quotedSpace = caseLabelOf('" 2"??) x');
+    assert.deepStrictEqual(quotedSpace.map((x) => x.text), [' 2??']);
+    assert.strictEqual(quotedSpace.some(isTwoXxRange), false);
+    // And every returned pattern keeps the invariant the range test relies on.
+    for (const lab of [falsePass, falseFail, quotedSpace]) {
+      for (const p of lab) assert.strictEqual(p.active.length, p.text.length, 'text and active must stay the same length');
+    }
   });
 });
 

--- a/tests/playwright-ui-verify.test.cjs
+++ b/tests/playwright-ui-verify.test.cjs
@@ -1212,6 +1212,23 @@ describe('#4176 — the capture fence, executed', { skip: BASH_OK ? false : 'no 
       'the file standing where the directory should be must be left alone');
   });
 
+  test('a dangling symlink at the base name is a collision, retried under a suffix — not a structural stop', () => {
+    // Round-review refutation of the structural guard: a dangling symlink OCCUPIES the name
+    // (mkdir fails EEXIST) while `[ -e ]` follows the link and says nothing is there, so the
+    // guard read a collision as structural and gave up. `[ -L ]` is what sees the link.
+    // (The fixture also pins that the planted link is never adopted as the directory.)
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-4176-dangle-'));
+    tmpDirs.push(dir);
+    const reviews = path.join(dir, '.planning', 'ui-reviews');
+    fs.mkdirSync(reviews, { recursive: true });
+    fs.symlinkSync(path.join(dir, 'nowhere'), path.join(reviews, '07-20300101-000000'));
+    const r = ok(runFence({ FIXED_DATE: '20300101-000000', PADDED_PHASE: '07', PROBE_3000: '200' }, dir));
+    assert.match(r.stdout, /Screenshots captured/, 'a taken name must be retried, not treated as a structural failure');
+    assert.strictEqual(r.captureStatus, 'captured (3/3 from http://localhost:3000)');
+    assert.ok(fs.existsSync(path.join(reviews, '07-20300101-000000-1')), 'the run must have taken the first suffix');
+    assert.ok(fs.lstatSync(path.join(reviews, '07-20300101-000000')).isSymbolicLink(), 'the planted link must be left alone');
+  });
+
   test('the last candidate suffix is tried, not skipped', () => {
     // The retry loop once incremented past the bound before forming the next candidate,
     // so with the base and `-1`..`-98` taken it reported exhaustion while `-99` was free.

--- a/tests/playwright-ui-verify.test.cjs
+++ b/tests/playwright-ui-verify.test.cjs
@@ -174,8 +174,17 @@ function guardedLines(lines) {
 // direction over-fires, which is the safe one.)
 // Inline comments are stripped too, not just whole-line ones. `--timeout=30000` moved into a
 // trailing comment is an ordinary edit, not sabotage, and it would otherwise keep satisfying the
-// time-bound assertion while no longer being passed to the command. Strip from an unquoted ` #`
-// to end of line BEFORE joining, which also closes the splice via a trailing comment.
+// time-bound assertion while no longer being passed to the command. Strip from ` #` to end of
+// line BEFORE joining, which also closes the splice via a trailing comment.
+//
+// KNOWN LIMIT, stated because the regex does not enforce what a looser comment here once claimed:
+// this is QUOTE-BLIND. It cannot tell a comment from a `#` inside a string, so a line such as
+// `--user-agent=" # " \` has its quoted `#` read as a comment start, taking the real continuation
+// backslash with it. The consequence is direction-dependent: an assertion REQUIRING a flag then
+// over-fires (safe), but a BAN — the `localhost:\d+` check below — would stop seeing a hard-coded
+// port that moved onto the hidden continuation line, which is a false clean. No line in the block
+// this reads contains a quoted ` #` today. Making it quote-aware means lexing bash, which is more
+// than a confirmed-bug fix should carry, so the limit is recorded rather than closed.
 function stripComment(line) {
   const stripped = line.replace(/\s+#.*$/, '');
   if (stripped === line) return line; // nothing removed — leave real continuations alone

--- a/tests/playwright-ui-verify.test.cjs
+++ b/tests/playwright-ui-verify.test.cjs
@@ -177,7 +177,15 @@ function guardedLines(lines) {
 // time-bound assertion while no longer being passed to the command. Strip from an unquoted ` #`
 // to end of line BEFORE joining, which also closes the splice via a trailing comment.
 function stripComment(line) {
-  return line.replace(/\s+#.*$/, '');
+  const stripped = line.replace(/\s+#.*$/, '');
+  if (stripped === line) return line; // nothing removed — leave real continuations alone
+  // A `\` that the removed text was hiding did NOT continue the line in bash, so this reader
+  // must not treat it as one. Driven: `echo one \ # x` followed by `--timeout=30000` runs the
+  // second line as its OWN command (`--timeout=30000: command not found`) — bash never joins
+  // them. Stripping the comment and keeping the backslash would make logicalLines() join what
+  // bash does not, so a flag on the following line would satisfy an assertion the real command
+  // never receives. That is a bypass this stripping would have CREATED, not one it inherited.
+  return stripped.replace(/\\+$/, '');
 }
 function captureInvocations(lines) {
   return logicalLines(lines.map(stripComment).filter((l) => !/^[\t ]*#/.test(l) && l.trim() !== ''))

--- a/tests/playwright-ui-verify.test.cjs
+++ b/tests/playwright-ui-verify.test.cjs
@@ -772,6 +772,44 @@ const http = require('http');
 const os = require('os');
 const { spawnSync, execFile } = require('child_process');
 
+// DELIVER A SCRIPT AS A FILE rather than through `bash -c`, wherever the script text is
+// generated or carries a backslash. Crossing the Win32 argv boundary an ADJACENT DOUBLED
+// backslash is collapsed before bash parses it, so `-c` hands Windows bash a script that is
+// not the one under test: `echo three \\` arrives as `echo three \`, which is a line
+// continuation, and swallows the command after it. Measured on Git Bash 5.2.37(1) (msys)
+// against WSL bash 5.2 with the five-line fixture below: `-c` yields 3 commands on msys and
+// 4 on POSIX, while the file form yields 4 on both. `bash -c 'exit 0'` above is deliberately
+// left as-is — it is a fixed, backslash-free liveness probe and cannot reach this.
+// ONE directory for the whole file, not one per call: the two properties below run 60 and
+// 250 cases, and a mkdtemp/rm pair per case is ~311 synchronous filesystem round-trips on a
+// platform where each is antivirus-scanned. It also removes a failure surface — `cleanup()`
+// swallows Windows EBUSY/ENOTEMPTY/EPERM, so a per-call teardown can both leak and mask the
+// result of the test that triggered it.
+let bashScriptDir = null;
+let bashScriptSeq = 0;
+function runBashScript(script, env) {
+  if (bashScriptDir === null) {
+    bashScriptDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-4176-bash-'));
+  }
+  // A FRESH NAME per call, inside the one directory. Reusing a single hot `script.sh` across
+  // 311 rapid overwrite-and-execute cycles invites the Windows failure this whole commit is
+  // about, one layer down: a scanner or a not-yet-released handle can transiently block the
+  // next overwrite, and `writeFileSync` has no retry. A new name cannot contend with the
+  // handle the previous call just closed, and costs one inode rather than one mkdtemp+rm.
+  const file = path.join(bashScriptDir, `script-${(bashScriptSeq += 1)}.sh`);
+  // Written VERBATIM, with no trailing newline appended: a script whose last line ends in a
+  // continuation would change meaning if one were added, and bash executes a final line that
+  // lacks one. `$0` and `BASH_SOURCE[0]` differ from the `-c` form (the pathname rather than
+  // `bash`); no caller here reads either, or any positional parameter.
+  fs.writeFileSync(file, script);
+  return spawnSync('bash', [file], {
+    encoding: 'utf8',
+    timeout: PROBE_TIMEOUT_MS,
+    ...(env ? { env: { ...process.env, ...env } } : {}),
+  });
+}
+after(() => { if (bashScriptDir !== null) cleanup(bashScriptDir); });
+
 // The probe is `node -e '<program>' "<url>"`. Take the program out verbatim.
 function probeProgram() {
   const line = logicalLines(screenshotApproachLines().map(stripComment))
@@ -1482,10 +1520,29 @@ describe('#4176 — bash reader, units', () => {
     assert.deepStrictEqual(logicalLines(['echo a \\', '  b \\ ', 'c']), ['echo a b \\ ', 'c']);
   });
 
+  // REGRESSION, #4224 round 4: the script must reach bash BYTE-INTACT. This is the platform
+  // defect that reddened `test (windows-latest, 24, shard 1/3)` — an adjacent doubled
+  // backslash is collapsed crossing the Win32 argv boundary, so `bash -c` delivered
+  // `echo three \\` as `echo three \`, a line continuation that swallowed the next command
+  // and made bash run 3 where POSIX runs 4. It asserts the DELIVERY, not the reader: it is
+  // the only check here that fails if the transport starts mangling text again, and on Linux
+  // it passes under either transport, so it is a Windows-only guard by construction. It is
+  // not the only check that would catch a mangling transport — the two tests that actually
+  // failed on Windows are proof it is not — but it is the only one that names the transport
+  // as the thing under test, so a future regression reports the cause rather than the symptom.
+  test('a doubled backslash survives delivery — bash runs two commands, not one',
+    { skip: BASH_OK ? false : 'no runnable bash on this host' }, () => {
+    const r = runBashScript('echo three \\\\\necho four');
+    assert.strictEqual(r.status, 0, `bash rejected the script: ${r.stderr}`);
+    assert.deepStrictEqual(splitLines(r.stdout).filter(Boolean), ['three \\', 'four'],
+      'the doubled backslash was collapsed in transit: bash saw a line continuation, '
+      + 'joined the two commands, and the script under test is not the script written');
+  });
+
   test('logicalLines agrees with bash on how many commands a continuation-bearing script runs',
     { skip: BASH_OK ? false : 'no runnable bash on this host' }, () => {
     const script = ['echo one \\ ', 'echo two', 'echo three \\\\', 'echo four \\', '  five'].join('\n');
-    const r = spawnSync('bash', ['-c', script], { encoding: 'utf8', timeout: PROBE_TIMEOUT_MS });
+    const r = runBashScript(script);
     const printed = splitLines(r.stdout).filter(Boolean);
     const modelled = logicalLines(splitLines(script)).map((l) => l.trim());
     assert.strictEqual(printed.length, modelled.length,
@@ -1689,7 +1746,7 @@ describe('#4176 — bash reader, property-based (fast-check)', () => {
           }
           const env = {};
           conds.forEach((c, i) => { env[`C${i}`] = truth[i] ? '1' : '0'; });
-          const r = spawnSync('bash', ['-c', lines.join('\n')], { encoding: 'utf8', env: { ...process.env, ...env }, timeout: PROBE_TIMEOUT_MS });
+          const r = runBashScript(lines.join('\n'), env);
           assert.strictEqual(r.status, 0, `bash rejected a generated script — the generator is wrong, not the reader:\n${lines.join('\n')}\n${r.stderr}`);
           const printed = new Set([...r.stdout.matchAll(/\bM(\d+)\b/g)].map((m) => Number(m[1])));
           assert.deepStrictEqual([...predicted].sort((a, b) => a - b), [...printed].sort((a, b) => a - b),
@@ -1722,7 +1779,7 @@ describe('#4176 — bash reader, property-based (fast-check)', () => {
           assert.ok(label !== null, `every generated label is legal bash, so the reader must parse it: ${JSON.stringify(labelText)}`);
           const claimed = label.some(isTwoXxRange);
           const script = 'for s in 200 250 299 199 300 500; do case "$s" in ' + labelText + ') printf Y;; *) printf N;; esac; done';
-          const r = spawnSync('bash', ['-c', script], { encoding: 'utf8', timeout: PROBE_TIMEOUT_MS });
+          const r = runBashScript(script);
           assert.strictEqual(r.status, 0, `bash cannot run the generated label ${JSON.stringify(labelText)}: ${r.stderr}`);
           reached += 1;
           const admitsAll2xx = r.stdout.slice(0, 3) === 'YYY';

--- a/tests/playwright-ui-verify.test.cjs
+++ b/tests/playwright-ui-verify.test.cjs
@@ -77,7 +77,7 @@ const AUDITOR_PATH = path.join(__dirname, '..', 'agents', 'gsd-ui-auditor.md');
 // body regex is ad-hoc markdown parsing (local/no-adhoc-markdown-parsing), and a
 // bare \n split is CRLF-fragile on Windows checkouts (local/no-crlf-fragile-split).
 // splitLines() handles the line endings; the scan below handles the fence.
-function screenshotApproachBlock() {
+function screenshotApproachLines() {
   const lines = splitLines(fs.readFileSync(AUDITOR_PATH, 'utf-8'));
   const FENCE = '`'.repeat(3);
   const OPENER = FENCE + 'bash';
@@ -98,7 +98,63 @@ function screenshotApproachBlock() {
     body.push(line);
   }
   assert.ok(body.length > 0, '<screenshot_approach> must contain a non-empty bash fence');
-  return body.join('\n');
+  return body;
+}
+
+function screenshotApproachBlock() {
+  return screenshotApproachLines().join('\n');
+}
+
+// Join backslash continuations, so a capture invocation or an `if ... ; then` spread
+// over four physical lines is ONE logical line. Without this, a structural read of the
+// block sees `if npx playwright screenshot "$DEV_URL" \` — a header with no `then` —
+// and silently declines to open a scope.
+function logicalLines(lines) {
+  const joined = [];
+  let buf = null;
+  for (const raw of lines) {
+    const piece = buf === null ? raw : `${buf} ${raw.trim()}`;
+    const trimmedEnd = piece.replace(/[\t ]+$/, '');
+    if (trimmedEnd.endsWith('\\')) {
+      buf = trimmedEnd.slice(0, -1).replace(/[\t ]+$/, '');
+      continue;
+    }
+    buf = null;
+    joined.push(piece);
+  }
+  if (buf !== null) joined.push(buf);
+  return joined;
+}
+
+// Every logical line paired with the shell conditions actually GOVERNING it — the
+// `if`/`elif`/`else` conditions of the enclosing scopes, innermost last. Loops and
+// `case` open a scope with no condition of their own, so a line inside one is still
+// correctly reported as ungoverned unless an `if` encloses it too.
+//
+// This is what a "the echo is gated" assertion has to read. Asking instead whether some
+// token appears EARLIER IN THE BLOCK TEXT than the echo answers a different question
+// entirely, and `CAPTURED=0` near the top of the block makes that question true forever:
+// moving the success echo back outside its `if [ "$CAPTURED" -eq 3 ]` branch — which is
+// precisely the #4176 bug — would not disturb it.
+function guardedLines(lines) {
+  const stack = [];
+  const rows = [];
+  for (const line of logicalLines(lines)) {
+    const t = line.trim();
+    const ifMatch = /^if[\t ]+(.{1,4000}?)[\t ]*;[\t ]*then$/.exec(t);
+    if (ifMatch) { stack.push(ifMatch[1]); continue; }
+    const elifMatch = /^elif[\t ]+(.{1,4000}?)[\t ]*;[\t ]*then$/.exec(t);
+    if (elifMatch) { if (stack.length) stack[stack.length - 1] = elifMatch[1]; continue; }
+    if (t === 'else') { if (stack.length) stack[stack.length - 1] = `!(${stack[stack.length - 1]})`; continue; }
+    if (t === 'fi') { stack.pop(); continue; }
+    if (/^(for|while|until)\b/.test(t) && /;[\t ]*do$/.test(t)) { stack.push(''); continue; }
+    if (t === 'do') { stack.push(''); continue; }
+    if (t === 'done') { stack.pop(); continue; }
+    if (/^case\b/.test(t) && /\bin$/.test(t)) { stack.push(''); continue; }
+    if (t === 'esac') { stack.pop(); continue; }
+    rows.push({ line: t, guards: stack.slice() });
+  }
+  return rows;
 }
 
 describe('#4176 — gsd-ui-auditor screenshot capture is honest', () => {
@@ -122,12 +178,27 @@ describe('#4176 — gsd-ui-auditor screenshot capture is honest', () => {
     const block = screenshotApproachBlock();
     const checksOutcome = /\[ -s "?\$SCREENSHOT_DIR|\[ -s |if npx |CAPTURED=|\$\?/.test(block);
     assert.ok(checksOutcome, 'an exit-status or file-existence check must gate the captured/not-captured signal');
-    // The unconditional echo is the actual defect: a "captured" claim must not
-    // sit outside any conditional that could have observed a failure.
-    const unconditional = block
-      .split('\n')
-      .some((l) => /^\s*echo "Screenshots captured/.test(l) && !/CAPTURED|-eq|-s /.test(block.slice(0, block.indexOf(l))));
-    assert.ok(!unconditional, '"Screenshots captured" must never be echoed without an outcome check');
+  });
+
+  // The structural half of the assertion above. A "captured" claim is a claim about an
+  // outcome, so what has to be true is that the branch printing it could only have been
+  // reached by observing that outcome — a property of the block's CONTROL FLOW, which a
+  // substring-proximity check cannot express and cannot fail on the regression it names.
+  test('every capture-success claim is governed by a conditional testing the capture count', () => {
+    const rows = guardedLines(screenshotApproachLines());
+    const CLAIM = /^echo "Screenshots (captured|PARTIALLY captured)\b/;
+    const claims = rows.filter((r) => CLAIM.test(r.line));
+    assert.ok(
+      claims.length > 0,
+      'expected the capture block to echo a success or partial-success claim'
+    );
+    for (const claim of claims) {
+      assert.ok(
+        claim.guards.some((cond) => /CAPTURED/.test(cond)),
+        'a capture-success claim must sit inside a conditional that tests the capture count; ' +
+          `governing conditions for ${JSON.stringify(claim.line)} were ${JSON.stringify(claim.guards)}`
+      );
+    }
   });
 
   test('all three documented ports are tried in the control flow', () => {

--- a/tests/playwright-ui-verify.test.cjs
+++ b/tests/playwright-ui-verify.test.cjs
@@ -312,7 +312,9 @@ function stripComment(line) {
     const c = line[i];
     const ctx = top();
     const wasWordStart = wordStart;
-    wordStart = stack.length === 0 && /[\t ]/.test(c);
+    // Unquoted whitespace OR an unquoted metacharacter ends the token, so the next
+    // character starts a word: `echo A;# fi` is a comment in bash. Found by the round review.
+    wordStart = stack.length === 0 && /[\t ;|&()<>]/.test(c);
     if (ctx === 'sq') { out += c; if (c === "'") stack.pop(); continue; }
     if (ctx === 'ansi') {                       // $'...' — backslash escapes ARE processed
       if (c === '\\' && i + 1 < line.length) { out += c + line[i + 1]; i += 1; continue; }
@@ -1438,6 +1440,15 @@ describe('#4176 — bash reader, units', () => {
     assert.strictEqual(stripComment('echo a#b'), 'echo a#b');
     assert.strictEqual(stripComment('# whole line'), '');
     assert.strictEqual(stripComment('echo "a # b" # c'), 'echo "a # b"');
+    // Operators end a token too — `#` right after one is at a word start. Round review.
+    assert.strictEqual(stripComment('echo A;# fi'), 'echo A;');
+    assert.strictEqual(stripComment('echo A|#fi'), 'echo A|');
+    assert.strictEqual(stripComment('echo A &&# fi'), 'echo A &&');
+    assert.strictEqual(stripComment('(echo A)#x'), '(echo A)');
+    assert.strictEqual(stripComment('echo A >#x'), 'echo A >');
+    assert.strictEqual(stripComment('x=#y'), 'x=#y');
+    assert.strictEqual(stripComment('echo ${x}#y'), 'echo ${x}#y');
+    assert.strictEqual(stripComment('echo "a;" #b'), 'echo "a;"');
   });
 
   test('logicalLines joins only a backslash that is the LAST character of the line, in an odd run', () => {
@@ -1502,7 +1513,7 @@ const scriptGen = fc.letrec((tie) => ({
     // What surrounds the marker: a plain echo, a quoted string carrying control keywords
     // (the `echo "we do work"` false-fire class), a trailing comment that itself carries
     // keywords (the `fi # comment` desync class), or a continuation across two lines.
-    dress: fc.constantFrom('plain', 'dq-keywords', 'sq-keywords', 'comment', 'continued', 'hash-in-quotes', 'backslash-space', 'escaped-backslash'),
+    dress: fc.constantFrom('plain', 'dq-keywords', 'sq-keywords', 'comment', 'continued', 'hash-in-quotes', 'backslash-space', 'escaped-backslash', 'operator-comment'),
   }),
   ifBlock: fc.record({
     kind: fc.constant('if'),
@@ -1550,6 +1561,8 @@ function render(tree, opts) {
         case 'backslash-space': emit(depth, `echo "${m}" \\ `); break;
         // An escaped backslash at the end of a complete line.
         case 'escaped-backslash': emit(depth, `echo "${m}" \\\\`); break;
+        // A comment opened right after an operator, no space — bash ends the word at `;`.
+        case 'operator-comment': emit(depth, `echo "${m}";# fi done esac`); break;
         default: throw new Error(`unknown dress ${node.dress}`);
       }
       expect.push({ id, guards: guards.slice(), exec });

--- a/tests/playwright-ui-verify.test.cjs
+++ b/tests/playwright-ui-verify.test.cjs
@@ -8,6 +8,7 @@ const fs = require('fs');
 const path = require('path');
 const { splitLines } = require('../gsd-core/bin/lib/text-lines.cjs');
 const { cleanup } = require('./helpers.cjs');
+const { PROBE_TIMEOUT_MS, HOOK_FANOUT_TIMEOUT_MS } = require('./helpers/timeouts.cjs');
 
 // #2994 fragmentization moved the automated_ui_verification step out of
 // verify-work.md into gsd-core/workflows/verify-work/steps/automated-ui-verification.md
@@ -799,7 +800,7 @@ const urlOf = (server) => `http://127.0.0.1:${server.address().port}`;
 // suite — a self-inflicted instance of the false-clean class the rest of this file is about.
 function runProbe(url) {
   return new Promise((resolve) => {
-    execFile(process.execPath, ['-e', probeProgram(), url], { timeout: 30000 },
+    execFile(process.execPath, ['-e', probeProgram(), url], { timeout: PROBE_TIMEOUT_MS },
       // MODEL THE WHOLE SHELL EXPRESSION, not just the program. The fence runs
       //   PROBE=$(node -e '…' "$url" 2>/dev/null || echo "000"); PROBE=${PROBE:-000}
       // so a program that PRINTS 200 and then exits non-zero yields `200000` — which
@@ -888,7 +889,7 @@ describe('#4176 — the probe program, executed against real servers', () => {
     // nothing to do with the server. The version is carried so the report can name it.
     const program = `delete globalThis.fetch; ${probeProgram()}`;
     const out = await new Promise((resolve) => {
-      execFile(process.execPath, ['-e', program, 'http://127.0.0.1:1/'], { timeout: 30000 },
+      execFile(process.execPath, ['-e', program, 'http://127.0.0.1:1/'], { timeout: PROBE_TIMEOUT_MS },
         (err, stdout) => resolve({ code: err && typeof err.code === 'number' ? err.code : 0, stdout: String(stdout) }));
     });
     assert.strictEqual(out.code, 0, 'the nofetch branch must not throw');
@@ -911,7 +912,7 @@ describe('#4176 — the probe program, executed against real servers', () => {
 // platform: a `process.platform === 'win32'` gate also skips silently on any non-Windows
 // host without bash, and claims Windows has none when Git Bash is often present.
 const BASH_OK = (() => {
-  const r = spawnSync('bash', ['-c', 'exit 0'], { encoding: 'utf8', timeout: 15000 });
+  const r = spawnSync('bash', ['-c', 'exit 0'], { encoding: 'utf8', timeout: PROBE_TIMEOUT_MS });
   return r.status === 0;
 })();
 
@@ -1017,7 +1018,7 @@ describe('#4176 — the capture fence, executed', { skip: BASH_OK ? false : 'no 
     const r = spawnSync('bash', [script], {
       cwd: dir,
       encoding: 'utf8',
-      timeout: 60000,
+      timeout: HOOK_FANOUT_TIMEOUT_MS,
       env: {
         ...process.env,
         PATH: `${bin}${path.delimiter}${process.env.PATH}`,
@@ -1484,7 +1485,7 @@ describe('#4176 — bash reader, units', () => {
   test('logicalLines agrees with bash on how many commands a continuation-bearing script runs',
     { skip: BASH_OK ? false : 'no runnable bash on this host' }, () => {
     const script = ['echo one \\ ', 'echo two', 'echo three \\\\', 'echo four \\', '  five'].join('\n');
-    const r = spawnSync('bash', ['-c', script], { encoding: 'utf8', timeout: 15000 });
+    const r = spawnSync('bash', ['-c', script], { encoding: 'utf8', timeout: PROBE_TIMEOUT_MS });
     const printed = splitLines(r.stdout).filter(Boolean);
     const modelled = logicalLines(splitLines(script)).map((l) => l.trim());
     assert.strictEqual(printed.length, modelled.length,
@@ -1688,7 +1689,7 @@ describe('#4176 — bash reader, property-based (fast-check)', () => {
           }
           const env = {};
           conds.forEach((c, i) => { env[`C${i}`] = truth[i] ? '1' : '0'; });
-          const r = spawnSync('bash', ['-c', lines.join('\n')], { encoding: 'utf8', env: { ...process.env, ...env }, timeout: 15000 });
+          const r = spawnSync('bash', ['-c', lines.join('\n')], { encoding: 'utf8', env: { ...process.env, ...env }, timeout: PROBE_TIMEOUT_MS });
           assert.strictEqual(r.status, 0, `bash rejected a generated script — the generator is wrong, not the reader:\n${lines.join('\n')}\n${r.stderr}`);
           const printed = new Set([...r.stdout.matchAll(/\bM(\d+)\b/g)].map((m) => Number(m[1])));
           assert.deepStrictEqual([...predicted].sort((a, b) => a - b), [...printed].sort((a, b) => a - b),
@@ -1721,7 +1722,7 @@ describe('#4176 — bash reader, property-based (fast-check)', () => {
           assert.ok(label !== null, `every generated label is legal bash, so the reader must parse it: ${JSON.stringify(labelText)}`);
           const claimed = label.some(isTwoXxRange);
           const script = 'for s in 200 250 299 199 300 500; do case "$s" in ' + labelText + ') printf Y;; *) printf N;; esac; done';
-          const r = spawnSync('bash', ['-c', script], { encoding: 'utf8', timeout: 15000 });
+          const r = spawnSync('bash', ['-c', script], { encoding: 'utf8', timeout: PROBE_TIMEOUT_MS });
           assert.strictEqual(r.status, 0, `bash cannot run the generated label ${JSON.stringify(labelText)}: ${r.stderr}`);
           reached += 1;
           const admitsAll2xx = r.stdout.slice(0, 3) === 'YYY';

--- a/tests/playwright-ui-verify.test.cjs
+++ b/tests/playwright-ui-verify.test.cjs
@@ -281,6 +281,24 @@ describe('#4176 — gsd-ui-auditor screenshot capture is honest', () => {
     }
   });
 
+  test('capture invocations are time-bounded, as the probe is', () => {
+    // `playwright screenshot` forwards --timeout to context.setDefaultTimeout() and
+    // defaults it to 0, i.e. NO timeout — so this CLI path drops the bound the
+    // Playwright library applies by default. An unbounded capture reinstates the
+    // hang the probe's own time bound exists to prevent, one step later.
+    // logicalLines, because the invocation spans four physical lines.
+    const captures = logicalLines(screenshotApproachLines())
+      .map((l) => l.trim())
+      .filter((l) => l.includes('playwright screenshot'));
+    assert.ok(captures.length > 0, 'expected at least one capture invocation');
+    for (const line of captures) {
+      assert.ok(
+        /--timeout[= ]/.test(line),
+        `capture must be time-bounded — playwright screenshot defaults to no timeout: ${line}`
+      );
+    }
+  });
+
   test('a total capture failure removes its stray files, not just an empty directory', () => {
     // rmdir alone cannot honour a "leaves nothing behind" claim: it succeeds only on a
     // genuinely empty directory and its stderr is discarded, so a zero-byte or partial

--- a/tests/playwright-ui-verify.test.cjs
+++ b/tests/playwright-ui-verify.test.cjs
@@ -7,6 +7,7 @@ const assert = require('node:assert/strict');
 const fs = require('fs');
 const path = require('path');
 const { splitLines } = require('../gsd-core/bin/lib/text-lines.cjs');
+const { cleanup } = require('./helpers.cjs');
 
 // #2994 fragmentization moved the automated_ui_verification step out of
 // verify-work.md into gsd-core/workflows/verify-work/steps/automated-ui-verification.md
@@ -696,7 +697,10 @@ describe('#4176 — gsd-ui-auditor screenshot capture is honest', () => {
     // hard-coded `Screenshots: captured` line satisfied a scan of the raw source: the
     // commented lines still matched, and the rendered text no longer carried the
     // variable at all. Driven.
-    const rendered = fs.readFileSync(AUDITOR_PATH, 'utf-8').replace(/<!--[\s\S]*?-->/g, '');
+    // Bounded quantifier: an unbounded `[\s\S]*?` over readFileSync content is a
+    // catastrophic-backtracking risk this repo lints for (local/no-unbounded-quantifier).
+    // 20k is far longer than any comment in this file and far short of the file itself.
+    const rendered = fs.readFileSync(AUDITOR_PATH, 'utf-8').replace(/<!--[\s\S]{0,20000}?-->/g, '');
     const surfaces = splitLines(rendered)
       .filter((l) => /^\*\*Screenshots:\*\*/.test(l.trim()));
     assert.ok(surfaces.length > 0, 'expected a Screenshots report field in the agent output template');
@@ -759,7 +763,7 @@ const urlOf = (server) => `http://127.0.0.1:${server.address().port}`;
 // live servers while the two that "passed" passed vacuously. Measured while writing this
 // suite — a self-inflicted instance of the false-clean class the rest of this file is about.
 function runProbe(url) {
-  return new Promise((resolve, reject) => {
+  return new Promise((resolve) => {
     execFile(process.execPath, ['-e', probeProgram(), url], { timeout: 30000 },
       // MODEL THE WHOLE SHELL EXPRESSION, not just the program. The fence runs
       //   PROBE=$(node -e '…' "$url" 2>/dev/null || echo "000"); PROBE=${PROBE:-000}
@@ -851,7 +855,9 @@ const BASH_OK = (() => {
 
 describe('#4176 — the capture fence, executed', { skip: BASH_OK ? false : 'no runnable bash on this host' }, () => {
   const tmpDirs = [];
-  after(() => { for (const d of tmpDirs) fs.rmSync(d, { recursive: true, force: true }); });
+  // cleanup(), not a raw fs.rmSync: the helper carries the Windows-EBUSY retry budget, and
+  // these directories hold files a spawned bash was writing moments earlier.
+  after(() => { for (const d of tmpDirs) cleanup(d); });
 
   // Stub `node` and `npx` on PATH, run the fence, and read what it printed, what it left
   // on disk, what it passed to the capture binary, and what CAPTURE_STATUS ended up as.
@@ -901,13 +907,12 @@ describe('#4176 — the capture fence, executed', { skip: BASH_OK ? false : 'no 
       + 'case " $SHOT_WRITE " in *" $name "*) printf png > "$out";; esac\n'
       + 'case " $SHOT_EMPTY " in *" $name "*) : > "$out";; esac\n'
       + 'case " $SHOT_EXIT " in *" $name "*) exit 1;; esac\nexit 0\n', { mode: 0o755 });
-    // A `date` stub, so the collision case can actually be CONSTRUCTED. Without it the
-    // uniqueness test was vacuous: two runs a second apart get different names from the
-    // timestamp alone, so it passed with the uniqueness mechanism removed entirely.
-    // Driven — that is exactly how the first version of this test passed.
-    if (env.FIXED_DATE) {
-      fs.writeFileSync(path.join(bin, 'date'), `#!/bin/sh\nprintf %s "${env.FIXED_DATE}"\n`, { mode: 0o755 });
-    }
+    // The `date` override is a SHELL FUNCTION, injected into the script below — never a
+    // file on PATH. Git Bash searches /usr/bin ahead of the converted Windows PATH, so a
+    // stub named after a coreutils binary is shadowed there: measured on the
+    // windows-latest runner, where the fence used the REAL clock, the collision could not
+    // be constructed, and both fixtures passed vacuously while the Linux shards were
+    // green. A function is looked up before PATH on every platform.
     const argvLog = path.join(dir, 'argv.log');
     const script = path.join(dir, 'fence.sh');
     // No `set -u`: the agent does not run this block under it, and adding it changes the
@@ -926,8 +931,11 @@ describe('#4176 — the capture fence, executed', { skip: BASH_OK ? false : 'no 
     // the last. A file the block never names cannot be forged by the block's own output.
     const statusFile = path.join(dir, 'capture-status.out');
     const rcFile = path.join(dir, 'fence-rc.out');
+    const dateOverride = env.FIXED_DATE
+      ? `date() { printf %s ${JSON.stringify(env.FIXED_DATE)}; }\n`
+      : '';
     fs.writeFileSync(script,
-      `PADDED_PHASE=${env.PADDED_PHASE || '07'}\n${screenshotApproachBlock()}\n`
+      `PADDED_PHASE=${env.PADDED_PHASE || '07'}\n${dateOverride}${screenshotApproachBlock()}\n`
       + 'FENCE_RC=$?\n'
       + `printf %s "$CAPTURE_STATUS" > ${JSON.stringify(statusFile)}\n`
       + `printf %s "$FENCE_RC" > ${JSON.stringify(rcFile)}\n`);
@@ -1053,6 +1061,12 @@ describe('#4176 — the capture fence, executed', { skip: BASH_OK ? false : 'no 
     tmpDirs.push(dir);
     const fixed = { FIXED_DATE: '20300101-000000', PADDED_PHASE: '07' };
     const first = ok(runFence({ ...fixed, PROBE_3000: '200' }, dir));
+    // PROVE THE CLOCK WAS FROZEN. If the override does not take, the two audits get
+    // different names from the timestamp alone, they never contend, and this test passes
+    // having constructed nothing — which is exactly what happened on windows-latest when
+    // the override was a file on PATH that Git Bash shadowed with /usr/bin/date.
+    assert.ok(first.shotDirs[0] && first.shotDirs[0].startsWith(`07-${fixed.FIXED_DATE}`),
+      `the date override did not take — this fixture cannot construct a collision: ${JSON.stringify(first.shotDirs)}`);
     // The second audit fails every viewport, so its cleanup runs — under a shared
     // directory that cleanup is what deleted the first audit's work.
     const second = ok(runFence({ ...fixed, PROBE_3000: '200', SHOT_EXIT: 'desktop mobile tablet',
@@ -1077,7 +1091,12 @@ describe('#4176 — the capture fence, executed', { skip: BASH_OK ? false : 'no 
     fs.mkdirSync(path.join(reviews, '07-20300101-000000'));
     for (let i = 1; i <= 99; i += 1) fs.mkdirSync(path.join(reviews, `07-20300101-000000-${i}`));
     const r = ok(runFence({ FIXED_DATE: '20300101-000000', PADDED_PHASE: '07', PROBE_3000: '200' }, dir));
-    assert.match(r.stdout, /Could not allocate a review directory/);
+    // Same guard, same reason: without a frozen clock the run allocates a fresh name, the
+    // 100 occupied directories are never contended, and the exhaustion branch is not
+    // reached at all. Measured on windows-latest, where this fixture failed for that
+    // reason rather than for the reason it names.
+    assert.doesNotMatch(r.stdout, /Screenshots captured/,
+      'the date override did not take — the allocation was never exhausted');
     assert.strictEqual(r.captureStatus, 'not captured (capture failed)');
     assert.doesNotMatch(r.stdout, /Screenshots captured/);
     assert.strictEqual(r.invocations.length, 0,

--- a/tests/playwright-ui-verify.test.cjs
+++ b/tests/playwright-ui-verify.test.cjs
@@ -6,6 +6,7 @@ const { test, describe } = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('fs');
 const path = require('path');
+const { splitLines } = require('../gsd-core/bin/lib/text-lines.cjs');
 
 // #2994 fragmentization moved the automated_ui_verification step out of
 // verify-work.md into gsd-core/workflows/verify-work/steps/automated-ui-verification.md
@@ -71,12 +72,33 @@ describe('Playwright-MCP UI verification integration', () => {
 // grep for "5173" passed on the broken version.
 const AUDITOR_PATH = path.join(__dirname, '..', 'agents', 'gsd-ui-auditor.md');
 
+// Line-based rather than a fence regex: an unbounded [\s\S]*? over readFileSync
+// content is a backtracking risk (local/no-unbounded-quantifier), a triple-fence
+// body regex is ad-hoc markdown parsing (local/no-adhoc-markdown-parsing), and a
+// bare \n split is CRLF-fragile on Windows checkouts (local/no-crlf-fragile-split).
+// splitLines() handles the line endings; the scan below handles the fence.
 function screenshotApproachBlock() {
-  const content = fs.readFileSync(AUDITOR_PATH, 'utf-8');
-  const section = content.split('<screenshot_approach>')[1].split('</screenshot_approach>')[0];
-  const fence = section.match(/```bash\n([\s\S]*?)\n```/);
-  assert.ok(fence, '<screenshot_approach> must contain a bash fence');
-  return fence[1];
+  const lines = splitLines(fs.readFileSync(AUDITOR_PATH, 'utf-8'));
+  const FENCE = '`'.repeat(3);
+  const OPENER = FENCE + 'bash';
+  const body = [];
+  let inSection = false;
+  let inFence = false;
+  for (const line of lines) {
+    if (!inSection) {
+      if (line.includes('<screenshot_approach>')) inSection = true;
+      continue;
+    }
+    if (line.includes('</screenshot_approach>')) break;
+    if (!inFence) {
+      if (line.trim() === OPENER) inFence = true;
+      continue;
+    }
+    if (line.trim() === FENCE) break;
+    body.push(line);
+  }
+  assert.ok(body.length > 0, '<screenshot_approach> must contain a non-empty bash fence');
+  return body.join('\n');
 }
 
 describe('#4176 — gsd-ui-auditor screenshot capture is honest', () => {

--- a/tests/playwright-ui-verify.test.cjs
+++ b/tests/playwright-ui-verify.test.cjs
@@ -1091,7 +1091,7 @@ describe('#4176 — the capture fence, executed', { skip: BASH_OK ? false : 'no 
       const r = ok(runFence({ PROBE_3000: '200', SHOT_EXIT: failed,
         SHOT_WRITE: 'desktop mobile tablet' }));
       assert.match(r.stdout, new RegExp(`PARTIALLY captured .*\\(2/3\\).*failed: ?${failed}`));
-      // THE VALUE names the count and the failed viewport, as docs/AGENTS.md said it did.
+      // THE VALUE names the count and the failed viewport, as the agent catalogue in the docs tree already said it did.
       assert.strictEqual(r.captureStatus, `partially captured (2/3 from http://localhost:3000; failed: ${failed})`);
       // Restricting the cleanup to empty files only also passed every earlier fixture,
       // because none paired a failure with a non-empty artefact — a plausible-looking
@@ -1403,4 +1403,250 @@ describe('#4176 — bash reader, units', () => {
     assert.strictEqual(printed.length, modelled.length,
       `bash ran ${printed.length} commands, the reader modelled ${modelled.length}: ${JSON.stringify(modelled)}`);
   });
+});
+
+// ---------------------------------------------------------------------------
+// PROPERTY TESTS for the bash reader (TESTING-STANDARDS.md § Property-based testing tier:
+// a module that parses must carry at least one fast-check property asserting a domain
+// invariant). The reader above is a real parser of shell quoting and control flow, and
+// the 19-category mutant battery that hardened it is example-based: every fixture was
+// written by the same author with the same model of bash, which CONTRIBUTING.md's
+// fixture-provenance rule (#2371) names as the limit of what such a fixture can find.
+//
+// DOCUMENT-SHAPED, NOT WRITER-SEEDED. The generator below produces bash from a grammar of
+// the constructs the block uses — nested if/elif/else, loops, case, two-line `then`,
+// continuations, comments, quoted strings carrying control keywords — and it knows, for
+// every payload line it emits, which conditions enclose it. It is seeded from nothing the
+// reader produces, so it can generate scripts the reader's author never thought to write.
+//
+// TWO ORACLES, and the second is the one that matters. Property 1 checks the reader against
+// the generator's own knowledge of the structure it emitted. Property 2 checks it against
+// BASH: the same script is executed with a random truth assignment for every condition, and
+// a payload must print exactly when the reader says its governing conditions all hold. A
+// reader that agrees with the generator but not with bash is modelling the wrong language.
+// Property 3 puts `caseLabelOf` + `isTwoXxRange` — the pair that decides whether the probe's
+// accept arm is a RANGE — against bash's own `case` matching: a label the pair calls a 2xx
+// range must, when bash runs it, admit 200, 250 and 299 and refuse 199, 300 and 500.
+//
+// Deterministic, per CONTRIBUTING.md: the seed is pinned, the run count is bounded, and
+// fast-check prints the seed, path and counterexample on failure so a run can be replayed.
+// ---------------------------------------------------------------------------
+
+const fc = require('fast-check');
+
+const FC_SEED = 4176;
+
+// The grammar. `payload` is an `echo` carrying a marker `M<id>`; blocks carry bodies. Depth
+// is bounded by the recursion itself (tie: fc.letrec with a depth-limited `oneof`).
+const scriptGen = fc.letrec((tie) => ({
+  payload: fc.record({
+    kind: fc.constant('payload'),
+    // What surrounds the marker: a plain echo, a quoted string carrying control keywords
+    // (the `echo "we do work"` false-fire class), a trailing comment that itself carries
+    // keywords (the `fi # comment` desync class), or a continuation across two lines.
+    dress: fc.constantFrom('plain', 'dq-keywords', 'sq-keywords', 'comment', 'continued', 'hash-in-quotes', 'backslash-space', 'escaped-backslash'),
+  }),
+  ifBlock: fc.record({
+    kind: fc.constant('if'),
+    twoLine: fc.boolean(),                 // `if COND` / `then` on the next line
+    thenTail: fc.boolean(),                // `then :` — a command on the then line itself
+    // minLength 1: bash rejects an empty then/elif/else body and an empty loop body
+    // (`if x; then fi` is a syntax error). A case arm may be empty, so it is not bounded.
+    thenBody: fc.array(tie('node'), { minLength: 1, maxLength: 3 }),
+    elifBody: fc.option(fc.array(tie('node'), { minLength: 1, maxLength: 2 }), { nil: null }),
+    elseBody: fc.option(fc.array(tie('node'), { minLength: 1, maxLength: 2 }), { nil: null }),
+  }),
+  loop: fc.record({ kind: fc.constant('loop'), keyword: fc.constantFrom('for', 'while', 'until'), body: fc.array(tie('node'), { minLength: 1, maxLength: 3 }) }),
+  caseBlock: fc.record({ kind: fc.constant('case'), body: fc.array(tie('node'), { maxLength: 3 }) }),
+  node: fc.oneof({ depthSize: 'small', maxDepth: 3, withCrossShrink: true },
+    tie('payload'), tie('ifBlock'), tie('loop'), tie('caseBlock')),
+  script: fc.array(tie('node'), { minLength: 1, maxLength: 5 }),
+}));
+
+// Render a generated tree to bash lines, recording for each marker the guard stack the
+// reader is expected to report — `''` for a loop or case scope, the condition text for an
+// `if`, the elif's own text for an elif body, and `!(cond)` for an else body. This mirrors
+// the reader's MODEL of governance (which condition text governs a line), which is not the
+// same as bash's execution semantics for elif; property 2 therefore generates no elif.
+function render(tree, opts) {
+  const lines = [];
+  const expect = [];   // { id, guards, exec } — exec: does bash run this line under `truth`?
+  let nextCond = 0;
+  let nextId = 0;
+  let nextLoop = 0;
+  const conds = [];    // condition text per index, so property 2 can assign truth values
+  const emit = (depth, text) => lines.push(`${'  '.repeat(depth)}${text}`);
+  const walk = (node, depth, guards, exec) => {
+    if (node.kind === 'payload') {
+      const id = nextId++;
+      const m = `M${id}`;
+      switch (node.dress) {
+        case 'plain': emit(depth, `echo "${m}"`); break;
+        case 'dq-keywords': emit(depth, `echo "if then else fi do done case esac ${m}"`); break;
+        case 'sq-keywords': emit(depth, `echo 'fi; done; esac ${m}'`); break;
+        case 'comment': emit(depth, `echo "${m}" # fi done esac if then`); break;
+        case 'hash-in-quotes': emit(depth, `echo "${m} # not a comment"`); break;
+        case 'continued': emit(depth, `echo \\`); emit(depth + 1, `"${m}"`); break;
+        // Backslash, SPACE, newline: escapes the space, ends the line. A reader that trims
+        // before it looks for the backslash joins the NEXT line into this echo.
+        case 'backslash-space': emit(depth, `echo "${m}" \\ `); break;
+        // An escaped backslash at the end of a complete line.
+        case 'escaped-backslash': emit(depth, `echo "${m}" \\\\`); break;
+        default: throw new Error(`unknown dress ${node.dress}`);
+      }
+      expect.push({ id, guards: guards.slice(), exec });
+      return;
+    }
+    if (node.kind === 'loop') {
+      // Every loop runs its body exactly ONCE, on a variable of its own: a shared one
+      // would let an outer loop's termination stop an inner loop before its first pass.
+      const v = `L${nextLoop++}`;
+      const header = node.keyword === 'for' ? 'for x in 1; do'
+        : node.keyword === 'while' ? `while [ "\${${v}:-0}" = 0 ]; do`
+          : `until [ "\${${v}:-0}" = 1 ]; do`;
+      emit(depth, header);
+      if (node.keyword !== 'for') emit(depth + 1, `${v}=1`);
+      for (const child of node.body) walk(child, depth + 1, [...guards, ''], exec);
+      emit(depth, 'done');
+      return;
+    }
+    if (node.kind === 'case') {
+      emit(depth, 'case x in');
+      emit(depth + 1, '*)');
+      for (const child of node.body) walk(child, depth + 2, [...guards, ''], exec);
+      emit(depth + 1, ';;');
+      emit(depth, 'esac');
+      return;
+    }
+    // if
+    const ci = nextCond++;
+    const cond = `[ "$C${ci}" = 1 ]`;
+    conds.push(cond);
+    const truth = opts.truth ? Boolean(opts.truth[ci]) : true;
+    if (node.twoLine) { emit(depth, `if ${cond}`); emit(depth, node.thenTail ? 'then :' : 'then'); }
+    else emit(depth, `if ${cond}; then`);
+    for (const child of node.thenBody) walk(child, depth + 1, [...guards, cond], exec && truth);
+    let taken = truth;
+    let top = cond;   // what the reader's stack holds for this scope when `else` arrives
+    if (node.elifBody !== null && !opts.noElif) {
+      const ei = nextCond++;
+      const econd = `[ "$C${ei}" = 1 ]`;
+      conds.push(econd);
+      const etruth = opts.truth ? Boolean(opts.truth[ei]) : true;
+      emit(depth, `elif ${econd}; then`);
+      for (const child of node.elifBody) walk(child, depth + 1, [...guards, econd], exec && !taken && etruth);
+      taken = taken || etruth;
+      top = econd;    // the elif's OWN condition — not whatever a nested `if` pushed last
+    }
+    if (node.elseBody !== null) {
+      // The reader models `else` as the negation of whatever condition is on top of its
+      // stack at that point — the elif's when one was emitted, the if's otherwise.
+      emit(depth, 'else');
+      for (const child of node.elseBody) walk(child, depth + 1, [...guards, `!(${top})`], exec && !taken);
+    }
+    emit(depth, 'fi');
+  };
+  for (const node of tree) walk(node, 0, [], true);
+  return { lines, expect, conds };
+}
+
+const markerOf = (line) => { const m = /\bM(\d+)\b/.exec(line); return m ? Number(m[1]) : null; };
+
+describe('#4176 — bash reader, property-based (fast-check)', () => {
+  test('property: the guards the reader reports are the guards the generator wrote', () => {
+    fc.assert(
+      fc.property(scriptGen.script, (tree) => {
+        const { lines, expect } = render(tree, {});
+        const rows = guardedLines(lines);
+        const seen = new Map();
+        for (const row of rows) {
+          const id = markerOf(row.line);
+          if (id !== null) seen.set(id, row.guards);
+        }
+        for (const e of expect) {
+          assert.ok(seen.has(e.id), `marker M${e.id} was not reported as a governed line\n${lines.join('\n')}`);
+          assert.deepStrictEqual(seen.get(e.id), e.guards,
+            `marker M${e.id}: reader guards ${JSON.stringify(seen.get(e.id))} != expected ${JSON.stringify(e.guards)}\n${lines.join('\n')}`);
+        }
+        assert.strictEqual(seen.size, expect.length, `reader reported ${seen.size} markers for ${expect.length} payloads`);
+      }),
+      { seed: FC_SEED, numRuns: 200 }
+    );
+  });
+
+  test('property: a payload prints under bash exactly when the reader says its guards all hold',
+    { skip: BASH_OK ? false : 'no runnable bash on this host' }, () => {
+      fc.assert(
+        fc.property(scriptGen.script, fc.array(fc.boolean(), { maxLength: 64 }), (tree, truth) => {
+          const { lines, expect, conds } = render(tree, { truth, noElif: true });
+          const rows = guardedLines(lines);
+          // Evaluate the reader's guards under the same truth assignment.
+          const evalGuard = (g) => {
+            if (g === '') return true;
+            const neg = /^!\((.*)\)$/.exec(g);
+            const body = neg ? neg[1] : g;
+            const m = /\$C(\d+)/.exec(body);
+            assert.ok(m, `unrecognised guard ${JSON.stringify(g)}`);
+            const v = Boolean(truth[Number(m[1])]);
+            return neg ? !v : v;
+          };
+          const predicted = new Set();
+          for (const row of rows) {
+            const id = markerOf(row.line);
+            if (id !== null && row.guards.every(evalGuard)) predicted.add(id);
+          }
+          const env = {};
+          conds.forEach((c, i) => { env[`C${i}`] = truth[i] ? '1' : '0'; });
+          const r = spawnSync('bash', ['-c', lines.join('\n')], { encoding: 'utf8', env: { ...process.env, ...env }, timeout: 15000 });
+          assert.strictEqual(r.status, 0, `bash rejected a generated script — the generator is wrong, not the reader:\n${lines.join('\n')}\n${r.stderr}`);
+          const printed = new Set([...r.stdout.matchAll(/\bM(\d+)\b/g)].map((m) => Number(m[1])));
+          assert.deepStrictEqual([...predicted].sort((a, b) => a - b), [...printed].sort((a, b) => a - b),
+            `reader predicted ${JSON.stringify([...predicted])} but bash printed ${JSON.stringify([...printed])}\n${lines.join('\n')}`);
+          // And the expectation is consistent with bash too — a check on the oracle's oracle.
+          const expected = expect.filter((e) => e.exec).map((e) => e.id).sort((a, b) => a - b);
+          assert.deepStrictEqual([...printed].sort((a, b) => a - b), expected, 'generator exec model disagrees with bash');
+        }),
+        { seed: FC_SEED, numRuns: 60 }
+      );
+    });
+
+  test('property: the reader and bash agree on whether a case label admits the 2xx range',
+    { skip: BASH_OK ? false : 'no runnable bash on this host' }, () => {
+      // SHAPE-AWARE, because a character-soup alphabet almost never produces a label the
+      // reader calls a range, and a property that never reaches its oracle is vacuous —
+      // the first version of this test ran 300 cases in 2ms and killed no mutant. Every
+      // piece here is legal bash on its own (balanced quotes), so the composition is a
+      // label bash can run, and the interesting ones — an escaped `?`, a quoted digit, a
+      // leading `(`, whitespace at either edge, a second pattern — are the majority.
+      const ws = fc.constantFrom('', ' ', '\t', '  ');
+      const lead = fc.constantFrom('2', '"2"', "'2'", '\\2', '3', '"3"', '20');
+      const tail = fc.constantFrom('??', '\\?\\?', '?\\?', '\\??', '"??"', '"?"?', '?"?"', '[0-9][0-9]', '"[0-9]"[0-9]', '*', '"*"', '\\*', '', '?');
+      const extra = fc.constantFrom('', '|3??', '|401', '| 401 ', '|"x y"', '|2??', '|"2"??');
+      const labelGen = fc.tuple(fc.constantFrom('', '('), ws, lead, tail, ws, extra).map((parts) => parts.join(''));
+      let reached = 0;
+      fc.assert(
+        fc.property(labelGen, (labelText) => {
+          const label = caseLabelOf(`${labelText}) DEV_URL=x ;;`);
+          assert.ok(label !== null, `every generated label is legal bash, so the reader must parse it: ${JSON.stringify(labelText)}`);
+          const claimed = label.some(isTwoXxRange);
+          const script = 'for s in 200 250 299 199 300 500; do case "$s" in ' + labelText + ') printf Y;; *) printf N;; esac; done';
+          const r = spawnSync('bash', ['-c', script], { encoding: 'utf8', timeout: 15000 });
+          assert.strictEqual(r.status, 0, `bash cannot run the generated label ${JSON.stringify(labelText)}: ${r.stderr}`);
+          reached += 1;
+          const admitsAll2xx = r.stdout.slice(0, 3) === 'YYY';
+          const refusesOthers = r.stdout.slice(3) === 'NNN';
+          // SOUNDNESS, every label: a claimed range admits the whole 2xx range under bash.
+          if (claimed) assert.ok(admitsAll2xx, `the reader called ${JSON.stringify(labelText)} a 2xx range; bash matched 200,250,299 as ${r.stdout.slice(0, 3)}`);
+          // The full agreement, single-pattern labels: on these shapes the reader's verdict
+          // IS bash's verdict, in both directions. A second pattern is excluded only because
+          // `some(isTwoXxRange)` deliberately says nothing about what the OTHER pattern admits.
+          if (label.length === 1) {
+            assert.strictEqual(claimed, admitsAll2xx && refusesOthers,
+              `${JSON.stringify(labelText)}: reader says ${claimed ? 'range' : 'not a range'}, bash matched 200,250,299,199,300,500 as ${r.stdout}`);
+          }
+        }),
+        { seed: FC_SEED, numRuns: 250 }
+      );
+      assert.ok(reached >= 200, `the property reached its bash oracle only ${reached} times — vacuous`);
+    });
 });

--- a/tests/playwright-ui-verify.test.cjs
+++ b/tests/playwright-ui-verify.test.cjs
@@ -995,8 +995,14 @@ describe('#4176 — the capture fence, executed', { skip: BASH_OK ? false : 'no 
     const mkdirCounter = env.COUNT_MKDIR
       ? `mkdir() { printf 'mkdir %s\\n' "$*" >> ${JSON.stringify(mkdirLog)}; command mkdir "$@"; }\n`
       : '';
+    // RACE_MKDIR: the FIRST mkdir of a candidate (no -p) fails and creates nothing, as if the
+    // name had been taken and freed between the call and the checks that follow it. The
+    // second attempt runs for real. Constructs the two-syscall race deterministically.
+    const mkdirRace = env.RACE_MKDIR
+      ? `__raced=0\nmkdir() { if [ "$1" != -p ] && [ "$__raced" = 0 ]; then __raced=1; return 1; fi; command mkdir "$@"; }\n`
+      : '';
     fs.writeFileSync(script,
-      `PADDED_PHASE=${env.PADDED_PHASE || '07'}\n${dateOverride}${mkdirCounter}${screenshotApproachBlock()}\n`
+      `PADDED_PHASE=${env.PADDED_PHASE || '07'}\n${dateOverride}${mkdirCounter}${mkdirRace}${screenshotApproachBlock()}\n`
       + 'FENCE_RC=$?\n'
       + `printf %s "$CAPTURE_STATUS" > ${JSON.stringify(statusFile)}\n`
       + `printf %s "$FENCE_RC" > ${JSON.stringify(rcFile)}\n`);
@@ -1211,8 +1217,9 @@ describe('#4176 — the capture fence, executed', { skip: BASH_OK ? false : 'no 
     assert.strictEqual(r.captureStatus, 'not captured (could not create a review directory under .planning/ui-reviews)');
     assert.match(r.stdout, /Could not allocate a review directory — could not create/);
     assert.strictEqual(r.invocations.length, 0, 'nothing may be captured with no directory');
-    // One `mkdir -p` for the parent, one candidate, then stop. Before the fix this was 101.
-    assert.ok(r.mkdirCalls.length <= 2,
+    // One `mkdir -p` for the parent, one candidate, one re-try that tells a race from
+    // structure, then stop. Before the fix this was 101.
+    assert.ok(r.mkdirCalls.length <= 3,
       `the allocator must not retry a structural failure: ${r.mkdirCalls.length} mkdir calls\n${r.mkdirCalls.slice(0, 5).join('\n')}`);
     assert.strictEqual(fs.readFileSync(path.join(dir, '.planning', 'ui-reviews'), 'utf8'), 'not a directory',
       'the file standing where the directory should be must be left alone');
@@ -1233,6 +1240,18 @@ describe('#4176 — the capture fence, executed', { skip: BASH_OK ? false : 'no 
     assert.strictEqual(r.captureStatus, 'captured (3/3 from http://localhost:3000)');
     assert.ok(fs.existsSync(path.join(reviews, '07-20300101-000000-1')), 'the run must have taken the first suffix');
     assert.ok(fs.lstatSync(path.join(reviews, '07-20300101-000000')).isSymbolicLink(), 'the planted link must be left alone');
+  });
+
+  test('a name taken and freed between mkdir and the checks is won on the retry, not read as structural', () => {
+    // The round review's refutation of the structural guard: between `mkdir` failing and
+    // `[ -e ]`/`[ -L ]` running, another audit could have removed the name it had just won,
+    // and both tests then say "absent" — which the guard read as "unwritable" and gave up
+    // on. One more attempt separates the two. The harness's RACE_MKDIR wrapper makes the
+    // first candidate mkdir fail without creating anything, exactly that window.
+    const r = ok(runFence({ PROBE_3000: '200', RACE_MKDIR: '1', FIXED_DATE: '20300101-000000', PADDED_PHASE: '07' }));
+    assert.match(r.stdout, /Screenshots captured/, 'a freed name must be won on the retry');
+    assert.strictEqual(r.captureStatus, 'captured (3/3 from http://localhost:3000)');
+    assert.deepStrictEqual(r.shotDirs, ['07-20300101-000000'], 'the BASE name must be the one won, not a suffix');
   });
 
   test('the last candidate suffix is tried, not skipped', () => {

--- a/tests/playwright-ui-verify.test.cjs
+++ b/tests/playwright-ui-verify.test.cjs
@@ -961,8 +961,15 @@ describe('#4176 — the capture fence, executed', { skip: BASH_OK ? false : 'no 
     const dateOverride = env.FIXED_DATE
       ? `date() { printf %s ${JSON.stringify(env.FIXED_DATE)}; }\n`
       : '';
+    // Same mechanism, for COUNTING: a fixture that asserts the allocator gave up early
+    // needs to see how many times it asked, and a wrapper function that delegates to the
+    // real binary is the only observation point that does not change what mkdir does.
+    const mkdirLog = path.join(dir, 'mkdir.log');
+    const mkdirCounter = env.COUNT_MKDIR
+      ? `mkdir() { printf 'mkdir %s\\n' "$*" >> ${JSON.stringify(mkdirLog)}; command mkdir "$@"; }\n`
+      : '';
     fs.writeFileSync(script,
-      `PADDED_PHASE=${env.PADDED_PHASE || '07'}\n${dateOverride}${screenshotApproachBlock()}\n`
+      `PADDED_PHASE=${env.PADDED_PHASE || '07'}\n${dateOverride}${mkdirCounter}${screenshotApproachBlock()}\n`
       + 'FENCE_RC=$?\n'
       + `printf %s "$CAPTURE_STATUS" > ${JSON.stringify(statusFile)}\n`
       + `printf %s "$FENCE_RC" > ${JSON.stringify(rcFile)}\n`);
@@ -980,13 +987,17 @@ describe('#4176 — the capture fence, executed', { skip: BASH_OK ? false : 'no 
     });
     const stdout = r.stdout || '';
     const reviews = path.join(dir, '.planning', 'ui-reviews');
-    const shotDirs = fs.existsSync(reviews) ? fs.readdirSync(reviews).sort() : [];
+    // isDirectory, not existsSync: one fixture plants a FILE at this path, and readdir on it throws.
+    const isDir = (p) => { try { return fs.statSync(p).isDirectory(); } catch { return false; } };
+    const shotDirs = isDir(reviews) ? fs.readdirSync(reviews).sort() : [];
     const filesIn = (d) => fs.readdirSync(path.join(reviews, d)).sort();
     const argvRaw = fs.existsSync(argvLog) ? fs.readFileSync(argvLog, 'utf8') : '';
     const readOut = (f) => (fs.existsSync(f) ? fs.readFileSync(f, 'utf8') : null);
     const status = readOut(statusFile);
     const rcRead = readOut(rcFile);
+    const mkdirCalls = fs.existsSync(mkdirLog) ? splitLines(fs.readFileSync(mkdirLog, 'utf8')).filter(Boolean) : [];
     return {
+      mkdirCalls,
       stdout,
       exitCode: rcRead !== null && rcRead !== '' ? Number(rcRead) : r.status,
       stderr: r.stderr || '',
@@ -1150,12 +1161,34 @@ describe('#4176 — the capture fence, executed', { skip: BASH_OK ? false : 'no 
     // string, while the block calls $CAPTURE_STATUS the single source of truth. The
     // remedies differ (free a name or fix the directory, versus fix the browser), so the
     // value has to.
-    assert.strictEqual(r.captureStatus, 'not captured (could not allocate a review directory under .planning/ui-reviews)');
+    assert.strictEqual(r.captureStatus, 'not captured (all 100 candidate names under .planning/ui-reviews/07-20300101-000000 are taken)');
     assert.doesNotMatch(r.stdout, /Screenshots captured/);
     assert.strictEqual(r.invocations.length, 0,
       'nothing may be captured when no directory was allocated — the path would be outside the project');
     assert.strictEqual(fs.readdirSync(reviews).length, 100,
       'the exhausted run must not have created a directory of its own');
+  });
+
+  test('a structural mkdir failure gives up at once, with its own reason, instead of retrying 100 names', () => {
+    // Round-2 nit 6. A parent that is unwritable, missing, or — as here — a FILE fails
+    // every candidate for a reason no suffix cures, and the loop asked 100 times anyway.
+    // A file rather than a permission bit, because chmod is inert on the windows-latest
+    // runner and as root; ENOTDIR is structural everywhere. The count is observed through
+    // the harness's mkdir wrapper, so "gave up at once" is measured rather than inferred
+    // from the absence of directories.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-4176-notdir-'));
+    tmpDirs.push(dir);
+    fs.mkdirSync(path.join(dir, '.planning'));
+    fs.writeFileSync(path.join(dir, '.planning', 'ui-reviews'), 'not a directory');
+    const r = ok(runFence({ PROBE_3000: '200', COUNT_MKDIR: '1' }, dir));
+    assert.strictEqual(r.captureStatus, 'not captured (could not create a review directory under .planning/ui-reviews)');
+    assert.match(r.stdout, /Could not allocate a review directory — could not create/);
+    assert.strictEqual(r.invocations.length, 0, 'nothing may be captured with no directory');
+    // One `mkdir -p` for the parent, one candidate, then stop. Before the fix this was 101.
+    assert.ok(r.mkdirCalls.length <= 2,
+      `the allocator must not retry a structural failure: ${r.mkdirCalls.length} mkdir calls\n${r.mkdirCalls.slice(0, 5).join('\n')}`);
+    assert.strictEqual(fs.readFileSync(path.join(dir, '.planning', 'ui-reviews'), 'utf8'), 'not a directory',
+      'the file standing where the directory should be must be left alone');
   });
 
   test('the last candidate suffix is tried, not skipped', () => {

--- a/tests/playwright-ui-verify.test.cjs
+++ b/tests/playwright-ui-verify.test.cjs
@@ -157,6 +157,22 @@ function guardedLines(lines) {
   return rows;
 }
 
+// Capture INVOCATIONS, not every line that mentions one. The block documents its own flags in
+// comments, and a comment naming `playwright screenshot` — the one explaining --timeout does
+// exactly this — is prose, not a call site. Reading it as one inflates the invocation count and,
+// worse, lets an assertion pass on the DOCUMENTATION of a property instead of the property: the
+// --timeout check below was satisfied in part by a comment containing the string `--timeout`.
+// That is the same class as the whole-block substring defect the port assertion names, which is
+// why the exclusion lives here once rather than in each caller.
+// logicalLines first: the invocation spans four physical lines, so its flags are only all on one
+// line after continuations are joined.
+function captureInvocations(lines) {
+  return logicalLines(lines)
+    .map((l) => l.trim())
+    .filter((l) => !l.startsWith('#'))
+    .filter((l) => l.includes('playwright screenshot'));
+}
+
 describe('#4176 — gsd-ui-auditor screenshot capture is honest', () => {
   test('dev-server probe follows redirects and is time-bounded', () => {
     const block = screenshotApproachBlock();
@@ -278,13 +294,21 @@ describe('#4176 — gsd-ui-auditor screenshot capture is honest', () => {
   });
 
   test('the resolved port — not a hard-coded 3000 — is what gets captured', () => {
-    const block = screenshotApproachBlock();
-    const captureLines = block.split('\n').filter((l) => l.includes('playwright screenshot'));
+    const captureLines = captureInvocations(screenshotApproachLines());
     assert.ok(captureLines.length > 0, 'expected at least one capture invocation');
     for (const line of captureLines) {
+      // Negative-only was the hole, and it is the SAME defect class the test above names:
+      // banning the one literal `localhost:3000` leaves a hard-coded `localhost:5173` or
+      // `localhost:8080` passing, while the defect #4176 names is "the capture targets a
+      // hard-coded port", not "the capture targets 3000". Ban the shape, then require the
+      // resolved variable positively — a ban alone cannot say what the line SHOULD contain.
       assert.ok(
-        !line.includes('localhost:3000'),
-        `capture must use the resolved port variable, not a literal localhost:3000: ${line.trim()}`
+        !/localhost:\d+/.test(line),
+        `capture must not hard-code any port: ${line.trim()}`
+      );
+      assert.ok(
+        line.includes('$DEV_URL'),
+        `capture must use the resolved URL variable: ${line.trim()}`
       );
     }
   });
@@ -294,10 +318,10 @@ describe('#4176 — gsd-ui-auditor screenshot capture is honest', () => {
     // defaults it to 0, i.e. NO timeout — so this CLI path drops the bound the
     // Playwright library applies by default. An unbounded capture reinstates the
     // hang the probe's own time bound exists to prevent, one step later.
-    // logicalLines, because the invocation spans four physical lines.
-    const captures = logicalLines(screenshotApproachLines())
-      .map((l) => l.trim())
-      .filter((l) => l.includes('playwright screenshot'));
+    // captureInvocations, not a bare filter: the comment four lines above the call site names
+    // both `playwright screenshot` and `--timeout`, so a bare filter counted it as an invocation
+    // and it satisfied this assertion by quoting the flag rather than passing it.
+    const captures = captureInvocations(screenshotApproachLines());
     assert.ok(captures.length > 0, 'expected at least one capture invocation');
     for (const line of captures) {
       assert.ok(
@@ -329,10 +353,21 @@ describe('#4176 — gsd-ui-auditor screenshot capture is honest', () => {
   });
 
   test('report surfaces can express partial capture', () => {
+    // Was a whole-FILE substring check — the same defect class as the Major finding and as the
+    // port check above, and shipped by this PR rather than inherited. The template prose alone
+    // satisfied it, so deleting the block's partial branch outright would not have failed it.
+    // Pin both ends positively instead: the block must PRODUCE a partial status, and a report
+    // surface outside the block must CONSUME the variable — a status computed and never
+    // rendered is not a surface that can express anything.
+    const block = screenshotApproachBlock();
     const content = fs.readFileSync(AUDITOR_PATH, 'utf-8');
     assert.ok(
-      /partially captured/i.test(content),
-      'the Screenshots field must be able to say partial — full/none alone cannot describe 2 of 3'
+      /CAPTURE_STATUS=["']?partially captured/i.test(block),
+      'the capture block must PRODUCE a partial status — full/none alone cannot describe 2 of 3'
+    );
+    assert.ok(
+      /\$CAPTURE_STATUS/.test(content.replace(block, '')),
+      'a report surface outside the block must render $CAPTURE_STATUS, or the status is computed and dropped'
     );
   });
 });

--- a/tests/playwright-ui-verify.test.cjs
+++ b/tests/playwright-ui-verify.test.cjs
@@ -322,6 +322,31 @@ describe('#4176 — gsd-ui-auditor screenshot capture is honest', () => {
     }
   });
 
+  // Self-found by the round's guard-shape census, not by the review: the case arm above
+  // FIXES A SET at author time (the statuses that count as auth-gated) while the domain it
+  // rules on — what a local dev server may answer — is owned by the server, so the set can
+  // fall behind without this code changing. 407 (proxy authentication required) and 511
+  // (network authentication required) each mean the server ANSWERED and demanded
+  // credentials; omitting them reports a PRESENT server as an absent one, which is the very
+  // defect #4176 names, one status family over.
+  // Read the case LABEL that governs the assignment, not the block text: `block.includes('407')`
+  // would be satisfied by the comment explaining it — the same substring defect as finding 1.
+  test('the whole auth-required status class is recorded as gated, not misreported as absent', () => {
+    const gatedArms = logicalLines(screenshotApproachLines())
+      .map((l) => l.trim())
+      .filter((l) => /DEV_GATED=/.test(l) && !/^DEV_GATED=""$/.test(l));
+    assert.ok(gatedArms.length > 0, 'expected a case arm recording an auth-gated server');
+    const labels = gatedArms
+      .map((l) => l.split(')')[0])
+      .map((lab) => lab.split('|').map((s) => s.trim()));
+    for (const status of ['401', '403', '407', '511']) {
+      assert.ok(
+        labels.some((lab) => lab.includes(status)),
+        `HTTP ${status} means authentication is required, so a server answering it is PRESENT and gated — not absent: case labels were ${JSON.stringify(labels)}`
+      );
+    }
+  });
+
   test('the resolved port — not a hard-coded 3000 — is what gets captured', () => {
     const captureLines = captureInvocations(screenshotApproachLines());
     assert.ok(captureLines.length > 0, 'expected at least one capture invocation');

--- a/tests/playwright-ui-verify.test.cjs
+++ b/tests/playwright-ui-verify.test.cjs
@@ -136,13 +136,44 @@ function logicalLines(lines) {
 // entirely, and `CAPTURED=0` near the top of the block makes that question true forever:
 // moving the success echo back outside its `if [ "$CAPTURED" -eq 3 ]` branch — which is
 // precisely the #4176 bug — would not disturb it.
+//
+// IT FAILS CLOSED, and that is the whole difference between this and its first version.
+// A hand-written reader of a language it does not lex WILL meet a form it does not know;
+// what decides whether that is a defect is which way it errs. The first version erred
+// SILENTLY: an unrecognised line was pushed as an ordinary row, so a construct that
+// should have popped the scope stack left a stale condition on it, and the next line
+// inherited a guard that does not govern it — a FALSE PASS on exactly the regression
+// this test names. Three were driven against it:
+//   `fi # end capture-count branch`   -> `fi` not matched, stack never popped
+//   `if [ "$CAPTURED" -eq 3 ]` + a bare `then` on the NEXT line (legal bash)
+//   `if ...; then ...; fi; echo ...`  all on one logical line
+// So: comments are stripped before the walk (which is what the first form needed), the
+// two-line `then` form is recognised, and ANY residual line still carrying a bare
+// control keyword this walker did not consume THROWS. A test that cannot parse the
+// block fails loudly; it never reports on a stack it has lost track of.
 function guardedLines(lines) {
   const stack = [];
   const rows = [];
-  for (const line of logicalLines(lines)) {
-    const t = line.trim();
+  let pendingIf = null;   // an `if <cond>` whose `then` is on a later line
+  for (const raw of logicalLines(lines.map(stripComment))) {
+    const t = raw.trim();
+    if (t === '') continue;
+    if (pendingIf !== null) {
+      // Only `then` may follow; anything else means we mis-read the `if` header.
+      if (t === 'then' || t.startsWith('then ')) {
+        stack.push(pendingIf);
+        pendingIf = null;
+        const tail = t === 'then' ? '' : t.slice(5).trim();
+        if (tail === '') continue;
+        rows.push({ line: tail, guards: stack.slice() });
+        continue;
+      }
+      throw new Error(`bash reader: '${pendingIf}' opened an if with no 'then' — got ${JSON.stringify(t)}`);
+    }
     const ifMatch = /^if[\t ]+(.{1,4000}?)[\t ]*;[\t ]*then$/.exec(t);
     if (ifMatch) { stack.push(ifMatch[1]); continue; }
+    const ifPending = /^if[\t ]+(.{1,4000}?)[\t ]*$/.exec(t);
+    if (ifPending && !/;/.test(ifPending[1])) { pendingIf = ifPending[1]; continue; }
     const elifMatch = /^elif[\t ]+(.{1,4000}?)[\t ]*;[\t ]*then$/.exec(t);
     if (elifMatch) { if (stack.length) stack[stack.length - 1] = elifMatch[1]; continue; }
     if (t === 'else') { if (stack.length) stack[stack.length - 1] = `!(${stack[stack.length - 1]})`; continue; }
@@ -152,50 +183,89 @@ function guardedLines(lines) {
     if (t === 'done') { stack.pop(); continue; }
     if (/^case\b/.test(t) && /\bin$/.test(t)) { stack.push(''); continue; }
     if (t === 'esac') { stack.pop(); continue; }
+    // FAIL CLOSED. A control keyword this walker did not consume above means the block
+    // uses a form it cannot model, and continuing would report guards it no longer knows.
+    // Word-boundary matched so `elif`/`fi` inside a string or an identifier does not fire;
+    // an over-fire here costs a loud test failure, an under-fire costs a false clean.
+    if (/(^|[\t ;&|(])(if|then|elif|fi|do|done|case|esac)([\t ;&|)]|$)/.test(t)) {
+      throw new Error(`bash reader: unparsed control construct — ${JSON.stringify(t)}`);
+    }
     rows.push({ line: t, guards: stack.slice() });
   }
+  if (pendingIf !== null) throw new Error(`bash reader: dangling if — ${JSON.stringify(pendingIf)}`);
+  if (stack.length !== 0) throw new Error(`bash reader: ${stack.length} unclosed scope(s) at end of block`);
   return rows;
 }
 
-// Capture INVOCATIONS, not every line that mentions one. The block documents its own flags in
-// comments, and a comment naming `playwright screenshot` — the one explaining --timeout does
-// exactly this — is prose, not a call site. Reading it as one inflates the invocation count and,
-// worse, lets an assertion pass on the DOCUMENTATION of a property instead of the property: the
-// --timeout check below was satisfied in part by a comment containing the string `--timeout`.
-// That is the same class as the whole-block substring defect the port assertion names, which is
-// why the exclusion lives here once rather than in each caller.
-// logicalLines first: the invocation spans four physical lines, so its flags are only all on one
-// line after continuations are joined.
-// Comments are dropped from the PHYSICAL lines, BEFORE continuations are joined. Doing it after
-// is a false clean: a comment ending in a backslash splices the following real invocation onto
-// itself, the joined line then starts with `#`, and the invocation disappears from the set — so
-// the assertions over it pass on an empty selection. Filtering first makes that shape impossible
-// rather than merely unlikely. (A trailing comment on a real code line is still selected; that
-// direction over-fires, which is the safe one.)
-// Inline comments are stripped too, not just whole-line ones. `--timeout=30000` moved into a
-// trailing comment is an ordinary edit, not sabotage, and it would otherwise keep satisfying the
-// time-bound assertion while no longer being passed to the command. Strip from ` #` to end of
-// line BEFORE joining, which also closes the splice via a trailing comment.
+// Strip a trailing `#` comment, QUOTE-AWARE.
 //
-// KNOWN LIMIT, stated because the regex does not enforce what a looser comment here once claimed:
-// this is QUOTE-BLIND. It cannot tell a comment from a `#` inside a string, so a line such as
-// `--user-agent=" # " \` has its quoted `#` read as a comment start, taking the real continuation
-// backslash with it. The consequence is direction-dependent: an assertion REQUIRING a flag then
-// over-fires (safe), but a BAN — the `localhost:\d+` check below — would stop seeing a hard-coded
-// port that moved onto the hidden continuation line, which is a false clean. No line in the block
-// this reads contains a quoted ` #` today. Making it quote-aware means lexing bash, which is more
-// than a confirmed-bug fix should carry, so the limit is recorded rather than closed.
+// The first version was a single regex, `line.replace(/\s+#.*$/, '')`, and it carried a
+// comment admitting it was quote-blind. That admission was driven into a false PASS: a
+// line such as
+//     --user-agent="$DEV_URL # " \
+// has its quoted `#` read as a comment start, taking the real continuation backslash with
+// it, so the NEXT physical line — which in the constructed case carried a hard-coded
+// `http://localhost:3000` — vanished from the selection entirely and the ban that exists
+// to catch exactly that passed on an invocation that no longer included it. Documenting a
+// hole is not closing one.
+//
+// So this walks the line and tracks quoting. It is not a bash lexer and does not claim to
+// be: it knows single quotes (literal, no escapes inside), double quotes (backslash
+// escapes), and a backslash escape outside quotes. That is the quoting the block actually
+// uses, and it is what the false PASS above needed. A `#` starts a comment only when it is
+// outside quotes AND at the start of a word — `foo#bar` is one word to bash, not a comment.
 function stripComment(line) {
-  const stripped = line.replace(/\s+#.*$/, '');
-  if (stripped === line) return line; // nothing removed — leave real continuations alone
-  // A `\` that the removed text was hiding did NOT continue the line in bash, so this reader
-  // must not treat it as one. Driven: `echo one \ # x` followed by `--timeout=30000` runs the
-  // second line as its OWN command (`--timeout=30000: command not found`) — bash never joins
-  // them. Stripping the comment and keeping the backslash would make logicalLines() join what
-  // bash does not, so a flag on the following line would satisfy an assertion the real command
-  // never receives. That is a bypass this stripping would have CREATED, not one it inherited.
-  return stripped.replace(/\\+$/, '');
+  let out = '';
+  let quote = null;       // null | "'" | '"'
+  for (let i = 0; i < line.length; i += 1) {
+    const c = line[i];
+    if (quote === "'") { out += c; if (c === "'") quote = null; continue; }
+    if (quote === '"') {
+      if (c === '\\' && i + 1 < line.length) { out += c + line[i + 1]; i += 1; continue; }
+      out += c; if (c === '"') quote = null; continue;
+    }
+    if (c === '\\' && i + 1 < line.length) { out += c + line[i + 1]; i += 1; continue; }
+    if (c === "'" || c === '"') { out += c; quote = c; continue; }
+    if (c === '#' && (i === 0 || /[\t ]/.test(line[i - 1]))) {
+      // A `\` that the removed text was hiding did NOT continue the line in bash, so this
+      // reader must not treat it as one. Driven: `echo one \ # x` followed by
+      // `--timeout=30000` runs the second line as its OWN command — bash never joins them.
+      // Keeping the backslash would make logicalLines() join what bash does not, so a flag
+      // on the following line would satisfy an assertion the real command never receives.
+      return out.replace(/[\t ]+$/, '').replace(/\\+$/, '');
+    }
+    out += c;
+  }
+  return out;
 }
+
+
+// The patterns of a `case` arm, or null when the line is not one.
+//
+// `line.split(')')[0].split('|')` was the first version and it is wrong on legal bash in
+// two ways, both driven. A leading `(` — `(401|403|407|511)` is valid — yields
+// `["(401","403",...]`, so `401` reads as MISSING and the assertion false-FAILS. And a `)`
+// inside an earlier pattern truncates the label. Strip an optional leading `(`, then take
+// up to the FIRST unquoted `)`; a quoted one is part of a pattern, not the terminator.
+function caseLabelOf(line) {
+  const t = line.trim().replace(/^\(/, '');
+  let quote = null;
+  let end = -1;
+  for (let i = 0; i < t.length; i += 1) {
+    const c = t[i];
+    if (quote) { if (c === quote) quote = null; continue; }
+    if (c === "'" || c === '"') { quote = c; continue; }
+    if (c === '\\') { i += 1; continue; }
+    if (c === ')') { end = i; break; }
+  }
+  if (end <= 0) return null;
+  const label = t.slice(0, end);
+  // A case label is patterns joined by `|`; anything with a space or `=` in it is a
+  // command line that merely happens to contain a `)`, not an arm.
+  if (/[\t =]/.test(label)) return null;
+  return label.split('|').map((x) => x.trim()).filter((x) => x !== '');
+}
+
 function captureInvocations(lines) {
   return logicalLines(lines.map(stripComment).filter((l) => !/^[\t ]*#/.test(l) && l.trim() !== ''))
     .map((l) => l.trim())
@@ -203,8 +273,22 @@ function captureInvocations(lines) {
 }
 
 describe('#4176 — gsd-ui-auditor screenshot capture is honest', () => {
+  // CODE, not prose. Every assertion below reads the comment-stripped block: the block
+  // documents its own flags in comments, and a regression that deletes `redirect:"follow"`
+  // while leaving the phrase in the paragraph above it would otherwise still pass. That is
+  // the same substring defect the review's finding 1 names, and it was DRIVEN against the
+  // previous version of this test with `{/* redirect:"follow" */ signal: ...}`.
+  // stripComment knows BASH comments. The probe's argument is a JavaScript program
+  // embedded in that bash, and a `/* redirect:"follow" */` left behind after the real key
+  // was deleted satisfied every regex below — driven, 15/15 green on a probe that had
+  // reverted to fetch's inherited default. Strip JS comments too. This is a belt: the
+  // authoritative check on the probe's redirect behaviour is the executed one further
+  // down, which runs the extracted program against a real redirecting server.
+  const stripJsComments = (t) => t.replace(/\/\*[\s\S]*?\*\//g, ' ');
+  const codeBlock = () => stripJsComments(screenshotApproachLines().map(stripComment).join('\n'));
+
   test('dev-server probe follows redirects and is time-bounded', () => {
-    const block = screenshotApproachBlock();
+    const block = codeBlock();
     const usesCurlL = /curl[\t ]+(-[A-Za-z]{0,10}L|--location)\b/.test(block);
     const usesFetch = /\bfetch\(/.test(block);
     assert.ok(usesCurlL || usesFetch, 'probe must issue its request via curl or fetch()');
@@ -227,7 +311,7 @@ describe('#4176 — gsd-ui-auditor screenshot capture is honest', () => {
   });
 
   test('probe accepts any 2xx rather than exact-matching 200', () => {
-    const block = screenshotApproachBlock();
+    const block = codeBlock();
     assert.ok(
       !/=[\s]*"200"/.test(block),
       'probe must not exact-match "200" — that misreads redirects and other 2xx as no-server'
@@ -236,14 +320,32 @@ describe('#4176 — gsd-ui-auditor screenshot capture is honest', () => {
     // 200) ... ;; esac` carries no `=` at all, so it reintroduces the same
     // 2xx-but-not-200 misread while passing the ban above. Assert positively that a 2xx
     // RANGE is what the probe accepts.
-    const acceptsRange =
-      /2\?\?\)/.test(block) ||               // case glob:  2??)
-      /2\[0-9\]\[0-9\]\)/.test(block) ||     // case class: 2[0-9][0-9])
-      /-ge[\t ]+200\b/.test(block) ||        // arithmetic lower bound
-      /\br\.ok\b/.test(block);               // fetch's own 2xx predicate
+    // READ THE ARM THAT GOVERNS `DEV_URL=`, not the block. A block-wide search for a
+    // range idiom is satisfied by a range test that decides nothing — driven against the
+    // previous version of this test with
+    //     200) [ "$PROBE" -ge 200 ] && DEV_URL=...; break ;;
+    // which admits ONLY 200 at the case label, carries no `=` for the ban above to catch,
+    // and offers the `-ge 200` the range check was looking for. 15/15 passed on a block
+    // that had reinstated the exact-match bug.
+    const acceptArm = logicalLines(screenshotApproachLines().map(stripComment))
+      .map((l) => l.trim())
+      .find((l) => /DEV_URL=/.test(l) && !/^DEV_URL=""$/.test(l));
+    assert.ok(acceptArm, 'expected an arm that resolves DEV_URL from the probe status');
+    const armLabel = caseLabelOf(acceptArm);
+    // WHERE the range lives has to match where the DECISION is made. When a `case` label
+    // gates the arm, that label IS the acceptance test and a range check inside the arm
+    // body is vacuous — `200) [ "$PROBE" -ge 200 ] && DEV_URL=...` admits only 200 and the
+    // `-ge` never rejects anything. So the alternatives are mutually exclusive by
+    // construction: a case-gated arm is judged on its LABEL, and only an arm with no case
+    // label may earn acceptance from a comparison in its body.
+    const acceptsRange = armLabel !== null
+      ? armLabel.some((pat) => /^2(\?\?|\[0-9\]\[0-9\]|\*)$/.test(pat))
+      : (/-ge[\t ]+200\b/.test(acceptArm) || /\br\.ok\b/.test(block));
     assert.ok(
       acceptsRange,
-      'probe must accept a 2xx RANGE (a 2?? / 2[0-9][0-9] case glob, a >= 200 comparison, or r.ok) — not an enumerated status'
+      armLabel !== null
+        ? `the case label that admits a status must be a 2xx RANGE (2?? / 2[0-9][0-9] / 2*), not an enumerated status — a range test inside an exact-match arm decides nothing: label was ${JSON.stringify(armLabel)}`
+        : `the arm that sets DEV_URL must accept a 2xx RANGE, not an enumerated status: ${acceptArm}`
     );
   });
 
@@ -315,9 +417,15 @@ describe('#4176 — gsd-ui-auditor screenshot capture is honest', () => {
       .filter((l) => /DEV_GATED=/.test(l) && !/^DEV_GATED=""$/.test(l));
     assert.ok(assignments.length > 0, 'expected the port loop to record an auth-gated server');
     for (const line of assignments) {
+      // THE OPERATOR IS THE PROPERTY, not the presence of a test. Driven against the
+      // previous version: swapping `||` for `&&` leaves DEV_GATED permanently EMPTY —
+      // strictly worse than the last-wins bug this guards — and all 15 tests passed,
+      // because a `-n` test was still textually present. Accept exactly the two forms
+      // that mean "keep the first": `[ -n "$DEV_GATED" ] ||` and `[ -z "$DEV_GATED" ] &&`.
       assert.ok(
-        /\[[\t ]+-[nz][\t ]+"?\$DEV_GATED"?[\t ]+\]/.test(line),
-        `the auth-gated port must be recorded first-wins, or the reason names the LAST gated port: ${line}`
+        /\[[\t ]+-n[\t ]+"?\$DEV_GATED"?[\t ]+\][\t ]*\|\|/.test(line)
+          || /\[[\t ]+-z[\t ]+"?\$DEV_GATED"?[\t ]+\][\t ]*&&/.test(line),
+        `the auth-gated port must be recorded first-wins — \`[ -n "$DEV_GATED" ] ||\` or \`[ -z "$DEV_GATED" ] &&\`; the operator is what makes it first-wins, not the test: ${line}`
       );
     }
   });
@@ -336,9 +444,7 @@ describe('#4176 — gsd-ui-auditor screenshot capture is honest', () => {
       .map((l) => l.trim())
       .filter((l) => /DEV_GATED=/.test(l) && !/^DEV_GATED=""$/.test(l));
     assert.ok(gatedArms.length > 0, 'expected a case arm recording an auth-gated server');
-    const labels = gatedArms
-      .map((l) => l.split(')')[0])
-      .map((lab) => lab.split('|').map((s) => s.trim()));
+    const labels = gatedArms.map((l) => caseLabelOf(l) || []);
     for (const status of ['401', '403', '407', '511']) {
       assert.ok(
         labels.some((lab) => lab.includes(status)),
@@ -378,30 +484,50 @@ describe('#4176 — gsd-ui-auditor screenshot capture is honest', () => {
     const captures = captureInvocations(screenshotApproachLines());
     assert.ok(captures.length > 0, 'expected at least one capture invocation');
     for (const line of captures) {
+      // A VALUE, AND A POSITIVE ONE. `--timeout=0` is playwright's own spelling of NO
+      // timeout, so a presence check accepts the exact state this assertion exists to
+      // forbid — driven against the previous version, which passed 15/15 with every
+      // capture at `--timeout=0`.
+      const flag = /--timeout[= ]([0-9]+)\b/.exec(line);
+      assert.ok(flag, `capture must be time-bounded — playwright screenshot defaults to no timeout: ${line}`);
       assert.ok(
-        /--timeout[= ]/.test(line),
-        `capture must be time-bounded — playwright screenshot defaults to no timeout: ${line}`
+        Number(flag[1]) > 0,
+        `--timeout=0 IS playwright's no-timeout setting — the bound must be positive: ${line}`
       );
     }
   });
 
-  test('a total capture failure removes its stray files, not just an empty directory', () => {
+  test('a failed viewport removes the file it may have written, by name', () => {
     // rmdir alone cannot honour a "leaves nothing behind" claim: it succeeds only on a
     // genuinely empty directory and its stderr is discarded, so a zero-byte or partial
     // .png from a crashed browser — which `[ -s ]` correctly scores as a failure —
-    // leaves BOTH the file and the directory in place, silently.
+    // would leave BOTH the file and the directory in place, silently.
+    //
+    // The removal lives in the capture loop's FAILURE arm, not in the all-failed branch,
+    // and that placement is the finding: scoped to the all-failed branch it left the
+    // PARTIAL case — two good shots and one stray file — still overclaimed by the docs.
+    // It is also BY NAME rather than a `*.png` glob, because the review directory is
+    // keyed to the phase and a whole second, so a concurrent audit of the same phase can
+    // share it and a glob would delete that audit's captures.
     const rows = guardedLines(screenshotApproachLines());
+    const removals = rows.filter((r) => /^rm -f\b/.test(r.line));
+    assert.ok(removals.length > 0, 'expected the capture loop to remove a failed viewport\u2019s stray file');
+    for (const row of removals) {
+      assert.ok(
+        !/\*/.test(row.line),
+        `stray-file removal must name the file, never glob the directory — a concurrent audit shares it: ${row.line}`
+      );
+      assert.ok(
+        /\$SHOT_NAME/.test(row.line),
+        `stray-file removal must target the viewport that just failed: ${row.line}`
+      );
+    }
     const removesDir = rows.filter((r) => /^rmdir\b/.test(r.line));
     assert.ok(removesDir.length > 0, 'expected the all-failed branch to remove the review directory');
-    const removesFiles = rows.filter((r) => /\brm -f[\t ].*\$SCREENSHOT_DIR/.test(r.line));
-    assert.ok(
-      removesFiles.length > 0,
-      'the all-failed branch must remove the files a crashed capture wrote, or rmdir cannot clean up after one'
-    );
-    for (const row of removesFiles) {
+    for (const row of removesDir) {
       assert.ok(
         row.guards.some((cond) => /CAPTURED/.test(cond)),
-        `stray-file removal must be confined to the capture-failure branch; governing conditions were ${JSON.stringify(row.guards)}`
+        `directory removal must be confined to the capture-failure branch; governing conditions were ${JSON.stringify(row.guards)}`
       );
     }
   });

--- a/tests/playwright-ui-verify.test.cjs
+++ b/tests/playwright-ui-verify.test.cjs
@@ -281,6 +281,27 @@ describe('#4176 — gsd-ui-auditor screenshot capture is honest', () => {
     }
   });
 
+  test('a total capture failure removes its stray files, not just an empty directory', () => {
+    // rmdir alone cannot honour a "leaves nothing behind" claim: it succeeds only on a
+    // genuinely empty directory and its stderr is discarded, so a zero-byte or partial
+    // .png from a crashed browser — which `[ -s ]` correctly scores as a failure —
+    // leaves BOTH the file and the directory in place, silently.
+    const rows = guardedLines(screenshotApproachLines());
+    const removesDir = rows.filter((r) => /^rmdir\b/.test(r.line));
+    assert.ok(removesDir.length > 0, 'expected the all-failed branch to remove the review directory');
+    const removesFiles = rows.filter((r) => /\brm -f[\t ].*\$SCREENSHOT_DIR/.test(r.line));
+    assert.ok(
+      removesFiles.length > 0,
+      'the all-failed branch must remove the files a crashed capture wrote, or rmdir cannot clean up after one'
+    );
+    for (const row of removesFiles) {
+      assert.ok(
+        row.guards.some((cond) => /CAPTURED/.test(cond)),
+        `stray-file removal must be confined to the capture-failure branch; governing conditions were ${JSON.stringify(row.guards)}`
+      );
+    }
+  });
+
   test('report surfaces can express partial capture', () => {
     const content = fs.readFileSync(AUDITOR_PATH, 'utf-8');
     assert.ok(

--- a/tests/playwright-ui-verify.test.cjs
+++ b/tests/playwright-ui-verify.test.cjs
@@ -204,7 +204,15 @@ describe('#4176 — gsd-ui-auditor screenshot capture is honest', () => {
 
   test('capture success is checked, not assumed', () => {
     const block = screenshotApproachBlock();
-    const checksOutcome = /\[ -s "?\$SCREENSHOT_DIR|\[ -s |if npx |CAPTURED=|\$\?/.test(block);
+    // `CAPTURED=` is deliberately NOT an alternative here. It matches the unconditional
+    // `CAPTURED=0` initialisation, so a future block that keeps the counter and drops every
+    // real outcome check would still satisfy this — the counter's EXISTENCE is not evidence
+    // that anything was observed. (It does not weaken the regression this test names: the
+    // pre-fix block declared no counter at all, so every alternative below is absent from it
+    // and the test fails there either way. Removing it costs nothing and closes the forward
+    // hole.) The remaining alternatives each name an actual observation: the captured file is
+    // non-empty, or the capture command's own exit status is consumed.
+    const checksOutcome = /\[ -s "?\$SCREENSHOT_DIR|\[ -s |if npx |\$\?/.test(block);
     assert.ok(checksOutcome, 'an exit-status or file-existence check must gate the captured/not-captured signal');
   });
 

--- a/tests/playwright-ui-verify.test.cjs
+++ b/tests/playwright-ui-verify.test.cjs
@@ -166,10 +166,15 @@ function guardedLines(lines) {
 // why the exclusion lives here once rather than in each caller.
 // logicalLines first: the invocation spans four physical lines, so its flags are only all on one
 // line after continuations are joined.
+// Comments are dropped from the PHYSICAL lines, BEFORE continuations are joined. Doing it after
+// is a false clean: a comment ending in a backslash splices the following real invocation onto
+// itself, the joined line then starts with `#`, and the invocation disappears from the set — so
+// the assertions over it pass on an empty selection. Filtering first makes that shape impossible
+// rather than merely unlikely. (A trailing comment on a real code line is still selected; that
+// direction over-fires, which is the safe one.)
 function captureInvocations(lines) {
-  return logicalLines(lines)
+  return logicalLines(lines.filter((l) => !/^[\t ]*#/.test(l)))
     .map((l) => l.trim())
-    .filter((l) => !l.startsWith('#'))
     .filter((l) => l.includes('playwright screenshot'));
 }
 
@@ -360,14 +365,23 @@ describe('#4176 — gsd-ui-auditor screenshot capture is honest', () => {
     // surface outside the block must CONSUME the variable — a status computed and never
     // rendered is not a surface that can express anything.
     const block = screenshotApproachBlock();
-    const content = fs.readFileSync(AUDITOR_PATH, 'utf-8');
     assert.ok(
       /CAPTURE_STATUS=["']?partially captured/i.test(block),
       'the capture block must PRODUCE a partial status — full/none alone cannot describe 2 of 3'
     );
+    // Name the consuming surface POSITIVELY rather than subtracting the block from the file.
+    // `content.replace(block, '')` was two bugs in one: String#replace with a string argument
+    // drops only the FIRST occurrence, and the block is joined with '\n' by splitLines() while
+    // readFileSync returns the file's own '\r\n' on a Windows checkout — so the match fails
+    // outright, the block stays in the haystack, and the assertion is then satisfied by the
+    // block's own text. That is a false clean, and CRLF-fragility is a class this repo lints
+    // for (local/no-crlf-fragile-split). Assert on the Screenshots report field itself.
+    const surfaces = splitLines(fs.readFileSync(AUDITOR_PATH, 'utf-8'))
+      .filter((l) => /^\*\*Screenshots:\*\*/.test(l.trim()));
+    assert.ok(surfaces.length > 0, 'expected a Screenshots report field in the agent output template');
     assert.ok(
-      /\$CAPTURE_STATUS/.test(content.replace(block, '')),
-      'a report surface outside the block must render $CAPTURE_STATUS, or the status is computed and dropped'
+      surfaces.every((l) => l.includes('$CAPTURE_STATUS')),
+      'every Screenshots report field must render $CAPTURE_STATUS, or the status is computed and dropped'
     );
   });
 });

--- a/tests/playwright-ui-verify.test.cjs
+++ b/tests/playwright-ui-verify.test.cjs
@@ -845,6 +845,21 @@ describe('#4176 — the probe program, executed against real servers', () => {
     } finally { await close(server); }
   });
 
+  test('a node without fetch() says so, instead of reporting every port absent', async () => {
+    // The program is run on the SAME node with the global deleted first — a Node 16 is not
+    // on hand, and what matters is the branch the program takes when `fetch` is not a
+    // function, not which release lacks it. Without this branch the program throws, the
+    // shell reads "000", and a live dev server is reported absent by a road that has
+    // nothing to do with the server. The version is carried so the report can name it.
+    const program = `delete globalThis.fetch; ${probeProgram()}`;
+    const out = await new Promise((resolve) => {
+      execFile(process.execPath, ['-e', program, 'http://127.0.0.1:1/'], { timeout: 30000 },
+        (err, stdout) => resolve({ code: err && typeof err.code === 'number' ? err.code : 0, stdout: String(stdout) }));
+    });
+    assert.strictEqual(out.code, 0, 'the nofetch branch must not throw');
+    assert.strictEqual(out.stdout, `nofetch ${process.version}`);
+  });
+
   test('a server that answers something other than 2xx or an auth status still reports that status', async () => {
     for (const status of [404, 500, 503]) {
       const server = await listen((req, res) => { res.writeHead(status); res.end(); });
@@ -1226,6 +1241,20 @@ describe('#4176 — the capture fence, executed', { skip: BASH_OK ? false : 'no 
     assert.doesNotMatch(r.stdout, /No dev server/);
     assert.match(r.stdout, /Dev server at http:\/\/localhost:3000 accepted the connection but did not answer within 5s/);
     assert.strictEqual(r.captureStatus, 'not captured (dev server accepted the connection, no answer in 5s)');
+    assert.deepStrictEqual(r.shotDirs, []);
+  });
+
+  test('a node without fetch() is reported as "cannot probe", naming the version, and nothing is captured', () => {
+    // The stub prints what the real program prints on an old Node. The block must stop at
+    // the first port — three "nofetch" answers are not three absent servers — and the
+    // status must say the probe could not run, since that is the one outcome that says
+    // nothing about the ports at all.
+    const r = ok(runFence({ PROBE_3000: 'nofetch v16.20.2', PROBE_5173: '200' }));
+    assert.doesNotMatch(r.stdout, /No dev server/);
+    assert.doesNotMatch(r.stdout, /Screenshots captured/, 'no port was classified, so none may be captured from');
+    assert.match(r.stdout, /Cannot probe for a dev server: node v16\.20\.2 has no fetch\(\)/);
+    assert.strictEqual(r.captureStatus, 'not captured (cannot probe: node v16.20.2 has no fetch(); Node 18+ required)');
+    assert.strictEqual(r.invocations.length, 0);
     assert.deepStrictEqual(r.shotDirs, []);
   });
 

--- a/tests/playwright-ui-verify.test.cjs
+++ b/tests/playwright-ui-verify.test.cjs
@@ -327,7 +327,8 @@ function stripComment(line) {
     // parenthesised INSIDE a word: their `)` ends the construct, not the word, so a `#` right
     // after it is literal (`cat <(printf x)#c` prints `/dev/fd/63#c`). Same context as `$( )`.
     // Round review, continuation 2.
-    if (/[<>@*+?!]/.test(c) && line[i + 1] === '(') { out += c + line[i + 1]; i += 1; stack.push('cmd'); continue; }
+    // NOT inside double quotes, where these are literal text (`$(` is live there; these are not).
+    if (ctx !== 'dq' && /[<>@*+?!]/.test(c) && line[i + 1] === '(') { out += c + line[i + 1]; i += 1; stack.push('cmd'); continue; }
     // Nested parens inside `$( )`. A raw subshell — `$( (printf x); printf "%s" " # " )`
     // — closed the outer context at the INNER `)`, after which every quote was
     // misclassified and the trailing continuation was truncated away. Driven. Depth is
@@ -1461,6 +1462,11 @@ describe('#4176 — bash reader, units', () => {
     assert.strictEqual(stripComment('echo @(a)#c'), 'echo @(a)#c');
     assert.strictEqual(stripComment('echo @(a) #c'), 'echo @(a)');
     assert.strictEqual(stripComment('echo $(printf x)#c'), 'echo $(printf x)#c');
+    // Inside double quotes those openers are literal text; an unmatched one must not
+    // poison the context and swallow a real comment. Round review, continuation 3.
+    assert.strictEqual(stripComment('echo "@(a" # fi'), 'echo "@(a"');
+    assert.strictEqual(stripComment('echo "<(x" # fi'), 'echo "<(x"');
+    assert.strictEqual(stripComment('echo "$(printf x)" # fi'), 'echo "$(printf x)"');
   });
 
   test('logicalLines joins only a backslash that is the LAST character of the line, in an odd run', () => {
@@ -1525,7 +1531,7 @@ const scriptGen = fc.letrec((tie) => ({
     // What surrounds the marker: a plain echo, a quoted string carrying control keywords
     // (the `echo "we do work"` false-fire class), a trailing comment that itself carries
     // keywords (the `fi # comment` desync class), or a continuation across two lines.
-    dress: fc.constantFrom('plain', 'dq-keywords', 'sq-keywords', 'comment', 'continued', 'hash-in-quotes', 'backslash-space', 'escaped-backslash', 'operator-comment'),
+    dress: fc.constantFrom('plain', 'dq-keywords', 'sq-keywords', 'comment', 'continued', 'hash-in-quotes', 'backslash-space', 'escaped-backslash', 'operator-comment', 'quoted-opener-comment'),
   }),
   ifBlock: fc.record({
     kind: fc.constant('if'),
@@ -1575,6 +1581,8 @@ function render(tree, opts) {
         case 'escaped-backslash': emit(depth, `echo "${m}" \\\\`); break;
         // A comment opened right after an operator, no space — bash ends the word at `;`.
         case 'operator-comment': emit(depth, `echo "${m}";# fi done esac`); break;
+        // Opener-like text inside quotes, then a real comment carrying keywords.
+        case 'quoted-opener-comment': emit(depth, `echo "${m} <(x @(y" # fi done`); break;
         default: throw new Error(`unknown dress ${node.dress}`);
       }
       expect.push({ id, guards: guards.slice(), exec });


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #4176

---

## What was broken

`gsd-ui-auditor`'s sole screenshot path misread any redirecting dev server as absent, printed `Screenshots captured to $DIR` even when every capture command failed, and never tried the `5173` / `8080` fallback documented on the line directly below the code that hard-coded `3000`.

## What this fix does

The probe now follows redirects, accepts any 2xx, is time-bounded, and iterates all three documented ports; every capture runs against the port that actually answered. The captured/not-captured signal is derived from the observed exit statuses and the files on disk, and `$CAPTURE_STATUS` — the one value both report templates render — carries what the audit observed: `captured (3/3 from <url>)`, `partially captured (N/3 from <url>; failed: <viewports>)`, or `not captured (<reason>)` where the reason is one of: no dev server on any of the three ports; a server that answered but is auth-gated (`401`/`403`/`407`/`511`, with port and status); a server that answered something else (with port and status); a port that accepted the connection and did not answer within 5s; a `node` without `fetch()` (with its version); a review directory that could not be allocated (with why); or a capture that failed on all three viewports. "No dev server" now means no port **answered** — nothing listening, a refused connection, or a socket closed without a response — and never a server that answered, or accepted the connection and hung. Both report templates consume the variable; the transfer is asserted at their source lines, not by generating a report end to end.

## Root cause

Three independent defects inside one 28-line `<screenshot_approach>` block:

1. **`:113` / `:115` — redirect blindness.** `curl -s -o /dev/null -w "%{http_code}"` without `-L`, gated on an exact `[ "$DEV_STATUS" = "200" ]`. Any root path that redirects — Next.js middleware/i18n, trailing-slash normalization, an auth redirect — produced a redirect status (302 or 307, depending on the redirect) and fell to the `else` branch, so the audit silently degraded to code-only while the server was serving fine. The same equality also mis-read auth-gated `401`/`403` and any non-200 2xx, and the probe carried no time bound, so an accepting-but-unresponsive port hung it.

2. **`:120,125,130` + `:134` — unconditional success.** All three `npx playwright screenshot` invocations ended `2>/dev/null` with no exit-status or file check, and `:134` echoed success regardless. That false claim propagated into the `**Screenshots:**` field of the scored `UI-REVIEW.md` (`:302`) and the orchestrator return (`:409`), and left an empty timestamped `.planning/ui-reviews/<ts>/` directory behind.

3. **`:142` contradicted `:113`.** The prose said *"Try port 3000 first, then 5173 (Vite default), then 8080"*, but `3000` was hard-coded in the probe, in all three capture commands, and in the terminal verdict at `:136`, so the block emitted *"No dev server at localhost:3000"* before `5173` or `8080` were ever reached.

The probe follows the pattern already established in `gsd-core/references/checkpoints.md` — `fetch()` rather than `curl`, for the cross-platform reason that file's own comment gives. That makes **Node 18+ on the audited project's PATH** a precondition of the block — the project's runtime, not gsd-core's — and the block says so: on an older Node the program prints `nofetch <version>` instead of throwing, and the audit reports "cannot probe" rather than an absent server.

One implementation note worth surfacing, because it is the same failure class as defect 1: the probe writes with `process.stdout.write(String(r.status))`, never `console.log(r.status)`. `console.log` of a **number** is colorized by Node **whenever Node emits colour** — a TTY, or `FORCE_COLOR` — in which case the probe emits `\033[33m200\033[39m`, the `2??` case never matches, and every live dev server reads as absent again. Piped and uncoloured it prints `200` and works; writing the string is what makes it unconditional. Caught by running the block, not by reading it.

## Review round 2 — what changed after the first review

The review requested changes on six findings, all of which are addressed. Answering them turned up more than the six, so the shape of this PR has moved and the summary below reflects the current state rather than the original.

**The six findings.** The Major one — the "unconditional echo" guard being a substring-proximity check that could not fail on the regression it named — is closed by reading the block's **control flow**, and the maintainer's own reproduction is now a test: the pre-review suite passes 10/10 against a hoisted success echo, and the current suite fails on it. Finding 4's docs overclaim is closed by moving the stray-file cleanup into the capture loop's failure arm, which is what makes the claim true of a *partial* capture, and by rewriting the sentence. Findings 2, 3, 5 and the timeout nit are closed as requested.

**And then the tests themselves were attacked.** An adversarial cross-model pass over that round's own work, run four times, broke assertion after assertion with legal shell and legal JavaScript — a `--timeout=0`, a `fi # comment` that desynchronised the scope walker, an exact-match `case` label carrying a vacuous range test, a `redirect:"follow"` surviving only inside a JS comment, a quoted `#` hiding a line continuation. Each is fixed and each has a driven mutant.

**The durable answer was to stop reading the block and start running it.** Two suites execute rather than parse: the probe program is extracted verbatim and run against real local servers, and the whole bash fence runs under `bash` with stub `node`/`npx` on PATH, asserting what it **prints**, what it **leaves on disk**, and what it passes to the capture binary. That is the same verification method used in the review, made permanent, and it follows the existing house pattern in `tests/pause-work-improvements.test.cjs` and `tests/code-review-pipeline-regression.test.cjs`, which already extract and spawn a markdown bash fence.

**Two self-found changes to the block from that round.** The auth-gated arm covers `407` and `511` as well as `401`/`403`: a guard-shape census asked what set the `case` fixes at author time and whether its domain can gain a member without that code changing — it can, because the domain is what a dev server may answer — and `407`/`511` each mean the server **answered and demanded credentials**. And the review directory is allocated **atomically** — `mkdir` without `-p` in a bounded retry loop — so a total failure can remove it with `rm -rf`: two audits of the same phase both write `desktop.png`, `mobile.png` and `tablet.png`, so a filename can never establish whose file it is, and a PID suffix does not help because `$$` names a shell. Ownership has to come from winning the directory. Driven: 20 concurrent shells on a frozen clock produce 20 distinct directories and no collisions.

## Review round 3 — what changed after the second review

The second review requested changes on seven findings (five Minor, two Nit). All seven are addressed; nothing was declined. The round also found one thing of its own that the review did not, and its own cross-AI review pass found five more. The finding → commit map is in the response comment; the substance:

**Every answer is now recorded, not only the two the capture can use (finding 3).** A dev server answering `404`, `429`, `500` or `503` used to fall through both `case` arms and print "No dev server" — the issue's own defect, for every status family the two arms did not cover. A third arm records any other answering status first-wins, the loop keeps going so a later port holding a real 2xx still wins, and the status names the port and code. The earlier claim in this body that such statuses "receive no dedicated classification … deliberately" is withdrawn: the outcome was right, the reported reason was not. The same class sat one row over, unnamed by the review: the probe printed `000` for its **own timeout**, so a port that accepted the connection and never answered — the issue's third case — was reported as absent too. The program owns the only `AbortSignal` in play, so an abort can only be that bound; it now prints `timeout`, and the block reports the port as present and hung. Precedence among present-but-unusable answers is gated, then any other status, then timeout — by class, driven in both port orders.

**A Node without `fetch()` is its own outcome, and the precondition is stated (finding 5).** The doc note the review asked for is in the block and in `docs/AGENTS.md`. But a note leaves the false negative live — on an older Node the program throws, the shell reads `000` on every port, and a running dev server is reported absent by another road — so the program checks `typeof fetch` first and the block reports "cannot probe", naming the version, above every answer class. Executed against the real program with `globalThis.fetch` deleted, since no old Node was on hand and the branch is what matters.

**`$CAPTURE_STATUS` carries what its echo carries (finding 4).** Allocation exhaustion and "all three viewports failed" produced the identical string while the block calls that variable the single source of truth. The remedies differ, so the values now do — and the same rule is applied to every branch: the partial status had been the bare `partially captured`, so the N/3 and the failed viewport names that `docs/AGENTS.md` already said the field carried lived only in the transient echo.

**The allocator retries only a collision (nit 6).** `mkdir` also fails for a parent that is unwritable, missing or a file, or a full disk, and the loop asked 100 times either way. A candidate that failed and is still absent — `-L` as well as `-e`, because a dangling symlink occupies a name that `-e` follows and denies — is tried **once more**: a name taken and freed in the two-syscall window is simply won on the retry, a structural failure fails again and stops with its own reason. Driven three ways through the fence harness: a file standing where the parent directory should be (three `mkdir` calls, not 101 — counted through a wrapper function); a dangling symlink at the base name (retried under `-1`, link left alone); and the freed-name race itself, constructed with a wrapper that fails the first candidate `mkdir` without creating anything (the base name is won).

**The test file's bash reader (findings 1, 2, nit 7, and what the round's own review found).** `caseLabelOf` no longer desyncs its text from its per-character activity: the trim walks both arrays in lockstep and removes only unquoted edge whitespace, driven both ways on labels bash accepts (` 2?\?` read as a range; ` "2"??` read as not one). `logicalLines` treats a line as continued only on an odd run of backslashes with nothing after it, the way bash does (`echo a \ ` escapes the space and ends the line). `stripComment` opens a comment only at a **word start** — after unquoted whitespace or an operator (`;`, `|`, `&`, `(`, `)`, `<`, `>`), never after an escaped space, and never at a `)` that closes a process substitution or an extglob, which are inside a word; opener-like text inside double quotes is literal. Each of those four was a refutation from the round's own cross-AI review, driven against bash, and each has a unit for both polarities.

**Property tests (finding 1).** The reader is a parser, and this repo requires one to carry at least one `fast-check` property. Three were added, seed pinned, runs bounded, replay data printed on failure. A **document-shaped** generator of nested `if`/`elif`/`else`, `for`/`while`/`until`, `case`, two-line `then`, continuations, comments, quoted keywords, operator-adjacent and quoted-opener comments, and trailing-backslash-space lines knows which conditions enclose every payload it emits, and the reader must report exactly those guards. The same scripts are then **executed under bash** with a random truth assignment for every condition, and a payload must print exactly when the reader says its guards all hold — a reader that agrees with the generator but not with bash is modelling the wrong language. Third, a shape-aware generator of legal `case` labels is run through bash's own `case`, and the reader's "admits the 2xx range" verdict must be sound on every label and equal bash's verdict on single-pattern labels; that property asserts its own reach, because its first version ran 300 cases in 2ms and killed nothing. Seven reader mutants are each killed by a named property or unit with a printed counterexample: five revert this round's own fixes (the continuation rule, the lockstep trim, the word-start rule, the paren context, the quote guard), and two mutate pre-round behaviour the properties now cover (`else` no longer negating, comments not stripped before the walk).

**Found by this round's own full-suite run, not by the review.** The block's commentary had grown `agents/gsd-ui-auditor.md` to 27,210 bytes against the repo's 24,576-byte DEFAULT agent hard cap (`tests/agent-size-budget.test.cjs`), from 21,972 before the round. Every comment in the block was rewritten to one or two terse lines — the rationale lives in the commit messages and here — with every non-comment line asserted byte-identical during the rewrite. That commit left it at 22,244 bytes; the two allocator commits after it added comment lines, and it is 22,596 bytes at this head.

## Testing

### How I verified the fix

Two executed suites, a unit set and three properties for the reader, and a reversion-control matrix.

**The probe program, run against real local HTTP servers:**

| Server | Probe result |
|---|---|
| `307` → a live `200` | `200` — a redirecting dev server is not an absent one |
| `204` | `204` — a 2xx that is not 200 still resolves |
| `401` | `401` — present and gated, not absent |
| `404` / `500` / `503` | that status — present, answering, not serving a page |
| Closed port | `000` |
| Accepts, never answers | `timeout`, in under 20s — present and hung, not absent |
| Same node with `fetch` deleted | `nofetch <version>` — the block reports "cannot probe" |

**The whole bash fence, run under `bash` with stub `node`/`npx`**, asserting printed output, on-disk state, capture argv and `$CAPTURE_STATUS` (23 fixtures): no dev server creates no directory; a total failure never claims success in the message *or* the status, and leaves nothing behind; a capture that exits 0 without writing is not a capture, nor one that writes a real file but exits non-zero; a partial capture keeps the shots that worked, removes the failed viewport's file, and names the count and the viewport in the status, for **each** of the three viewports; the resolved port is the one captured; `200`/`201`/`204`/`206`/`299` all resolve; the **first** auth-gated port is reported; `401`/`403`/`407`/`511` read as gated; `404`/`429`/`500`/`503` read as present with port and status; a later 2xx outranks an earlier `404`; a timeout reads as present and hung; the gated > other > timeout precedence holds in both port orders; a `nofetch` answer stops probing, reports "cannot probe" with the version, and captures nothing; every capture invocation carries a positive `--timeout`; audits colliding on the same second get separate directories and a failing third audit removes only its own; a structural allocation failure stops after three `mkdir` calls with its own reason; a dangling symlink at the base name is retried under a suffix; a freed-name race is won on the retry; the last free suffix is used rather than skipped; an exhausted allocation invokes nothing and names the exhaustion.

**Reversion controls and mutants — thirty-four.** The nineteen mutant categories from the earlier rounds keep the tests that killed them; they were not re-driven this round. This round adds fifteen, each firing on a named test: eight reversions of the block's own fixes (the other-status arm removed; the timeout mapping reverted to `000`; the `nofetch` branch removed; the allocation status folded back into "capture failed"; the partial status without its count; the structural guard removed; the symlink guard removed; the race retry removed), five reversions of the reader's fixes, and two mutants of pre-round reader behaviour, as listed above. Every reversion was run against the final tree with the fix reverted in isolation, and every one fails a named test.

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

`tests/playwright-ui-verify.test.cjs` carries **48 test cases** for this issue (52 including the four pre-existing tests in the file): 11 source-level over the `<screenshot_approach>` bash fence, 7 executed probe, 23 executed fence, 4 reader units, 3 fast-check properties. The source-level ones read the **bash fence specifically**, not the whole file — the pre-fix defect was precisely that the fallback existed as a guidance sentence while the code hard-coded one port, so a whole-file grep for `5173` passed on the broken version.

**Negative-controlled.** The six original assertions fail 0/6 against the pre-fix `agents/gsd-ui-auditor.md` and pass 6/6 after. The fifteen controls and mutants this round added each fire. Four of the probe tests — the 204, the 401, the closed port, and the accept-but-never-answer bound — are covered by the executed run itself rather than by a mutant, and saying otherwise would overstate the battery.

The fence suite, the reader's bash cross-checks and the two bash-oracle properties are gated on a **runnable `bash`** rather than on the platform. The two precedent files gate differently — `code-review-pipeline-regression.test.cjs` on `process.platform === 'win32'`, and `pause-work-improvements.test.cjs` with a `hasShell()` probe on one of its suites — so what is cited as precedent is the extract-and-spawn pattern, not the gate.

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

The `curl` → `fetch()` change is the cross-platform direction: it removes a `curl` dependency from the probe, matching the rationale already recorded in `gsd-core/references/checkpoints.md` (`:494-495`, rationale at `:530`). The structural-failure fixture plants a **file** where the parent directory should be rather than dropping a permission bit, because `chmod` is inert on the windows-latest runner and as root. Verified here on Linux, not on other platforms.

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`) — with one honest caveat, below
- [x] `.changeset/` fragment added
- [x] No unnecessary dependencies added

**On `npm test`:** re-measured for this round with the full suite at this head: 37,485 tests, 21 failures, 31 skipped. Every one of the 21 also fails at the pre-round tree — established by running every test file carrying a failure (828 files) at that tree and diffing the failing names — and **zero** are in a file this PR touches. They are the same environment-dependent set reported in the previous rounds (`install` / `runtime-homes` / `shadow-report` / `health-diagnostic` / skills-root), which assert `getGlobalConfigDir` resolves `~/.claude` while my shell sets `CLAUDE_CONFIG_DIR` elsewhere; CI, with its clean environment, passed the same jobs at the previous head. The one failure this round *did* introduce — the agent size cap — was found by that run and fixed before pushing. `npm run lint:ci`, `docs-lint`, `changeset-lint`, `default-flip-documentation`, `test:qa` + the smell ratchet, `plugin-validate`, `ci-test-scope` and the npm-integrity check all pass at this head. Each of the fourteen commits was checked independently against this test file and the linter, so the sequence is bisectable.

Beyond the coupled `:302` / `:409` template fields the issue's triage named, one further line changed: the completion-checklist item read *"Screenshots captured (or noted as unavailable)"*, which is disjunctive and cannot express partial capture at all. It is newly wrong under the three-state contract this PR introduces, so it changed with it rather than being left to contradict the new behavior.

## Breaking changes

The `**Screenshots:**` field of `UI-REVIEW.md` and of the orchestrator return can now report `captured (3/3 from <url>)`, `partially captured (N/3 from <url>; failed: …)` and a specific not-captured reason. Before, `:302` offered `{captured / not captured (no dev server)}` and `:409` only `{captured / not captured}` — the orchestrator return could not even name the reason. Anything parsing that field for the two old literals should widen. This is the fix: the old field could not distinguish a successful capture from a total failure.

The review directory's name now carries a numeric suffix when its base name is already taken (`07-20260906-034512`, then `-1`, `-2`, …). Nothing is documented as parsing that name.

The screenshot block now requires Node 18+ on the audited project's PATH, where it previously required `curl`. `npx playwright` already required a current Node, so the bound is stated rather than new.

## Known limits, stated rather than left to be found

- The source-level bash reader in the test file is **not a bash lexer**: it does not model heredocs, `case` pattern parentheses as word content, or arithmetic context. A construct it does not recognise makes it throw or false-fail **when that construct carries a control keyword** — that is the polarity it was built to, and every shape the review passes found this round was driven to either fix it or confirm that polarity. The blind spot is the construct that carries none: a heredoc whose body has no keyword is read as ordinary rows without complaint, which is silent. Its structural claims are backstopped by the executed **fence** suite, which does not use it; the executed **probe** suite uses it for extraction (`stripComment` and `logicalLines`), so that suite is not independent of the reader.
- The probe maps both `TimeoutError` and the generic `AbortError` to `timeout`, on the reasoning that the program owns the only abort signal in play. Driven: a hung server → `timeout`; a socket closed immediately and a redirect loop → `000`. Which Node/undici releases spell the abort `AbortError` was not pinned; the mapping is correct under either spelling.
- Atomic allocation establishes ownership **at creation**. It is not a claim about the pathname for all time; another process substituting a parent directory mid-audit defeats it, which was driven. The one-more-attempt rule closes a name taken and freed in the window between `mkdir` and the checks; a name taken, freed and taken **again** inside that window is read as a collision and retried under the next suffix, which is the safe reading.
- That `playwright screenshot` defaults `--timeout` to `0` is a vendor claim about the Playwright CLI. It is the stated reason for the flag; it was not independently verified offline.
- The transfer of `$CAPTURE_STATUS` into the rendered `UI-REVIEW.md` is asserted at the template's source line, not by generating a report end to end.
- The fence harness's "successful" capture is three ASCII bytes, not an image. Nothing here establishes image validity, real-browser behaviour, or a bound on an `npx` install/startup hang before `--timeout` can apply.
- "No dev server creates no review directory" is scoped to the **screenshot fence**. The auditor's earlier `<gitignore_gate>` creates `.planning/ui-reviews/` and its `.gitignore` separately, and is not exercised here.
- A `node` absent from PATH entirely still reads as "no dev server" — the probe's `|| echo "000"` catches the command-not-found — because the fence harness cannot construct that case without also losing `mkdir` and `date`, and a branch I could not drive was not added.

---

## Disclosure

This fix was authored in a clean worktree against pristine `upstream/next`; the three non-changeset files it touches are also locally patched in my own environment, and that local patch already addressed defects 1 and 2 by a different route. Every line here was written from the upstream source, and the same disclosure was made when #4176 was filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R5ty69FXXzmsrto3Yrk6Aw
https://claude.ai/code/session_014GVeNM6KLYAty7kFFpjeB4
