### PR TITLE
enhance(#4285): read context-monitor thresholds from .planning/config.json

### DIFF
--- a/.changeset/kind-ibex-greet.md
+++ b/.changeset/kind-ibex-greet.md
@@ -1,5 +1,5 @@
 ---
 type: Added
-pr: 4285
+pr: 4475
 ---
 Context-monitor WARNING/CRITICAL fire-points are now readable from `.planning/config.json` via `hooks.context_warning_threshold` (default 35) and `hooks.context_critical_threshold` (default 25). Both are remaining-context percentages, so warning must sit above critical; a non-numeric, out-of-range or inverted pair is ignored and both defaults apply. Projects that do not set the keys are unaffected.

--- a/.changeset/kind-ibex-greet.md
+++ b/.changeset/kind-ibex-greet.md
@@ -1,0 +1,5 @@
+---
+type: Added
+pr: 4285
+---
+Context-monitor WARNING/CRITICAL fire-points are now readable from `.planning/config.json` via `hooks.context_warning_threshold` (default 35) and `hooks.context_critical_threshold` (default 25). Both are remaining-context percentages, so warning must sit above critical; a non-numeric, out-of-range or inverted pair is ignored and both defaults apply. Projects that do not set the keys are unaffected.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -79,6 +79,8 @@ GSD stores project settings in `.planning/config.json`. Created during `/gsd-new
   },
   "hooks": {
     "context_warnings": true,
+    "context_warning_threshold": 35,
+    "context_critical_threshold": 25,
     "workflow_guard": false
   },
   "statusline": {
@@ -803,6 +805,8 @@ for a worked example.
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
 | `hooks.context_warnings` | boolean | `true` | Show context window usage warnings via context monitor hook |
+| `hooks.context_warning_threshold` | number | `35` | Remaining-context percentage at or below which the context monitor emits CONTEXT WARNING. Must be greater than `hooks.context_critical_threshold`; a non-numeric, out-of-range (outside 0-100) or inverted pair is ignored and both defaults apply (#4285) |
+| `hooks.context_critical_threshold` | number | `25` | Remaining-context percentage at or below which the context monitor escalates to CONTEXT CRITICAL. Must be less than `hooks.context_warning_threshold`; see the note above for how an invalid pair is handled (#4285) |
 | `hooks.workflow_guard` | boolean | `false` | Warn when file edits happen outside GSD workflow context (advises using `/gsd-quick` or `/gsd-fast`). When enabled, the hook's one hard block — `git add -f` on `agent-*`/`worktree-agent-*` branches — also fails closed on internal error (see `docs/explanation/security-model.md`, #3504) |
 | `statusline.show_last_command` | boolean | `false` | Append `last: /<cmd>` suffix to the statusline showing the most recently invoked slash command. Opt-in; reads the active session transcript to extract the latest `<command-name>` tag (closes #2538) |
 | `statusline.context_position` | string | `"end"` | Position of the context-window meter. `"end"` (default) renders at line tail; `"front"` renders immediately after the model name so the meter stays visible in narrow terminals. Closes #2937 |

--- a/docs/context-monitor.md
+++ b/docs/context-monitor.md
@@ -28,6 +28,25 @@ breadcrumb bookkeeping.
 | WARNING | <= 35% | Wrap up current task, avoid starting new complex work |
 | CRITICAL | <= 25% | Stop immediately, save state (`/gsd-pause-work`) |
 
+Both fire-points are configurable per project in `.planning/config.json`. The
+values are *remaining* context percentages, so the warning threshold must sit
+above the critical one:
+
+```json
+{
+  "hooks": {
+    "context_warnings": true,
+    "context_warning_threshold": 35,
+    "context_critical_threshold": 25
+  }
+}
+```
+
+Either key may be omitted, in which case the default above applies. A pair that
+is non-numeric, outside `0`-`100`, or inverted (`warning <= critical`) is
+ignored as a pair and both defaults are used — the hook never blocks the tool
+call it rides in on, so it degrades rather than failing on bad config.
+
 ## Debounce
 
 To avoid spamming the agent with repeated warnings:

--- a/gsd-core/bin/shared/config-defaults.manifest.json
+++ b/gsd-core/bin/shared/config-defaults.manifest.json
@@ -70,6 +70,8 @@
   },
   "hooks": {
     "context_warnings": true,
+    "context_warning_threshold": 35,
+    "context_critical_threshold": 25,
     "workflow_guard": false
   },
   "ship": {

--- a/gsd-core/bin/shared/config-schema.manifest.json
+++ b/gsd-core/bin/shared/config-schema.manifest.json
@@ -76,6 +76,8 @@
     "planner.stall_threshold_minutes",
     "workflow.inline_plan_threshold",
     "hooks.context_warnings",
+    "hooks.context_warning_threshold",
+    "hooks.context_critical_threshold",
     "hooks.workflow_guard",
     "workflow.context_coverage_gate",
     "statusline.show_last_command",

--- a/gsd-core/references/planning-config.md
+++ b/gsd-core/references/planning-config.md
@@ -361,6 +361,8 @@ Set via `hooks.*` namespace (e.g., `"hooks": { "context_warnings": true }`).
 | Key | Type | Default | Allowed Values | Description |
 |-----|------|---------|----------------|-------------|
 | `hooks.context_warnings` | boolean | `true` | `true`, `false` | Show warnings when context budget is exceeded |
+| `hooks.context_warning_threshold` | number | `35` | `0`-`100`, above `context_critical_threshold` | Remaining-context percentage at or below which CONTEXT WARNING fires |
+| `hooks.context_critical_threshold` | number | `25` | `0`-`100`, below `context_warning_threshold` | Remaining-context percentage at or below which CONTEXT CRITICAL fires |
 
 ### Learnings Fields
 

--- a/hooks/gsd-context-monitor.js
+++ b/hooks/gsd-context-monitor.js
@@ -11,9 +11,11 @@
 // 3. When remaining context drops below thresholds, it injects a warning
 //    as additionalContext, which the agent sees in its conversation
 //
-// Thresholds:
+// Thresholds (defaults; both are REMAINING context percentages):
 //   WARNING  (remaining <= 35%): Agent should wrap up current task
 //   CRITICAL (remaining <= 25%): Agent should stop immediately and save state
+// Overridable per project via `hooks.context_warning_threshold` and
+// `hooks.context_critical_threshold` in .planning/config.json (#4285).
 //
 // Debounce: 5 tool uses between warnings to avoid spam
 // Severity escalation bypasses debounce (WARNING -> CRITICAL fires immediately)
@@ -30,10 +32,45 @@ const { HOOK_ON_CRASH, allow, crash } = require('./lib/hook-exit.js');
 // context warning is far cheaper than stalling the agent's work (#3911).
 const ON_CRASH = HOOK_ON_CRASH.ALLOW;
 
-const WARNING_THRESHOLD = 35;  // remaining_percentage <= 35%
-const CRITICAL_THRESHOLD = 25; // remaining_percentage <= 25%
+const DEFAULT_WARNING_THRESHOLD = 35;  // remaining_percentage <= 35%
+const DEFAULT_CRITICAL_THRESHOLD = 25; // remaining_percentage <= 25%
 const STALE_SECONDS = 60;      // ignore metrics older than 60s
 const DEBOUNCE_CALLS = 5;      // min tool uses between warnings
+
+/**
+ * Resolve the two fire-points from the `hooks` block of .planning/config.json (#4285).
+ *
+ * Both keys are REMAINING context percentages -- the same unit the bridge file
+ * reports -- so a valid pair has warning ABOVE critical, not below it.
+ *
+ * A pair that is non-numeric, outside 0-100, or inverted is ignored WHOLESALE
+ * and the defaults stand. Two reasons: this hook must never block the tool call
+ * it rides in on (ON_CRASH above), so it cannot throw on operator config; and a
+ * half-applied pair (custom warning, default critical) is a worse failure than
+ * an ignored one -- it would fire at a boundary nobody asked for.
+ *
+ * @param {object} [hooks] - the `hooks` object from .planning/config.json, if any
+ * @returns {{ warning: number, critical: number }}
+ */
+function resolveThresholds(hooks) {
+  const defaults = {
+    warning: DEFAULT_WARNING_THRESHOLD,
+    critical: DEFAULT_CRITICAL_THRESHOLD,
+  };
+  if (!hooks || typeof hooks !== 'object') return defaults;
+
+  const warning = hooks.context_warning_threshold === undefined
+    ? DEFAULT_WARNING_THRESHOLD
+    : hooks.context_warning_threshold;
+  const critical = hooks.context_critical_threshold === undefined
+    ? DEFAULT_CRITICAL_THRESHOLD
+    : hooks.context_critical_threshold;
+
+  const inRange = v => typeof v === 'number' && Number.isFinite(v) && v >= 0 && v <= 100;
+  if (!inRange(warning) || !inRange(critical) || warning <= critical) return defaults;
+
+  return { warning, critical };
+}
 // How long after a PreCompact readings stay suspect. The watermark records the
 // compaction's START; the compaction keeps running after it, and a statusline
 // render during it stamps the PRE-compaction reading with a CURRENT timestamp
@@ -270,12 +307,16 @@ process.stdin.on('end', () => {
     // Collapsed existsSync+readFileSync into a single read guarded by try/catch
     // (ENOENT or parse error → use defaults, same as old "planningDir absent" branch).
     const cwd = data.cwd || process.cwd();
+    let thresholds = resolveThresholds(null);
     try {
       const configPath = path.join(cwd, '.planning', 'config.json');
       const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
       if (config.hooks?.context_warnings === false) {
         allow(undefined);
       }
+      // #4285: the same read also resolves the two fire-points, so an operator
+      // never has to edit this managed file to move them.
+      thresholds = resolveThresholds(config.hooks);
     } catch (e) {
       // Missing or unparseable config → proceed with defaults (context warnings enabled)
     }
@@ -352,7 +393,7 @@ process.stdin.on('end', () => {
     const usedPct = metrics.used_pct;
 
     // No warning needed
-    if (remaining > WARNING_THRESHOLD) {
+    if (remaining > thresholds.warning) {
       allow(undefined);
     }
 
@@ -389,7 +430,7 @@ process.stdin.on('end', () => {
 
     warnData.callsSinceWarn = (warnData.callsSinceWarn || 0) + 1;
 
-    const isCritical = remaining <= CRITICAL_THRESHOLD;
+    const isCritical = remaining <= thresholds.critical;
     const currentLevel = isCritical ? 'critical' : 'warning';
 
     // Emit immediately on first warning, then debounce subsequent ones

--- a/src/config-loader.cts
+++ b/src/config-loader.cts
@@ -145,6 +145,8 @@ const CONFIG_DEFAULTS = {
   exa_search: _getConfigDefault('exa_search'),
   text_mode: _getNestedConfigDefault('workflow', 'text_mode'),
   compact_content: _getNestedConfigDefault('workflow', 'compact_content'),
+  context_warning_threshold: _getNestedConfigDefault('hooks', 'context_warning_threshold'),
+  context_critical_threshold: _getNestedConfigDefault('hooks', 'context_critical_threshold'),
   sub_repos: _getNestedConfigDefault('planning', 'sub_repos'),
   pr_strict: _getNestedConfigDefault('planning', 'pr_strict'),
   resolve_model_ids: _getConfigDefault('resolve_model_ids'),

--- a/src/config.cts
+++ b/src/config.cts
@@ -372,6 +372,8 @@ function buildNewProjectConfig(userChoices: Record<string, unknown>): Record<str
     },
     hooks: {
       context_warnings: true,
+      context_warning_threshold: 35,
+      context_critical_threshold: 25,
     },
     project_code: null,
     phase_naming: 'sequential',

--- a/src/config.cts
+++ b/src/config.cts
@@ -109,6 +109,11 @@ const SCHEMA_DEFAULTS: Record<string, unknown> = {
   // single source of truth, matching workflow.smart_zone_tokens /
   // planning.pr_strict / workflow.inline_plan_threshold below.
   'workflow.compact_content': CONFIG_DEFAULTS.compact_content,
+  // #4285: context-monitor fire-points, in REMAINING context percent. Derived
+  // from the defaults manifest via CONFIG_DEFAULTS so the manifest stays the
+  // single source of truth, matching workflow.compact_content above.
+  'hooks.context_warning_threshold': CONFIG_DEFAULTS.context_warning_threshold,
+  'hooks.context_critical_threshold': CONFIG_DEFAULTS.context_critical_threshold,
   // Derived from the defaults manifest rather than restated, so the manifest
   // stays the single source of truth for the smart-zone budget (#2630).
   'workflow.smart_zone_tokens': CONFIG_DEFAULTS.smart_zone_tokens,

--- a/tests/config-field-docs.test.cjs
+++ b/tests/config-field-docs.test.cjs
@@ -102,6 +102,8 @@ describe('config-field-docs', () => {
       api_coverage_gate: 'workflow.api_coverage_gate',
       text_mode: 'workflow.text_mode',
       compact_content: 'workflow.compact_content',
+      context_warning_threshold: 'hooks.context_warning_threshold',
+      context_critical_threshold: 'hooks.context_critical_threshold',
       subagent_timeout: 'workflow.subagent_timeout',
       branching_strategy: 'git.branching_strategy',
       phase_branch_template: 'git.phase_branch_template',

--- a/tests/perf-317-context-monitor-fs.test.cjs
+++ b/tests/perf-317-context-monitor-fs.test.cjs
@@ -14,6 +14,7 @@
  *   - #2289 — output-envelope allowlist; side effects still run on silent events
  *   - #1974 — one-time critical-session breadcrumb
  *   - #3709 — PreCompact clears the warn sentinel AND the metrics bridge
+ *   - #4285 — WARNING/CRITICAL thresholds read from .planning/config.json
  * Extend this list when folding in the next one.
  */
 
@@ -2492,4 +2493,115 @@ describe('#3709 round 3: DEBOUNCE_CALLS and STALE_SECONDS at their limits', () =
     }
   });
 
+});
+
+
+// ─── 5. #4285: thresholds configurable via .planning/config.json ─────────────
+
+describe('#4285: context-monitor thresholds read from .planning/config.json', () => {
+  /**
+   * Run the monitor against a project whose `.planning/config.json` holds the
+   * given `hooks` block. Returns the parsed severity, or null when the hook
+   * stayed silent (i.e. `remaining` was above the resolved warning threshold).
+   *
+   * @param {object|null} hooks - the `hooks` block to write, or null to omit config
+   * @param {number} remaining  - remaining_percentage in the bridge file
+   * @returns {'critical'|'warning'|null}
+   */
+  function severityFor(hooks, remaining) {
+    const sessionId = `test-4285-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const testCwd = fs.mkdtempSync(path.join(tmpDir, 'gsd-4285-'));
+    const metricsPath = path.join(tmpDir, `claude-ctx-${sessionId}.json`);
+    const warnPath = path.join(tmpDir, `claude-ctx-${sessionId}-warned.json`);
+
+    if (hooks !== null) {
+      const planningDir = path.join(testCwd, '.planning');
+      fs.mkdirSync(planningDir, { recursive: true });
+      fs.writeFileSync(path.join(planningDir, 'config.json'), JSON.stringify({ hooks }));
+    }
+
+    fs.writeFileSync(metricsPath, JSON.stringify({
+      session_id: sessionId,
+      remaining_percentage: remaining,
+      used_pct: 100 - remaining,
+      timestamp: Math.floor(Date.now() / 1000),
+    }));
+
+    let stdout = '';
+    try {
+      stdout = execFileSync(process.execPath, [MONITOR_PATH], {
+        input: JSON.stringify({ session_id: sessionId, cwd: testCwd, hook_event_name: 'PostToolUse' }),
+        encoding: 'utf-8',
+        timeout: 5000,
+      });
+    } catch (e) {
+      stdout = e.stdout || '';
+    } finally {
+      try { fs.unlinkSync(metricsPath); } catch { /* already absent */ }
+      try { fs.unlinkSync(warnPath); } catch { /* already absent */ }
+      cleanup(testCwd);
+    }
+
+    if (stdout === '') return null;
+    const text = JSON.parse(stdout)?.hookSpecificOutput?.additionalContext ?? '';
+    if (text.includes('CONTEXT CRITICAL')) return 'critical';
+    if (text.includes('CONTEXT WARNING')) return 'warning';
+    return null;
+  }
+
+  test('absent keys keep the shipped 35/25 fire-points', () => {
+    // The compatibility lock: every project without the new keys must behave
+    // exactly as before. 40 is above 35, 30 is between, 20 is below 25.
+    assert.strictEqual(severityFor({ context_warnings: true }, 40), null);
+    assert.strictEqual(severityFor({ context_warnings: true }, 30), 'warning');
+    assert.strictEqual(severityFor({ context_warnings: true }, 20), 'critical');
+  });
+
+  test('a configured warning threshold moves the warning fire-point', () => {
+    // 45 is silent by default (above 35) and must warn once the threshold moves
+    // above it — the assertion the default-only test cannot make.
+    assert.strictEqual(severityFor({ context_warning_threshold: 50 }, 45), 'warning');
+    assert.strictEqual(severityFor({ context_warning_threshold: 50 }, 55), null);
+  });
+
+  test('a configured critical threshold moves the escalation point', () => {
+    // 30 warns by default; raising critical past it must escalate instead.
+    assert.strictEqual(severityFor({ context_critical_threshold: 32 }, 30), 'critical');
+    assert.strictEqual(severityFor({ context_critical_threshold: 32 }, 34), 'warning');
+  });
+
+  test('both keys together are honored', () => {
+    const hooks = { context_warning_threshold: 60, context_critical_threshold: 50 };
+    assert.strictEqual(severityFor(hooks, 65), null);
+    assert.strictEqual(severityFor(hooks, 55), 'warning');
+    assert.strictEqual(severityFor(hooks, 45), 'critical');
+  });
+
+  test('an invalid pair falls back to BOTH defaults, never a half-applied pair', () => {
+    // Each case pins a distinct rejection reason. The probe is remaining=30:
+    // 'warning' proves the 35/25 defaults are in force, because every invalid
+    // pair below would have produced a different verdict had it been applied.
+    const invalid = [
+      { context_warning_threshold: 'thirty', label: 'non-numeric' },
+      { context_warning_threshold: 150, label: 'above 100' },
+      { context_critical_threshold: -5, label: 'below 0' },
+      { context_warning_threshold: 20, context_critical_threshold: 40, label: 'inverted' },
+      { context_warning_threshold: 25, context_critical_threshold: 25, label: 'equal' },
+      { context_warning_threshold: NaN, label: 'NaN (arrives as null through JSON)' },
+      // Half-applied risk: a valid critical beside an invalid warning must not
+      // be adopted on its own — 40 would escalate at remaining=30 if it were.
+      { context_warning_threshold: null, context_critical_threshold: 40, label: 'one invalid, one valid' },
+    ];
+    for (const { label, ...hooks } of invalid) {
+      assert.strictEqual(severityFor(hooks, 30), 'warning', `${label} must fall back to 35/25`);
+    }
+  });
+
+  test('context_warnings=false still wins over configured thresholds', () => {
+    // The off switch is evaluated before the thresholds are resolved.
+    assert.strictEqual(
+      severityFor({ context_warnings: false, context_warning_threshold: 90 }, 80),
+      null,
+    );
+  });
 });


