### PR TITLE
fix(#4268): harden tdd-single-statement.test.cjs against reworded restatements and backend divergence

### DIFF
--- a/tests/tdd-backend-wiring.test.cjs
+++ b/tests/tdd-backend-wiring.test.cjs
@@ -241,12 +241,21 @@ describe('#4266 — TDD_APPLICABLE is actually computed in both backends', () =>
   });
 
   test('both backends\' gsd_run query phase.tdd-applicable command-substitution calls are byte-identical', () => {
+    // #4268 Standards review: both real backend files also carry this exact
+    // substring inside an unrelated FATAL echo message a few lines after the
+    // real assignment line (`echo "FATAL: ... 'gsd_run query
+    // phase.tdd-applicable' failed. ..."`). A bare `.includes()` match
+    // happened to work only because `.find()` hits the assignment line
+    // first in document order. Anchor on `=$(` immediately before the call —
+    // only the real `..._RAW=$(gsd_run query phase.tdd-applicable ...)`
+    // assignment line has that shape; the FATAL message's `'gsd_run query
+    // phase.tdd-applicable' failed` is preceded by a quote, not `=$(`.
     const harnessLine = read(BACKENDS['execute-phase.md'].assignmentFile)
       .split('\n')
-      .find((l) => l.includes('gsd_run query phase.tdd-applicable'));
+      .find((l) => l.includes('=$(gsd_run query phase.tdd-applicable'));
     const worktreeLine = read(BACKENDS['executor-isolation-dispatch.md'].assignmentFile)
       .split('\n')
-      .find((l) => l.includes('gsd_run query phase.tdd-applicable'));
+      .find((l) => l.includes('=$(gsd_run query phase.tdd-applicable'));
     assert.ok(harnessLine, 'execute-phase.md backend must carry a gsd_run query phase.tdd-applicable call');
     assert.ok(worktreeLine, 'executor-isolation-dispatch.md backend must carry a gsd_run query phase.tdd-applicable call');
 

--- a/tests/tdd-backend-wiring.test.cjs
+++ b/tests/tdd-backend-wiring.test.cjs
@@ -46,6 +46,24 @@ const BACKENDS = {
   'executor-isolation-dispatch.md': { referenceFile: WORKTREE_PATH, assignmentFile: WORKTREE_PATH },
 };
 
+// #4268: the two backends' `gsd_run query phase.tdd-applicable` calls differ
+// today ONLY in their variable-name prefix (`TDD_APPLICABLE_RAW=$(...)` vs
+// `_TDD_APPLICABLE_RAW=$(...)`), and nothing asserts the command-substitution
+// CONTENT itself stays byte-identical — a one-word divergence (e.g. dropping
+// `2>/dev/null` or changing `--pick applicable` in only one backend) ships
+// green. This extracts the call starting at `gsd_run query
+// phase.tdd-applicable` through the end of the line, stripping only the
+// trailing `)` that closes the `$( ... )` command substitution — i.e.
+// everything up to and including the variable-name-and-`=$(` prefix is
+// discarded, exactly per #4268.
+function extractQueryCall(line) {
+  const start = line.indexOf('gsd_run query phase.tdd-applicable');
+  if (start === -1) return null;
+  let call = line.slice(start);
+  if (call.endsWith(')')) call = call.slice(0, -1);
+  return call;
+}
+
 describe('#4266 — TDD_APPLICABLE is actually computed in both backends', () => {
   // A backend may assign TDD_APPLICABLE directly from the `gsd_run query
   // phase.tdd-applicable` call (harness: `TDD_APPLICABLE=$(gsd_run query
@@ -207,5 +225,40 @@ describe('#4266 — TDD_APPLICABLE is actually computed in both backends', () =>
       assert.ok(line, `${name} still lists tdd.md as a conditional embed entry`);
       assert.ok(/TDD_APPLICABLE \?/.test(line), `${name}'s tdd.md entry must stay conditional on TDD_APPLICABLE (#3990)`);
     }
+  });
+
+  test('RED-first: the predicate-equality comparison actually has teeth on a one-token divergence', () => {
+    // Prove the comparison catches a divergence BEFORE trusting it against
+    // the real files — a deliberately mutated in-memory pair, no file edits.
+    const original = 'gsd_run query phase.tdd-applicable "{phase_dir}/{plan_file}" --pick applicable 2>/dev/null';
+    const mutated = original.replace('--pick applicable', '--pick other');
+    assert.notEqual(mutated, original, 'sanity: the mutated fixture must actually differ from the original');
+    assert.throws(
+      () => assert.equal(mutated, original),
+      (err) => err instanceof assert.AssertionError,
+      'assert.equal must fail on a one-token divergence between two backends\' predicate calls — otherwise the real-file check below has no teeth',
+    );
+  });
+
+  test('both backends\' gsd_run query phase.tdd-applicable command-substitution calls are byte-identical', () => {
+    const harnessLine = read(BACKENDS['execute-phase.md'].assignmentFile)
+      .split('\n')
+      .find((l) => l.includes('gsd_run query phase.tdd-applicable'));
+    const worktreeLine = read(BACKENDS['executor-isolation-dispatch.md'].assignmentFile)
+      .split('\n')
+      .find((l) => l.includes('gsd_run query phase.tdd-applicable'));
+    assert.ok(harnessLine, 'execute-phase.md backend must carry a gsd_run query phase.tdd-applicable call');
+    assert.ok(worktreeLine, 'executor-isolation-dispatch.md backend must carry a gsd_run query phase.tdd-applicable call');
+
+    const harnessCall = extractQueryCall(harnessLine);
+    const worktreeCall = extractQueryCall(worktreeLine);
+    assert.equal(
+      harnessCall,
+      worktreeCall,
+      '#4268: the harness and worktree backends must issue byte-identical phase.tdd-applicable command-substitution calls ' +
+        '(only the variable-name-and-`=$(` prefix may differ), got:\n' +
+        `  execute-phase.md (harness):              ${harnessCall}\n` +
+        `  executor-isolation-dispatch.md (worktree): ${worktreeCall}`,
+    );
   });
 });

