### PR TITLE
fix(#4079): forbid ScheduleWakeup wake-tool escape hatch at background-wait sites

### DIFF
--- a/.changeset/agile-cranes-caper.md
+++ b/.changeset/agile-cranes-caper.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 4299
 ---
 **Background waits no longer emit a red ScheduleWakeup validation error** — while a background subagent (researcher/planner/checker or the manager dashboard's dispatch) was in flight, the orchestrator could literalize "I'll wait" by calling the host's ScheduleWakeup tool with partial arguments, surfacing "`prompt` is required when `stop` is not true."; every GSD wait-instruction site now explicitly forbids wake-up scheduling. (#4079)

--- a/.changeset/agile-cranes-caper.md
+++ b/.changeset/agile-cranes-caper.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**Background waits no longer emit a red ScheduleWakeup validation error** — while a background subagent (researcher/planner/checker or the manager dashboard's dispatch) was in flight, the orchestrator could literalize "I'll wait" by calling the host's ScheduleWakeup tool with partial arguments, surfacing "`prompt` is required when `stop` is not true."; every GSD wait-instruction site now explicitly forbids wake-up scheduling. (#4079)

--- a/gsd-core/workflows/manager.md
+++ b/gsd-core/workflows/manager.md
@@ -274,7 +274,7 @@ Important: You are running in the background. Do NOT use AskUserQuestion — mak
 )
 ```
 
-> **ORCHESTRATOR RULE — BACKGROUND DISPATCH**: After calling Agent() above with `run_in_background=true`, do NOT do any planning work for this phase independently. Return to the dashboard immediately and wait for the background agent to report back. Only resume planning-related work when the subagent result is available.
+> **ORCHESTRATOR RULE — BACKGROUND DISPATCH**: After calling Agent() above with `run_in_background=true`, do NOT do any planning work for this phase independently. Return to the dashboard immediately and wait for the background agent to report back. Only resume planning-related work when the subagent result is available. Never call `ScheduleWakeup` or any host wake/sleep-scheduling tool while waiting (#4079) — a partial-args wake call surfaces a red validation error; the dashboard loop is the wait.
 
 Display:
 
@@ -328,7 +328,7 @@ Important: You are running in the background. Do NOT use AskUserQuestion — mak
 )
 ```
 
-> **ORCHESTRATOR RULE — BACKGROUND DISPATCH**: After calling Agent() above with `run_in_background=true`, do NOT do any execution work for this phase independently. Return to the dashboard immediately and wait for the background agent to report back. Only resume execution-related work when the subagent result is available.
+> **ORCHESTRATOR RULE — BACKGROUND DISPATCH**: After calling Agent() above with `run_in_background=true`, do NOT do any execution work for this phase independently. Return to the dashboard immediately and wait for the background agent to report back. Only resume execution-related work when the subagent result is available. Never call `ScheduleWakeup` or any host wake/sleep-scheduling tool while waiting (#4079) — a partial-args wake call surfaces a red validation error; the dashboard loop is the wait.
 
 Display:
 

--- a/gsd-core/workflows/plan-phase.md
+++ b/gsd-core/workflows/plan-phase.md
@@ -409,7 +409,7 @@ Agent(
 )
 ```
 
-> **ORCHESTRATOR RULE — ALL RUNTIMES**: After calling Agent() above, stop working on this task immediately. Do not read more files, edit code, or run tests related to this task while the subagent is active. Wait for the subagent to return its result. This prevents duplicate work, conflicting edits, and wasted context. Only resume when the subagent result is available.
+> **ORCHESTRATOR RULE — ALL RUNTIMES**: After calling Agent() above, stop working on this task immediately. Do not read more files, edit code, or run tests related to this task while the subagent is active. Wait for the subagent to return its result. This prevents duplicate work, conflicting edits, and wasted context. Only resume when the subagent result is available. Never call `ScheduleWakeup` or any host wake/sleep-scheduling tool to literalize this wait (#4079) — the Agent() call returns on its own; a partial-args wake call surfaces a red validation error.
 
 ### Handle Researcher Return
 
@@ -672,7 +672,7 @@ Agent(
 )
 ```
 
-> **ORCHESTRATOR RULE — ALL RUNTIMES**: After calling Agent() above, stop working on this task immediately. Do not read more files, edit code, or run tests related to this task while the subagent is active. Wait for the subagent to return its result. This prevents duplicate work, conflicting edits, and wasted context. Only resume when the subagent result is available.
+> **ORCHESTRATOR RULE — ALL RUNTIMES**: After calling Agent() above, stop working on this task immediately. Do not read more files, edit code, or run tests related to this task while the subagent is active. Wait for the subagent to return its result. This prevents duplicate work, conflicting edits, and wasted context. Only resume when the subagent result is available. Never call `ScheduleWakeup` or any host wake/sleep-scheduling tool to literalize this wait (#4079) — the Agent() call returns on its own; a partial-args wake call surfaces a red validation error.
 
 **Handle return:**
 - **`## PATTERN MAPPING COMPLETE`:** Update `PATTERNS_PATH` to the created file path, continue to step 8.

--- a/gsd-core/workflows/plan-phase/steps/stall-detection-helpers.md
+++ b/gsd-core/workflows/plan-phase/steps/stall-detection-helpers.md
@@ -48,6 +48,15 @@ min), real, bounded call that reliably hands control back — the outer
 threshold is enforced by `dispatch_ts` accumulating across calls, not by one
 call's own duration.
 
+**Never a wake-up call between cycles (#4079):** while the orchestrator waits
+between `gsd_stall_watch` cycles, it must NOT call `ScheduleWakeup` (or any
+host wake/sleep-scheduling tool, e.g. the `/loop` pacing surface) to
+literalize "I'll wait". The `gsd_stall_watch` bash call IS the wait mechanism;
+wake-up scheduling is never part of it, and a partial-args `ScheduleWakeup`
+call surfaces the host's red validation error (`prompt` is required when
+`stop` is not true). Just issue the next watch call (or let the blocking
+Agent() return) — nothing else.
+
 **Disclosed tradeoff:** the first cycle always sleeps a full
 `PLANNER_STALL_INTERVAL_MINUTES` before its first check, so a planner that
 completes in seconds is not observed by this path until that interval

--- a/tests/plan-phase-background-wait-wakeup.test.cjs
+++ b/tests/plan-phase-background-wait-wakeup.test.cjs
@@ -32,8 +32,9 @@
 
 const { describe, test } = require('node:test');
 const assert = require('node:assert/strict');
-const fs = require('node:fs');
 const path = require('node:path');
+
+const { readFileNormalized } = require('./helpers.cjs');
 
 const REPO_ROOT = path.join(__dirname, '..');
 const PLAN_PHASE_PATH = path.join(REPO_ROOT, 'gsd-core', 'workflows', 'plan-phase.md');
@@ -42,17 +43,13 @@ const STALL_HELPERS_PATH = path.join(
 );
 const MANAGER_PATH = path.join(REPO_ROOT, 'gsd-core', 'workflows', 'manager.md');
 
-function readNormalized(p) {
-  return fs.readFileSync(p, 'utf-8').replace(/\r\n/g, '\n');
-}
-
 // The phase6 shrink-only line for plan-phase.md (tests/phase6-capstone-
 // conformance.test.cjs PRE_PHASE6) — mirrored here so a guard sentence can
 // never quietly push the file past it.
 const PLAN_PHASE_PHASE6_LINE = 94519;
 
 function lfByteCount(p) {
-  return Buffer.byteLength(readNormalized(p), 'utf-8');
+  return Buffer.byteLength(readFileNormalized(p), 'utf-8');
 }
 
 /** Split plan-phase.md into its ORCHESTRATOR RULE blocks. */
@@ -64,7 +61,7 @@ function orchestratorRules(content) {
 
 describe('#4079 background-wait wake-tool guard', () => {
   test('every synchronous stop-and-wait ORCHESTRATOR RULE in plan-phase.md forbids ScheduleWakeup (#4079)', () => {
-    const content = readNormalized(PLAN_PHASE_PATH);
+    const content = readFileNormalized(PLAN_PHASE_PATH);
     const stopAndWaitRules = orchestratorRules(content).filter(
       (rule) => /stop working on this task immediately/.test(rule)
     );
@@ -82,7 +79,7 @@ describe('#4079 background-wait wake-tool guard', () => {
   });
 
   test('stall-detection-helpers.md forbids ScheduleWakeup between gsd_stall_watch cycles (#4079)', () => {
-    const content = readNormalized(STALL_HELPERS_PATH);
+    const content = readFileNormalized(STALL_HELPERS_PATH);
     assert.match(
       content,
       /ScheduleWakeup/,
@@ -102,7 +99,7 @@ describe('#4079 background-wait wake-tool guard', () => {
   });
 
   test('manager.md background-dispatch wait rules forbid ScheduleWakeup (#4079)', () => {
-    const content = readNormalized(MANAGER_PATH);
+    const content = readFileNormalized(MANAGER_PATH);
     const dispatchRules = content.split('\n')
       .filter((line) => line.includes('ORCHESTRATOR RULE — BACKGROUND DISPATCH'))
       .map((line) => line.trim());
@@ -120,7 +117,7 @@ describe('#4079 background-wait wake-tool guard', () => {
   });
 
   test('plan-phase.md still uses gsd_stall_watch at all three stall-watch sites (negative space)', () => {
-    const content = readNormalized(PLAN_PHASE_PATH);
+    const content = readFileNormalized(PLAN_PHASE_PATH);
     const stallWatchRules = orchestratorRules(content).filter(
       (rule) => rule.includes('gsd_stall_watch')
     );
@@ -143,7 +140,7 @@ describe('#4079 background-wait wake-tool guard', () => {
   });
 
   test('manager.md background-dispatch semantics unchanged (FLATTEN gate preserved)', () => {
-    const content = readNormalized(MANAGER_PATH);
+    const content = readFileNormalized(MANAGER_PATH);
     assert.match(content, /dispatch-should-flatten/, 'FLATTEN resolution must be preserved');
     assert.match(
       content,

--- a/tests/plan-phase-background-wait-wakeup.test.cjs
+++ b/tests/plan-phase-background-wait-wakeup.test.cjs
@@ -1,0 +1,154 @@
+// allow-test-rule: source-text-is-the-product — see #2650, #4079
+// Workflow markdown is the installed orchestration contract.
+
+'use strict';
+
+/**
+ * #4079 — background-wait pattern lets the orchestrator reach for the host's
+ * `ScheduleWakeup` tool with partial arguments.
+ *
+ * On Claude Code, a `ScheduleWakeup` tool is surfaced in-session (the /loop
+ * dynamic-pacing surface). While a GSD workflow waits on a background subagent
+ * (researcher / pattern-mapper synchronous Agent() stop-and-wait, the
+ * planner/checker/revision `gsd_stall_watch` polling waits, or the manager
+ * dashboard's background dispatch), the orchestrator model could spontaneously
+ * literalize "I'll wait" by calling `ScheduleWakeup` — a tool GSD never
+ * documents — with incomplete arguments, surfacing the host's red validation
+ * error: "`prompt` is required when `stop` is not true."
+ *
+ * The fix is contract-level, not code-level: every wait-instruction site now
+ * carries an explicit prohibition — never call `ScheduleWakeup` or any host
+ * wake/sleep-scheduling tool to literalize a wait; the sanctioned mechanisms
+ * (blocking Agent() return, `gsd_stall_watch` bash polling) ARE the wait.
+ *
+ * These are content-contract tests over the shipped workflow text (same
+ * "source text is the product" pattern as tests/plan-phase-stall-detection
+ * .test.cjs) — they fail on any future edit that drops the guard.
+ *
+ * Seam: gsd-core/workflows/plan-phase.md,
+ *       gsd-core/workflows/plan-phase/steps/stall-detection-helpers.md,
+ *       gsd-core/workflows/manager.md
+ */
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const REPO_ROOT = path.join(__dirname, '..');
+const PLAN_PHASE_PATH = path.join(REPO_ROOT, 'gsd-core', 'workflows', 'plan-phase.md');
+const STALL_HELPERS_PATH = path.join(
+  REPO_ROOT, 'gsd-core', 'workflows', 'plan-phase', 'steps', 'stall-detection-helpers.md'
+);
+const MANAGER_PATH = path.join(REPO_ROOT, 'gsd-core', 'workflows', 'manager.md');
+
+function readNormalized(p) {
+  return fs.readFileSync(p, 'utf-8').replace(/\r\n/g, '\n');
+}
+
+// The phase6 shrink-only line for plan-phase.md (tests/phase6-capstone-
+// conformance.test.cjs PRE_PHASE6) — mirrored here so a guard sentence can
+// never quietly push the file past it.
+const PLAN_PHASE_PHASE6_LINE = 94519;
+
+function lfByteCount(p) {
+  return Buffer.byteLength(readNormalized(p), 'utf-8');
+}
+
+/** Split plan-phase.md into its ORCHESTRATOR RULE blocks. */
+function orchestratorRules(content) {
+  return content.split('\n')
+    .filter((line) => line.includes('ORCHESTRATOR RULE'))
+    .map((line) => line.trim());
+}
+
+describe('#4079 background-wait wake-tool guard', () => {
+  test('every synchronous stop-and-wait ORCHESTRATOR RULE in plan-phase.md forbids ScheduleWakeup (#4079)', () => {
+    const content = readNormalized(PLAN_PHASE_PATH);
+    const stopAndWaitRules = orchestratorRules(content).filter(
+      (rule) => /stop working on this task immediately/.test(rule)
+    );
+    assert.ok(
+      stopAndWaitRules.length >= 2,
+      `expected at least 2 stop-and-wait ORCHESTRATOR RULEs (researcher + pattern mapper), found ${stopAndWaitRules.length}`
+    );
+    const missing = stopAndWaitRules.filter((rule) => !/ScheduleWakeup/.test(rule));
+    assert.deepEqual(
+      missing,
+      [],
+      `every synchronous stop-and-wait rule must forbid ScheduleWakeup (${missing.length} do not). ` +
+      'A model told only to "wait" reaches for any in-session scheduling tool with partial args (#4079).'
+    );
+  });
+
+  test('stall-detection-helpers.md forbids ScheduleWakeup between gsd_stall_watch cycles (#4079)', () => {
+    const content = readNormalized(STALL_HELPERS_PATH);
+    assert.match(
+      content,
+      /ScheduleWakeup/,
+      'the stall-wait fragment (read+executed at step 7.99 before every stall-watch wait) ' +
+      'must name ScheduleWakeup so the prohibition is loaded exactly when the wait happens'
+    );
+    assert.match(
+      content,
+      /gsd_stall_watch[\s\S]{0,400}ScheduleWakeup|ScheduleWakeup[\s\S]{0,400}gsd_stall_watch/,
+      'the prohibition must be tied to the gsd_stall_watch wait cycle, not float disconnected'
+    );
+    assert.match(
+      content,
+      /never part of|not part of|Do NOT call/i,
+      'the fragment must state the wait tool is never part of the sanctioned wait'
+    );
+  });
+
+  test('manager.md background-dispatch wait rules forbid ScheduleWakeup (#4079)', () => {
+    const content = readNormalized(MANAGER_PATH);
+    const dispatchRules = content.split('\n')
+      .filter((line) => line.includes('ORCHESTRATOR RULE — BACKGROUND DISPATCH'))
+      .map((line) => line.trim());
+    assert.ok(
+      dispatchRules.length >= 2,
+      `expected at least 2 BACKGROUND DISPATCH rules (plan + execute), found ${dispatchRules.length}`
+    );
+    const missing = dispatchRules.filter((rule) => !/ScheduleWakeup/.test(rule));
+    assert.deepEqual(
+      missing,
+      [],
+      'every background-dispatch wait rule must forbid ScheduleWakeup — the dashboard wait ' +
+      'is exactly where the model literalizes "I\'ll wait" with a partial-args wake call (#4079)'
+    );
+  });
+
+  test('plan-phase.md still uses gsd_stall_watch at all three stall-watch sites (negative space)', () => {
+    const content = readNormalized(PLAN_PHASE_PATH);
+    const stallWatchRules = orchestratorRules(content).filter(
+      (rule) => rule.includes('gsd_stall_watch')
+    );
+    assert.ok(
+      stallWatchRules.length >= 3,
+      `expected >= 3 gsd_stall_watch ORCHESTRATOR RULEs (planner, checker, revision), found ${stallWatchRules.length}`
+    );
+    // The sanctioned mechanism is unchanged — the guard only closes the escape hatch.
+    assert.match(content, /marker_received/);
+    assert.match(content, /stalled/);
+  });
+
+  test('plan-phase.md stays under the phase6 shrink-only line (#4079 guard)', () => {
+    const bytes = lfByteCount(PLAN_PHASE_PATH);
+    assert.ok(
+      bytes < PLAN_PHASE_PHASE6_LINE,
+      `plan-phase.md is ${bytes} LF bytes — must stay < ${PLAN_PHASE_PHASE6_LINE} ` +
+      '(tests/phase6-capstone-conformance.test.cjs PRE_PHASE6)'
+    );
+  });
+
+  test('manager.md background-dispatch semantics unchanged (FLATTEN gate preserved)', () => {
+    const content = readNormalized(MANAGER_PATH);
+    assert.match(content, /dispatch-should-flatten/, 'FLATTEN resolution must be preserved');
+    assert.match(
+      content,
+      /Return to the dashboard immediately and wait for the background agent to report back/,
+      'the dashboard-return wait semantics must be preserved'
+    );
+  });
+});


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

> **Required.** This PR will be auto-closed if no valid issue link is found.

Fixes #4079

> The linked issue has the `confirmed-bug` label.

---

## What was broken

While a GSD workflow waited on a background subagent (researcher / planner / checker via the stall-watch loop, or the manager dashboard's background dispatch), the orchestrator could literalize "I'll wait" by calling the host session's `ScheduleWakeup` tool (the `/loop` pacing surface) with partial arguments, surfacing the red validation error `` `prompt` is required when `stop` is not true. `` No GSD code or workflow ever called `ScheduleWakeup` — the tool simply had no documented prohibition at the wait sites, so the in-session tool filled the vacuum on runtimes that surface it.

## What this fix does

Adds an explicit prohibition to every GSD wait-instruction site: never call `ScheduleWakeup` (or any host wake/sleep-scheduling tool) to literalize a wait — the sanctioned mechanisms (blocking `Agent()` return, `gsd_stall_watch` bash polling, the manager dashboard loop) ARE the wait. Touched sites:

- `gsd-core/workflows/plan-phase.md` — both synchronous stop-and-wait ORCHESTRATOR RULEs (gsd-phase-researcher, pattern mapper)
- `gsd-core/workflows/plan-phase/steps/stall-detection-helpers.md` — the fragment read+executed (step 7.99) before every planner/checker/revision `gsd_stall_watch` wait
- `gsd-core/workflows/manager.md` — both `ORCHESTRATOR RULE — BACKGROUND DISPATCH` rules (plan + execute)

## Root cause

A contract omission, not a regression: the wait patterns (#2650 stall-watch, #1708 background dispatch) predate runtimes surfacing a `ScheduleWakeup` tool in-session and never anticipated the model reaching for it between wait cycles. No executable code (`src/**`, `bin/**`) changes; this is an orchestration-contract fix.

Assumption stated per repo convention: `execute-phase.md`'s identical stop-and-wait rule is intentionally left untouched — it is a CODEX-runtime guard on runtimes with no `ScheduleWakeup` surface, and that file sits ~250 bytes under its phase6 shrink-only line.

## Testing

### How I verified the fix

TDD via gsd-test: the regression suite `tests/plan-phase-background-wait-wakeup.test.cjs` failed RED at `b2d39eaa5905a13268b1d6d8ff4acc42ca4e3e75` (4 failures — guard absent at all sites) and the full bench passed GREEN after the fix (verdict `passed`, linux-node24, recorded). Content-contract tests assert the guard at every wait site plus negative-space rows: the three `gsd_stall_watch` rules, the manager FLATTEN gate / dashboard-return semantics, and the plan-phase.md phase6 byte line are all preserved.

### Regression test added?

- [x] Yes — `tests/plan-phase-background-wait-wakeup.test.cjs` (fails on any future edit that drops the guard)

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux (gsd-test bench, linux-node24)
- [ ] N/A (not platform-specific)

### Runtimes tested

- [x] Claude Code (the only runtime surfacing `ScheduleWakeup`; the guard text is runtime-neutral prose)
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass (gsd-test verdict `passed` on the PR head)
- [x] `.changeset/` fragment added (`npm run changeset -- --type Fixed --pr 0 ...`, real PR number backfilled)
- [x] No unnecessary dependencies added

## Breaking changes

None — the sanctioned wait mechanisms are byte-preserved; only the wake-tool escape hatch is closed.
