### PR TITLE
fix(#4257): harvest only prose phase references; W002 names its workstream scope

### DIFF
--- a/.changeset/witty-ravens-fly.md
+++ b/.changeset/witty-ravens-fly.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**W002 no longer fires on quoted commands in STATE.md** — the health check read GSD's own command names (like ``/gsd-execute-phase 5`` in a ledger row) and anything inside backticks as phase references, so healthy multi-workstream projects reported degraded with false warnings; under an active workstream the warning now also says its declared-phase list is workstream-scoped (`... are declared in workstream <name>`) instead of making an unqualified project-wide claim. (#4257)

--- a/.changeset/witty-ravens-fly.md
+++ b/.changeset/witty-ravens-fly.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 4486
 ---
 **W002 no longer fires on quoted commands in STATE.md** — the health check read GSD's own command names (like ``/gsd-execute-phase 5`` in a ledger row) and anything inside backticks as phase references, so healthy multi-workstream projects reported degraded with false warnings; under an active workstream the warning now also says its declared-phase list is workstream-scoped (`... are declared in workstream <name>`) instead of making an unqualified project-wide claim. (#4257)

--- a/src/health-diagnostic-rules/state-consistency.cts
+++ b/src/health-diagnostic-rules/state-consistency.cts
@@ -175,6 +175,17 @@ const RULE_W002: Rule = {
     );
 
     const diagnostics: Diagnostic[] = [];
+    // #4257: the valid set above is WORKSTREAM-scoped by construction (every
+    // source field is read from `planningPaths(cwd)`'s base, which resolves
+    // under `.planning/workstreams/<active-ws>/`), and per-workstream phase
+    // numbering is deliberate — so under a workstream the message must NAME
+    // that scope rather than make an unqualified project-wide claim (a
+    // reference to a phase declared only in a SIBLING workstream reads as
+    // "undeclared" against this list; that is the scope speaking, not drift).
+    // Root scope (`workstream === null`, flat or root-planning projects)
+    // keeps the byte-identical message — no clause is appended when none
+    // applies.
+    const scopeClause = snapshot.workstream ? ` in workstream ${snapshot.workstream}` : '';
     for (const ref of snapshot.statePhaseTokens.value) {
       const dotIdx = ref.indexOf('.');
       const head = dotIdx === -1 ? ref : ref.slice(0, dotIdx);
@@ -184,7 +195,7 @@ const RULE_W002: Rule = {
       diagnostics.push({
         code: 'W002',
         severity: SEVERITY.WARNING,
-        message: `STATE.md references phase ${ref}, but only phases ${sortedValid.join(', ')} are declared`,
+        message: `STATE.md references phase ${ref}, but only phases ${sortedValid.join(', ')} are declared${scopeClause}`,
         remedy: adviseRemedy(
           'Review STATE.md manually before changing it; /gsd-health --repair will not overwrite an existing STATE.md for phase mismatches',
         ),

--- a/src/planning-snapshot.cts
+++ b/src/planning-snapshot.cts
@@ -38,7 +38,15 @@ import planningWorkspace = require('./planning-workspace.cjs');
 // `phase_id_convention` reader, from the same §7 owner module `planningPaths`
 // comes from. Resolved once in `buildPlanningSnapshot` — see the
 // `phaseIdConvention` field's comment for why one resolution point matters.
-const { planningPaths, planningRoot, resolvePhaseIdConvention } = planningWorkspace;
+// #4257: `resolveEnvWorkstream` is that same module's ONE owner of the env
+// workstream discriminator `planningDir` applies — the name W002's scope
+// clause prints comes from the same resolution point that scoped the reads.
+const { planningPaths, planningRoot, resolvePhaseIdConvention, resolveEnvWorkstream } = planningWorkspace;
+// #4257: canonical CommonMark code strippers (markdown-sectionizer is the
+// repo's T0 structural seam, adopted per the #2365 composition order — fenced
+// blocks first, then inline spans) so the `statePhaseTokens` harvest sees
+// PROSE, not quoted literals.
+import { stripFencedCode, stripInlineCode } from './markdown-sectionizer.cjs';
 import { platformReadSync, execGit } from './shell-command-projection.cjs';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import frontmatterMod = require('./frontmatter.cjs');
@@ -278,6 +286,18 @@ interface PlanningSnapshot {
   // for it at all, so a check that can fail a repo runs only for the convention
   // that repo opted into.
   roadmapBracketIncoherences: { value: BracketIncoherence[]; scope: Scope };
+  // ─── #4257 addition ────────────────────────────────────────────────────────
+  // The name of the workstream every workstream-aware read in THIS snapshot
+  // was scoped to, `null` on a flat/root-scope project. Derived from
+  // `resolveEnvWorkstream()` — the ONE env discriminator `planningDir`
+  // itself applies when `planningPaths(cwd)` resolves the base — so the
+  // field cannot disagree with the base the fields were actually read from
+  // (one resolution point; the #612 PR-2 two-readers-two-bases lesson).
+  // Additive-only in the `archivedPhaseTokens` (#3652) shape; backs W002's
+  // scope clause (`... are declared in workstream <name>`), which names the
+  // scope because per-workstream phase numbering is deliberate and a
+  // cross-workstream "declared" union would silence genuine drift.
+  workstream: string | null;
 }
 
 /**
@@ -346,9 +366,11 @@ interface StateFields {
  *   a whole-body fallback, together.
  * - `statePhaseTokens` scans the WHOLE document (`verify.cts`'s exact
  *   `PHASE_NUMBER_TOKEN_SOURCE` regex, relocated verbatim from
- *   `verify.cts:1731-1735`), not just the Current Position section, so it is
- *   NOT degraded to `TRUNCATED` by a missing section header — it stays
- *   `COMPLETE` whenever the file itself was read successfully.
+ *   `verify.cts:1731-1735`; #4257 adds the left word boundary and the
+ *   fenced-block/inline-span strip — see the harvest site's comment), not
+ *   just the Current Position section, so it is NOT degraded to `TRUNCATED`
+ *   by a missing section header — it stays `COMPLETE` whenever the file
+ *   itself was read successfully.
  */
 function buildStateFields(statePath: string): StateFields {
   let content: string | null;
@@ -411,9 +433,32 @@ function buildStateFields(statePath: string): StateFields {
     scope: currentPositionScope,
   });
   const statePhaseTokens = {
-    value: [...content.matchAll(new RegExp(`[Pp]hase\\s+(${PHASE_NUMBER_TOKEN_SOURCE})`, 'g'))].map(
-      (m) => m[1],
-    ),
+    // #4257: harvest PROSE phase references, not every literal token match.
+    // Two precisions over the pre-#4257 verbatim relocation of verify.cts's
+    // scan (which was `[Pp]hase\s+(TOKEN)`, unanchored, over the raw file):
+    //
+    // 1. Strip fenced code blocks, then inline code spans (the #2365
+    //    composition order, via the canonical markdown-sectionizer seam) —
+    //    a token inside backticks is a QUOTED LITERAL (a ledger row quoting
+    //    `` `/gsd-execute-phase 5` `` or `` `- [ ] **Phase 40:` `` from a
+    //    sibling roadmap), not a reference. Pinned tradeoff: a GENUINE
+    //    reference written in backticks stops counting too — a quoted
+    //    literal and a reference are indistinguishable inside a code span.
+    // 2. Left word boundary `(?<![-\w])` — the `-phase 5` tail of GSD's own
+    //    command names (`/gsd-execute-phase 5`, bare or in prose) is a
+    //    command mention, not a reference, and word-suffixed carriers
+    //    (`myphase 5`) never were references. `Phase 5` at line start,
+    //    `**Phase 5:**`, `(Phase 5)`, `[Phase 5]`, and `### Phase 5:` all
+    //    still harvest — the char before `Phase` is not in `[-\w]`.
+    //
+    // Still scans the WHOLE document (frontmatter included — the `Phase: 3`
+    // field syntax never matched, `phase` is followed by a colon, not `\s`),
+    // still `COMPLETE` whenever the file itself was read successfully.
+    value: [
+      ...stripInlineCode(stripFencedCode(content).text).matchAll(
+        new RegExp(`(?<![-\\w])[Pp]hase\\s+(${PHASE_NUMBER_TOKEN_SOURCE})`, 'g'),
+      ),
+    ].map((m) => m[1]),
     scope: SCOPE.COMPLETE,
   };
 
@@ -1207,6 +1252,11 @@ function buildPlanningSnapshot(cwd: string): PlanningSnapshot {
   // See the `phaseIdConvention` field's comment for why one resolution point is
   // load-bearing rather than a micro-optimisation.
   const phaseIdConvention = resolvePhaseIdConvention(cwd) ?? null;
+  // #4257: the workstream `planningPaths(cwd)` just scoped every read to
+  // (its `planningDir` call applies this exact discriminator when handed no
+  // `ws`), resolved through the same owner so W002's scope clause names the
+  // scope the valid set was ACTUALLY built from.
+  const workstream = resolveEnvWorkstream();
   const milestone = getMilestoneInfo(cwd);
   // #612: deliberately LEFT to `listMilestonePhaseDirs`'s own lazy resolve —
   // this call is byte-identical to upstream's.
@@ -1263,6 +1313,7 @@ function buildPlanningSnapshot(cwd: string): PlanningSnapshot {
     phaseIdConvention,
     roadmapSentinelPhaseTokens: roadmapDeclared.sentinelTokens,
     roadmapBracketIncoherences: buildRoadmapBracketIncoherencesField(paths.roadmap, phaseIdConvention),
+    workstream,
   };
 }
 

--- a/src/planning-workspace.cts
+++ b/src/planning-workspace.cts
@@ -125,9 +125,26 @@ const PLANNING_LOCK_RETRY_ERRNOS = new Set([
 // compatible with the structural type the store expects.
 type WorkstreamAdapterOpts = Record<string, unknown>;
 
+/**
+ * #4257: the ONE owner of the env workstream discriminator `planningDir`
+ * itself applies when handed no `ws` argument. `planningPaths(cwd)` — and
+ * therefore every workstream-scoped `PlanningSnapshot` read — resolves its
+ * base through exactly this read, and the CLI bootstrap has already folded
+ * the stored active-workstream pointer into the env by the time any
+ * diagnostic runs (`resolveActiveWorkstream` → `applyResolvedWorkstreamEnv`,
+ * `active-workstream-store.cjs`). Exposed so a consumer that needs to NAME
+ * the scope those reads used (W002's warning message, via the snapshot's
+ * `workstream` field) derives it from the same resolution point instead of
+ * growing a second env read site that can drift (the #612 PR-2
+ * two-readers-two-bases lesson).
+ */
+function resolveEnvWorkstream(): string | null {
+  return process.env['GSD_WORKSTREAM'] ?? null;
+}
+
 function planningDir(cwd: string, ws?: string | null, project?: string | null): string {
   if (project === undefined) project = process.env['GSD_PROJECT'] ?? null;
-  if (ws === undefined) ws = process.env['GSD_WORKSTREAM'] ?? null;
+  if (ws === undefined) ws = resolveEnvWorkstream();
 
   // Reject path separators and traversal components in project/workstream names
   const BAD_SEGMENT = /[/\\]|\.\./;
@@ -667,6 +684,7 @@ export = {
   createMemoryPointerAdapter,
   planningDir,
   planningRoot,
+  resolveEnvWorkstream,
   resolvePhaseIdConvention,
   listAvailableWorkstreams,
   planningPaths,

--- a/tests/health-diagnostic-rules/state-consistency.test.cjs
+++ b/tests/health-diagnostic-rules/state-consistency.test.cjs
@@ -329,7 +329,11 @@ describe('W002 — STATE.md references a phase not declared on disk or ROADMAP',
         '',
         '## Ledger',
         '',
-        '- `- [ ] **Phase 40:** quoted from the beta roadmap',
+        // Closed code span (matching the A3 snapshot-level twin and the
+        // 50-test-matrix.md B2 row). An UNTERMINATED backtick run is literal
+        // text per CommonMark, so its content is prose and W002 SHOULD fire
+        // on it — not the fixture this row pins.
+        '- `- [ ] **Phase 40:** quoted from the beta roadmap`',
         '',
       ].join('\n'),
     );

--- a/tests/health-diagnostic-rules/state-consistency.test.cjs
+++ b/tests/health-diagnostic-rules/state-consistency.test.cjs
@@ -152,7 +152,9 @@ describe('W002 — STATE.md references a phase not declared on disk or ROADMAP',
     assert.equal(diagnostics.length, 1);
     assert.equal(diagnostics[0].code, 'W002');
     assert.equal(diagnostics[0].severity, SEVERITY.WARNING);
-    assert.match(diagnostics[0].message, /STATE\.md references phase 9, but only phases .* are declared/);
+    // #4257: root scope (no active workstream) keeps the BYTE-IDENTICAL
+    // message grammar — no scope clause is appended when none applies.
+    assert.match(diagnostics[0].message, /STATE\.md references phase 9, but only phases .* are declared$/);
     assert.deepEqual(diagnostics[0].remedy, {
       action: REMEDY_ACTION.ADVISE,
       risk: REMEDY_RISK.NONE,
@@ -239,6 +241,133 @@ describe('W002 — STATE.md references a phase not declared on disk or ROADMAP',
     const snapshot = buildPlanningSnapshot(cwd);
     const diagnostics = ruleFor('W002').check(snapshot);
     assert.deepEqual(diagnostics, []);
+  });
+
+  // ─── #4257: command mentions are not phase references; the warning names ──
+  // ─── its workstream scope ─────────────────────────────────────────────────
+  //
+  // Fixture shape: the issue's own repro — active workstream `alpha` declares
+  // phases 1-2, sibling `beta` declares phase 5, and alpha's STATE.md carries
+  // a Queue/Ledger row mentioning the phase via a GSD command name or a quoted
+  // roadmap line. GSD_WORKSTREAM is set directly (save/restore per
+  // tests/health-diagnostic.test.cjs:598-602) — the same discriminator
+  // planningDir applies and the CLI bootstrap folds the stored pointer into.
+  function withWorkstreamEnv(t, name) {
+    const prev = process.env['GSD_WORKSTREAM'];
+    if (name === null) delete process.env['GSD_WORKSTREAM'];
+    else process.env['GSD_WORKSTREAM'] = name;
+    t.after(() => {
+      if (prev === undefined) delete process.env['GSD_WORKSTREAM'];
+      else process.env['GSD_WORKSTREAM'] = prev;
+    });
+  }
+
+  function makeTwoWorkstreamFixture(cwd, stateQueueLine) {
+    writeFile(cwd, '.planning/config.json', '{}');
+    writeFile(
+      cwd,
+      '.planning/workstreams/alpha/ROADMAP.md',
+      '## v1.0 Current 🚧\n\n### Phase 1: One\n\n### Phase 2: Two\n',
+    );
+    writeFile(
+      cwd,
+      '.planning/workstreams/beta/ROADMAP.md',
+      '## v1.0 Current 🚧\n\n### Phase 5: Five\n',
+    );
+    writeFile(
+      cwd,
+      '.planning/workstreams/alpha/STATE.md',
+      [
+        '---',
+        'status: planning',
+        '---',
+        '',
+        '## Current Position',
+        '',
+        'Phase: 1 of 2 (One)',
+        'Status: planning',
+        '',
+        '## Queue',
+        '',
+        `- ${stateQueueLine}`,
+        '',
+      ].join('\n'),
+    );
+  }
+
+  test('#4257 row 1 (regression): `/gsd-execute-phase 5` in a Queue row is a command mention, not a phase reference — no W002 even though 5 is only declared in a sibling workstream', (t) => {
+    const cwd = createTempDir('gsd-4257-w002-1-');
+    t.after(() => cleanup(cwd));
+    makeTwoWorkstreamFixture(cwd, '`/gsd-execute-phase 5`');
+    withWorkstreamEnv(t, 'alpha');
+
+    const snapshot = buildPlanningSnapshot(cwd);
+    assert.deepEqual(ruleFor('W002').check(snapshot), []);
+  });
+
+  test('#4257: a quoted roadmap line `- [ ] **Phase 40:**` in a code span is a quoted literal, not a reference — no W002', (t) => {
+    const cwd = createTempDir('gsd-4257-w002-2-');
+    t.after(() => cleanup(cwd));
+    writeFile(cwd, '.planning/config.json', '{}');
+    writeFile(
+      cwd,
+      '.planning/workstreams/alpha/ROADMAP.md',
+      '## v1.0 Current 🚧\n\n### Phase 1: One\n\n### Phase 2: Two\n',
+    );
+    writeFile(
+      cwd,
+      '.planning/workstreams/beta/ROADMAP.md',
+      '## v1.0 Current 🚧\n\n### Phase 40: Forty\n',
+    );
+    writeFile(
+      cwd,
+      '.planning/workstreams/alpha/STATE.md',
+      [
+        '---',
+        'status: planning',
+        '---',
+        '',
+        '## Ledger',
+        '',
+        '- `- [ ] **Phase 40:** quoted from the beta roadmap',
+        '',
+      ].join('\n'),
+    );
+    withWorkstreamEnv(t, 'alpha');
+
+    const snapshot = buildPlanningSnapshot(cwd);
+    assert.deepEqual(ruleFor('W002').check(snapshot), []);
+  });
+
+  test('#4257: a GENUINE undeclared prose reference still warns under a workstream, and the warning names its scope', (t) => {
+    const cwd = createTempDir('gsd-4257-w002-3-');
+    t.after(() => cleanup(cwd));
+    makeTwoWorkstreamFixture(cwd, 'Phase 5 wrap-up blocked on beta');
+    withWorkstreamEnv(t, 'alpha');
+
+    const snapshot = buildPlanningSnapshot(cwd);
+    const diagnostics = ruleFor('W002').check(snapshot);
+
+    assert.equal(diagnostics.length, 1);
+    assert.equal(diagnostics[0].code, 'W002');
+    // The valid set is workstream-scoped BY DESIGN (planningPaths under
+    // GSD_WORKSTREAM); the message must say so — phase 5 IS declared, in
+    // sibling `beta`, and the unqualified form read as a false project-wide
+    // claim (#4257 sub-defect 2).
+    assert.equal(
+      diagnostics[0].message,
+      'STATE.md references phase 5, but only phases 1, 2 are declared in workstream alpha',
+    );
+  });
+
+  test('#4257: a command mention naming a DECLARED phase stays silent (no false negative introduced either)', (t) => {
+    const cwd = createTempDir('gsd-4257-w002-4-');
+    t.after(() => cleanup(cwd));
+    makeTwoWorkstreamFixture(cwd, '`/gsd-execute-phase 2`');
+    withWorkstreamEnv(t, 'alpha');
+
+    const snapshot = buildPlanningSnapshot(cwd);
+    assert.deepEqual(ruleFor('W002').check(snapshot), []);
   });
 });
 

--- a/tests/planning-snapshot.test.cjs
+++ b/tests/planning-snapshot.test.cjs
@@ -813,6 +813,248 @@ describe('statePhaseTokens field (Phase 11, #3309)', () => {
     assert.deepStrictEqual(snap.currentPhaseLabel, { value: null, scope: SCOPE.UNREADABLE });
     assert.strictEqual(emitted, 1, 'the shared STATE.md read must not double-emit across fields');
   });
+
+  // ─── #4257: harvest precision — a command MENTION is not a phase REFERENCE ──
+  //
+  // The pre-#4257 scan (`[Pp]hase\s+(TOKEN)`, unanchored, over the raw file)
+  // harvested the `-phase 5` tail of GSD's own command names and any token
+  // inside an inline code span / fenced block, so a ledger row quoting
+  // `/gsd-execute-phase 5` fired W002 as an undeclared-phase reference. The
+  // #4257 grammar: strip fenced blocks, then inline spans (the canonical
+  // markdown-sectionizer seam + composition order, #2365), THEN match with a
+  // left word boundary `(?<![-\w])` so a hyphen- or word-suffixed carrier
+  // (`execute-phase`, `myphase`) is not a reference while `Phase 5`,
+  // `**Phase 5:**`, `(Phase 5)` still are.
+  test('#4257 row 1 (regression): `/gsd-execute-phase 5` in a Queue ledger row inside an inline code span is NOT harvested', (t) => {
+    const cwd = createTempDir('gsd-4257-spt1-');
+    t.after(() => cleanup(cwd));
+    writeState(cwd, { milestone: 'v1.0' });
+    appendToState(cwd, [
+      '',
+      '## Current Position',
+      '',
+      'Phase: 1 of 2',
+      '',
+      '## Queue',
+      '',
+      '- `/gsd-execute-phase 5`',
+      '',
+    ].join('\n'));
+
+    const snap = buildPlanningSnapshot(cwd);
+    assert.deepStrictEqual(snap.statePhaseTokens, { value: [], scope: SCOPE.COMPLETE });
+  });
+
+  test('#4257: a bare `/gsd-execute-phase 5` command mention (no backticks) is NOT harvested — left word boundary', (t) => {
+    const cwd = createTempDir('gsd-4257-spt2-');
+    t.after(() => cleanup(cwd));
+    writeState(cwd, { milestone: 'v1.0' });
+    appendToState(cwd, [
+      '',
+      '## Queue',
+      '',
+      '- Run /gsd-execute-phase 5 when the ledger clears',
+      '',
+    ].join('\n'));
+
+    const snap = buildPlanningSnapshot(cwd);
+    assert.deepStrictEqual(snap.statePhaseTokens, { value: [], scope: SCOPE.COMPLETE });
+  });
+
+  test('#4257: a quoted roadmap line `- [ ] **Phase 40:**` inside an inline code span is NOT harvested', (t) => {
+    const cwd = createTempDir('gsd-4257-spt3-');
+    t.after(() => cleanup(cwd));
+    writeState(cwd, { milestone: 'v1.0' });
+    appendToState(cwd, [
+      '',
+      '## Ledger',
+      '',
+      '- `- [ ] **Phase 40:** quoted from a sibling workstream roadmap`',
+      '',
+    ].join('\n'));
+
+    const snap = buildPlanningSnapshot(cwd);
+    assert.deepStrictEqual(snap.statePhaseTokens, { value: [], scope: SCOPE.COMPLETE });
+  });
+
+  test('#4257: a `Phase 9` mention inside a fenced code block is NOT harvested', (t) => {
+    const cwd = createTempDir('gsd-4257-spt4-');
+    t.after(() => cleanup(cwd));
+    writeState(cwd, { milestone: 'v1.0' });
+    appendToState(cwd, [
+      '',
+      '## Notes',
+      '',
+      '```',
+      'Phase 9 was quoted here verbatim',
+      '```',
+      '',
+    ].join('\n'));
+
+    const snap = buildPlanningSnapshot(cwd);
+    assert.deepStrictEqual(snap.statePhaseTokens, { value: [], scope: SCOPE.COMPLETE });
+  });
+
+  test('#4257 tradeoff (pinned by the issue): a GENUINE reference written in backticks stops counting', (t) => {
+    const cwd = createTempDir('gsd-4257-spt5-');
+    t.after(() => cleanup(cwd));
+    writeState(cwd, { milestone: 'v1.0' });
+    appendToState(cwd, [
+      '',
+      '## Decisions',
+      '',
+      '- see `Phase 5` notes for the rationale',
+      '',
+    ].join('\n'));
+
+    const snap = buildPlanningSnapshot(cwd);
+    assert.deepStrictEqual(snap.statePhaseTokens, { value: [], scope: SCOPE.COMPLETE });
+  });
+
+  test('#4257: word-suffixed carriers (myphase 5, alphaphase 3) are NOT harvested — boundary covers non-command suffixes too', (t) => {
+    const cwd = createTempDir('gsd-4257-spt6-');
+    t.after(() => cleanup(cwd));
+    writeState(cwd, { milestone: 'v1.0' });
+    appendToState(cwd, [
+      '',
+      '## Decisions',
+      '',
+      '- myphase 5 and alphaphase 3 are words, not references',
+      '',
+    ].join('\n'));
+
+    const snap = buildPlanningSnapshot(cwd);
+    assert.deepStrictEqual(snap.statePhaseTokens, { value: [], scope: SCOPE.COMPLETE });
+  });
+
+  test('#4257 mixed form: prose reference survives while command mention and quoted literal are dropped from the same file', (t) => {
+    const cwd = createTempDir('gsd-4257-spt7-');
+    t.after(() => cleanup(cwd));
+    writeState(cwd, { milestone: 'v1.0' });
+    appendToState(cwd, [
+      '',
+      '## Current Position',
+      '',
+      'Phase: 1 of 2',
+      '',
+      '## Queue',
+      '',
+      '- `/gsd-execute-phase 9` once Phase 5 wraps (see `Phase 12` notes)',
+      '',
+    ].join('\n'));
+
+    const snap = buildPlanningSnapshot(cwd);
+    assert.deepStrictEqual(snap.statePhaseTokens, { value: ['5'], scope: SCOPE.COMPLETE });
+  });
+
+  // KEEP rows — the #4257 boundary must NOT narrow legitimate references.
+  test('#4257 keep: bold `**Phase 5:**` and parenthesised `(Phase 5)` and heading `### Phase 5:` forms still harvest', (t) => {
+    const cwd = createTempDir('gsd-4257-spt8-');
+    t.after(() => cleanup(cwd));
+    writeState(cwd, { milestone: 'v1.0' });
+    appendToState(cwd, [
+      '',
+      '### Phase 5: Five',
+      '',
+      '- **Phase 5:** started',
+      '- (Phase 5) pending review',
+      '',
+    ].join('\n'));
+
+    const snap = buildPlanningSnapshot(cwd);
+    assert.deepStrictEqual(snap.statePhaseTokens, { value: ['5', '5', '5'], scope: SCOPE.COMPLETE });
+  });
+
+  test('#4257 keep: silent forms stay silent (Phase5, flag form, non-English word)', (t) => {
+    const cwd = createTempDir('gsd-4257-spt9-');
+    t.after(() => cleanup(cwd));
+    writeState(cwd, { milestone: 'v1.0' });
+    appendToState(cwd, [
+      '',
+      '## Queue',
+      '',
+      '- `gsd-tools phase --insert 5`',
+      '- `Phase5` shorthand does not count',
+      '- фаза 5 is not the token either',
+      '',
+    ].join('\n'));
+
+    const snap = buildPlanningSnapshot(cwd);
+    assert.deepStrictEqual(snap.statePhaseTokens, { value: [], scope: SCOPE.COMPLETE });
+  });
+});
+
+// ─── workstream field (#4257) ────────────────────────────────────────────────
+
+describe('workstream field (#4257)', () => {
+  // The env save/restore pattern mirrors tests/health-diagnostic.test.cjs:598-602
+  // and tests/config-loader.test.cjs:499-509 — GSD_WORKSTREAM is the SAME
+  // discriminator planningDir applies (planning-workspace.cts:130), and the
+  // CLI bootstrap folds the stored active-workstream pointer into it
+  // (active-workstream-store.cts:488-494), so setting it directly is the
+  // faithful rule-level simulation of "workstream alpha is active".
+  function withWorkstreamEnv(t, name) {
+    const prev = process.env['GSD_WORKSTREAM'];
+    if (name === null) delete process.env['GSD_WORKSTREAM'];
+    else process.env['GSD_WORKSTREAM'] = name;
+    t.after(() => {
+      if (prev === undefined) delete process.env['GSD_WORKSTREAM'];
+      else process.env['GSD_WORKSTREAM'] = prev;
+    });
+  }
+
+  test('flat project (no GSD_WORKSTREAM): workstream is null', (t) => {
+    const cwd = createTempDir('gsd-4257-ws1-');
+    t.after(() => cleanup(cwd));
+    writeState(cwd, { milestone: 'v1.0' });
+    withWorkstreamEnv(t, null);
+
+    const snap = buildPlanningSnapshot(cwd);
+    assert.strictEqual(snap.workstream, null);
+  });
+
+  test('GSD_WORKSTREAM=alpha: workstream names the scope every workstream-aware read used', (t) => {
+    const cwd = createTempDir('gsd-4257-ws2-');
+    t.after(() => cleanup(cwd));
+    writeFile(cwd, '.planning/workstreams/alpha/STATE.md', [
+      '---',
+      'milestone: v1.0',
+      '---',
+      '',
+      '## Decisions',
+      '',
+      '- Phase 2 wrapped',
+      '',
+    ].join('\n'));
+    withWorkstreamEnv(t, 'alpha');
+
+    const snap = buildPlanningSnapshot(cwd);
+    assert.strictEqual(snap.workstream, 'alpha');
+  });
+
+  test('non-divergence: the field names the base statePhaseTokens was actually read from', (t) => {
+    const cwd = createTempDir('gsd-4257-ws3-');
+    t.after(() => cleanup(cwd));
+    // Root STATE.md carries Phase 7; workstream STATE.md carries Phase 5. The
+    // tokens must come from the WORKSTREAM file (planningPaths scoped it) and
+    // the field must name that same workstream — one resolution point, two
+    // observable answers that cannot disagree.
+    writeState(cwd, { milestone: 'v1.0' });
+    appendToState(cwd, ['', '- Phase 7 lives at root scope', ''].join('\n'));
+    writeFile(cwd, '.planning/workstreams/alpha/STATE.md', [
+      '---',
+      'milestone: v1.0',
+      '---',
+      '',
+      '- Phase 5 lives in the workstream',
+      '',
+    ].join('\n'));
+    withWorkstreamEnv(t, 'alpha');
+
+    const snap = buildPlanningSnapshot(cwd);
+    assert.deepStrictEqual(snap.statePhaseTokens, { value: ['5'], scope: SCOPE.COMPLETE });
+    assert.strictEqual(snap.workstream, 'alpha');
+  });
 });
 
 describe('stateStatus field (Phase 11, #3309)', () => {


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #4257

---

## What was broken

`/gsd-health` (`gsd-tools validate health`) reported healthy multi-workstream projects as `degraded` with a false W002: the `statePhaseTokens` harvest scanned STATE.md's raw text with the unanchored regex `[Pp]hase\s+(TOKEN)`, so the `-phase 5` tail of GSD's own command names (`` `/gsd-execute-phase 5` ``) and any phase-shaped token inside an inline code span (`` `- [ ] **Phase 40:` `` quoted from a sibling roadmap) were harvested as phase references. Additionally, when W002 did fire, its message — `STATE.md references phase 5, but only phases 1, 2 are declared` — made an unqualified project-wide claim while the declared-phase list it summarizes is deliberately workstream-scoped, so a phase declared in a sibling workstream read as "undeclared".

## What this fix does

1. **Harvest precision** (`src/planning-snapshot.cts`, `buildStateFields`): before scanning, strip fenced code blocks then inline code spans via the canonical `markdown-sectionizer` seam (`stripFencedCode` + `stripInlineCode`, the #2365 composition order) — a token inside backticks is a quoted literal, not a reference — and match with a left word boundary `(?<![-\w])[Pp]hase\s+(TOKEN)` so a command mention (`/gsd-execute-phase 5`, bare or quoted) and word-suffixed carriers (`myphase 5`) are not harvested. `Phase 5`, `**Phase 5:**`, `(Phase 5)`, `[Phase 5]`, and `### Phase 5:` headings still are.
2. **Scope-qualified warning** (`src/health-diagnostic-rules/state-consistency.cts`, W002): the message now appends the active workstream — `... only phases 1, 2 are declared in workstream alpha` — sourced from a new additive `PlanningSnapshot.workstream` field derived via `resolveEnvWorkstream()`, extracted in `src/planning-workspace.cts` as the ONE owner of the env discriminator `planningDir` itself applies, so the clause cannot disagree with the base the valid set was actually read from. Root scope (no active workstream) keeps the byte-identical message.

Pinned tradeoff (per the issue): a genuine phase reference written inside backticks or a fenced block now stops counting — inside a code span a quoted literal and a reference are indistinguishable, and W002 must be safe on any file that quotes commands or roadmap lines.

Not done, deliberately (the issue's own scoping): no cross-workstream union of declared phases (per-workstream phase numbering is deliberate — every roadmap starts at Phase 1, a union would silence genuine drift), and the optional labelled cross-workstream `info` (issue fix-sketch item (c)) is left as a follow-up candidate since it is not part of the acceptance checklist.

## Root cause

The W002 harvest was a verbatim relocation (#3309) of `verify.cts`'s original scan — unanchored and markdown-blind from the start; the multi-workstream ledger pattern (quoting `/gsd-*-phase N` command names in STATE.md) is what surfaced it. The message grammar predates the workstream-scoped valid set and was never updated to name the scope `buildValidPhaseSet` summarizes (all three of its sources — `phaseDirs`, `roadmapDeclaredPhases`, `archivedPhaseTokens` — are built from `planningPaths(cwd)`, workstream-scoped under an active workstream). Full diagnosis: `.gsd/bug/fix-4257-w002-phase-ref-scope/10-diagnosis.md` (in-repo run artifacts).

## Testing

### How I verified the fix

- Reproduced both sub-defects through the real CLI (`gsd-tools validate health`) with the issue's verbatim repro script on the base commit (RED, recorded in the run artifacts' diagnosis) and re-ran the same harness on the fix: `status: healthy`, no warnings; the prose-swap control still fires, now with `in workstream alpha`; the closed-span quoted-literal control (`` - `- [ ] **Phase 40:` `` …) is silent; the root-scope flat-project message is byte-identical (`STATE.md references phase 99, but only phases 01, 1 are declared`).
- TDD: tests-only commit (RED) run through the full gsd-test bench — the new rows fail on the unmodified source; fix commit GREEN end-to-end (44254/44254, linux-node24, pass recorded by `gsd-verify-and-record`).

### Regression test added?

- [x] Yes — `tests/planning-snapshot.test.cjs` (harvest precision rows + the additive `workstream` field rows) and `tests/health-diagnostic-rules/state-consistency.test.cjs` (W002 under workstream and root scope, scope clause asserted, root grammar pinned unchanged)

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux (full gsd-test bench, linux-node24)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific — fix and verification are CLI/node-level)

---

## Checklist

- [x] Issue linked above with `Fixes #4257`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (verified through gsd-test bench on the fix head, not local `npm test`)
- [x] `.changeset/` fragment added
- [x] No unnecessary dependencies added

## Breaking changes

None for legitimate prose references, genuinely undeclared references (still warn), root-scope output (byte-identical), or the #612 bracket-convention valid-set handling (untouched). Behavioral delta, stated for completeness: tokens that appear ONLY inside inline code spans or fenced blocks in STATE.md no longer count as phase references — including a genuine reference an author chose to backtick (pinned by a fixture per the issue's stated tradeoff).

## Assumptions (open to maintainer correction)

- The scope clause interpolates the workstream name bare (`in workstream alpha`), matching the repo's plain-prose message style (`W005`, `W021` interpolate values without quotes/backticks); the issue's markdown formatting around the name was read as emphasis, not message content.
- No `docs/` change: the changeset is typed `Fixed` (no docs-required trigger), and no shipped doc enumerates W002's message verbatim — `gsd-core/workflows/health.md`'s W002 sample output line is a pre-existing paraphrase (`but only phases 1-3 exist`) in runtime-loaded workflow text, and `docs/how-to/recover-and-troubleshoot.md` describes the remediation without quoting the message (localized in 4 other languages; updating one without the others would create translation drift).