--- a/tests/tdd-single-statement.test.cjs
+++ b/tests/tdd-single-statement.test.cjs
@@ -10,6 +10,18 @@
  * The contract now: one canonical statement in tdd.md, consumers carry
  * pointers, and the embed lists load tdd.md only when the dispatch is TDD.
  * Deployed text IS the runtime-loaded product; shape assertions are the check.
+ *
+ * #4268 design decision (ADR-3473: pointers, not restatements): a compact,
+ * single-sentence citation that names the tdd.md section and commit-scope
+ * tokens (e.g. execute-plan.md's and gsd-executor.md's "execute RED → GREEN
+ * → REFACTOR exactly as specified in the canonical
+ * `references/tdd.md` reference — the 'Red-Green-Refactor Cycle' section's
+ * commit-scope contract...") is LEGAL — it is a pointer, not a restatement.
+ * A multi-step re-derivation that independently re-explains what to DO in
+ * each of the RED/GREEN/REFACTOR phases (the #3990 shape) is NOT legal, even
+ * if reworded so no literal commit-scope substring matches. See
+ * restatesCycleStructurally() below for the detector and its threshold
+ * reasoning.
  */
 
 const { test, describe } = require('node:test');
@@ -32,6 +44,64 @@ function restatesCycle(text) {
   if (red === -1) return false;
   const green = text.indexOf('commit: `feat({phase}-{plan})', red);
   return green !== -1;
+}
+
+// #4268: restatesCycle() above only catches the exact literal commit-scope
+// substring — a REWORDED restatement of the same RED/GREEN/REFACTOR
+// procedure ships green. This detector is structural instead of literal, and
+// stays within the #4228 linear-scan constraint (anchor lookups via
+// String#search on a single unbounded-but-simple \b<WORD>\b pattern, chained
+// sequentially — never two lazy spans inside one regex).
+//
+// Design (ADR-3473: pointers, not restatements):
+//   - Find the FIRST word-boundary RED, then the FIRST GREEN after it, then
+//     the FIRST REFACTOR after THAT (document order, three sequential linear
+//     scans — O(n), no backtracking).
+//   - A compact one-sentence pointer packs all three words within the same
+//     clause/line (e.g. "RED → GREEN → REFACTOR" or "RED-GREEN-REFACTOR"),
+//     so the RED..REFACTOR span is on the order of 10-20 characters. An
+//     actual restatement re-explains each phase in its own prose/list item,
+//     so the span runs to several hundred characters.
+//   - Threshold: 200 characters. Measured empirically (see tests below)
+//     against the real execute-plan.md and gsd-executor.md pointer text
+//     (spans of 10-14 chars) and a realistic paraphrased-restatement fixture
+//     (span of 424 chars) — 200 sits with wide margin on both sides.
+//   - Second, independent structural signal: three DISTINCT markdown
+//     list-marker lines (`- `, `* `, or `N. `/`N) `), one each carrying RED,
+//     GREEN, and REFACTOR — mirroring tdd.md's own numbered-step shape. The
+//     legitimate pointer's "2. **Cycle...): execute RED → GREEN →
+//     REFACTOR" puts all three words on ONE list line, so requiring three
+//     DISTINCT line indices avoids flagging it.
+// Either signal alone is sufficient to flag a restatement.
+const RESTATEMENT_SPAN_THRESHOLD = 200;
+const LIST_MARKER_RE = /^\s*(?:[-*]|\d+[.)])\s/;
+
+function findOwnListLineIndex(lines, word) {
+  const wordRe = new RegExp(`\\b${word}\\b`);
+  return lines.findIndex((l) => LIST_MARKER_RE.test(l) && wordRe.test(l));
+}
+
+function restatesCycleStructurally(text) {
+  const redIdx = text.search(/\bRED\b/);
+  if (redIdx === -1) return false;
+  const afterRed = text.slice(redIdx);
+  const greenRel = afterRed.search(/\bGREEN\b/);
+  if (greenRel === -1) return false;
+  const greenIdx = redIdx + greenRel;
+  const afterGreen = text.slice(greenIdx);
+  const refactorRel = afterGreen.search(/\bREFACTOR\b/);
+  if (refactorRel === -1) return false;
+  const refactorIdx = greenIdx + refactorRel;
+
+  if (refactorIdx - redIdx > RESTATEMENT_SPAN_THRESHOLD) return true;
+
+  const segment = text.slice(redIdx, refactorIdx + 'REFACTOR'.length);
+  const lines = segment.split('\n');
+  const redLine = findOwnListLineIndex(lines, 'RED');
+  const greenLine = findOwnListLineIndex(lines, 'GREEN');
+  const refactorLine = findOwnListLineIndex(lines, 'REFACTOR');
+  if (redLine === -1 || greenLine === -1 || refactorLine === -1) return false;
+  return redLine !== greenLine && greenLine !== refactorLine && redLine !== refactorLine;
 }
 
 describe('#3990 — one statement of the cycle', () => {
@@ -70,5 +140,37 @@ describe('#3990 — one statement of the cycle', () => {
       assert.ok(/TDD_APPLICABLE \?/.test(line),
         `${name}'s tdd.md entry must be conditional on TDD_APPLICABLE (#3990), got: ${line.trim()}`);
     }
+  });
+});
+
+describe('#4268 — reworded restatement detection (structural, not literal)', () => {
+  test('flags a reworded multi-step re-derivation of RED/GREEN/REFACTOR', () => {
+    const fixture = [
+      '## TDD procedure for this task',
+      '',
+      '1. RED: write a failing test that captures the missing behavior, run the',
+      '   suite, and confirm it fails for the expected reason before touching any',
+      '   implementation code. Commit the failing test on its own.',
+      '2. GREEN: write the minimal implementation needed to make that test pass,',
+      '   run the full suite again, and confirm every test is green before moving',
+      '   on. Commit the passing implementation separately from the test.',
+      '3. REFACTOR: clean up the implementation and tests while keeping the suite',
+      '   green throughout, committing only if something actually changed.',
+    ].join('\n');
+    assert.ok(restatesCycleStructurally(fixture),
+      'a reworded, multi-step re-derivation of RED/GREEN/REFACTOR must be flagged even with no literal commit-scope match');
+    // Confirm the literal-only detector is indeed blind to this fixture —
+    // this is the #4268 gap restatesCycleStructurally exists to close.
+    assert.ok(!restatesCycle(fixture),
+      'sanity check: the fixture must NOT contain the literal commit-scope substring (that is the gap being closed)');
+  });
+
+  test('does not flag the real execute-plan.md and gsd-executor.md pointer text', () => {
+    const plan = read('gsd-core/workflows/execute-plan.md');
+    const executor = read('agents/gsd-executor.md');
+    assert.ok(!restatesCycleStructurally(plan),
+      'execute-plan.md\'s compact citation of RED/GREEN/REFACTOR must not be flagged as a restatement');
+    assert.ok(!restatesCycleStructurally(executor),
+      'gsd-executor.md\'s compact citation of RED/GREEN/REFACTOR must not be flagged as a restatement');
   });
 });

