### PR TITLE
fix(#4217): reconcile artifacts before classifying an abnormally-ended executor

### DIFF
--- a/.changeset/wise-cats-parade.md
+++ b/.changeset/wise-cats-parade.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 4390
+---
+**An executor that finished its plan is no longer reported as failed when its session ends abnormally** — execute-phase now reconciles the plan SUMMARY and matching commits before classifying any plan as failed, on every runtime and however the child ended (interrupted, closed, timed out, `turn_aborted`), and never re-dispatches work that is already committed. (#4217)

--- a/docs/INVENTORY-MANIFEST.json
+++ b/docs/INVENTORY-MANIFEST.json
@@ -616,6 +616,7 @@
       "discuss-phase-assumptions/steps/auto-advance-dispatch.md",
       "docs-update/steps/dispatch-monorepo-packages.md",
       "execute-phase/steps/codebase-drift-gate.md",
+      "execute-phase/steps/completion-reconciliation.md",
       "execute-phase/steps/executor-isolation-dispatch.md",
       "execute-phase/steps/gap-closure-artifacts.md",
       "execute-phase/steps/partial-wave.md",

--- a/gsd-core/workflows/execute-phase.md
+++ b/gsd-core/workflows/execute-phase.md
@@ -31,16 +31,13 @@ Orchestrator coordinates, not executes. Each subagent loads the full execute-pla
   Code), you MUST spawn gsd-executor agents — inline execution is not authorized. Check for
   actual tool availability, not runtime name.
 
-- **Codex:** Native subagent spawning may end a child without a normal terminal response
-  (`turn_aborted`) even when the plan is finished. Apply the completion-signal fallback in
-  step 3 before classifying anything as failed — see #4217.
+- **Codex:** a subagent may end `turn_aborted` with the plan finished — reconcile, don't fail (#4217).
 
 **Fallback rule:** If a spawned agent completes its work (commits visible, SUMMARY.md exists) but
 the orchestrator never receives the completion signal, treat it as successful based on spot-checks
 and continue to the next wave/plan. Never block indefinitely waiting for a signal — always verify
-via filesystem and git state. This holds however the child's session ended, including when the
-orchestrator itself interrupted or closed it (#4217): artifacts and git state decide, not the
-shape of the transport's last message.
+via filesystem and git state. This holds however the session ended, the
+orchestrator's own interrupt included (#4217).
 </runtime_compatibility>
 
 <required_reading>
@@ -854,14 +851,7 @@ increases monotonically across waves. `{status}` is `complete` (success),
    [checkpoint] phase {PHASE_NUMBER} wave {N}/{M} plan {plan_id} checkpoint ({P}/{Q} plans done)
    ```
 
-   **Completion signal fallback (EVERY runtime — any spawn whose terminal response may not arrive):**
-
-   #4217: the heading previously named Copilot, and on Codex the parent read that as
-   "not my runtime", waited for a normal terminal child response, then interrupted and
-   closed a child that had already implemented the plan, passed verification, made the
-   commits and written the SUMMARY — closing it as `turn_aborted` with the completion
-   evidence sitting on disk. The rule below is runtime-neutral and always was; the
-   heading now says so.
+   **Completion signal fallback (EVERY runtime — a terminal response may not arrive):**
 
    If a spawned agent does not return a completion signal but appears to have finished
    its work, do NOT block indefinitely. Instead, verify completion via spot-checks:
@@ -879,26 +869,9 @@ increases monotonically across waves. `{status}` is `complete` (success),
    **If SUMMARY.md exists AND commits are found:** The agent completed successfully —
    treat as done and proceed to step 5. Log: `"✓ {Plan ID} completed (verified via spot-check — completion signal not received)"`
 
-   **An abnormally-ended child is not evidence of failure (#4217).** This reconciliation
-   is REQUIRED before any plan is classified as failed, and it applies to every way a
-   child can end without a normal terminal response — interrupted, aborted, closed,
-   killed, timed out, or a runtime-level `turn_aborted`. Run the same two spot-checks
-   above against the artifacts and git state:
+   **Before failing ANY plan** — a child interrupted, closed or `turn_aborted` included —
+   read and execute `execute-phase/steps/completion-reconciliation.md` (#4217).
 
-   - SUMMARY.md present AND matching commits present → the plan is **complete**. Log:
-     `"✓ {Plan ID} completed (verified via spot-check — child ended without a terminal response)"`,
-     proceed to step 5, and do NOT re-dispatch: the work is already committed, and a
-     second executor would redo it on top of itself.
-   - Otherwise → the plan is incomplete; route to the failure handler as usual.
-
-   The order matters: reconcile the artifacts FIRST, classify SECOND. How the child's
-   session ended is bookkeeping about the transport; what it wrote to disk and to git is
-   the evidence about the work.
-
-   **If SUMMARY.md does NOT exist after a reasonable wait:** The agent may still be
-   running or may have failed silently. Check `git log --oneline -5` for recent
-   activity. If commits are still appearing, wait longer. If no activity, report
-   the plan as failed and route to the failure handler in step 6.
 
    **Configurable stall surveillance (#3212):** Every `${EXECUTOR_STALL_INTERVAL_MINUTES}`
    minutes while waiting, inspect `git log "${EXPECTED_BRANCH}" --since="${DISPATCH_TS}"`

--- a/gsd-core/workflows/execute-phase.md
+++ b/gsd-core/workflows/execute-phase.md
@@ -31,10 +31,16 @@ Orchestrator coordinates, not executes. Each subagent loads the full execute-pla
   Code), you MUST spawn gsd-executor agents — inline execution is not authorized. Check for
   actual tool availability, not runtime name.
 
+- **Codex:** Native subagent spawning may end a child without a normal terminal response
+  (`turn_aborted`) even when the plan is finished. Apply the completion-signal fallback in
+  step 3 before classifying anything as failed — see #4217.
+
 **Fallback rule:** If a spawned agent completes its work (commits visible, SUMMARY.md exists) but
 the orchestrator never receives the completion signal, treat it as successful based on spot-checks
 and continue to the next wave/plan. Never block indefinitely waiting for a signal — always verify
-via filesystem and git state.
+via filesystem and git state. This holds however the child's session ended, including when the
+orchestrator itself interrupted or closed it (#4217): artifacts and git state decide, not the
+shape of the transport's last message.
 </runtime_compatibility>
 
 <required_reading>
@@ -848,7 +854,14 @@ increases monotonically across waves. `{status}` is `complete` (success),
    [checkpoint] phase {PHASE_NUMBER} wave {N}/{M} plan {plan_id} checkpoint ({P}/{Q} plans done)
    ```
 
-   **Completion signal fallback (Copilot and runtimes where Agent() may not return):**
+   **Completion signal fallback (EVERY runtime — any spawn whose terminal response may not arrive):**
+
+   #4217: the heading previously named Copilot, and on Codex the parent read that as
+   "not my runtime", waited for a normal terminal child response, then interrupted and
+   closed a child that had already implemented the plan, passed verification, made the
+   commits and written the SUMMARY — closing it as `turn_aborted` with the completion
+   evidence sitting on disk. The rule below is runtime-neutral and always was; the
+   heading now says so.
 
    If a spawned agent does not return a completion signal but appears to have finished
    its work, do NOT block indefinitely. Instead, verify completion via spot-checks:
@@ -865,6 +878,22 @@ increases monotonically across waves. `{status}` is `complete` (success),
 
    **If SUMMARY.md exists AND commits are found:** The agent completed successfully —
    treat as done and proceed to step 5. Log: `"✓ {Plan ID} completed (verified via spot-check — completion signal not received)"`
+
+   **An abnormally-ended child is not evidence of failure (#4217).** This reconciliation
+   is REQUIRED before any plan is classified as failed, and it applies to every way a
+   child can end without a normal terminal response — interrupted, aborted, closed,
+   killed, timed out, or a runtime-level `turn_aborted`. Run the same two spot-checks
+   above against the artifacts and git state:
+
+   - SUMMARY.md present AND matching commits present → the plan is **complete**. Log:
+     `"✓ {Plan ID} completed (verified via spot-check — child ended without a terminal response)"`,
+     proceed to step 5, and do NOT re-dispatch: the work is already committed, and a
+     second executor would redo it on top of itself.
+   - Otherwise → the plan is incomplete; route to the failure handler as usual.
+
+   The order matters: reconcile the artifacts FIRST, classify SECOND. How the child's
+   session ended is bookkeeping about the transport; what it wrote to disk and to git is
+   the evidence about the work.
 
    **If SUMMARY.md does NOT exist after a reasonable wait:** The agent may still be
    running or may have failed silently. Check `git log --oneline -5` for recent

--- a/gsd-core/workflows/execute-phase/steps/completion-reconciliation.md
+++ b/gsd-core/workflows/execute-phase/steps/completion-reconciliation.md
@@ -1,0 +1,38 @@
+Apply response_language to all user-facing prose — narration between tool calls, status updates, progress notes, and findings included; preserve code, paths, and identifiers.
+
+# Completion Reconciliation (#4217)
+
+Read this before classifying any plan as failed.
+
+## An abnormally-ended child is not evidence of failure
+
+A child can stop returning without having stopped working — and it can stop *after*
+having finished. Reported on Codex: an executor implemented its plan, passed
+verification, made the commits and wrote the SUMMARY; the parent kept waiting for a
+normal terminal response, then interrupted and closed it as `turn_aborted` with the
+completion evidence sitting on disk.
+
+This reconciliation is **REQUIRED before any plan is classified as failed**, and it
+applies to every way a child can end without a normal terminal response — interrupted,
+aborted, closed, killed, timed out, or a runtime-level `turn_aborted`.
+
+Run the same two spot-checks step 3 defines, against the artifacts and git state:
+
+- **SUMMARY.md present AND matching commits present → the plan is COMPLETE.** Log
+  `"✓ {Plan ID} completed (verified via spot-check — child ended without a terminal response)"`,
+  proceed to step 5, and do **NOT** re-dispatch: the work is already committed, and a
+  second executor would redo it on top of itself.
+- **Otherwise → the plan is incomplete.** Route to the failure handler as usual.
+
+## If SUMMARY.md does NOT exist after a reasonable wait
+
+The agent may still be running, or may have failed silently. Check `git log --oneline -5`
+for recent activity. If commits are still appearing, wait longer. If there is no activity,
+report the plan as failed and route to the failure handler in step 6.
+
+## Why the order matters
+
+Reconcile the artifacts FIRST, classify SECOND. How the child's session ended is
+bookkeeping about the transport; what it wrote to disk and to git is the evidence about
+the work. A runtime that reports an abnormal end is describing its own channel, not the
+plan.

--- a/tests/execute-phase-wave.test.cjs
+++ b/tests/execute-phase-wave.test.cjs
@@ -1195,49 +1195,63 @@ describe('execute-phase workflow: #3684 review findings — join normalization',
 // this was headed "(Copilot and runtimes where Agent() may not return)", so the
 // rule that already said "applies to all runtimes" forty lines later read as
 // someone else's rule.
+//
+// The policy itself lives in a step fragment, not the host: execute-phase.md
+// sits 15 bytes under the frozen #1168 ceiling, and "extract, not bump" is the
+// repo's stated remedy for that.
 describe('execute-phase: completion reconciliation for an abnormally-ended child (#4217)', () => {
   const workflow = fs.readFileSync(WORKFLOW_PATH, 'utf-8');
+  const FRAGMENT_PATH = path.join(
+    __dirname, '..', 'gsd-core', 'workflows', 'execute-phase', 'steps', 'completion-reconciliation.md');
+  const fragment = fs.existsSync(FRAGMENT_PATH) ? fs.readFileSync(FRAGMENT_PATH, 'utf-8') : '';
 
   test('the completion-signal fallback heading is runtime-neutral, not Copilot-scoped', () => {
-    // Bounded quantifier: the heading is one line, and an unbounded [^)]* over
-    // whole-file content is the catastrophic-backtracking shape the repo's
-    // no-unbounded-quantifier rule bans.
     assert.ok(
       /\*\*Completion signal fallback \(EVERY runtime[^)]{0,120}\):\*\*/.test(workflow),
       'the fallback heading must not scope itself to one runtime — that is how Codex read past it',
     );
   });
 
-  test('reconciliation is REQUIRED before any plan is classified as failed', () => {
-    assert.match(
-      workflow,
-      /An abnormally-ended child is not evidence of failure \(#4217\)/,
-      'the workflow must state that an abnormal end is not a failure verdict',
-    );
-    assert.match(
-      workflow,
-      /REQUIRED before any plan is classified as failed/,
-      'reconciliation must be ordered BEFORE classification, not offered as an alternative',
-    );
+  test('the host routes to the fragment BEFORE any plan is failed', () => {
+    assert.match(workflow, /Before failing ANY plan/,
+      'the host must state the ordering — reconcile first, classify second');
+    assert.match(workflow, /execute-phase\/steps\/completion-reconciliation\.md/,
+      'the host must point at the reconciliation fragment');
+    assert.match(workflow, /interrupted, closed or `turn_aborted` included/,
+      'the abnormal-end shapes must be named where the orchestrator decides, not only in the fragment');
+  });
+
+  test('the fragment exists and states reconciliation as REQUIRED before failure', () => {
+    assert.ok(fragment.length > 0, 'execute-phase/steps/completion-reconciliation.md must exist');
+    assert.match(fragment, /An abnormally-ended child is not evidence of failure/);
+    assert.match(fragment, /REQUIRED before any plan is classified as failed/,
+      'reconciliation must be ordered BEFORE classification, not offered as an alternative');
   });
 
   test('every abnormal termination shape is named, so none reads as out of scope', () => {
     // The Codex report is `turn_aborted`; naming only that would repeat the
     // heading mistake one runtime later.
     for (const shape of ['interrupted', 'aborted', 'closed', 'killed', 'timed out', 'turn_aborted']) {
-      assert.ok(
-        workflow.includes(shape),
-        `the abnormal-termination list must name "${shape}"`,
-      );
+      assert.ok(fragment.includes(shape), `the abnormal-termination list must name "${shape}"`);
     }
   });
 
   test('SUMMARY + matching commits resolve to complete, and forbid re-dispatch', () => {
-    const clause = workflow.slice(workflow.indexOf('An abnormally-ended child is not evidence of failure'));
-    assert.match(clause, /SUMMARY\.md present AND matching commits present/,
+    assert.match(fragment, /SUMMARY\.md present AND matching commits present/,
       'the complete-verdict predicate must be stated');
-    assert.match(clause, /do NOT re-dispatch/,
+    assert.match(fragment, /do \*\*NOT\*\* re-dispatch/,
       're-dispatching a plan whose commits already landed would redo the work on top of itself');
+    assert.match(fragment, /Reconcile the artifacts FIRST, classify SECOND/,
+      'the ordering rule must survive the extraction');
+  });
+
+  test('the fragment absorbed the sibling arm, so the policy is in one place', () => {
+    assert.match(fragment, /If SUMMARY\.md does NOT exist after a reasonable wait/,
+      'the incomplete arm moved here with the complete arm — one file owns the policy');
+    assert.ok(
+      !/If SUMMARY\.md does NOT exist after a reasonable wait/.test(workflow),
+      'the host must not keep a second copy of the arm',
+    );
   });
 
   test('Codex is named in the runtime-compatibility block', () => {
@@ -1248,14 +1262,16 @@ describe('execute-phase: completion reconciliation for an abnormally-ended child
     assert.ok(compat.length > 0, 'the runtime_compatibility block must exist');
     assert.match(compat, /\*\*Codex:\*\*/,
       'Codex must be named where Claude Code and Copilot are — its absence is what made the fallback read as not-my-runtime');
+    assert.match(compat, /reconcile, don't fail/,
+      "the Codex entry must carry the verdict, not just the runtime's name");
   });
 
-  test('the fallback rule holds however the session ended, including an orchestrator-initiated close', () => {
+  test('the fallback rule holds however the session ended, orchestrator interrupts included', () => {
     const compat = workflow.slice(
       workflow.indexOf('<runtime_compatibility>'),
       workflow.indexOf('</runtime_compatibility>'),
     );
-    assert.match(compat, /including when the\s{1,10}orchestrator itself interrupted or closed it/,
+    assert.match(compat, /however the session ended, the\s{1,10}orchestrator's own interrupt included/,
       'the orchestrator closing the child is the exact case #4217 reports — it must not be an exception');
   });
 });

--- a/tests/execute-phase-wave.test.cjs
+++ b/tests/execute-phase-wave.test.cjs
@@ -1182,3 +1182,80 @@ describe('execute-phase workflow: #3684 review findings — join normalization',
     }
   });
 });
+
+// ── #4217: an abnormally-ended child must be reconciled, not failed ──────────
+//
+// allow-test-rule: source-text-is-the-product — the workflow .md IS the
+// instruction the orchestrator executes; its text is the artifact under test.
+//
+// On Codex the parent waited for a normal terminal child response, then
+// interrupted and closed a child that had already implemented the plan, passed
+// verification, made the commits and written the SUMMARY — closing it as
+// `turn_aborted` with the completion evidence on disk. The fallback that covers
+// this was headed "(Copilot and runtimes where Agent() may not return)", so the
+// rule that already said "applies to all runtimes" forty lines later read as
+// someone else's rule.
+describe('execute-phase: completion reconciliation for an abnormally-ended child (#4217)', () => {
+  const workflow = fs.readFileSync(WORKFLOW_PATH, 'utf-8');
+
+  test('the completion-signal fallback heading is runtime-neutral, not Copilot-scoped', () => {
+    // Bounded quantifier: the heading is one line, and an unbounded [^)]* over
+    // whole-file content is the catastrophic-backtracking shape the repo's
+    // no-unbounded-quantifier rule bans.
+    assert.ok(
+      /\*\*Completion signal fallback \(EVERY runtime[^)]{0,120}\):\*\*/.test(workflow),
+      'the fallback heading must not scope itself to one runtime — that is how Codex read past it',
+    );
+  });
+
+  test('reconciliation is REQUIRED before any plan is classified as failed', () => {
+    assert.match(
+      workflow,
+      /An abnormally-ended child is not evidence of failure \(#4217\)/,
+      'the workflow must state that an abnormal end is not a failure verdict',
+    );
+    assert.match(
+      workflow,
+      /REQUIRED before any plan is classified as failed/,
+      'reconciliation must be ordered BEFORE classification, not offered as an alternative',
+    );
+  });
+
+  test('every abnormal termination shape is named, so none reads as out of scope', () => {
+    // The Codex report is `turn_aborted`; naming only that would repeat the
+    // heading mistake one runtime later.
+    for (const shape of ['interrupted', 'aborted', 'closed', 'killed', 'timed out', 'turn_aborted']) {
+      assert.ok(
+        workflow.includes(shape),
+        `the abnormal-termination list must name "${shape}"`,
+      );
+    }
+  });
+
+  test('SUMMARY + matching commits resolve to complete, and forbid re-dispatch', () => {
+    const clause = workflow.slice(workflow.indexOf('An abnormally-ended child is not evidence of failure'));
+    assert.match(clause, /SUMMARY\.md present AND matching commits present/,
+      'the complete-verdict predicate must be stated');
+    assert.match(clause, /do NOT re-dispatch/,
+      're-dispatching a plan whose commits already landed would redo the work on top of itself');
+  });
+
+  test('Codex is named in the runtime-compatibility block', () => {
+    const compat = workflow.slice(
+      workflow.indexOf('<runtime_compatibility>'),
+      workflow.indexOf('</runtime_compatibility>'),
+    );
+    assert.ok(compat.length > 0, 'the runtime_compatibility block must exist');
+    assert.match(compat, /\*\*Codex:\*\*/,
+      'Codex must be named where Claude Code and Copilot are — its absence is what made the fallback read as not-my-runtime');
+  });
+
+  test('the fallback rule holds however the session ended, including an orchestrator-initiated close', () => {
+    const compat = workflow.slice(
+      workflow.indexOf('<runtime_compatibility>'),
+      workflow.indexOf('</runtime_compatibility>'),
+    );
+    assert.match(compat, /including when the\s{1,10}orchestrator itself interrupted or closed it/,
+      'the orchestrator closing the child is the exact case #4217 reports — it must not be an exception');
+  });
+});

--- a/tests/execute-phase-wave.test.cjs
+++ b/tests/execute-phase-wave.test.cjs
@@ -1185,8 +1185,8 @@ describe('execute-phase workflow: #3684 review findings — join normalization',
 
 // ── #4217: an abnormally-ended child must be reconciled, not failed ──────────
 //
-// allow-test-rule: source-text-is-the-product — the workflow .md IS the
-// instruction the orchestrator executes; its text is the artifact under test.
+// allow-test-rule: source-text-is-the-product (#4217) — the workflow .md IS
+// the instruction the orchestrator executes; its text is the artifact under test.
 //
 // On Codex the parent waited for a normal terminal child response, then
 // interrupted and closed a child that had already implemented the plan, passed

--- a/tests/fixtures/install-tree/antigravity.json
+++ b/tests/fixtures/install-tree/antigravity.json
@@ -383,6 +383,7 @@
   "gsd-core/workflows/eval-review.md",
   "gsd-core/workflows/execute-phase.md",
   "gsd-core/workflows/execute-phase/steps/codebase-drift-gate.md",
+  "gsd-core/workflows/execute-phase/steps/completion-reconciliation.md",
   "gsd-core/workflows/execute-phase/steps/executor-isolation-dispatch.md",
   "gsd-core/workflows/execute-phase/steps/gap-closure-artifacts.md",
   "gsd-core/workflows/execute-phase/steps/partial-wave.md",

--- a/tests/fixtures/install-tree/augment.json
+++ b/tests/fixtures/install-tree/augment.json
@@ -455,6 +455,7 @@
   "gsd-core/workflows/eval-review.md",
   "gsd-core/workflows/execute-phase.md",
   "gsd-core/workflows/execute-phase/steps/codebase-drift-gate.md",
+  "gsd-core/workflows/execute-phase/steps/completion-reconciliation.md",
   "gsd-core/workflows/execute-phase/steps/executor-isolation-dispatch.md",
   "gsd-core/workflows/execute-phase/steps/gap-closure-artifacts.md",
   "gsd-core/workflows/execute-phase/steps/partial-wave.md",

--- a/tests/fixtures/install-tree/claude-local.json
+++ b/tests/fixtures/install-tree/claude-local.json
@@ -348,6 +348,7 @@
   "gsd-core/workflows/eval-review.md",
   "gsd-core/workflows/execute-phase.md",
   "gsd-core/workflows/execute-phase/steps/codebase-drift-gate.md",
+  "gsd-core/workflows/execute-phase/steps/completion-reconciliation.md",
   "gsd-core/workflows/execute-phase/steps/executor-isolation-dispatch.md",
   "gsd-core/workflows/execute-phase/steps/gap-closure-artifacts.md",
   "gsd-core/workflows/execute-phase/steps/partial-wave.md",

--- a/tests/fixtures/install-tree/claude.json
+++ b/tests/fixtures/install-tree/claude.json
@@ -383,6 +383,7 @@
   "gsd-core/workflows/eval-review.md",
   "gsd-core/workflows/execute-phase.md",
   "gsd-core/workflows/execute-phase/steps/codebase-drift-gate.md",
+  "gsd-core/workflows/execute-phase/steps/completion-reconciliation.md",
   "gsd-core/workflows/execute-phase/steps/executor-isolation-dispatch.md",
   "gsd-core/workflows/execute-phase/steps/gap-closure-artifacts.md",
   "gsd-core/workflows/execute-phase/steps/partial-wave.md",

--- a/tests/fixtures/install-tree/cline.json
+++ b/tests/fixtures/install-tree/cline.json
@@ -385,6 +385,7 @@
   "gsd-core/workflows/eval-review.md",
   "gsd-core/workflows/execute-phase.md",
   "gsd-core/workflows/execute-phase/steps/codebase-drift-gate.md",
+  "gsd-core/workflows/execute-phase/steps/completion-reconciliation.md",
   "gsd-core/workflows/execute-phase/steps/executor-isolation-dispatch.md",
   "gsd-core/workflows/execute-phase/steps/gap-closure-artifacts.md",
   "gsd-core/workflows/execute-phase/steps/partial-wave.md",

--- a/tests/fixtures/install-tree/codebuddy.json
+++ b/tests/fixtures/install-tree/codebuddy.json
@@ -455,6 +455,7 @@
   "gsd-core/workflows/eval-review.md",
   "gsd-core/workflows/execute-phase.md",
   "gsd-core/workflows/execute-phase/steps/codebase-drift-gate.md",
+  "gsd-core/workflows/execute-phase/steps/completion-reconciliation.md",
   "gsd-core/workflows/execute-phase/steps/executor-isolation-dispatch.md",
   "gsd-core/workflows/execute-phase/steps/gap-closure-artifacts.md",
   "gsd-core/workflows/execute-phase/steps/partial-wave.md",

--- a/tests/fixtures/install-tree/codex.json
+++ b/tests/fixtures/install-tree/codex.json
@@ -419,6 +419,7 @@
   "gsd-core/workflows/eval-review.md",
   "gsd-core/workflows/execute-phase.md",
   "gsd-core/workflows/execute-phase/steps/codebase-drift-gate.md",
+  "gsd-core/workflows/execute-phase/steps/completion-reconciliation.md",
   "gsd-core/workflows/execute-phase/steps/executor-isolation-dispatch.md",
   "gsd-core/workflows/execute-phase/steps/gap-closure-artifacts.md",
   "gsd-core/workflows/execute-phase/steps/partial-wave.md",

--- a/tests/fixtures/install-tree/copilot.json
+++ b/tests/fixtures/install-tree/copilot.json
@@ -384,6 +384,7 @@
   "gsd-core/workflows/eval-review.md",
   "gsd-core/workflows/execute-phase.md",
   "gsd-core/workflows/execute-phase/steps/codebase-drift-gate.md",
+  "gsd-core/workflows/execute-phase/steps/completion-reconciliation.md",
   "gsd-core/workflows/execute-phase/steps/executor-isolation-dispatch.md",
   "gsd-core/workflows/execute-phase/steps/gap-closure-artifacts.md",
   "gsd-core/workflows/execute-phase/steps/partial-wave.md",

--- a/tests/fixtures/install-tree/cursor.json
+++ b/tests/fixtures/install-tree/cursor.json
@@ -383,6 +383,7 @@
   "gsd-core/workflows/eval-review.md",
   "gsd-core/workflows/execute-phase.md",
   "gsd-core/workflows/execute-phase/steps/codebase-drift-gate.md",
+  "gsd-core/workflows/execute-phase/steps/completion-reconciliation.md",
   "gsd-core/workflows/execute-phase/steps/executor-isolation-dispatch.md",
   "gsd-core/workflows/execute-phase/steps/gap-closure-artifacts.md",
   "gsd-core/workflows/execute-phase/steps/partial-wave.md",

--- a/tests/fixtures/install-tree/hermes.json
+++ b/tests/fixtures/install-tree/hermes.json
@@ -383,6 +383,7 @@
   "gsd-core/workflows/eval-review.md",
   "gsd-core/workflows/execute-phase.md",
   "gsd-core/workflows/execute-phase/steps/codebase-drift-gate.md",
+  "gsd-core/workflows/execute-phase/steps/completion-reconciliation.md",
   "gsd-core/workflows/execute-phase/steps/executor-isolation-dispatch.md",
   "gsd-core/workflows/execute-phase/steps/gap-closure-artifacts.md",
   "gsd-core/workflows/execute-phase/steps/partial-wave.md",

--- a/tests/fixtures/install-tree/kilo.json
+++ b/tests/fixtures/install-tree/kilo.json
@@ -455,6 +455,7 @@
   "gsd-core/workflows/eval-review.md",
   "gsd-core/workflows/execute-phase.md",
   "gsd-core/workflows/execute-phase/steps/codebase-drift-gate.md",
+  "gsd-core/workflows/execute-phase/steps/completion-reconciliation.md",
   "gsd-core/workflows/execute-phase/steps/executor-isolation-dispatch.md",
   "gsd-core/workflows/execute-phase/steps/gap-closure-artifacts.md",
   "gsd-core/workflows/execute-phase/steps/partial-wave.md",

--- a/tests/fixtures/install-tree/kimi-code.json
+++ b/tests/fixtures/install-tree/kimi-code.json
@@ -384,6 +384,7 @@
   "gsd-core/workflows/eval-review.md",
   "gsd-core/workflows/execute-phase.md",
   "gsd-core/workflows/execute-phase/steps/codebase-drift-gate.md",
+  "gsd-core/workflows/execute-phase/steps/completion-reconciliation.md",
   "gsd-core/workflows/execute-phase/steps/executor-isolation-dispatch.md",
   "gsd-core/workflows/execute-phase/steps/gap-closure-artifacts.md",
   "gsd-core/workflows/execute-phase/steps/partial-wave.md",

--- a/tests/fixtures/install-tree/kimi.json
+++ b/tests/fixtures/install-tree/kimi.json
@@ -420,6 +420,7 @@
   "gsd-core/workflows/eval-review.md",
   "gsd-core/workflows/execute-phase.md",
   "gsd-core/workflows/execute-phase/steps/codebase-drift-gate.md",
+  "gsd-core/workflows/execute-phase/steps/completion-reconciliation.md",
   "gsd-core/workflows/execute-phase/steps/executor-isolation-dispatch.md",
   "gsd-core/workflows/execute-phase/steps/gap-closure-artifacts.md",
   "gsd-core/workflows/execute-phase/steps/partial-wave.md",

--- a/tests/fixtures/install-tree/opencode.json
+++ b/tests/fixtures/install-tree/opencode.json
@@ -455,6 +455,7 @@
   "gsd-core/workflows/eval-review.md",
   "gsd-core/workflows/execute-phase.md",
   "gsd-core/workflows/execute-phase/steps/codebase-drift-gate.md",
+  "gsd-core/workflows/execute-phase/steps/completion-reconciliation.md",
   "gsd-core/workflows/execute-phase/steps/executor-isolation-dispatch.md",
   "gsd-core/workflows/execute-phase/steps/gap-closure-artifacts.md",
   "gsd-core/workflows/execute-phase/steps/partial-wave.md",

--- a/tests/fixtures/install-tree/pi.json
+++ b/tests/fixtures/install-tree/pi.json
@@ -243,6 +243,7 @@
   "gsd-core/workflows/eval-review.md",
   "gsd-core/workflows/execute-phase.md",
   "gsd-core/workflows/execute-phase/steps/codebase-drift-gate.md",
+  "gsd-core/workflows/execute-phase/steps/completion-reconciliation.md",
   "gsd-core/workflows/execute-phase/steps/executor-isolation-dispatch.md",
   "gsd-core/workflows/execute-phase/steps/gap-closure-artifacts.md",
   "gsd-core/workflows/execute-phase/steps/partial-wave.md",

--- a/tests/fixtures/install-tree/qwen.json
+++ b/tests/fixtures/install-tree/qwen.json
@@ -383,6 +383,7 @@
   "gsd-core/workflows/eval-review.md",
   "gsd-core/workflows/execute-phase.md",
   "gsd-core/workflows/execute-phase/steps/codebase-drift-gate.md",
+  "gsd-core/workflows/execute-phase/steps/completion-reconciliation.md",
   "gsd-core/workflows/execute-phase/steps/executor-isolation-dispatch.md",
   "gsd-core/workflows/execute-phase/steps/gap-closure-artifacts.md",
   "gsd-core/workflows/execute-phase/steps/partial-wave.md",

--- a/tests/fixtures/install-tree/trae.json
+++ b/tests/fixtures/install-tree/trae.json
@@ -383,6 +383,7 @@
   "gsd-core/workflows/eval-review.md",
   "gsd-core/workflows/execute-phase.md",
   "gsd-core/workflows/execute-phase/steps/codebase-drift-gate.md",
+  "gsd-core/workflows/execute-phase/steps/completion-reconciliation.md",
   "gsd-core/workflows/execute-phase/steps/executor-isolation-dispatch.md",
   "gsd-core/workflows/execute-phase/steps/gap-closure-artifacts.md",
   "gsd-core/workflows/execute-phase/steps/partial-wave.md",

--- a/tests/fixtures/install-tree/windsurf.json
+++ b/tests/fixtures/install-tree/windsurf.json
@@ -311,6 +311,7 @@
   "gsd-core/workflows/eval-review.md",
   "gsd-core/workflows/execute-phase.md",
   "gsd-core/workflows/execute-phase/steps/codebase-drift-gate.md",
+  "gsd-core/workflows/execute-phase/steps/completion-reconciliation.md",
   "gsd-core/workflows/execute-phase/steps/executor-isolation-dispatch.md",
   "gsd-core/workflows/execute-phase/steps/gap-closure-artifacts.md",
   "gsd-core/workflows/execute-phase/steps/partial-wave.md",

--- a/tests/fixtures/install-tree/zcode.json
+++ b/tests/fixtures/install-tree/zcode.json
@@ -455,6 +455,7 @@
   "gsd-core/workflows/eval-review.md",
   "gsd-core/workflows/execute-phase.md",
   "gsd-core/workflows/execute-phase/steps/codebase-drift-gate.md",
+  "gsd-core/workflows/execute-phase/steps/completion-reconciliation.md",
   "gsd-core/workflows/execute-phase/steps/executor-isolation-dispatch.md",
   "gsd-core/workflows/execute-phase/steps/gap-closure-artifacts.md",
   "gsd-core/workflows/execute-phase/steps/partial-wave.md",


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #4217

---

## What was broken

An executor implemented its plan, passed focused verification, created the expected commits, wrote the SUMMARY and made the final metadata commit. The parent kept waiting for a normal terminal child response, then interrupted and closed the child, ending with `turn_aborted` — with **both** the expected SUMMARY and the matching commits already on disk. The documented completion fallback was not applied.

## What this fix does

Makes the reconciliation mandatory and unambiguously runtime-neutral: artifacts and git state decide whether a plan is complete, and how the child's session ended does not.

## Root cause

The rule was already correct — and already claimed universality:

> **This fallback applies to all runtimes.**

But its heading read **"(Copilot and runtimes where Agent() may not return)"**, and `<runtime_compatibility>` named only Claude Code and Copilot. An orchestrator on Codex reading top-down meets a Copilot-scoped heading long before it meets the "all runtimes" sentence. Two further gaps made the Codex case fall outside the prose as written:

1. the fallback is phrased for a child that "does not return a completion signal", not for one the orchestrator itself **interrupted and closed** — `turn_aborted` is a terminal state, so the "no signal yet, keep verifying" framing does not obviously cover it;
2. nothing stated the **order**: reconcile first, classify second.

## How

`gsd-core/workflows/execute-phase.md`:

- the fallback heading becomes **"(EVERY runtime — any spawn whose terminal response may not arrive)"**;
- a new clause, *"An abnormally-ended child is not evidence of failure (#4217)"*, makes reconciliation **REQUIRED before any plan is classified as failed** and names every shape of abnormal end — interrupted, aborted, closed, killed, timed out, `turn_aborted` — so the next runtime does not read its own case as unlisted;
- the complete verdict is spelled out: SUMMARY present **AND** matching commits present → complete, proceed to step 5, and **do NOT re-dispatch** (the work is already committed; a second executor would redo it on top of itself);
- the order is stated outright: *"reconcile the artifacts FIRST, classify SECOND. How the child's session ended is bookkeeping about the transport; what it wrote to disk and to git is the evidence about the work."*;
- **Codex** is named in `<runtime_compatibility>` beside Claude Code and Copilot, and the fallback rule now says it holds *however* the session ended, including when the orchestrator itself interrupted or closed the child.

**The policy lives in a step fragment, not the host.** `execute-phase.md` sits 77 bytes under a frozen 93600-byte ceiling (#1168) and CI caught the first attempt at +1928; "extract, not bump" is the repo's stated remedy and this workflow already carries policy detail that way. `execute-phase/steps/completion-reconciliation.md` owns the whole reconciliation policy — **both arms**. The incomplete arm (*"If SUMMARY.md does NOT exist after a reasonable wait"*) moved with it rather than staying inline: the two arms are one decision, and splitting them across two files is what left no room for the second in the first place. The host is 93585 bytes, 15 under the ceiling.

No production code changes — the workflow `.md` is the instruction the orchestrator executes.

## Testing

### How I verified the fix

Eight prose-contract assertions added to `tests/execute-phase-wave.test.cjs` (this file's existing contract-test home, already carrying the `allow-test-rule: source-text-is-the-product` marker):

- the fallback heading is runtime-neutral, not scoped to one runtime;
- reconciliation is stated as **REQUIRED before** classification, not offered as an alternative;
- every abnormal-termination shape is named — asserting the list, because naming only `turn_aborted` would repeat the heading mistake one runtime later;
- SUMMARY + matching commits resolves to complete **and** forbids re-dispatch;
- Codex appears in `<runtime_compatibility>`;
- the fallback rule survives an orchestrator-initiated close — the exact reported case.

Green here; the block was **red on `next`** before the fix. Whole file: **77 pass / 0 fail**. Also green: `claude-orchestration` (127, including the #1168 ceiling gate), `workflow-size-budget` (127), `workflow-size` (9), `frontmatter` (138), `config` (188), and `emitted-attribution` (133). `check-contract-drift`, `lint-planning-prompt-drift`, `lint-workflow-shellcheck` (0 new findings) and `lint-docs-command-form` all clean.

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [x] N/A (not platform-specific — the report notes the same)

### Runtimes tested

- [x] Other: the change is to runtime-neutral orchestration prose; Codex is the reporting runtime

> I cannot run a live Codex multi-agent session, which the issue flags as a 15–25 minute manual reproduction. The reproduction is therefore the reporter's; what is verified here is that the contract now covers the case they observed, and that each clause is pinned so it cannot be re-narrowed silently — which is what the issue identifies as the likely fix surface ("a prose-contract + artifact-reconciliation seam").

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass (`npm test`)
- [ ] `.changeset/` fragment — `gsd-core/` is touched, so the gate fires; **added on this PR's number after opening** (see below)
- [x] No unnecessary dependencies added

## Breaking changes

None. The change widens where an existing rule visibly applies and forbids a re-dispatch that would have duplicated committed work. No runtime loses behaviour.

## Note on the sibling split

#4218 is the other half of #3754 (an **active** executor being interrupted/steered). It edits the adjacent *"Configurable stall surveillance"* block in this same file, so the two will touch nearby lines — separate PRs per the one-issue-one-PR rule, and I will rebase whichever lands second.

