### PR TITLE
ci: raise the test-lane budget 21→32 minutes — measured cost grew past the cap

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -171,7 +171,7 @@ jobs:
     # change beyond sharing the same job-level `timeout-minutes`.
     # tests/ci-test-job-timeout-budget.test.cjs holds every lane here to a
     # headroom factor over its own measured cost.
-    timeout-minutes: 21
+    timeout-minutes: 32
     env:
       GSD_PLUGIN_ROOT: .ci-gsd-plugin-root-disabled
       # #2665: a live-config leak fails the run on Linux/macOS lanes. Windows
@@ -411,7 +411,7 @@ jobs:
         continue-on-error: true
         env:
           CI_JOB_LABEL: "test (${{ matrix.os }}, ${{ matrix.node-version }}${{ matrix.shard && format(', shard {0}', matrix.shard) || '' }})"
-          CI_JOB_TIMEOUT_MINUTES: '21'
+          CI_JOB_TIMEOUT_MINUTES: '32'
         run: node scripts/ci-check-job-near-cap.cjs
 
   test-inert:

--- a/tests/ci-test-job-timeout-budget.test.cjs
+++ b/tests/ci-test-job-timeout-budget.test.cjs
@@ -65,7 +65,16 @@ const LANE_COSTS = [
     // figure — rounded up from the higher, cancelled-run observation, since a
     // cancelled run's own timestamp is still real elapsed time even though the
     // job never finished.
-    measuredMinutes: 14,
+    // #4070's method applied again: the 14-minute figure went stale after
+    // #4207's run-tests temp-root regression suite landed — its rows spawn
+    // real runner instances on the windows scoped lane (each booting the full
+    // build), and windows shards 1-2 were CANCELLED at 99% of the 21-minute
+    // cap on three consecutive runs (33722188315 and two reruns; ubuntu and
+    // macos lanes green throughout, other PRs' windows lanes green — the
+    // long pole is this lane's windows matrix alone). A cancelled run's own
+    // timestamp is still real elapsed time: >=21 minutes, so 21 is the
+    // honest floor and the budget moves 21 -> 32 (1.5x headroom).
+    measuredMinutes: 21,
     // Sharded three ways as of #2952, so this is ONE shard's cost, not the
     // whole unit suite. Shard 1 is the long pole because the unsharded aux
     // suites (integration/security/install/slow) ride on it — #4070 fixed the
@@ -242,7 +251,7 @@ test('mutation.yml mutate job timeout budgets (#4036)', async (t) => {
 
 test('near-cap check CI_JOB_TIMEOUT_MINUTES literals match each job\'s own timeout-minutes (#4036)', async (t) => {
   const staticLanes = [
-    { workflowFile: 'test.yml', jobKey: 'test', envLiteral: '21' },
+    { workflowFile: 'test.yml', jobKey: 'test', envLiteral: '32' },
     { workflowFile: 'test.yml', jobKey: 'test-full', envLiteral: '45' },
     { workflowFile: 'install-smoke.yml', jobKey: 'smoke', envLiteral: '12' },
   ];


### PR DESCRIPTION
## Fix PR

## Linked Issue

Refs #4020 (the change whose regression suite grew the lane past the cap); closes no issue — this is a CI-budget correction using the gate's own documented method.

## What was broken

Every Windows lane of the `test` job has been CANCELLED at 99% of its 21-minute cap on three consecutive runs (33722188315 + two reruns; also `next`'s own post-#4216 Tests run), while ubuntu/macos lanes pass and other PRs' windows lanes pass — deterministic, not infra. The scoped windows lane now includes #4207's run-tests temp-root regression suite, whose rows spawn real runner instances (each booting the full build), pushing the lane past its budget.

## What this fix does

Raises the `test` job's `timeout-minutes` and the near-cap check's `CI_JOB_TIMEOUT_MINUTES` 21 → 32, and updates the budget gate's measured cost 14 → 21 with the observed evidence — exactly the #4070 method this gate documents for itself ("a cancelled run's own timestamp is still real elapsed time"). 32 = ⌈21 × 1.5⌉, the required headroom.

## Testing

Full `gsd-test` matrix green on the final sha (`0406f340`, linux-node24 42291/0 — including the budget-parity suite that pins the two literals together).

## Breaking changes

None.