### PR DESCRIPTION

## Enhancement PR

> **Using the wrong template?**
> — Bug fix: use [fix.md](?template=fix.md)
> — New feature: use [feature.md](?template=feature.md)

---

## Linked Issue

Closes #4285

---

## What this enhancement improves

`hooks/gsd-context-monitor.js` — the managed `PostToolUse` hook that injects CONTEXT WARNING / CONTEXT CRITICAL. Its two fire-points become readable from `.planning/config.json`.

## Before / After

**Before:** the fire-points are module constants.

```js
const WARNING_THRESHOLD = 35;  // remaining_percentage <= 35%
const CRITICAL_THRESHOLD = 25; // remaining_percentage <= 25%
```

The hook already reads `.planning/config.json`, but the only key it honors there is `hooks.context_warnings`, an on/off boolean. So an operator who wants to be warned earlier or later has two options: accept 35/25, or turn the warnings off entirely. Editing the hook is not a third — it is in the MANAGED array in `hooks/managed-hooks-registry.cjs`, so the next update re-stages the vendored body and the edit is silently gone.

**After:** the same config read resolves two optional numeric keys.

```json
{
  "hooks": {
    "context_warnings": true,
    "context_warning_threshold": 35,
    "context_critical_threshold": 25
  }
}
```

Absent keys resolve to today's 35/25, so every existing project behaves identically.

