### PR TITLE
fix(#4395): make gsd-debug-session-manager's own gsd-debugger spawn blocking

### DIFF
--- a/agents/gsd-debug-session-manager.md
+++ b/agents/gsd-debug-session-manager.md
@@ -93,12 +93,15 @@ goal: {goal}
 </mode>
 ```
 
+> **Foreground, blocking spawn — #4395.** This call MUST carry `run_in_background: false` — Claude Code backgrounds subagents by default, and only that flag makes the spawn wait for `gsd-debugger` to actually finish before Step 3 inspects its return. Without it, this agent can reach Step 3/Step 4 while its own spawned `gsd-debugger` is still running detached: the manager then returns a summary with no real completion behind it, the orchestrator's `#2257` auto-resume correctly re-spawns a fresh session manager per `debug.md`, and that spawns a SECOND `gsd-debugger` racing the still-live first one on the same debug file — the same blocking requirement `#2196` already established one level up, for the orchestrator's own spawn of this agent.
+
 ```
 Agent(
   prompt=filled_prompt,
   subagent_type="gsd-debugger",
   model="{debugger_model}",
-  description="Debug {slug}"
+  description="Debug {slug}",
+  run_in_background=false
 )
 ```
 
@@ -389,6 +392,7 @@ If the session was abandoned by user choice, return (terminal — user stopped):
 <success_criteria>
 - [ ] Debug file read as first action
 - [ ] Debugger model resolved before every spawn
+- [ ] gsd-debugger spawned with `run_in_background: false` (#4395) — never left running detached across a Step 4 return
 - [ ] Each spawned agent gets fresh context via file path (not inlined content)
 - [ ] User responses wrapped in DATA_START/DATA_END before passing to continuation agents
 - [ ] Specialist dispatch executed when specialist_dispatch_enabled and hint maps to a skill

--- a/tests/debug-session-management.test.cjs
+++ b/tests/debug-session-management.test.cjs
@@ -567,3 +567,48 @@ describe('#3448 debug auto-resume must thread the recorded next_action', () => {
     });
   });
 });
+
+// Tests for #4395: the orchestrator's own spawn of gsd-debug-session-manager
+// carries `run_in_background: false` (#2196), but the manager's OWN Step 2
+// spawn of its internal gsd-debugger sub-agent did not — Claude Code
+// backgrounds subagents by default, so that nested spawn could return before
+// gsd-debugger genuinely finished. The manager then reached Step 3/Step 4 with
+// no real completion behind it, returned a non-terminal summary, the
+// orchestrator's (correctly-behaving) #2257 auto-resume re-spawned a fresh
+// session manager, and THAT spawned a second gsd-debugger — colliding with
+// the still-live first one on the same `.planning/debug/{slug}.md` file.
+// Reported 3x in one /gsd:debug invocation, surfaced only because a peer
+// agent self-reported the write collision.
+//
+// The fix adds the same `run_in_background: false` requirement to the
+// manager's Step 2 spawn that #2196 already established for the
+// orchestrator's spawn of the manager one level up, so gsd-debugger can never
+// be left running detached across a Step 3/Step 4 return.
+describe('#4395 gsd-debug-session-manager gsd-debugger spawn must be blocking', () => {
+  const SESSION_MANAGER_MD_4395 = path.join(__dirname, '..', 'agents', 'gsd-debug-session-manager.md');
+  // allow-test-rule: source-text-is-the-product (#4395)
+  // agent prose IS the runtime contract under test
+  const managerContent4395 = fs.readFileSync(SESSION_MANAGER_MD_4395, 'utf-8');
+
+  const step2Start4395 = managerContent4395.indexOf('## Step 2: Spawn gsd-debugger Agent');
+  const step3Start4395 = managerContent4395.indexOf('## Step 3: Handle Agent Return');
+  const step2Section4395 = step2Start4395 !== -1 && step3Start4395 !== -1
+    ? managerContent4395.slice(step2Start4395, step3Start4395)
+    : '';
+
+  test('Step 2 exists', () => {
+    assert.notEqual(step2Start4395, -1, 'gsd-debug-session-manager.md must contain Step 2');
+  });
+
+  test('the gsd-debugger Agent() spawn carries run_in_background: false', () => {
+    assert.ok(/run_in_background\s*[:=]\s*false/.test(step2Section4395),
+      'Step 2 gsd-debugger spawn must declare run_in_background: false so it is never left running detached');
+  });
+
+  test('Step 2 documents WHY the spawn must be blocking (references the #2196 precedent and the collision failure mode)', () => {
+    assert.ok(/#2196/.test(step2Section4395),
+      'Step 2 must reference #2196 as the precedent for this same blocking requirement one level up');
+    assert.ok(/detached|collid/i.test(step2Section4395),
+      'Step 2 must explain the failure mode this guards against (a detached/colliding second gsd-debugger)');
+  });
+});


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #4395

---

## What was broken

`gsd-debug-session-manager`'s Step 2 spawn of its internal `gsd-debugger` sub-agent did not carry `run_in_background: false`. Claude Code backgrounds subagents by default, so the manager could reach Step 3/Step 4 and return a non-terminal summary while its own spawned `gsd-debugger` was still running detached. The orchestrator's (correctly-behaving) `#2257` auto-resume then re-spawned a fresh session manager, which spawned a second `gsd-debugger` — colliding with the still-live first one on the same `.planning/debug/{slug}.md` file. Reported 3x in one `/gsd:debug` invocation.

## What this fix does

Adds `run_in_background: false` to the Step 2 `Agent()` call in `agents/gsd-debug-session-manager.md`, matching the `#2196` precedent already established one level up for the orchestrator's own spawn of this agent. This makes the manager's spawn of `gsd-debugger` genuinely blocking, so it can never be left running detached across a Step 3/Step 4 return.

## Root cause

`#2196` fixed exactly this class of bug at the orchestrator layer (its spawn of the session manager). The same fix was never applied one level down, at the session manager's own spawn of `gsd-debugger` — an asymmetry between the two nested Agent() calls that this PR closes.

## Testing

### How I verified the fix

Read `gsd-debug-session-manager.md`'s Step 2 spawn and confirmed it was the only `Agent()` call in the file lacking the blocking flag (all Step 3 "continuation agent" spawns reuse the Step 2 format, so this is a single fix point). Ran the full `debug-session-management.test.cjs` suite locally: 52/52 pass.

### Regression test added?

- [x] Yes — added a `#4395` describe block asserting the Step 2 spawn declares `run_in_background: false` and documents the `#2196` precedent + collision failure mode.

### Platforms tested

- [x] Windows (including backslash path handling)
- [ ] macOS
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`) — ran the affected suite directly (52/52 pass); this is a text-only agent-prose change with no code path to affect the wider suite.
- [ ] `.changeset/` fragment added if this is a user-facing fix — this is an internal agent-orchestration prompt fix with no user-facing runtime behavior change to changelog; will add if a maintainer disagrees.
- [x] No unnecessary dependencies added

## Breaking changes

None