### PR TITLE
fix(#4104): park the prohibition-enforcement hang fixture on a settling timer

### DIFF
--- a/.changeset/happy-lynx-fly.md
+++ b/.changeset/happy-lynx-fly.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 4331
 ---
 **Test machines no longer accumulate immortal 100%-CPU orphan processes when a test runner is killed mid-hang** — the prohibition-enforcement hang fixture busy-looped `while (true) {}`, so a worker orphaned by a chunk timeout, CI cancellation, or Ctrl+C burned a core indefinitely (users found orphans days old); the fixture now parks on a settling 10s timer — still hung for any enforcement bound, ~0% CPU if leaked, and guaranteed to self-terminate. (#4104)

--- a/.changeset/happy-lynx-fly.md
+++ b/.changeset/happy-lynx-fly.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**Test machines no longer accumulate immortal 100%-CPU orphan processes when a test runner is killed mid-hang** — the prohibition-enforcement hang fixture busy-looped `while (true) {}`, so a worker orphaned by a chunk timeout, CI cancellation, or Ctrl+C burned a core indefinitely (users found orphans days old); the fixture now parks on a settling 10s timer — still hung for any enforcement bound, ~0% CPU if leaked, and guaranteed to self-terminate. (#4104)

--- a/tests/prohibition-enforcement.test.cjs
+++ b/tests/prohibition-enforcement.test.cjs
@@ -729,11 +729,19 @@ describe('prohibition-enforcement REAL runner end-to-end (#1259)', () => {
     fs.writeFileSync(tf, HANGS_BODY);
     const child = spawn(process.execPath, [tf], { stdio: 'ignore' });
     t.after(() => { try { child.kill('SIGKILL'); } catch { /* already gone */ } });
+    // Fast-fail on a spawn error (execPath unspawnable): the poll below keys on exit/signal, which
+    // a failed spawn never sets, so without this the 20s ceiling would expire with a misleading
+    // "did not self-terminate" message instead of the real cause.
+    child.on('error', (err) => {
+      assert.fail(`could not spawn the fixture directly: ${err.message}`);
+    });
     const CEILING_MS = 20_000;
     const stillHangingAt = Date.now() + 750; // > half the 1500ms enforcement bound: it must not finish early
     const deadline = Date.now() + CEILING_MS;
     const poll = () => {
-      if (child.exitCode !== null) {
+      // `exitCode !== null` alone misses a SIGNALED exit (exitCode stays null when a signal ends
+      // the child); signalCode covers that, and the assertions below then name it as the failure.
+      if (child.exitCode !== null || child.signalCode !== null) {
         // Exited. If it exited BEFORE the still-hanging checkpoint the fixture is no longer a hang
         // fixture at all (breaks the enforcement test it serves — the negative space in 10-diagnosis).
         assert.ok(Date.now() >= stillHangingAt,

--- a/tests/prohibition-enforcement.test.cjs
+++ b/tests/prohibition-enforcement.test.cjs
@@ -509,7 +509,7 @@ describe('prohibition-enforcement REAL runner end-to-end (#1259)', () => {
   // (#4105), whose non-exit relies on unstated runtime behavior.
   const HANGS_BODY =
     "const { test } = require('node:test');\n" +
-    "test('hangs forever', () => { while (true) {} });\n";
+    "test('hangs forever', () => new Promise((resolve) => { setTimeout(resolve, 10_000); }));\n";
 
   test('a genuine non-vacuous passing node-test proven fail-first greens via the real runner + real prover', (t) => {
     const enforce = require(ENFORCEMENT_LIB);

--- a/tests/prohibition-enforcement.test.cjs
+++ b/tests/prohibition-enforcement.test.cjs
@@ -499,6 +499,17 @@ describe('prohibition-enforcement real-runner helpers (#1259)', () => {
 // SF-01 slip past the injected-double tests. Typed-field assertions only.
 describe('prohibition-enforcement REAL runner end-to-end (#1259)', () => {
   const fs = require('node:fs');
+  const { spawn } = require('node:child_process');
+
+  // The hang fixture served to the bounded-timeout test below, hoisted so the #4104 self-exit
+  // regression cannot drift from the body it guards. Parks on a SETTLING 10s timer: still "hung"
+  // for any enforcement bound (the test below uses 1500ms), ~0% CPU while parked, and guaranteed
+  // to self-terminate (#4104) — unlike the retired `while (true) {}` busy loop, which orphaned at
+  // 100% CPU forever when the runner was killed, and unlike a never-settling `new Promise(() => {})`
+  // (#4105), whose non-exit relies on unstated runtime behavior.
+  const HANGS_BODY =
+    "const { test } = require('node:test');\n" +
+    "test('hangs forever', () => { while (true) {} });\n";
 
   test('a genuine non-vacuous passing node-test proven fail-first greens via the real runner + real prover', (t) => {
     const enforce = require(ENFORCEMENT_LIB);
@@ -687,9 +698,14 @@ describe('prohibition-enforcement REAL runner end-to-end (#1259)', () => {
     const dir = createTempDir('prohib-hang-');
     t.after(() => cleanup(dir));
     const tf = path.join(dir, 'hang.test.cjs');
-    // A test that never returns; the bounded timeout must kill it and dispose non-green.
-    fs.writeFileSync(tf,
-      "const { test } = require('node:test');\ntest('hangs forever', () => { while (true) {} });\n");
+    // A test that never returns within the enforcement bound; the bounded timeout must kill it and
+    // dispose non-green. The body PARKS on a settling setTimeout (#4104) rather than busy-looping
+    // `while (true) {}`: still "hung" for any enforcement timeout (10s >> the 1500ms bound below),
+    // but an orphaned worker costs ~0% CPU while parked and self-exits when the timer settles —
+    // never an immortal 100%-CPU process when the runner is killed. Deliberately NOT the
+    // never-settling `new Promise(() => {})` shape (the #4105 Node-24 concern): the settle is
+    // stated platform behavior, so the self-exit is guaranteed rather than incidental.
+    fs.writeFileSync(tf, HANGS_BODY);
     const result = enforce.runProhibitionEnforcement(
       TEST_TIER,
       { kind: 'node-test', target: tf, failFirst: true },
@@ -697,6 +713,44 @@ describe('prohibition-enforcement REAL runner end-to-end (#1259)', () => {
     );
     assert.notEqual(result.status, 'green', 'a hung check must be killed and fail closed — never hang verify or green');
     assert.equal(result.located, true);
+  });
+
+  test('the #4104 hang fixture parks (~0% CPU) and self-terminates — no immortal 100%-CPU orphan', (t, done) => {
+    // Regression (#4104): the enforcement hang test above relies on `t.after` cleanup and the
+    // bounded timeout, but if the RUNNER itself is killed (chunk timeout, CI cancel, Ctrl+C) nothing
+    // owns the fixture's worker. Old body: `while (true) {}` — orphaned at ~100% CPU forever
+    // (reproduced: worker reparented to PID 1 at 100.0% CPU surviving `kill -9` of the runner).
+    // Deterministic guard, no orphan hunt: spawn the EXACT served body directly, observe that it
+    // (a) is still running shortly into the enforcement-timeout window (it genuinely hangs), and
+    // (b) exits on its own — natural exit, no signal — inside a generous ceiling.
+    const dir = createTempDir('prohib-hang-selfexit-');
+    t.after(() => cleanup(dir));
+    const tf = path.join(dir, 'hang.test.cjs');
+    fs.writeFileSync(tf, HANGS_BODY);
+    const child = spawn(process.execPath, [tf], { stdio: 'ignore' });
+    t.after(() => { try { child.kill('SIGKILL'); } catch { /* already gone */ } });
+    const CEILING_MS = 20_000;
+    const stillHangingAt = Date.now() + 750; // > half the 1500ms enforcement bound: it must not finish early
+    const deadline = Date.now() + CEILING_MS;
+    const poll = () => {
+      if (child.exitCode !== null) {
+        // Exited. If it exited BEFORE the still-hanging checkpoint the fixture is no longer a hang
+        // fixture at all (breaks the enforcement test it serves — the negative space in 10-diagnosis).
+        assert.ok(Date.now() >= stillHangingAt,
+          `fixture must still be hanging at 750ms (exited after only ${Date.now() - (stillHangingAt - 750)}ms)`);
+        assert.equal(child.signalCode, null,
+          'fixture must SELF-terminate (natural exit) — a signal means we had to kill it (#4104 regression)');
+        assert.equal(child.exitCode, 0, 'the parked timer settles and the test passes cleanly');
+        done();
+        return;
+      }
+      if (Date.now() >= deadline) {
+        child.kill('SIGKILL');
+        assert.fail(`fixture did not self-terminate within ${CEILING_MS}ms — immortal process (#4104 regression)`);
+      }
+      setTimeout(poll, 250);
+    };
+    setImmediate(poll);
   });
 
   test('an EMPTY node-test file (exit 0, zero tests) does NOT green via the real runner (BL-01)', (t) => {


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #4104

## What was broken

The prohibition-enforcement hang fixture (`tests/prohibition-enforcement.test.cjs:687`) wrote a test whose body was `while (true) {}`. When the test runner was killed while that fixture executed — a `run-tests.cjs` chunk timeout, a CI job cancellation, or a local Ctrl+C — the fixture's per-file worker was orphaned, reparented to PID 1, and, being a busy loop, burned ~100% of a core indefinitely. The reporter found eight such orphans, up to 7 days old (~3.6 cores of permanent load from suites that had long exited), and the leaked CPU starved later chunks into misleading per-chunk timeouts.

## What this fix does

The fixture body is hoisted to a shared `HANGS_BODY` and now parks on a **settling 10s timer** (`new Promise((resolve) => { setTimeout(resolve, 10_000); })`) instead of busy-looping:

- Still "hung" for any enforcement bound — the existing bounded-timeout test uses `timeoutMs: 1500`, so 10s is >6x the window it must hang for; that test's assertion (non-green, fail-closed, B2) is unchanged and still passes.
- ~0% CPU while parked if the worker does leak — the damage the issue reported is gone even when nothing reaps the process.
- **Guaranteed self-termination**: the timer settles and the process exits on its own, so no orphan can outlive the fixture by more than the park duration regardless of how the runner dies (including SIGKILL, which no runner-side reap can cover).

Deliberately NOT the never-settling `new Promise(() => {})` shape used by the sibling `run-tests-harness` fixture (#4105) — that non-exit relies on unstated runtime behavior off Node 24; a settling `setTimeout` is stated platform behavior.

## Root cause

`while (true) {}` blocks the event loop with runnable code, so an unreaped orphan is a permanent busy loop. Nothing in the test owned the worker when the runner itself died: `t.after` cleanup only removes the temp directory, and the enforcement runner's `timeout` bound only covers the case where the runner survives to enforce it. Runner-side process-group reaping is open PR #3681 (issue #3660) and is complementary — it cannot help when the runner is SIGKILLed (CI cancellation), which is exactly when the fixture-side self-limit is the only defense.

## Testing

### How I verified the fix

- Reproduced the defect first (Node v24.19.0, macOS): spawned the verbatim fixture via `node --test`, SIGKILLed the runner, and observed the worker reparented to PID 1 at 98.8–100.0% CPU, still alive 2s later (orphan then cleaned up by hand).
- TDD, RED before fix: a new regression test that spawns the exact served `HANGS_BODY` directly and asserts it (a) is still running 750ms in (genuinely hangs — guards the negative space that the fixture must not exit too early for the enforcement-timeout test it serves) and (b) exits on its own — natural exit, no signal — inside a 20s ceiling. Proven RED at `c639700866` via gsd-test (`fixture did not self-terminate within 20000ms — immortal process`), green after the fix at `cba34c12d`.
- Full gsd-test bench (linux-node24, 43538 tests) and `npm run lint:ci` pass.

### Regression test added?

- [x] Yes — `the #4104 hang fixture parks (~0% CPU) and self-terminates — no immortal 100%-CPU orphan` (deterministic: observes the fixture's own process; no orphan hunt, no real runner kill)

### Platforms tested

- [x] macOS (local reproduction + fix verification)
- [x] Linux (gsd-test bench, linux-node24)
- [ ] Windows (fixture body is platform-neutral JS; the park/settle semantics are not platform-specific)

### Runtimes tested

- [x] N/A (not runtime-specific — test-fixture-only change; no CLI host surface touched)

## Checklist

- [x] Issue linked above with `Fixes #4104`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — one test file, no `src/**` changes (runner-side reap stays with PR #3681)
- [x] Regression test added
- [x] All existing tests pass (gsd-test bench)
- [x] `.changeset/` fragment added
- [x] No unnecessary dependencies added

## Breaking changes

None — the fixture still hangs past every enforcement bound that observes it; only its CPU cost and post-orphan lifetime change.