--- a/tests/tdd-single-statement.test.cjs
+++ b/tests/tdd-single-statement.test.cjs
@@ -22,12 +22,22 @@
  * if reworded so no literal commit-scope substring matches. See
  * restatesCycleStructurally() below for the detector and its threshold
  * reasoning.
+ *
+ * #4268 follow-up (Standards+Spec review, same issue): a length/list-marker
+ * signal alone is evadable — a compact, no-list-marker, reworded restatement
+ * kept under the span threshold sails through undetected. The actual
+ * invariant this file protects is DEFERRAL, not length: a legitimate mention
+ * of RED/GREEN/REFACTOR always points at tdd.md as the authority; a
+ * restatement never needs to, because it isn't citing anything — it's
+ * re-deriving the procedure itself. That is now the PRIMARY signal; span and
+ * list-marker remain secondary, defense-in-depth OR-conditions.
  */
 
 const { test, describe } = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
+const fc = require('fast-check');
 
 const ROOT = path.join(__dirname, '..');
 const read = (p) => fs.readFileSync(path.join(ROOT, p), 'utf8');
@@ -56,24 +66,45 @@ function restatesCycle(text) {
 // Design (ADR-3473: pointers, not restatements):
 //   - Find the FIRST word-boundary RED, then the FIRST GREEN after it, then
 //     the FIRST REFACTOR after THAT (document order, three sequential linear
-//     scans — O(n), no backtracking).
-//   - A compact one-sentence pointer packs all three words within the same
-//     clause/line (e.g. "RED → GREEN → REFACTOR" or "RED-GREEN-REFACTOR"),
-//     so the RED..REFACTOR span is on the order of 10-20 characters. An
-//     actual restatement re-explains each phase in its own prose/list item,
-//     so the span runs to several hundred characters.
-//   - Threshold: 200 characters. Measured empirically (see tests below)
-//     against the real execute-plan.md and gsd-executor.md pointer text
-//     (spans of 10-14 chars) and a realistic paraphrased-restatement fixture
-//     (span of 424 chars) — 200 sits with wide margin on both sides.
-//   - Second, independent structural signal: three DISTINCT markdown
-//     list-marker lines (`- `, `* `, or `N. `/`N) `), one each carrying RED,
-//     GREEN, and REFACTOR — mirroring tdd.md's own numbered-step shape. The
-//     legitimate pointer's "2. **Cycle...): execute RED → GREEN →
-//     REFACTOR" puts all three words on ONE list line, so requiring three
-//     DISTINCT line indices avoids flagging it.
-// Either signal alone is sufficient to flag a restatement.
+//     scans — O(n), no backtracking). Factored into measureCycleSpan() below
+//     so its arithmetic can be tested directly (boundary coverage) without
+//     going through the full multi-signal decision.
+//   - PRIMARY signal (#4268 Standards+Spec review): deferral detection. A
+//     legitimate RED/GREEN/REFACTOR mention always names tdd.md as the
+//     authority nearby; a restatement never does, because it is re-deriving
+//     the procedure instead of citing it. If the RED..REFACTOR span, extended
+//     by a fixed trailing window, contains NO reference to `tdd.md`,
+//     `references/tdd`, or `canonical`, it is flagged — REGARDLESS of length
+//     or list-marker shape. This is what makes the signal non-evadable by a
+//     compact, reworded restatement: shortening or dropping list markers does
+//     nothing to manufacture a citation that was never there.
+//   - Trailing window: 500 characters past the REFACTOR anchor. Measured
+//     empirically against the real files (2026-09-04): execute-plan.md's
+//     citation of `~/.claude/gsd-core/references/tdd.md` sits 228 chars past
+//     the REFACTOR anchor; gsd-executor.md's citation of
+//     `gsd-core/references/tdd.md` sits 82 chars past it. 500 clears both
+//     with wide margin while staying well short of the whole-file scan the
+//     #4228 postmortem (see comment above restatesCycle()) warns against.
+//   - SECONDARY signals (defense in depth, OR-ed in, kept from the original
+//     design): span > 200 chars, or three DISTINCT markdown list-marker
+//     lines (`- `, `* `, or `N. `/`N) `) each carrying one of RED/GREEN/
+//     REFACTOR. These still catch something wildly long or exhaustively
+//     itemized even if it happens to mention "tdd.md" somewhere in the
+//     window as camouflage — a case the primary signal alone cannot see.
+//     Threshold 200 and the list-marker shape are unchanged from the
+//     original measurement: real pointers span 10-14 chars; a realistic
+//     paraphrased restatement spans 424 chars.
+// Limitation (stated honestly, not resolved by this design): a restatement
+// that is BOTH compact/no-list-marker AND happens to mention "tdd.md" (or
+// "canonical") somewhere within the 500-char trailing window — without that
+// mention actually deferring the procedure to it — would still pass. The
+// deferral check is a presence check on the marker text, not a semantic
+// check that the marker is doing deferral work. Closing that gap needs a
+// stronger check (e.g. requiring the marker to sit in the same sentence/
+// clause as the cycle words) that is not implemented here.
 const RESTATEMENT_SPAN_THRESHOLD = 200;
+const DEFERRAL_WINDOW_TRAILING = 500;
+const DEFERRAL_MARKER_RE = /tdd\.md|references\/tdd|canonical/;
 const LIST_MARKER_RE = /^\s*(?:[-*]|\d+[.)])\s/;
 
 function findOwnListLineIndex(lines, word) {
@@ -81,21 +112,40 @@ function findOwnListLineIndex(lines, word) {
   return lines.findIndex((l) => LIST_MARKER_RE.test(l) && wordRe.test(l));
 }
 
-function restatesCycleStructurally(text) {
+// Sequential linear scan for the first RED -> first GREEN-after-RED -> first
+// REFACTOR-after-that triple. Returns null if the document doesn't carry the
+// full RED/GREEN/REFACTOR sequence. Factored out of restatesCycleStructurally
+// so the span arithmetic itself has a directly-testable seam (#4268 Standards
+// review, boundary coverage).
+function measureCycleSpan(text) {
   const redIdx = text.search(/\bRED\b/);
-  if (redIdx === -1) return false;
+  if (redIdx === -1) return null;
   const afterRed = text.slice(redIdx);
   const greenRel = afterRed.search(/\bGREEN\b/);
-  if (greenRel === -1) return false;
+  if (greenRel === -1) return null;
   const greenIdx = redIdx + greenRel;
   const afterGreen = text.slice(greenIdx);
   const refactorRel = afterGreen.search(/\bREFACTOR\b/);
-  if (refactorRel === -1) return false;
+  if (refactorRel === -1) return null;
   const refactorIdx = greenIdx + refactorRel;
+  const refactorEndIdx = refactorIdx + 'REFACTOR'.length;
+  return { redIdx, greenIdx, refactorIdx, refactorEndIdx, span: refactorIdx - redIdx };
+}
 
-  if (refactorIdx - redIdx > RESTATEMENT_SPAN_THRESHOLD) return true;
+function hasNearbyDeferralMarker(text, cycle) {
+  const windowEnd = Math.min(text.length, cycle.refactorEndIdx + DEFERRAL_WINDOW_TRAILING);
+  const window = text.slice(cycle.redIdx, windowEnd);
+  return DEFERRAL_MARKER_RE.test(window);
+}
 
-  const segment = text.slice(redIdx, refactorIdx + 'REFACTOR'.length);
+function restatesCycleStructurally(text) {
+  const cycle = measureCycleSpan(text);
+  if (!cycle) return false;
+
+  if (!hasNearbyDeferralMarker(text, cycle)) return true;
+  if (cycle.span > RESTATEMENT_SPAN_THRESHOLD) return true;
+
+  const segment = text.slice(cycle.redIdx, cycle.refactorEndIdx);
   const lines = segment.split('\n');
   const redLine = findOwnListLineIndex(lines, 'RED');
   const greenLine = findOwnListLineIndex(lines, 'GREEN');
@@ -172,5 +222,106 @@ describe('#4268 — reworded restatement detection (structural, not literal)', (
       'execute-plan.md\'s compact citation of RED/GREEN/REFACTOR must not be flagged as a restatement');
     assert.ok(!restatesCycleStructurally(executor),
       'gsd-executor.md\'s compact citation of RED/GREEN/REFACTOR must not be flagged as a restatement');
+  });
+
+  // #4268 Standards+Spec review: the reviewer proved by execution that the
+  // original span/list-marker-only design is defeated by a compact,
+  // single-paragraph, no-list-marker restatement kept under the 200-char
+  // span threshold (their crafted fixtures: ~142 and ~169 chars). This
+  // fixture (189 chars, span 134 — well under the old threshold, no list
+  // markers, no tdd.md/canonical mention) is that exact class of gap: it
+  // fully re-derives what to DO in each phase without citing tdd.md
+  // anywhere. Under the pre-fix span+list-marker-only logic this returned
+  // false (a false negative); the deferral-detection primary signal now
+  // catches it regardless of length or list-marker shape.
+  test('flags a compact, no-list-marker restatement that never cites tdd.md (the reviewer-found gap)', () => {
+    const fixture = 'RED: write a failing test proving the bug exists. GREEN: write the '
+      + 'smallest change that makes the test pass and keep the suite green. '
+      + 'REFACTOR: clean the code up now that everything passes.';
+    assert.equal(fixture.length, 189, 'sanity: fixture is compact, well under the old span threshold');
+    assert.ok(!/tdd\.md|references\/tdd|canonical/.test(fixture),
+      'sanity: fixture must not mention tdd.md/canonical — that is the gap being closed');
+    assert.ok(!/^\s*(?:[-*]|\d+[.)])\s/m.test(fixture),
+      'sanity: fixture must carry no markdown list markers — that is the other axis of the gap');
+    assert.ok(restatesCycleStructurally(fixture),
+      'a compact, no-list-marker restatement must be flagged once it fails to cite tdd.md as the authority');
+  });
+
+  // #4268 Standards review — boundary coverage (CLAUDE.md: "Tests MUST
+  // exercise inputs at limit-1, limit, and limit+1"). Tested against
+  // measureCycleSpan() directly rather than restatesCycleStructurally(): any
+  // fixture built without a tdd.md/canonical mention (required to isolate
+  // the span arithmetic from list-marker noise) would ALSO trip the primary
+  // deferral-detection OR-condition regardless of its span, so the top-level
+  // function can't isolate the span check alone. The internal helper can.
+  describe('RESTATEMENT_SPAN_THRESHOLD boundary (limit-1 / limit / limit+1)', () => {
+    // Builds "RED GREEN " + '.'.repeat(n) + "REFACTOR" so that
+    // measureCycleSpan(...).span === targetSpan exactly. The '.' filler is a
+    // non-word character so \bREFACTOR\b still matches at the boundary, and
+    // the fixture carries no markdown list markers or tdd.md/canonical text.
+    function makeCycleSpanFixture(targetSpan) {
+      const prefix = 'RED GREEN ';
+      const fillerLen = targetSpan - prefix.length;
+      assert.ok(fillerLen >= 0, 'targetSpan must be large enough to hold the fixed prefix');
+      return prefix + '.'.repeat(fillerLen) + 'REFACTOR';
+    }
+
+    test('limit-1 (199): span condition does not fire', () => {
+      const fixture = makeCycleSpanFixture(RESTATEMENT_SPAN_THRESHOLD - 1);
+      const cycle = measureCycleSpan(fixture);
+      assert.equal(cycle.span, RESTATEMENT_SPAN_THRESHOLD - 1);
+      assert.equal(cycle.span > RESTATEMENT_SPAN_THRESHOLD, false);
+    });
+
+    test('limit (200): span condition does not fire (threshold is exclusive)', () => {
+      const fixture = makeCycleSpanFixture(RESTATEMENT_SPAN_THRESHOLD);
+      const cycle = measureCycleSpan(fixture);
+      assert.equal(cycle.span, RESTATEMENT_SPAN_THRESHOLD);
+      assert.equal(cycle.span > RESTATEMENT_SPAN_THRESHOLD, false);
+    });
+
+    test('limit+1 (201): span condition fires', () => {
+      const fixture = makeCycleSpanFixture(RESTATEMENT_SPAN_THRESHOLD + 1);
+      const cycle = measureCycleSpan(fixture);
+      assert.equal(cycle.span, RESTATEMENT_SPAN_THRESHOLD + 1);
+      assert.equal(cycle.span > RESTATEMENT_SPAN_THRESHOLD, true);
+      // And end-to-end: with no tdd.md mention this also fires via the
+      // primary deferral signal, so restatesCycleStructurally must be true
+      // regardless — confirming the OR-composition doesn't mask a fired
+      // secondary condition.
+      assert.ok(restatesCycleStructurally(fixture));
+    });
+  });
+
+  // #4268 Standards review: fast-check property test (CLAUDE.md: "Parsers,
+  // budget limits, and bijective contracts must include at least one
+  // fast-check (fc) property test" — RESTATEMENT_SPAN_THRESHOLD is a budget
+  // limit). This directly property-tests the Finding-1 fix: ANY filler
+  // (sanitized to strip newlines, list-marker punctuation, and any
+  // RED/GREEN/REFACTOR/tdd/canonical substrings it might otherwise
+  // accidentally contain) inserted into a compact, no-list-marker
+  // RED/GREEN/REFACTOR restatement template that never cites tdd.md must be
+  // flagged — independent of the filler's length.
+  test('property: a no-tdd.md, no-list-marker RED/GREEN/REFACTOR restatement is always flagged regardless of filler length', () => {
+    const fillerArb = fc.string({ maxLength: 300 }).map((s) => s
+      .replace(/[\r\n]/g, ' ')
+      .replace(/[-*]/g, '.')
+      .replace(/\bRED\b/gi, 'xxx')
+      .replace(/\bGREEN\b/gi, 'xxx')
+      .replace(/\bREFACTOR\b/gi, 'xxx')
+      .replace(/tdd/gi, 'xxx')
+      .replace(/canonical/gi, 'xxx'));
+
+    fc.assert(
+      fc.property(fillerArb, (filler) => {
+        const fixture = [
+          `RED: write a failing test. ${filler}`,
+          `GREEN: make it pass. ${filler}`,
+          'REFACTOR: clean it up.',
+        ].join(' ');
+        return restatesCycleStructurally(fixture) === true;
+      }),
+      { numRuns: 20 },
+    );
   });
 });


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #4268

