### PR TITLE
fix(#4220): terminate the sweep protect walk on dirname's fixed point

### DIFF
--- a/scripts/run-tests.cjs
+++ b/scripts/run-tests.cjs
@@ -36,7 +36,11 @@
 'use strict';
 
 const { readdirSync, readFileSync, mkdtempSync, rmSync, unlinkSync, writeFileSync } = require('fs');
-const { join, basename } = require('path');
+// Captured whole (not just the two destructured helpers) so
+// collectSweepProtectPaths can default to it while still accepting an
+// injected `path.win32` from tests — see #4220.
+const nodePath = require('path');
+const { join, basename } = nodePath;
 const { tmpdir } = require('os');
 const { pathToFileURL } = require('url');
 const { execFileSync } = require('child_process');
@@ -402,6 +406,55 @@ function setupRunTempRoot() {
   const root = inherited || mkdtempSync(join(tmpdir(), RUN_TEMP_ROOT_PREFIX));
   for (const key of ['TMPDIR', 'TEMP', 'TMP']) process.env[key] = root;
   return root;
+}
+
+/**
+ * Build the sweep's protect set: every ancestor path of every SELECTED test
+ * file, plus the files themselves. `sweepRunTempRoot` consumes it as a set of
+ * ABSOLUTE paths and only ever asks it about DIRECT children of the run root
+ * (`protect.has(join(root, name))`), so ancestors that live outside the root
+ * are harmless surplus — the walk does not need to know where the root is
+ * beyond stopping early when it reaches it.
+ *
+ * Extracted from runTests (#4220) so the ancestor walk is reachable from a
+ * unit test with an injected `pathMod`. It is pure.
+ *
+ * TERMINATION (#4220 — the bug this extraction exists to pin down): stop at
+ * the filesystem root via dirname's FIXED POINT (`dirname(x) === x`), never
+ * via a string-length sentinel. #4207 shipped `cur.length > 1`, which is a
+ * POSIX-only root test: `path.posix.dirname('/')` is `'/'` (length 1, so the
+ * loop exits) but `path.win32.dirname('C:\\')` is `'C:\\'` (length 3, so the
+ * loop never exits). One selected file OUTSIDE the run root — i.e. every
+ * normal `tests/*.test.cjs` — was therefore enough to spin here forever on
+ * Windows. It was silent and allocation-free (re-adding a present value to a
+ * Set is a no-op), so the job produced no output at all and simply sat until
+ * the CI cap killed it: every Windows shard on `next` timed out, scoped and
+ * full alike, from #4207 until this fix.
+ *
+ * Exported for in-process tests (tests/run-tests-temp-root.test.cjs).
+ *
+ * @param {string[]} selected absolute paths of the run's selected test files
+ * @param {string} runTempRoot the run-scoped temp root (walk stops there)
+ * @param {{dirname: (p: string) => string}} [pathMod] injectable for tests
+ * @returns {Set<string>} absolute paths the sweep must not remove
+ */
+function collectSweepProtectPaths(selected, runTempRoot, pathMod = nodePath) {
+  const { dirname } = pathMod;
+  const protect = new Set();
+  for (const f of selected) {
+    let cur = f;
+    while (cur && cur !== runTempRoot) {
+      const parent = dirname(cur);
+      // The filesystem root: '/' and 'C:\' alike. Break BEFORE adding it —
+      // protecting the root itself is meaningless (it is never a direct child
+      // of runTempRoot) and #4207 did not add it on POSIX either.
+      if (parent === cur) break;
+      protect.add(cur);
+      cur = parent;
+    }
+    if (cur === runTempRoot) protect.add(f); // exact-file case
+  }
+  return protect;
 }
 
 /**
@@ -1135,18 +1188,8 @@ function main() {
   // chunk still runs — a harness may stage synthetic test files under the run
   // root (tests/run-tests-harness.test.cjs's 30-file chunking fixture). Protect
   // every ancestor of every selected file that lies INSIDE the run root.
-  const sweepProtectSet = new Set();
-  {
-    const { dirname } = require('path');
-    for (const f of selected) {
-      let cur = f;
-      while (cur && cur !== runTempRoot && cur.length > 1) {
-        sweepProtectSet.add(cur);
-        cur = dirname(cur);
-      }
-      if (cur === runTempRoot) sweepProtectSet.add(f); // exact-file case
-    }
-  }
+  // #4220 — the walk lives in collectSweepProtectPaths; see its TERMINATION note.
+  const sweepProtectSet = collectSweepProtectPaths(selected, runTempRoot);
 
   // Sandbox the overlay home so the loader's global scan ($GSD_HOME/.gsd/capabilities)
   // cannot read a developer's real installed capabilities during tests (ADR-1244 D2).
@@ -1641,6 +1684,9 @@ module.exports = {
   walkTestFiles,
   // #4020: run-scoped temp root — see the block above their definitions.
   setupRunTempRoot,
+  // #4220: exported so the walk's termination is assertable under injected
+  // win32 path semantics — see its JSDoc.
+  collectSweepProtectPaths,
   sweepRunTempRoot,
   assertTempRootBounded,
 };

--- a/tests/run-tests-temp-root.test.cjs
+++ b/tests/run-tests-temp-root.test.cjs
@@ -12,6 +12,10 @@
  *
  * Unit rows exercise the runner's exported helpers in-process (the harness
  * convention); the spawn row drives the real CLI.
+ *
+ * #4220 extends this file to the protect-set walk that feeds the sweep; the
+ * rows drive it with an injected path module because the defect is unreachable
+ * from POSIX-only assertions. See collectSweepProtectPaths for the why.
  */
 
 const { test, describe } = require('node:test');
@@ -100,6 +104,133 @@ describe('#4020 — run-tests temp root', () => {
     assert.equal(protectedSwept, 1, 'only the unprotected entry is removed');
     assert.ok(fs.existsSync(path.join(root, 'gsd-leak-x')), 'the protected entry survives');
     assert.ok(!fs.existsSync(path.join(root, 'gsd-leak-y')), 'the unprotected entry is removed');
+  });
+
+  // #4220 — the ancestor walk that feeds sweepRunTempRoot's protect set.
+  // collectSweepProtectPaths's JSDoc carries the account of the defect; what
+  // matters here is that these rows inject the path module, because a
+  // pure-POSIX assertion cannot observe the class at all.
+  //
+  // BOUNDED BY CONSTRUCTION: the injected dirname throws once its call budget
+  // is spent, so a regression fails this test loudly instead of re-hanging CI
+  // the way the bug hangs the runner.
+  const budgetedPath = (impl, budget) => {
+    const state = { calls: 0 };
+    return {
+      state,
+      pathMod: {
+        dirname(p) {
+          if (++state.calls > budget) {
+            throw new Error(`ancestor walk exceeded ${budget} dirname() calls — it does not terminate`);
+          }
+          return impl.dirname(p);
+        },
+      },
+    };
+  };
+
+  test('the sweep protect walk terminates at a win32 drive root', () => {
+    const runner = require('../scripts/run-tests.cjs');
+    assert.equal(typeof runner.collectSweepProtectPaths, 'function',
+      'the runner must export collectSweepProtectPaths for in-process verification');
+
+    // The shape that hung CI: a selected file on C:\ while the run temp root is
+    // on a DIFFERENT branch of the tree, so the walk can never meet it and must
+    // stop at the drive root on its own.
+    const root = 'C:\\Users\\runner\\AppData\\Local\\Temp\\gsd-test-run-abc123';
+    const selected = ['C:\\a\\gsd-core\\tests\\run-tests-temp-root.test.cjs'];
+    const { state, pathMod } = budgetedPath(path.win32, 64);
+
+    let protectSet;
+    assert.doesNotThrow(
+      () => { protectSet = runner.collectSweepProtectPaths(selected, root, pathMod); },
+      'the walk terminates at the win32 drive root instead of spinning on it');
+    assert.ok(state.calls <= 8,
+      `the walk visits one ancestor per level (observed ${state.calls} dirname calls)`);
+    // #4207 semantics preserved: every ancestor between the file and the drive
+    // root is protected, and the drive root itself is not (it is never a direct
+    // child of the run root, so protecting it would be meaningless).
+    assert.ok(protectSet.has('C:\\a\\gsd-core\\tests\\run-tests-temp-root.test.cjs'), 'the file itself is protected');
+    assert.ok(protectSet.has('C:\\a\\gsd-core\\tests'), 'its parent directory is protected');
+    assert.ok(protectSet.has('C:\\a'), 'the topmost non-root ancestor is protected');
+    assert.ok(!protectSet.has('C:\\'), 'the drive root itself is not added');
+  });
+
+  test('the sweep protect walk terminates at a UNC and a long-path win32 root', () => {
+    // Adversarial review (#4220): rows using only `C:\\` pin the ONE sentinel
+    // that shipped, not the class. A "Windows-aware" length check
+    // (`cur.length > 3`) or a drive-letter regex (`/^[A-Za-z]:\\$/`) both pass
+    // those rows and both still spin here — a UNC share root and a `\\\\?\\`
+    // long-path root are neither short nor drive-letter-shaped. Only a dirname
+    // FIXED POINT terminates on all four.
+    const runner = require('../scripts/run-tests.cjs');
+    const root = 'C:\\Temp\\gsd-test-run-abc';
+    const selected = [
+      '\\\\srv\\share\\gsd-core\\tests\\a.test.cjs',
+      '\\\\?\\C:\\a\\gsd-core\\tests\\a.test.cjs',
+    ];
+    const { state, pathMod } = budgetedPath(path.win32, 64);
+
+    let protectSet;
+    assert.doesNotThrow(
+      () => { protectSet = runner.collectSweepProtectPaths(selected, root, pathMod); },
+      'the walk terminates at a UNC share root and at a long-path root');
+    assert.ok(state.calls <= 16, `bounded ancestor walk (observed ${state.calls} dirname calls)`);
+    // The fixed points themselves — path.win32.dirname returns these unchanged —
+    // must not be protected, exactly as the drive root is not.
+    assert.ok(protectSet.has('\\\\srv\\share\\gsd-core'), 'the topmost non-root UNC ancestor is protected');
+    assert.ok(!protectSet.has('\\\\srv\\share\\'), 'the UNC share root itself is not added');
+    assert.ok(protectSet.has('\\\\?\\C:\\a'), 'the topmost non-root long-path ancestor is protected');
+    assert.ok(!protectSet.has('\\\\?\\C:\\'), 'the long-path root itself is not added');
+  });
+
+  test('the sweep protect walk terminates at a posix filesystem root', () => {
+    const runner = require('../scripts/run-tests.cjs');
+    const root = '/tmp/gsd-test-run-abc123';
+    const selected = ['/home/runner/gsd-core/tests/run-tests-temp-root.test.cjs'];
+    const { state, pathMod } = budgetedPath(path.posix, 64);
+
+    let protectSet;
+    assert.doesNotThrow(
+      () => { protectSet = runner.collectSweepProtectPaths(selected, root, pathMod); },
+      'the walk terminates at the posix filesystem root');
+    assert.ok(state.calls <= 8, `bounded ancestor walk (observed ${state.calls} dirname calls)`);
+    assert.ok(protectSet.has('/home/runner/gsd-core/tests'), 'the parent directory is protected');
+    assert.ok(!protectSet.has('/'), 'the filesystem root itself is not added');
+  });
+
+  test('the sweep protect walk protects ancestors inside the run temp root', () => {
+    // #4020's actual purpose, asserted under BOTH path flavours: a harness
+    // stages synthetic test files under the run root, and the walk must protect
+    // the directory chain up to (but not including) the root so the
+    // between-chunk sweep leaves them standing for later chunks.
+    const runner = require('../scripts/run-tests.cjs');
+
+    for (const [label, impl, root, file, ancestor] of [
+      ['win32', path.win32, 'C:\\Temp\\gsd-test-run-abc', 'C:\\Temp\\gsd-test-run-abc\\staged\\a.test.cjs', 'C:\\Temp\\gsd-test-run-abc\\staged'],
+      ['posix', path.posix, '/tmp/gsd-test-run-abc', '/tmp/gsd-test-run-abc/staged/a.test.cjs', '/tmp/gsd-test-run-abc/staged'],
+    ]) {
+      const { pathMod } = budgetedPath(impl, 64);
+      const protectSet = runner.collectSweepProtectPaths([file], root, pathMod);
+      assert.ok(protectSet.has(file), `${label}: the staged file is protected`);
+      assert.ok(protectSet.has(ancestor),
+        `${label}: the staged file's directory — a DIRECT child of the run root, i.e. exactly what sweepRunTempRoot tests — is protected`);
+      assert.ok(!protectSet.has(root), `${label}: the run root itself is not in the protect set`);
+    }
+  });
+
+  test('the sweep protect walk keeps the exact-file case', () => {
+    // A selected path that IS the run root: the loop body never runs, and the
+    // `if (cur === runTempRoot)` branch below it is what puts the entry in the
+    // set. #4207 shipped that branch unreachable on Windows (the loop above it
+    // never exited); assert it under win32 so it stays reachable.
+    const runner = require('../scripts/run-tests.cjs');
+    const root = 'C:\\Temp\\gsd-test-run-abc';
+    const { state, pathMod } = budgetedPath(path.win32, 64);
+    const protectSet = runner.collectSweepProtectPaths([root], root, pathMod);
+    assert.deepEqual([...protectSet], [root],
+      'the exact-file case adds the path itself and nothing else');
+    assert.equal(state.calls, 0, 'no ancestor walk is needed when the file IS the root');
   });
 
   test('the leak guard fails fast naming the leaked roots', (t) => {


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #4220

Reported, bisected and isolated by @davdittrich, who identified #4207 as the cause by merging that commit alone onto a previously green head. Triage and `confirmed-bug` by @trek-e.

---

## What was broken

Every Windows CI shard on `next` timed out — scoped at 21 minutes, full at 45 — from #4207 (`7d6d788b5`) until now. `next` could not produce a green required Windows matrix, so no PR that synchronized with it could become merge-ready regardless of what it touched.

## What this fix does

Ends the sweep's ancestor walk at `dirname`'s fixed point (`dirname(x) === x`) instead of at a string-length sentinel. Nothing else about #4207 changes.

## Root cause

#4207 protects every ancestor of every selected test file from the between-chunk temp sweep by walking `dirname` upward, ending on `cur.length > 1`. That is a POSIX-only test for "reached the filesystem root":

```
path.posix.dirname('/')     === '/'      length 1  → loop exits
path.win32.dirname('C:\\')  === 'C:\\'   length 3  → loop never exits
```

One selected file outside the run temp root — i.e. every ordinary `tests/*.test.cjs` — was enough to spin forever on Windows. It spun *silently* and without allocating, since re-adding a present value to a `Set` is a no-op, so the job emitted no output and simply sat until the cap killed it. That is why a single-file scoped shard failed identically to a full one: it has nothing to do with test volume, only with whether any selected path lies outside the root. The `if (cur === runTempRoot)` exact-file branch below the loop was unreachable on Windows for the same reason.

The fix computes the parent before the add, so the root itself is still never protected and the produced set is unchanged for every path the runner constructs.

## Testing

### How I verified the fix

Reverting only the termination condition (keeping the extraction) fails the new rows:

```
✖ the sweep protect walk terminates at a win32 drive root
  "ancestor walk exceeded 64 dirname() calls — it does not terminate"
```

Mutation-checked against three plausible sentinels — the shipped `cur.length > 1`, a "Windows-aware" `cur.length > 3`, and a drive-letter regex `/^[A-Za-z]:\\$/`. All three hang; all three are caught. The latter two survive a `C:\`-only test, which is why a row covers a UNC share root and a `\\?\` long-path root too: the rows pin the *class*, not the one sentinel that shipped.

Back-compatibility was checked by differential execution against #4207's loop reconstructed verbatim, over structured and fuzzed corpora in both path flavours. For every path the runner can construct the sets are identical. (`selected` is built as `join(testDir, f)` with an absolute `testDir`; the only divergence found anywhere was that a *relative* path with a one-character segment now gains that segment, since `length > 1` also stopped at any 1-char string. New output is a superset in 100% of cases where #4207 terminated.)

Also confirmed against the real consumer: `sweepRunTempRoot` only ever asks `protect.has(join(root, name))` for direct children of the run root, and the set of protected direct children is unchanged.

| Gate | Result |
|---|---|
| `node --test tests/run-tests-temp-root.test.cjs tests/run-tests-harness.test.cjs` | 189/189 |
| 8 other test files referencing `run-tests.cjs` | 422 pass, 10 skipped |
| `npm run lint` | clean |
| `lint-fix-has-regression-tests` / `lint-regression-test-names` | pass |
| `qa-smell-ratchet` / `lint-source-test-name-collision` / `check-contract-drift` | pass |
| `changeset/lint.cjs` | `ok_no_user_facing_changes` |

I cannot exercise the real Windows matrix locally — that verification is this PR's own CI run.

### Regression test added?

- [x] Yes — added a test that would have caught this bug

Four rows in `tests/run-tests-temp-root.test.cjs`, driving the walk with an injected `path.win32` / `path.posix`. A pure-POSIX assertion cannot observe this class at all, which is how the bug reached `next` past a green Linux and macOS matrix. The injected `dirname` throws once its call budget is spent, so a regression fails in milliseconds instead of re-hanging CI the way the bug does.

The walk moves into an exported `collectSweepProtectPaths` to make that possible. It previously ran inline in `main()` with no observable output, so there was no other seam; the behavioral change is still only the termination condition.

### Platforms tested

- [ ] macOS
- [x] Windows (including backslash path handling) — via injected `path.win32`, plus UNC and `\\?\` roots; the real matrix runs in this PR's CI
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass
- [x] `.changeset/` fragment — not required; `changeset/lint.cjs` gates on `bin/ gsd-core/ src/ agents/ commands/ hooks/` and this touches only `scripts/` and `tests/`, returning `ok_no_user_facing_changes`. CONTRIBUTING.md names "CI tweaks / test refactors" as non-user-facing.
- [x] No unnecessary dependencies added

## Breaking changes

None. #4207's run-scoped temp root, sweep, ancestor protection, TMPDIR precedence and nested-runner ownership gating are all untouched — only the walk's termination condition changes.

> Note: #4226 also touches `scripts/run-tests.cjs`, in different regions (chunk ranking and the `module.exports` block). No semantic overlap with the sweep walk; at most a trivial conflict in the exports list depending on merge order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BCPSU591zVS9vLPd3gKnqn