## How it was implemented

- `hooks/gsd-context-monitor.js` — `WARNING_THRESHOLD` / `CRITICAL_THRESHOLD` become `DEFAULT_*`, and a new `resolveThresholds(hooks)` resolves the pair. The existing `.planning/config.json` read calls it; the two comparison sites use the resolved values. No second file read, no new I/O on the hot path.
- Validation: both keys are *remaining* context percentages — the unit the statusline bridge reports — so a valid pair has warning **above** critical. A pair that is non-numeric, outside 0–100, or inverted is ignored **wholesale** and both defaults stand. Two reasons: the hook's `ON_CRASH = ALLOW` contract (#3911) means it must not throw on operator config; and a half-applied pair (custom warning, default critical) would fire at a boundary nobody asked for, which is a worse failure than an ignored one.
- The defaults are wired the same way `workflow.compact_content` was in #4441: `gsd-core/bin/shared/config-defaults.manifest.json` holds the two numbers as the single source of truth, `CONFIG_DEFAULTS` (`src/config-loader.cts`) derives them via `_getNestedConfigDefault`, and `SCHEMA_DEFAULTS` (`src/config.cts`) derives from `CONFIG_DEFAULTS` rather than restating literals.
- `gsd-core/bin/shared/config-schema.manifest.json` — both keys registered as valid, so `/gsd-settings` does not report them as unknown.
- `tests/config-field-docs.test.cjs` — `NAMESPACE_MAP` entries for the two flat `CONFIG_DEFAULTS` keys; without them that test looks for a bare `context_warning_threshold` doc row and fails.
- Docs: `docs/context-monitor.md`, `docs/CONFIGURATION.md`, `gsd-core/references/planning-config.md`.

