### PR TITLE
chore(#4241): add merge_group trigger to test.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,15 @@ on:
     branches:
       - next
       - main
+  # #4241: GitHub's merge queue fires `merge_group`, not `pull_request` or
+  # `push`, for the temporary merge-group commit it creates. Without this
+  # trigger, `required-tests` (the registered "Required tests" branch-
+  # protection check) never schedules for a queued PR and the queue stalls
+  # waiting on a check that never runs. See:
+  # https://docs.github.com/en/actions/how-tos/using-features-for-actions/using-merge-queues
+  # This is prerequisite wiring only — the merge queue itself is enabled via
+  # a separate, manual "Require merge queue" branch-protection toggle.
+  merge_group:
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -232,7 +232,15 @@ jobs:
       # even when a rebase-merged PR lands as multiple discrete commits in
       # one push (HEAD~1 would be wrong there: it could already contain an
       # earlier commit's newly-introduced vulnerable package, masking it).
-      AUDIT_BASELINE_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || (github.event_name == 'push' && github.event.before) || '' }}
+      # #4241: a merge_group event carries no pull_request/push context, so
+      # without this arm it silently fell through to the '' branch --
+      # resolveBaselineRef()'s documented-unreachable origin/next live-tip
+      # fallback (npm-audit-baseline.cjs), reopening the exact race #4196
+      # fixed, but only for merge-queue runs. github.event.merge_group.base_sha
+      # is "the SHA of the merge group's parent commit" (GitHub's merge_group
+      # webhook payload) -- the base tip the temporary merge-group commit was
+      # built against, pinned for the life of the run same as the other two arms.
+      AUDIT_BASELINE_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || (github.event_name == 'push' && github.event.before) || (github.event_name == 'merge_group' && github.event.merge_group.base_sha) || '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -472,7 +480,15 @@ jobs:
       # even when a rebase-merged PR lands as multiple discrete commits in
       # one push (HEAD~1 would be wrong there: it could already contain an
       # earlier commit's newly-introduced vulnerable package, masking it).
-      AUDIT_BASELINE_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || (github.event_name == 'push' && github.event.before) || '' }}
+      # #4241: a merge_group event carries no pull_request/push context, so
+      # without this arm it silently fell through to the '' branch --
+      # resolveBaselineRef()'s documented-unreachable origin/next live-tip
+      # fallback (npm-audit-baseline.cjs), reopening the exact race #4196
+      # fixed, but only for merge-queue runs. github.event.merge_group.base_sha
+      # is "the SHA of the merge group's parent commit" (GitHub's merge_group
+      # webhook payload) -- the base tip the temporary merge-group commit was
+      # built against, pinned for the life of the run same as the other two arms.
+      AUDIT_BASELINE_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || (github.event_name == 'push' && github.event.before) || (github.event_name == 'merge_group' && github.event.merge_group.base_sha) || '' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
@@ -575,7 +591,15 @@ jobs:
       # even when a rebase-merged PR lands as multiple discrete commits in
       # one push (HEAD~1 would be wrong there: it could already contain an
       # earlier commit's newly-introduced vulnerable package, masking it).
-      AUDIT_BASELINE_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || (github.event_name == 'push' && github.event.before) || '' }}
+      # #4241: a merge_group event carries no pull_request/push context, so
+      # without this arm it silently fell through to the '' branch --
+      # resolveBaselineRef()'s documented-unreachable origin/next live-tip
+      # fallback (npm-audit-baseline.cjs), reopening the exact race #4196
+      # fixed, but only for merge-queue runs. github.event.merge_group.base_sha
+      # is "the SHA of the merge group's parent commit" (GitHub's merge_group
+      # webhook payload) -- the base tip the temporary merge-group commit was
+      # built against, pinned for the life of the run same as the other two arms.
+      AUDIT_BASELINE_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || (github.event_name == 'push' && github.event.before) || (github.event_name == 'merge_group' && github.event.merge_group.base_sha) || '' }}
     strategy:
       fail-fast: false
       matrix:

--- a/tests/ci-test-scope.test.cjs
+++ b/tests/ci-test-scope.test.cjs
@@ -614,6 +614,34 @@ describe('test-full shard matrix parity (#1212)', () => {
       'test.yml must trigger `on: merge_group` so required-tests schedules for merge-queue commits',
     );
   });
