### PR TITLE
fix(#4205): filter gsd_run, not gsd-tools, when isolating PATH in launcher fixtures

### DIFF
--- a/tests/runtime-launcher-parity.test.cjs
+++ b/tests/runtime-launcher-parity.test.cjs
@@ -55,8 +55,11 @@ const SNIPPET_FILE = path.join(WORKFLOWS_DIR, '_runtime-launcher.snippet.sh');
  *    fixture that exits 0 appends `export PATH='<temp dir>'` to the
  *    developer's real env file — 11 lines per suite run, each naming a
  *    /tmp dir the fixture has already deleted.
+ *  - BASH_ENV: sourced by non-interactive bash BEFORE the script, which is
+ *    after this scrub is applied — so one inherited var re-injects any of
+ *    the others. Measured: a BASH_ENV exporting CODEX_HOME turns (H) red.
  */
-const SNIPPET_SCRUB = { GEMINI_CONFIG_DIR: '', CLAUDE_ENV_FILE: '' };
+const SNIPPET_SCRUB = { GEMINI_CONFIG_DIR: '', CLAUDE_ENV_FILE: '', BASH_ENV: '' };
 function snippetEnv(overrides = {}) {
   return { ...process.env, ...TEST_ENV_BASE, ...SNIPPET_SCRUB, ...overrides };
 }
@@ -1703,6 +1706,11 @@ function makeTempDir() {
 }
 
 function runResolver({ cwd, runtimeDir, pathDir }) {
+  // RUNTIME_DIR='' is INDISTINGUISHABLE from unset to the resolver's
+  // ${RUNTIME_DIR:-$(git rev-parse --show-toplevel)} — an empty value silently
+  // falls back to the real repo root and resolves its real install. Fail loudly
+  // instead; every caller passes one.
+  if (!runtimeDir) throw new Error('runResolver requires runtimeDir: an empty value resolves the real repo root');
   const script = [
     'set -e',
     extractResolverSnippet(),
@@ -1721,7 +1729,7 @@ function runResolver({ cwd, runtimeDir, pathDir }) {
     cwd,
     env: snippetEnv({
       PATH: `${pathDir}${path.delimiter}${process.env.PATH || ''}`,
-      RUNTIME_DIR: runtimeDir || '',
+      RUNTIME_DIR: runtimeDir,
     }),
   });
   throwIfFailed(r, 'bash -c <runtime resolver snippet>');

--- a/tests/runtime-launcher-parity.test.cjs
+++ b/tests/runtime-launcher-parity.test.cjs
@@ -133,18 +133,19 @@ function plantExecutable(dir, name) {
 /**
  * Every filename the launcher's `command -v gsd_run` arm could resolve.
  *
- * msys bash appends an executable extension during PATH lookup, so on Windows a
- * directory holding only `gsd_run.exe` is reachable even though `gsd_run` is
- * absent. PATHEXT is folded in as well: it is a cmd.exe mechanism rather than a
- * bash one, so it over-matches, and over-matching is free here — a directory
- * dropped for a `gsd_run.cmd` bash could not have run costs the fixture
- * nothing now that buildIsolatedPath() always supplies its own node.
+ * The arm runs under bash, so this models bash's lookup, not cmd.exe's. The
+ * Cygwin/msys rule is that `.exe` may be omitted from a command while ".bat and
+ * .com ... you cannot omit the extension" — so `gsd_run.exe` is reachable for a
+ * bare `gsd_run` and `gsd_run.cmd`/`.ps1` are not, whatever PATHEXT says.
+ *
+ * Matching PATHEXT instead would drop more directories than bash can reach, and
+ * that is not free: buildIsolatedPath() restores node to the isolated PATH but
+ * nothing restores bash, which the fixtures spawn by name. A wider drop set is
+ * a wider chance of removing the directory bash itself lives in and failing the
+ * fixture with ENOENT instead of an assertion.
  */
 const GSD_RUN_NAMES = process.platform === 'win32'
-  ? ['gsd_run', ...(process.env.PATHEXT || '.COM;.EXE;.BAT;.CMD')
-      .split(';')
-      .filter(Boolean)
-      .map((ext) => `gsd_run${ext.toLowerCase()}`)]
+  ? ['gsd_run', 'gsd_run.exe']
   : ['gsd_run'];
 
 /** True when `dir` holds a gsd_run the launcher's PATH arm could resolve. */
@@ -1372,7 +1373,7 @@ describe('bug-891: non-Claude runtime home fallback arms', () => {
   // test is that prepend's guard: make it conditional again — as it was on
   // Windows, where the helper returned `nodeBinDir: null` — and (ii) goes red.
   test(
-    '(B0) buildIsolatedPath: node is resolvable and gsd_run is not when they share a PATH dir',
+    '(B0) buildIsolatedPath invariants: node survives, every reachable gsd_run name and every relative dir does not',
     (t) => {
       // Build a fake bin dir that contains BOTH a gsd_run executable and node,
       // simulating a dev setup (fnm/nvm/Homebrew) where both land in the same
@@ -1417,10 +1418,14 @@ describe('bug-891: non-Claude runtime home fallback arms', () => {
       );
 
       // (iii) every name the launcher's PATH arm can resolve must be filtered,
-      // not just the extensionless one. One name on POSIX; on Windows the
-      // PATHEXT set, where a gsd_run.exe-only directory is the reachable leak
-      // an extensionless probe misses (#4344).
-      const survived = GSD_RUN_NAMES.filter((name) => {
+      // not just the extensionless one — a gsd_run.exe-only directory is the
+      // reachable Windows leak an extensionless probe misses (#4344). The list
+      // is written out rather than taken from GSD_RUN_NAMES: sweeping the
+      // constant under test with itself cannot catch that constant being wrong.
+      const reachableNames = process.platform === 'win32'
+        ? ['gsd_run', 'gsd_run.exe']
+        : ['gsd_run'];
+      const survived = reachableNames.filter((name) => {
         const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-891-ext-'));
         t.after(() => cleanup(dir));
         plantExecutable(dir, name);
@@ -1431,30 +1436,32 @@ describe('bug-891: non-Claude runtime home fallback arms', () => {
       assert.deepStrictEqual(
         survived,
         [],
-        'every GSD_RUN_NAMES entry must be filtered out of the isolated PATH',
+        'every name bash can resolve for a bare gsd_run must be filtered out of the isolated PATH',
       );
 
       // (iv) every surviving element is absolute. A shell resolves an empty
       // element, `.`, or any relative entry against the *child's* working
       // directory, so each one is a way to put a cwd gsd_run back on PATH —
       // and hasGsdRun cannot see any of them, because it probes relative to the
-      // runner's cwd instead. Three ways one arrives: an ambient `::`, an
-      // explicit `.`, and a PATH every entry of which was filtered (which used
-      // to leave a trailing delimiter, meaning the same thing).
+      // runner's cwd instead. Four ways one arrives: an ambient `::`, an
+      // explicit `.`, a relative entry, and a PATH every entry of which was
+      // filtered (which used to leave a trailing delimiter, meaning the same
+      // thing).
+      // Each case names the dirs that must survive, so the assertion has an
+      // oracle of its own rather than re-running the implementation's filter.
       const relativeElementCases = {
-        emptyElement: `${emptyDir}${path.delimiter}${path.delimiter}${emptyDir}`,
-        dotElement: `${emptyDir}${path.delimiter}.${path.delimiter}${emptyDir}`,
-        relativeElement: `${emptyDir}${path.delimiter}sub/dir`,
-        fullyFiltered: fakeBinDir,
+        emptyElement: [`${emptyDir}${path.delimiter}${path.delimiter}${emptyDir}`, [emptyDir, emptyDir]],
+        dotElement: [`${emptyDir}${path.delimiter}.${path.delimiter}${emptyDir}`, [emptyDir, emptyDir]],
+        relativeElement: [`${emptyDir}${path.delimiter}sub/dir`, [emptyDir]],
+        fullyFiltered: [fakeBinDir, []],
       };
-      for (const [label, basePath] of Object.entries(relativeElementCases)) {
+      for (const [label, [basePath, expected]] of Object.entries(relativeElementCases)) {
         const probe = buildIsolatedPath(basePath);
         t.after(() => cleanup(probe.nodeBinDir));
-        const relative = probe.isolatedPath.split(path.delimiter).filter((dir) => !path.isAbsolute(dir));
         assert.deepStrictEqual(
-          relative,
-          [],
-          `${label}: isolated PATH must carry only absolute dirs (a relative one resolves the child's cwd), got: ${probe.isolatedPath}`,
+          probe.isolatedPath.split(path.delimiter),
+          [probe.nodeBinDir, ...expected],
+          `${label}: only absolute, gsd_run-free dirs may survive (a relative one resolves the child's cwd), got: ${probe.isolatedPath}`,
         );
       }
     },

--- a/tests/runtime-launcher-parity.test.cjs
+++ b/tests/runtime-launcher-parity.test.cjs
@@ -393,7 +393,18 @@ describe('runtime-launcher-parity (#373)', () => {
 
       const r = runHookSeam(scriptPath, [], {
         interpreter: 'bash',
-        env: { ...process.env, PATH: isolatedPath, HOME: base },
+        // Loud-guard requires every runtime-home arm to genuinely miss, not
+        // just PATH (#4205 class: an ambient config-dir var pointing at a
+        // real install would resolve here instead of the hard error).
+        env: {
+          ...process.env, PATH: isolatedPath, HOME: base,
+          CLAUDE_CONFIG_DIR: undefined, HERMES_HOME: undefined, CURSOR_CONFIG_DIR: undefined,
+          CODEX_HOME: undefined, GEMINI_CONFIG_DIR: undefined, COPILOT_CONFIG_DIR: undefined,
+          WINDSURF_CONFIG_DIR: undefined, AUGMENT_CONFIG_DIR: undefined, TRAE_CONFIG_DIR: undefined,
+          QWEN_CONFIG_DIR: undefined, CODEBUDDY_CONFIG_DIR: undefined, CLINE_CONFIG_DIR: undefined,
+          GROK_AGENTS_HOME: undefined, ANTIGRAVITY_CONFIG_DIR: undefined, OPENCODE_CONFIG_DIR: undefined,
+          KILO_CONFIG_DIR: undefined,
+        },
       });
       const threw = r.exitCode !== 0;
       const stderrOutput = r.stderr || '';
@@ -592,7 +603,14 @@ describe('runtime-launcher-parity (#373)', () => {
       }
 
       const stdout = runBashFile(scriptPath, {
-        env: { ...process.env, PATH: systemPaths.join(path.delimiter), HOME: fakeHome },
+        // Ambient CLAUDE_CONFIG_DIR/HERMES_HOME/CURSOR_CONFIG_DIR all resolve
+        // arms checked before CODEX_HOME (#4205 class: same env-leak bug, this
+        // time via config-dir vars rather than PATH) — clear them so only
+        // HOME's default $HOME/.codex fallback can win.
+        env: {
+          ...process.env, PATH: systemPaths.join(path.delimiter), HOME: fakeHome,
+          CLAUDE_CONFIG_DIR: undefined, HERMES_HOME: undefined, CURSOR_CONFIG_DIR: undefined,
+        },
       });
 
       const normStdout = stdout.replace(/\\/g, '/');
@@ -1002,7 +1020,9 @@ describe('bug-211: launcher ~/.claude home fallback', () => {
       }
 
       const stdout = runBashFile(scriptPath, {
-        env: { ...process.env, PATH: systemPaths.join(path.delimiter), HOME: fakeHome },
+        // Ambient CLAUDE_CONFIG_DIR would override the $HOME/.claude default
+        // this test relies on (#4205 class: env-leak, not PATH-leak).
+        env: { ...process.env, PATH: systemPaths.join(path.delimiter), HOME: fakeHome, CLAUDE_CONFIG_DIR: undefined },
       });
 
       // GSD_TOOLS must point into the fake ~/.claude dir
@@ -1057,7 +1077,18 @@ describe('bug-211: launcher ~/.claude home fallback', () => {
 
       const r = runHookSeam(scriptPath, [], {
         interpreter: 'bash',
-        env: { ...process.env, PATH: isolatedPath, HOME: fakeHome },
+        // "All three miss" requires every runtime-home arm to genuinely miss,
+        // not just the first (#4205 class: an ambient config-dir var pointing
+        // at a real install would resolve here instead of the hard error).
+        env: {
+          ...process.env, PATH: isolatedPath, HOME: fakeHome,
+          CLAUDE_CONFIG_DIR: undefined, HERMES_HOME: undefined, CURSOR_CONFIG_DIR: undefined,
+          CODEX_HOME: undefined, GEMINI_CONFIG_DIR: undefined, COPILOT_CONFIG_DIR: undefined,
+          WINDSURF_CONFIG_DIR: undefined, AUGMENT_CONFIG_DIR: undefined, TRAE_CONFIG_DIR: undefined,
+          QWEN_CONFIG_DIR: undefined, CODEBUDDY_CONFIG_DIR: undefined, CLINE_CONFIG_DIR: undefined,
+          GROK_AGENTS_HOME: undefined, ANTIGRAVITY_CONFIG_DIR: undefined, OPENCODE_CONFIG_DIR: undefined,
+          KILO_CONFIG_DIR: undefined,
+        },
       });
       const threw = r.exitCode !== 0;
       const stderrOutput = r.stderr || '';
@@ -1096,8 +1127,10 @@ describe('bug-211: launcher ~/.claude home fallback', () => {
  *
  * Asserts:
  * (A) Snippet contains all expected non-Claude runtime home probes (structural).
- * (B) HERMES_HOME behavioral: when RUNTIME_DIR misses and gsd_run is NOT on
- *     PATH, a stub at ${HERMES_HOME}/gsd-core/bin/gsd-tools.cjs is invoked.
+ * (B0) buildIsolatedPath() co-location invariant (see below).
+ * (B1) HERMES_HOME behavioral: when RUNTIME_DIR misses and gsd_run is NOT on
+ *     PATH — including a leaked ambient gsd_run planted on PATH, #4205 — a
+ *     stub at ${HERMES_HOME}/gsd-core/bin/gsd-tools.cjs is invoked.
  * (C) Default Hermes path behavioral: stub at $HOME/.hermes/gsd-core/bin/
  *     gsd-tools.cjs is invoked when HERMES_HOME is not set.
  * (D) Resolution order: non-Claude homes are probed BEFORE the hard error,
@@ -1435,7 +1468,9 @@ describe('bug-891: non-Claude runtime home fallback arms', () => {
       fs.writeFileSync(scriptPath, scriptContent);
 
       const stdout = runBashFile(scriptPath, {
-        env: { ...process.env, PATH: isolatedPath, HOME: fakeHome, HERMES_HOME: fakeHermesHome },
+        // CLAUDE_CONFIG_DIR resolves before HERMES_HOME; clear it so ambient
+        // leakage can't preempt the arm under test (#4205 class, env vector).
+        env: { ...process.env, PATH: isolatedPath, HOME: fakeHome, HERMES_HOME: fakeHermesHome, CLAUDE_CONFIG_DIR: undefined },
       });
 
       assert.ok(
@@ -1452,59 +1487,6 @@ describe('bug-891: non-Claude runtime home fallback arms', () => {
       );
     },
   );
-
-  // ── (B) Behavioral: HERMES_HOME stub is resolved ──────────────────────────
-  test('(B) gsd_run resolves ${HERMES_HOME}/gsd-core/bin/ stub when set and local+PATH both miss', () => {
-    const fakeHome       = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-891-home-b-'));
-    const fakeHermesHome = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-891-hermes-'));
-    const fakeRuntime    = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-891-rt-'));
-    const { isolatedPath, nodeBinDir } = buildIsolatedPath();
-    try {
-      const hermesBinDir = path.join(fakeHermesHome, 'gsd-core', 'bin');
-      fs.mkdirSync(hermesBinDir, { recursive: true });
-
-      const stubPath = path.join(hermesBinDir, 'gsd-tools.cjs');
-      fs.writeFileSync(
-        stubPath,
-        '#!/usr/bin/env node\nconsole.log("HERMES_HOME_STUB:" + process.argv.slice(2).join(","));\n',
-      );
-      fs.chmodSync(stubPath, 0o755);
-
-      const snippet = fs.readFileSync(SNIPPET_FILE, 'utf8');
-      // Export HOME to an isolated temp dir (no .claude install there) so the
-      // $HOME/.claude arm is skipped and we fall through to the HERMES_HOME arm.
-      const scriptContent =
-        `unset GSD_TOOLS\n` +
-        `export HOME=${JSON.stringify(fakeHome)}\n` +
-        `export RUNTIME_DIR=${JSON.stringify(fakeRuntime)}\n` +
-        `export HERMES_HOME=${JSON.stringify(fakeHermesHome)}\n` +
-        snippet +
-        `\nprintf "GSD_TOOLS=%s\\n" "$GSD_TOOLS"\n` +
-        `gsd_run ping test\n`;
-
-      const scriptPath = path.join(fakeRuntime, 'test-hermes-home.sh');
-      fs.writeFileSync(scriptPath, scriptContent);
-
-      const stdout = runBashFile(scriptPath, {
-        env: { ...process.env, PATH: isolatedPath, HOME: fakeHome, HERMES_HOME: fakeHermesHome },
-      });
-
-      const normStdout = stdout.replace(/\\/g, '/');
-      assert.ok(
-        normStdout.includes('gsd-core/bin/'),
-        `Expected GSD_TOOLS to resolve into hermes gsd-core/bin/, got:\n${stdout.trim()}`,
-      );
-      assert.ok(
-        stdout.includes('HERMES_HOME_STUB:ping,test'),
-        `Expected stub output "HERMES_HOME_STUB:ping,test", got:\n${stdout.trim()}`,
-      );
-    } finally {
-      cleanup(fakeHome);
-      cleanup(fakeHermesHome);
-      cleanup(fakeRuntime);
-      if (nodeBinDir) cleanup(nodeBinDir);
-    }
-  });
 
   // ── (C) Behavioral: default .hermes path used when HERMES_HOME not set ────
   test('(C) gsd_run resolves $HOME/.hermes/gsd-core/bin/ stub when HERMES_HOME is unset', () => {
@@ -1535,7 +1517,11 @@ describe('bug-891: non-Claude runtime home fallback arms', () => {
       fs.writeFileSync(scriptPath, scriptContent);
 
       const stdout = runBashFile(scriptPath, {
-        env: { ...process.env, PATH: isolatedPath, HOME: fakeHome },
+        // CLAUDE_CONFIG_DIR resolves before the HERMES_HOME arm under test
+        // (#4205 class, env vector); script-level `unset HERMES_HOME` above
+        // already handles that var, but Node's env spread still needs to
+        // clear CLAUDE_CONFIG_DIR before bash ever sees it.
+        env: { ...process.env, PATH: isolatedPath, HOME: fakeHome, CLAUDE_CONFIG_DIR: undefined },
       });
 
       const normStdout = stdout.replace(/\\/g, '/');

--- a/tests/runtime-launcher-parity.test.cjs
+++ b/tests/runtime-launcher-parity.test.cjs
@@ -382,7 +382,7 @@ describe('runtime-launcher-parity (#373)', () => {
 
       // Build a PATH that has noToolsBin first (no gsd_run stub there) but retains
       // system paths needed for bash. Exclude any PATH entry that contains a gsd_run
-      // binary (#4205: the resolver's actual PATH-fallback probe target).
+      // binary. See #4205 / buildIsolatedPath() below for why gsd_run.
       const systemPaths = (process.env.PATH || '/usr/bin:/bin')
         .split(path.delimiter)
         .filter((p) => {
@@ -580,7 +580,7 @@ describe('runtime-launcher-parity (#373)', () => {
           return false;
         }
       };
-      // #4205: filter on gsd_run, the resolver's actual PATH-fallback probe target.
+      // #4205: filter on gsd_run — see buildIsolatedPath() below for why.
       const systemPaths = (process.env.PATH || '/usr/bin:/bin')
         .split(path.delimiter)
         .filter((p) => !hasExecutable(p, 'gsd_run'));
@@ -972,10 +972,10 @@ describe('bug-211: launcher ~/.claude home fallback', () => {
       fs.writeFileSync(scriptPath, scriptContent);
 
       // Build a PATH with no gsd_run binary to force the ~/.claude arm.
-      // Filter out directories that contain a gsd_run executable (#4205: the
-      // resolver's actual PATH-fallback probe target, not `gsd-tools`). If node
-      // lives in the same directory as gsd_run, create a dedicated shim dir with
-      // a symlink to node only (no gsd_run there).
+      // Filter out directories that contain a gsd_run executable (#4205; see
+      // buildIsolatedPath() below for why). If node lives in the same directory
+      // as gsd_run, create a dedicated shim dir with a symlink to node only
+      // (no gsd_run there).
       const nodeBinResult = runHookSeam('node', [], { interpreter: 'which' });
       throwIfFailed(nodeBinResult, 'which node');
       const nodeBin = nodeBinResult.stdout.trim();
@@ -1042,7 +1042,7 @@ describe('bug-211: launcher ~/.claude home fallback', () => {
       const scriptPath = path.join(fakeRuntime, 'test-allfail.sh');
       fs.writeFileSync(scriptPath, scriptContent);
 
-      // #4205: filter on gsd_run, the resolver's actual PATH-fallback probe target.
+      // #4205: filter on gsd_run — see buildIsolatedPath() below for why.
       const systemPaths = (process.env.PATH || '/usr/bin:/bin')
         .split(path.delimiter)
         .filter((p) => {
@@ -1334,8 +1334,7 @@ describe('bug-891: non-Claude runtime home fallback arms', () => {
       t.after(() => cleanup(fakeBinDir));
       t.after(() => cleanup(emptyDir));
 
-      // Fake gsd_run shim (executable file) — the resolver's actual PATH-fallback
-      // probe target (#4205: NOT `gsd-tools`).
+      // Fake gsd_run shim (executable file). See #4205 / buildIsolatedPath() above.
       const fakeGsdRun = path.join(fakeBinDir, 'gsd_run');
       fs.writeFileSync(fakeGsdRun, '#!/bin/sh\necho fake-gsd-run\n');
       fs.chmodSync(fakeGsdRun, 0o755);
@@ -1412,7 +1411,7 @@ describe('bug-891: non-Claude runtime home fallback arms', () => {
       } finally {
         process.env.PATH = origPath;
       }
-      t.after(() => { if (nodeBinDir) cleanup(nodeBinDir); });
+      t.after(() => cleanup(nodeBinDir));
 
       const hermesBinDir = path.join(fakeHermesHome, 'gsd-core', 'bin');
       fs.mkdirSync(hermesBinDir, { recursive: true });
@@ -1443,10 +1442,13 @@ describe('bug-891: non-Claude runtime home fallback arms', () => {
         !stdout.includes('SENTINEL_INVOKED'),
         `Expected the leaked PATH gsd_run to never be invoked, got:\n${stdout.trim()}`,
       );
-      const normStdout = stdout.replace(/\\/g, '/');
       assert.ok(
-        normStdout.includes('gsd-core/bin/') && stdout.includes('HERMES_HOME_STUB:ping,test'),
-        `Expected resolver to fall through to the HERMES_HOME stub despite the leaked PATH gsd_run, got:\n${stdout.trim()}`,
+        stdout.includes('gsd-core/bin/'),
+        `Expected GSD_TOOLS to resolve into hermes gsd-core/bin/, got:\n${stdout.trim()}`,
+      );
+      assert.ok(
+        stdout.includes('HERMES_HOME_STUB:ping,test'),
+        `Expected stub output "HERMES_HOME_STUB:ping,test", got:\n${stdout.trim()}`,
       );
     },
   );

--- a/tests/runtime-launcher-parity.test.cjs
+++ b/tests/runtime-launcher-parity.test.cjs
@@ -1142,8 +1142,8 @@ describe('bug-211: launcher ~/.claude home fallback', () => {
  * (B0) buildIsolatedPath() co-location invariant (see below).
  * (B) HERMES_HOME behavioral: when RUNTIME_DIR misses and gsd_run is NOT on
  *     PATH, the stub at ${HERMES_HOME}/gsd-core/bin/gsd-tools.cjs is invoked.
- *     On POSIX it also plants a leaked gsd_run on PATH first (#4205), which is
- *     what makes it fail on a clean machine as well as a leaking one.
+ *     It plants a leaked gsd_run on PATH first (#4205), on every platform,
+ *     which is what makes it fail on a clean machine as well as a leaking one.
  * (C) Default Hermes path behavioral: stub at $HOME/.hermes/gsd-core/bin/
  *     gsd-tools.cjs is invoked when HERMES_HOME is not set.
  * (D) Resolution order: non-Claude homes are probed BEFORE the hard error,
@@ -1276,9 +1276,10 @@ function extractShellBlocks(content) {
  * process.execPath, prepend it to the gsd_run-filtered PATH.  The filtered
  * PATH excludes any directory that contains an executable `gsd_run`.
  *
- * On Windows the co-location bug does not apply (gsd_run resolves via .cmd/.ps1,
- * not the bare binary probed here), and symlinks may require elevated privileges,
- * so we skip the symlink step entirely on that platform.
+ * On Windows symlinks may require elevated privileges, so the symlink step is
+ * skipped there; the filter itself still applies, because npm writes the same
+ * extensionless gsd_run shim beside gsd_run.cmd and X_OK degrades to F_OK on
+ * that platform (#4344).
  *
  * The caller is responsible for cleaning up `result.nodeBinDir` when non-null
  * (pass it to `cleanup()` in a `t.after` or `finally` block).
@@ -1436,10 +1437,10 @@ describe('bug-891: non-Claude runtime home fallback arms', () => {
   // the stub: on a CLEAN machine the bare HERMES_HOME assertion passes whether
   // buildIsolatedPath() filters gsd_run or gsd-tools, so it only catches the bug
   // on a machine that already has the leak. Planting the sentinel makes it fail
-  // on any machine. The sentinel is POSIX-only (an extensionless sh script), so
-  // it is skipped on Windows — where this test still covers the HERMES_HOME arm
-  // itself, which is why it is not gated behind the platform check wholesale.
-  // Windows-native coverage of the leak is tracked in #4344.
+  // on any machine — including Windows, where the leak the filter must catch is
+  // the extensionless Bourne shim npm writes beside gsd_run.cmd, and where
+  // fs.constants.X_OK "has no effect ... (will behave like fs.constants.F_OK)"
+  // per the fs docs, so the same probe sees it (#4344).
   test('(B) buildIsolatedPath strips a leaked PATH gsd_run; the ${HERMES_HOME} stub wins', (t) => {
     const fakeHome       = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-891-home-b-'));
     const fakeHermesHome = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-891-hermes-'));
@@ -1448,20 +1449,36 @@ describe('bug-891: non-Claude runtime home fallback arms', () => {
     t.after(() => cleanup(fakeHermesHome));
     t.after(() => cleanup(fakeRuntime));
 
-    if (process.platform !== 'win32') {
-      const sentinelBinDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-4205-sentinel-'));
-      t.after(() => cleanup(sentinelBinDir));
-      const sentinelPath = path.join(sentinelBinDir, 'gsd_run');
-      fs.writeFileSync(sentinelPath, '#!/bin/sh\necho "SENTINEL_INVOKED:$*"\n');
-      fs.chmodSync(sentinelPath, 0o755);
-      // Simulate the reported leak: a real gsd_run reachable on PATH.
-      const prevPath = process.env.PATH;
-      process.env.PATH = `${sentinelBinDir}${path.delimiter}${process.env.PATH}`;
-      t.after(() => { process.env.PATH = prevPath; });
-    }
+    const sentinelBinDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-4205-sentinel-'));
+    t.after(() => cleanup(sentinelBinDir));
+    const sentinelPath = path.join(sentinelBinDir, 'gsd_run');
+    fs.writeFileSync(sentinelPath, '#!/bin/sh\necho "SENTINEL_INVOKED:$*"\n');
+    fs.chmodSync(sentinelPath, 0o755);
 
-    const { isolatedPath, nodeBinDir } = buildIsolatedPath();
+    // Simulate the reported leak: a real gsd_run reachable on PATH.
+    const prevPath = process.env.PATH;
+    process.env.PATH = `${sentinelBinDir}${path.delimiter}${prevPath}`;
+    let isolated;
+    try {
+      isolated = buildIsolatedPath();
+    } finally {
+      // Restore before the child spawns, not in a t.after: on Windows
+      // process.env spreads as `Path`, so a still-live leak would compete with
+      // snippetEnv()'s `PATH` override for the casing the child receives.
+      process.env.PATH = prevPath;
+    }
+    const { isolatedPath, nodeBinDir } = isolated;
     t.after(() => { if (nodeBinDir) cleanup(nodeBinDir); });
+
+    // The leak assertion that holds on every platform: a filter probing the
+    // wrong name leaves sentinelBinDir on the isolated PATH. The stdout
+    // assertions below cannot carry that on Windows, where whether bash
+    // resolves the shim depends on the mount's exec heuristics, not on the
+    // filter under test.
+    assert.ok(
+      !isolatedPath.split(path.delimiter).includes(sentinelBinDir),
+      `Expected buildIsolatedPath to strip the leaked ${sentinelBinDir}, got:\n${isolatedPath}`,
+    );
 
     const hermesBinDir = path.join(fakeHermesHome, 'gsd-core', 'bin');
     fs.mkdirSync(hermesBinDir, { recursive: true });

--- a/tests/runtime-launcher-parity.test.cjs
+++ b/tests/runtime-launcher-parity.test.cjs
@@ -59,16 +59,21 @@ const SNIPPET_FILE = path.join(WORKFLOWS_DIR, '_runtime-launcher.snippet.sh');
 const SNIPPET_SCRUB = { GEMINI_CONFIG_DIR: '', CLAUDE_ENV_FILE: '', BASH_ENV: '' };
 function snippetEnv(overrides = {}) {
   const env = { ...process.env, ...TEST_ENV_BASE, ...SNIPPET_SCRUB, ...overrides };
-  // Windows env vars are case-insensitive; a spread of process.env is not.
-  // The host PATH enumerates as `Path` there, so `{ ...process.env, PATH: x }`
+  // Windows env vars are case-insensitive; a spread of process.env is not. The
+  // host PATH enumerates as `Path` there, so `{ ...process.env, PATH: x }`
   // yields BOTH keys — and libuv's make_program_env sorts the child's block
-  // case-insensitively but never drops duplicates, so the child can still
-  // resolve the host PATH and defeat the isolation this whole file rests on.
-  // Drop every other casing whenever a caller supplies its own PATH.
-  if ('PATH' in overrides) {
-    for (const key of Object.keys(env)) {
-      if (key !== 'PATH' && key.toUpperCase() === 'PATH') delete env[key];
-    }
+  // case-insensitively but never drops duplicates, so the ambient twin of
+  // anything scrubbed here still reaches the child and defeats the isolation
+  // this whole file rests on. Every key this function sets wins over any other
+  // casing of itself; keys it does not set are left alone, so a caller that
+  // passes no PATH override still gets the host PATH.
+  const canonical = new Map(
+    [...Object.keys(TEST_ENV_BASE), ...Object.keys(SNIPPET_SCRUB), ...Object.keys(overrides)]
+      .map((key) => [key.toUpperCase(), key]),
+  );
+  for (const key of Object.keys(env)) {
+    const owner = canonical.get(key.toUpperCase());
+    if (owner !== undefined && owner !== key) delete env[key];
   }
   return env;
 }
@@ -89,8 +94,10 @@ function runBashFile(scriptPath, options = {}) {
 const NODE_BIN = process.platform === 'win32' ? 'node.exe' : 'node';
 
 /**
- * Put an executable copy of this interpreter in `dir` under `name`, and return
- * `dir` so a caller can prepend it to a PATH.
+ * Put an executable link to this interpreter in `dir` under `name`, and return
+ * `dir` so a caller can prepend it to a PATH. Callers use it for both halves of
+ * a fixture: the node the launcher needs, and the gsd_run sentinel it must not
+ * reach. The content never matters, only that the name resolves.
  *
  * Windows symlinks need elevation, so a hard link is used there instead: it
  * needs no privilege, but it cannot cross volumes, hence the copy fallback.
@@ -155,15 +162,18 @@ function hasGsdRun(dir) {
  * @returns {{ isolatedPath: string, nodeBinDir: string }}
  */
 function buildIsolatedPath(basePath = process.env.PATH) {
-  // An empty PATH element means "the current directory" to a POSIX shell, so
-  // it is dropped along with the gsd_run-bearing dirs: keeping one would put
-  // the fixture's own cwd on PATH, and `path.join('', 'gsd_run')` probes cwd
-  // rather than a directory, so hasGsdRun cannot even see what it would admit.
-  // Joining the surviving dirs (rather than the filtered string) also keeps a
-  // fully-filtered PATH from ending in a delimiter, which means the same thing.
-  const filteredDirs = (basePath || '/usr/bin:/bin')
+  // Only absolute directories survive. An empty element means "the current
+  // directory" to a POSIX shell and `.` says so explicitly, so either one puts
+  // the child's cwd on PATH — and hasGsdRun cannot see what it would admit,
+  // since `path.join('.', 'gsd_run')` probes the *runner's* cwd instead of the
+  // child's. Joining the survivors (rather than the filtered string) also keeps
+  // a fully-filtered PATH from ending in a delimiter, which means the same
+  // thing. Dropping a relative entry can only tighten the isolation, never
+  // loosen it.
+  const fallback = ['/usr/bin', '/bin'].join(path.delimiter);
+  const filteredDirs = (basePath || fallback)
     .split(path.delimiter)
-    .filter((p) => p !== '' && !hasGsdRun(p));
+    .filter((p) => path.isAbsolute(p) && !hasGsdRun(p));
 
   const nodeBinDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-891-node-'));
   try {
@@ -1416,20 +1426,27 @@ describe('bug-891: non-Claude runtime home fallback arms', () => {
         'every GSD_RUN_NAMES entry must be filtered out of the isolated PATH',
       );
 
-      // (iv) no empty element survives, in either of the two ways one appears:
-      // an ambient `::` in the input, and a PATH every entry of which was
-      // filtered. A POSIX shell reads an empty element as the current
-      // directory, which would put the fixture's own cwd back on PATH.
-      const emptyElementCases = {
-        ambient: `${emptyDir}${path.delimiter}${path.delimiter}${emptyDir}`,
+      // (iv) every surviving element is absolute. A shell resolves an empty
+      // element, `.`, or any relative entry against the *child's* working
+      // directory, so each one is a way to put a cwd gsd_run back on PATH —
+      // and hasGsdRun cannot see any of them, because it probes relative to the
+      // runner's cwd instead. Three ways one arrives: an ambient `::`, an
+      // explicit `.`, and a PATH every entry of which was filtered (which used
+      // to leave a trailing delimiter, meaning the same thing).
+      const relativeElementCases = {
+        emptyElement: `${emptyDir}${path.delimiter}${path.delimiter}${emptyDir}`,
+        dotElement: `${emptyDir}${path.delimiter}.${path.delimiter}${emptyDir}`,
+        relativeElement: `${emptyDir}${path.delimiter}sub/dir`,
         fullyFiltered: fakeBinDir,
       };
-      for (const [label, basePath] of Object.entries(emptyElementCases)) {
+      for (const [label, basePath] of Object.entries(relativeElementCases)) {
         const probe = buildIsolatedPath(basePath);
         t.after(() => cleanup(probe.nodeBinDir));
-        assert.ok(
-          !probe.isolatedPath.split(path.delimiter).includes(''),
-          `${label}: isolated PATH must carry no empty element (it would resolve cwd), got: ${probe.isolatedPath}`,
+        const relative = probe.isolatedPath.split(path.delimiter).filter((dir) => !path.isAbsolute(dir));
+        assert.deepStrictEqual(
+          relative,
+          [],
+          `${label}: isolated PATH must carry only absolute dirs (a relative one resolves the child's cwd), got: ${probe.isolatedPath}`,
         );
       }
     },
@@ -1455,15 +1472,18 @@ describe('bug-891: non-Claude runtime home fallback arms', () => {
 
     const sentinelBinDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-4205-sentinel-'));
     t.after(() => cleanup(sentinelBinDir));
-    const sentinelPath = path.join(sentinelBinDir, 'gsd_run');
-    fs.writeFileSync(sentinelPath, '#!/bin/sh\necho "SENTINEL_INVOKED:$*"\n');
-    fs.chmodSync(sentinelPath, 0o755);
     if (process.platform === 'win32') {
-      // What msys bash resolves for a bare `gsd_run` there: it appends `.exe`
-      // during PATH lookup, while the extensionless script above is executable
-      // only under the mount's `#!` heuristic. Any real executable serves — the
-      // assertions are about where GSD_TOOLS lands, not what the sentinel says.
+      // What msys bash resolves for a bare `gsd_run`: it appends `.exe` during
+      // PATH lookup. Planted ALONE, so the leak this fixture proves is the
+      // extension-only one — an extensionless sibling would let an
+      // extension-blind filter strip the directory for the wrong reason and
+      // pass. It cannot print SENTINEL_INVOKED (it is this interpreter under
+      // another name), which is what the GSD_TOOLS assertion below is for.
       linkExecutable(sentinelBinDir, 'gsd_run.exe');
+    } else {
+      const sentinelPath = path.join(sentinelBinDir, 'gsd_run');
+      fs.writeFileSync(sentinelPath, '#!/bin/sh\necho "SENTINEL_INVOKED:$*"\n');
+      fs.chmodSync(sentinelPath, 0o755);
     }
 
     // Simulate the reported leak: a real gsd_run reachable on PATH. Passed in
@@ -1519,8 +1539,13 @@ describe('bug-891: non-Claude runtime home fallback arms', () => {
     );
     // The same claim without depending on the sentinel producing output:
     // whatever the resolver picked, it did not come from the leaked directory.
+    // Matched by basename, not by absolute path — git-bash prints `/c/Users/…`
+    // where os.tmpdir() gives `C:\Users\…` (see the note above the (E) PATH
+    // fallback assertion), so an absolute-path comparison never matches on
+    // Windows and would assert nothing there. The mkdtemp suffix keeps the
+    // basename unique.
     assert.ok(
-      !normStdout.includes(sentinelBinDir.replace(/\\/g, '/')),
+      !normStdout.includes(path.basename(sentinelBinDir)),
       `Expected GSD_TOOLS to resolve outside the leaked ${sentinelBinDir}, got:\n${stdout.trim()}`,
     );
     // Assert the hermes dir itself: every arm of the resolver ends in

--- a/tests/runtime-launcher-parity.test.cjs
+++ b/tests/runtime-launcher-parity.test.cjs
@@ -1130,7 +1130,9 @@ describe('bug-211: launcher ~/.claude home fallback', () => {
  * Asserts:
  * (A) Snippet contains all expected non-Claude runtime home probes (structural).
  * (B0) buildIsolatedPath() co-location invariant (see below).
- * (B1) HERMES_HOME behavioral: when RUNTIME_DIR misses and gsd_run is NOT on
+ * (B) HERMES_HOME behavioral, cross-platform: the ${HERMES_HOME} stub is
+ *     resolved when local and PATH both miss.
+ * (B1) HERMES_HOME behavioral, POSIX-only: when RUNTIME_DIR misses and gsd_run is NOT on
  *     PATH — including a leaked ambient gsd_run planted on PATH, #4205 — a
  *     stub at ${HERMES_HOME}/gsd-core/bin/gsd-tools.cjs is invoked.
  * (C) Default Hermes path behavioral: stub at $HOME/.hermes/gsd-core/bin/
@@ -1894,26 +1896,21 @@ function runBashFile(scriptPath, options = {}) {
 const LOCAL_CLAUDE_PROBE = '_GSD_RUNTIME_ROOT}/.claude/gsd-core/bin/';
 
 /**
- * Build a PATH that strips gsd_run but keeps node and system binaries.
- * Accepts additional bin dirs to prepend.
+ * Return the full system PATH with extra bin dirs prepended. Deliberately does
+ * NOT filter gsd_run — unlike buildIsolatedPath() above, which does.
  *
- * We cannot simply remove the whole directory that contains gsd_run because
- * that directory may also contain node (e.g. /opt/homebrew/bin on macOS).
- * Instead, we keep the system PATH as-is and rely on the test's RUNTIME_DIR
- * having no gsd-core/bin/ sub-path, so the resolver's first two checks
- * (RUNTIME_DIR/gsd-core/bin/ and RUNTIME_DIR/.claude/gsd-core/bin/)
- * are the only ones exercised before we hit our stub.
+ * The isolation here comes from resolution ORDER, not from the PATH contents.
+ * Callers give RUNTIME_DIR a .claude/gsd-core/bin/ stub, and the resolver
+ * checks RUNTIME_DIR/gsd-core/bin/ then RUNTIME_DIR/.claude/gsd-core/bin/
+ * before it ever reaches `command -v gsd_run`, so an ambient gsd_run on PATH
+ * is unreachable for these tests. Keeping PATH whole is what keeps node
+ * resolvable when node co-locates with a global gsd_run (e.g. /opt/homebrew/bin).
  *
- * The extra extraBefore dirs (e.g. noToolsBin) sit first but have no gsd_run
- * binary, so command -v gsd_run still falls back to PATH lookup. However,
- * the snippet's elif arm that uses `command -v gsd_run` will find the real
- * installed one unless we mask it. To mask it without losing node, we create
- * a noToolsBin dir that shadows gsd_run with a sentinel that must NOT be
- * called — and we only call makeIsolatedPath for tests where the .claude stub
- * must win before PATH is consulted (i.e. the elif PATH arm is never reached).
+ * That makes this helper safe ONLY for tests whose stub wins before the PATH
+ * arm. Any test that must prove the PATH arm itself misses needs
+ * buildIsolatedPath(), which excludes gsd_run-bearing directories outright.
  *
- * For B: stub is at RUNTIME_DIR/.claude/... so resolver picks it at elif-1 (before command -v).
- * For C: same — local .claude/ is checked before command -v and before $HOME/.claude.
+ * For B and C: the stub sits at RUNTIME_DIR/.claude/..., picked at elif-1.
  */
 function makeIsolatedPath(extraBefore = []) {
   // Keep full system PATH so node remains accessible.
@@ -1993,7 +1990,8 @@ describe('bug-444: resolver finds repo-local .claude install', () => {
       const scriptPath = path.join(fakeRoot, 'test-local-claude.sh');
       fs.writeFileSync(scriptPath, scriptContent);
 
-      // Keep node in PATH (needed to run the .cjs stub); remove gsd-tools
+      // Keep node in PATH (needed to run the .cjs stub); the .claude arm
+      // resolves before the PATH arm, so gsd_run is never probed here.
       const isolatedPath = makeIsolatedPath([noToolsBin]);
 
       const stdout = runBashFile(scriptPath, {

--- a/tests/runtime-launcher-parity.test.cjs
+++ b/tests/runtime-launcher-parity.test.cjs
@@ -119,6 +119,18 @@ function linkExecutable(dir, name) {
 }
 
 /**
+ * Plant `dir/name` as a file an X_OK probe accepts, and return `dir`. For
+ * fixtures that only need a name to be *found*: nothing ever executes these,
+ * so they cost a zero-byte write instead of a link to (or, across volumes, a
+ * copy of) the whole interpreter.
+ */
+function plantExecutable(dir, name) {
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, name), '', { mode: 0o755 });
+  return dir;
+}
+
+/**
  * Every filename the launcher's `command -v gsd_run` arm could resolve.
  *
  * msys bash appends an executable extension during PATH lookup, so on Windows a
@@ -170,12 +182,11 @@ function buildIsolatedPath(basePath = process.env.PATH) {
   // a fully-filtered PATH from ending in a delimiter, which means the same
   // thing. Dropping a relative entry can only tighten the isolation, never
   // loosen it.
-  const fallback = ['/usr/bin', '/bin'].join(path.delimiter);
-  const filteredDirs = (basePath || fallback)
+  const filteredDirs = (basePath ?? '')
     .split(path.delimiter)
     .filter((p) => path.isAbsolute(p) && !hasGsdRun(p));
 
-  const nodeBinDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-891-node-'));
+  const nodeBinDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-node-'));
   try {
     linkExecutable(nodeBinDir, NODE_BIN);
   } catch (err) {
@@ -1372,14 +1383,11 @@ describe('bug-891: non-Claude runtime home fallback arms', () => {
       t.after(() => cleanup(fakeBinDir));
       t.after(() => cleanup(emptyDir));
 
-      // Fake gsd_run shim (executable file). See #4205 / buildIsolatedPath() above.
-      const fakeGsdRun = path.join(fakeBinDir, 'gsd_run');
-      fs.writeFileSync(fakeGsdRun, '#!/bin/sh\necho fake-gsd-run\n');
-      fs.chmodSync(fakeGsdRun, 0o755);
-
-      // node co-located with gsd_run — the fnm/nvm/Homebrew layout, and the
-      // Windows global-install layout the same helper has to survive.
-      linkExecutable(fakeBinDir, NODE_BIN);
+      // gsd_run co-located with node — the fnm/nvm/Homebrew layout, and the
+      // Windows global-install layout the same helper has to survive. Both are
+      // probed, never run.
+      plantExecutable(fakeBinDir, 'gsd_run');
+      plantExecutable(fakeBinDir, NODE_BIN);
 
       // Filter ONLY the two controlled dirs (no real system dirs). This makes
       // the test machine-independent: on any machine, the only place node
@@ -1415,7 +1423,7 @@ describe('bug-891: non-Claude runtime home fallback arms', () => {
       const survived = GSD_RUN_NAMES.filter((name) => {
         const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-891-ext-'));
         t.after(() => cleanup(dir));
-        linkExecutable(dir, name);
+        plantExecutable(dir, name);
         const probe = buildIsolatedPath(dir);
         t.after(() => cleanup(probe.nodeBinDir));
         return probe.isolatedPath.split(path.delimiter).includes(dir);
@@ -1459,9 +1467,11 @@ describe('bug-891: non-Claude runtime home fallback arms', () => {
   // the stub: on a CLEAN machine the bare HERMES_HOME assertion passes whether
   // buildIsolatedPath() filters gsd_run or gsd-tools, so it only catches the bug
   // on a machine that already has the leak. Planting the sentinel makes it fail
-  // on any machine, and on either platform: the sentinel is planted in both the
-  // extensionless form npm installs and, on Windows, the `gsd_run.exe` form msys
-  // bash resolves for a bare `gsd_run` (#4344).
+  // on any machine, and on either platform: the sentinel is planted in the one
+  // form that platform's shell resolves — the extensionless shim npm installs
+  // on POSIX, `gsd_run.exe` alone on Windows (see below for why alone). Note
+  // that only the POSIX sentinel can print SENTINEL_INVOKED; on Windows the
+  // basename assertion is what carries the guarantee (#4344).
   test('(B) buildIsolatedPath strips a leaked PATH gsd_run; the ${HERMES_HOME} stub wins', (t) => {
     const fakeHome       = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-891-home-b-'));
     const fakeHermesHome = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-891-hermes-'));

--- a/tests/runtime-launcher-parity.test.cjs
+++ b/tests/runtime-launcher-parity.test.cjs
@@ -90,6 +90,31 @@ function runBashFile(scriptPath, options = {}) {
 }
 
 /**
+ * Create `dir` holding a single `node` entry that points at this interpreter,
+ * and return `dir` so a caller can unshift it onto a PATH. The fixtures that
+ * filter gsd_run-bearing directories out of PATH need this when node itself
+ * lives in one of the directories they removed.
+ *
+ * Windows symlinks need elevation, so a hard link is used there instead: it
+ * needs no privilege, but it cannot cross volumes, hence the copy fallback.
+ */
+function linkNodeShim(dir) {
+  fs.mkdirSync(dir, { recursive: true });
+  if (process.platform !== 'win32') {
+    fs.symlinkSync(process.execPath, path.join(dir, 'node'));
+    return dir;
+  }
+  const target = path.join(dir, 'node.exe');
+  try {
+    fs.linkSync(process.execPath, target);
+  } catch (err) {
+    if (err.code !== 'EXDEV') throw err;
+    fs.copyFileSync(process.execPath, target);
+  }
+  return dir;
+}
+
+/**
  * Read the canonical preamble from the snippet file (all lines, no trailing newline).
  */
 function expectedPreamble() {
@@ -632,10 +657,7 @@ describe('runtime-launcher-parity (#373)', () => {
         .split(path.delimiter)
         .filter((p) => !hasExecutable(p, 'gsd_run'));
       if (!systemPaths.some((p) => hasExecutable(p, 'node'))) {
-        const nodeShimDir = path.join(fakeRuntime, 'node-shim');
-        fs.mkdirSync(nodeShimDir, { recursive: true });
-        fs.symlinkSync(process.execPath, path.join(nodeShimDir, 'node'));
-        systemPaths.unshift(nodeShimDir);
+        systemPaths.unshift(linkNodeShim(path.join(fakeRuntime, 'node-shim')));
       }
 
       const stdout = runBashFile(scriptPath, {
@@ -1031,9 +1053,6 @@ describe('bug-211: launcher ~/.claude home fallback', () => {
       // buildIsolatedPath() below for why). If node lives in the same directory
       // as gsd_run, create a dedicated shim dir with a symlink to node only
       // (no gsd_run there).
-      const nodeBinResult = runHookSeam('node', [], { interpreter: 'which' });
-      throwIfFailed(nodeBinResult, 'which node');
-      const nodeBin = nodeBinResult.stdout.trim();
       const systemPaths = (process.env.PATH || '/usr/bin:/bin')
         .split(path.delimiter)
         .filter((p) => {
@@ -1044,16 +1063,13 @@ describe('bug-211: launcher ~/.claude home fallback', () => {
             return true;
           }
         });
-      // If node's dir was filtered (it contained gsd_run), create a shim dir
-      // with just a node symlink so the stub's shebang (#!/usr/bin/env node) resolves.
-      const nodeShimDir = path.join(fakeRuntime, 'node-shim');
+      // If node's dir was filtered (it contained gsd_run), add a shim dir with
+      // just node so the stub's shebang (#!/usr/bin/env node) resolves.
       if (!systemPaths.some((p) => {
         try { fs.accessSync(path.join(p, 'node'), fs.constants.X_OK); return true; }
         catch { return false; }
       })) {
-        fs.mkdirSync(nodeShimDir, { recursive: true });
-        fs.symlinkSync(nodeBin, path.join(nodeShimDir, 'node'));
-        systemPaths.unshift(nodeShimDir);
+        systemPaths.unshift(linkNodeShim(path.join(fakeRuntime, 'node-shim')));
       }
 
       const stdout = runBashFile(scriptPath, {

--- a/tests/runtime-launcher-parity.test.cjs
+++ b/tests/runtime-launcher-parity.test.cjs
@@ -48,7 +48,7 @@ const SNIPPET_FILE = path.join(WORKFLOWS_DIR, '_runtime-launcher.snippet.sh');
  * CODEX_HOME and XDG_CONFIG_HOME, and adding a 17th runtime home would have
  * left it silently stale — the exact shape of #4205.
  *
- * Two keys the derived set cannot supply, both still live in the snippet:
+ * Three keys the derived set cannot supply:
  *  - GEMINI_CONFIG_DIR: the gemini runtime is retired (#1928) so the registry
  *    no longer carries it, but the snippet still probes its arm.
  *  - CLAUDE_ENV_FILE: a WRITE sink, not a read path. Left ambient, every
@@ -61,7 +61,19 @@ const SNIPPET_FILE = path.join(WORKFLOWS_DIR, '_runtime-launcher.snippet.sh');
  */
 const SNIPPET_SCRUB = { GEMINI_CONFIG_DIR: '', CLAUDE_ENV_FILE: '', BASH_ENV: '' };
 function snippetEnv(overrides = {}) {
-  return { ...process.env, ...TEST_ENV_BASE, ...SNIPPET_SCRUB, ...overrides };
+  const env = { ...process.env, ...TEST_ENV_BASE, ...SNIPPET_SCRUB, ...overrides };
+  // Windows env vars are case-insensitive; a spread of process.env is not.
+  // The host PATH enumerates as `Path` there, so `{ ...process.env, PATH: x }`
+  // yields BOTH keys — and libuv's make_program_env sorts the child's block
+  // case-insensitively but never drops duplicates, so the child can still
+  // resolve the host PATH and defeat the isolation this whole file rests on.
+  // Drop every other casing whenever a caller supplies its own PATH.
+  if ('PATH' in overrides) {
+    for (const key of Object.keys(env)) {
+      if (key !== 'PATH' && key.toUpperCase() === 'PATH') delete env[key];
+    }
+  }
+  return env;
 }
 
 /**
@@ -430,9 +442,13 @@ describe('runtime-launcher-parity (#373)', () => {
       const stderrOutput = r.stderr || '';
 
       assert.ok(threw, 'Expected the script to exit non-zero when gsd-tools.cjs is missing and gsd_run is not on PATH');
+      // Match the launcher's own diagnostic, not a bare "not found": when node
+      // itself is missing from the isolated PATH, bash's own
+      // `bash: node: command not found` satisfies the loose form and a
+      // regressed guard passes.
       assert.ok(
-        stderrOutput.includes('not found') || stderrOutput.includes('ERROR'),
-        `Expected stderr to contain "not found" or "ERROR", got: ${stderrOutput.trim()}`,
+        stderrOutput.includes('ERROR: gsd-tools.cjs not found'),
+        `Expected stderr to contain "ERROR: gsd-tools.cjs not found", got: ${stderrOutput.trim()}`,
       );
     } finally {
       cleanup(base);
@@ -626,8 +642,9 @@ describe('runtime-launcher-parity (#373)', () => {
         // Ambient CLAUDE_CONFIG_DIR/HERMES_HOME/CURSOR_CONFIG_DIR resolve arms
         // checked before CODEX_HOME, and an ambient CODEX_HOME overrides the
         // $HOME/.codex default this test asserts (#4205 class: same env-leak
-        // bug, this time via config-dir vars rather than PATH) — clear all
-        // four so only HOME's default $HOME/.codex fallback can win.
+        // bug, this time via config-dir vars rather than PATH). snippetEnv()'s
+        // derived TEST_ENV_BASE clears all four, so only HOME's default
+        // $HOME/.codex fallback can win.
         env: { PATH: systemPaths.join(path.delimiter), HOME: fakeHome },
       });
 
@@ -1106,9 +1123,13 @@ describe('bug-211: launcher ~/.claude home fallback', () => {
       const stderrOutput = r.stderr || '';
 
       assert.ok(threw, 'Expected non-zero exit when all three resolution arms miss');
+      // Match the launcher's own diagnostic, not a bare "not found": when node
+      // itself is missing from the isolated PATH, bash's own
+      // `bash: node: command not found` satisfies the loose form and a
+      // regressed guard passes.
       assert.ok(
-        stderrOutput.includes('not found') || stderrOutput.includes('ERROR'),
-        `Expected stderr to contain "not found" or "ERROR", got: ${stderrOutput.trim()}`,
+        stderrOutput.includes('ERROR: gsd-tools.cjs not found'),
+        `Expected stderr to contain "ERROR: gsd-tools.cjs not found", got: ${stderrOutput.trim()}`,
       );
     } finally {
       cleanup(fakeHome);
@@ -1284,13 +1305,15 @@ function extractShellBlocks(content) {
  * The caller is responsible for cleaning up `result.nodeBinDir` when non-null
  * (pass it to `cleanup()` in a `t.after` or `finally` block).
  *
+ * @param {string} [basePath] PATH to filter. Callers planting a leaked gsd_run
+ *   pass their own string rather than mutating `process.env.PATH`.
  * @returns {{ isolatedPath: string, nodeBinDir: string|null }}
  */
-function buildIsolatedPath() {
+function buildIsolatedPath(basePath = process.env.PATH) {
   // #4205: the resolver's PATH-fallback arm probes `command -v gsd_run` (not
   // `gsd-tools`) — filter on the actual probe target so a real installed
   // gsd_run can't leak through and shadow the runtime-home fallback.
-  const filteredPath = (process.env.PATH || '/usr/bin:/bin')
+  const filteredPath = (basePath || '/usr/bin:/bin')
     .split(path.delimiter)
     .filter((p) => {
       try { fs.accessSync(path.join(p, 'gsd_run'), fs.constants.X_OK); return false; }
@@ -1391,17 +1414,10 @@ describe('bug-891: non-Claude runtime home fallback arms', () => {
       // node symlink pointing at the real interpreter (co-located with gsd_run)
       fs.symlinkSync(process.execPath, path.join(fakeBinDir, 'node'));
 
-      // Set PATH to ONLY the two controlled dirs (no real system dirs).
-      // This makes the test machine-independent: on any machine, the only place
-      // node *could* come from before the fix is fakeBinDir — which gets filtered.
-      const origPath = process.env.PATH;
-      process.env.PATH = fakeBinDir + path.delimiter + emptyDir;
-      let result;
-      try {
-        result = buildIsolatedPath();
-      } finally {
-        process.env.PATH = origPath;
-      }
+      // Filter ONLY the two controlled dirs (no real system dirs). This makes
+      // the test machine-independent: on any machine, the only place node
+      // *could* come from before the fix is fakeBinDir — which gets filtered.
+      const result = buildIsolatedPath(fakeBinDir + path.delimiter + emptyDir);
       t.after(() => cleanup(result.nodeBinDir));
 
       const returnedDirs = result.isolatedPath.split(path.delimiter);
@@ -1455,19 +1471,12 @@ describe('bug-891: non-Claude runtime home fallback arms', () => {
     fs.writeFileSync(sentinelPath, '#!/bin/sh\necho "SENTINEL_INVOKED:$*"\n');
     fs.chmodSync(sentinelPath, 0o755);
 
-    // Simulate the reported leak: a real gsd_run reachable on PATH.
-    const prevPath = process.env.PATH;
-    process.env.PATH = `${sentinelBinDir}${path.delimiter}${prevPath}`;
-    let isolated;
-    try {
-      isolated = buildIsolatedPath();
-    } finally {
-      // Restore before the child spawns, not in a t.after: on Windows
-      // process.env spreads as `Path`, so a still-live leak would compete with
-      // snippetEnv()'s `PATH` override for the casing the child receives.
-      process.env.PATH = prevPath;
-    }
-    const { isolatedPath, nodeBinDir } = isolated;
+    // Simulate the reported leak: a real gsd_run reachable on PATH. Passed in
+    // rather than assigned to process.env.PATH — the runner's own environment
+    // stays untouched, so no other fixture can observe the leak.
+    const { isolatedPath, nodeBinDir } = buildIsolatedPath(
+      `${sentinelBinDir}${path.delimiter}${process.env.PATH}`,
+    );
     t.after(() => { if (nodeBinDir) cleanup(nodeBinDir); });
 
     // The leak assertion that holds on every platform: a filter probing the
@@ -1557,8 +1566,8 @@ describe('bug-891: non-Claude runtime home fallback arms', () => {
       const stdout = runBashFile(scriptPath, {
         // CLAUDE_CONFIG_DIR resolves before the HERMES_HOME arm under test
         // (#4205 class, env vector); script-level `unset HERMES_HOME` above
-        // already handles that var, but Node's env spread still needs to
-        // clear CLAUDE_CONFIG_DIR before bash ever sees it.
+        // already handles that var, and snippetEnv()'s derived TEST_ENV_BASE
+        // clears CLAUDE_CONFIG_DIR before bash ever sees it.
         env: { PATH: isolatedPath, HOME: fakeHome },
       });
 

--- a/tests/runtime-launcher-parity.test.cjs
+++ b/tests/runtime-launcher-parity.test.cjs
@@ -13,11 +13,11 @@
  * (D) Loud guard behavioral: missing gsd-tools.cjs exits non-zero and emits
  *     "not found" to stderr.
  * (E) PATH fallback behavioral: when no local gsd-tools.cjs, the elif branch
- *     resolves to the gsd-tools binary on PATH (#3668).
+ *     resolves to the gsd_run binary on PATH (#3668).
  * (F) Regression locks: the snippet file contains no /gsd-tools substring; and
  *     no line in workflows/do.md matches /\/gsd[:-][a-z]/ (dispatcher-parity
  *     scanner must not read the preamble as a slash-command stub).
- * (H) Codex shim fallback: when PATH has no gsd-tools, $HOME/.codex/gsd-core/bin
+ * (H) Codex shim fallback: when PATH has no gsd_run, $HOME/.codex/gsd-core/bin
  *     can satisfy gsd_run for Codex shim-only installs.
  */
 
@@ -360,12 +360,12 @@ describe('runtime-launcher-parity (#373)', () => {
   });
 
   // ─── (D) Loud guard: missing runtime is fatal ─────────────────────────────
-  test('(D) missing gsd-tools.cjs and no PATH gsd-tools causes loud non-zero exit with "not found" on stderr', () => {
+  test('(D) missing gsd-tools.cjs and no PATH gsd_run causes loud non-zero exit with "not found" on stderr', () => {
     // Create temp dir with a space in the name, but NO gsd-tools.cjs.
-    // We ensure gsd-tools is not on PATH by prepending a dir that has no
-    // gsd-tools binary (system binaries remain on PATH so bash/node work).
+    // We ensure gsd_run is not on PATH by prepending a dir that has no
+    // gsd_run binary (system binaries remain on PATH so bash/node work).
     const base = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd 373 notools '));
-    // Place a no-op dir first in PATH; no gsd-tools stub there.
+    // Place a no-op dir first in PATH; no gsd_run stub there.
     const noToolsBin = path.join(base, 'nobin');
     fs.mkdirSync(noToolsBin, { recursive: true });
     try {
@@ -380,12 +380,13 @@ describe('runtime-launcher-parity (#373)', () => {
       const scriptPath = path.join(base, 'test-guard.sh');
       fs.writeFileSync(scriptPath, scriptContent);
 
-      // Build a PATH that has noToolsBin first (no gsd-tools stub there) but retains
-      // system paths needed for bash. Exclude any PATH entry that contains a gsd-tools binary.
+      // Build a PATH that has noToolsBin first (no gsd_run stub there) but retains
+      // system paths needed for bash. Exclude any PATH entry that contains a gsd_run
+      // binary (#4205: the resolver's actual PATH-fallback probe target).
       const systemPaths = (process.env.PATH || '/usr/bin:/bin')
         .split(path.delimiter)
         .filter((p) => {
-          try { fs.accessSync(path.join(p, 'gsd-tools'), fs.constants.X_OK); return false; }
+          try { fs.accessSync(path.join(p, 'gsd_run'), fs.constants.X_OK); return false; }
           catch { return true; }
         });
       const isolatedPath = [noToolsBin, ...systemPaths].join(path.delimiter);
@@ -397,7 +398,7 @@ describe('runtime-launcher-parity (#373)', () => {
       const threw = r.exitCode !== 0;
       const stderrOutput = r.stderr || '';
 
-      assert.ok(threw, 'Expected the script to exit non-zero when gsd-tools.cjs is missing and gsd-tools is not on PATH');
+      assert.ok(threw, 'Expected the script to exit non-zero when gsd-tools.cjs is missing and gsd_run is not on PATH');
       assert.ok(
         stderrOutput.includes('not found') || stderrOutput.includes('ERROR'),
         `Expected stderr to contain "not found" or "ERROR", got: ${stderrOutput.trim()}`,
@@ -518,7 +519,7 @@ describe('runtime-launcher-parity (#373)', () => {
   });
 
   // ─── (H) Codex shim fallback behavioral ------------------------------------
-  test('(H) gsd_run resolves $HOME/.codex/gsd-core/bin/ shim when PATH has no gsd-tools', () => {
+  test('(H) gsd_run resolves $HOME/.codex/gsd-core/bin/ shim when PATH has no gsd_run', () => {
     const CODEX_HOME_PROBE = '.codex/gsd-core/bin/';
 
     const snippetContent = fs.readFileSync(SNIPPET_FILE, 'utf8');
@@ -579,9 +580,10 @@ describe('runtime-launcher-parity (#373)', () => {
           return false;
         }
       };
+      // #4205: filter on gsd_run, the resolver's actual PATH-fallback probe target.
       const systemPaths = (process.env.PATH || '/usr/bin:/bin')
         .split(path.delimiter)
-        .filter((p) => !hasExecutable(p, 'gsd-tools'));
+        .filter((p) => !hasExecutable(p, 'gsd_run'));
       if (!systemPaths.some((p) => hasExecutable(p, 'node'))) {
         const nodeShimDir = path.join(fakeRuntime, 'node-shim');
         fs.mkdirSync(nodeShimDir, { recursive: true });
@@ -940,7 +942,7 @@ describe('bug-211: launcher ~/.claude home fallback', () => {
   });
 
   // --- (C) Behavioral: ~/.claude stub is resolved when local and PATH both miss
-  test('(C) gsd_run resolves $HOME/.claude/gsd-core/bin/ stub when no local install and gsd-tools not on PATH', () => {
+  test('(C) gsd_run resolves $HOME/.claude/gsd-core/bin/ stub when no local install and gsd_run not on PATH', () => {
     // Build a fake $HOME with a stub at .claude/gsd-core/bin/gsd-tools.cjs
     const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-211-home-'));
     // RUNTIME_DIR points to a directory with no gsd-tools.cjs
@@ -969,10 +971,11 @@ describe('bug-211: launcher ~/.claude home fallback', () => {
       const scriptPath = path.join(fakeRuntime, 'test-home-fb.sh');
       fs.writeFileSync(scriptPath, scriptContent);
 
-      // Build a PATH with no gsd-tools binary to force the ~/.claude arm.
-      // Filter out directories that contain a gsd-tools executable. If node lives
-      // in the same directory as gsd-tools, create a dedicated shim dir with a
-      // symlink to node only (no gsd-tools there).
+      // Build a PATH with no gsd_run binary to force the ~/.claude arm.
+      // Filter out directories that contain a gsd_run executable (#4205: the
+      // resolver's actual PATH-fallback probe target, not `gsd-tools`). If node
+      // lives in the same directory as gsd_run, create a dedicated shim dir with
+      // a symlink to node only (no gsd_run there).
       const nodeBinResult = runHookSeam('node', [], { interpreter: 'which' });
       throwIfFailed(nodeBinResult, 'which node');
       const nodeBin = nodeBinResult.stdout.trim();
@@ -980,13 +983,13 @@ describe('bug-211: launcher ~/.claude home fallback', () => {
         .split(path.delimiter)
         .filter((p) => {
           try {
-            fs.accessSync(path.join(p, 'gsd-tools'), fs.constants.X_OK);
+            fs.accessSync(path.join(p, 'gsd_run'), fs.constants.X_OK);
             return false;
           } catch {
             return true;
           }
         });
-      // If node's dir was filtered (it contained gsd-tools), create a shim dir
+      // If node's dir was filtered (it contained gsd_run), create a shim dir
       // with just a node symlink so the stub's shebang (#!/usr/bin/env node) resolves.
       const nodeShimDir = path.join(fakeRuntime, 'node-shim');
       if (!systemPaths.some((p) => {
@@ -1039,11 +1042,12 @@ describe('bug-211: launcher ~/.claude home fallback', () => {
       const scriptPath = path.join(fakeRuntime, 'test-allfail.sh');
       fs.writeFileSync(scriptPath, scriptContent);
 
+      // #4205: filter on gsd_run, the resolver's actual PATH-fallback probe target.
       const systemPaths = (process.env.PATH || '/usr/bin:/bin')
         .split(path.delimiter)
         .filter((p) => {
           try {
-            fs.accessSync(path.join(p, 'gsd-tools'), fs.constants.X_OK);
+            fs.accessSync(path.join(p, 'gsd_run'), fs.constants.X_OK);
             return false;
           } catch {
             return true;
@@ -1234,10 +1238,13 @@ function extractShellBlocks(content) {
  * @returns {{ isolatedPath: string, nodeBinDir: string|null }}
  */
 function buildIsolatedPath() {
+  // #4205: the resolver's PATH-fallback arm probes `command -v gsd_run` (not
+  // `gsd-tools`) — filter on the actual probe target so a real installed
+  // gsd_run can't leak through and shadow the runtime-home fallback.
   const filteredPath = (process.env.PATH || '/usr/bin:/bin')
     .split(path.delimiter)
     .filter((p) => {
-      try { fs.accessSync(path.join(p, 'gsd-tools'), fs.constants.X_OK); return false; }
+      try { fs.accessSync(path.join(p, 'gsd_run'), fs.constants.X_OK); return false; }
       catch { return true; }
     })
     .join(path.delimiter);
@@ -1304,10 +1311,10 @@ describe('bug-891: non-Claude runtime home fallback arms', () => {
   });
 
   // ── (B0) Regression: buildIsolatedPath keeps node resolvable when node and ──
-  //        gsd-tools co-locate in the same PATH directory.                     ─
+  //        gsd_run co-locate in the same PATH directory.                       ─
   //
   // Machine-independence guarantee: PATH is set to ONLY two controlled dirs —
-  // fakeBinDir (holds both fake gsd-tools AND a node symlink) plus a fresh
+  // fakeBinDir (holds both fake gsd_run AND a node symlink) plus a fresh
   // empty dir (no executables at all). The real system PATH is NOT appended.
   //
   //   Old logic: filters out fakeBinDir → only the empty dir remains → node
@@ -1315,24 +1322,25 @@ describe('bug-891: non-Claude runtime home fallback arms', () => {
   //   New logic: prepends its own nodeBinDir → node resolvable despite fakeBinDir
   //              being filtered → both assertions pass.
   test(
-    '(B0) buildIsolatedPath: node is resolvable and gsd-tools is not when they share a PATH dir',
+    '(B0) buildIsolatedPath: node is resolvable and gsd_run is not when they share a PATH dir',
     { skip: process.platform === 'win32' ? 'POSIX-only co-location scenario' : false },
     (t) => {
-      // Build a fake bin dir that contains BOTH a gsd-tools executable and a node
+      // Build a fake bin dir that contains BOTH a gsd_run executable and a node
       // symlink, simulating a dev setup (fnm/nvm/Homebrew) where both land in the
       // same bin directory.
       const fakeBinDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-891-colocated-'));
-      // A second fresh empty dir — contains neither gsd-tools nor node.
+      // A second fresh empty dir — contains neither gsd_run nor node.
       const emptyDir   = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-891-empty-'));
       t.after(() => cleanup(fakeBinDir));
       t.after(() => cleanup(emptyDir));
 
-      // Fake gsd-tools shim (executable file)
-      const fakeGsdTools = path.join(fakeBinDir, 'gsd-tools');
-      fs.writeFileSync(fakeGsdTools, '#!/bin/sh\necho fake-gsd-tools\n');
-      fs.chmodSync(fakeGsdTools, 0o755);
+      // Fake gsd_run shim (executable file) — the resolver's actual PATH-fallback
+      // probe target (#4205: NOT `gsd-tools`).
+      const fakeGsdRun = path.join(fakeBinDir, 'gsd_run');
+      fs.writeFileSync(fakeGsdRun, '#!/bin/sh\necho fake-gsd-run\n');
+      fs.chmodSync(fakeGsdRun, 0o755);
 
-      // node symlink pointing at the real interpreter (co-located with gsd-tools)
+      // node symlink pointing at the real interpreter (co-located with gsd_run)
       fs.symlinkSync(process.execPath, path.join(fakeBinDir, 'node'));
 
       // Set PATH to ONLY the two controlled dirs (no real system dirs).
@@ -1350,15 +1358,15 @@ describe('bug-891: non-Claude runtime home fallback arms', () => {
 
       const returnedDirs = result.isolatedPath.split(path.delimiter);
 
-      // (i) gsd-tools must NOT be resolvable on the returned PATH
-      const gsdToolsResolvable = returnedDirs.some((dir) => {
-        try { fs.accessSync(path.join(dir, 'gsd-tools'), fs.constants.X_OK); return true; }
+      // (i) gsd_run must NOT be resolvable on the returned PATH
+      const gsdRunResolvable = returnedDirs.some((dir) => {
+        try { fs.accessSync(path.join(dir, 'gsd_run'), fs.constants.X_OK); return true; }
         catch { return false; }
       });
       assert.equal(
-        gsdToolsResolvable,
+        gsdRunResolvable,
         false,
-        'gsd-tools must not be resolvable on the isolated PATH (home-fallback would be bypassed)',
+        'gsd_run must not be resolvable on the isolated PATH (home-fallback would be bypassed)',
       );
 
       // (ii) node must BE resolvable on the returned PATH (the new nodeBinDir makes it so)
@@ -1370,6 +1378,75 @@ describe('bug-891: non-Claude runtime home fallback arms', () => {
         nodeResolvable,
         true,
         'node must be resolvable on the isolated PATH (launcher runs: node "$GSD_TOOLS" "$@")',
+      );
+    },
+  );
+
+  // ── (B1) Regression #4205: a leaked/installed gsd_run reachable on PATH ──
+  //        must be filtered by buildIsolatedPath so the resolver still falls
+  //        through to a runtime-home stub instead of invoking it.
+  test(
+    '(B1) a leaked PATH gsd_run is never invoked; HERMES_HOME stub is used instead',
+    { skip: process.platform === 'win32' ? 'POSIX-only PATH executable scenario' : false },
+    (t) => {
+      const sentinelBinDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-4205-sentinel-'));
+      t.after(() => cleanup(sentinelBinDir));
+      const sentinelPath = path.join(sentinelBinDir, 'gsd_run');
+      fs.writeFileSync(sentinelPath, '#!/bin/sh\necho "SENTINEL_INVOKED:$*"\n');
+      fs.chmodSync(sentinelPath, 0o755);
+
+      const fakeHome       = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-4205-home-'));
+      const fakeHermesHome = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-4205-hermes-'));
+      const fakeRuntime    = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-4205-rt-'));
+      t.after(() => cleanup(fakeHome));
+      t.after(() => cleanup(fakeHermesHome));
+      t.after(() => cleanup(fakeRuntime));
+
+      // Simulate the leaked-installation scenario: a real gsd_run reachable on
+      // the ambient PATH before buildIsolatedPath filters it out.
+      const origPath = process.env.PATH;
+      process.env.PATH = sentinelBinDir + path.delimiter + origPath;
+      let isolatedPath, nodeBinDir;
+      try {
+        ({ isolatedPath, nodeBinDir } = buildIsolatedPath());
+      } finally {
+        process.env.PATH = origPath;
+      }
+      t.after(() => { if (nodeBinDir) cleanup(nodeBinDir); });
+
+      const hermesBinDir = path.join(fakeHermesHome, 'gsd-core', 'bin');
+      fs.mkdirSync(hermesBinDir, { recursive: true });
+      const stubPath = path.join(hermesBinDir, 'gsd-tools.cjs');
+      fs.writeFileSync(
+        stubPath,
+        '#!/usr/bin/env node\nconsole.log("HERMES_HOME_STUB:" + process.argv.slice(2).join(","));\n',
+      );
+      fs.chmodSync(stubPath, 0o755);
+
+      const snippet = fs.readFileSync(SNIPPET_FILE, 'utf8');
+      const scriptContent =
+        `unset GSD_TOOLS\n` +
+        `export HOME=${JSON.stringify(fakeHome)}\n` +
+        `export RUNTIME_DIR=${JSON.stringify(fakeRuntime)}\n` +
+        `export HERMES_HOME=${JSON.stringify(fakeHermesHome)}\n` +
+        snippet +
+        `\nprintf "GSD_TOOLS=%s\\n" "$GSD_TOOLS"\n` +
+        `gsd_run ping test\n`;
+      const scriptPath = path.join(fakeRuntime, 'test-sentinel-gsd-run.sh');
+      fs.writeFileSync(scriptPath, scriptContent);
+
+      const stdout = runBashFile(scriptPath, {
+        env: { ...process.env, PATH: isolatedPath, HOME: fakeHome, HERMES_HOME: fakeHermesHome },
+      });
+
+      assert.ok(
+        !stdout.includes('SENTINEL_INVOKED'),
+        `Expected the leaked PATH gsd_run to never be invoked, got:\n${stdout.trim()}`,
+      );
+      const normStdout = stdout.replace(/\\/g, '/');
+      assert.ok(
+        normStdout.includes('gsd-core/bin/') && stdout.includes('HERMES_HOME_STUB:ping,test'),
+        `Expected resolver to fall through to the HERMES_HOME stub despite the leaked PATH gsd_run, got:\n${stdout.trim()}`,
       );
     },
   );

--- a/tests/runtime-launcher-parity.test.cjs
+++ b/tests/runtime-launcher-parity.test.cjs
@@ -403,7 +403,7 @@ describe('runtime-launcher-parity (#373)', () => {
           WINDSURF_CONFIG_DIR: undefined, AUGMENT_CONFIG_DIR: undefined, TRAE_CONFIG_DIR: undefined,
           QWEN_CONFIG_DIR: undefined, CODEBUDDY_CONFIG_DIR: undefined, CLINE_CONFIG_DIR: undefined,
           GROK_AGENTS_HOME: undefined, ANTIGRAVITY_CONFIG_DIR: undefined, OPENCODE_CONFIG_DIR: undefined,
-          KILO_CONFIG_DIR: undefined,
+          KILO_CONFIG_DIR: undefined, XDG_CONFIG_HOME: undefined,
         },
       });
       const threw = r.exitCode !== 0;
@@ -603,13 +603,15 @@ describe('runtime-launcher-parity (#373)', () => {
       }
 
       const stdout = runBashFile(scriptPath, {
-        // Ambient CLAUDE_CONFIG_DIR/HERMES_HOME/CURSOR_CONFIG_DIR all resolve
-        // arms checked before CODEX_HOME (#4205 class: same env-leak bug, this
-        // time via config-dir vars rather than PATH) — clear them so only
-        // HOME's default $HOME/.codex fallback can win.
+        // Ambient CLAUDE_CONFIG_DIR/HERMES_HOME/CURSOR_CONFIG_DIR resolve arms
+        // checked before CODEX_HOME, and an ambient CODEX_HOME overrides the
+        // $HOME/.codex default this test asserts (#4205 class: same env-leak
+        // bug, this time via config-dir vars rather than PATH) — clear all
+        // four so only HOME's default $HOME/.codex fallback can win.
         env: {
           ...process.env, PATH: systemPaths.join(path.delimiter), HOME: fakeHome,
           CLAUDE_CONFIG_DIR: undefined, HERMES_HOME: undefined, CURSOR_CONFIG_DIR: undefined,
+          CODEX_HOME: undefined,
         },
       });
 
@@ -1087,7 +1089,7 @@ describe('bug-211: launcher ~/.claude home fallback', () => {
           WINDSURF_CONFIG_DIR: undefined, AUGMENT_CONFIG_DIR: undefined, TRAE_CONFIG_DIR: undefined,
           QWEN_CONFIG_DIR: undefined, CODEBUDDY_CONFIG_DIR: undefined, CLINE_CONFIG_DIR: undefined,
           GROK_AGENTS_HOME: undefined, ANTIGRAVITY_CONFIG_DIR: undefined, OPENCODE_CONFIG_DIR: undefined,
-          KILO_CONFIG_DIR: undefined,
+          KILO_CONFIG_DIR: undefined, XDG_CONFIG_HOME: undefined,
         },
       });
       const threw = r.exitCode !== 0;
@@ -1413,6 +1415,65 @@ describe('bug-891: non-Claude runtime home fallback arms', () => {
       );
     },
   );
+
+
+  // ── (B) Behavioral: HERMES_HOME stub is resolved ──────────────────────────
+  test('(B) gsd_run resolves ${HERMES_HOME}/gsd-core/bin/ stub when set and local+PATH both miss', () => {
+    const fakeHome       = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-891-home-b-'));
+    const fakeHermesHome = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-891-hermes-'));
+    const fakeRuntime    = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-891-rt-'));
+    const { isolatedPath, nodeBinDir } = buildIsolatedPath();
+    try {
+      const hermesBinDir = path.join(fakeHermesHome, 'gsd-core', 'bin');
+      fs.mkdirSync(hermesBinDir, { recursive: true });
+
+      const stubPath = path.join(hermesBinDir, 'gsd-tools.cjs');
+      fs.writeFileSync(
+        stubPath,
+        '#!/usr/bin/env node\nconsole.log("HERMES_HOME_STUB:" + process.argv.slice(2).join(","));\n',
+      );
+      fs.chmodSync(stubPath, 0o755);
+
+      const snippet = fs.readFileSync(SNIPPET_FILE, 'utf8');
+      // Export HOME to an isolated temp dir (no .claude install there) so the
+      // $HOME/.claude arm is skipped and we fall through to the HERMES_HOME arm.
+      const scriptContent =
+        `unset GSD_TOOLS\n` +
+        `export HOME=${JSON.stringify(fakeHome)}\n` +
+        `export RUNTIME_DIR=${JSON.stringify(fakeRuntime)}\n` +
+        `export HERMES_HOME=${JSON.stringify(fakeHermesHome)}\n` +
+        snippet +
+        `\nprintf "GSD_TOOLS=%s\\n" "$GSD_TOOLS"\n` +
+        `gsd_run ping test\n`;
+
+      const scriptPath = path.join(fakeRuntime, 'test-hermes-home.sh');
+      fs.writeFileSync(scriptPath, scriptContent);
+
+      const stdout = runBashFile(scriptPath, {
+        // CLAUDE_CONFIG_DIR resolves before HERMES_HOME; clear it so ambient
+        // leakage cannot preempt the arm under test (#4205 class, env vector).
+        env: {
+          ...process.env, PATH: isolatedPath, HOME: fakeHome,
+          HERMES_HOME: fakeHermesHome, CLAUDE_CONFIG_DIR: undefined,
+        },
+      });
+
+      const normStdout = stdout.replace(/\\/g, '/');
+      assert.ok(
+        normStdout.includes('gsd-core/bin/'),
+        `Expected GSD_TOOLS to resolve into hermes gsd-core/bin/, got:\n${stdout.trim()}`,
+      );
+      assert.ok(
+        stdout.includes('HERMES_HOME_STUB:ping,test'),
+        `Expected stub output "HERMES_HOME_STUB:ping,test", got:\n${stdout.trim()}`,
+      );
+    } finally {
+      cleanup(fakeHome);
+      cleanup(fakeHermesHome);
+      cleanup(fakeRuntime);
+      if (nodeBinDir) cleanup(nodeBinDir);
+    }
+  });
 
   // ── (B1) Regression #4205: a leaked/installed gsd_run reachable on PATH ──
   //        must be filtered by buildIsolatedPath so the resolver still falls

--- a/tests/runtime-launcher-parity.test.cjs
+++ b/tests/runtime-launcher-parity.test.cjs
@@ -42,19 +42,16 @@ const SNIPPET_FILE = path.join(WORKFLOWS_DIR, '_runtime-launcher.snippet.sh');
  * Env for any fixture that sources the snippet (#4205).
  *
  * TEST_ENV_BASE is DERIVED from the same capability registry the resolver
- * reads — see the note at tests/helpers.cjs, "#2665: this list is DERIVED,
- * not hand-maintained. A hand-written list is exactly what reopened this bug
- * twice". It was right: the hand-written list this replaces missed both
- * CODEX_HOME and XDG_CONFIG_HOME, and adding a 17th runtime home would have
- * left it silently stale — the exact shape of #4205.
+ * reads (see tests/helpers.cjs, #2665), so a new runtime home cannot leave it
+ * silently stale — the shape of #4205.
  *
  * Three keys the derived set cannot supply:
  *  - GEMINI_CONFIG_DIR: the gemini runtime is retired (#1928) so the registry
  *    no longer carries it, but the snippet still probes its arm.
  *  - CLAUDE_ENV_FILE: a WRITE sink, not a read path. Left ambient, every
  *    fixture that exits 0 appends `export PATH='<temp dir>'` to the
- *    developer's real env file — 11 lines per suite run, each naming a
- *    /tmp dir the fixture has already deleted.
+ *    developer's real env file, each line naming a /tmp dir the fixture has
+ *    already deleted.
  *  - BASH_ENV: sourced by non-interactive bash BEFORE the script, which is
  *    after this scrub is applied — so one inherited var re-injects any of
  *    the others. Measured: a BASH_ENV exporting CODEX_HOME turns (H) red.
@@ -89,22 +86,22 @@ function runBashFile(scriptPath, options = {}) {
   return r.stdout;
 }
 
+const NODE_BIN = process.platform === 'win32' ? 'node.exe' : 'node';
+
 /**
- * Create `dir` holding a single `node` entry that points at this interpreter,
- * and return `dir` so a caller can unshift it onto a PATH. The fixtures that
- * filter gsd_run-bearing directories out of PATH need this when node itself
- * lives in one of the directories they removed.
+ * Put an executable copy of this interpreter in `dir` under `name`, and return
+ * `dir` so a caller can prepend it to a PATH.
  *
  * Windows symlinks need elevation, so a hard link is used there instead: it
  * needs no privilege, but it cannot cross volumes, hence the copy fallback.
  */
-function linkNodeShim(dir) {
+function linkExecutable(dir, name) {
   fs.mkdirSync(dir, { recursive: true });
+  const target = path.join(dir, name);
   if (process.platform !== 'win32') {
-    fs.symlinkSync(process.execPath, path.join(dir, 'node'));
+    fs.symlinkSync(process.execPath, target);
     return dir;
   }
-  const target = path.join(dir, 'node.exe');
   try {
     fs.linkSync(process.execPath, target);
   } catch (err) {
@@ -112,6 +109,66 @@ function linkNodeShim(dir) {
     fs.copyFileSync(process.execPath, target);
   }
   return dir;
+}
+
+/**
+ * Every filename the launcher's `command -v gsd_run` arm could resolve.
+ *
+ * msys bash appends an executable extension during PATH lookup, so on Windows a
+ * directory holding only `gsd_run.exe` is reachable even though `gsd_run` is
+ * absent. PATHEXT is folded in as well: it is a cmd.exe mechanism rather than a
+ * bash one, so it over-matches, and over-matching is free here — a directory
+ * dropped for a `gsd_run.cmd` bash could not have run costs the fixture
+ * nothing now that buildIsolatedPath() always supplies its own node.
+ */
+const GSD_RUN_NAMES = process.platform === 'win32'
+  ? ['gsd_run', ...(process.env.PATHEXT || '.COM;.EXE;.BAT;.CMD')
+      .split(';')
+      .filter(Boolean)
+      .map((ext) => `gsd_run${ext.toLowerCase()}`)]
+  : ['gsd_run'];
+
+/** True when `dir` holds a gsd_run the launcher's PATH arm could resolve. */
+function hasGsdRun(dir) {
+  return GSD_RUN_NAMES.some((name) => {
+    try { fs.accessSync(path.join(dir, name), fs.constants.X_OK); return true; }
+    catch { return false; }
+  });
+}
+
+/**
+ * Build a PATH the launcher's `command -v gsd_run` arm cannot resolve anything
+ * from, while a bare `node` lookup still succeeds — the precondition every
+ * runtime-home fallback fixture needs.
+ *
+ * Directories holding a resolvable gsd_run are dropped (#4205: the arm probes
+ * `gsd_run`, not `gsd-tools`), then a dedicated dir carrying only node is
+ * prepended. The prepend is unconditional because dropping the directory node
+ * itself lives in is a normal outcome, not an exotic one: fnm, nvm, Homebrew
+ * and Windows global installs all co-locate the two.
+ *
+ * The caller cleans up `result.nodeBinDir` (pass it to `cleanup()` in a
+ * `t.after` or `finally` block).
+ *
+ * @param {string} [basePath] PATH to filter. Callers planting a leaked gsd_run
+ *   pass their own string rather than mutating `process.env.PATH`.
+ * @returns {{ isolatedPath: string, nodeBinDir: string }}
+ */
+function buildIsolatedPath(basePath = process.env.PATH) {
+  const filteredPath = (basePath || '/usr/bin:/bin')
+    .split(path.delimiter)
+    .filter((p) => !hasGsdRun(p))
+    .join(path.delimiter);
+
+  const nodeBinDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-891-node-'));
+  try {
+    linkExecutable(nodeBinDir, NODE_BIN);
+  } catch (err) {
+    cleanup(nodeBinDir);
+    throw err;
+  }
+
+  return { isolatedPath: nodeBinDir + path.delimiter + filteredPath, nodeBinDir };
 }
 
 /**
@@ -425,7 +482,7 @@ describe('runtime-launcher-parity (#373)', () => {
   });
 
   // ─── (D) Loud guard: missing runtime is fatal ─────────────────────────────
-  test('(D) missing gsd-tools.cjs and no PATH gsd_run causes loud non-zero exit with "not found" on stderr', () => {
+  test('(D) missing gsd-tools.cjs and no PATH gsd_run causes loud non-zero exit with "not found" on stderr', (t) => {
     // Create temp dir with a space in the name, but NO gsd-tools.cjs.
     // We ensure gsd_run is not on PATH by prepending a dir that has no
     // gsd_run binary (system binaries remain on PATH so bash/node work).
@@ -445,16 +502,11 @@ describe('runtime-launcher-parity (#373)', () => {
       const scriptPath = path.join(base, 'test-guard.sh');
       fs.writeFileSync(scriptPath, scriptContent);
 
-      // Build a PATH that has noToolsBin first (no gsd_run stub there) but retains
-      // system paths needed for bash. Exclude any PATH entry that contains a gsd_run
-      // binary. See #4205 / buildIsolatedPath() below for why gsd_run.
-      const systemPaths = (process.env.PATH || '/usr/bin:/bin')
-        .split(path.delimiter)
-        .filter((p) => {
-          try { fs.accessSync(path.join(p, 'gsd_run'), fs.constants.X_OK); return false; }
-          catch { return true; }
-        });
-      const isolatedPath = [noToolsBin, ...systemPaths].join(path.delimiter);
+      // noToolsBin first (no gsd_run stub there), then a PATH no gsd_run is
+      // resolvable from.
+      const isolated = buildIsolatedPath();
+      t.after(() => cleanup(isolated.nodeBinDir));
+      const isolatedPath = [noToolsBin, isolated.isolatedPath].join(path.delimiter);
 
       const r = runHookSeam(scriptPath, [], {
         interpreter: 'bash',
@@ -591,7 +643,7 @@ describe('runtime-launcher-parity (#373)', () => {
   });
 
   // ─── (H) Codex shim fallback behavioral ------------------------------------
-  test('(H) gsd_run resolves $HOME/.codex/gsd-core/bin/ shim when PATH has no gsd_run', () => {
+  test('(H) gsd_run resolves $HOME/.codex/gsd-core/bin/ shim when PATH has no gsd_run', (t) => {
     const CODEX_HOME_PROBE = '.codex/gsd-core/bin/';
 
     const snippetContent = fs.readFileSync(SNIPPET_FILE, 'utf8');
@@ -644,21 +696,8 @@ describe('runtime-launcher-parity (#373)', () => {
       const scriptPath = path.join(fakeRuntime, 'test-codex-home-fb.sh');
       fs.writeFileSync(scriptPath, scriptContent);
 
-      const hasExecutable = (dir, name) => {
-        try {
-          fs.accessSync(path.join(dir, name), fs.constants.X_OK);
-          return true;
-        } catch {
-          return false;
-        }
-      };
-      // #4205: filter on gsd_run — see buildIsolatedPath() below for why.
-      const systemPaths = (process.env.PATH || '/usr/bin:/bin')
-        .split(path.delimiter)
-        .filter((p) => !hasExecutable(p, 'gsd_run'));
-      if (!systemPaths.some((p) => hasExecutable(p, 'node'))) {
-        systemPaths.unshift(linkNodeShim(path.join(fakeRuntime, 'node-shim')));
-      }
+      const { isolatedPath, nodeBinDir } = buildIsolatedPath();
+      t.after(() => cleanup(nodeBinDir));
 
       const stdout = runBashFile(scriptPath, {
         // Ambient CLAUDE_CONFIG_DIR/HERMES_HOME/CURSOR_CONFIG_DIR resolve arms
@@ -667,7 +706,7 @@ describe('runtime-launcher-parity (#373)', () => {
         // bug, this time via config-dir vars rather than PATH). snippetEnv()'s
         // derived TEST_ENV_BASE clears all four, so only HOME's default
         // $HOME/.codex fallback can win.
-        env: { PATH: systemPaths.join(path.delimiter), HOME: fakeHome },
+        env: { PATH: isolatedPath, HOME: fakeHome },
       });
 
       const normStdout = stdout.replace(/\\/g, '/');
@@ -974,7 +1013,6 @@ const fs = require('node:fs');
 const path = require('node:path');
 const os = require('node:os');
 const { runHook: runHookSeam } = require('./helpers/process-seam.cjs');
-const { throwIfFailed } = require('./helpers/git-fixture.cjs');
 const { cleanup } = require('./helpers.cjs');
 
 const WORKFLOWS_DIR = path.join(__dirname, '..', 'gsd-core', 'workflows');
@@ -982,18 +1020,6 @@ const SNIPPET_FILE = path.join(WORKFLOWS_DIR, '_runtime-launcher.snippet.sh');
 // Representative propagated workflow file (has a gsd_run call):
 const REPRESENTATIVE_FILE = path.join(WORKFLOWS_DIR, 'add-backlog.md');
 
-/**
- * Run a bash script FILE via the process seam, preserving the throw-on-
- * nonzero-exit semantics of the execFileSync('bash', [path], ...) idiom
- * this replaces.
- */
-function runBashFile(scriptPath, options = {}) {
-  const r = runHookSeam(scriptPath, [], {
-    interpreter: 'bash', ...options, env: snippetEnv(options.env),
-  });
-  throwIfFailed(r, `bash ${scriptPath}`);
-  return r.stdout;
-}
 
 const CLAUDE_HOME_PROBE = '.claude/gsd-core/bin/';
 
@@ -1019,7 +1045,7 @@ describe('bug-211: launcher ~/.claude home fallback', () => {
   });
 
   // --- (C) Behavioral: ~/.claude stub is resolved when local and PATH both miss
-  test('(C) gsd_run resolves $HOME/.claude/gsd-core/bin/ stub when no local install and gsd_run not on PATH', () => {
+  test('(C) gsd_run resolves $HOME/.claude/gsd-core/bin/ stub when no local install and gsd_run not on PATH', (t) => {
     // Build a fake $HOME with a stub at .claude/gsd-core/bin/gsd-tools.cjs
     const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-211-home-'));
     // RUNTIME_DIR points to a directory with no gsd-tools.cjs
@@ -1048,34 +1074,15 @@ describe('bug-211: launcher ~/.claude home fallback', () => {
       const scriptPath = path.join(fakeRuntime, 'test-home-fb.sh');
       fs.writeFileSync(scriptPath, scriptContent);
 
-      // Build a PATH with no gsd_run binary to force the ~/.claude arm.
-      // Filter out directories that contain a gsd_run executable (#4205; see
-      // buildIsolatedPath() below for why). If node lives in the same directory
-      // as gsd_run, create a dedicated shim dir with a symlink to node only
-      // (no gsd_run there).
-      const systemPaths = (process.env.PATH || '/usr/bin:/bin')
-        .split(path.delimiter)
-        .filter((p) => {
-          try {
-            fs.accessSync(path.join(p, 'gsd_run'), fs.constants.X_OK);
-            return false;
-          } catch {
-            return true;
-          }
-        });
-      // If node's dir was filtered (it contained gsd_run), add a shim dir with
-      // just node so the stub's shebang (#!/usr/bin/env node) resolves.
-      if (!systemPaths.some((p) => {
-        try { fs.accessSync(path.join(p, 'node'), fs.constants.X_OK); return true; }
-        catch { return false; }
-      })) {
-        systemPaths.unshift(linkNodeShim(path.join(fakeRuntime, 'node-shim')));
-      }
+      // A PATH with no resolvable gsd_run, to force the ~/.claude arm. The
+      // helper also supplies node, which the stub's #!/usr/bin/env node needs.
+      const { isolatedPath, nodeBinDir } = buildIsolatedPath();
+      t.after(() => cleanup(nodeBinDir));
 
       const stdout = runBashFile(scriptPath, {
         // Ambient CLAUDE_CONFIG_DIR would override the $HOME/.claude default
         // this test relies on (#4205 class: env-leak, not PATH-leak).
-        env: { PATH: systemPaths.join(path.delimiter), HOME: fakeHome },
+        env: { PATH: isolatedPath, HOME: fakeHome },
       });
 
       // GSD_TOOLS must point into the fake ~/.claude dir
@@ -1096,7 +1103,7 @@ describe('bug-211: launcher ~/.claude home fallback', () => {
   });
 
   // --- (D) All three miss -> hard error -------------------------------------
-  test('(D) hard error when local, PATH, and ~/.claude all miss', () => {
+  test('(D) hard error when local, PATH, and ~/.claude all miss', (t) => {
     const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-211-nohome-'));
     const fakeRuntime = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-211-nort-'));
     // noToolsBin so PATH check finds nothing
@@ -1115,18 +1122,9 @@ describe('bug-211: launcher ~/.claude home fallback', () => {
       const scriptPath = path.join(fakeRuntime, 'test-allfail.sh');
       fs.writeFileSync(scriptPath, scriptContent);
 
-      // #4205: filter on gsd_run — see buildIsolatedPath() below for why.
-      const systemPaths = (process.env.PATH || '/usr/bin:/bin')
-        .split(path.delimiter)
-        .filter((p) => {
-          try {
-            fs.accessSync(path.join(p, 'gsd_run'), fs.constants.X_OK);
-            return false;
-          } catch {
-            return true;
-          }
-        });
-      const isolatedPath = [noToolsBin, ...systemPaths].join(path.delimiter);
+      const isolated = buildIsolatedPath();
+      t.after(() => cleanup(isolated.nodeBinDir));
+      const isolatedPath = [noToolsBin, isolated.isolatedPath].join(path.delimiter);
 
       const r = runHookSeam(scriptPath, [], {
         interpreter: 'bash',
@@ -1200,26 +1198,12 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
 const os = require('node:os');
-const { runHook: runHookSeam } = require('./helpers/process-seam.cjs');
-const { throwIfFailed } = require('./helpers/git-fixture.cjs');
 const { cleanup } = require('./helpers.cjs');
 const { escapeRegex } = require('../gsd-core/bin/lib/pattern.cjs');
 
 const WORKFLOWS_DIR = path.join(__dirname, '..', 'gsd-core', 'workflows');
 const SNIPPET_FILE = path.join(WORKFLOWS_DIR, '_runtime-launcher.snippet.sh');
 
-/**
- * Run a bash script FILE via the process seam, preserving the throw-on-
- * nonzero-exit semantics of the execFileSync('bash', [path], ...) idiom
- * this replaces.
- */
-function runBashFile(scriptPath, options = {}) {
-  const r = runHookSeam(scriptPath, [], {
-    interpreter: 'bash', ...options, env: snippetEnv(options.env),
-  });
-  throwIfFailed(r, `bash ${scriptPath}`);
-  return r.stdout;
-}
 
 // Every non-Claude runtime home probe the snippet must contain.
 // Key: runtime name (for diagnostics). Value: the substring that must appear
@@ -1304,54 +1288,6 @@ function extractShellBlocks(content) {
   return blocks;
 }
 
-/**
- * Build a PATH with no gsd_run binary so the PATH fallback branch is skipped,
- * while guaranteeing that a bare `node` lookup still resolves regardless of whether
- * the real node binary co-locates with a global gsd_run shim (e.g. fnm/nvm/Homebrew).
- *
- * Strategy (POSIX only): create a temp dir containing only a `node` symlink →
- * process.execPath, prepend it to the gsd_run-filtered PATH.  The filtered
- * PATH excludes any directory that contains an executable `gsd_run`.
- *
- * On Windows symlinks may require elevated privileges, so the symlink step is
- * skipped there; the filter itself still applies, because npm writes the same
- * extensionless gsd_run shim beside gsd_run.cmd and X_OK degrades to F_OK on
- * that platform (#4344).
- *
- * The caller is responsible for cleaning up `result.nodeBinDir` when non-null
- * (pass it to `cleanup()` in a `t.after` or `finally` block).
- *
- * @param {string} [basePath] PATH to filter. Callers planting a leaked gsd_run
- *   pass their own string rather than mutating `process.env.PATH`.
- * @returns {{ isolatedPath: string, nodeBinDir: string|null }}
- */
-function buildIsolatedPath(basePath = process.env.PATH) {
-  // #4205: the resolver's PATH-fallback arm probes `command -v gsd_run` (not
-  // `gsd-tools`) — filter on the actual probe target so a real installed
-  // gsd_run can't leak through and shadow the runtime-home fallback.
-  const filteredPath = (basePath || '/usr/bin:/bin')
-    .split(path.delimiter)
-    .filter((p) => {
-      try { fs.accessSync(path.join(p, 'gsd_run'), fs.constants.X_OK); return false; }
-      catch { return true; }
-    })
-    .join(path.delimiter);
-
-  // Windows: no symlink (see JSDoc above); callers must handle nodeBinDir === null.
-  if (process.platform === 'win32') {
-    return { isolatedPath: filteredPath, nodeBinDir: null };
-  }
-
-  const nodeBinDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-891-node-'));
-  try {
-    fs.symlinkSync(process.execPath, path.join(nodeBinDir, 'node'));
-  } catch (err) {
-    cleanup(nodeBinDir);
-    throw err;
-  }
-
-  return { isolatedPath: nodeBinDir + path.delimiter + filteredPath, nodeBinDir };
-}
 
 describe('bug-891: non-Claude runtime home fallback arms', () => {
 
@@ -1401,21 +1337,20 @@ describe('bug-891: non-Claude runtime home fallback arms', () => {
   // ── (B0) Regression: buildIsolatedPath keeps node resolvable when node and ──
   //        gsd_run co-locate in the same PATH directory.                       ─
   //
-  // Machine-independence guarantee: PATH is set to ONLY two controlled dirs —
-  // fakeBinDir (holds both fake gsd_run AND a node symlink) plus a fresh
-  // empty dir (no executables at all). The real system PATH is NOT appended.
+  // Machine-independence guarantee: the filtered PATH is ONLY two controlled
+  // dirs — fakeBinDir (holds both fake gsd_run AND node) plus a fresh empty dir
+  // (no executables at all). The real system PATH is NOT appended.
   //
-  //   Old logic: filters out fakeBinDir → only the empty dir remains → node
-  //              UNresolvable → assertion (ii) FAILS (true-red on any machine).
-  //   New logic: prepends its own nodeBinDir → node resolvable despite fakeBinDir
-  //              being filtered → both assertions pass.
+  // Filtering fakeBinDir out is correct and unavoidable, so the only thing that
+  // keeps node reachable is the nodeBinDir buildIsolatedPath() prepends. This
+  // test is that prepend's guard: make it conditional again — as it was on
+  // Windows, where the helper returned `nodeBinDir: null` — and (ii) goes red.
   test(
     '(B0) buildIsolatedPath: node is resolvable and gsd_run is not when they share a PATH dir',
-    { skip: process.platform === 'win32' ? 'POSIX-only co-location scenario' : false },
     (t) => {
-      // Build a fake bin dir that contains BOTH a gsd_run executable and a node
-      // symlink, simulating a dev setup (fnm/nvm/Homebrew) where both land in the
-      // same bin directory.
+      // Build a fake bin dir that contains BOTH a gsd_run executable and node,
+      // simulating a dev setup (fnm/nvm/Homebrew) where both land in the same
+      // bin directory.
       const fakeBinDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-891-colocated-'));
       // A second fresh empty dir — contains neither gsd_run nor node.
       const emptyDir   = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-891-empty-'));
@@ -1427,8 +1362,9 @@ describe('bug-891: non-Claude runtime home fallback arms', () => {
       fs.writeFileSync(fakeGsdRun, '#!/bin/sh\necho fake-gsd-run\n');
       fs.chmodSync(fakeGsdRun, 0o755);
 
-      // node symlink pointing at the real interpreter (co-located with gsd_run)
-      fs.symlinkSync(process.execPath, path.join(fakeBinDir, 'node'));
+      // node co-located with gsd_run — the fnm/nvm/Homebrew layout, and the
+      // Windows global-install layout the same helper has to survive.
+      linkExecutable(fakeBinDir, NODE_BIN);
 
       // Filter ONLY the two controlled dirs (no real system dirs). This makes
       // the test machine-independent: on any machine, the only place node
@@ -1439,10 +1375,7 @@ describe('bug-891: non-Claude runtime home fallback arms', () => {
       const returnedDirs = result.isolatedPath.split(path.delimiter);
 
       // (i) gsd_run must NOT be resolvable on the returned PATH
-      const gsdRunResolvable = returnedDirs.some((dir) => {
-        try { fs.accessSync(path.join(dir, 'gsd_run'), fs.constants.X_OK); return true; }
-        catch { return false; }
-      });
+      const gsdRunResolvable = returnedDirs.some(hasGsdRun);
       assert.equal(
         gsdRunResolvable,
         false,
@@ -1451,13 +1384,31 @@ describe('bug-891: non-Claude runtime home fallback arms', () => {
 
       // (ii) node must BE resolvable on the returned PATH (the new nodeBinDir makes it so)
       const nodeResolvable = returnedDirs.some((dir) => {
-        try { fs.accessSync(path.join(dir, 'node'), fs.constants.X_OK); return true; }
+        try { fs.accessSync(path.join(dir, NODE_BIN), fs.constants.X_OK); return true; }
         catch { return false; }
       });
       assert.equal(
         nodeResolvable,
         true,
         'node must be resolvable on the isolated PATH (launcher runs: node "$GSD_TOOLS" "$@")',
+      );
+
+      // (iii) every name the launcher's PATH arm can resolve must be filtered,
+      // not just the extensionless one. One name on POSIX; on Windows the
+      // PATHEXT set, where a gsd_run.exe-only directory is the reachable leak
+      // an extensionless probe misses (#4344).
+      const survived = GSD_RUN_NAMES.filter((name) => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-891-ext-'));
+        t.after(() => cleanup(dir));
+        linkExecutable(dir, name);
+        const probe = buildIsolatedPath(dir);
+        t.after(() => cleanup(probe.nodeBinDir));
+        return probe.isolatedPath.split(path.delimiter).includes(dir);
+      });
+      assert.deepStrictEqual(
+        survived,
+        [],
+        'every GSD_RUN_NAMES entry must be filtered out of the isolated PATH',
       );
     },
   );
@@ -1469,10 +1420,9 @@ describe('bug-891: non-Claude runtime home fallback arms', () => {
   // the stub: on a CLEAN machine the bare HERMES_HOME assertion passes whether
   // buildIsolatedPath() filters gsd_run or gsd-tools, so it only catches the bug
   // on a machine that already has the leak. Planting the sentinel makes it fail
-  // on any machine — including Windows, where the leak the filter must catch is
-  // the extensionless Bourne shim npm writes beside gsd_run.cmd, and where
-  // fs.constants.X_OK "has no effect ... (will behave like fs.constants.F_OK)"
-  // per the fs docs, so the same probe sees it (#4344).
+  // on any machine, and on either platform: the sentinel is planted in both the
+  // extensionless form npm installs and, on Windows, the `gsd_run.exe` form msys
+  // bash resolves for a bare `gsd_run` (#4344).
   test('(B) buildIsolatedPath strips a leaked PATH gsd_run; the ${HERMES_HOME} stub wins', (t) => {
     const fakeHome       = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-891-home-b-'));
     const fakeHermesHome = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-891-hermes-'));
@@ -1486,6 +1436,13 @@ describe('bug-891: non-Claude runtime home fallback arms', () => {
     const sentinelPath = path.join(sentinelBinDir, 'gsd_run');
     fs.writeFileSync(sentinelPath, '#!/bin/sh\necho "SENTINEL_INVOKED:$*"\n');
     fs.chmodSync(sentinelPath, 0o755);
+    if (process.platform === 'win32') {
+      // What msys bash resolves for a bare `gsd_run` there: it appends `.exe`
+      // during PATH lookup, while the extensionless script above is executable
+      // only under the mount's `#!` heuristic. Any real executable serves — the
+      // assertions are about where GSD_TOOLS lands, not what the sentinel says.
+      linkExecutable(sentinelBinDir, 'gsd_run.exe');
+    }
 
     // Simulate the reported leak: a real gsd_run reachable on PATH. Passed in
     // rather than assigned to process.env.PATH — the runner's own environment
@@ -1493,13 +1450,12 @@ describe('bug-891: non-Claude runtime home fallback arms', () => {
     const { isolatedPath, nodeBinDir } = buildIsolatedPath(
       `${sentinelBinDir}${path.delimiter}${process.env.PATH}`,
     );
-    t.after(() => { if (nodeBinDir) cleanup(nodeBinDir); });
+    t.after(() => cleanup(nodeBinDir));
 
-    // The leak assertion that holds on every platform: a filter probing the
-    // wrong name leaves sentinelBinDir on the isolated PATH. The stdout
-    // assertions below cannot carry that on Windows, where whether bash
-    // resolves the shim depends on the mount's exec heuristics, not on the
-    // filter under test.
+    // Leak assertion that needs no subprocess: a filter probing the wrong name
+    // leaves sentinelBinDir on the isolated PATH. Deterministic on both
+    // platforms, so it stays red even where the stdout assertions below depend
+    // on the mount's exec heuristics rather than on the filter under test.
     assert.ok(
       !isolatedPath.split(path.delimiter).includes(sentinelBinDir),
       `Expected buildIsolatedPath to strip the leaked ${sentinelBinDir}, got:\n${isolatedPath}`,
@@ -1538,6 +1494,12 @@ describe('bug-891: non-Claude runtime home fallback arms', () => {
     assert.ok(
       !normStdout.includes('SENTINEL_INVOKED'),
       `Expected the leaked PATH gsd_run to never be invoked, got:\n${stdout.trim()}`,
+    );
+    // The same claim without depending on the sentinel producing output:
+    // whatever the resolver picked, it did not come from the leaked directory.
+    assert.ok(
+      !normStdout.includes(sentinelBinDir.replace(/\\/g, '/')),
+      `Expected GSD_TOOLS to resolve outside the leaked ${sentinelBinDir}, got:\n${stdout.trim()}`,
     );
     // Assert the hermes dir itself: every arm of the resolver ends in
     // gsd-core/bin/, so that substring alone cannot tell them apart.
@@ -1599,7 +1561,7 @@ describe('bug-891: non-Claude runtime home fallback arms', () => {
     } finally {
       cleanup(fakeHome);
       cleanup(fakeRuntime);
-      if (nodeBinDir) cleanup(nodeBinDir);
+      cleanup(nodeBinDir);
     }
   });
 
@@ -1877,25 +1839,11 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
 const os = require('node:os');
-const { runHook: runHookSeam } = require('./helpers/process-seam.cjs');
-const { throwIfFailed } = require('./helpers/git-fixture.cjs');
 const { cleanup } = require('./helpers.cjs');
 
 const WORKFLOWS_DIR = path.join(__dirname, '..', 'gsd-core', 'workflows');
 const SNIPPET_FILE = path.join(WORKFLOWS_DIR, '_runtime-launcher.snippet.sh');
 
-/**
- * Run a bash script FILE via the process seam, preserving the throw-on-
- * nonzero-exit semantics of the execFileSync('bash', [path], ...) idiom
- * this replaces.
- */
-function runBashFile(scriptPath, options = {}) {
-  const r = runHookSeam(scriptPath, [], {
-    interpreter: 'bash', ...options, env: snippetEnv(options.env),
-  });
-  throwIfFailed(r, `bash ${scriptPath}`);
-  return r.stdout;
-}
 
 // The probe string that must appear in the snippet for the new repo-local check.
 // The snippet uses _GSD_RUNTIME_ROOT as the intermediate variable.

--- a/tests/runtime-launcher-parity.test.cjs
+++ b/tests/runtime-launcher-parity.test.cjs
@@ -475,7 +475,7 @@ describe('runtime-launcher-parity (#373)', () => {
     // The resolution order must be:
     //   (1) local/RUNTIME_DIR  →  (2) PATH  →  (3) $HOME/.claude/gsd-core/bin  →  (4) hard error
     // We probe for .claude/gsd-core/bin (using ${_GSD_SHIM_NAME} indirection)
-    // between the `command -v gsd-tools` elif and the hard-error else branch.
+    // between the `command -v gsd_run` elif and the hard-error else branch.
     const CLAUDE_HOME_PROBE = '.claude/gsd-core/bin/';
 
     // Assert snippet itself contains the probe
@@ -882,7 +882,7 @@ describe('runtime-launcher-parity — agents (#1041)', () => {
  * Asserts:
  * (A) The canonical snippet file contains the ~/.claude fallback arm.
  * (B) A representative propagated workflow file contains the ~/.claude fallback arm.
- * (C) Behavioral: when RUNTIME_DIR misses and gsd-tools is NOT on PATH,
+ * (C) Behavioral: when RUNTIME_DIR misses and gsd_run is NOT on PATH,
  *     a stub at $HOME/.claude/gsd-core/bin/gsd-tools.cjs is resolved and invoked.
  * (D) The resolution order is preserved: local -> PATH -> ~/.claude -> hard error.
  *     When all three miss, exit non-zero.
@@ -1092,11 +1092,11 @@ describe('bug-211: launcher ~/.claude home fallback', () => {
  * Every non-Claude runtime (Hermes, Cursor, Codex, Copilot, Windsurf, …)
  * installs gsd-core into a *different* directory that the shim never tried,
  * causing a false-positive fatal ERROR on all non-Claude runtimes when
- * RUNTIME_DIR is not set and gsd-tools is not on PATH.
+ * RUNTIME_DIR is not set and gsd_run is not on PATH.
  *
  * Asserts:
  * (A) Snippet contains all expected non-Claude runtime home probes (structural).
- * (B) HERMES_HOME behavioral: when RUNTIME_DIR misses and gsd-tools is NOT on
+ * (B) HERMES_HOME behavioral: when RUNTIME_DIR misses and gsd_run is NOT on
  *     PATH, a stub at ${HERMES_HOME}/gsd-core/bin/gsd-tools.cjs is invoked.
  * (C) Default Hermes path behavioral: stub at $HOME/.hermes/gsd-core/bin/
  *     gsd-tools.cjs is invoked when HERMES_HOME is not set.
@@ -1220,15 +1220,15 @@ function extractShellBlocks(content) {
 }
 
 /**
- * Build a PATH with no gsd-tools binary so the PATH fallback branch is skipped,
+ * Build a PATH with no gsd_run binary so the PATH fallback branch is skipped,
  * while guaranteeing that a bare `node` lookup still resolves regardless of whether
- * the real node binary co-locates with a global gsd-tools shim (e.g. fnm/nvm/Homebrew).
+ * the real node binary co-locates with a global gsd_run shim (e.g. fnm/nvm/Homebrew).
  *
  * Strategy (POSIX only): create a temp dir containing only a `node` symlink →
- * process.execPath, prepend it to the gsd-tools-filtered PATH.  The filtered
- * PATH excludes any directory that contains an executable `gsd-tools`.
+ * process.execPath, prepend it to the gsd_run-filtered PATH.  The filtered
+ * PATH excludes any directory that contains an executable `gsd_run`.
  *
- * On Windows the co-location bug does not apply (gsd-tools resolves via .cmd/.ps1,
+ * On Windows the co-location bug does not apply (gsd_run resolves via .cmd/.ps1,
  * not the bare binary probed here), and symlinks may require elevated privileges,
  * so we skip the symlink step entirely on that platform.
  *
@@ -1617,7 +1617,7 @@ describe('bug-891: non-Claude runtime home fallback arms', () => {
  *
  * A user project normally does not contain gsd-core/bin/gsd-tools.cjs.
  * The snippets should still prefer RUNTIME_DIR for local/dev installs, then
- * fall back to the installed gsd-tools binary on PATH.
+ * fall back to the installed gsd_run binary on PATH.
  */
 'use strict';
 
@@ -1705,7 +1705,7 @@ function runResolver({ cwd, runtimeDir, pathDir }) {
   ].join('\n');
 
   // Consolidation #1969: POSIX-shell resolver. These tests create an
-  // extension-less `gsd-tools` PATH stub (mode 0o755) and exec it via `bash -c`;
+  // extension-less `gsd_run` PATH stub (mode 0o755) and exec it via `bash -c`;
   // Windows Git Bash ignores the exec bit for extension-less PATH scripts, so the
   // suite is guarded to POSIX (matches the host suite's own bash -c guard).
   if (process.platform === 'win32') return '';
@@ -1845,21 +1845,21 @@ function runBashFile(scriptPath, options = {}) {
 const LOCAL_CLAUDE_PROBE = '_GSD_RUNTIME_ROOT}/.claude/gsd-core/bin/';
 
 /**
- * Build a PATH that strips gsd-tools but keeps node and system binaries.
+ * Build a PATH that strips gsd_run but keeps node and system binaries.
  * Accepts additional bin dirs to prepend.
  *
- * We cannot simply remove the whole directory that contains gsd-tools because
+ * We cannot simply remove the whole directory that contains gsd_run because
  * that directory may also contain node (e.g. /opt/homebrew/bin on macOS).
  * Instead, we keep the system PATH as-is and rely on the test's RUNTIME_DIR
  * having no gsd-core/bin/ sub-path, so the resolver's first two checks
  * (RUNTIME_DIR/gsd-core/bin/ and RUNTIME_DIR/.claude/gsd-core/bin/)
  * are the only ones exercised before we hit our stub.
  *
- * The extra extraBefore dirs (e.g. noToolsBin) sit first but have no gsd-tools
- * binary, so command -v gsd-tools still falls back to PATH lookup. However,
- * the snippet's elif arm that uses `command -v gsd-tools` will find the real
+ * The extra extraBefore dirs (e.g. noToolsBin) sit first but have no gsd_run
+ * binary, so command -v gsd_run still falls back to PATH lookup. However,
+ * the snippet's elif arm that uses `command -v gsd_run` will find the real
  * installed one unless we mask it. To mask it without losing node, we create
- * a noToolsBin dir that shadows gsd-tools with a sentinel that must NOT be
+ * a noToolsBin dir that shadows gsd_run with a sentinel that must NOT be
  * called — and we only call makeIsolatedPath for tests where the .claude stub
  * must win before PATH is consulted (i.e. the elif PATH arm is never reached).
  *
@@ -1869,7 +1869,7 @@ const LOCAL_CLAUDE_PROBE = '_GSD_RUNTIME_ROOT}/.claude/gsd-core/bin/';
 function makeIsolatedPath(extraBefore = []) {
   // Keep full system PATH so node remains accessible.
   // Tests B and C exercise only the RUNTIME_DIR/.claude arm which fires
-  // before command -v gsd-tools — so the real gsd-tools on PATH is never reached.
+  // before command -v gsd_run — so the real gsd_run on PATH is never reached.
   const systemPaths = (process.env.PATH || '/usr/bin:/bin').split(path.delimiter);
   return [...extraBefore, ...systemPaths].join(path.delimiter);
 }

--- a/tests/runtime-launcher-parity.test.cjs
+++ b/tests/runtime-launcher-parity.test.cjs
@@ -31,7 +31,7 @@ const path = require('node:path');
 const os = require('node:os');
 const { runHook: runHookSeam } = require('./helpers/process-seam.cjs');
 const { throwIfFailed } = require('./helpers/git-fixture.cjs');
-const { cleanup } = require('./helpers.cjs');
+const { cleanup, TEST_ENV_BASE } = require('./helpers.cjs');
 const { escapeRegex } = require('../gsd-core/bin/lib/pattern.cjs');
 
 const WORKFLOWS_DIR = path.join(__dirname, '..', 'gsd-core', 'workflows');
@@ -39,12 +39,37 @@ const AGENTS_DIR = path.join(__dirname, '..', 'agents');
 const SNIPPET_FILE = path.join(WORKFLOWS_DIR, '_runtime-launcher.snippet.sh');
 
 /**
+ * Env for any fixture that sources the snippet (#4205).
+ *
+ * TEST_ENV_BASE is DERIVED from the same capability registry the resolver
+ * reads — see the note at tests/helpers.cjs, "#2665: this list is DERIVED,
+ * not hand-maintained. A hand-written list is exactly what reopened this bug
+ * twice". It was right: the hand-written list this replaces missed both
+ * CODEX_HOME and XDG_CONFIG_HOME, and adding a 17th runtime home would have
+ * left it silently stale — the exact shape of #4205.
+ *
+ * Two keys the derived set cannot supply, both still live in the snippet:
+ *  - GEMINI_CONFIG_DIR: the gemini runtime is retired (#1928) so the registry
+ *    no longer carries it, but the snippet still probes its arm.
+ *  - CLAUDE_ENV_FILE: a WRITE sink, not a read path. Left ambient, every
+ *    fixture that exits 0 appends `export PATH='<temp dir>'` to the
+ *    developer's real env file — 11 lines per suite run, each naming a
+ *    /tmp dir the fixture has already deleted.
+ */
+const SNIPPET_SCRUB = { GEMINI_CONFIG_DIR: '', CLAUDE_ENV_FILE: '' };
+function snippetEnv(overrides = {}) {
+  return { ...process.env, ...TEST_ENV_BASE, ...SNIPPET_SCRUB, ...overrides };
+}
+
+/**
  * Run a bash script FILE via the process seam, preserving the throw-on-
  * nonzero-exit semantics of the execFileSync('bash', [path], ...) idiom
  * this replaces.
  */
 function runBashFile(scriptPath, options = {}) {
-  const r = runHookSeam(scriptPath, [], { interpreter: 'bash', ...options });
+  const r = runHookSeam(scriptPath, [], {
+    interpreter: 'bash', ...options, env: snippetEnv(options.env),
+  });
   throwIfFailed(r, `bash ${scriptPath}`);
   return r.stdout;
 }
@@ -396,15 +421,7 @@ describe('runtime-launcher-parity (#373)', () => {
         // Loud-guard requires every runtime-home arm to genuinely miss, not
         // just PATH (#4205 class: an ambient config-dir var pointing at a
         // real install would resolve here instead of the hard error).
-        env: {
-          ...process.env, PATH: isolatedPath, HOME: base,
-          CLAUDE_CONFIG_DIR: undefined, HERMES_HOME: undefined, CURSOR_CONFIG_DIR: undefined,
-          CODEX_HOME: undefined, GEMINI_CONFIG_DIR: undefined, COPILOT_CONFIG_DIR: undefined,
-          WINDSURF_CONFIG_DIR: undefined, AUGMENT_CONFIG_DIR: undefined, TRAE_CONFIG_DIR: undefined,
-          QWEN_CONFIG_DIR: undefined, CODEBUDDY_CONFIG_DIR: undefined, CLINE_CONFIG_DIR: undefined,
-          GROK_AGENTS_HOME: undefined, ANTIGRAVITY_CONFIG_DIR: undefined, OPENCODE_CONFIG_DIR: undefined,
-          KILO_CONFIG_DIR: undefined, XDG_CONFIG_HOME: undefined,
-        },
+        env: snippetEnv({ PATH: isolatedPath, HOME: base }),
       });
       const threw = r.exitCode !== 0;
       const stderrOutput = r.stderr || '';
@@ -451,7 +468,7 @@ describe('runtime-launcher-parity (#373)', () => {
       fs.writeFileSync(scriptPath, scriptContent);
 
       const stdout = runBashFile(scriptPath, {
-        env: { ...process.env, PATH: `${pathBinDir}${path.delimiter}${process.env.PATH || ''}` },
+        env: { PATH: `${pathBinDir}${path.delimiter}${process.env.PATH || ''}` },
       });
 
       // The PATH fallback must have resolved GSD_TOOLS to the stub binary.
@@ -608,11 +625,7 @@ describe('runtime-launcher-parity (#373)', () => {
         // $HOME/.codex default this test asserts (#4205 class: same env-leak
         // bug, this time via config-dir vars rather than PATH) — clear all
         // four so only HOME's default $HOME/.codex fallback can win.
-        env: {
-          ...process.env, PATH: systemPaths.join(path.delimiter), HOME: fakeHome,
-          CLAUDE_CONFIG_DIR: undefined, HERMES_HOME: undefined, CURSOR_CONFIG_DIR: undefined,
-          CODEX_HOME: undefined,
-        },
+        env: { PATH: systemPaths.join(path.delimiter), HOME: fakeHome },
       });
 
       const normStdout = stdout.replace(/\\/g, '/');
@@ -933,7 +946,9 @@ const REPRESENTATIVE_FILE = path.join(WORKFLOWS_DIR, 'add-backlog.md');
  * this replaces.
  */
 function runBashFile(scriptPath, options = {}) {
-  const r = runHookSeam(scriptPath, [], { interpreter: 'bash', ...options });
+  const r = runHookSeam(scriptPath, [], {
+    interpreter: 'bash', ...options, env: snippetEnv(options.env),
+  });
   throwIfFailed(r, `bash ${scriptPath}`);
   return r.stdout;
 }
@@ -1024,7 +1039,7 @@ describe('bug-211: launcher ~/.claude home fallback', () => {
       const stdout = runBashFile(scriptPath, {
         // Ambient CLAUDE_CONFIG_DIR would override the $HOME/.claude default
         // this test relies on (#4205 class: env-leak, not PATH-leak).
-        env: { ...process.env, PATH: systemPaths.join(path.delimiter), HOME: fakeHome, CLAUDE_CONFIG_DIR: undefined },
+        env: { PATH: systemPaths.join(path.delimiter), HOME: fakeHome },
       });
 
       // GSD_TOOLS must point into the fake ~/.claude dir
@@ -1082,15 +1097,7 @@ describe('bug-211: launcher ~/.claude home fallback', () => {
         // "All three miss" requires every runtime-home arm to genuinely miss,
         // not just the first (#4205 class: an ambient config-dir var pointing
         // at a real install would resolve here instead of the hard error).
-        env: {
-          ...process.env, PATH: isolatedPath, HOME: fakeHome,
-          CLAUDE_CONFIG_DIR: undefined, HERMES_HOME: undefined, CURSOR_CONFIG_DIR: undefined,
-          CODEX_HOME: undefined, GEMINI_CONFIG_DIR: undefined, COPILOT_CONFIG_DIR: undefined,
-          WINDSURF_CONFIG_DIR: undefined, AUGMENT_CONFIG_DIR: undefined, TRAE_CONFIG_DIR: undefined,
-          QWEN_CONFIG_DIR: undefined, CODEBUDDY_CONFIG_DIR: undefined, CLINE_CONFIG_DIR: undefined,
-          GROK_AGENTS_HOME: undefined, ANTIGRAVITY_CONFIG_DIR: undefined, OPENCODE_CONFIG_DIR: undefined,
-          KILO_CONFIG_DIR: undefined, XDG_CONFIG_HOME: undefined,
-        },
+        env: snippetEnv({ PATH: isolatedPath, HOME: fakeHome }),
       });
       const threw = r.exitCode !== 0;
       const stderrOutput = r.stderr || '';
@@ -1130,11 +1137,10 @@ describe('bug-211: launcher ~/.claude home fallback', () => {
  * Asserts:
  * (A) Snippet contains all expected non-Claude runtime home probes (structural).
  * (B0) buildIsolatedPath() co-location invariant (see below).
- * (B) HERMES_HOME behavioral, cross-platform: the ${HERMES_HOME} stub is
- *     resolved when local and PATH both miss.
- * (B1) HERMES_HOME behavioral, POSIX-only: when RUNTIME_DIR misses and gsd_run is NOT on
- *     PATH — including a leaked ambient gsd_run planted on PATH, #4205 — a
- *     stub at ${HERMES_HOME}/gsd-core/bin/gsd-tools.cjs is invoked.
+ * (B) HERMES_HOME behavioral: when RUNTIME_DIR misses and gsd_run is NOT on
+ *     PATH, the stub at ${HERMES_HOME}/gsd-core/bin/gsd-tools.cjs is invoked.
+ *     On POSIX it also plants a leaked gsd_run on PATH first (#4205), which is
+ *     what makes it fail on a clean machine as well as a leaking one.
  * (C) Default Hermes path behavioral: stub at $HOME/.hermes/gsd-core/bin/
  *     gsd-tools.cjs is invoked when HERMES_HOME is not set.
  * (D) Resolution order: non-Claude homes are probed BEFORE the hard error,
@@ -1168,7 +1174,9 @@ const SNIPPET_FILE = path.join(WORKFLOWS_DIR, '_runtime-launcher.snippet.sh');
  * this replaces.
  */
 function runBashFile(scriptPath, options = {}) {
-  const r = runHookSeam(scriptPath, [], { interpreter: 'bash', ...options });
+  const r = runHookSeam(scriptPath, [], {
+    interpreter: 'bash', ...options, env: snippetEnv(options.env),
+  });
   throwIfFailed(r, `bash ${scriptPath}`);
   return r.stdout;
 }
@@ -1419,137 +1427,84 @@ describe('bug-891: non-Claude runtime home fallback arms', () => {
   );
 
 
-  // ── (B) Behavioral: HERMES_HOME stub is resolved ──────────────────────────
-  test('(B) gsd_run resolves ${HERMES_HOME}/gsd-core/bin/ stub when set and local+PATH both miss', () => {
+  // ── (B) Behavioral: HERMES_HOME stub is resolved, even past a leaked PATH ──
+  //
+  // #4205 regression, and the reason this asserts the sentinel rather than just
+  // the stub: on a CLEAN machine the bare HERMES_HOME assertion passes whether
+  // buildIsolatedPath() filters gsd_run or gsd-tools, so it only catches the bug
+  // on a machine that already has the leak. Planting the sentinel makes it fail
+  // on any machine. The sentinel is POSIX-only (an extensionless sh script), so
+  // it is skipped on Windows — where this test still covers the HERMES_HOME arm
+  // itself, which is why it is not gated behind the platform check wholesale.
+  // Windows-native coverage of the leak is tracked in #4344.
+  test('(B) buildIsolatedPath strips a leaked PATH gsd_run; the ${HERMES_HOME} stub wins', (t) => {
     const fakeHome       = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-891-home-b-'));
     const fakeHermesHome = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-891-hermes-'));
     const fakeRuntime    = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-891-rt-'));
-    const { isolatedPath, nodeBinDir } = buildIsolatedPath();
-    try {
-      const hermesBinDir = path.join(fakeHermesHome, 'gsd-core', 'bin');
-      fs.mkdirSync(hermesBinDir, { recursive: true });
+    t.after(() => cleanup(fakeHome));
+    t.after(() => cleanup(fakeHermesHome));
+    t.after(() => cleanup(fakeRuntime));
 
-      const stubPath = path.join(hermesBinDir, 'gsd-tools.cjs');
-      fs.writeFileSync(
-        stubPath,
-        '#!/usr/bin/env node\nconsole.log("HERMES_HOME_STUB:" + process.argv.slice(2).join(","));\n',
-      );
-      fs.chmodSync(stubPath, 0o755);
-
-      const snippet = fs.readFileSync(SNIPPET_FILE, 'utf8');
-      // Export HOME to an isolated temp dir (no .claude install there) so the
-      // $HOME/.claude arm is skipped and we fall through to the HERMES_HOME arm.
-      const scriptContent =
-        `unset GSD_TOOLS\n` +
-        `export HOME=${JSON.stringify(fakeHome)}\n` +
-        `export RUNTIME_DIR=${JSON.stringify(fakeRuntime)}\n` +
-        `export HERMES_HOME=${JSON.stringify(fakeHermesHome)}\n` +
-        snippet +
-        `\nprintf "GSD_TOOLS=%s\\n" "$GSD_TOOLS"\n` +
-        `gsd_run ping test\n`;
-
-      const scriptPath = path.join(fakeRuntime, 'test-hermes-home.sh');
-      fs.writeFileSync(scriptPath, scriptContent);
-
-      const stdout = runBashFile(scriptPath, {
-        // CLAUDE_CONFIG_DIR resolves before HERMES_HOME; clear it so ambient
-        // leakage cannot preempt the arm under test (#4205 class, env vector).
-        env: {
-          ...process.env, PATH: isolatedPath, HOME: fakeHome,
-          HERMES_HOME: fakeHermesHome, CLAUDE_CONFIG_DIR: undefined,
-        },
-      });
-
-      const normStdout = stdout.replace(/\\/g, '/');
-      assert.ok(
-        normStdout.includes('gsd-core/bin/'),
-        `Expected GSD_TOOLS to resolve into hermes gsd-core/bin/, got:\n${stdout.trim()}`,
-      );
-      assert.ok(
-        stdout.includes('HERMES_HOME_STUB:ping,test'),
-        `Expected stub output "HERMES_HOME_STUB:ping,test", got:\n${stdout.trim()}`,
-      );
-    } finally {
-      cleanup(fakeHome);
-      cleanup(fakeHermesHome);
-      cleanup(fakeRuntime);
-      if (nodeBinDir) cleanup(nodeBinDir);
-    }
-  });
-
-  // ── (B1) Regression #4205: a leaked/installed gsd_run reachable on PATH ──
-  //        must be filtered by buildIsolatedPath so the resolver still falls
-  //        through to a runtime-home stub instead of invoking it.
-  test(
-    '(B1) a leaked PATH gsd_run is never invoked; HERMES_HOME stub is used instead',
-    { skip: process.platform === 'win32' ? 'POSIX-only PATH executable scenario' : false },
-    (t) => {
+    if (process.platform !== 'win32') {
       const sentinelBinDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-4205-sentinel-'));
       t.after(() => cleanup(sentinelBinDir));
       const sentinelPath = path.join(sentinelBinDir, 'gsd_run');
       fs.writeFileSync(sentinelPath, '#!/bin/sh\necho "SENTINEL_INVOKED:$*"\n');
       fs.chmodSync(sentinelPath, 0o755);
+      // Simulate the reported leak: a real gsd_run reachable on PATH.
+      const prevPath = process.env.PATH;
+      process.env.PATH = `${sentinelBinDir}${path.delimiter}${process.env.PATH}`;
+      t.after(() => { process.env.PATH = prevPath; });
+    }
 
-      const fakeHome       = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-4205-home-'));
-      const fakeHermesHome = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-4205-hermes-'));
-      const fakeRuntime    = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-4205-rt-'));
-      t.after(() => cleanup(fakeHome));
-      t.after(() => cleanup(fakeHermesHome));
-      t.after(() => cleanup(fakeRuntime));
+    const { isolatedPath, nodeBinDir } = buildIsolatedPath();
+    t.after(() => { if (nodeBinDir) cleanup(nodeBinDir); });
 
-      // Simulate the leaked-installation scenario: a real gsd_run reachable on
-      // the ambient PATH before buildIsolatedPath filters it out.
-      const origPath = process.env.PATH;
-      process.env.PATH = sentinelBinDir + path.delimiter + origPath;
-      let isolatedPath, nodeBinDir;
-      try {
-        ({ isolatedPath, nodeBinDir } = buildIsolatedPath());
-      } finally {
-        process.env.PATH = origPath;
-      }
-      t.after(() => cleanup(nodeBinDir));
+    const hermesBinDir = path.join(fakeHermesHome, 'gsd-core', 'bin');
+    fs.mkdirSync(hermesBinDir, { recursive: true });
 
-      const hermesBinDir = path.join(fakeHermesHome, 'gsd-core', 'bin');
-      fs.mkdirSync(hermesBinDir, { recursive: true });
-      const stubPath = path.join(hermesBinDir, 'gsd-tools.cjs');
-      fs.writeFileSync(
-        stubPath,
-        '#!/usr/bin/env node\nconsole.log("HERMES_HOME_STUB:" + process.argv.slice(2).join(","));\n',
-      );
-      fs.chmodSync(stubPath, 0o755);
+    const stubPath = path.join(hermesBinDir, 'gsd-tools.cjs');
+    fs.writeFileSync(
+      stubPath,
+      '#!/usr/bin/env node\nconsole.log("HERMES_HOME_STUB:" + process.argv.slice(2).join(","));\n',
+    );
+    fs.chmodSync(stubPath, 0o755);
 
-      const snippet = fs.readFileSync(SNIPPET_FILE, 'utf8');
-      const scriptContent =
-        `unset GSD_TOOLS\n` +
-        `export HOME=${JSON.stringify(fakeHome)}\n` +
-        `export RUNTIME_DIR=${JSON.stringify(fakeRuntime)}\n` +
-        `export HERMES_HOME=${JSON.stringify(fakeHermesHome)}\n` +
-        snippet +
-        `\nprintf "GSD_TOOLS=%s\\n" "$GSD_TOOLS"\n` +
-        `gsd_run ping test\n`;
-      const scriptPath = path.join(fakeRuntime, 'test-sentinel-gsd-run.sh');
-      fs.writeFileSync(scriptPath, scriptContent);
+    const snippet = fs.readFileSync(SNIPPET_FILE, 'utf8');
+    // HOME points at an isolated temp dir with no .claude install, so the
+    // $HOME/.claude arm misses and the HERMES_HOME arm is the one under test.
+    const scriptContent =
+      `unset GSD_TOOLS\n` +
+      `export HOME=${JSON.stringify(fakeHome)}\n` +
+      `export RUNTIME_DIR=${JSON.stringify(fakeRuntime)}\n` +
+      `export HERMES_HOME=${JSON.stringify(fakeHermesHome)}\n` +
+      snippet +
+      `\nprintf "GSD_TOOLS=%s\\n" "$GSD_TOOLS"\n` +
+      `gsd_run ping test\n`;
 
-      const stdout = runBashFile(scriptPath, {
-        // CLAUDE_CONFIG_DIR resolves before HERMES_HOME; clear it so ambient
-        // leakage can't preempt the arm under test (#4205 class, env vector).
-        env: { ...process.env, PATH: isolatedPath, HOME: fakeHome, HERMES_HOME: fakeHermesHome, CLAUDE_CONFIG_DIR: undefined },
-      });
+    const scriptPath = path.join(fakeRuntime, 'test-hermes-home.sh');
+    fs.writeFileSync(scriptPath, scriptContent);
 
-      assert.ok(
-        !stdout.includes('SENTINEL_INVOKED'),
-        `Expected the leaked PATH gsd_run to never be invoked, got:\n${stdout.trim()}`,
-      );
-      assert.ok(
-        stdout.includes('gsd-core/bin/'),
-        `Expected GSD_TOOLS to resolve into hermes gsd-core/bin/, got:\n${stdout.trim()}`,
-      );
-      assert.ok(
-        stdout.includes('HERMES_HOME_STUB:ping,test'),
-        `Expected stub output "HERMES_HOME_STUB:ping,test", got:\n${stdout.trim()}`,
-      );
-    },
-  );
+    const stdout = runBashFile(scriptPath, {
+      env: { PATH: isolatedPath, HOME: fakeHome, HERMES_HOME: fakeHermesHome },
+    });
+
+    const normStdout = stdout.replace(/\\/g, '/');
+    assert.ok(
+      !normStdout.includes('SENTINEL_INVOKED'),
+      `Expected the leaked PATH gsd_run to never be invoked, got:\n${stdout.trim()}`,
+    );
+    // Assert the hermes dir itself: every arm of the resolver ends in
+    // gsd-core/bin/, so that substring alone cannot tell them apart.
+    assert.ok(
+      normStdout.includes(fakeHermesHome.replace(/\\/g, '/')),
+      `Expected GSD_TOOLS to resolve into ${fakeHermesHome}, got:\n${stdout.trim()}`,
+    );
+    assert.ok(
+      normStdout.includes('HERMES_HOME_STUB:ping,test'),
+      `Expected stub output "HERMES_HOME_STUB:ping,test", got:\n${stdout.trim()}`,
+    );
+  });
 
   // ── (C) Behavioral: default .hermes path used when HERMES_HOME not set ────
   test('(C) gsd_run resolves $HOME/.hermes/gsd-core/bin/ stub when HERMES_HOME is unset', () => {
@@ -1584,7 +1539,7 @@ describe('bug-891: non-Claude runtime home fallback arms', () => {
         // (#4205 class, env vector); script-level `unset HERMES_HOME` above
         // already handles that var, but Node's env spread still needs to
         // clear CLAUDE_CONFIG_DIR before bash ever sees it.
-        env: { ...process.env, PATH: isolatedPath, HOME: fakeHome, CLAUDE_CONFIG_DIR: undefined },
+        env: { PATH: isolatedPath, HOME: fakeHome },
       });
 
       const normStdout = stdout.replace(/\\/g, '/');
@@ -1764,11 +1719,10 @@ function runResolver({ cwd, runtimeDir, pathDir }) {
   const r = runHookSeam('-c', [script], {
     interpreter: 'bash',
     cwd,
-    env: {
-      ...process.env,
+    env: snippetEnv({
       PATH: `${pathDir}${path.delimiter}${process.env.PATH || ''}`,
       RUNTIME_DIR: runtimeDir || '',
-    },
+    }),
   });
   throwIfFailed(r, 'bash -c <runtime resolver snippet>');
   return r.stdout;
@@ -1886,7 +1840,9 @@ const SNIPPET_FILE = path.join(WORKFLOWS_DIR, '_runtime-launcher.snippet.sh');
  * this replaces.
  */
 function runBashFile(scriptPath, options = {}) {
-  const r = runHookSeam(scriptPath, [], { interpreter: 'bash', ...options });
+  const r = runHookSeam(scriptPath, [], {
+    interpreter: 'bash', ...options, env: snippetEnv(options.env),
+  });
   throwIfFailed(r, `bash ${scriptPath}`);
   return r.stdout;
 }
@@ -1995,7 +1951,7 @@ describe('bug-444: resolver finds repo-local .claude install', () => {
       const isolatedPath = makeIsolatedPath([noToolsBin]);
 
       const stdout = runBashFile(scriptPath, {
-        env: { ...process.env, PATH: isolatedPath, HOME: fakeHome },
+        env: { PATH: isolatedPath, HOME: fakeHome },
       });
 
       // Must have resolved to the local .claude stub
@@ -2058,7 +2014,7 @@ describe('bug-444: resolver finds repo-local .claude install', () => {
       const isolatedPath = makeIsolatedPath([noToolsBin]);
 
       const stdout = runBashFile(scriptPath, {
-        env: { ...process.env, PATH: isolatedPath, HOME: fakeHome },
+        env: { PATH: isolatedPath, HOME: fakeHome },
       });
 
       assert.ok(

--- a/tests/runtime-launcher-parity.test.cjs
+++ b/tests/runtime-launcher-parity.test.cjs
@@ -155,10 +155,15 @@ function hasGsdRun(dir) {
  * @returns {{ isolatedPath: string, nodeBinDir: string }}
  */
 function buildIsolatedPath(basePath = process.env.PATH) {
-  const filteredPath = (basePath || '/usr/bin:/bin')
+  // An empty PATH element means "the current directory" to a POSIX shell, so
+  // it is dropped along with the gsd_run-bearing dirs: keeping one would put
+  // the fixture's own cwd on PATH, and `path.join('', 'gsd_run')` probes cwd
+  // rather than a directory, so hasGsdRun cannot even see what it would admit.
+  // Joining the surviving dirs (rather than the filtered string) also keeps a
+  // fully-filtered PATH from ending in a delimiter, which means the same thing.
+  const filteredDirs = (basePath || '/usr/bin:/bin')
     .split(path.delimiter)
-    .filter((p) => !hasGsdRun(p))
-    .join(path.delimiter);
+    .filter((p) => p !== '' && !hasGsdRun(p));
 
   const nodeBinDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-891-node-'));
   try {
@@ -168,7 +173,7 @@ function buildIsolatedPath(basePath = process.env.PATH) {
     throw err;
   }
 
-  return { isolatedPath: nodeBinDir + path.delimiter + filteredPath, nodeBinDir };
+  return { isolatedPath: [nodeBinDir, ...filteredDirs].join(path.delimiter), nodeBinDir };
 }
 
 /**
@@ -1410,6 +1415,23 @@ describe('bug-891: non-Claude runtime home fallback arms', () => {
         [],
         'every GSD_RUN_NAMES entry must be filtered out of the isolated PATH',
       );
+
+      // (iv) no empty element survives, in either of the two ways one appears:
+      // an ambient `::` in the input, and a PATH every entry of which was
+      // filtered. A POSIX shell reads an empty element as the current
+      // directory, which would put the fixture's own cwd back on PATH.
+      const emptyElementCases = {
+        ambient: `${emptyDir}${path.delimiter}${path.delimiter}${emptyDir}`,
+        fullyFiltered: fakeBinDir,
+      };
+      for (const [label, basePath] of Object.entries(emptyElementCases)) {
+        const probe = buildIsolatedPath(basePath);
+        t.after(() => cleanup(probe.nodeBinDir));
+        assert.ok(
+          !probe.isolatedPath.split(path.delimiter).includes(''),
+          `${label}: isolated PATH must carry no empty element (it would resolve cwd), got: ${probe.isolatedPath}`,
+        );
+      }
     },
   );
 


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

> **Required.** This PR will be auto-closed if no valid issue link is found.

Fixes #4205
Fixes #4320

#4320 reported 15 failing cases across 12 files. Its acceptance asks for the 3
`runtime-launcher-parity` cases to be fixed and the remaining ~12 to be
re-characterized from a clean environment, with a "root cause identified **or**
ruled out as environment-specific" — not repaired here. Both are delivered; the
mapping is in **#4320's 15 cases** below.

> The linked issue must have the `confirmed-bug` label. If it doesn't, ask a maintainer to confirm the bug before continuing.

---

## What was broken

PATH-isolation fixtures in `tests/runtime-launcher-parity.test.cjs` filtered PATH entries for an executable named `gsd-tools`, but the runtime launcher's PATH-fallback arm actually probes `command -v gsd_run`. A real installed `gsd_run` reachable on the developer/CI PATH survived the filter and got invoked instead of each fixture's intended runtime-home stub, so negative tests passed without proving PATH was empty and positive home-fallback tests failed with confusing "Unknown command" errors from the unrelated real CLI.

A code-review pass on this PR (adversarial second opinion, full repo access) surfaced the same class of leak via a different vector: the resolver's runtime-home elif chain checks `CLAUDE_CONFIG_DIR` before `HERMES_HOME`/`CURSOR_CONFIG_DIR`/`CODEX_HOME`/etc., but the fixtures targeting those later arms never cleared the earlier config-dir env vars from the spread `process.env`. An ambient `CLAUDE_CONFIG_DIR` pointing at a real install silently wins over the fixture's intended stub — same bug shape as the PATH leak, different variable. Confirmed with a real leaked install (not simulated): 7 tests go red without a fix, green with it.

## What this fix does

**PATH vector (#4205 as filed):** changed every PATH-isolation filter in the file — the shared `buildIsolatedPath()` helper plus five duplicated inline copies across tests (D), (H), and the bug-211 fold's (C)/(D) — to exclude directories containing `gsd_run` instead of `gsd-tools`. Updated the (B0) co-location regression test's fake binary to `gsd_run` to match. Folded into `(B)`: plants a sentinel `gsd_run` on PATH and asserts the resolver still falls through to the `HERMES_HOME` stub instead of the sentinel. The sentinel is planted on every platform, and the returned isolated PATH is asserted to exclude the sentinel's directory, so the Windows shards prove the filter rather than passing vacuously.

**Env-var vector (same class, found in review):** cleared the ambient config-dir env vars (`CLAUDE_CONFIG_DIR` and, for the two "everything must miss" hard-error tests, the full `*_CONFIG_DIR`/`*_HOME` set) from the 7 fixture env objects whose target arm sits behind one of those checks in the resolver's elif chain.

**Cleanup:** removed bug-891's (B) test — a strict subset of (B1) once the PATH sentinel is filtered, both exercise the identical HERMES_HOME resolution; (B1) already asserts everything (B) did, plus the sentinel-not-invoked check. Consolidated six near-identical `#4205` rationale comments to pointers at one canonical explanation. Fixed 6 stale doc-comment spots still describing the PATH probe as `gsd-tools`.

## Root cause

#3146 renamed the launcher's PATH-fallback probe target from `gsd-tools` to `gsd_run` in production code (`gsd-core/workflows/_runtime-launcher.snippet.sh`), but the test fixtures' PATH-isolation filters — copy-pasted across the bug-211, bug-891, and standalone-Codex test blocks — were never updated to match. The env-var leak is a sibling gap in the same fixtures: they isolate PATH but never isolate the config-dir env vars the same resolver chain also consults.

## #4320's 15 cases

Re-run on a clean `git worktree` at `origin/next@17e163f15`, and cross-checked against this
branch's fork CI (3 ubuntu shards, `# fail 0`).

| Cases | File | Outcome |
|---|---|---|
| 3 — `runtime-launcher-parity (#373)`, `folded:bug-211-…`, `folded:bug-891-…` | `runtime-launcher-parity.test.cjs` | **Fixed by this PR** |
| 7 — `verify:post — …` | `loop-hooks-verify-post-e2e.test.cjs` | Pass clean; real-HOME isolation already tracked in #4291 |
| 1 — `A. execGit normalization (#3071)` | `faulty-deps.test.cjs` | Passes clean — environment-specific |
| 1 — `docs-guard lane: lint-docs-guard-registration.cjs` | `ci-docs-guard-registry.test.cjs` | Passes clean — environment-specific |
| 1 — `differential attribution over the real tree` | `emitted-attribution.test.cjs` | Passes clean (133/133). Fails only where the differential actually runs, flagging whole corpora for a `tests/`-only diff — a baseline-resolution artifact of a shallow clone |
| 1 — `folded:bug-167-query-meta-command` | `command-routing-hub.test.cjs` | **Root-caused → #4342**: the fixture runs `gsd-tools` against the real `.planning/` and `~/.gsd/defaults.json` |
| 7 leaf — `commit-docs-guard enable/disable (#3588 B1-B15)` | `commands.test.cjs` | **Root-caused → #4341**: `isolateGlobalGitConfig()` is called from three describe bodies, all evaluated before any test; suite A's `after` restores `undefined` and deletes `GIT_CONFIG_GLOBAL`, dropping suites B and D onto the real `~/.gitconfig`. Reproduced: B alone 15/15 pass, whole file 7/15 fail |

That last one is the direct answer to #4320's headline — "fails only inside the full run,
passes in isolation" — and it is a real defect, not host noise.

## Review findings addressed

Two independent reviews plus two adversarial passes ran against this branch. Everything they
raised is either fixed here or ticketed:

| Finding | Resolution |
|---|---|
| `(H)` never scrubbed an ambient `CODEX_HOME`, the very default it asserts | Fixed; red/green proven with a planted install |
| Two hard-error fixtures missed `XDG_CONFIG_HOME`, which the opencode/kilo arms fall through | Fixed |
| Deleting bug-891 `(B)` dropped Windows coverage — `(B1)` is `skip: win32` | `(B1)` folded into `(B)`, and the sentinel is now planted on Windows too. `fs.constants.X_OK` "has no effect on Windows (will behave like `fs.constants.F_OK`)" per the fs docs, and npm writes an extensionless Bourne `gsd_run` shim beside `gsd_run.cmd`, so the existing probe already sees the leak there |
| `CLAUDE_ENV_FILE` unscrubbed — fixtures **wrote** `export PATH='<deleted tmp dir>'` into the developer's real env file, 11 lines per run | Fixed; now 0 |
| The 17-key scrub was hand-written, which `tests/helpers.cjs` warns "is exactly what reopened this bug twice" | Replaced with derived `TEST_ENV_BASE`, applied at `runBashFile`/`runResolver` so all snippet fixtures are covered |
| `BASH_ENV` is sourced *after* the scrub and re-injects any var | Fixed |
| `runResolver`'s `RUNTIME_DIR: ''` reads as unset, falling back to the real repo root | Now rejected |
| `makeIsolatedPath`'s docblock described a filter and sentinel that never existed | Rewritten to match the code |
| Windows PATH filter is extension-blind | Fixed here. `buildIsolatedPath()` now always prepends a directory holding node (`linkExecutable()`, hard link on Windows where symlinks need elevation), so the fallback exists *before* the filter widens — the ordering trek-e's review required. The filter then probes every name `command -v gsd_run` can resolve: msys bash appends an executable extension during PATH lookup, so a `gsd_run.exe`-only directory is reachable on Windows; PATHEXT is folded in as well. `(B0)` asserts every name in that set is filtered and now runs on Windows instead of being skipped there; `(B)` plants a `gsd_run.exe` sentinel beside the extensionless one npm installs |
| Shell launcher probes `GEMINI_CONFIG_DIR`, which `envRuntimeDirs()` is tested to ignore | Ticketed #4347 — removal is user-facing for pre-#1928 installs |
| Four inline copies of the PATH filter | Fixed here, closing #4348. `buildIsolatedPath()` moves to module scope and the four sites call it; `grep -c '^function buildIsolatedPath'` is 1 and `fs.accessSync` survives at two sites only. Extension-awareness then landed in one place instead of five, which is the whole reason the consolidation is in this PR rather than deferred |

## Testing

### How I verified the fix

- `node --test tests/runtime-launcher-parity.test.cjs`: 30/30 pass (31 minus the removed duplicate).
- PATH vector: reverted the fix locally with a real `gsd_run` stub planted on PATH — reproduced the exact issue symptom (leaked binary invoked instead of the intended stub); restored the fix and re-ran with the leaked binary present throughout: all pass.
- Red-proved both new mechanisms: reverting the probe to `gsd-tools` turns `(B0)` and `(B)` red; making the node prepend conditional again turns `(B0)`'s node assertion red.
- Consolidation: the filter predicate lived in five hand-maintained copies — the drift that caused #4205 — and four of them pointed readers at a `buildIsolatedPath()` that was block-scoped out of their reach. It moves to module scope and the four inline copies call it; the three shadow `runBashFile()` declarations this PR had to edit identically go with them. Net −52 lines on this pass.
- Reviewed by `critical-code-reviewer`, `ponytail-review`, and an independent adversarial pass (agy, gemini-3.8-flash-high), all three with full source access. Findings out of this PR's scope filed upstream: #4409, #4411, #4412.
- Windows-inclusive leak assertion: reverted the filter's probe name to `gsd-tools` with the sentinel planted — `(B)` fails on the new isolated-PATH assertion; restored, 30/30 pass.
- Env-var vector: planted a real fake install and set ambient `CLAUDE_CONFIG_DIR` to it — 7 tests (`(D)`, `(H)`, bug-211 `(C)`/`(D)`, `(B1)`, `(B)` pre-removal, `(C)`) failed with the leaked stub's output in place of the intended one; with the scrub in place, all pass under the same ambient leak.
- Independent adversarial review (agy, gemini-3.8-flash-high) + a separate critical-code-review/ponytail pass: both verified the fixes against source (not just the diff) and confirmed all 3 of the issue's acceptance criteria are met.
- Rehearsed on a fork PR (davdittrich/gsd-core#27) first: full CI matrix green, CodeRabbit 0 actionable comments.

### Regression test added?

- [x] Yes — added a test that would have caught this bug

### Platforms tested

- [ ] macOS
- [x] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [ ] Fix is scoped to the reported bug — no unrelated changes included — **partially, three additions, each flagged rather than silently included**: (1) an env-var leak of the same class in the same fixtures, found during review; (2) the Windows half the review asked for — node fallback, extension-aware filter, un-skipped `(B0)`; (3) hoisting `buildIsolatedPath()` to module scope, closing #4348, because extension-awareness would otherwise have been hand-copied into five sites, which is the drift that caused this bug. Findings outside that scope were filed instead: #4409, #4411, #4412, #4424
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`) — 30/30 locally; on the rehearsal PR davdittrich/gsd-core#30 every check passes except `test (ubuntu-latest, 24, shard 3/3)`, which fails in `tests/hooks-opt-in.test.cjs` with `141 !== 2` for a reason this branch does not touch: `hooks/gsd-validate-commit.sh` runs under `pipefail` and its `printf | head -1` can take SIGPIPE, filed as #4429. All three `windows-latest` shards pass, and `(B0)` is confirmed executed rather than skipped in the Windows shard log
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied — N/A: test-only change under `tests/`, not in the changeset-lint-gated paths (`bin/`, `gsd-core/`, `src/`, `agents/`, `commands/`, `hooks/`, `sdk/src/`)
- [x] No unnecessary dependencies added

## Breaking changes

None