The hook keeps its own `DEFAULT_*` constants rather than importing them: it runs standalone on every `PostToolUse` and must not depend on the compiled lib being built.

`context_warnings: false` is still evaluated before the thresholds are resolved, so the off switch keeps winning.

## Testing

### How I verified the enhancement works

Six tests folded into `tests/perf-317-context-monitor-fs.test.cjs`, which that file's own header names as the home for context-monitor behavior. They drive the real hook as a child process against a temp project, the same shape as the existing config tests there:

- absent keys keep 35/25 — the compatibility lock (silent at 40, warning at 30, critical at 20)
- a configured warning threshold moves the warning fire-point (45 is silent by default; warns at `context_warning_threshold: 50`)
- a configured critical threshold moves the escalation point (30 warns by default; escalates at `context_critical_threshold: 32`)
- both keys together
- every invalid shape falls back to **both** defaults — non-numeric, >100, <0, inverted, equal, NaN, and the half-applied case where one key is valid and the other is not
- `context_warnings: false` still wins over a configured threshold

`node --test tests/perf-317-context-monitor-fs.test.cjs tests/config-field-docs.test.cjs tests/config.test.cjs` → **344 pass / 0 fail**.

Full `npm test`: **PENDING**. Every failure it reports is pre-existing — each one reproduces by the same test name on the unmodified base commit `03c770be4`, verified by running those files in a clean worktree of that commit. They are environmental under my sandbox (PATH resolution, `os.tmpdir()`, and network): `getGlobalConfigDir (CodeBuddy)`, `getGlobalConfigDir (Windsurf)`, `quick-batch: /gsd:quick command + workflow stay byte-identical`, `differential attribution over the real tree`, `chain resolves with the real execPath under a minimal PATH`, `#3662 runtime-resolving managed hook runners`, `cleanup throws and does not chdir or delete when target is outside os.tmpdir()`.

