### PR TITLE
fix(#4355): add --merge-async to test:coverage:unit:raw

### DIFF
--- a/.changeset/zesty-ravens-snooze.md
+++ b/.changeset/zesty-ravens-snooze.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**Fixed a silent CI failure in the raw-coverage test shards.** `test:coverage:unit:raw` (used by test.yml's sharded lane and release.yml's rc/finalize jobs) could OOM-crash after the test suite itself passed cleanly, showing no error beyond a bare non-zero exit code.

--- a/.changeset/zesty-ravens-snooze.md
+++ b/.changeset/zesty-ravens-snooze.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 4356
 ---
 **Fixed a silent CI failure in the raw-coverage test shards.** `test:coverage:unit:raw` (used by test.yml's sharded lane and release.yml's rc/finalize jobs) could OOM-crash after the test suite itself passed cleanly, showing no error beyond a bare non-zero exit code.

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "test:coverage": "c8 --check-coverage --lines 70 --branches 60 --reporter text --include 'gsd-core/bin/lib/**/*.cjs' --exclude 'tests/**' --all node scripts/run-tests.cjs",
     "test:coverage:scripts-floor": "c8 report --check-coverage --lines 55 --merge-async --include 'scripts/**/*.cjs' --exclude 'tests/**' --all",
     "test:coverage:unit": "c8 --reporter text --reporter json-summary --merge-async --include 'gsd-core/bin/lib/**/*.cjs' --exclude 'tests/**' --all node scripts/run-tests.cjs --suite unit && node scripts/check-coverage-gate.cjs",
-    "test:coverage:unit:raw": "c8 --reporter none node scripts/run-tests.cjs --suite unit",
+    "test:coverage:unit:raw": "c8 --reporter none --merge-async node scripts/run-tests.cjs --suite unit",
     "test:coverage:report": "c8 report --reporter text --reporter json-summary --merge-async --include 'gsd-core/bin/lib/**/*.cjs' --exclude 'tests/**' --all && node scripts/check-coverage-gate.cjs",
     "test:coverage:all": "npm run test:coverage",
     "test:mutation": "stryker run",

--- a/tests/c8-merge-async-flag.test.cjs
+++ b/tests/c8-merge-async-flag.test.cjs
@@ -19,6 +19,22 @@
 // #4068's own new test file plus other suite growth pushed the un-flagged sync merge
 // over the 8192 MB heap ceiling (#4172).
 //
+// #4355: #4068's fix ALSO missed test:coverage:unit:raw, based on an incorrect
+// assumption (see the test this replaces, below) that `--reporter none` makes c8
+// skip the merge/report dispatch entirely. Verified false against
+// node_modules/c8/lib/report.js: Report.prototype.run() unconditionally awaits
+// `this.getCoverageMapFromAllCoverageFiles()` to build `context.coverageMap` BEFORE
+// it ever looks at `this.reporter` -- the reporter list only controls what happens
+// to that already-merged map in the loop AFTER, so `--reporter none` skips nothing
+// but the final text/json output. Without --merge-async this still runs the
+// synchronous `_getMergedProcessCov()`, which loads every raw per-process V8
+// coverage dump into memory at once -- the same #4068/#4172 OOM shape, confirmed
+// live on release.yml's finalize-test job (run 33997057100, shard 2/3: "# fail 0"
+// then a silent exit 1 ~21s later with no stack trace -- an external OOM-kill of
+// the wrapping c8 process). test:coverage:unit:raw is used by both test.yml's
+// sharded full-test lane and (since #4335) release.yml's rc-test/finalize-test
+// matrix jobs, so every shard of every CI run and release was exposed.
+//
 // IMPORTANT c8@11.0.0 gotcha (verified against node_modules/c8/lib/commands/
 // check-coverage.js and report.js directly): the `check-coverage` CLI subcommand's
 // handler does NOT forward `argv.mergeAsync` into the `Report(...)` constructor --
@@ -102,7 +118,7 @@ describe('coverage-merge-async-flag (#4068, #4172)', () => {
   });
 
   test('--merge-async lands in the c8 invocation, not after the node runner', () => {
-    for (const key of ['test:coverage:unit', 'test:coverage:report', 'test:coverage:scripts-floor']) {
+    for (const key of ['test:coverage:unit', 'test:coverage:report', 'test:coverage:scripts-floor', 'test:coverage:unit:raw']) {
       const script = scripts[key];
       const flagIndex = script.indexOf('--merge-async');
       const nodeIndex = script.indexOf(' node ');
@@ -131,19 +147,22 @@ describe('coverage-merge-async-flag (#4068, #4172)', () => {
     );
   });
 
-  test('test:coverage:unit:raw is intentionally unchanged (--reporter none skips the merge/report phase entirely)', () => {
+  test('test:coverage:unit:raw carries --merge-async (#4355)', () => {
+    assert.match(
+      scripts['test:coverage:unit:raw'],
+      /(?:^|\s)c8\s.*--merge-async/,
+      'test:coverage:unit:raw must pass --merge-async to c8 -- `--reporter none` does ' +
+        'NOT skip the merge phase (Report.run() computes it unconditionally before ' +
+        'ever consulting the reporter list, verified against ' +
+        'node_modules/c8/lib/report.js), so without this flag it still OOMs the same ' +
+        'way #4068/#4172 already fixed on the other three coverage scripts (#4355)'
+    );
     assert.match(
       scripts['test:coverage:unit:raw'],
       /--reporter none/,
-      'test:coverage:unit:raw must keep --reporter none -- this is what defers all ' +
-        'merging to the separate coverage-gate job (test:coverage:report)'
-    );
-    assert.doesNotMatch(
-      scripts['test:coverage:unit:raw'],
-      /--merge-async/,
-      '--merge-async on a --reporter none run is a no-op (Report.run() never ' +
-        'reaches the merge dispatch) and would misleadingly imply this script does ' +
-        'its own merging'
+      'test:coverage:unit:raw must keep --reporter none -- the merge still needs to ' +
+        'happen for c8 to write nothing misleading, but the actual report output is ' +
+        'deferred to the separate coverage-gate job (test:coverage:report)'
     );
   });
 });


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #4355

## What was broken

`test:coverage:unit:raw` (`c8 --reporter none node scripts/run-tests.cjs --suite unit`) could OOM-crash after the test suite itself had already passed cleanly, exiting 1 with no stack trace or diagnostic — confirmed live on `release.yml`'s `finalize-test` job ([run 33997057100](https://github.com/open-gsd/gsd-core/actions/runs/33997057100/job/101390370486), shard 2/3).

## What this fix does

Adds `--merge-async` to `test:coverage:unit:raw`, matching the other three coverage-invoking scripts (`test:coverage:unit`, `test:coverage:report`, `test:coverage:scripts-floor`), all of which already carry it from #4068/#4172.

## Root cause

`c8@11.0.0`'s `Report.prototype.run()` (`node_modules/c8/lib/report.js`) unconditionally awaits `this.getCoverageMapFromAllCoverageFiles()` to build `context.coverageMap` **before** it ever looks at `this.reporter` — the reporter list only controls what happens to that already-computed map afterward. `--reporter none` therefore skips the *output formatting* step, not the merge itself.

Without `--merge-async`, that merge uses the synchronous `_getMergedProcessCov()`, which loads every raw per-process V8 coverage dump in `coverage/tmp` fully into memory at once — the exact OOM shape already fixed twice in this repo (#4068, #4172) on the other three coverage scripts. `tests/c8-merge-async-flag.test.cjs` (added by #4068) had asserted the *opposite* for this script, based on the same now-disproven "`--reporter none` skips the merge" assumption — corrected here.

`test:coverage:unit:raw` is used by both `test.yml`'s sharded full-test lane and (since #4335) `release.yml`'s `rc-test`/`finalize-test` matrix jobs, so every shard of every CI run and release dry-run was exposed.

## Testing

### How I verified the fix

- Read `node_modules/c8/lib/report.js` and `node_modules/c8/lib/commands/check-coverage.js` directly to confirm the merge-dispatch and flag-forwarding behavior (see issue #4355 for the full trace).
- Built a standalone repro against this repo's pinned `c8@11.0.0` `Report` class with realistic synthetic V8 coverage dumps (400 files, ~700 KB each, 273 MB total): the sync merge path (`mergeAsync:false`) crashed with `JavaScript heap out of memory` under a constrained heap; the async path (`mergeAsync:true`) completed cleanly at a flat memory footprint.
- Ran `gsd-test` against this branch's head commit — see verdict below.

### Regression test added?

- [x] Yes — `tests/c8-merge-async-flag.test.cjs`'s `test:coverage:unit:raw carries --merge-async (#4355)` test now asserts the flag is present (previously asserted the opposite); the file's shared `--merge-async lands in the c8 invocation, not after the node runner` ordering test now also covers this script.

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

`gsd-test`'s remote matrix is Linux-only; this is a Linux CI-pipeline defect (`release.yml`/`test.yml` run on `ubuntu-latest`), so Linux coverage is the relevant surface.

### Runtimes tested

- [x] N/A (not runtime-specific)

## Checklist

- [x] Issue linked above with `Fixes #4355` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added (`Fixed`, backfilled with the PR number below)
- [x] No unnecessary dependencies added

## Breaking changes

None