## What was broken

`tests/tdd-single-statement.test.cjs` (added by #4228 for #3990) had two detection gaps: (1) `restatesCycle()` keyed on one exact literal commit-scope substring, so a reworded restatement of the RED/GREEN/REFACTOR procedure in `execute-plan.md` or `gsd-executor.md` would ship green undetected; (2) `tests/tdd-backend-wiring.test.cjs`'s embed-conditional test never compared the two TDD-dispatch backends' `gsd_run query phase.tdd-applicable` predicate calls against each other, so a one-word divergence between them (e.g. a changed `--pick` flag in only one backend) shipped green. (The issue's third named gap — nothing proves `TDD_APPLICABLE` has a real definition — was already covered by `tests/tdd-backend-wiring.test.cjs`'s `assertTddApplicableIsComputed`, added by epic #4272 Phase 2 after this issue was filed; verified by inspection, no new test needed.)

## What this fix does

Adds `restatesCycleStructurally()`, a structural detector built around **deferral, not length**: the actual invariant this file protects is that any legitimate mention of RED/GREEN/REFACTOR points at `tdd.md` as the authority nearby, while a restatement never does (it's re-deriving the procedure, not citing it). Flags a passage that mentions the cycle with no `tdd.md`/`canonical` reference within a 500-char trailing window — regardless of length or list-marker shape — with span-length and list-marker-structure kept as secondary, defense-in-depth signals. Adds a byte-identity assertion between the two backends' `phase.tdd-applicable` command-substitution calls (normalized for their differing variable-name prefixes), proven to have teeth via a RED-first mutation check.

## Root cause

Both original tests used literal/shape heuristics calibrated against the specific defect each was written to catch, rather than the general invariant (ADR-3473: pointers, not restatements) the file's own header comment already states.

## Testing

### How I verified the fix

- `tests/tdd-single-statement.test.cjs` (new `describe('#4268 …')` block) — a fixture proving the hardened detector flags a reworded multi-step re-derivation; a second fixture proving it does *not* flag the real `execute-plan.md`/`gsd-executor.md` pointer text; boundary tests at the span threshold (199/200/201, via a factored-out `measureCycleSpan()` seam); a `fast-check` property test proving the fix holds for arbitrary filler text.
- `tests/tdd-backend-wiring.test.cjs` — a RED-first mutation-teeth proof, then the real byte-identity assertion; anchored the line lookup on `=$(gsd_run query phase.tdd-applicable` (not a bare substring match) after finding the naive match happened to work only because a same-substring FATAL echo message came later in document order.
- Two orthogonal review passes (Standards/Spec two-axis + an isolated adversarial security pass). The first Standards+Spec pass found a real, confirmed gap by *executing* the initial detector against crafted compact fixtures (proving a false negative) plus a boundary-coverage miss and two minor findings — all fixed and independently re-verified by hand against the real files before re-review. See `.gsd/phase/fix-4268-tdd-single-statement-hardening/60-review.json`.
- `gsd-test`, final verdict on the pushed sha (`f157fa0d1914847f926d243263b8cd55cea19d7d`): **passed, 42844/42844, 0 failures** (plex2).

### Regression test added?

- [x] Yes — new tests in both `tests/tdd-single-statement.test.cjs` and `tests/tdd-backend-wiring.test.cjs`.

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included (tests/ only)
- [x] Regression test added
- [x] All existing tests pass (verified via `gsd-test`, not `npm test` directly — see Testing)
- [x] No `.changeset/` fragment — the linked issue's own pre-submission checklist marks this as not changing user-facing behavior; `no-changelog` label applied instead
- [x] No unnecessary dependencies added (`fast-check` is an existing devDependency already used elsewhere in the test suite)

## Breaking changes

None. This changes only test-file detection power; no src/, workflow, or agent file is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
