### PR TITLE
fix(#4187): status reader resolves a bare VERIFICATION.md like resolve-file

### DIFF
--- a/.changeset/fierce-quails-leap.md
+++ b/.changeset/fierce-quails-leap.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 4388
 ---
 **`query verification.status` now resolves a bare `VERIFICATION.md` like `verification.resolve-file` does** — a phase whose only verification report was a bare `VERIFICATION.md` was reported as `missing` and told to re-run `/gsd-execute-phase` even though the report said `status: passed` and `verification.resolve-file` resolved it in the same directory. (#4187)

--- a/.changeset/fierce-quails-leap.md
+++ b/.changeset/fierce-quails-leap.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`query verification.status` now resolves a bare `VERIFICATION.md` like `verification.resolve-file` does** — a phase whose only verification report was a bare `VERIFICATION.md` was reported as `missing` and told to re-run `/gsd-execute-phase` even though the report said `status: passed` and `verification.resolve-file` resolved it in the same directory. (#4187)

--- a/src/verification.cts
+++ b/src/verification.cts
@@ -467,12 +467,23 @@ interface ResolveVerificationFileOptions {
    * determinePhaseStatus and two `verification_path` projectors in
    * `src/init.cts`) additionally accept a BARE `VERIFICATION.md` — a form
    * this module's own two callers (`findStaleVerificationSummary`,
-   * `readVerificationStatus`) have never accepted, because a bare filename
+   * `readVerificationStatus`) had never accepted, because a bare filename
    * carries no phase token and `.endsWith('-VERIFICATION.md')` structurally
    * excludes it. Defaults to `false`, which is byte-for-behavior identical to
    * the pre-existing (non-optioned) resolver — no call-site edit required for
-   * the two callers in THIS module. Set `true` only from a call site whose
-   * pre-fix behavior already accepted a bare match.
+   * callers that do not want the bare tier.
+   *
+   * #4187: that historical asymmetry was drift, not contract. Six call sites
+   * grew around the shared resolver and five opted in (`cmdVerificationResolveFile`,
+   * `determinePhaseStatus`, both init `verification_path` projectors), leaving
+   * the status reader as the lone holdout — so `query verification.resolve-file`
+   * resolved a bare report in a directory where `query verification.status`
+   * answered `missing` and recommended re-running execute-phase for an
+   * already-verified phase. Since #4187 the two module-internal call sites
+   * pass `true` as well: every reader of the report set now recognizes the
+   * bare name. Tier order is unchanged — a dashed candidate (canonical or
+   * not, if it belongs to THIS phase) still outranks the bare match — so this
+   * only changes directories whose SOLE report is bare.
    */
   allowBare?: boolean;
   /**
@@ -720,9 +731,16 @@ function findStaleVerificationSummary(
     // or sentinel-numbered canonically-shaped file cannot outrank this
     // phase's own (possibly non-canonical) report. #3511: phaseDirName scopes
     // the fallback path to this same phase (see resolveVerificationFile docs).
+    // #4187: allowBare — this staleness seam must see the same report set the
+    // status reader sees, or a bare report could never read `stale` while its
+    // dashed twin could (two answers from one verb).
     const phaseDirName = path.basename(phaseDir);
     const phaseToken = extractPhaseToken(phaseDirName);
-    const verificationFile = resolveVerificationFile(phaseFiles, { phaseToken, phaseDirName });
+    const verificationFile = resolveVerificationFile(phaseFiles, {
+      allowBare: true,
+      phaseToken,
+      phaseDirName,
+    });
     if (!verificationFile) return { determined: true, stale: false };
 
     const summaryFiles = (scanPhasePlans(phaseDir) as { summaryFiles: string[] }).summaryFiles
@@ -766,7 +784,9 @@ function findStaleVerificationSummary(
  * 1. Find the phase's verification report via `resolveVerificationFile`
  *    (canonical `<phase-token>-VERIFICATION.md` preferred; falls back to the
  *    alphabetically-first `*-VERIFICATION.md` that belongs to THIS phase when
- *    none is canonical — #3357/#3511). If none → status 'missing'.
+ *    none is canonical — #3357/#3511; and, when the directory's only report
+ *    is a bare `VERIFICATION.md`, that file — #4187, matching
+ *    `verification.resolve-file`). If none → status 'missing'.
  * 2. Extract `status` from FRONTMATTER ONLY via the shared extractFrontmatter
  *    parser (DEFECT.FRONTMATTER-SCALAR-BROAD-GREP fix — parser anchors at byte 0).
  *    If no frontmatter block or no `status` key → status 'missing'.
@@ -814,7 +834,12 @@ function readVerificationStatus(
     // sentinel-numbered canonically-shaped file cannot outrank this phase's
     // own (possibly non-canonical) report. #3511: baseName also scopes the
     // fallback path to this same phase (see resolveVerificationFile docs).
-    verificationFile = resolveVerificationFile(entries, { phaseToken, phaseDirName: baseName });
+    // #4187: allowBare — the status reader must recognize a bare
+    // `VERIFICATION.md` exactly like `verification.resolve-file`,
+    // `determinePhaseStatus`, and the init verification_path projectors
+    // already do; without it a verified phase reported `missing` and
+    // recommended re-running execute-phase.
+    verificationFile = resolveVerificationFile(entries, { allowBare: true, phaseToken, phaseDirName: baseName });
   } catch {
     // Directory unreadable → treat as missing
     verificationFile = null;

--- a/src/verification.cts
+++ b/src/verification.cts
@@ -474,16 +474,18 @@ interface ResolveVerificationFileOptions {
    * callers that do not want the bare tier.
    *
    * #4187: that historical asymmetry was drift, not contract. Six call sites
-   * grew around the shared resolver and five opted in (`cmdVerificationResolveFile`,
-   * `determinePhaseStatus`, both init `verification_path` projectors), leaving
-   * the status reader as the lone holdout — so `query verification.resolve-file`
-   * resolved a bare report in a directory where `query verification.status`
-   * answered `missing` and recommended re-running execute-phase for an
-   * already-verified phase. Since #4187 the two module-internal call sites
-   * pass `true` as well: every reader of the report set now recognizes the
-   * bare name. Tier order is unchanged — a dashed candidate (canonical or
-   * not, if it belongs to THIS phase) still outranks the bare match — so this
-   * only changes directories whose SOLE report is bare.
+   * grew around the shared resolver and four opted in
+   * (`cmdVerificationResolveFile`, `determinePhaseStatus`, both init
+   * `verification_path` projectors) — the two module-internal status-path
+   * call sites (`readVerificationStatus`, `findStaleVerificationSummary`)
+   * did not, so `query verification.resolve-file` resolved a bare report in
+   * a directory where `query verification.status` answered `missing` and
+   * recommended re-running execute-phase for an already-verified phase.
+   * Since #4187 those two pass `true` as well: every reader of the report
+   * set now recognizes the bare name. Tier order is unchanged — a dashed
+   * candidate (canonical or not, if it belongs to THIS phase) still outranks
+   * the bare match — so this only changes directories whose SOLE report is
+   * bare.
    */
   allowBare?: boolean;
   /**

--- a/tests/verification-status.test.cjs
+++ b/tests/verification-status.test.cjs
@@ -1209,11 +1209,15 @@ describe('#3357/#3492: phase-pinned *-VERIFICATION.md resolution when multiple c
 // commands.cts (determinePhaseStatus) and two verification_path projectors in
 // init.cts each hand-rolled a fourth variant of this same selection: they
 // additionally accept a BARE `VERIFICATION.md`, which this module's own two
-// callers (findStaleVerificationSummary, readVerificationStatus) never have.
-// `allowBare` threads that one behavioral difference through the single
-// resolver instead of leaving a fourth hand-rolled implementation behind
-// (#3473 F2). A bare match is ranked BELOW any dashed candidate — canonical
-// or not — because a dashed file names its phase and a bare one does not.
+// callers (findStaleVerificationSummary, readVerificationStatus) originally
+// did not. `allowBare` threads that one behavioral difference through the
+// single resolver instead of leaving a fourth hand-rolled implementation
+// behind (#3473 F2). A bare match is ranked BELOW any dashed candidate —
+// canonical or not — because a dashed file names its phase and a bare one
+// does not. Since #4187 the two module-internal call sites pass `allowBare:
+// true` as well (see the #4187 describe below), so every reader of the report
+// set now agrees; the option's default remains `false` for callers that have
+// not opted in.
 describe('#3473 F2: resolveVerificationFile allowBare option', () => {
 
   test('allowBare defaults to false — a bare-only list returns null without the option', () => {

--- a/tests/verification-status.test.cjs
+++ b/tests/verification-status.test.cjs
@@ -1281,7 +1281,7 @@ describe('#3473 F2: resolveVerificationFile allowBare option', () => {
 // Two read-only verbs disagreed about the same directory at the same instant
 // (#4187). The fix opts the status reader — and findStaleVerificationSummary,
 // its internal legacy staleness check, whose only production caller is
-// readVerificationStatus — into the same `allowBare: true` the other five call
+// readVerificationStatus — into the same `allowBare: true` the other four call
 // sites already pass. Tier order is unchanged: a dashed candidate (canonical or
 // not) still outranks the bare name, so only bare-ONLY directories change
 // behavior, from `missing` to the report's actual frontmatter status.

--- a/tests/verification-status.test.cjs
+++ b/tests/verification-status.test.cjs
@@ -1265,6 +1265,210 @@ describe('#3473 F2: resolveVerificationFile allowBare option', () => {
 
 });
 
+// ─── #4187: a bare VERIFICATION.md is a first-class report on the status surface ──
+//
+// `query verification.resolve-file` (cmdVerificationResolveFile), the phase-status
+// surface (commands.cts determinePhaseStatus) and both init verification_path
+// projectors all resolve a BARE `VERIFICATION.md` — but readVerificationStatus
+// (the reader behind `query verification.status`, isPhaseComplete, and the state/
+// roadmap completion projections) called the same shared resolver WITHOUT
+// `allowBare`, so a phase whose only report was bare read as `missing` and was
+// told to re-run execute-phase even when the report said `status: passed`.
+// Two read-only verbs disagreed about the same directory at the same instant
+// (#4187). The fix opts the status reader — and findStaleVerificationSummary,
+// its internal legacy staleness check, whose only production caller is
+// readVerificationStatus — into the same `allowBare: true` the other five call
+// sites already pass. Tier order is unchanged: a dashed candidate (canonical or
+// not) still outranks the bare name, so only bare-ONLY directories change
+// behavior, from `missing` to the report's actual frontmatter status.
+describe('#4187: status surface recognizes a bare VERIFICATION.md', () => {
+
+  test('#4187 regression: bare VERIFICATION.md with status: passed reads as passed, not missing', (t) => {
+    const dir = mkPhaseDir('bare-passed', '99-probe');
+    t.after(() => cleanup(path.dirname(dir)));
+
+    writeVerificationMd(dir, 'VERIFICATION.md', 'passed');
+    const result = readVerificationStatus(dir, { phaseCleanCommitTimesMs: () => new Map() });
+    assert.equal(result.status, 'passed', 'a bare report is a report — the phase is verified');
+    assert.equal(result.next_command, '', 'passed must route to no next command');
+    assert.equal(result.staleCheckIndeterminate, undefined, 'the staleness check must run to completion');
+  });
+
+  test('#4187: bare report with status: human_needed routes to verify-work', (t) => {
+    const dir = mkPhaseDir('bare-human', '99-probe');
+    t.after(() => cleanup(path.dirname(dir)));
+
+    writeVerificationMd(dir, 'VERIFICATION.md', 'human_needed');
+    const result = readVerificationStatus(dir, { phaseCleanCommitTimesMs: () => new Map() });
+    assert.equal(result.status, 'human_needed');
+    assert.equal(result.next_command, '/gsd-verify-work 99');
+  });
+
+  test('#4187: bare report with status: gaps_found routes to plan-phase --gaps', (t) => {
+    const dir = mkPhaseDir('bare-gaps', '99-probe');
+    t.after(() => cleanup(path.dirname(dir)));
+
+    writeVerificationMd(dir, 'VERIFICATION.md', 'gaps_found');
+    const result = readVerificationStatus(dir, { phaseCleanCommitTimesMs: () => new Map() });
+    assert.equal(result.status, 'gaps_found');
+    assert.equal(result.next_command, '/gsd-plan-phase 99 --gaps');
+  });
+
+  test('#4187 negative space: no verification file at all still reads missing with the execute-phase recommendation', (t) => {
+    const dir = mkPhaseDir('bare-none', '99-probe');
+    t.after(() => cleanup(path.dirname(dir)));
+
+    const result = readVerificationStatus(dir);
+    assert.equal(result.status, 'missing', 'a genuinely absent report must stay missing');
+    assert.equal(result.next_command, '/gsd-execute-phase 99', 'the missing recommendation is correct here and must not change');
+  });
+
+  test('#4187 parity: bare + canonical dashed report — the dashed file wins on the status surface too', (t) => {
+    const dir = mkPhaseDir('bare-vs-dashed', '99-probe');
+    t.after(() => cleanup(path.dirname(dir)));
+
+    writeVerificationMd(dir, 'VERIFICATION.md', 'gaps_found');
+    writeVerificationMd(dir, '99-VERIFICATION.md', 'passed');
+    const result = readVerificationStatus(dir, { phaseCleanCommitTimesMs: () => new Map() });
+    assert.equal(result.status, 'passed', 'a dashed file names its phase and must outrank the bare match');
+  });
+
+  test('#4187 parity: bare + cross-phase dashed stray — #3511 scoping falls through to the bare report', (t) => {
+    const dir = mkPhaseDir('bare-vs-stray', '99-probe');
+    t.after(() => cleanup(path.dirname(dir)));
+
+    writeVerificationMd(dir, 'VERIFICATION.md', 'passed');
+    writeVerificationMd(dir, '04-VERIFICATION.md', 'gaps_found');
+    const result = readVerificationStatus(dir, { phaseCleanCommitTimesMs: () => new Map() });
+    assert.equal(result.status, 'passed', 'the stray belongs to phase 04; the bare file is this phase\'s only own report');
+  });
+
+  test('#4187 parity: same-dir non-canonical dashed report only — unchanged behavior', (t) => {
+    const dir = mkPhaseDir('dashed-noncanon', '99-probe');
+    t.after(() => cleanup(path.dirname(dir)));
+
+    writeVerificationMd(dir, '99-CORRECTION-VERIFICATION.md', 'passed');
+    const result = readVerificationStatus(dir, { phaseCleanCommitTimesMs: () => new Map() });
+    assert.equal(result.status, 'passed');
+  });
+
+  test('#4187: directory scoping — a bare report in a DIFFERENT directory does not leak into the queried one', (t) => {
+    const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-4187-otherdir-'));
+    t.after(() => cleanup(baseDir));
+    const queried = path.join(baseDir, '99-probe');
+    const neighbor = path.join(baseDir, '98-other');
+    fs.mkdirSync(queried);
+    fs.mkdirSync(neighbor);
+    writeVerificationMd(neighbor, 'VERIFICATION.md', 'passed');
+
+    const result = readVerificationStatus(queried);
+    assert.equal(result.status, 'missing', 'the neighbor directory\'s report must not answer for the queried one');
+  });
+
+  test('#4187: bare report with no frontmatter block resolves but reads missing', (t) => {
+    const dir = mkPhaseDir('bare-no-fm', '99-probe');
+    t.after(() => cleanup(path.dirname(dir)));
+
+    fs.writeFileSync(path.join(dir, 'VERIFICATION.md'), '# Verification\n');
+    const result = readVerificationStatus(dir);
+    assert.equal(result.status, 'missing', 'a resolved file with no frontmatter status is the pre-existing missing path');
+  });
+
+  test('#4187 staleness: a bare report older than its summary reads stale (legacy mtime path)', (t) => {
+    const dir = mkPhaseDir('bare-stale', '99-probe');
+    t.after(() => cleanup(path.dirname(dir)));
+
+    writeVerificationMd(dir, 'VERIFICATION.md', 'passed');
+    setMtime(path.join(dir, 'VERIFICATION.md'), '2020-01-01T00:00:00Z');
+    // Root-style summary placement — mirrors the #3492 fixture above.
+    const summaryPath = path.join(dir, '99-01-SUMMARY.md');
+    fs.writeFileSync(summaryPath, '# summary\n');
+    setMtime(summaryPath, '2021-01-01T00:00:00Z');
+
+    const result = readVerificationStatus(dir, { phaseCleanCommitTimesMs: () => new Map() });
+    assert.equal(result.status, 'stale', 'a bare report must be staleness-checked like a dashed one');
+    assert.equal(result.next_command, '/gsd-verify-work 99');
+  });
+
+  test('#4187 unit (findStaleVerificationSummary): staleness is computed against the bare report', (t) => {
+    const dir = mkPhaseDir('bare-stale-unit', '99-probe');
+    t.after(() => cleanup(path.dirname(dir)));
+
+    writeVerificationMd(dir, 'VERIFICATION.md', 'passed');
+    setMtime(path.join(dir, 'VERIFICATION.md'), '2020-01-01T00:00:00Z');
+    const summaryPath = path.join(dir, '99-01-SUMMARY.md');
+    fs.writeFileSync(summaryPath, '# summary\n');
+    setMtime(summaryPath, '2021-01-01T00:00:00Z');
+
+    const result = findStaleVerificationSummary(dir, fs, () => new Map());
+    assert.equal(result.determined, true);
+    assert.equal(result.stale, true);
+    assert.equal(result.verificationFile, 'VERIFICATION.md', 'the staleness seam must see the bare report');
+  });
+});
+
+// ─── #4187 CLI parity: the two query verbs must agree on the same directory ───
+//
+// The issue's repro shape: run `query verification.resolve-file` and
+// `query verification.status` back to back against ONE fixture directory and
+// assert they never disagree about whether a report exists (and, when one does,
+// about WHICH file is the report — enforced by giving the candidates distinct
+// frontmatter statuses and asserting the routed status matches the expected
+// winner).
+describe('#4187 CLI parity: verification.resolve-file and verification.status agree', () => {
+  const { runGsdTools } = require('./helpers.cjs');
+
+  function runBothVerbs(dir) {
+    const resolveRes = runGsdTools(['query', 'verification.resolve-file', dir, '--raw'], dir);
+    const statusRes = runGsdTools(['query', 'verification.status', dir, '--raw'], dir);
+    assert.equal(resolveRes.success, true, `resolve-file failed: ${resolveRes.error}`);
+    assert.equal(statusRes.success, true, `status failed: ${statusRes.error}`);
+    return { resolvedPath: resolveRes.output.trimEnd(), status: JSON.parse(statusRes.output).status, nextCommand: JSON.parse(statusRes.output).next_command };
+  }
+
+  test('bare report: resolve-file finds it and status reads passed (the #4187 repro)', (t) => {
+    const dir = mkPhaseDir('cli-bare', '99-probe');
+    t.after(() => cleanup(path.dirname(dir)));
+
+    writeVerificationMd(dir, 'VERIFICATION.md', 'passed');
+    const { resolvedPath, status, nextCommand } = runBothVerbs(dir);
+    assert.equal(resolvedPath, path.join(dir, 'VERIFICATION.md'));
+    assert.equal(status, 'passed', 'status must not report missing for a file resolve-file resolves');
+    assert.equal(nextCommand, '');
+  });
+
+  test('no report: resolve-file is empty and status is missing (agreement in the other direction)', (t) => {
+    const dir = mkPhaseDir('cli-none', '99-probe');
+    t.after(() => cleanup(path.dirname(dir)));
+
+    const { resolvedPath, status } = runBothVerbs(dir);
+    assert.equal(resolvedPath, '', 'resolve-file must report no file');
+    assert.equal(status, 'missing');
+  });
+
+  test('bare + canonical dashed: both verbs pick the dashed file', (t) => {
+    const dir = mkPhaseDir('cli-both', '99-probe');
+    t.after(() => cleanup(path.dirname(dir)));
+
+    writeVerificationMd(dir, 'VERIFICATION.md', 'gaps_found');
+    writeVerificationMd(dir, '99-VERIFICATION.md', 'passed');
+    const { resolvedPath, status } = runBothVerbs(dir);
+    assert.equal(resolvedPath, path.join(dir, '99-VERIFICATION.md'));
+    assert.equal(status, 'passed', 'status must read the same winner resolve-file picked');
+  });
+
+  test('bare + cross-phase stray: both verbs pick the bare file', (t) => {
+    const dir = mkPhaseDir('cli-stray', '99-probe');
+    t.after(() => cleanup(path.dirname(dir)));
+
+    writeVerificationMd(dir, 'VERIFICATION.md', 'passed');
+    writeVerificationMd(dir, '04-VERIFICATION.md', 'gaps_found');
+    const { resolvedPath, status } = runBothVerbs(dir);
+    assert.equal(resolvedPath, path.join(dir, 'VERIFICATION.md'));
+    assert.equal(status, 'passed', 'status must read the same winner resolve-file picked');
+  });
+});
+
 // ─── #3518: resolveUatFile — phase-pinned, deterministic *-UAT.md pick ───────
 //
 // Both uat_path projectors in src/init.cts picked the phase's UAT artifact


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #4187

---

## What was broken

Two read-only verbs disagreed about the same directory at the same instant: `query verification.resolve-file` resolved a bare `VERIFICATION.md`, while `query verification.status` reported the `missing` sentinel for that same file and recommended re-running `/gsd-execute-phase <N>` — telling the operator to re-enter a phase whose report already said `status: passed` (or `human_needed`).

## What this fix does

`readVerificationStatus` — and `findStaleVerificationSummary`, the internal legacy staleness check whose only production caller is `readVerificationStatus` — now pass `allowBare: true` to the shared `resolveVerificationFile` resolver, exactly like the four call sites that already did (`cmdVerificationResolveFile`, `determinePhaseStatus`, and both init `verification_path` projectors). A phase whose only report is a bare `VERIFICATION.md` now reads its actual frontmatter status on every surface, and the two verbs agree.

## Root cause

Six call sites grew around the single phase-pinned resolver from #3357/#3473 F2, and four opted into the bare-name tier while the two module-internal status-path call sites did not — the `allowBare` option's original migration rule ("set `true` only from a call site whose pre-fix behavior already accepted a bare match") preserved a historical asymmetry that the other surfaces had already abandoned. The one inconsistent caller was the one whose answer routes the operator. Tier order is unchanged — a dashed candidate (canonical or not, if it belongs to this phase) still outranks the bare name — so only directories whose SOLE report is bare change behavior, from `missing` to the report's actual status.

**Assumption stated** (ambiguity the issue leaves open, resolved by code and conventions): the issue's suggested fix names only the status reader's call site. This PR also opts in `findStaleVerificationSummary` (`src/verification.cts`), because it is the same verb's staleness seam — without it, a bare report could never read `stale` while its byte-identical dashed twin could, leaving a two-readers-two-answers disagreement one level inside the very verb this issue is about. The issue's alternative (narrowing `resolve-file` to refuse the bare name) was considered and rejected: it moves the disagreement to `determinePhaseStatus`/init instead of fixing it, blinds the verify-work WRITER to existing bare reports (reintroducing the duplicate-report class #3357 fixed), and invalidates real user data.

## Testing

### How I verified the fix

- RED first: committed the regression matrix on the unfixed tree and ran the full gsd-test bench — 10 of 11 failures were exactly the new #4187 tests failing (`missing` where `passed`/`human_needed`/`gaps_found`/`stale` was expected).
- The issue's verbatim repro, run back to back against the same fixture directory (`99-probe/VERIFICATION.md`, `status: passed`): before, `resolve-file` returned the path while `status` returned `missing` + `/gsd-execute-phase 99`; after, both agree on `{"status":"passed","next_action":"Verification passed — continue.","next_command":""}` (the issue's positive-control shape).
- Full gsd-test bench (linux-node24, default selection) green on the final head — see review notes in the issue's fix artifacts.

### Regression test added?

- [x] Yes — added a test that would have caught this bug

`tests/verification-status.test.cjs` grows two describe blocks:
- a unit/behavioral matrix (bare passed/human_needed/gaps_found routing; genuinely-missing still `missing` with the unchanged execute-phase recommendation; bare + canonical dashed → dashed wins; bare + cross-phase stray → #3511 scoping falls through to bare; other-directory placement; frontmatter-less bare → `missing`; bare + newer summary → `stale`; `findStaleVerificationSummary` unit on the bare report);
- a CLI parity block that runs BOTH query verbs as real subprocesses against one fixture directory and asserts they agree on every row — the two-readers contract at the verb level, which had no coverage before.

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

(Path handling is `path.join`-based and exercised through the same seams on all platforms; CI matrix covers the rest.)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #4187`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included (two `allowBare: true` call-site flags + docblocks + tests)
- [x] Regression test added
- [x] All existing tests pass (`npm test` equivalent via the gsd-test bench)
- [x] `.changeset/` fragment added (`Fixed`)
- [x] No unnecessary dependencies added

## Breaking changes

None for any directory that resolves a dashed report today (tier order preserved). A directory whose ONLY report is a bare `VERIFICATION.md` now reads its actual status instead of `missing` on the status surface and its completion consumers (`isPhaseComplete`, `phase.complete`, STATE/roadmap progress) — which is the fix; `stats`/`progress` already reported those phases Complete via `determinePhaseStatus`, so the pre-fix state was cross-surface incoherence.