+
+  test('every AUDIT_BASELINE_REF pin covers merge_group, not just pull_request/push (#4241)', () => {
+    // scripts/npm-audit-baseline.cjs's resolveBaselineRef() documents its
+    // origin/next live-tip fallback as UNREACHABLE from CI because
+    // AUDIT_BASELINE_REF is "always set by test.yml". A merge_group event
+    // carries neither pull_request nor push context, so a ternary that only
+    // branches on those two silently falls through to '' for a merge-queue
+    // run -- reopening the exact origin/next-can-advance-mid-run race #4196
+    // fixed, but only for merge_group. Every job that sets AUDIT_BASELINE_REF
+    // must also branch on merge_group, using merge_group.base_sha (the base
+    // tip the temporary merge-group commit was built against).
+    const text = fs.readFileSync(path.join(WORKFLOWS_DIR, 'test.yml'), 'utf8');
+    const doc = yaml.load(text);
+
+    const jobsUnderTest = Object.entries(doc.jobs).filter(
+      ([, job]) => job.env && typeof job.env.AUDIT_BASELINE_REF === 'string',
+    );
+    assert.ok(jobsUnderTest.length >= 3, `expected at least 3 jobs to pin AUDIT_BASELINE_REF, got ${jobsUnderTest.length}`);
+
+    for (const [name, job] of jobsUnderTest) {
+      const expr = job.env.AUDIT_BASELINE_REF;
+      assert.ok(
+        expr.includes("github.event_name == 'merge_group'") && expr.includes('github.event.merge_group.base_sha'),
+        `job ${name}: AUDIT_BASELINE_REF must branch on merge_group using ` +
+        `github.event.merge_group.base_sha, got: ${expr}`,
+      );
+    }
+  });
 });
 
 describe('emitted-provenance selection (#1691 drift guard, retargeted by #2724)', () => {

--- a/tests/ci-test-scope.test.cjs
+++ b/tests/ci-test-scope.test.cjs
@@ -599,6 +599,21 @@ describe('test-full shard matrix parity (#1212)', () => {
       'required-tests must `needs: test-full` so all shard legs aggregate into the gate',
     );
   });
+
+  test('workflow triggers on merge_group (#4241)', () => {
+    // GitHub's merge queue fires `merge_group`, not `pull_request` or `push`,
+    // for the temporary merge-group commit it creates. Without this trigger
+    // the whole workflow — and therefore `required-tests` — never schedules
+    // for a queued PR, silently stalling the merge queue on a check that
+    // never runs. `on.merge_group` has no required config, so its presence
+    // as a key (even with a `null`/empty value) is what matters here.
+    const text = fs.readFileSync(path.join(WORKFLOWS_DIR, 'test.yml'), 'utf8');
+    const doc = yaml.load(text);
+    assert.ok(
+      Object.prototype.hasOwnProperty.call(doc.on, 'merge_group'),
+      'test.yml must trigger `on: merge_group` so required-tests schedules for merge-queue commits',
+    );
+  });
 });
 
 describe('emitted-provenance selection (#1691 drift guard, retargeted by #2724)', () => {


### PR DESCRIPTION
<!-- pr-template-exempt: CI/tooling chore (type: chore) — not a bug fix (no broken production behavior, no `confirmed-bug` label) and not a user-facing enhancement/feature. Adds a workflow trigger plus its regression test; the tests/ file falls outside the auto-exempt tooling-path allowlist, hence this marker. -->

## What

Adds `merge_group:` to `.github/workflows/test.yml`'s top-level `on:` block, alongside the existing `push`/`pull_request`/`workflow_dispatch` triggers, plus a regression test asserting the trigger is present.

Closes #4241

## Why

GitHub's merge-queue documentation: "You must use the `merge_group` event to trigger your GitHub Actions workflow when a pull request is added to a merge queue... Without this trigger, status checks will not be triggered when you add a pull request to a merge queue."

`next`'s branch protection already registers `required-tests` ("Required tests") as a required status check. When a human later flips on "Require merge queue" in branch protection (a manual UI step this PR does not perform), GitHub fires `merge_group` — not `pull_request` or `push` — for the temporary merge-group commit it creates. Without this trigger, `required-tests` would never schedule for a queued PR, permanently stalling the queue on a check that never runs.

## How it was implemented

- `.github/workflows/test.yml`: added `merge_group:` to the top-level `on:` block. The whole workflow (and therefore every job `required-tests` transitively `needs:`) now fires on merge-group events too, matching how the file already handles `push` vs `pull_request` uniformly — no job-level `if:` split was needed.
- `tests/ci-test-scope.test.cjs`: added a test asserting `on.merge_group` is a key in the parsed workflow YAML, alongside the existing sibling test pinning `required-tests`'s `needs:` array.
- **Follow-up from orthogonal code review (blocking finding, fixed in a second commit):** the three `AUDIT_BASELINE_REF` pins (`test`, `test-inert`, `test-full` jobs) only branched on `pull_request`/`push`, so a `merge_group` run silently fell through to `''` — `scripts/npm-audit-baseline.cjs`'s `resolveBaselineRef()` documents its `origin/next` live-tip fallback as *unreachable from CI* precisely because `AUDIT_BASELINE_REF` is "always set by test.yml", so this would have quietly reopened the exact `origin/next`-can-advance-mid-run race #4196 fixed, but only for merge-queue runs. All three pins now also branch on `merge_group`, using `github.event.merge_group.base_sha` — confirmed against GitHub's own webhook payload schema (`github/docs` `src/webhooks/data/fpt/merge_group.child-params.json`): "The SHA of the merge group's parent commit." A second regression test asserts every `AUDIT_BASELINE_REF` pin covers `merge_group` with that exact field.

### `if:`-condition audit (no changes required)

Traced every `github.event_name`-conditioned branch that `required-tests` depends on:

- `changes` job's scope-classifier step branches on `EVENT_NAME != 'pull_request'`. A `merge_group` event takes that branch (the same one `push`/`workflow_dispatch` already take): `full_matrix=true`, `code_changed=true`, `product_changed=true`. `scripts/ci-test-scope.cjs` itself is never invoked for a non-`pull_request` event, so its `merge_group`-payload shape is never touched — no crash risk.
- `preflight` (`pr-mergeable-preflight.yml` → `scripts/ci-pr-mergeability.cjs`) reads `GITHUB_EVENT_NAME` and fails open (zero API calls, `verdict=INDETERMINATE`, `mergeable=true`) for any event other than `pull_request` — confirmed in the script, not inferred.
- The "Rebase check" step and the "Restore emitted-baseline cache" step in `test`/`test-full`/`test-inert` are gated `if: github.event_name == 'pull_request'` and are skipped for `merge_group`, same as they already are for `push`. This is intentional and pre-existing: GitHub already produces the merged merge-group commit itself, so an in-job rebase merge is redundant, and a cache miss degrades to an in-job baseline build per ADR-2719 §5 rather than failing.
- `GSD_EMITTED_BASE` resolves to `''` for `merge_group`, identical to its existing fallback for `workflow_dispatch`/`push` (`GSD_EMITTED_BASE` is `github.event.pull_request.base.sha` unconditionally, already empty for every non-`pull_request` event including `push` today) — not a new code path, and `resolveBase()`'s degrade-to-in-job-build-on-miss behavior (ADR-2719 §5) is the documented, safe default there.
- `AUDIT_BASELINE_REF` initially had the same gap as above, but for a **hard-fail-classed** value per `resolveBaselineRef()`'s own doc comment — see the blocking finding below, now fixed.
- `publish-emitted-baseline` stays scoped to `github.event_name == 'push' && github.ref == 'refs/heads/next'` and is unaffected by this trigger addition, correctly so — it only runs after `next` actually advances via a real push.

No job's `if:` needed a third branch for scheduling; one job's baseline-pinning **value** did (see below).

### Non-blocking judgement call, left as-is

`concurrency.group` (`test.yml:26`, unchanged by this PR) uses `github.head_ref || github.run_id`. `head_ref` is unset on `merge_group`, so every merge-queue run gets a unique concurrency group — no dedup/cancel across requeues of the same queue entry. Flagged by review as non-blocking. Left unchanged here: (1) the merge queue is not yet enabled, so no `merge_group` runs exist to observe the actual behavior against; (2) `pr-mergeable-preflight.yml`'s own header explicitly avoids adding a `concurrency:` block because a caller-matching group name with `cancel-in-progress` on both sides can cancel the running caller — the same collision risk applies here and deserves its own considered change, not a drive-by edit inside this trigger-wiring PR.

### Separate in-flight fix note

Per the brief for this change: the `changes` job's PR-time-vs-push-time scope-computation asymmetry is tracked as its own, separate issue. This PR does not touch that logic — `merge_group` simply falls into the pre-existing non-`pull_request` branch untouched.

## Testing

- `npm run lint:ci` — all green (all 40+ lint/gen-sync steps, including `lint-workflow-shellcheck` — 200 pre-existing findings from baseline, 0 new), re-run clean after the `AUDIT_BASELINE_REF` fix commit.
- `gsd-test --base next --head 8572659950794f64ef0b7087cce287c4c0b7bde3` (via `gsd-verify-and-record.cjs`, `--bench plex2`) — the final sha including the `AUDIT_BASELINE_REF` fix. Verdict recorded below.
- `node -e` sanity check confirming `js-yaml` parses the new `on:` block with `merge_group` present as a key, and that both new AUDIT_BASELINE_REF expressions still parse as valid GitHub Actions expression syntax.

### Regression test added?

- [x] Yes — `tests/ci-test-scope.test.cjs`: `workflow triggers on merge_group (#4241)` (trigger presence) and `every AUDIT_BASELINE_REF pin covers merge_group, not just pull_request/push (#4241)` (baseline-ref fix).

## Important caveat — this does NOT activate the merge queue

This PR is workflow-side wiring only. `next`'s branch protection still needs a human to manually enable "Require merge queue" in the GitHub UI (confirmed not scriptable via the REST branch-protection endpoint or the GraphQL `BranchProtectionRule` schema). Merging this PR, on its own, changes nothing about the repo's actual merge behavior until that manual step happens.

## Breaking changes

None. Adds a workflow trigger only; no existing trigger, job, or `if:` condition is modified.
