### PR TITLE
fix(#4398): render the pending-todo link relative to the project root

### DIFF
--- a/.changeset/eager-moles-purr.md
+++ b/.changeset/eager-moles-purr.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 4417
+---
+Pending-todo bullets in STATE.md now link to the todo relative to the project root, so the 240-character cap no longer drops the "Needs ..." clause based on how long your checkout path is.

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -1938,7 +1938,7 @@ Capture ideas, tasks, notes, and seeds to their appropriate destination. Default
 
 **Produces:** `.planning/todos/` (default), note files (--note), ROADMAP.md backlog section (--backlog), `.planning/seeds/SEED-NNN-slug.md` (--seed)
 
-**STATE.md rendering:** each capture (or `--list` action that changes the pending count) refreshes STATE.md's "### Pending Todos" section to one bullet per pending todo, each capped at 240 characters — `- [date] [area] title — [todo file](path) — Needs ...`. A todo with no clear next step omits the "Needs ..." clause rather than the bullet. Refresh is fail-safe: a failed or malformed lookup leaves the existing section untouched rather than clearing it.
+**STATE.md rendering:** each capture (or `--list` action that changes the pending count) refreshes STATE.md's "### Pending Todos" section to one bullet per pending todo, each capped at 240 characters — `- [date] [area] title — [todo file](path) — Needs ...`. The link target is the todo's path relative to the project root (`.planning/todos/pending/<file>.md`), so the rendered bullet does not vary with the checkout location (#4398) — the `todos[].path` JSON field remains absolute per #2376. A todo with no clear next step omits the "Needs ..." clause rather than the bullet. Refresh is fail-safe: a failed or malformed lookup leaves the existing section untouched rather than clearing it.
 
 ```bash
 /gsd-capture "Consider adding dark mode support"   # Add todo

--- a/gsd-core/templates/state.md
+++ b/gsd-core/templates/state.md
@@ -174,6 +174,8 @@ Updated after each plan completion.
 **Pending Todos:** Ideas captured via /gsd-add-todo
 - One bullet per pending todo, rendered by `init.todos`'s `pending_todos_markdown`
   (each bullet capped at 240 characters: `- [date] [area] title — [todo file](path) — Needs ...`)
+- The link target is the todo's path relative to the project root, so the bullet
+  reads the same from any checkout (#4398); the `todos[].path` JSON field stays absolute
 - `None yet.` when there are no pending todos
 - No collapse-by-count fallback — every pending todo gets its own line, always
   (see #2618 design doc for why a "count if many" fallback was rejected)

--- a/src/init.cts
+++ b/src/init.cts
@@ -2266,18 +2266,47 @@ function truncatePendingTodoText(value: string, maxLen: number): string {
  * algorithm duplicated as a test oracle is exactly the divergence class
  * this avoids).
  */
-function renderPendingTodosMarkdown(todos: Record<string, unknown>[]): string {
+function renderPendingTodosMarkdown(
+  todos: Record<string, unknown>[],
+  projectRoot?: string,
+): string {
   if (!Array.isArray(todos) || todos.length === 0) {
     return 'None yet.';
   }
-  return todos.map((todo) => renderPendingTodoBullet(todo)).join('\n');
+  return todos.map((todo) => renderPendingTodoBullet(todo, projectRoot)).join('\n');
 }
 
 function pendingTodoFieldAsString(value: unknown, fallback: string): string {
   return typeof value === 'string' && value.length > 0 ? value : fallback;
 }
 
-function renderPendingTodoBullet(todo: Record<string, unknown>): string {
+/**
+ * #4398: the bullet's link target, rendered relative to the project root.
+ *
+ * `todos[].path` is absolute by #2376 and stays that way in the JSON, but
+ * splicing that absolute path into the bullet made the 240-char budget a
+ * function of WHERE the repo is checked out: the same todo kept its
+ * "Needs ..." clause under a short root and lost it under a long one, so the
+ * needs -> title -> area drop order below fired on machine-dependent input.
+ * Relativizing the link restores determinism and matches the canonical
+ * example this feature documents (`.planning/todos/pending/<file>.md`).
+ *
+ * Falls back to the absolute path whenever relativizing would misrepresent
+ * the location -- no root to measure against, or a todo that resolves
+ * outside the project. That keeps the existing "link correctness > strict
+ * cap" rule intact: an over-budget bullet is a cosmetic loss, a link that
+ * points somewhere else is a wrong answer.
+ */
+function pendingTodoLinkTarget(value: unknown, projectRoot?: string): string {
+  const absolute = pendingTodoFieldAsString(value, '');
+  if (!absolute || !projectRoot) return absolute;
+  const relative = toPosixPath(path.relative(projectRoot, toNativePath(absolute)));
+  if (!relative || relative.startsWith('../') || relative === '..') return absolute;
+  if (path.isAbsolute(relative)) return absolute;
+  return relative;
+}
+
+function renderPendingTodoBullet(todo: Record<string, unknown>, projectRoot?: string): string {
   const date = sanitizePendingTodoInline(pendingTodoFieldAsString(todo['created'], 'unknown'));
   let area = sanitizePendingTodoInline(pendingTodoFieldAsString(todo['area'], 'general'));
   let title = sanitizePendingTodoInline(pendingTodoFieldAsString(todo['title'], 'Untitled'));
@@ -2287,7 +2316,7 @@ function renderPendingTodoBullet(todo: Record<string, unknown>): string {
     typeof todo['needs'] === 'string'
       ? sanitizePendingTodoInline(todo['needs']).replace(/\.+$/, '')
       : '';
-  const link = `[todo file](${pendingTodoFieldAsString(todo['path'], '')})`;
+  const link = `[todo file](${pendingTodoLinkTarget(todo['path'], projectRoot)})`;
 
   const assemble = (): string => {
     const needsClause = needs ? ` — Needs ${needs}.` : '';
@@ -2420,7 +2449,7 @@ function cmdInitTodos(cwd: string, area: string | undefined, raw: boolean): void
     // (rather than emitted with possibly-wrong data) when pendingReadOk is
     // false, so the workflow's fail-safe check can key off field presence.
     pending_read_ok: pendingReadOk,
-    ...(pendingReadOk ? { pending_todos_markdown: renderPendingTodosMarkdown(todos) } : {}),
+    ...(pendingReadOk ? { pending_todos_markdown: renderPendingTodosMarkdown(todos, cwd) } : {}),
   };
 
   output(withProjectRoot(cwd, result), raw);

--- a/tests/state-todos-render.test.cjs
+++ b/tests/state-todos-render.test.cjs
@@ -252,6 +252,85 @@ test('cmdInitTodos: bullet order is filename-sorted regardless of write/insertio
   assert.ok(lines[2].includes('Third todo'));
 });
 
+// ─── #4398: the bullet must not depend on where the repo is checked out ────
+
+// The #2618 cap fires needs -> title -> area, and the link is never truncated.
+// While the link carried the ABSOLUTE todo path, the length of the checkout
+// root was an input to that ladder: the same todo kept its "Needs ..." clause
+// under /tmp/x and lost it under macOS's /private/var/folders/... temp root,
+// so `next` was green on Linux and red on the macOS shard for one line of
+// prose nobody wrote differently. Asserting a clause survives at SOME path
+// length is what let that through, so this pins the invariant instead:
+// identical inputs, different roots, byte-identical bullet.
+function writeTodoFixture(root) {
+  const pendingDir = path.join(root, '.planning', 'todos', 'pending');
+  fs.mkdirSync(pendingDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(pendingDir, '2026-09-01-fix-retry-logic.md'),
+    [
+      '---',
+      'created: 2026-09-01T00:00:00.000Z',
+      'title: Fix retry logic',
+      'area: api',
+      'severity: major',
+      '---',
+      '',
+      '## Problem',
+      '',
+      'Retries are unbounded.',
+      '',
+      '## Solution',
+      '',
+      'Add a max-attempts cap.',
+      '',
+    ].join('\n'),
+  );
+}
+
+test('#4398 cmdInitTodos: the rendered bullet is identical from a short and a deep checkout root', (t) => {
+  const shallowRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-4398-'));
+  t.after(() => cleanup(shallowRoot));
+  // Nested inside the same temp dir so both roots live on one filesystem and
+  // the ONLY difference between the two runs is absolute path length.
+  const deepRoot = path.join(shallowRoot, 'nested', 'a'.repeat(60), 'b'.repeat(60), 'project');
+  fs.mkdirSync(deepRoot, { recursive: true });
+
+  writeTodoFixture(shallowRoot);
+  writeTodoFixture(deepRoot);
+
+  const shallow = runQueryInitTodos(shallowRoot);
+  const deep = runQueryInitTodos(deepRoot);
+
+  assert.ok(
+    deep.project_root.length - shallow.project_root.length > 120,
+    'fixture is only meaningful if the two roots differ substantially in length',
+  );
+  assert.equal(
+    deep.pending_todos_markdown,
+    shallow.pending_todos_markdown,
+    'the bullet must not vary with the checkout root',
+  );
+  // Guards the regression in both directions: relativizing the LINK must not
+  // have relativized the #2376 JSON field, which stays absolute by contract.
+  assert.ok(path.isAbsolute(shallow.todos[0].path));
+  assert.ok(path.isAbsolute(deep.todos[0].path));
+});
+
+test('#4398 cmdInitTodos: the bullet links to the todo relative to the project root', (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-4398-'));
+  t.after(() => cleanup(dir));
+  writeTodoFixture(dir);
+
+  const json = runQueryInitTodos(dir);
+  const expectedLink = '[todo file](.planning/todos/pending/2026-09-01-fix-retry-logic.md)';
+  assert.ok(
+    json.pending_todos_markdown.includes(expectedLink),
+    `expected the documented repo-relative link, got: ${json.pending_todos_markdown}`,
+  );
+  // The clause the cap used to eat is now budget-independent, so it survives.
+  assert.match(json.pending_todos_markdown, /Needs Add a max-attempts cap\.$/m);
+});
+
 // ─── workflow parity guard (DEFECT.GENERATIVE-FIX) ─────────────────────────
 
 function extractUpdateStateStep(workflowPath) {


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #4398

---

## What was broken

`next`'s own required check `full test (macos-latest, 24, shard 3/3)` was red at `tests/state-todos-render.test.cjs:196`: the rendered pending-todo bullet silently lost its `Needs ...` clause depending on where the repository happened to be checked out.

## What this fix does

Renders the bullet's `[todo file](…)` link relative to the project root, so the 240-char budget no longer varies with the checkout path. The cap, the needs → title → area drop order, and the absolute `todos[].path` JSON field (#2376) are all unchanged.

## Root cause

`renderPendingTodoBullet` embedded the absolute `todos[].path` verbatim as the link, and the documented degradation ladder never truncates the link — so the length of the absolute base decided which rung the ladder stopped on:

- Linux `/tmp/...` → assembled line ≈ 172 chars → under the cap → clause kept → green
- macOS `/private/var/folders/d8/hvxvltxn0.../T/...` → ≈ 244 chars → over the cap → clause dropped first → red

The ladder itself is correct and is exactly what `gsd-core/templates/state.md` documents. The defect is that it was being fed a machine-dependent input. #4384's own canonical example (`.planning/todos/pending/2026-09-01-fix-retry-logic.md`) and every unit fixture in `state-todos-render.test.cjs` already use the repo-relative form — only the CLI path emitted an absolute one.

The fallback matters and is deliberate: a todo that resolves outside the project root keeps its absolute link. That preserves the existing "link correctness > strict cap" rule already stated in the code — an over-budget bullet is cosmetic, a link pointing somewhere else is a wrong answer.

## Testing

### How I verified the fix

`node --test tests/state-todos-render.test.cjs` → 19/19.

Fail-first, on Linux, by rebuilding against `next`'s `src/init.cts` with the new tests in place:

```
✖ #4398 cmdInitTodos: the rendered bullet is identical from a short and a deep checkout root
✖ #4398 cmdInitTodos: the bullet links to the todo relative to the project root
# pass 17  # fail 2
```

Then with the fix: `# pass 19  # fail 0`.

I also reproduced the original macOS-only failure on Linux before fixing it, by lengthening `TMPDIR` alone — which isolates path length as the single variable:

```
$ TMPDIR=<~120-char root> node --test tests/state-todos-render.test.cjs
AssertionError: The input did not match /Needs Add a max-attempts cap\.$/m
$ node --test tests/state-todos-render.test.cjs
ok
```

`tests/state-todos-render.test.cjs:196` — the test that is red on `next` — now passes unmodified under both a short and a long temp root. It is left exactly as `#4384` wrote it: with the link relativized it guards real behavior instead of the environment, so it needs no relaxing.

### Regression test added?

- [x] Yes — added a test that would have caught this bug

Two, and neither asserts a length. The first renders the same todo from two roots ~120 chars apart and requires byte-identical bullets; the second pins the documented repo-relative link and re-asserts the `Needs` clause. Asserting that the clause survives at *some* path length is what let this through in the first place, so the invariant under test is determinism. Both also assert `todos[].path` is still absolute, so the fix cannot regress #2376 in the other direction.

### Platforms tested

- [x] Linux
- [ ] macOS
- [ ] Windows (including backslash path handling)
- [ ] N/A (not platform-specific)

I do not have a macOS machine; CI's macOS shard is the check that matters here and it is the one this PR is meant to turn green. Windows path handling goes through the existing `toNativePath`/`toPosixPath` seam before `path.relative`, and the absolute-path fallback covers any case where relativizing would escape the root.

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix
- [x] No unnecessary dependencies added

## Breaking changes

The rendered `pending_todos_markdown` link target changes from an absolute path to a project-root-relative one. This is the documented and originally-intended form, and the absolute path remains available in the `todos[].path` JSON field, so no consumer loses information.
