### PR TITLE
docs(#4123): add gsd-qoder EoS registry entry

### DIFF
--- a/.changeset/4123-gsd-qoder-eos-entry.md
+++ b/.changeset/4123-gsd-qoder-eos-entry.md
@@ -1,5 +1,5 @@
 ---
 type: Added
-pr: 0
+pr: 4278
 ---
 **The EoS Registry now lists GSD for Qoder** — discover the independently maintained `cainiao1992/gsd-qoder` protocol-v1 host integration for Alibaba's Qoder CLI and Qoder Desktop, including exact install and uninstall commands, supported interface points, and negotiated host axes. (#4123)

--- a/.changeset/4123-gsd-qoder-eos-entry.md
+++ b/.changeset/4123-gsd-qoder-eos-entry.md
@@ -1,0 +1,5 @@
+---
+type: Added
+pr: 0
+---
+**The EoS Registry now lists GSD for Qoder** — discover the independently maintained `cainiao1992/gsd-qoder` protocol-v1 host integration for Alibaba's Qoder CLI and Qoder Desktop, including exact install and uninstall commands, supported interface points, and negotiated host axes. (#4123)

--- a/docs/registries/eos-registry.md
+++ b/docs/registries/eos-registry.md
@@ -10,6 +10,7 @@ _To add your integration, see the [registry README](./README.md)._
 |---|---|---|---|---|
 | [GSD Cursor Model Profiles](https://github.com/clezcoding/gsd-cursor) | Adds six researched Cursor runtime profiles \(max / hybrid / value / budget / frontier / openweight\) to GSD, writes current and legacy tier-map surfaces, routes all six GSD phases, validates local model availability, and restores prior managed settings on uninstall without modifying gsd-core. | ![release](https://img.shields.io/github/v/release/clezcoding/gsd-cursor?sort=semver&include_prereleases) | `>=1.0.0` | [discuss](https://github.com/open-gsd/gsd-core/discussions/2578) |
 | [GSD for Oh My Pi](https://github.com/tchivs/gsd-omp) | Embeds GSD in Oh My Pi through OMP's native ExtensionAPI, programmatic slash commands, task isolation, lifecycle events, filesystem state, and managed agent and skill projection. | ![release](https://img.shields.io/github/v/release/tchivs/gsd-omp?sort=semver&include_prereleases) | `>=1.7.0` | [discuss](https://github.com/open-gsd/gsd-core/discussions/2342) |
+| [GSD for Qoder](https://github.com/cainiao1992/gsd-qoder) | Embeds GSD in Qoder — Alibaba's AI coding product family \(Qoder CLI and Qoder Desktop\) — by projecting GSD's agents, skills, and hook scripts into the Qoder config directory \(\~/.qoder, or \~/.qoder-cn for the China edition, or QODER\_CONFIG\_DIR\), applying Qoder-specific path and subagent-frontmatter conversions, merging GSD's lifecycle hooks into settings.json without disturbing existing user settings, and recording an install manifest so uninstall removes exactly what was projected. | ![release](https://img.shields.io/github/v/release/cainiao1992/gsd-qoder?sort=semver&include_prereleases) | `1.12.0` | [discuss](https://github.com/open-gsd/gsd-core/discussions/4122) |
 | [GSD for Reasonix](https://github.com/onionviolet/gsd-reasonix) | Renders the GSD workflow set as native Reasonix slash-command launchers, mapping GSD's host-neutral instructions onto Reasonix's own tools \(task/fleet for subagents, ask for questions, todo\_write for plans, complete\_step for evidence-backed sign-off\), and excludes the shared \~/.agents/skills convention root so the Codex launcher tree stops shadowing them. | ![release](https://img.shields.io/github/v/release/onionviolet/gsd-reasonix?sort=semver&include_prereleases) | `>=1.10.0` | [discuss](https://github.com/open-gsd/gsd-core/discussions/3379) |
 
 ## GSD Cursor Model Profiles
@@ -45,6 +46,23 @@ gsd-omp uninstall && npm uninstall --global gsd-omp
 - **GSD compatibility:** `>=1.7.0`, protocol v1
 - **License:** MIT
 - **Discussion / ranking:** https://github.com/open-gsd/gsd-core/discussions/2342
+
+## GSD for Qoder
+- **Repository:** https://github.com/cainiao1992/gsd-qoder — [latest release](https://github.com/cainiao1992/gsd-qoder/releases/latest)
+- **What it is:** Embeds GSD in Qoder — Alibaba's AI coding product family \(Qoder CLI and Qoder Desktop\) — by projecting GSD's agents, skills, and hook scripts into the Qoder config directory \(\~/.qoder, or \~/.qoder-cn for the China edition, or QODER\_CONFIG\_DIR\), applying Qoder-specific path and subagent-frontmatter conversions, merging GSD's lifecycle hooks into settings.json without disturbing existing user settings, and recording an install manifest so uninstall removes exactly what was projected.
+- **Author:** cainiao1992
+- **Every interaction with GSD:** Interface points: command, dispatch, model, hooks, state, artifact; profile: declarative-cli; protocol v1; axes: embeddingMode=declarative, commandSurface=slash-file, dispatch=Named and nested Qoder subagent dispatch with background execution and a full subagent toolkit; no numeric nesting depth is documented, and isolation is none because Qoder's worktree is a frontmatter-declared, per-agent-definition property rather than a dispatch-time parameter, modelMode=passive, hookBus=host, stateIO=filesystem, transport=mcp, runtime=node, effortSurface=argv
+- **Install:**
+```sh
+npm install --global github:cainiao1992/gsd-qoder#v0.3.4 && gsd-qoder install
+```
+- **Uninstall:**
+```sh
+gsd-qoder uninstall && npm uninstall --global gsd-qoder
+```
+- **GSD compatibility:** `1.12.0`, protocol v1
+- **License:** Apache-2.0
+- **Discussion / ranking:** https://github.com/open-gsd/gsd-core/discussions/4122
 
 ## GSD for Reasonix
 - **Repository:** https://github.com/onionviolet/gsd-reasonix — [latest release](https://github.com/onionviolet/gsd-reasonix/releases/latest)

--- a/docs/registries/eos.json
+++ b/docs/registries/eos.json
@@ -66,6 +66,42 @@
     "discussion": "https://github.com/open-gsd/gsd-core/discussions/2342"
   },
   {
+    "id": "gsd-qoder",
+    "name": "GSD for Qoder",
+    "type": "eos",
+    "repo": "cainiao1992/gsd-qoder",
+    "description": "Embeds GSD in Qoder — Alibaba's AI coding product family (Qoder CLI and Qoder Desktop) — by projecting GSD's agents, skills, and hook scripts into the Qoder config directory (~/.qoder, or ~/.qoder-cn for the China edition, or QODER_CONFIG_DIR), applying Qoder-specific path and subagent-frontmatter conversions, merging GSD's lifecycle hooks into settings.json without disturbing existing user settings, and recording an install manifest so uninstall removes exactly what was projected.",
+    "author": "cainiao1992",
+    "license": "Apache-2.0",
+    "enginesGsd": "1.12.0",
+    "protocolVersion": 1,
+    "install": "npm install --global github:cainiao1992/gsd-qoder#v0.3.4 && gsd-qoder install",
+    "uninstall": "gsd-qoder uninstall && npm uninstall --global gsd-qoder",
+    "interactions": {
+      "interfacePoints": [
+        "command",
+        "dispatch",
+        "model",
+        "hooks",
+        "state",
+        "artifact"
+      ],
+      "profile": "declarative-cli",
+      "axes": {
+        "embeddingMode": "declarative",
+        "commandSurface": "slash-file",
+        "dispatch": "Named and nested Qoder subagent dispatch with background execution and a full subagent toolkit; no numeric nesting depth is documented, and isolation is none because Qoder's worktree is a frontmatter-declared, per-agent-definition property rather than a dispatch-time parameter",
+        "modelMode": "passive",
+        "hookBus": "host",
+        "stateIO": "filesystem",
+        "transport": "mcp",
+        "runtime": "node",
+        "effortSurface": "argv"
+      }
+    },
+    "discussion": "https://github.com/open-gsd/gsd-core/discussions/4122"
+  },
+  {
     "id": "gsd-reasonix",
     "name": "GSD for Reasonix",
     "type": "eos",


### PR DESCRIPTION
Closes #4123 · Discussion: [#4122](https://github.com/open-gsd/gsd-core/discussions/4122)

## Registry type

- [ ] Capability Registry entry — adds/updates one object in `docs/registries/capabilities.json`
- [x] EoS Registry entry — adds/updates one object in `docs/registries/eos.json`
- [ ] Reviewer Lane Registry entry — adds/updates one object in `docs/registries/reviewers.json`

## The entry

```json
{
  "id": "gsd-qoder",
  "name": "GSD for Qoder",
  "type": "eos",
  "repo": "cainiao1992/gsd-qoder",
  "description": "Embeds GSD in Qoder — Alibaba's AI coding product family (Qoder CLI and Qoder Desktop) — by projecting GSD's agents, skills, and hook scripts into the Qoder config directory (~/.qoder, or ~/.qoder-cn for the China edition, or QODER_CONFIG_DIR), applying Qoder-specific path and subagent-frontmatter conversions, merging GSD's lifecycle hooks into settings.json without disturbing existing user settings, and recording an install manifest so uninstall removes exactly what was projected.",
  "author": "cainiao1992",
  "license": "Apache-2.0",
  "enginesGsd": "1.12.0",
  "protocolVersion": 1,
  "install": "npm install --global github:cainiao1992/gsd-qoder#v0.3.4 && gsd-qoder install",
  "uninstall": "gsd-qoder uninstall && npm uninstall --global gsd-qoder",
  "interactions": {
    "interfacePoints": [
      "command",
      "dispatch",
      "model",
      "hooks",
      "state",
      "artifact"
    ],
    "profile": "declarative-cli",
    "axes": {
      "embeddingMode": "declarative",
      "commandSurface": "slash-file",
      "dispatch": "Named and nested Qoder subagent dispatch with background execution and a full subagent toolkit; no numeric nesting depth is documented, and isolation is none because Qoder's worktree is a frontmatter-declared, per-agent-definition property rather than a dispatch-time parameter",
      "modelMode": "passive",
      "hookBus": "host",
      "stateIO": "filesystem",
      "transport": "mcp",
      "runtime": "node",
      "effortSurface": "argv"
    }
  },
  "discussion": "https://github.com/open-gsd/gsd-core/discussions/4122"
}
```

---

## Required-field checklist

- [x] `id`, `name`, `type`, `repo`, `description`, `author`, `license`, `enginesGsd`, `install`, `uninstall`, `interactions`, `discussion` are all present and non-empty
- [ ] **(Capability entries only)** `interactions.loopExtensionPoints` is a non-empty subset of the 12 Loop Extension Points, `interactions.hookKinds` ⊆ `{step, contribution, gate}`, and `interactions.configKeys` / `requires` / `runtimeCompat` / `produces` / `consumes` are present (empty arrays are fine where nothing applies) — N/A, this PR adds an EoS entry
- [x] **(EoS entries only)** `protocolVersion` is an integer ≥ 1 (`1`), `interactions.interfacePoints` is a non-empty subset of the six interface points, `interactions.profile` is one of `programmatic-cli` / `declarative-cli` / `ide` (`declarative-cli`), and `interactions.axes` has exactly the eight required axis keys plus, optionally, `effortSurface` (`argv` / `none`) — all eight required keys present plus `effortSurface: argv`
- [ ] **(Reviewer entries only)** `interactions.slug` matches the lane slug grammar `^[a-z0-9][a-z0-9_-]*$`, `interactions.flags` is a non-empty array matching `^--[a-z0-9][a-z0-9-]*$`, `interactions.transport` is `spawn` or `openai-http`, `interactions.evidenceClass` is `source-grounded` or `diff-only`, `interactions.reviewsSection` is a non-empty string (max 200 characters), and `interactions.requiresBinaries` / `configKeys` / `runtimeCompat` are present (empty arrays are fine where nothing applies) — N/A, this PR adds an EoS entry

## Ownership & non-endorsement

- [x] `repo` links to a repository **I own or am the primary maintainer of** — not a fork, mirror, or someone else's project
- [x] I understand that inclusion in this registry means only that a maintainer merged this PR — it is **not** an endorsement, and GSD has not reviewed, tested, audited, or verified my solution or its claimed GSD interactions
- [x] I understand this entry is removed only for illegal content, malware, spam, or a dead/non-functional link — never for quality — and a maintainer may remove it on that narrow basis without further notice

## One entry, one PR

- [x] This PR adds or updates exactly **one** entry, in exactly one of `capabilities.json` / `eos.json` / `reviewers.json`
- [x] I have not bundled any other registry entry, code change, or unrelated docs change into this PR

## Generated file in sync

- [x] I ran `npm run gen:registry` after editing the JSON source, and this PR includes the regenerated `docs/registries/eos-registry.md`
- [x] I did **not** hand-edit the generated `.md` file directly — all edits were made to the JSON source

## Documentation

- [x] This PR includes both the JSON source file and the regenerated markdown file under `docs/registries/`

## Checklist

- [x] `npm run validate:registry` passes locally against my entry
- [x] `discussion` links to a GitHub Discussion in the `EoS Registry` category — [#4122](https://github.com/open-gsd/gsd-core/discussions/4122) (category: EoS Registry)
- [x] `.changeset/` fragment added with an `Added` type describing the new listing (`pr:` field backfilled to 4278 in `10103b3`)

---

Local verification at `870b6ca` (rebased on `next`@`f4bf449`): `node scripts/registry-schema.cjs` 0 errors on the four-entry file; `node scripts/gen-registry.cjs --check` — `docs/registries/*.md are up to date.`; `npm run validate:registry` — `ok validate-registry: all entries valid`.
