### PR TITLE
fix(#4409): stop CRLF-tainted extractShellBlocks shadow in bug-891 fold

### DIFF
--- a/tests/runtime-launcher-parity.test.cjs
+++ b/tests/runtime-launcher-parity.test.cjs
@@ -1226,7 +1226,6 @@ const fs = require('node:fs');
 const path = require('node:path');
 const os = require('node:os');
 const { cleanup } = require('./helpers.cjs');
-const { escapeRegex } = require('../gsd-core/bin/lib/pattern.cjs');
 
 const WORKFLOWS_DIR = path.join(__dirname, '..', 'gsd-core', 'workflows');
 const SNIPPET_FILE = path.join(WORKFLOWS_DIR, '_runtime-launcher.snippet.sh');
@@ -1254,67 +1253,10 @@ const EXPECTED_RUNTIME_PROBES = {
   kilo:        'kilo}/gsd-core/bin/',
 };
 
-/**
- * Collect all workflow .md files recursively.
- */
-function collectWorkflowFiles() {
-  const results = [];
-  function walk(dir) {
-    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-      const full = path.join(dir, entry.name);
-      if (entry.isDirectory()) {
-        walk(full);
-      } else if (entry.isFile() && entry.name.endsWith('.md')) {
-        results.push(full);
-      }
-    }
-  }
-  walk(WORKFLOWS_DIR);
-  return results;
-}
-
-/**
- * Extract all bash/sh/shell fenced blocks from markdown content.
- */
-function extractShellBlocks(content) {
-  const allLines = content.split('\n');
-  const blocks = [];
-  let inBlock = false;
-  let blockLang = null;
-  let blockLines = [];
-  let blockIndent = '';
-  let closingPattern = null;
-
-  for (let i = 0; i < allLines.length; i++) {
-    const line = allLines[i];
-    if (!inBlock) {
-      const fenceOpen = line.match(/^(\s*)```(\w+)?\s*$/);
-      if (fenceOpen) {
-        inBlock = true;
-        blockIndent = fenceOpen[1];
-        blockLang = (fenceOpen[2] || '').toLowerCase();
-        blockLines = [];
-        closingPattern = new RegExp('^' + escapeRegex(blockIndent) + '```\\s*$');
-        continue;
-      }
-    } else {
-      if (closingPattern.test(line)) {
-        if (['bash', 'sh', 'shell', 'zsh', ''].includes(blockLang)) {
-          blocks.push({ lines: blockLines });
-        }
-        inBlock = false;
-        blockLang = null;
-        blockLines = [];
-        blockIndent = '';
-        closingPattern = null;
-        continue;
-      }
-      blockLines.push(line);
-    }
-  }
-  return blocks;
-}
-
+// collectWorkflowFiles and extractShellBlocks are intentionally not redeclared
+// here — this block reuses the CRLF-safe module-scope copies above (bug #4409:
+// a redeclared copy here shadowed them and split only on '\n', leaking '\r'
+// into extracted block lines on CRLF checkouts).
 
 describe('bug-891: non-Claude runtime home fallback arms', () => {
 
@@ -1677,6 +1619,19 @@ describe('bug-891: non-Claude runtime home fallback arms', () => {
         `Run \`node scripts/sync-runtime-launcher.cjs\` to propagate:\n` +
         missing.join('\n'),
     );
+  });
+
+  // Regression for bug #4409: this fold used to redeclare its own
+  // extractShellBlocks that split only on '\n', leaking '\r' into every
+  // extracted line on CRLF checkouts. Assert the CRLF-safe module-scope
+  // copy is what actually resolves inside this nested block scope.
+  test('(F) extractShellBlocks strips \\r from CRLF-fenced blocks inside this fold scope', () => {
+    const crlfContent = '```bash\r\ngsd_run foo\r\n```\r\n';
+    const blocks = extractShellBlocks(crlfContent);
+    assert.strictEqual(blocks.length, 1);
+    for (const line of blocks[0].lines) {
+      assert.ok(!line.includes('\r'), `expected no CR in extracted line, got ${JSON.stringify(line)}`);
+    }
   });
 });
   });


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

> **Required.** This PR will be auto-closed if no valid issue link is found.

Fixes #4409

> The linked issue must have the `confirmed-bug` label. If it doesn't, ask a maintainer to confirm the bug before continuing.

---

## What was broken

`tests/runtime-launcher-parity.test.cjs`'s `bug-891` fold block redeclared `extractShellBlocks` and `collectWorkflowFiles`, shadowing the CRLF-safe module-scope copies via ordinary lexical scoping. The shadow copy split only on `'\n'`, so on CRLF checkouts (Windows, `core.autocrlf=true`) it leaked a trailing `\r` into every extracted shell-block line for assertions inside that fold.

## What this fix does

Deletes both duplicate declarations from the fold block. The module-scope copies (`content.split(/\r?\n/)`) are already in lexical scope and are used identically — only `.lines` is consumed at both call sites. Also removes the now-dead `escapeRegex` import that existed solely for the deleted local copy.

## Root cause

Two full re-implementations of the same helpers existed in one file: one at module scope (CRLF-safe), one nested inside a `describe` fold (not CRLF-safe). JS block scoping resolves the nearer declaration first, so any assertion textually inside that fold silently used the buggy copy instead of the correct one one scope out.

## Testing

### How I verified the fix

- `node --test tests/runtime-launcher-parity.test.cjs` — 31/31 pass.
- Red proof: temporarily reinstated the deleted fold-local `extractShellBlocks` and confirmed the new regression test fails with the exact `\r`-tainted symptom described in the issue, then reverted.
- `npx eslint tests/runtime-launcher-parity.test.cjs` — clean, 0 errors/warnings.
- Adversarial review (critical-code-reviewer + ponytail-review lenses, Opus, full codegraph/serena access): verdict SHIP — confirmed both helpers fully deduplicated repo-wide, no orphaned imports/bindings, no second CRLF-splitting convention introduced (matches `src/text-lines.cts`'s `splitLines()`).
- Found one adjacent issue during that review — a *separate*, divergent `extractShellBlocks` in `tests/capability-registry.test.cjs:6192` with the same bug class. Out of scope for this fix (#4409's own issue body scopes sibling-file divergences out as "tracked separately"); filed as #4489.
- Fork CI ran the full matrix (macOS, Windows, Linux) — all green: https://github.com/davdittrich/gsd-core/pull/35

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why: <!-- e.g., environment-specific, non-deterministic -->

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [ ] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

Not a user-facing fix (test-only, outside `.changeset/`-gated paths) — no fragment added. I don't have permission to apply the `no-changelog` label myself; a maintainer will need to add it.

## Breaking changes

None
