### PR TITLE
fix(#4363): bump download-artifact and setup-node off node20 runtimes

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -127,7 +127,7 @@ jobs:
         run: echo "CI_JOB_START_EPOCH_MS=$(( $(date +%s) * 1000 ))" >> "$GITHUB_ENV"
 
       - name: Set up Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version-file: .nvmrc
           cache: npm

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -127,7 +127,7 @@ jobs:
         run: echo "CI_JOB_START_EPOCH_MS=$(( $(date +%s) * 1000 ))" >> "$GITHUB_ENV"
 
       - name: Set up Node
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
           node-version-file: .nvmrc
           cache: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -452,7 +452,7 @@ jobs:
       # exactly the layout c8 expects from a single run (test.yml's
       # coverage-gate job does the identical merge for the same reason).
       - name: Download every shard's raw coverage
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           pattern: coverage-tmp-rc-shard-*
           path: coverage/tmp
@@ -727,7 +727,7 @@ jobs:
         run: npm ci
 
       - name: Download every shard's raw coverage
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           pattern: coverage-tmp-finalize-shard-*
           path: coverage/tmp

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -747,7 +747,7 @@ jobs:
       # is exactly the layout c8 expects from a single run. The dumps are
       # per-process files with distinct names, so there is nothing to collide.
       - name: Download every shard's raw coverage
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           pattern: coverage-tmp-shard-*
           path: coverage/tmp


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #4363

## What was broken

Two SHA-pinned actions still declare `runs.using: node20` in their `action.yml`: `actions/download-artifact@v6.0.0` (three coverage-merge steps in `test.yml`/`release.yml`) and `actions/setup-node@v4.4.0` (`mutation.yml`). This fires a Node.js 20 deprecation warning on every CI run.

## What this fix does

Bumps both pins to a `node24`-declaring release:

- `actions/download-artifact@018cc2cf...` (v6.0.0) → `actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c` (v8.0.1, latest) in `test.yml:750`, `release.yml:455`, `release.yml:730`.
- `actions/setup-node@49933ea...` (v4.4.0) → `actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f` (v6.3.0) in `mutation.yml:130` — matching the pin already used at all 6 other `setup-node` call sites in `test.yml`/`release.yml`, rather than introducing a third major version of the same action. (First commit bumped this to v7.0.0/latest; the Standards review below flagged the unjustified version split and it was corrected to v6.3.0 for consistency — both v6.3.0 and v7.0.0 declare `node24`.)

## Root cause

Both pins predate the actions' migration to `node24`; nothing kept them in sync as newer major releases shipped. `runs.using` (the action's own execution runtime) is orthogonal to the `node-version:` input `setup-node` installs for the project — this repo's `node-version`/`.nvmrc` was already `24` everywhere, so the warning was purely about the pinned actions' own runtime declaration.

## Testing

### How I verified the fix

Fetched `action.yml` from the GitHub API at each pinned commit (current and proposed) and confirmed `runs.using` directly rather than assuming from tag/version numbers — `v6.0.0`/`v4.4.0` are `node20`; `v8.0.1`/`v6.3.0` are `node24`. Cross-checked every other SHA-pinned action across `.github/workflows/*.yml` the same way; all others already report `node24`. Validated the edited workflow files parse with `js-yaml`. Ran `gsd-test` and recorded a pass for both commits' SHAs. Ran the two mandated orthogonal reviews (`/code-review`, isolated Standards + Spec sub-agents; `/security-review`, isolated sub-agent) plus `npm run lint:ci` — Spec and Security came back clean; Standards flagged the setup-node version-split noted above, which is fixed in the second commit. `lint:ci`'s regression-test gate was run with `GSD_SKIP_REGRESSION_TEST_GATE=1` (documented escape in `CONTRIBUTING.md`) since this is a CI-pin bump with no unit-testable application behavior.

### Regression test added?

- [x] No — explain why: CI-workflow-runtime pin, not application logic; there is no unit-testable behavior change (inputs/outputs of both actions are unchanged — `pattern`/`merge-multiple` for download-artifact, `node-version-file`/`cache` for setup-node). Verification is the workflow itself no longer emitting the deprecation warning on its next run.

### Platforms tested

- [x] N/A (not platform-specific)

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #4363`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`gsd-test`)
- [x] `no-changelog` label applied — CI-tweak, no user-facing package behavior change
- [x] No unnecessary dependencies added

## Breaking changes

`actions/download-artifact` v8 changes its `digest-mismatch` default from silently warning to erroring on a corrupted download (security-positive default). This does not change what these three steps do under normal operation and is not a breaking change to this repo's behavior.