`npm run lint:ci` is clean apart from `lint-workflow-shellcheck`, which cannot download ShellCheck in my sandbox (`getaddrinfo ENOTFOUND github.com`). Also verified pre-existing — it exits 1 identically on the unmodified base, and this PR touches no shell scripts.

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [x] Other: verified by driving the hook directly as a child process with a `PostToolUse` payload, not from inside a live host session. The change is in the hook's config resolution, which is host-independent, but I have not exercised it end-to-end under any runtime and did not want to tick a box I had not earned.
- [ ] N/A (not runtime-specific)

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue — no additions or removals
- [x] If scope changed during implementation, I updated the issue and got re-approval before continuing

Two notes on the file list, both same-scope: the issue cites paths and line numbers from `main`, which on `next` are `src/config.cts` (`bin/lib/config.cjs` is its build output) and `gsd-core/bin/shared/config-schema.manifest.json`. And the issue lists the four translated copies of `docs/context-monitor.md`; I left those in their current language, matching #4441, which documented its key in `docs/CONFIGURATION.md` and `gsd-core/references/planning-config.md` only.

---

## Documentation

- [x] Updated the relevant file(s) under `docs/` to reflect this change
- [x] All `docs/` content added in this PR is written in English
- [ ] If genuinely no user-facing docs impact (infrastructure / internal refactor / test-only), apply the `no-docs` label **or** add `<!-- docs-exempt: <reason> -->` inside each triggering changeset fragment and leave a comment explaining why.

## Checklist

- [x] Issue linked above with `Closes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `approved-enhancement` label — **PR will be closed if missing**
- [x] Changes are scoped to the approved enhancement — nothing extra included
- [x] All existing tests pass (`npm test`) — with the pre-existing, base-reproducing failures disclosed above
- [x] New or updated tests cover the enhanced behavior
- [x] `.changeset/` fragment added (`npm run changeset -- --type Added --pr <NNN> --body "..."`) — the `pr` field carries the issue number and is backfilled to the real PR number in a follow-up commit, per the #4441 precedent
- [x] No unnecessary dependencies added

## Breaking changes

None. Both keys are optional and absent config resolves to the current 35/25, so every existing project behaves identically after upgrading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
