### PR TITLE
fix(#4105): park the #3889 hang fixture on a settling timer

### DIFF
--- a/.changeset/noble-seals-jump.md
+++ b/.changeset/noble-seals-jump.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 4349
 ---
 **The #3889 chunk-timeout tests now keep testing the timeout diagnostic regardless of the Node line's test-runner shutdown behavior** — the hang fixture returned a never-settling promise that holds no event-loop handle, so whether the chunk actually hung (and got killed by the per-chunk timeout, exercising the diagnostic) was decided by the runtime: on Node 24/26 the runner happens to hold the loop open, but on other lines the child exits on its own in ~60ms and the two timeout assertions silently assert nothing, failing later as a confusing 72ms chunk failure. The fixture now parks on a settling 10s timer (the #4104 idiom): the hang is a property of the fixture on every runtime, it stays ~0% CPU while parked, and it self-terminates if orphaned; a new regression guard pins that property (still hanging past the chunk bound, natural exit). Behavior on Node 24 (the CI/bench matrix line) is unchanged. (#4105)

--- a/.changeset/noble-seals-jump.md
+++ b/.changeset/noble-seals-jump.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**The #3889 chunk-timeout tests now keep testing the timeout diagnostic regardless of the Node line's test-runner shutdown behavior** — the hang fixture returned a never-settling promise that holds no event-loop handle, so whether the chunk actually hung (and got killed by the per-chunk timeout, exercising the diagnostic) was decided by the runtime: on Node 24/26 the runner happens to hold the loop open, but on other lines the child exits on its own in ~60ms and the two timeout assertions silently assert nothing, failing later as a confusing 72ms chunk failure. The fixture now parks on a settling 10s timer (the #4104 idiom): the hang is a property of the fixture on every runtime, it stays ~0% CPU while parked, and it self-terminates if orphaned; a new regression guard pins that property (still hanging past the chunk bound, natural exit). Behavior on Node 24 (the CI/bench matrix line) is unchanged. (#4105)

--- a/tests/run-tests-harness.test.cjs
+++ b/tests/run-tests-harness.test.cjs
@@ -896,9 +896,23 @@ test('noop', () => {});
     // once (via `before`) and every assertion group below reads from those
     // captured results instead of spawning its own. This is the whole
     // savings — no assertion is weakened or removed.
-    const HANGS_FOREVER_BODY = `'use strict';
+    // The fixture served to the timeout-path run below (#4105). Parks on a
+    // SETTLING timer — the #4104 idiom — so the hang is a property of the
+    // FIXTURE on every Node line, not of the runtime: the retired
+    // `new Promise(() => {})` shape held NO libuv handle, so whether the
+    // spawned child hung was decided by the Node line's test-runner shutdown
+    // behavior (measured: v24/v26 happen to hold the loop open; v22.22.0
+    // exits on its own in ~60ms with `# cancelled 1`, so the chunk never
+    // reached the timeout path and T1/T4 below asserted nothing). The park
+    // must outlast the chunk bound below with wide margin (asserted
+    // structurally in the #4105 regression test), stays ~0% CPU while parked,
+    // and the settle guarantees the fixture SELF-TERMINATES if a kill orphans
+    // it — unlike `setInterval`-forever (never exits) or `while (true) {}`
+    // (100% CPU forever), the two shapes #4104's pairing note rules out.
+    const HANG_PARK_MS = 10_000;
+    const HANGS_BODY = `'use strict';
 const { test } = require('node:test');
-test('hangs forever', () => new Promise(() => {}));
+test('hangs forever', () => new Promise((resolve) => { setTimeout(resolve, ${HANG_PARK_MS}); }));
 `;
 
     // The per-chunk timeout the timeout-path run below arms. Hoisted (#4105)
@@ -929,7 +943,7 @@ test('hangs forever', () => new Promise(() => {}));
       // box that has to boot node --test, register the hang, and observe
       // the kill inside the window.
       timeoutDir = createTempDir('gsd-3889-timeout-');
-      fs.writeFileSync(path.join(timeoutDir, 'hangs.test.cjs'), HANGS_FOREVER_BODY, 'utf8');
+      fs.writeFileSync(path.join(timeoutDir, 'hangs.test.cjs'), HANGS_BODY, 'utf8');
       timeoutRun = runHarness(timeoutDir, [], {
         RUN_TESTS_NO_FORCE_EXIT: '1',
         RUN_TESTS_CHUNK_TIMEOUT_MS: String(CHUNK_TIMEOUT_MS_FOR_HANG_RUN),
@@ -995,7 +1009,8 @@ test('hangs forever', () => new Promise(() => {}));
     // T1: on a chunk timeout, the diagnostic must NAME the file that was
     // still executing — not merely list every file the chunk contained (the
     // pre-instrumentation behavior). A test that hangs INSIDE its own body
-    // (never resolving) keeps its test:start event unmatched by any
+    // (parks on a settling timer that outlasts the chunk bound, so it never
+    // resolves inside the window) keeps its test:start event unmatched by any
     // test:pass/test:fail in the ndjson companion reporter's output, which
     // is exactly the signal the diagnostic reads back on timeout.
     test('a chunk timeout names the file that was in flight when killed', () => {
@@ -1181,10 +1196,17 @@ test('hangs forever', () => new Promise(() => {}));
     // exit/signal/liveness behavior only — never a measured duration value
     // (RULESET.TESTS.no-timing-assertion).
     test('the #3889 hang fixture genuinely hangs by itself and self-terminates (#4105)', (t, done) => {
+      // (a) Structural margin, single-sourced with the served body: the park
+      // must outlast the chunk bound by >= 4x, so a loaded box's scheduling
+      // jitter can never let the timer settle before the harness kill fires.
+      assert.ok(
+        HANG_PARK_MS >= 4 * CHUNK_TIMEOUT_MS_FOR_HANG_RUN,
+        `fixture park (${HANG_PARK_MS}ms) must exceed the chunk bound (${CHUNK_TIMEOUT_MS_FOR_HANG_RUN}ms) with margin`,
+      );
       const dir = createTempDir('gsd-3889-hang-fixture-');
       t.after(() => cleanup(dir));
       const tf = path.join(dir, 'hangs.test.cjs');
-      fs.writeFileSync(tf, HANGS_FOREVER_BODY, 'utf8');
+      fs.writeFileSync(tf, HANGS_BODY, 'utf8');
       const child = spawn(process.execPath, [tf], { stdio: 'ignore' });
       t.after(() => { try { child.kill('SIGKILL'); } catch { /* already gone */ } });
       // Fast-fail on a spawn error (execPath unspawnable): the poll below keys
@@ -1194,9 +1216,9 @@ test('hangs forever', () => new Promise(() => {}));
       child.on('error', (err) => {
         assert.fail(`could not spawn the fixture directly: ${err.message}`);
       });
-      // 2x the intended 10s park (#4105 fix); also bounds a fully-immortal
-      // body (the RED state) well inside this suite's chunk budget.
-      const CEILING_MS = 20_000;
+      // 2x the park: generous for a loaded runner, still bounded so an
+      // immortal body fails loudly well inside this suite's chunk budget.
+      const CEILING_MS = 2 * HANG_PARK_MS;
       const spawnedAt = Date.now();
       // Past the chunk bound the harness kills at: the fixture must still be
       // hanging HERE, alone — this is the vacuity guard. +400ms covers child

--- a/tests/run-tests-harness.test.cjs
+++ b/tests/run-tests-harness.test.cjs
@@ -20,6 +20,7 @@ const { describe, test, before, after, beforeEach, afterEach } = require('node:t
 const assert = require('node:assert/strict');
 const fs = require('fs');
 const path = require('path');
+const { spawn } = require('node:child_process');
 
 const { runNode } = require('./helpers/process-seam.cjs');
 const { toLegacyResult } = require('./helpers/git-fixture.cjs');
@@ -900,6 +901,11 @@ const { test } = require('node:test');
 test('hangs forever', () => new Promise(() => {}));
 `;
 
+    // The per-chunk timeout the timeout-path run below arms. Hoisted (#4105)
+    // so the #4105 fixture guard below asserts against the SAME bound the
+    // harness run uses, not a re-typed literal that can drift from it.
+    const CHUNK_TIMEOUT_MS_FOR_HANG_RUN = 2000;
+
     let successDir;
     let successRun;
     let eventsDirBefore;
@@ -926,7 +932,7 @@ test('hangs forever', () => new Promise(() => {}));
       fs.writeFileSync(path.join(timeoutDir, 'hangs.test.cjs'), HANGS_FOREVER_BODY, 'utf8');
       timeoutRun = runHarness(timeoutDir, [], {
         RUN_TESTS_NO_FORCE_EXIT: '1',
-        RUN_TESTS_CHUNK_TIMEOUT_MS: '2000',
+        RUN_TESTS_CHUNK_TIMEOUT_MS: String(CHUNK_TIMEOUT_MS_FOR_HANG_RUN),
       });
     });
 
@@ -1149,6 +1155,78 @@ test('hangs forever', () => new Promise(() => {}));
         /run-tests: chunk 1\/1 was killed after \d+ms/,
         `expected the new killed/elapsed line; STDERR:\n${timeoutRun.stderr}`,
       );
+    });
+
+    // Regression (#4105): T1/T4 above are only meaningful if the fixture
+    // above GENUINELY hangs, and the hang must be a property of the FIXTURE,
+    // not of the runtime's test-runner shutdown behavior. A never-settling
+    // `new Promise(() => {})` holds NO libuv handle, so whether the spawned
+    // child hangs is decided by the Node line: on v24/v26 the runner happens
+    // to hold the loop open, but on v22 the child exits on its own in ~60ms
+    // (`# cancelled 1`, rc=1) — the chunk then never reaches the timeout path
+    // and T1/T4 assert nothing about the timeout diagnostic (measured:
+    // v22.22.0 `node --test` exits after 61ms). RED at this test's introducing
+    // sha against the then-current body: on Node 24 it fails the
+    // self-termination arm (an unheld never-settling promise also never
+    // self-terminates on lines where the runner DOES hold it open), and on
+    // off-24 lines it fails the still-hanging arm. Deterministic guard, same
+    // shape as the #4104 self-exit regression: spawn the EXACT served body
+    // directly — no harness, no runner — and observe that it (a) is still
+    // running past the chunk bound the harness run above arms (it hangs by
+    // itself, without any runtime holding it), and (b) exits on its own —
+    // natural exit, no signal — inside a generous ceiling (an orphaned
+    // fixture must not outlive its intended park). Liveness of a SUBPROCESS
+    // cannot be driven through the clock seam (mock.timers cannot reach
+    // inside a separately spawned node), so the guard asserts observable
+    // exit/signal/liveness behavior only — never a measured duration value
+    // (RULESET.TESTS.no-timing-assertion).
+    test('the #3889 hang fixture genuinely hangs by itself and self-terminates (#4105)', (t, done) => {
+      const dir = createTempDir('gsd-3889-hang-fixture-');
+      t.after(() => cleanup(dir));
+      const tf = path.join(dir, 'hangs.test.cjs');
+      fs.writeFileSync(tf, HANGS_FOREVER_BODY, 'utf8');
+      const child = spawn(process.execPath, [tf], { stdio: 'ignore' });
+      t.after(() => { try { child.kill('SIGKILL'); } catch { /* already gone */ } });
+      // Fast-fail on a spawn error (execPath unspawnable): the poll below keys
+      // on exit/signal, which a failed spawn never sets, so without this the
+      // ceiling would expire with a misleading "did not self-terminate"
+      // message instead of the real cause (same hardening as #4104).
+      child.on('error', (err) => {
+        assert.fail(`could not spawn the fixture directly: ${err.message}`);
+      });
+      // 2x the intended 10s park (#4105 fix); also bounds a fully-immortal
+      // body (the RED state) well inside this suite's chunk budget.
+      const CEILING_MS = 20_000;
+      const spawnedAt = Date.now();
+      // Past the chunk bound the harness kills at: the fixture must still be
+      // hanging HERE, alone — this is the vacuity guard. +400ms covers child
+      // spawn startup so the checkpoint measures the fixture, not boot time.
+      const stillHangingAt = spawnedAt + CHUNK_TIMEOUT_MS_FOR_HANG_RUN + 400;
+      const deadline = spawnedAt + CEILING_MS;
+      const poll = () => {
+        // `exitCode !== null` alone misses a SIGNALED exit (exitCode stays
+        // null when a signal ends the child); signalCode covers that, and the
+        // assertions below then name it as the failure.
+        if (child.exitCode !== null || child.signalCode !== null) {
+          assert.ok(
+            Date.now() >= stillHangingAt,
+            `fixture must still be hanging past the ${CHUNK_TIMEOUT_MS_FOR_HANG_RUN}ms chunk bound — ` +
+              `it exited after only ${Date.now() - spawnedAt}ms ` +
+              '(#4105 regression: the hang is the runtime\'s, not the fixture\'s)',
+          );
+          assert.strictEqual(child.signalCode, null,
+            'fixture must SELF-terminate (natural exit) — a signal means we had to kill it (#4105/#4104 regression)');
+          assert.strictEqual(child.exitCode, 0, 'the parked fixture settles and its test passes cleanly');
+          done();
+          return;
+        }
+        if (Date.now() >= deadline) {
+          child.kill('SIGKILL');
+          assert.fail(`fixture did not self-terminate within ${CEILING_MS}ms — immortal process (#4105/#4104 regression)`);
+        }
+        setTimeout(poll, 200);
+      };
+      setImmediate(poll);
     });
   });
 });

--- a/tests/run-tests-harness.test.cjs
+++ b/tests/run-tests-harness.test.cjs
@@ -1184,18 +1184,21 @@ test('hangs forever', () => new Promise((resolve) => { setTimeout(resolve, ${HAN
     // sha against the then-current body: on Node 24 it fails the
     // self-termination arm (an unheld never-settling promise also never
     // self-terminates on lines where the runner DOES hold it open), and on
-    // off-24 lines it fails the still-hanging arm. Deterministic guard, same
-    // shape as the #4104 self-exit regression: spawn the EXACT served body
-    // directly — no harness, no runner — and observe that it (a) is still
-    // running past the chunk bound the harness run above arms (it hangs by
-    // itself, without any runtime holding it), and (b) exits on its own —
-    // natural exit, no signal — inside a generous ceiling (an orphaned
-    // fixture must not outlive its intended park). Liveness of a SUBPROCESS
+    // off-24 lines it fails the still-hanging arm. Deterministic guard, the
+    // #4104 self-exit regression's event-driven shape: spawn the EXACT served
+    // body directly — no harness, no runner, no polling — and observe that its
+    // natural 'exit' event (a) arrives no earlier than past the chunk bound
+    // the harness run above arms (it hangs by itself, without any runtime
+    // holding it up), and (b) carries a natural exit — exit code 0, no
+    // signal. The `{ timeout: 2 * HANG_PARK_MS }` backstop (the
+    // health-validation #663 pattern) fails an immortal body — one that never
+    // delivers 'exit' — instead of hanging the suite; a `{ timeout }` option
+    // is the no-elapsed-assertion-compliant bound. Liveness of a SUBPROCESS
     // cannot be driven through the clock seam (mock.timers cannot reach
     // inside a separately spawned node), so the guard asserts observable
     // exit/signal/liveness behavior only — never a measured duration value
     // (RULESET.TESTS.no-timing-assertion).
-    test('the #3889 hang fixture genuinely hangs by itself and self-terminates (#4105)', (t, done) => {
+    test('the #3889 hang fixture genuinely hangs by itself and self-terminates (#4105)', { timeout: 2 * HANG_PARK_MS }, (t, done) => {
       // (a) Structural margin, single-sourced with the served body: the park
       // must outlast the chunk bound by >= 4x, so a loaded box's scheduling
       // jitter can never let the timer settle before the harness kill fires.
@@ -1208,47 +1211,37 @@ test('hangs forever', () => new Promise((resolve) => { setTimeout(resolve, ${HAN
       const tf = path.join(dir, 'hangs.test.cjs');
       fs.writeFileSync(tf, HANGS_BODY, 'utf8');
       const child = spawn(process.execPath, [tf], { stdio: 'ignore' });
+      // The runner timeout above fails an immortal body; this hook guarantees
+      // the child is reaped on every exit path, including that one.
       t.after(() => { try { child.kill('SIGKILL'); } catch { /* already gone */ } });
-      // Fast-fail on a spawn error (execPath unspawnable): the poll below keys
-      // on exit/signal, which a failed spawn never sets, so without this the
-      // ceiling would expire with a misleading "did not self-terminate"
-      // message instead of the real cause (same hardening as #4104).
+      const spawnedAt = Date.now();
+      // Past the chunk bound the harness kills at: the fixture's natural exit
+      // must arrive no earlier than this — that is the vacuity guard. +400ms
+      // covers child spawn startup so the checkpoint measures the fixture,
+      // not boot time.
+      const stillHangingAt = spawnedAt + CHUNK_TIMEOUT_MS_FOR_HANG_RUN + 400;
+      // Fast-fail on a spawn error (execPath unspawnable): 'exit' never fires
+      // for a failed spawn, so without this the runner timeout would expire
+      // with a generic timeout message instead of the real cause (same
+      // hardening as #4104).
       child.on('error', (err) => {
         assert.fail(`could not spawn the fixture directly: ${err.message}`);
       });
-      // 2x the park: generous for a loaded runner, still bounded so an
-      // immortal body fails loudly well inside this suite's chunk budget.
-      const CEILING_MS = 2 * HANG_PARK_MS;
-      const spawnedAt = Date.now();
-      // Past the chunk bound the harness kills at: the fixture must still be
-      // hanging HERE, alone — this is the vacuity guard. +400ms covers child
-      // spawn startup so the checkpoint measures the fixture, not boot time.
-      const stillHangingAt = spawnedAt + CHUNK_TIMEOUT_MS_FOR_HANG_RUN + 400;
-      const deadline = spawnedAt + CEILING_MS;
-      const poll = () => {
-        // `exitCode !== null` alone misses a SIGNALED exit (exitCode stays
-        // null when a signal ends the child); signalCode covers that, and the
-        // assertions below then name it as the failure.
-        if (child.exitCode !== null || child.signalCode !== null) {
-          assert.ok(
-            Date.now() >= stillHangingAt,
-            `fixture must still be hanging past the ${CHUNK_TIMEOUT_MS_FOR_HANG_RUN}ms chunk bound — ` +
-              `it exited after only ${Date.now() - spawnedAt}ms ` +
-              '(#4105 regression: the hang is the runtime\'s, not the fixture\'s)',
-          );
-          assert.strictEqual(child.signalCode, null,
-            'fixture must SELF-terminate (natural exit) — a signal means we had to kill it (#4105/#4104 regression)');
-          assert.strictEqual(child.exitCode, 0, 'the parked fixture settles and its test passes cleanly');
-          done();
-          return;
-        }
-        if (Date.now() >= deadline) {
-          child.kill('SIGKILL');
-          assert.fail(`fixture did not self-terminate within ${CEILING_MS}ms — immortal process (#4105/#4104 regression)`);
-        }
-        setTimeout(poll, 200);
-      };
-      setImmediate(poll);
+      // `exitCode !== null` alone misses a SIGNALED exit (exitCode stays null
+      // when a signal ends the child); the assertions name signalCode as the
+      // failure when that happens.
+      child.on('exit', () => {
+        assert.ok(
+          Date.now() >= stillHangingAt,
+          `fixture must still be hanging past the ${CHUNK_TIMEOUT_MS_FOR_HANG_RUN}ms chunk bound — ` +
+            `it exited after only ${Date.now() - spawnedAt}ms ` +
+            '(#4105 regression: the hang is the runtime\'s, not the fixture\'s)',
+        );
+        assert.strictEqual(child.signalCode, null,
+          'fixture must SELF-terminate (natural exit) — a signal means we had to kill it (#4105/#4104 regression)');
+        assert.strictEqual(child.exitCode, 0, 'the parked fixture settles and its test passes cleanly');
+        done();
+      });
     });
   });
 });


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #4105

> The linked issue has the `confirmed-bug` label.

---

## What was broken

`tests/run-tests-harness.test.cjs`'s #3889 chunk-timeout fixture was
`test('hangs forever', () => new Promise(() => {}))` — a never-settling
promise that holds **no libuv handle**, so whether the spawned chunk child
actually hung was a property of the Node line's test-runner shutdown
behavior, not of the fixture. On v24/v26 the runner happens to hold the event
loop open; on v22.22.0 the child exits on its own in ~60ms (`# cancelled 1`,
rc=1), the chunk never reaches the timeout path (`chunk 1/1 failed after
72ms` instead of being killed at the bound), and the two timeout assertions —
`a chunk timeout names the file that was in flight when killed` (T1) and
`existing timeout diagnostic and abort behavior are unchanged` (T4) —
silently stop testing the timeout diagnostic, with a failure signature that
does not name the runtime as the variable. Nothing stated this load-bearing
runtime dependency, and a future v24.x/v26 shutdown change would flip it
silently.

## What this fix does

Parks the fixture on a **settling 10s timer** —
`new Promise((resolve) => { setTimeout(resolve, HANG_PARK_MS); })` — the #4104
idiom. The timer is an explicit handle, so the hang is a property of the
fixture on every runtime; 10s exceeds the 2000ms chunk bound by 5x (the
margin is asserted structurally against the same hoisted constant the harness
run uses); it costs ~0% CPU while parked; and the settle guarantees the
fixture self-terminates if a kill orphans it (the #4104 pairing concern —
deliberately not `setInterval`-forever and not `while (true) {}`). A new
failing-first regression guard spawns the exact served body directly and
asserts its natural `exit` event arrives no earlier than past the chunk bound
(it genuinely hangs by itself) and carries a natural exit (code 0, no
signal), with the node:test `{ timeout }` backstop bounding an immortal body.

## Root cause

The fixture's hang was incidental rather than constructed: the promise shape
outsources "does the process stay alive" to unstated node:test shutdown
behavior that differs across Node lines and is free to change. Introduced
with the #3889 instrumentation (8497833a15 / PR #4015; consolidated by
c1a2c33886). Full diagnosis with measurements on v22.22.0 / v24 / v26.8.1 in
the run artifacts.

## Testing

### How I verified the fix

- RED: the regression guard was committed and run first against the unfixed
  body — on the linux/Node 24 bench it failed exactly as designed
  (`fixture did not self-terminate ... — immortal process`), 43700 other
  tests passing (RED sha fe2a88b2853f8c9213cf4a52a38efbe04cfb60eb).
- GREEN: full gsd-test bench via the verification hook on the final HEAD.
- Off-24 evidence (scratch repros, not the suite): the old body under
  v22.22.0 exits rc=1 after ~61ms and the harness-level timeout run reports
  `chunk 1/1 failed after 72ms` with T1/T4 failing; with the parked body the
  same run on v22 and v26 is killed at the 2000ms bound and T1/T4 pass with
  the identical diagnostic — the assertions are meaningful on every runtime.
- Behavior on the Node 24 matrix line is unchanged: the chunk is still killed
  by the harness timeout (~2006ms) with the same `In flight when killed` and
  `exceeded the per-chunk timeout` diagnostics.

### Regression test added?

- [x] Yes — `the #3889 hang fixture genuinely hangs by itself and self-terminates (#4105)` (failing-first; pins the hang as the fixture's property plus self-termination)

### Platforms tested

- [x] macOS (local scratch repros, Node 26.8.1 and Node 22.22.0)
- [ ] Windows (no platform-specific surface: argv-array spawn, mkdtemp paths, runner timers)
- [x] Linux (gsd-test bench, Node 24)

### Runtimes tested

- [x] N/A (test-harness-only change; no agent runtime involved)

---

## Checklist

- [x] Issue linked above with `Fixes #4105`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — one test file, zero src/scripts changes
- [x] Regression test added
- [x] All existing tests pass (gsd-test bench via the verification hook)
- [x] `.changeset/` fragment added (`npm run changeset -- --type Fixed`; PR number backfilled)
- [x] No unnecessary dependencies added

## Breaking changes

None — test fixture and test-file constants only; no production code, no
shipped output, no API.

## Assumptions stated

- The issue's literal suggestion (`setInterval(() => {}, 1000)`) was not used:
  it holds a handle but never self-terminates, and the issue itself flags the
  #4104 pairing and endorses the parked `setTimeout` ("A parked setTimeout
  handle costs ~0% CPU if orphaned"). This reuses the #4104 house idiom.
- The parked duration is 10s (5x the 2000ms chunk bound; #4104 used 6.7x for
  its 1500ms bound). The margin is enforced by the guard's structural
  assertion (`HANG_PARK_MS >= 4 * CHUNK_TIMEOUT_MS_FOR_HANG_RUN`), so the two
  cannot silently drift apart.
- The guard adds ~10s wall-clock per lane (one spawn, self-bounded) — the same
  cost already accepted for the #4104 guard in prohibition-enforcement.
