### PR TITLE
fix(#4312): control the ambient env and home the runtime-home tests assert against

### DIFF
--- a/tests/install.test.cjs
+++ b/tests/install.test.cjs
@@ -116,13 +116,29 @@ describe('getGlobalConfigDir — all runtimes default paths', () => {
     return [...envs, ...skillsEnvs];
   });
   const ENV_KEYS = [...new Set([..._registryEnvKeys, 'GROK_AGENTS_HOME', 'XDG_CONFIG_HOME'])];
+  // #4312: captured before beforeEach pins HOME, so the guard below can assert
+  // the pin is actually in effect rather than trusting that it is.
+  const REAL_HOME_AT_LOAD = os.homedir();
   let savedEnv = {};
+  // #4312: clearing the env is only half of it. antigravity resolves through an
+  // fs probe (~/.gemini/antigravity{,-ide,-cli}), so on a machine that has
+  // antigravity-ide or antigravity-cli installed this row asserted the default
+  // and got the probe hit — red from a clean clone, with no env var involved.
+  // HOME is therefore pinned to an EMPTY fixture, which is the state a
+  // "home-relative default" describes. os.homedir() reads $HOME on POSIX and
+  // %USERPROFILE% on Windows; both are set so the pin holds on either.
+  let fixtureHome = null;
 
   beforeEach(() => {
     for (const key of ENV_KEYS) {
       savedEnv[key] = process.env[key];
       delete process.env[key];
     }
+    savedEnv.HOME = process.env.HOME;
+    savedEnv.USERPROFILE = process.env.USERPROFILE;
+    fixtureHome = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-4312-home-'));
+    process.env.HOME = fixtureHome;
+    process.env.USERPROFILE = fixtureHome;
   });
 
   afterEach(() => {
@@ -130,6 +146,11 @@ describe('getGlobalConfigDir — all runtimes default paths', () => {
       if (savedEnv[key] !== undefined) process.env[key] = savedEnv[key];
       else delete process.env[key];
     }
+    for (const key of ['HOME', 'USERPROFILE']) {
+      if (savedEnv[key] !== undefined) process.env[key] = savedEnv[key];
+      else delete process.env[key];
+    }
+    if (fixtureHome) { cleanup(fixtureHome); fixtureHome = null; }
   });
 
   for (const runtime of allRuntimes.filter(runtime => runtime !== 'kimi')) {
@@ -138,6 +159,17 @@ describe('getGlobalConfigDir — all runtimes default paths', () => {
       assert.strictEqual(getGlobalConfigDir(runtime), expected);
     });
   }
+
+  // #4312 regression guard, deterministic on CI: the rows above are hermetic
+  // only while the pin is in effect. Asserting the pin fails on EVERY machine
+  // if someone drops it, rather than only on one that has an antigravity-cli
+  // install — the conditionality that let the original defect survive.
+  test('#4312: the rows above run against a pinned, empty fixture home', () => {
+    assert.notStrictEqual(os.homedir(), REAL_HOME_AT_LOAD,
+      "os.homedir() must follow the pinned fixture, not the developer's real home");
+    assert.deepEqual(fs.readdirSync(os.homedir()), [],
+      'a home-relative DEFAULT is what resolution returns with no probe candidate present');
+  });
 });
 
 describe('getGlobalConfigDir/getConfigDirFromHome — antigravity 2.x layout detection', () => {
@@ -6624,6 +6656,12 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
 const { runNode, OUTCOME } = require('./helpers/process-seam.cjs');
+// #4312: these cases assert os.homedir()-derived skills roots while spawning a
+// child that inherits process.env, so an exported CLAUDE_CONFIG_DIR moved the
+// child's answer and reddened the suite. TEST_ENV_BASE blanks the registry-derived
+// config-location vars for the child; the product's honouring of them is correct
+// and untouched.
+const { TEST_ENV_BASE, scrubConfigLocationEnv } = require('./helpers.cjs');
 const os = require('node:os');
 const { scanFencedBlocks } = require('../gsd-core/bin/lib/markdown-sectionizer.cjs');
 
@@ -6659,7 +6697,7 @@ describe('install.js --skills-root', () => {
   for (const { runtime, expected } of CASES) {
     test(`resolves correct skills root for ${runtime}`, () => {
       const result = runNode([INSTALL_JS, '--skills-root', runtime], {
-        env: { ...process.env, GSD_TEST_MODE: undefined }, // ensure not in test mode
+        env: { ...process.env, ...TEST_ENV_BASE, GSD_TEST_MODE: undefined }, // ensure not in test mode
         timeoutMs: SKILLS_ROOT_PROBE_TIMEOUT_MS,
       });
       // Strip trailing newline
@@ -6701,7 +6739,7 @@ describe('#3024: gsd-tools query skills-root', () => {
   for (const { runtime, expected } of CASES) {
     test(`resolves correct skills root for ${runtime}`, () => {
       const result = runNode([TOOLS_PATH, 'query', 'skills-root', runtime, '--raw'], {
-        env: { ...process.env, GSD_TEST_MODE: '1' },
+        env: { ...process.env, ...TEST_ENV_BASE, GSD_TEST_MODE: '1' },
       });
       assert.equal(result.outcome, OUTCOME.EXITED, `gsd-tools did not exit cleanly: ${JSON.stringify(result)}`);
       assert.strictEqual(result.exitCode, 0, `gsd-tools exited ${result.exitCode}: ${result.stderr}`);
@@ -6712,7 +6750,7 @@ describe('#3024: gsd-tools query skills-root', () => {
 
   test('errors when runtime arg is missing', () => {
     const result = runNode([TOOLS_PATH, 'query', 'skills-root'], {
-      env: { ...process.env, GSD_TEST_MODE: '1' },
+      env: { ...process.env, ...TEST_ENV_BASE, GSD_TEST_MODE: '1' },
     });
     assert.equal(result.outcome, OUTCOME.EXITED, `gsd-tools did not exit cleanly: ${JSON.stringify(result)}`);
     assert.notStrictEqual(result.exitCode, 0, 'Should exit with error when runtime arg is missing');
@@ -6720,7 +6758,7 @@ describe('#3024: gsd-tools query skills-root', () => {
 
   test('non-raw form: query skills-root claude parses as JSON with expected skills_root', () => {
     const result = runNode([TOOLS_PATH, 'query', 'skills-root', 'claude'], {
-      env: { ...process.env, GSD_TEST_MODE: '1' },
+      env: { ...process.env, ...TEST_ENV_BASE, GSD_TEST_MODE: '1' },
     });
     assert.equal(result.outcome, OUTCOME.EXITED, `gsd-tools did not exit cleanly: ${JSON.stringify(result)}`);
     assert.strictEqual(result.exitCode, 0, `gsd-tools exited ${result.exitCode}: ${result.stderr}`);
@@ -6736,7 +6774,7 @@ describe('#3024: gsd-tools query skills-root', () => {
   test('defect B: unknown runtime does not silently resolve to claude skills root', () => {
     const claudeSkillsRoot = path.join(os.homedir(), '.claude', 'skills');
     const result = runNode([TOOLS_PATH, 'query', 'skills-root', 'bogus-runtime', '--raw'], {
-      env: { ...process.env, GSD_TEST_MODE: '1' },
+      env: { ...process.env, ...TEST_ENV_BASE, GSD_TEST_MODE: '1' },
     });
     assert.equal(result.outcome, OUTCOME.EXITED, `gsd-tools did not exit cleanly: ${JSON.stringify(result)}`);
     assert.notStrictEqual(result.exitCode, 0, 'Unknown runtime must exit non-zero');
@@ -6748,7 +6786,7 @@ describe('#3024: gsd-tools query skills-root', () => {
 
   test('empty runtime arg exits non-zero', () => {
     const result = runNode([TOOLS_PATH, 'query', 'skills-root', '', '--raw'], {
-      env: { ...process.env, GSD_TEST_MODE: '1' },
+      env: { ...process.env, ...TEST_ENV_BASE, GSD_TEST_MODE: '1' },
     });
     assert.equal(result.outcome, OUTCOME.EXITED, `gsd-tools did not exit cleanly: ${JSON.stringify(result)}`);
     assert.notStrictEqual(result.exitCode, 0, 'Empty runtime must exit non-zero');
@@ -6756,7 +6794,7 @@ describe('#3024: gsd-tools query skills-root', () => {
 
   test('whitespace-only runtime arg exits non-zero', () => {
     const result = runNode([TOOLS_PATH, 'query', 'skills-root', '   ', '--raw'], {
-      env: { ...process.env, GSD_TEST_MODE: '1' },
+      env: { ...process.env, ...TEST_ENV_BASE, GSD_TEST_MODE: '1' },
     });
     assert.equal(result.outcome, OUTCOME.EXITED, `gsd-tools did not exit cleanly: ${JSON.stringify(result)}`);
     assert.notStrictEqual(result.exitCode, 0, 'Whitespace-only runtime must exit non-zero');
@@ -6764,7 +6802,7 @@ describe('#3024: gsd-tools query skills-root', () => {
 
   test('HOSTILE: path-traversal runtime arg exits non-zero and emits no path', () => {
     const result = runNode([TOOLS_PATH, 'query', 'skills-root', '../../etc', '--raw'], {
-      env: { ...process.env, GSD_TEST_MODE: '1' },
+      env: { ...process.env, ...TEST_ENV_BASE, GSD_TEST_MODE: '1' },
     });
     assert.equal(result.outcome, OUTCOME.EXITED, `gsd-tools did not exit cleanly: ${JSON.stringify(result)}`);
     assert.notStrictEqual(result.exitCode, 0, 'Path-traversal runtime must exit non-zero');
@@ -6778,7 +6816,7 @@ describe('#3024: gsd-tools query skills-root', () => {
   // shell-injection safety, because no shell is ever invoked.
   test('HOSTILE: shell-metacharacter runtime arg exits non-zero with no output', () => {
     const result = runNode([TOOLS_PATH, 'query', 'skills-root', 'claude; rm -rf /', '--raw'], {
-      env: { ...process.env, GSD_TEST_MODE: '1' },
+      env: { ...process.env, ...TEST_ENV_BASE, GSD_TEST_MODE: '1' },
     });
     assert.equal(result.outcome, OUTCOME.EXITED, `gsd-tools did not exit cleanly: ${JSON.stringify(result)}`);
     assert.notStrictEqual(result.exitCode, 0, 'Shell-metacharacter runtime must exit non-zero');
@@ -6804,10 +6842,10 @@ describe('#3024: gsd-tools query skills-root', () => {
     for (const runtime of [...runtimeIds, ...HOSTILE_RUNTIME_IDS]) {
       const isHostile = HOSTILE_RUNTIME_IDS.includes(runtime);
       const toolsResult = runNode([TOOLS_PATH, 'query', 'skills-root', runtime, '--raw'], {
-        env: { ...process.env, GSD_TEST_MODE: '1' },
+        env: { ...process.env, ...TEST_ENV_BASE, GSD_TEST_MODE: '1' },
       });
       const installResult = runNode([INSTALL_JS, '--skills-root', runtime], {
-        env: { ...process.env, GSD_TEST_MODE: undefined },
+        env: { ...process.env, ...TEST_ENV_BASE, GSD_TEST_MODE: undefined },
       });
       assert.equal(toolsResult.outcome, OUTCOME.EXITED, `gsd-tools did not exit cleanly for ${JSON.stringify(runtime)}: ${JSON.stringify(toolsResult)}`);
       assert.equal(installResult.outcome, OUTCOME.EXITED, `install.js did not exit cleanly for ${JSON.stringify(runtime)}: ${JSON.stringify(installResult)}`);
@@ -6841,7 +6879,7 @@ describe('#3024: gsd-tools query skills-root', () => {
   test('HOSTILE: install.js --skills-root __proto__ does not silently resolve to claude skills root', () => {
     const claudeSkillsRoot = path.join(os.homedir(), '.claude', 'skills');
     const result = runNode([INSTALL_JS, '--skills-root', '__proto__'], {
-      env: { ...process.env, GSD_TEST_MODE: undefined },
+      env: { ...process.env, ...TEST_ENV_BASE, GSD_TEST_MODE: undefined },
     });
     assert.equal(result.outcome, OUTCOME.EXITED, `install.js did not exit cleanly: ${JSON.stringify(result)}`);
     assert.notStrictEqual(result.exitCode, 0, '__proto__ runtime must exit non-zero');
@@ -6863,7 +6901,7 @@ describe('#3024: gsd-tools query skills-root', () => {
     const claudeSkillsRoot = path.join(os.homedir(), '.claude', 'skills');
     const grokSkillsRoot = path.join(os.homedir(), '.agents', 'skills');
     const result = runNode([TOOLS_PATH, 'query', 'skills-root', 'grok', '--raw'], {
-      env: { ...process.env, GSD_TEST_MODE: '1', GROK_AGENTS_HOME: undefined },
+      env: { ...process.env, ...TEST_ENV_BASE, GSD_TEST_MODE: '1', GROK_AGENTS_HOME: undefined },
     });
     assert.equal(result.outcome, OUTCOME.EXITED, `gsd-tools did not exit cleanly: ${JSON.stringify(result)}`);
     assert.strictEqual(result.exitCode, 0, `grok must be accepted; gsd-tools exited ${result.exitCode}: ${result.stderr}`);
@@ -6886,7 +6924,7 @@ describe('#3024: gsd-tools query skills-root', () => {
   test("gemini: rejected — because its bare resolution is claude's fallback, not because it is merely unregistered", () => {
     const claudeSkillsRoot = path.join(os.homedir(), '.claude', 'skills');
     const result = runNode([TOOLS_PATH, 'query', 'skills-root', 'gemini', '--raw'], {
-      env: { ...process.env, GSD_TEST_MODE: '1' },
+      env: { ...process.env, ...TEST_ENV_BASE, GSD_TEST_MODE: '1' },
     });
     assert.equal(result.outcome, OUTCOME.EXITED, `gsd-tools did not exit cleanly: ${JSON.stringify(result)}`);
     assert.notStrictEqual(result.exitCode, 0, 'gemini must be rejected by isRegisteredRuntimeId');
@@ -6895,11 +6933,21 @@ describe('#3024: gsd-tools query skills-root', () => {
     // Prove the reason: gemini's underlying (ungated) resolution IS claude's
     // wrong-runtime fallback — unlike grok's, which resolves to a real,
     // distinct path (see the sibling grok test above).
-    const { getGlobalSkillsBase } = require('../gsd-core/bin/lib/runtime-homes.cjs');
-    assert.strictEqual(
-      getGlobalSkillsBase('gemini'), claudeSkillsRoot,
-      "gemini's bare resolution must be claude's fallback path — this is the wrong-runtime bug that justifies keeping gemini rejected"
-    );
+    //
+    // #4312/#2665: this call runs IN-PROCESS, so the child scrub above cannot
+    // reach it — an ambient CLAUDE_CONFIG_DIR beats the home-derived fallback
+    // and the assertion compared a home path against the contributor's config
+    // dir. scrubConfigLocationEnv() is the in-process half of the same idiom.
+    const restoreEnv = scrubConfigLocationEnv();
+    try {
+      const { getGlobalSkillsBase } = require('../gsd-core/bin/lib/runtime-homes.cjs');
+      assert.strictEqual(
+        getGlobalSkillsBase('gemini'), claudeSkillsRoot,
+        "gemini's bare resolution must be claude's fallback path — this is the wrong-runtime bug that justifies keeping gemini rejected"
+      );
+    } finally {
+      restoreEnv();
+    }
   });
 });
 

--- a/tests/runtime-homes-descriptor-drive.test.cjs
+++ b/tests/runtime-homes-descriptor-drive.test.cjs
@@ -1198,6 +1198,10 @@ const {
   getGlobalSkillDir,
 } = require(path.join(ROOT, 'gsd-core', 'bin', 'lib', 'runtime-homes.cjs'));
 
+// #4312: captured before any test pins HOME, so the pin guard below can assert
+// it is actually in effect rather than trusting that it is.
+const REAL_HOME_AT_LOAD = os.homedir();
+
 // Helper: run fn with an env var temporarily set
 function withEnv(key, value, fn) {
   const orig = process.env[key];
@@ -1211,24 +1215,49 @@ function withEnv(key, value, fn) {
 }
 
 describe('bug #3126: runtime-homes getGlobalConfigDir — defaults', () => {
+  // #4312: the expectations are RELATIVE segments, resolved against a fixture
+  // home inside each test rather than against the real os.homedir(). antigravity
+  // resolves through an fs probe (~/.gemini/antigravity{,-ide,-cli}), so a
+  // contributor who has antigravity-cli installed — and nothing else — got
+  // `.gemini/antigravity-cli` here and a red suite from a clean clone. The
+  // neighbouring GOLDEN DEFAULTS block already states this hazard and skips
+  // antigravity for it; pinning the home keeps the row instead of dropping it,
+  // and makes every other row immune to an installed runtime at the same time.
+  // The probe's PREFERENCE order is covered with an injected existsSync in the
+  // dot-home-nested suite, so nothing is lost here.
   const defaults = [
-    ['claude',      path.join(os.homedir(), '.claude')],
-    ['cursor',      path.join(os.homedir(), '.cursor')],
-    ['codex',       path.join(os.homedir(), '.codex')],
-    ['copilot',     path.join(os.homedir(), '.copilot')],
-    ['antigravity', path.join(os.homedir(), '.gemini', 'antigravity')],
-    ['windsurf',    path.join(os.homedir(), '.codeium', 'windsurf')],
-    ['augment',     path.join(os.homedir(), '.augment')],
-    ['trae',        path.join(os.homedir(), '.trae')],
-    ['qwen',        path.join(os.homedir(), '.qwen')],
-    ['hermes',      path.join(os.homedir(), '.hermes')],
-    ['codebuddy',   path.join(os.homedir(), '.codebuddy')],
-    ['cline',       path.join(os.homedir(), '.cline')],
-    ['opencode',    path.join(os.homedir(), '.config', 'opencode')],
-    ['kilo',        path.join(os.homedir(), '.config', 'kilo')],
+    ['claude',      ['.claude']],
+    ['cursor',      ['.cursor']],
+    ['codex',       ['.codex']],
+    ['copilot',     ['.copilot']],
+    ['antigravity', ['.gemini', 'antigravity']],
+    ['windsurf',    ['.codeium', 'windsurf']],
+    ['augment',     ['.augment']],
+    ['trae',        ['.trae']],
+    ['qwen',        ['.qwen']],
+    ['hermes',      ['.hermes']],
+    ['codebuddy',   ['.codebuddy']],
+    ['cline',       ['.cline']],
+    ['opencode',    ['.config', 'opencode']],
+    ['kilo',        ['.config', 'kilo']],
   ];
-  for (const [runtime, expected] of defaults) {
-    test(`${runtime} default configDir`, () => {
+  for (const [runtime, segments] of defaults) {
+    test(`${runtime} default configDir`, (t) => {
+      // os.homedir() reads $HOME on POSIX and %USERPROFILE% on Windows; both are
+      // set so the fixture holds on either. An EMPTY home is the point: it is
+      // the state the golden defaults describe — no probe candidate present.
+      const fixtureHome = require('node:fs').mkdtempSync(path.join(os.tmpdir(), 'gsd-4312-home-'));
+      const savedHome = { HOME: process.env.HOME, USERPROFILE: process.env.USERPROFILE };
+      process.env.HOME = fixtureHome;
+      process.env.USERPROFILE = fixtureHome;
+      t.after(() => {
+        for (const [k, v] of Object.entries(savedHome)) {
+          if (v === undefined) delete process.env[k];
+          else process.env[k] = v;
+        }
+        cleanup(fixtureHome);
+      });
+      const expected = path.join(fixtureHome, ...segments);
       // Derive env-var list from the registry so new runtimes are auto-covered.
       // GROK_AGENTS_HOME is kept explicitly (grok has no registry entry).
       const { runtimes: _reg3126 } = require(path.join(ROOT, 'gsd-core', 'bin', 'lib', 'capability-registry.cjs'));
@@ -1251,6 +1280,50 @@ describe('bug #3126: runtime-homes getGlobalConfigDir — defaults', () => {
       }
     });
   }
+  // #4312 regression guard, deterministic on CI: the rows above are only
+  // hermetic while the home pin is actually in effect. Asserting the pin itself
+  // fails on EVERY machine if someone drops it, instead of only on a machine
+  // that happens to have an antigravity-cli install — which is what let the
+  // original defect survive seven commits.
+  test('#4312: the default rows run against a pinned, empty fixture home', (t) => {
+    const realHome = REAL_HOME_AT_LOAD;
+    const fixtureHome = require('node:fs').mkdtempSync(path.join(os.tmpdir(), 'gsd-4312-pin-'));
+    const saved = { HOME: process.env.HOME, USERPROFILE: process.env.USERPROFILE };
+    process.env.HOME = fixtureHome;
+    process.env.USERPROFILE = fixtureHome;
+    t.after(() => {
+      for (const [k, v] of Object.entries(saved)) {
+        if (v === undefined) delete process.env[k];
+        else process.env[k] = v;
+      }
+      cleanup(fixtureHome);
+    });
+    assert.notStrictEqual(os.homedir(), realHome,
+      'os.homedir() must follow the pinned fixture, not the developer\'s real home');
+    assert.deepEqual(require('node:fs').readdirSync(fixtureHome), [],
+      'the fixture home must be empty — a golden DEFAULT is what resolution returns with no probe candidate present');
+    assert.strictEqual(getGlobalConfigDir('antigravity'), path.join(fixtureHome, '.gemini', 'antigravity'));
+  });
+
+  // The other half of the same contract: the probe is real, and it is why the
+  // rows cannot assert against whatever home the contributor happens to have.
+  test('#4312: an antigravity-cli install moves the resolved dir — the hazard the pin exists for', (t) => {
+    const decoyHome = require('node:fs').mkdtempSync(path.join(os.tmpdir(), 'gsd-4312-decoy-'));
+    require('node:fs').mkdirSync(path.join(decoyHome, '.gemini', 'antigravity-cli'), { recursive: true });
+    const saved = { HOME: process.env.HOME, USERPROFILE: process.env.USERPROFILE };
+    process.env.HOME = decoyHome;
+    process.env.USERPROFILE = decoyHome;
+    t.after(() => {
+      for (const [k, v] of Object.entries(saved)) {
+        if (v === undefined) delete process.env[k];
+        else process.env[k] = v;
+      }
+      cleanup(decoyHome);
+    });
+    assert.strictEqual(getGlobalConfigDir('antigravity'), path.join(decoyHome, '.gemini', 'antigravity-cli'),
+      'the fs probe is documented behaviour — a default row asserting the real home is asserting this away');
+  });
+
   test('unknown runtime falls back to ~/.claude', () => {
     withEnv('CLAUDE_CONFIG_DIR', undefined, () => {
       assert.strictEqual(getGlobalConfigDir('unknown-xyz'), path.join(os.homedir(), '.claude'));

--- a/tests/runtime-homes-descriptor-drive.test.cjs
+++ b/tests/runtime-homes-descriptor-drive.test.cjs
@@ -1302,7 +1302,9 @@ describe('bug #3126: runtime-homes getGlobalConfigDir — defaults', () => {
       'os.homedir() must follow the pinned fixture, not the developer\'s real home');
     assert.deepEqual(require('node:fs').readdirSync(fixtureHome), [],
       'the fixture home must be empty — a golden DEFAULT is what resolution returns with no probe candidate present');
-    assert.strictEqual(getGlobalConfigDir('antigravity'), path.join(fixtureHome, '.gemini', 'antigravity'));
+    withEnv('ANTIGRAVITY_CONFIG_DIR', undefined, () => {
+      assert.strictEqual(getGlobalConfigDir('antigravity'), path.join(fixtureHome, '.gemini', 'antigravity'));
+    });
   });
 
   // The other half of the same contract: the probe is real, and it is why the
@@ -1320,8 +1322,10 @@ describe('bug #3126: runtime-homes getGlobalConfigDir — defaults', () => {
       }
       cleanup(decoyHome);
     });
-    assert.strictEqual(getGlobalConfigDir('antigravity'), path.join(decoyHome, '.gemini', 'antigravity-cli'),
-      'the fs probe is documented behaviour — a default row asserting the real home is asserting this away');
+    withEnv('ANTIGRAVITY_CONFIG_DIR', undefined, () => {
+      assert.strictEqual(getGlobalConfigDir('antigravity'), path.join(decoyHome, '.gemini', 'antigravity-cli'),
+        'the fs probe is documented behaviour — a default row asserting the real home is asserting this away');
+    });
   });
 
   test('unknown runtime falls back to ~/.claude', () => {

--- a/tests/runtime-launcher-parity.test.cjs
+++ b/tests/runtime-launcher-parity.test.cjs
@@ -1071,6 +1071,52 @@ describe('bug-211: launcher ~/.claude home fallback', () => {
     );
   });
 
+  // --- (C0) Fixture env outranks the parent process -------------------------
+  test('(C0) an ambient CLAUDE_CONFIG_DIR cannot divert the fixture home (#4312)', (t) => {
+    const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-4312-home-'));
+    const fakeRuntime = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-4312-rt-'));
+    const decoy = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-4312-decoy-'));
+    const savedVar = process.env.CLAUDE_CONFIG_DIR;
+    process.env.CLAUDE_CONFIG_DIR = decoy;
+    t.after(() => {
+      if (savedVar === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+      else process.env.CLAUDE_CONFIG_DIR = savedVar;
+      cleanup(fakeHome);
+      cleanup(fakeRuntime);
+      cleanup(decoy);
+    });
+
+    for (const [root, marker] of [[fakeHome, 'FIXTURE'], [decoy, 'DECOY']]) {
+      const binDir = root === fakeHome
+        ? path.join(root, '.claude', 'gsd-core', 'bin')
+        : path.join(root, 'gsd-core', 'bin');
+      fs.mkdirSync(binDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(binDir, 'gsd-tools.cjs'),
+        `#!/usr/bin/env node\nconsole.log("${marker}:" + process.argv.slice(2).join(","));\n`,
+      );
+    }
+
+    const scriptPath = path.join(fakeRuntime, 'test-ambient-config-dir.sh');
+    fs.writeFileSync(
+      scriptPath,
+      `unset GSD_TOOLS\n`
+        + `export RUNTIME_DIR=${JSON.stringify(fakeRuntime)}\n`
+        + `export HOME=${JSON.stringify(fakeHome)}\n`
+        + fs.readFileSync(SNIPPET_FILE, 'utf8')
+        + `\ngsd_run ping test\n`,
+    );
+
+    const { isolatedPath, nodeBinDir } = buildIsolatedPath();
+    t.after(() => cleanup(nodeBinDir));
+    const stdout = runBashFile(scriptPath, {
+      env: { PATH: isolatedPath, HOME: fakeHome },
+    });
+
+    assert.match(stdout, /FIXTURE:ping,test/);
+    assert.doesNotMatch(stdout, /DECOY:/);
+  });
+
   // --- (C) Behavioral: ~/.claude stub is resolved when local and PATH both miss
   test('(C) gsd_run resolves $HOME/.claude/gsd-core/bin/ stub when no local install and gsd_run not on PATH', (t) => {
     // Build a fake $HOME with a stub at .claude/gsd-core/bin/gsd-tools.cjs


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #4312

---

## What was broken

Several tests depended on the contributor's ambient runtime configuration. Exported config-location variables could redirect child processes away from their fixtures, while an installed Antigravity variant could change filesystem-probed defaults. Product behavior was correct; the test harness was not hermetic.

## What this fix does

- Layers the registry-derived `TEST_ENV_BASE` into the affected `tests/install.test.cjs` child environments and uses `scrubConfigLocationEnv()` for its in-process resolver call.
- Pins `HOME` and `USERPROFILE` to empty fixtures for default-path tables, deriving expectations from those fixtures.
- Explicitly scrubs `ANTIGRAVITY_CONFIG_DIR` in both Antigravity probe guards.
- Adds the `(C0)` launcher regression proving an ambient `CLAUDE_CONFIG_DIR` cannot divert a fixture home.

`tests/runtime-launcher-parity.test.cjs` already received `TEST_ENV_BASE`/`snippetEnv()` through #4205 before this branch's current base. This PR does not claim or duplicate that plumbing; its change there is the new `(C0)` behavioral regression only.

## Root cause

Two independent ambient inputs were left uncontrolled:

1. Child environments inherited supported `*_CONFIG_DIR` variables from `process.env`.
2. Default-path assertions used the developer's real home, where filesystem probes can legitimately select an installed runtime variant such as `antigravity-cli`.

The tests therefore asserted a fixed answer while allowing their inputs to vary by machine.

## Testing

### How I verified the fix

After merging the current `next`:

- `node --test --test-name-pattern='#4312' tests/runtime-homes-descriptor-drive.test.cjs` — 2 pass / 0 fail.
- The broader branch suite previously passed in both hostile-env and clean-env arms with identical counts.

### Regression test added?

- [x] Yes — `(C0)` forces an ambient `CLAUDE_CONFIG_DIR`, two home-pin guards fail if the pin is removed, and a decoy `antigravity-cli` fixture proves why the pin is required.
- [ ] No — explain why:

### Platforms tested

- [x] Linux
- [ ] macOS
- [ ] Windows (including backslash path handling)
- [ ] N/A (not platform-specific)

### Runtimes tested

- [x] Other: runtime-agnostic test isolation; no runtime production behavior changes.

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] Related tests pass
- [ ] `.changeset/` fragment added — not applicable: tests-only diff
- [x] No unnecessary dependencies added

## Breaking changes

None. No production file is touched.
