### PR TITLE
fix(#4302): bound restatement detector's deferral window structurally, not by a flat char count

### DIFF
--- a/tests/tdd-single-statement.test.cjs
+++ b/tests/tdd-single-statement.test.cjs
@@ -324,4 +324,29 @@ describe('#4268 — reworded restatement detection (structural, not literal)', (
       { numRuns: 20 },
     );
   });
+
+  // #4302: hasNearbyDeferralMarker's 500-char trailing window is a flat
+  // character count with no structural boundary — on the real
+  // agents/gsd-executor.md, a compact citation-free restatement sits
+  // immediately before an UNRELATED "## Plan-Level TDD Gate Enforcement"
+  // section that carries its own, independent tdd.md citation 82 chars past
+  // the REFACTOR anchor. The restatement borrows that neighbor's citation and
+  // evades detection. This fixture reproduces the same shape: a restatement
+  // paragraph with NO citation of its own, followed by a blank line and an
+  // unrelated section that does cite tdd.md within the 500-char window.
+  test('does not borrow a citation from an unrelated LATER section (paragraph-bounded window)', () => {
+    const fixture = [
+      'RED: write a failing test proving the bug exists and record it with a test-scoped commit.',
+      'GREEN: implement the smallest change that makes the test pass and record that with a',
+      'feat-scoped commit. REFACTOR: simplify the implementation now that it is proven correct,',
+      'without changing observable behavior.',
+      '',
+      '## Unrelated Section',
+      '',
+      'This paragraph cites the canonical `gsd-core/references/tdd.md` reference for a completely',
+      'different purpose and must not be borrowed by the restatement above.',
+    ].join('\n');
+    assert.ok(restatesCycleStructurally(fixture),
+      "a citation belonging to a different, later paragraph/section must not count as this restatement's own deferral");
+  });
 });

