### PR TITLE
fix(#4306): forward real bytes through the #3912 A6 stderr-bytes mocks

### DIFF
--- a/tests/io.test.cjs
+++ b/tests/io.test.cjs
@@ -16,6 +16,7 @@ const assert = require('node:assert/strict');
 const path = require('node:path');
 const os = require('node:os');
 const fs = require('node:fs');
+const { captureFdSync } = require('./helpers.cjs');
 
 const io = require('../gsd-core/bin/lib/io.cjs');
 const {
@@ -1059,47 +1060,31 @@ describe('#3912 A6: error() stderr bytes are unchanged by this phase', () => {
     for (const version of VERSIONS_3912) {
       resolveContractVersion({ argv: ['node', 'x', `--exit-contract=${version}`], env: {} });
       let caught;
-      const chunks = [];
-      const origWrite = fs.writeSync;
-      fs.writeSync = (fd, buf, offset, length) => {
-        if (fd !== 2) return origWrite(fd, buf, offset, length);
-        const slice = Buffer.isBuffer(buf) ? buf.subarray(offset, offset + length) : Buffer.from(String(buf));
-        chunks.push(slice.toString('utf8'));
-        return slice.length;
-      };
-      try {
+      const stderr = captureFdSync(2, () => {
         io.setJsonErrorMode(false);
         try { io.error('boundary case', io.ERROR_REASON.SDK_MISSING_ARG); } catch (e) { caught = e; }
-      } finally {
-        fs.writeSync = origWrite;
-      }
+      });
       assert.ok(caught instanceof ExitError);
-      assert.strictEqual(chunks.join(''), 'Error: boundary case\n', `version=${version}`);
+      assert.strictEqual(stderr, 'Error: boundary case\n', `version=${version}`);
     }
   });
 
   test('json mode: the stderr envelope is identical regardless of contract version (only the thrown exit code differs)', () => {
     for (const version of VERSIONS_3912) {
       resolveContractVersion({ argv: ['node', 'x', `--exit-contract=${version}`], env: {} });
-      const chunks = [];
-      const origWrite = fs.writeSync;
-      fs.writeSync = (fd, buf, offset, length) => {
-        if (fd !== 2) return origWrite(fd, buf, offset, length);
-        const slice = Buffer.isBuffer(buf) ? buf.subarray(offset, offset + length) : Buffer.from(String(buf));
-        chunks.push(slice.toString('utf8'));
-        return slice.length;
-      };
       let caught;
+      let stderr;
       try {
-        io.setJsonErrorMode(true);
-        try { io.error('boundary case', io.ERROR_REASON.SDK_MISSING_ARG); } catch (e) { caught = e; }
+        stderr = captureFdSync(2, () => {
+          io.setJsonErrorMode(true);
+          try { io.error('boundary case', io.ERROR_REASON.SDK_MISSING_ARG); } catch (e) { caught = e; }
+        });
       } finally {
-        fs.writeSync = origWrite;
         io.setJsonErrorMode(false);
       }
       assert.ok(caught instanceof ExitError);
       assert.deepStrictEqual(
-        JSON.parse(chunks.join('').trim()),
+        JSON.parse(stderr.trim()),
         { ok: false, reason: 'sdk_missing_arg', message: 'boundary case' },
         `version=${version}`,
       );


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #4306

## What was broken

`tests/io.test.cjs`'s `#3912 A6: error() stderr bytes are unchanged by this phase` describe block has two tests that mock `fs.writeSync` to capture stderr (fd 2). Both fabricated a return byte count for fd 2 without ever forwarding the write to the real `fs.writeSync` — the exact same defect class fixed under #4306/#4308, just in a different describe block than the "bug #1008" one that fix targeted, so the original sweep missed it.

## What this fix does

Both mocks now forward every write to the real `fs.writeSync` first (so nothing is ever swallowed) and derive the captured chunk from the real returned byte count, matching the pattern already used everywhere else in this file and across the 17 other files migrated to `captureFdSync` under #4306.

## Root cause

Same mechanism as #4306: node:test's process-isolated runner reads the child's real stdout to reconstruct structured report frames interleaved with the child's own output; a mock that swallows a write on a shared fd risks corrupting that reconstruction. This specific mock only touched fd 2 (stderr), which — per the primary-source research done for #4306 — is not the fd node:test's report protocol travels over (that's fd 1/stdout), so this fix does not by itself explain the specific CI failure that led to finding it (see below). It's still the identical defect class and a real, independent latent risk, so it's fixed regardless of whether it was the proximate cause of any one observed failure.

**How this was found:** PR #4281, on a branch that already had #4306/#4308's fix merged in, hit the identical `"Unable to deserialize cloned data"` failure on `tests/io.test.cjs` in CI. That ruled out "the original fix was incomplete because it didn't merge yet" and meant a genuinely separate unsafe pattern had to still exist somewhere in the file. A full-file search (every `fs.writeSync`/`mock.method` occurrence in `tests/io.test.cjs`, including its folded `bug-1891-file-resolution` section) found exactly these two remaining sites and nothing else.

## Testing

### How I verified the fix

`gsd-test --base next --head 8a73e761be44d8d001ca0d99d19b343a1ec75f7f` — full Linux matrix, 43,498/43,498 passed, 0 failures. `npm run lint:ci` passes clean.

### Regression test added?

- [ ] Yes — added a test that would have caught this bug
- [x] No — explain why: same rationale as #4306 — this corrects existing test-support code to stop discarding real writes; the failure mode is a cross-process timing-dependent Node runtime interaction, not independently reproducible as a deterministic assertion.

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`) — verified via `gsd-test`, 43,498/43,498
- [x] `.changeset/` fragment added if this is a user-facing fix — not applicable: test-only change, `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
