### PR TITLE
fix(#4137): probe the Homebrew symlink before rewriting a managed hook's node path

### DIFF
--- a/.changeset/fierce-goats-wake.md
+++ b/.changeset/fierce-goats-wake.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 4369
+---
+**Managed hooks no longer break on a keg-only or unlinked Homebrew node** — the installer now probes `<prefix>/bin/node` before baking it into a hook command and falls back to the running node when that symlink does not exist, matching the fnm, mise and volta branches. (#4137)

--- a/src/runtime-hooks-surface.cts
+++ b/src/runtime-hooks-surface.cts
@@ -516,7 +516,17 @@ function normalizeNodePath(execPath: string, opts?: NodeNormOpts): string {
     /^(.+)\/Cellar\/node(@\d+)?\/[^/]+\/bin\/node(\.exe)?$/i,
   );
   if (homebrewMatch) {
-    return `${homebrewMatch[1]}/bin/node${homebrewMatch[3] || ''}`;
+    // #4137: probe the symlink before adopting it, exactly like the fnm, mise
+    // and volta branches. `<prefix>/bin/node` only exists while the formula is
+    // LINKED: a keg-only or versioned formula (`brew install node@22`) fills
+    // the Cellar without ever creating it, and an unlinked plain `node` is the
+    // same shape. Returning it unconditionally turned a stale-but-working pin
+    // into an immediately broken one — every managed hook then died with
+    // `<prefix>/bin/node: No such file or directory` at fire time, surfacing as
+    // a hook error rather than an installer one. On a miss fall through to the
+    // raw execPath: an upgrade-fragile path still beats a nonexistent one.
+    const symlink = `${homebrewMatch[1]}/bin/node${homebrewMatch[3] || ''}`;
+    if (existsSync(symlink)) return symlink;
   }
 
   // mise pins a concrete node version at <data>/installs/node/<ver>/bin/node

--- a/tests/install.test.cjs
+++ b/tests/install.test.cjs
@@ -2410,6 +2410,12 @@ const path = require('node:path');
 const HOOKS_SURFACE = require(path.join(__dirname, '..', 'gsd-core', 'bin', 'lib', 'runtime-hooks-surface.cjs'));
 const { normalizeNodePath, resolveNodeRunner, rewriteLegacyManagedNodeHookCommands } = HOOKS_SURFACE;
 
+// #4137: the Homebrew rewrite is existsSync-guarded like fnm/mise/volta, so a
+// test that asserts the MAPPING must state its precondition — the formula is
+// LINKED, i.e. <prefix>/bin/node exists. Without it these cases assert against
+// whatever node layout the CI host happens to have.
+const LINKED = { existsSync: () => true };
+
 // ─── normalizeNodePath ────────────────────────────────────────────────────────
 
 describe('Bug #3181: normalizeNodePath — exported as a function', () => {
@@ -2420,39 +2426,39 @@ describe('Bug #3181: normalizeNodePath — exported as a function', () => {
 
 describe('Bug #3181: normalizeNodePath — Intel Homebrew Cellar paths → /usr/local/bin/node', () => {
   test('simple versioned Intel Cellar path', () => {
-    const result = normalizeNodePath('/usr/local/Cellar/node/25.8.1/bin/node');
+    const result = normalizeNodePath('/usr/local/Cellar/node/25.8.1/bin/node', LINKED);
     assert.equal(result, '/usr/local/bin/node');
   });
 
   test('Intel Cellar path with long semver', () => {
-    const result = normalizeNodePath('/usr/local/Cellar/node/20.11.0/bin/node');
+    const result = normalizeNodePath('/usr/local/Cellar/node/20.11.0/bin/node', LINKED);
     assert.equal(result, '/usr/local/bin/node');
   });
 
   test('Intel Cellar path with prerelease version segment', () => {
-    const result = normalizeNodePath('/usr/local/Cellar/node/22.0.0-rc.1/bin/node');
+    const result = normalizeNodePath('/usr/local/Cellar/node/22.0.0-rc.1/bin/node', LINKED);
     assert.equal(result, '/usr/local/bin/node');
   });
 
   test('Intel versioned formula Cellar path (node@20) maps to stable symlink', () => {
-    const result = normalizeNodePath('/usr/local/Cellar/node@20/20.11.0/bin/node');
+    const result = normalizeNodePath('/usr/local/Cellar/node@20/20.11.0/bin/node', LINKED);
     assert.equal(result, '/usr/local/bin/node');
   });
 });
 
 describe('Bug #3181: normalizeNodePath — Apple Silicon Homebrew Cellar paths → /opt/homebrew/bin/node', () => {
   test('simple versioned Apple Silicon Cellar path', () => {
-    const result = normalizeNodePath('/opt/homebrew/Cellar/node/25.8.1/bin/node');
+    const result = normalizeNodePath('/opt/homebrew/Cellar/node/25.8.1/bin/node', LINKED);
     assert.equal(result, '/opt/homebrew/bin/node');
   });
 
   test('Apple Silicon Cellar path with another version', () => {
-    const result = normalizeNodePath('/opt/homebrew/Cellar/node/18.20.4/bin/node');
+    const result = normalizeNodePath('/opt/homebrew/Cellar/node/18.20.4/bin/node', LINKED);
     assert.equal(result, '/opt/homebrew/bin/node');
   });
 
   test('Apple Silicon versioned formula Cellar path (node@18) maps to stable symlink', () => {
-    const result = normalizeNodePath('/opt/homebrew/Cellar/node@18/18.20.4/bin/node');
+    const result = normalizeNodePath('/opt/homebrew/Cellar/node@18/18.20.4/bin/node', LINKED);
     assert.equal(result, '/opt/homebrew/bin/node');
   });
 });
@@ -2461,23 +2467,78 @@ describe('Bug #3181: normalizeNodePath — Apple Silicon Homebrew Cellar paths �
 // from the path itself, so one branch covers every Homebrew layout.
 describe('Bug #2185: normalizeNodePath — Linuxbrew + custom-prefix Cellar paths → <prefix>/bin/node', () => {
   test('Linuxbrew Cellar path maps to the stable linuxbrew symlink', () => {
-    const result = normalizeNodePath('/home/linuxbrew/.linuxbrew/Cellar/node/26.0.0/bin/node');
+    const result = normalizeNodePath('/home/linuxbrew/.linuxbrew/Cellar/node/26.0.0/bin/node', LINKED);
     assert.equal(result, '/home/linuxbrew/.linuxbrew/bin/node');
   });
 
   test('Linuxbrew Cellar path after a version bump (26.5.0) maps to stable symlink', () => {
-    const result = normalizeNodePath('/home/linuxbrew/.linuxbrew/Cellar/node/26.5.0/bin/node');
+    const result = normalizeNodePath('/home/linuxbrew/.linuxbrew/Cellar/node/26.5.0/bin/node', LINKED);
     assert.equal(result, '/home/linuxbrew/.linuxbrew/bin/node');
   });
 
   test('Linuxbrew versioned formula Cellar path (node@22) maps to stable symlink', () => {
-    const result = normalizeNodePath('/home/linuxbrew/.linuxbrew/Cellar/node@22/22.11.0/bin/node');
+    const result = normalizeNodePath('/home/linuxbrew/.linuxbrew/Cellar/node@22/22.11.0/bin/node', LINKED);
     assert.equal(result, '/home/linuxbrew/.linuxbrew/bin/node');
   });
 
   test('custom HOMEBREW_PREFIX Cellar path maps to its stable symlink', () => {
-    const result = normalizeNodePath('/custom/brew/Cellar/node/25.8.1/bin/node');
+    const result = normalizeNodePath('/custom/brew/Cellar/node/25.8.1/bin/node', LINKED);
     assert.equal(result, '/custom/brew/bin/node');
+  });
+});
+
+// #4137: `<prefix>/bin/node` is created by `brew link`. A keg-only or versioned
+// formula (`brew install node@22`) fills the Cellar without ever creating it,
+// and so does an unlinked plain `node`. The branch rewrote to that path
+// unconditionally — no existsSync — so on those layouts every managed hook was
+// baked to a file that does not exist and died at fire time with
+// `<prefix>/bin/node: No such file or directory`. fnm (#977/#3704), mise
+// (#1619) and volta (#2335) all probe before rewriting; Homebrew was the last
+// member of the family without the guard.
+const UNLINKED = { existsSync: () => false };
+
+describe('Bug #4137: normalizeNodePath — an unlinked Homebrew keg falls through to execPath', () => {
+  test('versioned formula (node@22) with no <prefix>/bin/node returns execPath unchanged', () => {
+    const kegOnly = '/opt/homebrew/Cellar/node@22/22.11.0/bin/node';
+    assert.equal(normalizeNodePath(kegOnly, UNLINKED), kegOnly);
+  });
+
+  test('unlinked plain formula with no <prefix>/bin/node returns execPath unchanged', () => {
+    const unlinked = '/usr/local/Cellar/node/25.8.1/bin/node';
+    assert.equal(normalizeNodePath(unlinked, UNLINKED), unlinked);
+  });
+
+  test('Linuxbrew and custom prefixes fall through on the same miss', () => {
+    for (const kegOnly of [
+      '/home/linuxbrew/.linuxbrew/Cellar/node@22/22.11.0/bin/node',
+      '/custom/brew/Cellar/node/25.8.1/bin/node',
+    ]) {
+      assert.equal(normalizeNodePath(kegOnly, UNLINKED), kegOnly,
+        `${kegOnly} has no linked symlink — the raw path must survive`);
+    }
+  });
+
+  test('the probe asks for exactly <prefix>/bin/node, and only that', () => {
+    const probed = [];
+    normalizeNodePath('/opt/homebrew/Cellar/node@22/22.11.0/bin/node', {
+      existsSync: p => { probed.push(p); return false; },
+    });
+    assert.deepEqual(probed, ['/opt/homebrew/bin/node']);
+  });
+
+  test('a linked keg still rewrites — #2185/#3181 behavior is preserved', () => {
+    assert.equal(
+      normalizeNodePath('/opt/homebrew/Cellar/node@22/22.11.0/bin/node', {
+        existsSync: p => p === '/opt/homebrew/bin/node',
+      }),
+      '/opt/homebrew/bin/node');
+  });
+
+  test('resolveNodeRunner bakes the raw Cellar path rather than a nonexistent symlink', () => {
+    const kegOnly = '/opt/homebrew/Cellar/node@22/22.11.0/bin/node';
+    assert.equal(
+      resolveNodeRunner({ execPath: kegOnly, existsSync: () => false }),
+      JSON.stringify(kegOnly));
   });
 });
 
@@ -2523,7 +2584,7 @@ describe('Bug #3181: resolveNodeRunner — maps Cellar execPath to stable symlin
         value: '/usr/local/Cellar/node/25.8.1/bin/node',
         configurable: true,
       });
-      const runner = resolveNodeRunner();
+      const runner = resolveNodeRunner(LINKED);
       assert.equal(runner, '"/usr/local/bin/node"',
         `expected stable Intel symlink, got: ${runner}`);
     } finally {
@@ -2538,7 +2599,7 @@ describe('Bug #3181: resolveNodeRunner — maps Cellar execPath to stable symlin
         value: '/opt/homebrew/Cellar/node/25.8.1/bin/node',
         configurable: true,
       });
-      const runner = resolveNodeRunner();
+      const runner = resolveNodeRunner(LINKED);
       assert.equal(runner, '"/opt/homebrew/bin/node"',
         `expected stable Apple Silicon symlink, got: ${runner}`);
     } finally {
@@ -2705,6 +2766,12 @@ const path = require('node:path');
 
 const { normalizeNodePath, resolveNodeRunner } = require(path.join(__dirname, '..', 'gsd-core', 'bin', 'lib', 'runtime-hooks-surface.cjs'));
 
+// #4137: the Homebrew rewrite is existsSync-guarded like fnm/mise/volta, so a
+// test that asserts the MAPPING must state its precondition — the formula is
+// LINKED, i.e. <prefix>/bin/node exists. Without it these cases assert against
+// whatever node layout the CI host happens to have.
+const LINKED = { existsSync: () => true };
+
 // ─── Synthetic paths used across tests ───────────────────────────────────────
 
 const EPHEMERAL_FNM_WIN = 'C:/Users/u/AppData/Local/fnm_multishells/15600_1781041703752/node.exe';
@@ -2788,14 +2855,14 @@ describe('Bug #977: normalizeNodePath — non-fnm paths are unaffected (no regre
 
   test('Intel Homebrew Cellar path still maps to stable symlink', () => {
     assert.equal(
-      normalizeNodePath('/usr/local/Cellar/node/25.8.1/bin/node'),
+      normalizeNodePath('/usr/local/Cellar/node/25.8.1/bin/node', LINKED),
       '/usr/local/bin/node',
     );
   });
 
   test('Apple Silicon Homebrew Cellar path still maps to stable symlink', () => {
     assert.equal(
-      normalizeNodePath('/opt/homebrew/Cellar/node/25.8.1/bin/node'),
+      normalizeNodePath('/opt/homebrew/Cellar/node/25.8.1/bin/node', LINKED),
       '/opt/homebrew/bin/node',
     );
   });


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #4137

---

## What was broken

`normalizeNodePath()` rewrote every Homebrew Cellar `execPath` to `<prefix>/bin/node` unconditionally — the one branch of the family with no existence check. That symlink is created by `brew link`, so on a keg-only or versioned formula (`brew install node@22`), or an unlinked plain `node`, the installer baked a path that does not exist and every managed hook died at fire time with `/bin/sh: <prefix>/bin/node: No such file or directory` — surfacing to the user as a hook error rather than an installer problem.

## What this fix does

`existsSync`-guards the Homebrew rewrite and falls through to the unmodified `execPath` on a miss, exactly as the `fnm` (#977/#3704), `mise` (#1619) and `volta` (#2335) branches already do. An upgrade-fragile path still beats a nonexistent one.

## Root cause

```js
if (homebrewMatch) {
  return `${homebrewMatch[1]}/bin/node${homebrewMatch[3] || ''}`;   // no existsSync
}
```

#2185 generalised this branch from a hardcoded prefix to a derived one (Intel, Apple Silicon, Linuxbrew, custom `HOMEBREW_PREFIX`) but did not add the existence check the sibling branches carry — three of them say so in their own comments: *"only rewrite when the shim exists … so a rewrite never turns a stale-but-working pin into an immediately broken one."* Homebrew was the last member of the family still carrying the original failure mode, now in a broader form.

## Testing

### How I verified the fix

`tests/install.test.cjs` — the owning module, so no new `bug-*.test.cjs` file (per `scripts/lint-regression-test-names.cjs`):

- new `Bug #4137` block: a versioned formula, an unlinked plain formula, and Linuxbrew / custom-prefix misses all fall through to `execPath`; the probe targets exactly `<prefix>/bin/node` and nothing else; a **linked** keg still rewrites (#2185/#3181 behavior preserved); `resolveNodeRunner` bakes the raw Cellar path rather than a nonexistent symlink.
- **5 of the 6 new cases fail without the source change** (`ℹ pass 1 / ℹ fail 5`), all 6 pass with it.
- The pre-existing #2185/#3181 mapping cases called `normalizeNodePath()` with no opts, so they asserted against whatever node layout the CI host happened to have. They now inject the precondition they always depended on (`LINKED = { existsSync: () => true }`); their expectations are unchanged.

Whole-file run: only a pre-existing, environment-dependent failure at `tests/install.test.cjs:123` (`getGlobalConfigDir`, reproduces identically on clean `next` — the #4312 class) remains.

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [x] Linux
- [ ] macOS
- [ ] Windows (including backslash path handling)
- [ ] N/A (not platform-specific)

> The bug is macOS/Linuxbrew-shaped, but the branch is pure path arithmetic and every case is driven through the injected `existsSync` seam, so the tests are host-independent.

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [x] N/A (not runtime-specific — managed hook node resolution is shared by every runtime)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added (`.changeset/fierce-goats-wake.md`, type `Fixed`)
- [x] No unnecessary dependencies added

## Breaking changes

None. On a linked formula the resolved path is identical to today; the only behavior change is on layouts where the previous result pointed at a file that does not exist.

---

### Note, not implemented here

On a **versioned** formula the truly stable path is `<prefix>/opt/node@<ver>/bin/node` (brew maintains `opt/` for keg-only formulae), and where an unrelated linked `node` exists this guard will still adopt `<prefix>/bin/node` — a working but possibly different generation. Adopting `opt/` would change the pinned expectations of #2185/#3181, so it is deliberately left out of a bug fix; happy to open a follow-up issue if you want that behavior.