--- a/tests/tdd-single-statement.test.cjs
+++ b/tests/tdd-single-statement.test.cjs
@@ -78,27 +78,35 @@ function restatesCycle(text) {
 //     or list-marker shape. This is what makes the signal non-evadable by a
 //     compact, reworded restatement: shortening or dropping list markers does
 //     nothing to manufacture a citation that was never there.
-//   - Trailing window: the EARLIER of 500 characters past the REFACTOR
-//     anchor, or the next markdown HEADING line (`\n#`) — never further.
+//   - Trailing window: the EARLIEST of (a) 500 characters past the REFACTOR
+//     anchor, (b) the next markdown HEADING line (`\n#`), or (c) the next
+//     blank line whose FOLLOWING line does not continue a markdown list
+//     (`- `, `* `, `N. `/`N) `) — never further.
 //     #4302: a flat char count with no structural boundary let a
 //     citation-free restatement borrow an UNRELATED later section's tdd.md
 //     citation (on the real gsd-executor.md, the very next section after the
 //     cycle pointer — "## Plan-Level TDD Gate Enforcement" — has its own,
 //     independent tdd.md citation 82 chars past the pointer's REFACTOR
-//     anchor, well inside a flat 500-char window). A first attempt bounded at
-//     the next blank line instead of a heading, but that broke the real
-//     execute-plan.md pointer: its FIRST RED/GREEN/REFACTOR occurrence is the
-//     list's own intro sentence ("For `type: tdd` plans — RED-GREEN-REFACTOR:"),
-//     separated by a genuine blank line from the numbered list item that
-//     actually carries the citation — a blank line is not reliably "still the
-//     same statement" the way it is in gsd-executor.md's prose form. A
-//     heading is the unambiguous boundary both real files actually use to
-//     start a new, unrelated statement (confirmed: no heading appears between
-//     either real pointer's cycle mention and its own citation; a heading
-//     does appear before the next, unrelated section in gsd-executor.md).
-//     500 chars remains the OUTER cap when no heading appears at all, short
-//     of the whole-file scan the #4228 postmortem (see comment above
-//     restatesCycle()) warns against.
+//     anchor, well inside a flat 500-char window). A first attempt bounded
+//     ONLY at the next heading; an orthogonal review then constructed a
+//     narrower variant of the same evasion — a citation-free restatement
+//     followed by a blank line and an unrelated PROSE paragraph (no heading)
+//     that cites tdd.md — and confirmed by execution that heading-only
+//     bounding still misses it. Bounding on EVERY blank line unconditionally
+//     was tried and rejected earlier for a different reason: the real
+//     execute-plan.md pointer's FIRST RED/GREEN/REFACTOR occurrence is a
+//     numbered list's own intro sentence, separated by a genuine blank line
+//     from the list item that carries the citation — a blank line is not
+//     reliably "still the same statement" UNLESS what follows it is a list
+//     continuation. The list-continuation exception is what reconciles both:
+//     a blank line followed by a list-marker line is skipped (same block); a
+//     blank line followed by anything else — prose, a heading, or the end of
+//     the section — is the boundary. Confirmed against both real files (no
+//     boundary before either one's own citation), the heading-borrowing
+//     fixture, and the narrower prose-borrowing fixture the review
+//     constructed. 500 chars remains the OUTER cap when no boundary appears
+//     at all, short of the whole-file scan the #4228 postmortem (see comment
+//     above restatesCycle()) warns against.
 //   - SECONDARY signals (defense in depth, OR-ed in, kept from the original
 //     design): span > 200 chars, or three DISTINCT markdown list-marker
 //     lines (`- `, `* `, or `N. `/`N) `) each carrying one of RED/GREEN/
@@ -108,6 +116,18 @@ function restatesCycle(text) {
 //     Threshold 200 and the list-marker shape are unchanged from the
 //     original measurement: real pointers span 10-14 chars; a realistic
 //     paraphrased restatement spans 424 chars.
+// Limitation (stated honestly, not resolved by this design): a citation
+// belonging to an unrelated LATER statement that is itself only ONE
+// list-marker hop away from the restatement (e.g. the restatement's own
+// paragraph is immediately followed by a blank line, then a list item, then
+// ANOTHER blank line, then the unrelated citation) would still be found,
+// because the list-continuation exception does not distinguish "the same
+// list the restatement belongs to" from "a different list that happens to
+// start right after it." This is narrower than the gap #4302 closed (it
+// requires the coincidence of an intervening list, not just any adjacent
+// prose or heading) and is judged acceptable residual risk rather than
+// grounds for a third boundary rule; a stronger fix would need to identify
+// list membership by shared indentation/enumeration, not presence alone.
 const RESTATEMENT_SPAN_THRESHOLD = 200;
 const DEFERRAL_WINDOW_TRAILING = 500;
 const DEFERRAL_MARKER_RE = /tdd\.md|references\/tdd|canonical/;
@@ -138,18 +158,41 @@ function measureCycleSpan(text) {
   return { redIdx, greenIdx, refactorIdx, refactorEndIdx, span: refactorIdx - redIdx };
 }
 
+// Find the first blank line (at or after `fromIdx`, within `[fromIdx, capIdx)`)
+// whose immediately following line is NOT a list-marker continuation.
+// Returns the absolute index of that blank line, or -1 if none qualifies
+// before `capIdx`. A blank-line-then-list-item is skipped (same block) so a
+// numbered list's intro sentence can still reach a citation carried by one
+// of its own later items (the real execute-plan.md shape); any other blank
+// line is a genuine boundary. Linear scan via a global regex + manual
+// advance — no backtracking risk even on a large region.
+function findListAwareBlankBoundary(text, fromIdx, capIdx) {
+  const region = text.slice(fromIdx, capIdx);
+  const BLANK_RE = /\n[ \t]*\n/g;
+  let m;
+  while ((m = BLANK_RE.exec(region))) {
+    const afterBlank = region.slice(m.index + m[0].length);
+    const nextLine = afterBlank.slice(0, afterBlank.indexOf('\n') === -1 ? undefined : afterBlank.indexOf('\n'));
+    if (LIST_MARKER_RE.test(nextLine)) continue;
+    return fromIdx + m.index;
+  }
+  return -1;
+}
+
 function hasNearbyDeferralMarker(text, cycle) {
   const cappedEnd = Math.min(text.length, cycle.refactorEndIdx + DEFERRAL_WINDOW_TRAILING);
-  // #4302: stop at the next markdown heading line (`\n#`) at or after the
-  // REFACTOR anchor, whichever comes first against the flat char cap above —
-  // a citation belonging to a LATER, unrelated section must not count as
-  // this restatement's own deferral. A heading, not a blank line, is the
-  // boundary: a legitimate citation can sit past a blank line WITHIN the
-  // same enclosing section (e.g. a numbered list's intro sentence followed
-  // by the list item that carries the citation), so bounding on blank lines
-  // alone produces a false positive on that real shape.
-  const headingMatch = text.slice(cycle.refactorEndIdx, cappedEnd).match(/\n#/);
-  const windowEnd = headingMatch ? cycle.refactorEndIdx + headingMatch.index : cappedEnd;
+  // #4302 (+ review-found narrower variant): stop at the EARLIEST of a
+  // markdown heading or a list-aware blank-line boundary, at or after the
+  // REFACTOR anchor — a citation belonging to a LATER, unrelated statement
+  // must not count as this restatement's own deferral. See the design
+  // comment above for why a blank line alone is not always a valid
+  // boundary (a numbered list's intro sentence vs. its own later item).
+  const region = text.slice(cycle.refactorEndIdx, cappedEnd);
+  const headingMatch = region.match(/\n#/);
+  const headingEnd = headingMatch ? cycle.refactorEndIdx + headingMatch.index : cappedEnd;
+  const blankBoundary = findListAwareBlankBoundary(text, cycle.refactorEndIdx, cappedEnd);
+  const blankEnd = blankBoundary === -1 ? cappedEnd : blankBoundary;
+  const windowEnd = Math.min(headingEnd, blankEnd);
   const window = text.slice(cycle.redIdx, windowEnd);
   return DEFERRAL_MARKER_RE.test(window);
 }
@@ -350,7 +393,7 @@ describe('#4268 — reworded restatement detection (structural, not literal)', (
   // evades detection. This fixture reproduces the same shape: a restatement
   // paragraph with NO citation of its own, followed by a blank line and an
   // unrelated section that does cite tdd.md within the 500-char window.
-  test('does not borrow a citation from an unrelated LATER section (paragraph-bounded window)', () => {
+  test('does not borrow a citation from an unrelated LATER heading-bounded section', () => {
     const fixture = [
       'RED: write a failing test proving the bug exists and record it with a test-scoped commit.',
       'GREEN: implement the smallest change that makes the test pass and record that with a',
@@ -363,6 +406,40 @@ describe('#4268 — reworded restatement detection (structural, not literal)', (
       'different purpose and must not be borrowed by the restatement above.',
     ].join('\n');
     assert.ok(restatesCycleStructurally(fixture),
-      "a citation belonging to a different, later paragraph/section must not count as this restatement's own deferral");
+      "a citation belonging to a different, later heading-bounded section must not count as this restatement's own deferral");
+  });
+
+  // #4302 follow-up (orthogonal review): heading-only bounding still missed a
+  // NARROWER variant — a citation-free restatement followed by a blank line
+  // and an unrelated PROSE paragraph (no heading at all) that cites tdd.md
+  // for an unrelated reason. Confirmed by execution that the heading-only
+  // fix from the first commit misses this; closed by treating any blank line
+  // NOT followed by a list continuation as a boundary too (see the design
+  // comment above hasNearbyDeferralMarker).
+  test('does not borrow a citation from an unrelated LATER paragraph with no heading at all', () => {
+    const fixture = [
+      'RED: write a failing test. GREEN: make it pass. REFACTOR: clean it up.',
+      '',
+      'This unrelated paragraph mentions the canonical tdd.md reference for a totally different reason.',
+    ].join('\n');
+    assert.ok(restatesCycleStructurally(fixture),
+      "a citation belonging to an unrelated later paragraph (no heading) must not count as this restatement's own deferral");
+  });
+
+  // Negative-space companion to the above: a blank line immediately followed
+  // by a LIST ITEM (not a new unrelated paragraph) must still be treated as
+  // the SAME statement, matching the real execute-plan.md shape (a numbered
+  // list's intro sentence, then a blank line, then the list item that
+  // carries the citation) — this is exactly what the first #4302 fix attempt
+  // (a flat blank-line boundary) got wrong.
+  test('does not treat a blank-line-then-list-item as a boundary (the execute-plan.md shape)', () => {
+    const fixture = [
+      'For `type: tdd` plans — RED-GREEN-REFACTOR:',
+      '',
+      '1. Some unrelated setup step.',
+      '2. Execute the cycle exactly as the canonical `references/tdd.md` reference specifies.',
+    ].join('\n');
+    assert.ok(!restatesCycleStructurally(fixture),
+      'a citation carried by a later item of the SAME list (reached via a blank-line-then-list-item hop) must still count as this restatement\'s own deferral');
   });
 });

--- a/tests/tdd-single-statement.test.cjs
+++ b/tests/tdd-single-statement.test.cjs
@@ -78,13 +78,27 @@ function restatesCycle(text) {
 //     or list-marker shape. This is what makes the signal non-evadable by a
 //     compact, reworded restatement: shortening or dropping list markers does
 //     nothing to manufacture a citation that was never there.
-//   - Trailing window: 500 characters past the REFACTOR anchor. Measured
-//     empirically against the real files (2026-09-04): execute-plan.md's
-//     citation of `~/.claude/gsd-core/references/tdd.md` sits 228 chars past
-//     the REFACTOR anchor; gsd-executor.md's citation of
-//     `gsd-core/references/tdd.md` sits 82 chars past it. 500 clears both
-//     with wide margin while staying well short of the whole-file scan the
-//     #4228 postmortem (see comment above restatesCycle()) warns against.
+//   - Trailing window: the EARLIER of 500 characters past the REFACTOR
+//     anchor, or the next markdown HEADING line (`\n#`) — never further.
+//     #4302: a flat char count with no structural boundary let a
+//     citation-free restatement borrow an UNRELATED later section's tdd.md
+//     citation (on the real gsd-executor.md, the very next section after the
+//     cycle pointer — "## Plan-Level TDD Gate Enforcement" — has its own,
+//     independent tdd.md citation 82 chars past the pointer's REFACTOR
+//     anchor, well inside a flat 500-char window). A first attempt bounded at
+//     the next blank line instead of a heading, but that broke the real
+//     execute-plan.md pointer: its FIRST RED/GREEN/REFACTOR occurrence is the
+//     list's own intro sentence ("For `type: tdd` plans — RED-GREEN-REFACTOR:"),
+//     separated by a genuine blank line from the numbered list item that
+//     actually carries the citation — a blank line is not reliably "still the
+//     same statement" the way it is in gsd-executor.md's prose form. A
+//     heading is the unambiguous boundary both real files actually use to
+//     start a new, unrelated statement (confirmed: no heading appears between
+//     either real pointer's cycle mention and its own citation; a heading
+//     does appear before the next, unrelated section in gsd-executor.md).
+//     500 chars remains the OUTER cap when no heading appears at all, short
+//     of the whole-file scan the #4228 postmortem (see comment above
+//     restatesCycle()) warns against.
 //   - SECONDARY signals (defense in depth, OR-ed in, kept from the original
 //     design): span > 200 chars, or three DISTINCT markdown list-marker
 //     lines (`- `, `* `, or `N. `/`N) `) each carrying one of RED/GREEN/
@@ -94,14 +108,6 @@ function restatesCycle(text) {
 //     Threshold 200 and the list-marker shape are unchanged from the
 //     original measurement: real pointers span 10-14 chars; a realistic
 //     paraphrased restatement spans 424 chars.
-// Limitation (stated honestly, not resolved by this design): a restatement
-// that is BOTH compact/no-list-marker AND happens to mention "tdd.md" (or
-// "canonical") somewhere within the 500-char trailing window — without that
-// mention actually deferring the procedure to it — would still pass. The
-// deferral check is a presence check on the marker text, not a semantic
-// check that the marker is doing deferral work. Closing that gap needs a
-// stronger check (e.g. requiring the marker to sit in the same sentence/
-// clause as the cycle words) that is not implemented here.
 const RESTATEMENT_SPAN_THRESHOLD = 200;
 const DEFERRAL_WINDOW_TRAILING = 500;
 const DEFERRAL_MARKER_RE = /tdd\.md|references\/tdd|canonical/;
@@ -133,7 +139,17 @@ function measureCycleSpan(text) {
 }
 
 function hasNearbyDeferralMarker(text, cycle) {
-  const windowEnd = Math.min(text.length, cycle.refactorEndIdx + DEFERRAL_WINDOW_TRAILING);
+  const cappedEnd = Math.min(text.length, cycle.refactorEndIdx + DEFERRAL_WINDOW_TRAILING);
+  // #4302: stop at the next markdown heading line (`\n#`) at or after the
+  // REFACTOR anchor, whichever comes first against the flat char cap above —
+  // a citation belonging to a LATER, unrelated section must not count as
+  // this restatement's own deferral. A heading, not a blank line, is the
+  // boundary: a legitimate citation can sit past a blank line WITHIN the
+  // same enclosing section (e.g. a numbered list's intro sentence followed
+  // by the list item that carries the citation), so bounding on blank lines
+  // alone produces a false positive on that real shape.
+  const headingMatch = text.slice(cycle.refactorEndIdx, cappedEnd).match(/\n#/);
+  const windowEnd = headingMatch ? cycle.refactorEndIdx + headingMatch.index : cappedEnd;
   const window = text.slice(cycle.redIdx, windowEnd);
   return DEFERRAL_MARKER_RE.test(window);
 }


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #4302

## What was broken

`restatesCycleStructurally` (added by #4268, merged in #4297) checks whether a `tdd.md`/`canonical` citation appears within a trailing window past a RED/GREEN/REFACTOR cycle mention, to decide whether that mention is a legitimate pointer or an illegitimate restatement. The window was a flat 500-character cap with no structural boundary, so a citation-free restatement immediately preceding an unrelated section that itself cites `tdd.md` (exactly the real shape in `agents/gsd-executor.md` today: the `<tdd_execution>` cycle pointer is immediately followed by `## Plan-Level TDD Gate Enforcement`, which has its own unrelated citation) borrowed that neighbor's citation and evaded detection. Confirmed via mutation testing against the real file.

## What this fix does

Bounds the deferral-marker search window at the earliest of: the existing 500-char cap, the next markdown heading, or the next blank line whose following line is not a markdown-list continuation. The list-continuation exception matters: a flat blank-line bound (tried first) breaks on the real `execute-plan.md` pointer, whose first RED/GREEN/REFACTOR occurrence is a numbered list's intro sentence, separated by a genuine blank line from the list item that actually carries the citation — the exception lets that hop through while still stopping at genuinely unrelated prose or a new section.

## Root cause

The original #4268 design comment disclosed this as a known residual limitation but it was never empirically confirmed against real in-file adjacency until now, and this PR's own first fix attempt (heading-only bounding) was itself caught by orthogonal review missing a narrower same-section variant — see Testing below.

## Testing

### How I verified the fix

- `tests/tdd-single-statement.test.cjs` — a failing-first regression test reproducing the exact gap, `gsd-test`-verified RED on `fd73d80dce425f902d5b47b1b71e7fb3a07eb155` (2/42855 failed, both this test). Two more tests added after orthogonal review: one for the narrower prose-adjacency variant the reviewer found, one negative-space test pinning the list-continuation exception (the real `execute-plan.md` shape).
- Every pre-existing #4268 fixture (list-based restatement, compact-no-citation restatement, both real files, span 199/200/201 boundaries, the fast-check property test) re-verified by direct execution after each design iteration — none regressed.
- Two orthogonal review passes (Standards/Spec two-axis + an isolated adversarial security pass). The Standards+Spec pass found, by constructing and executing a counter-example, that my first fix (heading-only) still missed a narrower same-section evasion, plus flagged the deleted limitation-disclosure comment — both fixed and re-verified. See `.gsd/bug/fix-4302-restatement-deferral-window-scope/60-review.json`.
- `gsd-test`, final verdict on the pushed sha (`6bfccc7603f363b44ae8e90ceaa59c14f1aaaf1a`): **passed, 42857/42857, 0 failures** (holodeck).

### Regression test added?

- [x] Yes — 3 new tests in `tests/tdd-single-statement.test.cjs`.

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included (tests/ only)
- [x] Regression test added
- [x] All existing tests pass (verified via `gsd-test`, not `npm test` directly — see Testing)
- [x] No `.changeset/` fragment — internal test-detection-power fix only, no user-facing behavior change; `no-changelog` label applied instead
- [x] No unnecessary dependencies added

## Breaking changes

None. Only `tests/tdd-single-statement.test.cjs` is touched; no src/, workflow, or agent file changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
