### PR TITLE
fix(#4197): dedup the update-context fast path against the selected global dir

### DIFF
--- a/.changeset/bold-jaguars-parade.md
+++ b/.changeset/bold-jaguars-parade.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`/gsd:update` no longer misreports a global install as LOCAL when the shell sits in $HOME** — running the update from a home-directory shell drove the installer's --local arm (settings.local.json + the #338 relocation) against a global install; the preferred-config-dir fast path now applies the same same-path dedup the rest of the detection cascade always has. (#4197)

--- a/.changeset/bold-jaguars-parade.md
+++ b/.changeset/bold-jaguars-parade.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 4413
 ---
 **`/gsd:update` no longer misreports a global install as LOCAL when the shell sits in $HOME** — running the update from a home-directory shell drove the installer's --local arm (settings.local.json + the #338 relocation) against a global install; the preferred-config-dir fast path now applies the same same-path dedup the rest of the detection cascade always has. (#4197)

--- a/src/update-context.cts
+++ b/src/update-context.cts
@@ -130,6 +130,27 @@ function preferFirst(entries: RuntimeDirEntry[], preferred: string): RuntimeDirE
   return [...pref, ...rest];
 }
 
+// GLOBAL probe: absolute env candidates first (in preferFirst order, first
+// hasInstall hit wins), then $HOME-relative. Single resolver shared by the
+// preferredConfigDir fast path's same-path dedup and the full cascade (#4197),
+// so both compare against the global dir the resolution would actually select —
+// an env-directed candidate, not necessarily the $HOME-relative pathname.
+function resolveGlobalCandidate(
+  fs: FsAdapter,
+  env: Record<string, string | undefined>,
+  home: string,
+  preferred: string,
+): { runtime: string; dir: string } {
+  for (const [rt, absdir] of preferFirst(envRuntimeDirs({ env, home }), preferred)) {
+    if (hasInstall(fs, absdir)) return { runtime: rt, dir: path.resolve(absdir) };
+  }
+  for (const [rt, reldir] of preferFirst(RUNTIME_DIRS, preferred)) {
+    const cand = path.resolve(home, reldir);
+    if (hasInstall(fs, cand)) return { runtime: rt, dir: cand };
+  }
+  return { runtime: '', dir: '' };
+}
+
 export interface ResolveUpdateContextOpts {
   home: string;
   cwd: string;
@@ -164,9 +185,15 @@ export function resolveUpdateContext({
   // Fast path: a validated preferredConfigDir (custom --config-dir install).
   if (preferredConfigDir && hasInstall(fs, preferredConfigDir)) {
     const resolvedPref = path.resolve(preferredConfigDir);
+    // Same-path dedup the cascade applies (#4197): a preferred dir that IS the
+    // selected global install (an env candidate or the $HOME-relative dir) is
+    // GLOBAL even when cwd === $HOME also makes it the cwd-relative match.
+    const { dir: globalDir } = resolveGlobalCandidate(fs, env, home, preferred);
     let scope: 'LOCAL' | 'GLOBAL' = 'GLOBAL';
-    for (const [, reldir] of RUNTIME_DIRS) {
-      if (path.resolve(cwd, reldir) === resolvedPref) { scope = 'LOCAL'; break; }
+    if (resolvedPref !== globalDir) {
+      for (const [, reldir] of RUNTIME_DIRS) {
+        if (path.resolve(cwd, reldir) === resolvedPref) { scope = 'LOCAL'; break; }
+      }
     }
     return {
       installedVersion: trustedVersionAt(fs, preferredConfigDir) ?? '0.0.0',
@@ -176,7 +203,6 @@ export function resolveUpdateContext({
     };
   }
 
-  const orderedEnv = preferFirst(envRuntimeDirs({ env, home }), preferred);
   const orderedRuntime = preferFirst(RUNTIME_DIRS, preferred);
 
   // LOCAL probe (relative to cwd).
@@ -186,17 +212,9 @@ export function resolveUpdateContext({
     if (hasInstall(fs, cand)) { localRuntime = rt; localDir = cand; break; }
   }
 
-  // GLOBAL probe: absolute env candidates first, then $HOME-relative.
-  let globalRuntime = '', globalDir = '';
-  for (const [rt, absdir] of orderedEnv) {
-    if (hasInstall(fs, absdir)) { globalRuntime = rt; globalDir = path.resolve(absdir); break; }
-  }
-  if (!globalRuntime) {
-    for (const [rt, reldir] of orderedRuntime) {
-      const cand = path.resolve(home, reldir);
-      if (hasInstall(fs, cand)) { globalRuntime = rt; globalDir = cand; break; }
-    }
-  }
+  // GLOBAL probe: absolute env candidates first, then $HOME-relative — the
+  // same resolver the fast path dedups against.
+  const { runtime: globalRuntime, dir: globalDir } = resolveGlobalCandidate(fs, env, home, preferred);
 
   const localValid = trustedVersionAt(fs, localDir);
   const isLocal = !!localValid && (!globalDir || localDir !== globalDir);

--- a/tests/update-context.test.cjs
+++ b/tests/update-context.test.cjs
@@ -165,6 +165,102 @@ describe('resolveUpdateContext: runtime probing + env overrides', () => {
   });
 });
 
+describe('resolveUpdateContext: preferredConfigDir fast-path dedup (#4197)', () => {
+  test('cwd === home does NOT misdetect as LOCAL on the preferredConfigDir fast path (dedup)', () => {
+    // #4197: the fast path derived scope from a cwd-relative match alone, so a
+    // global install probed with cwd === $HOME answered LOCAL. The cascade's
+    // same-path dedup (update.md: "local-over-global with same-path dedup (so
+    // CWD=$HOME does not misdetect as LOCAL)") must hold on the fast path too.
+    const fs = fakeFs({ [ver(`${HOME}/.claude`)]: '1.40.0\n', [marker(`${HOME}/.claude`)]: 'x' });
+    const r = resolveUpdateContext({
+      home: HOME, cwd: HOME, env: {}, fs,
+      preferredConfigDir: `${HOME}/.claude`, preferredRuntime: 'claude',
+    });
+    assert.equal(r.scope, 'GLOBAL');
+  });
+
+  test('same global install resolves identically from home and elsewhere on the fast path', () => {
+    const fs = fakeFs({ [ver(`${HOME}/.claude`)]: '1.40.0\n', [marker(`${HOME}/.claude`)]: 'x' });
+    const inputs = {
+      home: HOME, env: {}, fs,
+      preferredConfigDir: `${HOME}/.claude`, preferredRuntime: 'claude',
+    };
+    const fromElsewhere = resolveUpdateContext({ ...inputs, cwd: CWD });
+    assert.equal(fromElsewhere.scope, 'GLOBAL');
+    assert.deepEqual(
+      resolveUpdateContext({ ...inputs, cwd: HOME }),
+      fromElsewhere,
+      'scope must not depend on which directory the shell is sitting in',
+    );
+  });
+
+  test('genuine project-local install stays LOCAL on the fast path', () => {
+    // Control: the dedup must not over-correct into GLOBAL-always. A preferred
+    // dir that is the cwd-relative install and NOT the selected global is LOCAL.
+    const fs = fakeFs({ [ver(`${CWD}/.claude`)]: '1.39.0\n', [marker(`${CWD}/.claude`)]: 'x' });
+    const r = resolveUpdateContext({
+      home: HOME, cwd: CWD, env: {}, fs,
+      preferredConfigDir: `${CWD}/.claude`, preferredRuntime: 'claude',
+    });
+    assert.equal(r.scope, 'LOCAL');
+    assert.equal(r.installedVersion, '1.39.0');
+    assert.ok(sameDir(r.gsdDir, `${CWD}/.claude`), `gsdDir was ${r.gsdDir}`);
+  });
+
+  test('genuine project-local install stays LOCAL even with a global install also present', () => {
+    const fs = fakeFs({
+      [ver(`${CWD}/.claude`)]: '1.39.0\n', [marker(`${CWD}/.claude`)]: 'x',
+      [ver(`${HOME}/.claude`)]: '1.40.0\n', [marker(`${HOME}/.claude`)]: 'x',
+    });
+    const r = resolveUpdateContext({
+      home: HOME, cwd: CWD, env: {}, fs,
+      preferredConfigDir: `${CWD}/.claude`, preferredRuntime: 'claude',
+    });
+    assert.equal(r.scope, 'LOCAL');
+    assert.equal(r.installedVersion, '1.39.0');
+  });
+
+  test('env-directed global elsewhere: $HOME/.claude is LOCAL and the fast path agrees with the cascade', () => {
+    // The dedup must compare against the SELECTED global candidate (env-ranked),
+    // not the $HOME pathname: with CLAUDE_CONFIG_DIR pointing the global at
+    // /opt/claude-global, $HOME/.claude probed from cwd === $HOME is a genuine
+    // cwd-local install, and the cascade already answers LOCAL for it.
+    const custom = '/opt/claude-global';
+    const fs = fakeFs({
+      [ver(`${HOME}/.claude`)]: '1.39.0\n', [marker(`${HOME}/.claude`)]: 'x',
+      [ver(custom)]: '1.40.0\n', [marker(custom)]: 'x',
+    });
+    const env = { CLAUDE_CONFIG_DIR: custom };
+    const cascade = resolveUpdateContext({ home: HOME, cwd: HOME, env, fs });
+    const fast = resolveUpdateContext({
+      home: HOME, cwd: HOME, env, fs,
+      preferredConfigDir: `${HOME}/.claude`, preferredRuntime: 'claude',
+    });
+    assert.equal(cascade.scope, 'LOCAL');
+    assert.equal(fast.scope, cascade.scope);
+    assert.equal(fast.installedVersion, cascade.installedVersion);
+    assert.equal(fast.runtime, cascade.runtime);
+    assert.ok(sameDir(fast.gsdDir, cascade.gsdDir), `fast gsdDir ${fast.gsdDir} vs cascade ${cascade.gsdDir}`);
+  });
+
+  test('env candidate IS the preferred dir: fast path answers GLOBAL, matching the cascade', () => {
+    // A preferred dir that is also the env-directed global is the selected
+    // global — the cascade answers GLOBAL, and the fast path must agree.
+    const fs = fakeFs({ [ver(`${HOME}/.claude`)]: '1.40.0\n', [marker(`${HOME}/.claude`)]: 'x' });
+    const env = { CLAUDE_CONFIG_DIR: `${HOME}/.claude` };
+    const cascade = resolveUpdateContext({ home: HOME, cwd: HOME, env, fs });
+    const fast = resolveUpdateContext({
+      home: HOME, cwd: HOME, env, fs,
+      preferredConfigDir: `${HOME}/.claude`, preferredRuntime: 'claude',
+    });
+    assert.equal(cascade.scope, 'GLOBAL');
+    assert.equal(fast.scope, cascade.scope);
+    assert.equal(fast.installedVersion, cascade.installedVersion);
+    assert.equal(fast.runtime, cascade.runtime);
+    assert.ok(sameDir(fast.gsdDir, cascade.gsdDir), `fast gsdDir ${fast.gsdDir} vs cascade ${cascade.gsdDir}`);
+  });
+});
+
 describe('gsd-tools update-context (CLI): emits the JSON contract', () => {
   test('--config-dir fixture resolves to the documented 4-field JSON', () => {
     const tmp = nodeFs.mkdtempSync(path.join(os.tmpdir(), 'gsd-uc-'));


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #4197

---

## What was broken

`resolveUpdateContext`'s `preferredConfigDir` fast path decided `LOCAL` vs `GLOBAL` from a cwd-relative match alone, so a **global** install was reported as `LOCAL` whenever the shell's working directory happened to be `$HOME`. `/gsd-update` invoked from a home-directory shell then ran the installer's `--local` arm against the global install (`settings.local.json` + the #338 relocation out of the shared `settings.json`).

## What this fix does

Gives both paths **one** global-candidate resolver and dedups the fast path against the candidate it selects. A preferred dir that *is* the selected global install is `GLOBAL`; a cwd-relative match that is something else is `LOCAL`.

## Root cause

`src/update-context.cts` (fast path): scope came from `path.resolve(cwd, reldir) === resolvedPref` with no comparison against the global install the resolution would actually select. When `cwd === home`, `<cwd>/.claude` and `<home>/.claude` are one directory, so the loop cannot distinguish "a project-local install" from "a global install with the shell in `$HOME`". The cascade already settles exactly this at its `isLocal` check (`localValid && (!globalDir || localDir !== globalDir)`) — `update.md` documents the invariant for the whole cascade ("local-over-global with same-path dedup (so `CWD=$HOME` does not misdetect as LOCAL)"), and `tests/update-context.test.cjs`'s existing *"cwd === home does NOT misdetect as LOCAL (dedup)"* row only exercised the cascade, which is why the fast path could drop the guarantee silently. Introduced with the fast path itself in #499 (the #498 port).

### Why the dedup compares against the selected global candidate, not the `$HOME` pathname

The issue's sketched one-liner (also require `path.resolve(home, reldir) !== resolvedPref`) dedups against the `$HOME` **pathname**. That introduces the mirror-image bug: with `CLAUDE_CONFIG_DIR=/opt/claude-global` carrying the global install, `$HOME/.claude` probed from `cwd === $HOME` is a genuine cwd-local install — the cascade answers `LOCAL` there (its env-ranked global lives elsewhere) — but the pathname check would answer `GLOBAL` and point `run_update` at the env dir instead of the install the operator is sitting in. The fix therefore extracts `resolveGlobalCandidate` (env candidates first, then `$HOME`-relative, first validated hit wins) and uses it in **both** paths, so the fast path's dedup is the cascade's own comparison. The cascade's former inline probe is deleted in its favor; its selection (ordering, env-first, probe order) is unchanged.

**Disclosed behavior change beyond the reported symptom:** a preferred dir that is *also* the env-directed global previously answered `LOCAL` through the fast path and `GLOBAL` through the cascade; it now answers `GLOBAL` both ways (the cascade's answer), pinned by its own test row.

## Testing

### How I verified the fix

Reproduced at CLI level first, against a sandboxed `$HOME` under `/private/tmp` (symlink-free; a `/tmp` sandbox silently defeats the strict path compare) containing a fake global install — the real home directory untouched. Identical `--config-dir`, differing only in cwd:

```
pre-fix     cwd=$HOME  -> scope=LOCAL      cwd=elsewhere -> scope=GLOBAL
post-fix    cwd=$HOME  -> scope=GLOBAL     cwd=elsewhere -> scope=GLOBAL
```

The "pre-fix" row is the committed RED state (the new regression rows failed before the source change, 3 failures exactly as the test matrix predicted).

Full bench (`gsd-test`, default selection) on the final head; `npm run lint:ci` exit 0.

### Regression test added?

- [x] Yes — added a test that would have caught this bug

Six rows in `tests/update-context.test.cjs`: `cwd === home` resolves `GLOBAL` on the fast path (the issue's suggested regression test, verbatim in spirit); the same install resolves identically from home and elsewhere; a genuine project-local install stays `LOCAL` (control — with and without a competing global, so a `GLOBAL`-always "fix" cannot pass); the env-directed-global-elsewhere case pins that `$HOME/.claude` is `LOCAL` and the fast path matches the cascade; and the env-candidate-is-preferred case pins `GLOBAL` parity.

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [x] N/A (not platform-specific — the change is a `path.resolve` comparison; tests use the module's `fakeFs` with platform-normalized keys)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [x] N/A (not runtime-specific — `RUNTIME_DIRS` is shared by all runtimes; the fix is in the loop over it and verified for a non-claude reldir too)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass
- [x] `.changeset/` fragment added
- [x] No unnecessary dependencies added

## Breaking changes

None beyond the reported correction: a global install resolved from `$HOME` now reports `GLOBAL` instead of `LOCAL`, and a preferred dir that is also the env-directed global aligns with the cascade's `GLOBAL`. A genuine project-local install is unaffected, pinned by its own control rows. Out of scope, as the issue states: the pre-existing strict-compare fragility for symlink-aliased home or temp paths, which both paths share.
