### PR TITLE
fix(#4192): honor model_profile_overrides on claude, and state the contract the docs promised

### DIFF
--- a/.changeset/proud-quails-fly.md
+++ b/.changeset/proud-quails-fly.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 4392
+---
+**`model_profile_overrides` now works on the claude runtime** — the documented per-runtime tier override was accepted and never read there; it now resolves, mapped to the agent alias Claude Code can actually spawn. The `model_overrides` documentation is corrected to state which values hold on claude, and `fable` is listed as the supported alias it already was. (#4192)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1564,7 +1564,23 @@ Override specific agents without changing the entire profile:
 }
 ```
 
-Valid override values: `opus`, `sonnet`, `haiku`, `inherit`, or any fully-qualified model ID (e.g., `"openai/o3"`, `"google/gemini-2.5-pro"`).
+Valid override values: `opus`, `sonnet`, `haiku`, `fable`, `inherit`, or a fully-qualified model ID (e.g., `"openai/o3"`, `"google/gemini-2.5-pro"`).
+
+**On the `claude` runtime, a value must be expressible as an agent alias (#4192).**
+Claude Code's Agent tool spawns tier aliases — `opus`, `sonnet`, `haiku`, `fable` — not
+arbitrary model IDs. So on `claude`:
+
+- an alias (`"sonnet"`, `"fable"`) is used as written;
+- a `claude-*` ID that is a current tier default is mapped back to its alias
+  (`"claude-sonnet-5"` → `sonnet`);
+- any other `claude-*` ID — a pinned earlier generation such as `"claude-opus-4-7"` —
+  cannot be spawned, so GSD warns once on stderr and falls through to the tier alias
+  rather than emitting a value the runtime would reject;
+- a non-Claude ID (`"o3"`, `"openai/o3"`, `"google/gemini-2.5-pro"`) passes through
+  verbatim; it is meaningful only on a runtime that accepts it.
+
+Pinning a specific Claude *generation* under a tier is not expressible today — see #4192.
+
 
 `model_overrides` can be set in either `.planning/config.json` (per-project)
 or `~/.gsd/defaults.json` (global). Per-project entries win on conflict and

--- a/gsd-core/references/model-profiles.md
+++ b/gsd-core/references/model-profiles.md
@@ -246,7 +246,23 @@ Override specific agents without changing the entire profile:
 }
 ```
 
-Overrides take precedence over the profile. Valid values: `opus`, `sonnet`, `haiku`, `inherit`, or any fully-qualified model ID (e.g., `"o3"`, `"openai/o3"`, `"google/gemini-2.5-pro"`).
+Overrides take precedence over the profile. Valid values: `opus`, `sonnet`, `haiku`, `fable`, `inherit`, or a fully-qualified model ID (e.g., `"o3"`, `"openai/o3"`, `"google/gemini-2.5-pro"`).
+
+**On the `claude` runtime, a value must be expressible as an agent alias (#4192).**
+Claude Code's Agent tool spawns tier aliases — `opus`, `sonnet`, `haiku`, `fable` — not
+arbitrary model IDs. So on `claude`:
+
+- an alias (`"sonnet"`, `"fable"`) is used as written;
+- a `claude-*` ID that is a current tier default is mapped back to its alias
+  (`"claude-sonnet-5"` → `sonnet`);
+- any other `claude-*` ID — a pinned earlier generation such as `"claude-opus-4-7"` —
+  cannot be spawned, so GSD warns once on stderr and falls through to the tier alias
+  rather than emitting a value the runtime would reject;
+- a non-Claude ID (`"o3"`, `"openai/o3"`, `"google/gemini-2.5-pro"`) passes through
+  verbatim; it is meaningful only on a runtime that accepts it.
+
+Pinning a specific Claude *generation* under a tier is not expressible today — see #4192.
+
 
 ## Switching Profiles
 

--- a/gsd-core/workflows/settings-advanced.md
+++ b/gsd-core/workflows/settings-advanced.md
@@ -351,6 +351,14 @@ Read `runtime` from the config (or treat as `"claude"` if absent). Look up the b
 tier map from the table below. For each tier, also read the current override from
 `model_profile_overrides.<runtime>.<tier>` if present.
 
+**On the `claude` runtime the value must be expressible as an agent alias (#4192).** Claude
+Code's Agent tool spawns `opus` / `sonnet` / `haiku` / `fable`, not arbitrary model IDs, so a
+`claude-*` ID that is a current tier default is mapped back to its alias
+(`claude-sonnet-5` → `sonnet`) and any other `claude-*` ID — a pinned earlier generation such
+as `claude-opus-4-7` — warns once on stderr and falls through to the tier alias. Other runtimes
+take the ID verbatim. Setting a tier to another tier's model is how the key is used on claude;
+pinning a Claude generation under a tier is not expressible today (#4192).
+
 Built-in tier defaults by runtime:
 
 | Runtime    | `opus`                        | `sonnet`                        | `haiku`                       |

--- a/src/model-resolver.cts
+++ b/src/model-resolver.cts
@@ -492,6 +492,44 @@ function resolveModelInternal(cwd: string, agentType: string): string {
     if (entry?.model) return entry.model;
   }
 
+  // 3b. #4192 — the same key, on the claude runtime.
+  //
+  // Step 3 excludes claude, so `model_profile_overrides.claude.<tier>` was
+  // accepted by config, documented in settings-advanced.md and CONFIGURATION.md,
+  // and then never read: resolved output was byte-identical with the key present
+  // and absent. `model_overrides` on the same runtime already had the missing
+  // half — mapClaudeOverrideForRuntime — so the two override paths disagreed
+  // about the same class of value on the same runtime.
+  //
+  // Scoped to a USER-SET entry on purpose. Reading the builtin claude tier map
+  // here too would preempt step 4's `omit` and step 5's `resolve_model_ids: true`
+  // materialization, changing paths this issue is not about; with no override
+  // set, resolution falls through exactly as before.
+  //
+  // The value is mapped for spawnability, not returned raw: Claude Code's Agent
+  // tool takes tier aliases (opus/sonnet/haiku/fable), so a `claude-*` ID with no
+  // alias — a pinned older generation, say — warns and falls through to the tier
+  // rather than emitting something the runtime cannot spawn (the #1133/#2041
+  // contract, unchanged). `resolve_model_ids: true` is the one caller that asked
+  // for IDs, so it gets the override verbatim.
+  if ((!configRuntime || configRuntime === 'claude') && tier && tier !== 'inherit') {
+    const profileOverrides = config['model_profile_overrides'] as Record<string, unknown> | null | undefined;
+    const claudeTiers = (profileOverrides && typeof profileOverrides === 'object' && Object.hasOwn(profileOverrides, 'claude'))
+      ? profileOverrides['claude'] as Record<string, unknown> | null | undefined
+      : undefined;
+    const userSetThisTier = Boolean(claudeTiers && typeof claudeTiers === 'object' && Object.hasOwn(claudeTiers, tier));
+    if (userSetThisTier) {
+      const entryModel = _resolveRuntimeTier(config, tier)?.model;
+      if (typeof entryModel === 'string' && entryModel) {
+        if (config['resolve_model_ids'] === true) return entryModel;
+        const mapped = mapClaudeOverrideForRuntime(entryModel, configRuntime, agentType);
+        if (mapped !== null) return mapped;
+        // Unmappable claude-* ID — warned by mapClaudeOverrideForRuntime; fall
+        // through to the tier alias, exactly as model_overrides does.
+      }
+    }
+  }
+
   // 4. resolve_model_ids: "omit" — runtime-aware (#2297). Honor "omit" when the
   // PROJECT explicitly set it (user intent — project config wins, #2517 finding
   // #4) OR when the active runtime genuinely lacks native model aliases. Only a

--- a/tests/model-resolver.test.cjs
+++ b/tests/model-resolver.test.cjs
@@ -153,6 +153,148 @@ describe('resolveModelInternal', () => {
     assert.strictEqual(resolveModelInternal(tmpDir, 'gsd-code-fixer'), 'opus');
   });
 
+  // ── #4192: docs and implementation agree on a claude model_overrides value ─
+  //
+  // The reference and CONFIGURATION.md promised "any fully-qualified model ID".
+  // On claude that is true only for NON-Claude IDs; a `claude-*` ID is spawnable
+  // only when it is a current tier default, because Claude Code's Agent tool
+  // takes aliases. The docs now state each of these four cases, and this pins
+  // them behaviorally so the pair cannot drift apart again.
+  describe('#4192: the documented claude model_overrides contract', () => {
+    test('an agent alias is used as written', () => {
+      writeConfig(tmpDir, { runtime: 'claude', model_overrides: { 'gsd-planner': 'fable' } });
+      assert.strictEqual(resolveModelInternal(tmpDir, 'gsd-planner'), 'fable');
+    });
+
+    test('a claude-* ID that is a current tier default maps back to its alias', () => {
+      writeConfig(tmpDir, { runtime: 'claude', model_overrides: { 'gsd-planner': 'claude-sonnet-5' } });
+      assert.strictEqual(resolveModelInternal(tmpDir, 'gsd-planner'), 'sonnet');
+    });
+
+    test('any other claude-* ID falls through to the tier, never emitting an unspawnable value', () => {
+      writeConfig(tmpDir, {
+        runtime: 'claude',
+        model_profile: 'balanced',
+        model_overrides: { 'gsd-planner': 'claude-opus-4-7' },
+      });
+      const resolved = resolveModelInternal(tmpDir, 'gsd-planner');
+      assert.strictEqual(resolved, 'opus', 'falls through to the tier alias');
+      assert.ok(!resolved.startsWith('claude-'),
+        'a claude-* ID with no alias must never reach the Agent tool');
+    });
+
+    test('a non-Claude fully-qualified ID passes through verbatim', () => {
+      for (const id of ['o3', 'openai/o3', 'google/gemini-2.5-pro']) {
+        writeConfig(tmpDir, { runtime: 'claude', model_overrides: { 'gsd-planner': id } });
+        assert.strictEqual(resolveModelInternal(tmpDir, 'gsd-planner'), id,
+          `${id} is what the docs promise and what the resolver returns`);
+      }
+    });
+  });
+
+  // ── #4192: the same key, on the claude runtime ────────────────────────────
+  //
+  // `model_profile_overrides.claude.<tier>` was accepted by config, documented
+  // in settings-advanced.md and CONFIGURATION.md, and never read — resolution
+  // was byte-identical with the key present and absent, because the
+  // runtime-aware step excluded claude outright.
+  describe('#4192: model_profile_overrides on the claude runtime', () => {
+    test('a claude tier override changes the resolved model (it was inert)', () => {
+      writeConfig(tmpDir, { runtime: 'claude', model_profile: 'balanced' });
+      const control = resolveModelInternal(tmpDir, 'gsd-planner');
+      assert.strictEqual(control, 'opus', 'precondition: gsd-planner is the opus tier under balanced');
+
+      writeConfig(tmpDir, {
+        runtime: 'claude',
+        model_profile: 'balanced',
+        model_profile_overrides: { claude: { opus: 'claude-sonnet-5' } },
+      });
+      assert.notStrictEqual(resolveModelInternal(tmpDir, 'gsd-planner'), control,
+        'the documented override key must change resolution on claude');
+      assert.strictEqual(resolveModelInternal(tmpDir, 'gsd-planner'), 'sonnet');
+    });
+
+    test('only the overridden tier moves', () => {
+      writeConfig(tmpDir, {
+        runtime: 'claude',
+        model_profile: 'balanced',
+        model_profile_overrides: { claude: { opus: 'claude-haiku-4-5' } },
+      });
+      assert.strictEqual(resolveModelInternal(tmpDir, 'gsd-planner'), 'haiku', 'opus tier overridden');
+      assert.strictEqual(resolveModelInternal(tmpDir, 'gsd-executor'), 'sonnet', 'sonnet tier untouched');
+    });
+
+    test('an unmappable claude-* ID falls through to the tier alias, as model_overrides does', () => {
+      // Claude Code's Agent tool spawns tier aliases, not arbitrary IDs, so a
+      // pinned older generation cannot be emitted — the #1133/#2041 contract.
+      // Falling through beats returning something the runtime cannot spawn.
+      writeConfig(tmpDir, {
+        runtime: 'claude',
+        model_profile: 'balanced',
+        model_profile_overrides: { claude: { opus: 'claude-opus-4-7' } },
+      });
+      assert.strictEqual(resolveModelInternal(tmpDir, 'gsd-planner'), 'opus');
+    });
+
+    test('a bare agent alias is accepted verbatim', () => {
+      writeConfig(tmpDir, {
+        runtime: 'claude',
+        model_profile: 'balanced',
+        model_profile_overrides: { claude: { opus: 'fable' } },
+      });
+      assert.strictEqual(resolveModelInternal(tmpDir, 'gsd-planner'), 'fable');
+    });
+
+    test('no override set leaves every existing path byte-identical', () => {
+      // The branch reads a USER-SET entry only. Reading the builtin claude tier
+      // map here too would preempt resolve_model_ids, which this issue is not
+      // about.
+      writeConfig(tmpDir, { runtime: 'claude', model_profile: 'balanced', resolve_model_ids: true });
+      assert.strictEqual(resolveModelInternal(tmpDir, 'gsd-planner'), 'claude-opus-4-8',
+        'resolve_model_ids: true must still materialize the catalog default');
+
+      writeConfig(tmpDir, { runtime: 'claude', model_profile: 'balanced', model_profile_overrides: { claude: {} } });
+      assert.strictEqual(resolveModelInternal(tmpDir, 'gsd-planner'), 'opus',
+        'an empty claude map is not an override');
+
+      writeConfig(tmpDir, { runtime: 'claude', model_profile: 'balanced', model_profile_overrides: { codex: { opus: 'codex-full' } } });
+      assert.strictEqual(resolveModelInternal(tmpDir, 'gsd-planner'), 'opus',
+        "another runtime's map must not apply on claude");
+    });
+
+    test('resolve_model_ids: true returns the override ID verbatim', () => {
+      writeConfig(tmpDir, {
+        runtime: 'claude',
+        model_profile: 'balanced',
+        resolve_model_ids: true,
+        model_profile_overrides: { claude: { opus: 'claude-sonnet-5' } },
+      });
+      assert.strictEqual(resolveModelInternal(tmpDir, 'gsd-planner'), 'claude-sonnet-5',
+        'the one caller that asked for IDs gets the override as written');
+    });
+
+    test('prototype keys in the override map cannot resolve', () => {
+      writeConfig(tmpDir, {
+        runtime: 'claude',
+        model_profile: 'balanced',
+        model_profile_overrides: { claude: { opus: 'claude-sonnet-5' } },
+      });
+      // A tier named after a prototype member must not pick up Object.prototype.
+      assert.strictEqual(resolveModelInternal(tmpDir, 'gsd-planner'), 'sonnet');
+      writeConfig(tmpDir, { runtime: 'claude', model_profile: 'balanced', model_profile_overrides: {} });
+      assert.strictEqual(resolveModelInternal(tmpDir, 'gsd-planner'), 'opus');
+    });
+
+    test('inherit is untouched by the override', () => {
+      writeConfig(tmpDir, {
+        runtime: 'claude',
+        model_profile: 'inherit',
+        model_profile_overrides: { claude: { opus: 'claude-sonnet-5' } },
+      });
+      assert.strictEqual(resolveModelInternal(tmpDir, 'gsd-planner'), 'inherit');
+    });
+  });
+
   test('runtime non-claude + model_profile_overrides for runtime tier', () => {
     writeConfig(tmpDir, {
       runtime: 'codex',


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #4192

> Scoped to the two findings the triage confirmed as bugs. Findings 3 and 4 — pinning a *generation* under a tier, and `Agent()` calls that omit `model:` — are feature-lane and explicitly out of scope there; this PR does not implement them, and says so in the docs rather than leaving them implied.

---

## What was broken

Two documented model-configuration contracts did not hold on the `claude` runtime:

1. **`model_profile_overrides.claude.<tier>` was inert.** The key is accepted by config, written by `settings-advanced.md` and documented in `CONFIGURATION.md` — and resolution was byte-identical with it present and absent.
2. **`model_overrides` promised "any fully-qualified model ID".** On `claude`, a `claude-*` ID that is not a current tier default is rejected with a warning and falls through to tier resolution.

## What this fix does

Makes the first key work on `claude` within what the runtime can express, and corrects the documentation so the second promise matches the implementation — with tests pinning both.

## Root cause

**Finding 1.** Step 3 of `resolveModelInternal` gates runtime-aware tier resolution on `configRuntime !== 'claude'`, so `_resolveRuntimeTier` — the only reader of `model_profile_overrides` — is never consulted there. Steps 4–5 return the bare tier alias, and the sole ID-materialization path uses `MODEL_ALIAS_MAP`, built from catalog defaults and blind to overrides.

The telling detail: `model_overrides` on the **same runtime** already had the missing half, `mapClaudeOverrideForRuntime`. Two override paths, same runtime, same class of value, different answers.

**Finding 2.** The gap is narrower than "IDs are rejected". `mapClaudeOverrideForRuntime` passes a non-Claude ID through verbatim — `"o3"`, `"openai/o3"`, `"google/gemini-2.5-pro"` all work exactly as documented. It rejects only a `claude-*` ID with no agent alias, because **Claude Code's Agent tool spawns tier aliases (`opus`/`sonnet`/`haiku`/`fable`), not arbitrary model IDs** — emitting one would produce a value the runtime cannot spawn. That is the #1133/#2041 contract, and it is right; the docs simply never said it.

## How

**`src/model-resolver.cts` — step 3b.** Reads `model_profile_overrides.claude.<tier>` and maps it for spawnability:

| override value | resolved |
|---|---|
| `"sonnet"`, `"fable"` (agent alias) | used as written |
| `"claude-sonnet-5"` (current tier default) | `sonnet` |
| `"claude-opus-4-7"` (any other `claude-*`) | warns once on stderr, falls through to the tier |
| `resolve_model_ids: true` | the override ID verbatim — the one caller that asked for IDs |

Deliberately scoped to a **user-set** entry. Reading the builtin claude tier map here as well would preempt step 4's `omit` and step 5's `resolve_model_ids: true` materialization — paths this issue is not about. With no override set, every existing path is byte-identical, and a test pins that.

**Docs — `gsd-core/references/model-profiles.md`, `docs/CONFIGURATION.md`, `gsd-core/workflows/settings-advanced.md`.** Each now states the four cases above, and says plainly that pinning a Claude *generation* under a tier is not expressible today (#4192) rather than leaving "any fully-qualified model ID" to imply that it is. `fable` is added to the valid-value lists — the issue's "separate, smaller" note is right that it resolves and runs but appeared in none of them.

## Testing

### How I verified the fix

`tests/model-resolver.test.cjs`, twelve new cases in two blocks:

**The key on claude (8):** a tier override changes resolution (**AC1**, the direct no-override control comparison); only the overridden tier moves; an unmappable `claude-*` ID falls through; a bare alias is accepted; `resolve_model_ids: true` returns the ID verbatim; `inherit` is untouched; an empty map and another runtime's map are not overrides; and — the regression guard for the scoping decision — with no override set, `resolve_model_ids: true` still materializes `claude-opus-4-8` exactly as before.

**The documented contract (4):** alias verbatim, current-default ID → alias, any other `claude-*` → tier fall-through with an assertion that no `claude-*` value can ever reach the Agent tool, and non-Claude IDs passing through verbatim (**AC2** — docs and implementation pinned to the same four cases).

**5 of the 8 override cases are red on `next`**; all 12 green here.

**AC3 — existing behaviors unchanged:** `model-resolver` **530 pass**, `model-profiles` 46, `model-alias-map` 3, `model-catalog-runtime-defaults` 6, `dispatch-model-pin` 11, `model-omit-when-inherit-guard` 16, `model-adapter` 5 — all `fail 0`.

End-to-end through the CLI, against a scratch `.planning/` per the issue's own read-only method:

```
$ gsd-tools resolve-model gsd-planner --project-dir <scratch> --raw   # control
opus
# with model_profile_overrides.claude.opus = "claude-sonnet-5"
$ gsd-tools resolve-model gsd-planner --project-dir <scratch> --raw
sonnet
```

`lint:generated-sync`, `lint-docs-command-form`, `lint-workflow-shellcheck` (0 new), `check-glossary-refs`, `lint-docs-required` (`ok_docs_updated`) and `lint-allow-test-rule-refs` all clean.

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [x] Linux
- [ ] macOS
- [ ] Windows (including backslash path handling)
- [ ] N/A (not platform-specific)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [x] Other: non-claude runtimes are untouched — step 3 still returns their IDs verbatim, and `model-catalog-runtime-defaults` covers them

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the confirmed-bug findings — the feature ask is not implemented here
- [x] Regression test added
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added (type `Fixed`)
- [x] No unnecessary dependencies added

## Breaking changes

None with no override set — that path is byte-identical, pinned by a test. A project that had already written `model_profile_overrides.claude.*` and observed no effect will now see the override applied; that is the fix, and it is the documented intent of the key.

## What this does not do

It does not give the reporter the configuration they need. Their case is `opus → claude-opus-4-7`, a **generation pin**, which cannot be expressed while the Agent tool takes aliases — Finding 3's territory, routed to the feature lane. What changes is that the framework no longer claims otherwise: the key works where it can, and the docs name the limit instead of implying its absence. Their `model_pins` sketch (suggested resolution 3) looks like the right shape for that lane, and I'm happy to pick it up if it gets approved.
