### PR TITLE
fix(#3968): measure commit claims at all three surfaces — ledger, verifier BLOCKER, porcelain HANDOFF

### DIFF
--- a/.changeset/zesty-cranes-dance.md
+++ b/.changeset/zesty-cranes-dance.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 4230
 ---
 **Executor commit claims are measured, not narrated** — the executor records the pre-plan HEAD and derives `commits:` from `git rev-list` (HALT if code sits uncommitted), `/gsd:verify-work` reconciles the claim against git with the same instrument and flags a mismatch as a BLOCKER, and HANDOFF's `uncommitted_files` comes from `git status --porcelain`. (#3968)

--- a/.changeset/zesty-cranes-dance.md
+++ b/.changeset/zesty-cranes-dance.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**Executor commit claims are measured, not narrated** — the executor records the pre-plan HEAD and derives `commits:` from `git rev-list` (HALT if code sits uncommitted), `/gsd:verify-work` reconciles the claim against git with the same instrument and flags a mismatch as a BLOCKER, and HANDOFF's `uncommitted_files` comes from `git status --porcelain`. (#3968)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -171,7 +171,7 @@ jobs:
     # change beyond sharing the same job-level `timeout-minutes`.
     # tests/ci-test-job-timeout-budget.test.cjs holds every lane here to a
     # headroom factor over its own measured cost.
-    timeout-minutes: 21
+    timeout-minutes: 32
     env:
       GSD_PLUGIN_ROOT: .ci-gsd-plugin-root-disabled
       # #2665: a live-config leak fails the run on Linux/macOS lanes. Windows
@@ -411,7 +411,7 @@ jobs:
         continue-on-error: true
         env:
           CI_JOB_LABEL: "test (${{ matrix.os }}, ${{ matrix.node-version }}${{ matrix.shard && format(', shard {0}', matrix.shard) || '' }})"
-          CI_JOB_TIMEOUT_MINUTES: '21'
+          CI_JOB_TIMEOUT_MINUTES: '32'
         run: node scripts/ci-check-job-near-cap.cjs
 
   test-inert:

--- a/agents/gsd-executor.md
+++ b/agents/gsd-executor.md
@@ -670,7 +670,7 @@ changed code means the changes are sitting UNCOMMITTED in the working tree: **HA
 write the SUMMARY with a narrated count.** Surface the state (`git status --short`) and the
 failed/missing commit step in your return message so the orchestrator can recover the work.
 A measured `0` with NO code changes (docs-only/no-op plan) is legitimate — write it and move
-on. `/gsd-verify-work` cross-checks this number against git and flags a mismatch as a
+on. `/gsd:verify-work` cross-checks this number against git and flags a mismatch as a
 BLOCKER, so a narrated count will fail the phase later — measure it now.
 
 **Title:** `# Phase [X] Plan [Y]: [Name] Summary`

--- a/agents/gsd-executor.md
+++ b/agents/gsd-executor.md
@@ -537,6 +537,14 @@ git add src/types/user.ts
 ```bash
 gsd_run query commit-to-subrepo "{type}({phase}-{plan}): {concise task description}" --files file1 file2 ...
 ```
+**0b. Plan commit ledger (#3968, single-repo — capture ONCE per plan, before the FIRST commit):**
+```bash
+PLAN_HEAD_BEFORE=${PLAN_HEAD_BEFORE:-$(git rev-parse HEAD)}
+```
+The SUMMARY's `commits:` number is MEASURED from this ledger at SUMMARY-write time (see the
+write contract) — never counted from memory. Multi-repo (`sub_repos`) keeps recording the
+commit-to-subrepo JSON hashes instead; the ledger is the single-repo path.
+
 Returns JSON with per-repo commit hashes: `{ committed: true, repos: { "backend": { hash: "abc", files: [...] }, ... } }`. Record all hashes for SUMMARY.
 
 **Otherwise (standard single-repo):**
@@ -649,9 +657,21 @@ This file is the canonical output of this step. The orchestrator reads `.plannin
 actuals:
   tokens: 74000    # chars/4 over the files you actually changed
   tasks: 5         # tasks completed
-  commits: 7       # commits made
+  commits: 7       # MEASURED: git rev-list --count ${PLAN_HEAD_BEFORE}..HEAD (#3968)
 ```
 These pair with the plan's `estimate` to calibrate future estimates (ADR-2629). Do not round to look closer to the estimate — a flattering number corrupts every later projection.
+
+**`commits:` is measured, never narrated (#3968).** At SUMMARY-write time, derive it from the plan commit ledger captured in `<task_commit_protocol>` 0b:
+```bash
+COMMITS_ACTUAL=$(git rev-list --count ${PLAN_HEAD_BEFORE}..HEAD)
+```
+Write `commits: ${COMMITS_ACTUAL}` — including when it is `0`. A measured `0` while the plan
+changed code means the changes are sitting UNCOMMITTED in the working tree: **HALT — do not
+write the SUMMARY with a narrated count.** Surface the state (`git status --short`) and the
+failed/missing commit step in your return message so the orchestrator can recover the work.
+A measured `0` with NO code changes (docs-only/no-op plan) is legitimate — write it and move
+on. `/gsd-verify-work` cross-checks this number against git and flags a mismatch as a
+BLOCKER, so a narrated count will fail the phase later — measure it now.
 
 **Title:** `# Phase [X] Plan [Y]: [Name] Summary`
 

--- a/agents/gsd-executor.md
+++ b/agents/gsd-executor.md
@@ -537,20 +537,17 @@ git add src/types/user.ts
 ```bash
 gsd_run query commit-to-subrepo "{type}({phase}-{plan}): {concise task description}" --files file1 file2 ...
 ```
-**0c. Plan commit ledger (#3968, single-repo — BEFORE the first commit of the plan):**
-Each Bash call is a FRESH shell, so the ledger must persist on disk exactly like the #3097
-sentinel above — a shell variable would be unset at SUMMARY time and `git rev-list --count
-..HEAD` would silently measure zero. Per-plan filename so sequential plans cannot contaminate
-each other:
+**0c. Plan commit ledger (#3968, single-repo — before the first commit):**
+Each Bash call is a FRESH shell, so the ledger persists on disk like the #3097 sentinel above
+(a variable would be unset at SUMMARY time and `rev-list ..HEAD` would measure zero).
+Per-plan filename, so sequential plans cannot contaminate each other:
 ```bash
 _GSD_LEDGER="$(git rev-parse --git-dir)/gsd-plan-head-before-{phase}-{plan}"
 [ -f "$_GSD_LEDGER" ] || git rev-parse HEAD > "$_GSD_LEDGER"
-PLAN_HEAD_BEFORE=$(cat "$_GSD_LEDGER")
 ```
-The SUMMARY's `commits:` number is MEASURED from this ledger at SUMMARY-write time (see the
-write contract) and the base is recorded in the frontmatter as `plan_head_before:` so
-`/gsd:verify-work` can reconcile with the SAME instrument. Multi-repo (`sub_repos`) keeps
-recording the commit-to-subrepo JSON hashes instead; the ledger is the single-repo path.
+The SUMMARY's `commits:` is MEASURED from this ledger, the base recorded as
+`plan_head_before:` for `/gsd:verify-work`'s same-instrument check. Multi-repo keeps commit-to-subrepo
+JSON hashes instead.
 
 Returns JSON with per-repo commit hashes: `{ committed: true, repos: { "backend": { hash: "abc", files: [...] }, ... } }`. Record all hashes for SUMMARY.
 
@@ -668,18 +665,17 @@ actuals:
 ```
 These pair with the plan's `estimate` to calibrate future estimates (ADR-2629). Do not round to look closer to the estimate — a flattering number corrupts every later projection.
 
-**`commits:` is measured, never narrated (#3968).** At SUMMARY-write time, read the
-persisted plan commit ledger (see `<task_commit_protocol>` 0c — each Bash call is a fresh
-shell, so the base comes from disk, never memory):
+**`commits:` is measured, never narrated (#3968).** At SUMMARY write, read the persisted
+ledger (protocol 0c — a fresh shell per Bash call; the base comes from disk):
 ```bash
 PLAN_HEAD_BEFORE=$(cat "$(git rev-parse --git-dir)/gsd-plan-head-before-{phase}-{plan}")
 COMMITS_ACTUAL=$(git rev-list --count ${PLAN_HEAD_BEFORE}..HEAD)
 ```
-Write BOTH into the frontmatter — `commits: ${COMMITS_ACTUAL}` and
+Write BOTH into the frontmatter — `commits: ${COMMITS_ACTUAL}`,
 `plan_head_before: ${PLAN_HEAD_BEFORE}` — including when the count is `0`.
-A measured `0` with NO code changes (docs-only/no-op plan) is legitimate — write it and move
-on. `/gsd:verify-work` cross-checks this number against git and flags a mismatch as a
-BLOCKER, so a narrated count will fail the phase later — measure it now.
+A `0` with code changes means the changes sit UNCOMMITTED: **HALT — do not write the
+SUMMARY with a narrated count**; surface `git status --short` in your return. A `0` with no
+code changes (docs-only) is legitimate. `/gsd:verify-work` flags mismatches as BLOCKER.
 
 **Title:** `# Phase [X] Plan [Y]: [Name] Summary`
 

--- a/agents/gsd-executor.md
+++ b/agents/gsd-executor.md
@@ -537,13 +537,20 @@ git add src/types/user.ts
 ```bash
 gsd_run query commit-to-subrepo "{type}({phase}-{plan}): {concise task description}" --files file1 file2 ...
 ```
-**0b. Plan commit ledger (#3968, single-repo — capture ONCE per plan, before the FIRST commit):**
+**0c. Plan commit ledger (#3968, single-repo — BEFORE the first commit of the plan):**
+Each Bash call is a FRESH shell, so the ledger must persist on disk exactly like the #3097
+sentinel above — a shell variable would be unset at SUMMARY time and `git rev-list --count
+..HEAD` would silently measure zero. Per-plan filename so sequential plans cannot contaminate
+each other:
 ```bash
-PLAN_HEAD_BEFORE=${PLAN_HEAD_BEFORE:-$(git rev-parse HEAD)}
+_GSD_LEDGER="$(git rev-parse --git-dir)/gsd-plan-head-before-{phase}-{plan}"
+[ -f "$_GSD_LEDGER" ] || git rev-parse HEAD > "$_GSD_LEDGER"
+PLAN_HEAD_BEFORE=$(cat "$_GSD_LEDGER")
 ```
 The SUMMARY's `commits:` number is MEASURED from this ledger at SUMMARY-write time (see the
-write contract) — never counted from memory. Multi-repo (`sub_repos`) keeps recording the
-commit-to-subrepo JSON hashes instead; the ledger is the single-repo path.
+write contract) and the base is recorded in the frontmatter as `plan_head_before:` so
+`/gsd:verify-work` can reconcile with the SAME instrument. Multi-repo (`sub_repos`) keeps
+recording the commit-to-subrepo JSON hashes instead; the ledger is the single-repo path.
 
 Returns JSON with per-repo commit hashes: `{ committed: true, repos: { "backend": { hash: "abc", files: [...] }, ... } }`. Record all hashes for SUMMARY.
 
@@ -661,14 +668,15 @@ actuals:
 ```
 These pair with the plan's `estimate` to calibrate future estimates (ADR-2629). Do not round to look closer to the estimate — a flattering number corrupts every later projection.
 
-**`commits:` is measured, never narrated (#3968).** At SUMMARY-write time, derive it from the plan commit ledger captured in `<task_commit_protocol>` 0b:
+**`commits:` is measured, never narrated (#3968).** At SUMMARY-write time, read the
+persisted plan commit ledger (see `<task_commit_protocol>` 0c — each Bash call is a fresh
+shell, so the base comes from disk, never memory):
 ```bash
+PLAN_HEAD_BEFORE=$(cat "$(git rev-parse --git-dir)/gsd-plan-head-before-{phase}-{plan}")
 COMMITS_ACTUAL=$(git rev-list --count ${PLAN_HEAD_BEFORE}..HEAD)
 ```
-Write `commits: ${COMMITS_ACTUAL}` — including when it is `0`. A measured `0` while the plan
-changed code means the changes are sitting UNCOMMITTED in the working tree: **HALT — do not
-write the SUMMARY with a narrated count.** Surface the state (`git status --short`) and the
-failed/missing commit step in your return message so the orchestrator can recover the work.
+Write BOTH into the frontmatter — `commits: ${COMMITS_ACTUAL}` and
+`plan_head_before: ${PLAN_HEAD_BEFORE}` — including when the count is `0`.
 A measured `0` with NO code changes (docs-only/no-op plan) is legitimate — write it and move
 on. `/gsd:verify-work` cross-checks this number against git and flags a mismatch as a
 BLOCKER, so a narrated count will fail the phase later — measure it now.

--- a/gsd-core/workflows/pause-work.md
+++ b/gsd-core/workflows/pause-work.md
@@ -106,13 +106,23 @@ timestamp=$(gsd_run query current-timestamp full --raw)
   "decisions": [
     {"decision": "{what}", "rationale": "{why}", "phase": "{phase_number}"}
   ],
-  "uncommitted_files": [],
+  "uncommitted_files": ["XY path", "..."],  # #3968: MEASURED — see below
   "next_action": "{specific first action when resuming}",
   "context_notes": "{mental state, approach, what you were thinking}"
 }
 ```
 
 Any recorded `async_jobs` entries are the primary resume context on the next session — check them first before treating a PLAN-without-SUMMARY as incomplete work.
+
+**`uncommitted_files` is measured, never asserted (#3968).** Populate it from an actual call,
+not from memory — a narrated `[]` over a dirty tree is how 14 plans' worth of uncommitted
+code went invisible in the wild:
+```bash
+UNCOMMITTED=$(git status --porcelain)
+# One array entry per line ("XY path"); truncate the list at 50 entries and note the
+# elided count, but NEVER round it to empty — a non-empty porcelain output is the single
+# most load-bearing fact a resume session needs.
+```
 </step>
 
 <step name="write">

--- a/gsd-core/workflows/verify-work.md
+++ b/gsd-core/workflows/verify-work.md
@@ -174,22 +174,25 @@ ls "$phase_dir"/*-SUMMARY.md 2>/dev/null || true
 Read each SUMMARY.md to extract testable deliverables.
 
 **Commit-claim reconciliation (#3968).** A SUMMARY's `commits:` frontmatter is a MEASURED
-number (the executor derives it from its plan commit ledger), and this is where that claim is
-checked against reality — the executor's own narration is never the last word. For each
-`*-SUMMARY.md` with a `commits:` field, compare it against the git history that exists for
-the plan:
+number (the executor derives it from its on-disk plan commit ledger and records the base as
+`plan_head_before:`), and this is where that claim is checked against reality with the SAME
+instrument — the executor's own narration is never the last word. For each `*-SUMMARY.md`:
 ```bash
-# Over the plan's own scope: the anchored, milestone-bounded commit grep (#4003 shape).
-CLAIMED=$(grep -oE '^commits: [0-9]+' "$SUMMARY_FILE" | grep -oE '[0-9]+' || echo "absent")
-ACTUAL=$(git log --oneline -E --grep="${PLAN_SCOPE_RE}" | wc -l | tr -d ' ')
+BASE=$(grep -oE '^plan_head_before: [0-9a-f]{7,40}' "$SUMMARY_FILE" | awk '{print $2}')
+CLAIMED=$(grep -oE '^commits: [0-9]+' "$SUMMARY_FILE" | grep -oE '[0-9]+' || echo absent)
+ACTUAL=$(git rev-list --count ${BASE}..HEAD)
 ```
-A `commits: absent` SUMMARY (pre-#3968 legacy) is reported as a WARNING with the
-measured actual, not a mismatch. A CLAIMED ≠ ACTUAL mismatch is a **BLOCKER** — the phase
-must not read as done: real project evidence (#3968) showed 14 plans declaring `commits: 1`
-with zero git activity, their code sitting uncommitted and one `git reset --hard` from loss.
-Record it as `commit_claim_mismatch` with both numbers and the SUMMARY path; a mismatch
-means either the executor narrated instead of measuring or commits were lost after the
-fact — both require reconciliation before the phase can pass.
+- A `commits: absent` or `plan_head_before: absent` SUMMARY (pre-#3968 legacy) is reported as
+  a WARNING with the measured git state, not a mismatch.
+- `ACTUAL == CLAIMED` is consistent. `ACTUAL == CLAIMED + 1` is ALSO consistent: the
+  SUMMARY/metadata commit itself lands after the executor measured, so exactly one
+  post-measurement commit is expected.
+- Anything else is a **BLOCKER** — the phase must not read as done: real project evidence
+  (#3968) showed 14 plans declaring `commits: 1` with zero git activity, their code sitting
+  uncommitted and one `git reset --hard` from loss. Record it as `commit_claim_mismatch`
+  with both numbers and the SUMMARY path; a mismatch means either the executor narrated
+  instead of measuring or commits were lost after the fact — both require reconciliation
+  before the phase can pass.
 </step>
 
 <step name="extract_tests">

--- a/gsd-core/workflows/verify-work.md
+++ b/gsd-core/workflows/verify-work.md
@@ -172,6 +172,24 @@ ls "$phase_dir"/*-SUMMARY.md 2>/dev/null || true
 ```
 
 Read each SUMMARY.md to extract testable deliverables.
+
+**Commit-claim reconciliation (#3968).** A SUMMARY's `commits:` frontmatter is a MEASURED
+number (the executor derives it from its plan commit ledger), and this is where that claim is
+checked against reality — the executor's own narration is never the last word. For each
+`*-SUMMARY.md` with a `commits:` field, compare it against the git history that exists for
+the plan:
+```bash
+# Over the plan's own scope: the anchored, milestone-bounded commit grep (#4003 shape).
+CLAIMED=$(grep -oE '^commits: [0-9]+' "$SUMMARY_FILE" | grep -oE '[0-9]+' || echo "absent")
+ACTUAL=$(git log --oneline -E --grep="${PLAN_SCOPE_RE}" | wc -l | tr -d ' ')
+```
+A `commits: absent` SUMMARY (pre-#3968 legacy) is reported as a WARNING with the
+measured actual, not a mismatch. A CLAIMED ≠ ACTUAL mismatch is a **BLOCKER** — the phase
+must not read as done: real project evidence (#3968) showed 14 plans declaring `commits: 1`
+with zero git activity, their code sitting uncommitted and one `git reset --hard` from loss.
+Record it as `commit_claim_mismatch` with both numbers and the SUMMARY path; a mismatch
+means either the executor narrated instead of measuring or commits were lost after the
+fact — both require reconciliation before the phase can pass.
 </step>
 
 <step name="extract_tests">

--- a/gsd-core/workflows/verify-work.md
+++ b/gsd-core/workflows/verify-work.md
@@ -180,7 +180,7 @@ instrument — the executor's own narration is never the last word. For each `*-
 ```bash
 BASE=$(grep -oE '^plan_head_before: [0-9a-f]{7,40}' "$SUMMARY_FILE" | awk '{print $2}')
 CLAIMED=$(grep -oE '^commits: [0-9]+' "$SUMMARY_FILE" | grep -oE '[0-9]+' || echo absent)
-ACTUAL=$(git rev-list --count ${BASE}..HEAD)
+ACTUAL=$(git rev-list --count "${BASE}"..HEAD)
 ```
 - A `commits: absent` or `plan_head_before: absent` SUMMARY (pre-#3968 legacy) is reported as
   a WARNING with the measured git state, not a mismatch.

--- a/tests/ci-test-job-timeout-budget.test.cjs
+++ b/tests/ci-test-job-timeout-budget.test.cjs
@@ -65,7 +65,16 @@ const LANE_COSTS = [
     // figure — rounded up from the higher, cancelled-run observation, since a
     // cancelled run's own timestamp is still real elapsed time even though the
     // job never finished.
-    measuredMinutes: 14,
+    // #4070's method applied again: the 14-minute figure went stale after
+    // #4207's run-tests temp-root regression suite landed — its rows spawn
+    // real runner instances on the windows scoped lane (each booting the full
+    // build), and windows shards 1-2 were CANCELLED at 99% of the 21-minute
+    // cap on three consecutive runs (33722188315 and two reruns; ubuntu and
+    // macos lanes green throughout, other PRs' windows lanes green — the
+    // long pole is this lane's windows matrix alone). A cancelled run's own
+    // timestamp is still real elapsed time: >=21 minutes, so 21 is the
+    // honest floor and the budget moves 21 -> 32 (1.5x headroom).
+    measuredMinutes: 21,
     // Sharded three ways as of #2952, so this is ONE shard's cost, not the
     // whole unit suite. Shard 1 is the long pole because the unsharded aux
     // suites (integration/security/install/slow) ride on it — #4070 fixed the
@@ -242,7 +251,7 @@ test('mutation.yml mutate job timeout budgets (#4036)', async (t) => {
 
 test('near-cap check CI_JOB_TIMEOUT_MINUTES literals match each job\'s own timeout-minutes (#4036)', async (t) => {
   const staticLanes = [
-    { workflowFile: 'test.yml', jobKey: 'test', envLiteral: '21' },
+    { workflowFile: 'test.yml', jobKey: 'test', envLiteral: '32' },
     { workflowFile: 'test.yml', jobKey: 'test-full', envLiteral: '45' },
     { workflowFile: 'install-smoke.yml', jobKey: 'smoke', envLiteral: '12' },
   ];

--- a/tests/no-bare-gsd-tools-command-position.test.cjs
+++ b/tests/no-bare-gsd-tools-command-position.test.cjs
@@ -103,7 +103,7 @@ const BARE_COMMAND_RE = new RegExp(
 // Each entry MUST carry a one-line reason; the test prints the allowlist on
 // failure so a reviewer can see exactly what is sanctioned.
 const PROSE_ALLOWLIST = [
-  { file: 'agents/gsd-executor.md', line: 815, reason: 'describes the SDK return envelope of `gsd-tools query commit`; not an instruction to run the bare word' },
+  { file: 'agents/gsd-executor.md', line: 819, reason: 'describes the SDK return envelope of `gsd-tools query commit`; not an instruction to run the bare word' },
   { file: 'agents/gsd-phase-researcher.md', line: 33, reason: 'package-legitimacy provenance rule names the command as the source of an OK verdict; descriptive' },
   { file: 'agents/gsd-roadmapper.md', line: 647, reason: 'parenthetical "e.g." naming SDK queries a user *could* run; not an agent instruction' },
   { file: 'agents/gsd-intel-updater.md', line: 40, reason: 'cross-platform note names the `gsd-tools intel <subcommand>` CLI surface descriptively ("CLI invocations go through..."); not an agent instruction' },

--- a/tests/no-bare-gsd-tools-command-position.test.cjs
+++ b/tests/no-bare-gsd-tools-command-position.test.cjs
@@ -103,7 +103,7 @@ const BARE_COMMAND_RE = new RegExp(
 // Each entry MUST carry a one-line reason; the test prints the allowlist on
 // failure so a reviewer can see exactly what is sanctioned.
 const PROSE_ALLOWLIST = [
-  { file: 'agents/gsd-executor.md', line: 795, reason: 'describes the SDK return envelope of `gsd-tools query commit`; not an instruction to run the bare word' },
+  { file: 'agents/gsd-executor.md', line: 815, reason: 'describes the SDK return envelope of `gsd-tools query commit`; not an instruction to run the bare word' },
   { file: 'agents/gsd-phase-researcher.md', line: 33, reason: 'package-legitimacy provenance rule names the command as the source of an OK verdict; descriptive' },
   { file: 'agents/gsd-roadmapper.md', line: 647, reason: 'parenthetical "e.g." naming SDK queries a user *could* run; not an agent instruction' },
   { file: 'agents/gsd-intel-updater.md', line: 40, reason: 'cross-platform note names the `gsd-tools intel <subcommand>` CLI surface descriptively ("CLI invocations go through..."); not an agent instruction' },

--- a/tests/summary-commit-verification.test.cjs
+++ b/tests/summary-commit-verification.test.cjs
@@ -39,8 +39,8 @@ describe('#3968 — measured commit claims', () => {
     const verify = read('gsd-core/workflows/verify-work.md');
     assert.ok(verify.includes('Commit-claim reconciliation'),
       'verify-work must run a commit-claim reconciliation over each SUMMARY');
-    assert.ok(verify.includes('git rev-list --count'),
-      'the reconciliation compares the claimed count against rev-list');
+    assert.ok(/git (?:rev-list --count|log)/.test(verify.slice(verify.indexOf('Commit-claim reconciliation'), verify.indexOf('Commit-claim reconciliation') + 1800)),
+      'the reconciliation compares the claimed count against git');
     assert.ok(/BLOCKER/.test(verify.slice(verify.indexOf('Commit-claim reconciliation'), verify.indexOf('Commit-claim reconciliation') + 1800)),
       'a mismatch must be flagged BLOCKER — the phase must not read as done');
   });

--- a/tests/summary-commit-verification.test.cjs
+++ b/tests/summary-commit-verification.test.cjs
@@ -1,0 +1,58 @@
+'use strict';
+
+/**
+ * #3968 — commit claims must be measured, never narrated.
+ *
+ * Across 14 plans / 3 phases in a real project, `commits: 1` appeared in every
+ * SUMMARY while `git reflog` showed ZERO git activity in the window, and
+ * HANDOFF.json asserted `uncommitted_files: []` over a dirty tree — invisible
+ * because nothing downstream cross-checks the narration against git. The fix
+ * (maintainer decision, option c) spans three shipped surfaces; their text IS
+ * the runtime-loaded contract, so shape assertions are the faithful check.
+ */
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.join(__dirname, '..');
+const read = (p) => fs.readFileSync(path.join(ROOT, p), 'utf8');
+
+describe('#3968 — measured commit claims', () => {
+  test('executor measures commits, never narrates them', () => {
+    const executor = read('agents/gsd-executor.md');
+    // The ledger: HEAD captured at the plan's first commit, once per plan.
+    assert.ok(executor.includes('PLAN_HEAD_BEFORE'),
+      'the commit protocol must capture the pre-plan HEAD (PLAN_HEAD_BEFORE)');
+    assert.ok(executor.includes('git rev-list --count'),
+      'the SUMMARY commit count must come from git rev-list --count, not narration');
+    // A measured zero WITH code changes is a HALT, never a narrated success.
+    assert.ok(/HALT|do not write the SUMMARY/i.test(
+      executor.slice(executor.indexOf('#3968'), executor.indexOf('#3968') + 2000)),
+      'a measured zero with uncommitted code changes must halt the SUMMARY write');
+    // actuals.commits sources the same measured number (ADR-2629 shape kept).
+    assert.ok(executor.includes('actuals'),
+      'the actuals block is still present (calibration shape preserved)');
+  });
+
+  test('verify-work flags SUMMARY-vs-git mismatch as BLOCKER', () => {
+    const verify = read('gsd-core/workflows/verify-work.md');
+    assert.ok(verify.includes('commit-claim reconciliation'),
+      'verify-work must run a commit-claim reconciliation over each SUMMARY');
+    assert.ok(verify.includes('git rev-list --count'),
+      'the reconciliation compares the claimed count against rev-list');
+    assert.ok(/BLOCKER/.test(verify.slice(verify.indexOf('commit-claim reconciliation'), verify.indexOf('commit-claim reconciliation') + 1500)),
+      'a mismatch must be flagged BLOCKER — the phase must not read as done');
+  });
+
+  test('HANDOFF uncommitted_files come from git status --porcelain', () => {
+    const pause = read('gsd-core/workflows/pause-work.md');
+    assert.ok(pause.includes('git status --porcelain'),
+      'uncommitted_files must be populated from an actual git status --porcelain call');
+    // The asserted-empty template literal is gone as the only source.
+    const idx = pause.indexOf('uncommitted_files');
+    assert.ok(idx === -1 || /porcelain/.test(pause.slice(Math.max(0, idx - 3000), idx + 3000)),
+      'the uncommitted_files field is defined by the porcelain command, not a narrated []');
+  });
+});

--- a/tests/summary-commit-verification.test.cjs
+++ b/tests/summary-commit-verification.test.cjs
@@ -30,7 +30,7 @@ describe('#3968 — measured commit claims', () => {
     assert.ok(executor.includes('plan_head_before: ${PLAN_HEAD_BEFORE}'),
       'the base is recorded in the frontmatter so the verifier reconciles with the same instrument');
     // A measured zero WITH code changes is a HALT, never a narrated success.
-    assert.ok(/HALT — do not\s+write the SUMMARY/i.test(executor),
+    assert.ok(/HALT — do not write the\s+SUMMARY/i.test(executor),
       'a measured zero with uncommitted code changes must halt the SUMMARY write');
     // actuals.commits sources the measured count; the ADR-2629 calibration shape is kept.
     assert.ok(/commits: 7 .*MEASURED/.test(executor),

--- a/tests/summary-commit-verification.test.cjs
+++ b/tests/summary-commit-verification.test.cjs
@@ -41,7 +41,7 @@ describe('#3968 — measured commit claims', () => {
     const verify = read('gsd-core/workflows/verify-work.md');
     assert.ok(verify.includes('Commit-claim reconciliation'),
       'verify-work must run a commit-claim reconciliation over each SUMMARY');
-    assert.ok(verify.includes('ACTUAL=$(git rev-list --count ${BASE}..HEAD)'),
+    assert.ok(verify.includes('ACTUAL=$(git rev-list --count "${BASE}"..HEAD)'),
       'the reconciliation uses the SAME instrument as the executor (rev-list over the recorded base)');
     assert.ok(/ACTUAL == CLAIMED \+ 1/.test(verify),
       'the post-measurement SUMMARY commit is an expected +1, not a false BLOCKER');

--- a/tests/summary-commit-verification.test.cjs
+++ b/tests/summary-commit-verification.test.cjs
@@ -23,24 +23,28 @@ describe('#3968 — measured commit claims', () => {
   test('executor measures commits, never narrates them', () => {
     const executor = read('agents/gsd-executor.md');
     // The ledger: HEAD captured at the plan's first commit, once per plan.
-    assert.ok(executor.includes('PLAN_HEAD_BEFORE'),
-      'the commit protocol must capture the pre-plan HEAD (PLAN_HEAD_BEFORE)');
+    assert.ok(executor.includes('gsd-plan-head-before'),
+      'the ledger must persist on disk (each Bash call is a fresh shell — a variable measures zero)');
     assert.ok(executor.includes('git rev-list --count'),
       'the SUMMARY commit count must come from git rev-list --count, not narration');
+    assert.ok(executor.includes('plan_head_before: ${PLAN_HEAD_BEFORE}'),
+      'the base is recorded in the frontmatter so the verifier reconciles with the same instrument');
     // A measured zero WITH code changes is a HALT, never a narrated success.
     assert.ok(/HALT — do not\s+write the SUMMARY/i.test(executor),
       'a measured zero with uncommitted code changes must halt the SUMMARY write');
-    // actuals.commits sources the same measured number (ADR-2629 shape kept).
-    assert.ok(executor.includes('actuals'),
-      'the actuals block is still present (calibration shape preserved)');
+    // actuals.commits sources the measured count; the ADR-2629 calibration shape is kept.
+    assert.ok(/commits: 7 .*MEASURED/.test(executor),
+      'the actuals block sources its count from the measurement');
   });
 
   test('verify-work flags SUMMARY-vs-git mismatch as BLOCKER', () => {
     const verify = read('gsd-core/workflows/verify-work.md');
     assert.ok(verify.includes('Commit-claim reconciliation'),
       'verify-work must run a commit-claim reconciliation over each SUMMARY');
-    assert.ok(/git (?:rev-list --count|log)/.test(verify.slice(verify.indexOf('Commit-claim reconciliation'), verify.indexOf('Commit-claim reconciliation') + 1800)),
-      'the reconciliation compares the claimed count against git');
+    assert.ok(verify.includes('ACTUAL=$(git rev-list --count ${BASE}..HEAD)'),
+      'the reconciliation uses the SAME instrument as the executor (rev-list over the recorded base)');
+    assert.ok(/ACTUAL == CLAIMED \+ 1/.test(verify),
+      'the post-measurement SUMMARY commit is an expected +1, not a false BLOCKER');
     assert.ok(/BLOCKER/.test(verify.slice(verify.indexOf('Commit-claim reconciliation'), verify.indexOf('Commit-claim reconciliation') + 1800)),
       'a mismatch must be flagged BLOCKER — the phase must not read as done');
   });

--- a/tests/summary-commit-verification.test.cjs
+++ b/tests/summary-commit-verification.test.cjs
@@ -28,8 +28,7 @@ describe('#3968 — measured commit claims', () => {
     assert.ok(executor.includes('git rev-list --count'),
       'the SUMMARY commit count must come from git rev-list --count, not narration');
     // A measured zero WITH code changes is a HALT, never a narrated success.
-    assert.ok(/HALT|do not write the SUMMARY/i.test(
-      executor.slice(executor.indexOf('#3968'), executor.indexOf('#3968') + 2000)),
+    assert.ok(/HALT — do not\s+write the SUMMARY/i.test(executor),
       'a measured zero with uncommitted code changes must halt the SUMMARY write');
     // actuals.commits sources the same measured number (ADR-2629 shape kept).
     assert.ok(executor.includes('actuals'),
@@ -38,11 +37,11 @@ describe('#3968 — measured commit claims', () => {
 
   test('verify-work flags SUMMARY-vs-git mismatch as BLOCKER', () => {
     const verify = read('gsd-core/workflows/verify-work.md');
-    assert.ok(verify.includes('commit-claim reconciliation'),
+    assert.ok(verify.includes('Commit-claim reconciliation'),
       'verify-work must run a commit-claim reconciliation over each SUMMARY');
     assert.ok(verify.includes('git rev-list --count'),
       'the reconciliation compares the claimed count against rev-list');
-    assert.ok(/BLOCKER/.test(verify.slice(verify.indexOf('commit-claim reconciliation'), verify.indexOf('commit-claim reconciliation') + 1500)),
+    assert.ok(/BLOCKER/.test(verify.slice(verify.indexOf('Commit-claim reconciliation'), verify.indexOf('Commit-claim reconciliation') + 1800)),
       'a mismatch must be flagged BLOCKER — the phase must not read as done');
   });
 


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3968

## What was broken

`gsd-executor` writes `commits: N` into each plan's SUMMARY frontmatter as a self-narrated number. In the reporter's real project, 14 plans across 3 phases declared `commits: 1` while `git reflog` showed zero git activity — hundreds of lines of real implementation sitting uncommitted and undetected, with `HANDOFF.json` asserting `uncommitted_files: []` over a dirty tree. Nothing downstream cross-checked any of it. Maintainer decision (2026-09-02): option (c) — all three surfaces in one PR.

## What this fix does

- **Executor (measure at the source):** `<task_commit_protocol>` 0c persists a per-plan ledger (`gsd-plan-head-before-{phase}-{plan}` under the git dir — on disk, because each Bash call is a fresh shell and a variable would silently measure zero) before the plan's first commit; at SUMMARY-write time `commits:` comes from `git rev-list --count ${PLAN_HEAD_BEFORE}..HEAD` and the base is recorded as `plan_head_before:` in the frontmatter. A measured `0` WITH code changes HALTs the SUMMARY write — the uncommitted state is surfaced, never narrated past. A `0` with no code changes (docs-only) stays legitimate. `actuals.commits` sources the same number.
- **Verifier (reconcile with the same instrument):** verify-work's new commit-claim reconciliation reads `plan_head_before` from each SUMMARY and compares `git rev-list --count` — same instrument, no method mismatch. `ACTUAL == CLAIMED` passes; `ACTUAL == CLAIMED + 1` also passes (the SUMMARY/metadata commit lands after the executor measured); anything else is a **BLOCKER** (`commit_claim_mismatch` with both numbers). Pre-#3968 SUMMARYs without the field report a WARNING with the measured state, not a mismatch.
- **Pause path (measure, never assert):** HANDOFF's `uncommitted_files` is populated from an actual `git status --porcelain` call (truncate the list at 50 with an elided count, never round to empty).

An adversarial review of the first implementation caught two critical defects before this PR opened: the ledger as a shell variable (dead at SUMMARY time — fixed with the on-disk sentinel, same pattern as #3097) and the verifier originally counting via the plan-scope grep while the executor counted via rev-list (a guaranteed false BLOCKER from the post-SUMMARY docs commit — fixed by making both sides use rev-list over the recorded base, with the documented +1 expectation).

## Testing

### How I verified the fix

Failing-first under `gsd-test` (RED on `3da547db`: 4 failures, all the new suite), then green in the full serial matrix on `9de2e12b`. `tests/summary-commit-verification.test.cjs` pins: the on-disk ledger path, the rev-list measurement, the `plan_head_before` frontmatter, the HALT-on-uncommitted rule, the same-instrument reconciliation with the +1 expectation, the BLOCKER severity, and the porcelain source for `uncommitted_files`.

### Regression test added?

- [x] Yes — `tests/summary-commit-verification.test.cjs`

### Platforms tested

- [x] Linux (bench lane linux-node24)

### Runtimes tested

- [x] N/A (workflow prose + agent contract, runtime-independent)

## Checklist

- [x] Issue linked above with `Fixes #3968`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the maintainer-selected remedy (option c, all three surfaces)
- [x] Regression test added
- [x] All existing tests pass (`gsd-test` matrix green on the final sha)
- [x] `.changeset/` fragment added (`zesty-cranes-dance.md`, pr backfilled)
- [x] No unnecessary dependencies added

## Breaking changes

None. Pre-#3968 SUMMARYs (no `commits:`/`plan_head_before:` fields) reconcile as WARNINGs, not mismatches; the executor's ADR-2629 `actuals` shape is unchanged (only the source of `commits` becomes the measurement).

## Inline fixes folded into this PR

- **CI budget hotfix**: every Windows lane of the `test` job was CANCELLED at 99% of its 21-minute cap on three consecutive runs (incl. `next` itself) since #4207's regression suite — whose rows spawn real runner instances — grew the lane past its budget. This PR raises the lane budget 21→32 min and updates the budget gate's measured cost 14→21 using the gate's own #4070 method (a cancelled run's elapsed time is real measured cost). Also carries an SC2086 quoting fix in verify-work's reconciliation block.
