### PR TITLE
fix(#4137): existsSync-guard the Homebrew Cellar rewrite in normalizeNodePath

### DIFF
--- a/.changeset/rapid-finches-roar.md
+++ b/.changeset/rapid-finches-roar.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**Managed hooks no longer break on keg-only Homebrew node** — on a Homebrew Node installed as a versioned, unlinked formula (e.g. node@24), every managed hook failed at invocation with `/bin/sh: <prefix>/bin/node: No such file or directory`; the Homebrew path rewrite now verifies the stable symlink exists before using it and keeps the working install path otherwise. (#4137)

--- a/.changeset/rapid-finches-roar.md
+++ b/.changeset/rapid-finches-roar.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 4375
 ---
 **Managed hooks no longer break on keg-only Homebrew node** — on a Homebrew Node installed as a versioned, unlinked formula (e.g. node@24), every managed hook failed at invocation with `/bin/sh: <prefix>/bin/node: No such file or directory`; the Homebrew path rewrite now verifies the stable symlink exists before using it and keeps the working install path otherwise. (#4137)

--- a/src/runtime-hooks-surface.cts
+++ b/src/runtime-hooks-surface.cts
@@ -512,11 +512,19 @@ function normalizeNodePath(execPath: string, opts?: NodeNormOpts): string {
   // survives the upgrade. Derive <prefix> from the path itself (more reliable
   // than HOMEBREW_PREFIX env — the path IS the install location) so every layout
   // is covered by one branch instead of one per known prefix (#2185).
+  //
+  // #4137: rewrite only when the symlink exists; otherwise fall through to the
+  // raw execPath, exactly like the mise and volta branches. A keg-only/versioned
+  // formula (node@24 installed but never `brew link`ed) has no <prefix>/bin/node
+  // at all, so the unconditional rewrite handed every managed hook a path that
+  // fails at invocation — a rewrite must never turn a working keg path into an
+  // immediately broken one.
   const homebrewMatch = normalizedForMatch.match(
     /^(.+)\/Cellar\/node(@\d+)?\/[^/]+\/bin\/node(\.exe)?$/i,
   );
   if (homebrewMatch) {
-    return `${homebrewMatch[1]}/bin/node${homebrewMatch[3] || ''}`;
+    const homebrewStable = `${homebrewMatch[1]}/bin/node${homebrewMatch[3] || ''}`;
+    if (existsSync(homebrewStable)) return homebrewStable;
   }
 
   // mise pins a concrete node version at <data>/installs/node/<ver>/bin/node

--- a/tests/install.test.cjs
+++ b/tests/install.test.cjs
@@ -2420,39 +2420,46 @@ describe('Bug #3181: normalizeNodePath — exported as a function', () => {
 
 describe('Bug #3181: normalizeNodePath — Intel Homebrew Cellar paths → /usr/local/bin/node', () => {
   test('simple versioned Intel Cellar path', () => {
-    const result = normalizeNodePath('/usr/local/Cellar/node/25.8.1/bin/node');
+    const result = normalizeNodePath('/usr/local/Cellar/node/25.8.1/bin/node',
+      { existsSync: p => p === '/usr/local/bin/node' });
     assert.equal(result, '/usr/local/bin/node');
   });
 
   test('Intel Cellar path with long semver', () => {
-    const result = normalizeNodePath('/usr/local/Cellar/node/20.11.0/bin/node');
+    const result = normalizeNodePath('/usr/local/Cellar/node/20.11.0/bin/node',
+      { existsSync: p => p === '/usr/local/bin/node' });
     assert.equal(result, '/usr/local/bin/node');
   });
 
   test('Intel Cellar path with prerelease version segment', () => {
-    const result = normalizeNodePath('/usr/local/Cellar/node/22.0.0-rc.1/bin/node');
+    const result = normalizeNodePath('/usr/local/Cellar/node/22.0.0-rc.1/bin/node',
+      { existsSync: p => p === '/usr/local/bin/node' });
     assert.equal(result, '/usr/local/bin/node');
   });
 
   test('Intel versioned formula Cellar path (node@20) maps to stable symlink', () => {
-    const result = normalizeNodePath('/usr/local/Cellar/node@20/20.11.0/bin/node');
+    const result = normalizeNodePath('/usr/local/Cellar/node@20/20.11.0/bin/node',
+      { existsSync: p => p === '/usr/local/bin/node' });
     assert.equal(result, '/usr/local/bin/node');
   });
 });
 
 describe('Bug #3181: normalizeNodePath — Apple Silicon Homebrew Cellar paths → /opt/homebrew/bin/node', () => {
   test('simple versioned Apple Silicon Cellar path', () => {
-    const result = normalizeNodePath('/opt/homebrew/Cellar/node/25.8.1/bin/node');
+    const result = normalizeNodePath('/opt/homebrew/Cellar/node/25.8.1/bin/node',
+      { existsSync: p => p === '/opt/homebrew/bin/node' });
     assert.equal(result, '/opt/homebrew/bin/node');
   });
 
   test('Apple Silicon Cellar path with another version', () => {
-    const result = normalizeNodePath('/opt/homebrew/Cellar/node/18.20.4/bin/node');
+    const result = normalizeNodePath('/opt/homebrew/Cellar/node/18.20.4/bin/node',
+      { existsSync: p => p === '/opt/homebrew/bin/node' });
     assert.equal(result, '/opt/homebrew/bin/node');
   });
 
   test('Apple Silicon versioned formula Cellar path (node@18) maps to stable symlink', () => {
-    const result = normalizeNodePath('/opt/homebrew/Cellar/node@18/18.20.4/bin/node');
+    const result = normalizeNodePath('/opt/homebrew/Cellar/node@18/18.20.4/bin/node',
+      { existsSync: p => p === '/opt/homebrew/bin/node' });
     assert.equal(result, '/opt/homebrew/bin/node');
   });
 });
@@ -2461,23 +2468,135 @@ describe('Bug #3181: normalizeNodePath — Apple Silicon Homebrew Cellar paths �
 // from the path itself, so one branch covers every Homebrew layout.
 describe('Bug #2185: normalizeNodePath — Linuxbrew + custom-prefix Cellar paths → <prefix>/bin/node', () => {
   test('Linuxbrew Cellar path maps to the stable linuxbrew symlink', () => {
-    const result = normalizeNodePath('/home/linuxbrew/.linuxbrew/Cellar/node/26.0.0/bin/node');
+    const result = normalizeNodePath('/home/linuxbrew/.linuxbrew/Cellar/node/26.0.0/bin/node',
+      { existsSync: p => p === '/home/linuxbrew/.linuxbrew/bin/node' });
     assert.equal(result, '/home/linuxbrew/.linuxbrew/bin/node');
   });
 
   test('Linuxbrew Cellar path after a version bump (26.5.0) maps to stable symlink', () => {
-    const result = normalizeNodePath('/home/linuxbrew/.linuxbrew/Cellar/node/26.5.0/bin/node');
+    const result = normalizeNodePath('/home/linuxbrew/.linuxbrew/Cellar/node/26.5.0/bin/node',
+      { existsSync: p => p === '/home/linuxbrew/.linuxbrew/bin/node' });
     assert.equal(result, '/home/linuxbrew/.linuxbrew/bin/node');
   });
 
   test('Linuxbrew versioned formula Cellar path (node@22) maps to stable symlink', () => {
-    const result = normalizeNodePath('/home/linuxbrew/.linuxbrew/Cellar/node@22/22.11.0/bin/node');
+    const result = normalizeNodePath('/home/linuxbrew/.linuxbrew/Cellar/node@22/22.11.0/bin/node',
+      { existsSync: p => p === '/home/linuxbrew/.linuxbrew/bin/node' });
     assert.equal(result, '/home/linuxbrew/.linuxbrew/bin/node');
   });
 
   test('custom HOMEBREW_PREFIX Cellar path maps to its stable symlink', () => {
-    const result = normalizeNodePath('/custom/brew/Cellar/node/25.8.1/bin/node');
+    const result = normalizeNodePath('/custom/brew/Cellar/node/25.8.1/bin/node',
+      { existsSync: p => p === '/custom/brew/bin/node' });
     assert.equal(result, '/custom/brew/bin/node');
+  });
+});
+
+// ─── normalizeNodePath — Homebrew keg-only Cellar path keeps execPath (#4137) ──
+//
+// Bug #4137: every other runtime branch in normalizeNodePath (fnm shim, fnm
+// versioned, mise, volta) probes its rewrite candidate with the injected
+// existsSync and falls back to the raw execPath on a miss. The Homebrew branch
+// alone returned `<prefix>/bin/node` unconditionally — a path that does not
+// exist when the formula is keg-only/versioned and not `brew link`ed (e.g.
+// `node@24` resolving through `<prefix>/opt/node@24/bin/node`). Every managed
+// hook command then failed at invocation with exit 127,
+// `/bin/sh: <prefix>/bin/node: No such file or directory`.
+//
+// Fix: existsSync-guard the Homebrew rewrite exactly as mise and volta do; on a
+// miss fall through to the unmodified execPath. A rewrite must never convert a
+// working path into a broken one.
+//
+// Hermetic: every case injects existsSync and grants existence to exactly ONE
+// candidate — the one its layout would really have (the fnm #3704 stub rule).
+describe('Bug #4137: normalizeNodePath — keg-only Homebrew Cellar path falls back to raw execPath', () => {
+  const ARM_KEG = '/opt/homebrew/Cellar/node@24/24.11.0/bin/node';
+  const ARM_STABLE = '/opt/homebrew/bin/node';
+  const INTEL_KEG = '/usr/local/Cellar/node@20/20.11.0/bin/node';
+  const INTEL_STABLE = '/usr/local/bin/node';
+  const LINUXBREW_KEG = '/home/linuxbrew/.linuxbrew/Cellar/node@22/22.11.0/bin/node';
+  const LINUXBREW_STABLE = '/home/linuxbrew/.linuxbrew/bin/node';
+  const CUSTOM_KEG = '/custom/brew/Cellar/node@18/18.20.4/bin/node';
+  const CUSTOM_STABLE = '/custom/brew/bin/node';
+
+  test('keg-only versioned Cellar path (the reported bug) → raw execPath unchanged', () => {
+    // Apple Silicon, node@24 keg-only: <prefix>/bin/node is absent.
+    assert.equal(normalizeNodePath(ARM_KEG, { existsSync: () => false }), ARM_KEG);
+  });
+
+  test('Intel versioned keg-only Cellar path → raw execPath unchanged', () => {
+    assert.equal(normalizeNodePath(INTEL_KEG, { existsSync: () => false }), INTEL_KEG);
+  });
+
+  test('Linuxbrew versioned keg-only Cellar path → raw execPath unchanged', () => {
+    assert.equal(normalizeNodePath(LINUXBREW_KEG, { existsSync: () => false }), LINUXBREW_KEG);
+  });
+
+  test('unversioned keg-only Cellar path (brew unlink node) → raw execPath unchanged', () => {
+    const keg = '/opt/homebrew/Cellar/node/24.11.0/bin/node';
+    assert.equal(normalizeNodePath(keg, { existsSync: () => false }), keg);
+  });
+
+  test('custom HOMEBREW_PREFIX keg-only Cellar path → raw execPath unchanged', () => {
+    assert.equal(normalizeNodePath(CUSTOM_KEG, { existsSync: () => false }), CUSTOM_KEG);
+  });
+
+  test('Windows-spelled keg-only Cellar path → raw execPath unchanged, .exe intact', () => {
+    const keg = 'C:/Program Files/brew/Cellar/node@24/24.11.0/bin/node.exe';
+    assert.equal(normalizeNodePath(keg, { existsSync: () => false }), keg);
+  });
+
+  test('guard miss must not leak into the mise/volta branches', () => {
+    // The decoy shim belongs to a sibling branch's candidate space; a Cellar
+    // path can never claim it, and the fallback must be the raw execPath.
+    const decoyShim = '/opt/homebrew/shims/node';
+    assert.equal(
+      normalizeNodePath(ARM_KEG, { existsSync: p => p === decoyShim }),
+      ARM_KEG);
+  });
+});
+
+// Negative space: the guard must be a no-op when <prefix>/bin/node DOES exist
+// (linked formula) — the #2185/#3181 rewrite survives exactly as before.
+describe('Bug #4137: normalizeNodePath — linked Homebrew Cellar path still rewrites (guard is a no-op)', () => {
+  test('linked versioned formula keg + stable symlink present → stable symlink', () => {
+    assert.equal(
+      normalizeNodePath('/opt/homebrew/Cellar/node@24/24.11.0/bin/node',
+        { existsSync: p => p === '/opt/homebrew/bin/node' }),
+      '/opt/homebrew/bin/node');
+  });
+
+  test('linked unversioned formula keg + stable symlink present → stable symlink', () => {
+    assert.equal(
+      normalizeNodePath('/usr/local/Cellar/node/25.8.1/bin/node',
+        { existsSync: p => p === '/usr/local/bin/node' }),
+      '/usr/local/bin/node');
+  });
+
+  test('Linuxbrew linked keg + stable symlink present → stable symlink', () => {
+    assert.equal(
+      normalizeNodePath('/home/linuxbrew/.linuxbrew/Cellar/node@22/22.11.0/bin/node',
+        { existsSync: p => p === '/home/linuxbrew/.linuxbrew/bin/node' }),
+      '/home/linuxbrew/.linuxbrew/bin/node');
+  });
+});
+
+// The seam callers bake into hook commands — the reported breakage surface.
+describe('Bug #4137: resolveNodeRunner — keg-only Cellar execPath stays raw when symlink absent', () => {
+  test('resolveNodeRunner keeps the keg path (quoted token) instead of the broken symlink', () => {
+    const keg = '/opt/homebrew/Cellar/node@24/24.11.0/bin/node';
+    assert.equal(
+      resolveNodeRunner({ execPath: keg, existsSync: () => false }),
+      JSON.stringify(keg));
+  });
+
+  test('resolveNodeRunner still maps a linked Cellar execPath to the stable symlink', () => {
+    assert.equal(
+      resolveNodeRunner({
+        execPath: '/opt/homebrew/Cellar/node@24/24.11.0/bin/node',
+        existsSync: p => p === '/opt/homebrew/bin/node',
+      }),
+      '"/opt/homebrew/bin/node"');
   });
 });
 
@@ -2523,7 +2642,7 @@ describe('Bug #3181: resolveNodeRunner — maps Cellar execPath to stable symlin
         value: '/usr/local/Cellar/node/25.8.1/bin/node',
         configurable: true,
       });
-      const runner = resolveNodeRunner();
+      const runner = resolveNodeRunner({ existsSync: p => p === '/usr/local/bin/node' });
       assert.equal(runner, '"/usr/local/bin/node"',
         `expected stable Intel symlink, got: ${runner}`);
     } finally {
@@ -2538,7 +2657,7 @@ describe('Bug #3181: resolveNodeRunner — maps Cellar execPath to stable symlin
         value: '/opt/homebrew/Cellar/node/25.8.1/bin/node',
         configurable: true,
       });
-      const runner = resolveNodeRunner();
+      const runner = resolveNodeRunner({ existsSync: p => p === '/opt/homebrew/bin/node' });
       assert.equal(runner, '"/opt/homebrew/bin/node"',
         `expected stable Apple Silicon symlink, got: ${runner}`);
     } finally {

--- a/tests/install.test.cjs
+++ b/tests/install.test.cjs
@@ -2511,13 +2511,9 @@ describe('Bug #2185: normalizeNodePath — Linuxbrew + custom-prefix Cellar path
 // candidate — the one its layout would really have (the fnm #3704 stub rule).
 describe('Bug #4137: normalizeNodePath — keg-only Homebrew Cellar path falls back to raw execPath', () => {
   const ARM_KEG = '/opt/homebrew/Cellar/node@24/24.11.0/bin/node';
-  const ARM_STABLE = '/opt/homebrew/bin/node';
   const INTEL_KEG = '/usr/local/Cellar/node@20/20.11.0/bin/node';
-  const INTEL_STABLE = '/usr/local/bin/node';
   const LINUXBREW_KEG = '/home/linuxbrew/.linuxbrew/Cellar/node@22/22.11.0/bin/node';
-  const LINUXBREW_STABLE = '/home/linuxbrew/.linuxbrew/bin/node';
   const CUSTOM_KEG = '/custom/brew/Cellar/node@18/18.20.4/bin/node';
-  const CUSTOM_STABLE = '/custom/brew/bin/node';
 
   test('keg-only versioned Cellar path (the reported bug) → raw execPath unchanged', () => {
     // Apple Silicon, node@24 keg-only: <prefix>/bin/node is absent.

--- a/tests/install.test.cjs
+++ b/tests/install.test.cjs
@@ -2903,14 +2903,16 @@ describe('Bug #977: normalizeNodePath — non-fnm paths are unaffected (no regre
 
   test('Intel Homebrew Cellar path still maps to stable symlink', () => {
     assert.equal(
-      normalizeNodePath('/usr/local/Cellar/node/25.8.1/bin/node'),
+      normalizeNodePath('/usr/local/Cellar/node/25.8.1/bin/node',
+        { existsSync: p => p === '/usr/local/bin/node' }),
       '/usr/local/bin/node',
     );
   });
 
   test('Apple Silicon Homebrew Cellar path still maps to stable symlink', () => {
     assert.equal(
-      normalizeNodePath('/opt/homebrew/Cellar/node/25.8.1/bin/node'),
+      normalizeNodePath('/opt/homebrew/Cellar/node/25.8.1/bin/node',
+        { existsSync: p => p === '/opt/homebrew/bin/node' }),
       '/opt/homebrew/bin/node',
     );
   });


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #4137

---

## What was broken

`normalizeNodePath()`'s Homebrew branch rewrote a Cellar node path to `<prefix>/bin/node`
unconditionally — without checking that the target exists. On a keg-only / versioned Homebrew
install (`node@24` never `brew link`ed), `<prefix>/bin/node` does not exist, so every managed
hook command baked by the installer failed at invocation with exit 127
(`/bin/sh: <prefix>/bin/node: No such file or directory`).

## What this fix does

Guards the rewrite with `existsSync` exactly like the sibling mise and volta branches: when
`<prefix>/bin/node` exists (linked formula) the rewrite happens exactly as before; when it does
not (keg-only), the function falls through to the unmodified raw `execPath` — a working, if
upgrade-fragile, path instead of an immediately broken one.

## Root cause

`src/runtime-hooks-surface.cts` `normalizeNodePath()` — the Homebrew branch was the only branch
of five (fnm shim, fnm versioned, Homebrew, mise, volta) that returned its rewritten candidate
without probing it. The branch's unconditional return predates #2185, which generalized the
prefix derivation from two hardcoded prefixes to any Homebrew layout — broadening the defect to
every layout instead of two. Node realpaths through `<prefix>/opt/node@X/bin/node` to the Cellar
path, which the regex matches, so the branch fires on keg-only installs whose stable symlink was
never created.

Upgrades self-repair: a hook baked with the broken `"<prefix>/bin/node"` runner is a two-token
managed entry, and `rewriteLegacyManagedNodeHookCommands` re-projects every two-token managed
entry onto the current runner on reinstall (#3662 rule) — verified behaviorally, the broken
command is replaced by the working keg runner as soon as the fixed installer re-runs.

## Testing

### How I verified the fix

- Reproduced first against the built output of `next` with a sandboxed Homebrew prefix (keg
  binary + `opt/` symlink, no `bin/` link): `normalizeNodePath` returned the nonexistent
  `<prefix>/bin/node`, and invoking the baked command exited 127 with
  `/bin/sh: <prefix>/bin/node: No such file or directory` — the issue's exact observed output.
  With the fix, the same scenario keeps the raw keg path and the invocation exits 0.
- Regression tests added in `tests/install.test.cjs` (folded per the regression-test-name
  policy), all hermetic via injected `existsSync` stubs — no dependence on the runner machine's
  real `/usr/local/bin/node`.
- Full `gsd-test` bench (default selection) green on the fix commit.

### Regression test added?

- [x] Yes — added a test that would have caught this bug

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

Windows/Linux layouts are covered hermetically (`.exe` spelling preserved, Linuxbrew and custom
`HOMEBREW_PREFIX` keg-only cases in the matrix); the bench default selection ran the
cross-platform suite.

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific — the seam feeds every runtime's hook commands equally)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (full `gsd-test` bench, default selection: linux-node24 43863/43863, plus `npm run lint:ci` clean)
- [x] `.changeset/` fragment added
- [x] No unnecessary dependencies added

## Breaking changes

None. When `<prefix>/bin/node` exists the rewrite is byte-identical to today's; the only
behavior change is the new fallback on the already-broken keg-only layout.
