### PR TITLE
fix(#4439): render pending-todo 'created' as date-only, matching [date]

### DIFF
--- a/.changeset/steady-sloths-parade.md
+++ b/.changeset/steady-sloths-parade.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 4494
 ---
 **Pending-todo bullets in STATE.md now show a date, not a full timestamp** — `renderPendingTodosMarkdown` was echoing the todo's `created` frontmatter verbatim (a full ISO-8601 instant) into the rendered `[…]` bracket, instead of the date-only `[date]` format documented in `docs/reference/state-md.md` and `docs/COMMANDS.md`. (#4439)

--- a/.changeset/steady-sloths-parade.md
+++ b/.changeset/steady-sloths-parade.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**Pending-todo bullets in STATE.md now show a date, not a full timestamp** — `renderPendingTodosMarkdown` was echoing the todo's `created` frontmatter verbatim (a full ISO-8601 instant) into the rendered `[…]` bracket, instead of the date-only `[date]` format documented in `docs/reference/state-md.md` and `docs/COMMANDS.md`. (#4439)

--- a/src/init.cts
+++ b/src/init.cts
@@ -2308,8 +2308,24 @@ function pendingTodoLinkTarget(todo: Record<string, unknown>, projectRoot: strin
   return rel;
 }
 
+/**
+ * #4439: the stored `created:` frontmatter (and the JSON `todos[].created`
+ * field it round-trips through) is always a full ISO-8601 timestamp, by
+ * design — this is the display-only seam that reformats it to the
+ * date-only `[date]` bullet documented in docs/reference/state-md.md and
+ * docs/COMMANDS.md. A value that doesn't start with a well-formed
+ * `YYYY-MM-DD` (the 'unknown' fallback, or any other non-conforming
+ * string) passes through unchanged rather than being mangled.
+ */
+function pendingTodoDateOnly(value: string): string {
+  const match = value.match(/^\d{4}-\d{2}-\d{2}/);
+  return match ? match[0] : value;
+}
+
 function renderPendingTodoBullet(todo: Record<string, unknown>, projectRoot?: string): string {
-  const date = sanitizePendingTodoInline(pendingTodoFieldAsString(todo['created'], 'unknown'));
+  const date = pendingTodoDateOnly(
+    sanitizePendingTodoInline(pendingTodoFieldAsString(todo['created'], 'unknown')),
+  );
   let area = sanitizePendingTodoInline(pendingTodoFieldAsString(todo['area'], 'general'));
   let title = sanitizePendingTodoInline(pendingTodoFieldAsString(todo['title'], 'Untitled'));
   // Strip trailing "." so the fixed "Needs ....` template below never

--- a/tests/state-todos-render.test.cjs
+++ b/tests/state-todos-render.test.cjs
@@ -103,6 +103,22 @@ test('renderPendingTodosMarkdown: boundary — 240 chars (limit) is not truncate
   assert.equal(line, `- [2026-09-01] [api] ${title} — [todo file](${todo.path})`);
 });
 
+test('renderPendingTodosMarkdown: full ISO-8601 \'created\' renders a date-only bracket (#4439)', () => {
+  const line = renderPendingTodosMarkdown([makeTodo({ created: '2026-09-01T00:00:00.000Z', needs: undefined })]);
+  assert.match(line, /^- \[2026-09-01\] \[api\]/);
+  assert.doesNotMatch(line, /2026-09-01T/, 'full ISO timestamp must not leak into the rendered bullet');
+});
+
+test('renderPendingTodosMarkdown: \'created\' fallback (\'unknown\') is not sliced by the date-only formatter', () => {
+  const line = renderPendingTodosMarkdown([makeTodo({ created: undefined, needs: undefined })]);
+  assert.match(line, /^- \[unknown\] \[api\]/);
+});
+
+test('renderPendingTodosMarkdown: a malformed non-padded date is passed through unchanged, not mis-sliced', () => {
+  const line = renderPendingTodosMarkdown([makeTodo({ created: '2026-9-1', needs: undefined })]);
+  assert.match(line, /^- \[2026-9-1\] \[api\]/);
+});
+
 test('renderPendingTodosMarkdown: boundary — 241 chars (limit+1) truncates, needs dropped first', () => {
   const base = makeTodo({ needs: 'x', title: 'X' });
   const probe = renderPendingTodosMarkdown([base]);
@@ -142,7 +158,7 @@ test('property: rendered body always has one line per todo, each line <= 240 cha
   // than a vacuous one; the pathological "cap not achievable" case is
   // covered separately by the fixed "pathological" unit test above.
   const todoArb = fc.record({
-    created: fc.constantFrom('2026-01-01', '2025-12-31', 'unknown'),
+    created: fc.constantFrom('2026-01-01', '2025-12-31', 'unknown', '2026-01-01T00:00:00.000Z', '2026-9-1'),
     area: fc.string({ minLength: 0, maxLength: 40 }),
     title: fc.string({ minLength: 0, maxLength: 500 }),
     path: fc
@@ -320,6 +336,7 @@ test('cmdInitTodos: real todo file produces a rendered bullet via the CLI', (t) 
   const json = runQueryInitTodos(dir);
   assert.equal(json.pending_read_ok, true);
   assert.match(json.pending_todos_markdown, /Fix retry logic/);
+  assert.match(json.pending_todos_markdown, /^- \[2026-09-01\] \[api\]/m);
   // The Needs clause is asserted on the STRUCTURED field, not the rendered
   // bullet: the bullet embeds the todo file's ABSOLUTE path, so its total
   // length varies by runner tmpdir (macOS CI's /private/var/folders/… plus

--- a/tests/state-todos-render.test.cjs
+++ b/tests/state-todos-render.test.cjs
@@ -119,6 +119,11 @@ test('renderPendingTodosMarkdown: a malformed non-padded date is passed through 
   assert.match(line, /^- \[2026-9-1\] \[api\]/);
 });
 
+test('renderPendingTodosMarkdown: a non-4-digit year is not mis-sliced (near-miss YYYY-MM-DD shape)', () => {
+  const line = renderPendingTodosMarkdown([makeTodo({ created: '202-09-01T00:00:00.000Z', needs: undefined })]);
+  assert.match(line, /^- \[202-09-01T00:00:00\.000Z\] \[api\]/);
+});
+
 test('renderPendingTodosMarkdown: boundary — 241 chars (limit+1) truncates, needs dropped first', () => {
   const base = makeTodo({ needs: 'x', title: 'X' });
   const probe = renderPendingTodosMarkdown([base]);


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #4439

---

## What was broken

`renderPendingTodosMarkdown` (STATE.md's "### Pending Todos" section renderer) echoed a pending todo's `created` frontmatter verbatim into the rendered bullet's `[…]` bracket — showing a full ISO-8601 timestamp like `[2026-09-01T00:00:00.000Z]` instead of the date-only `[date]` format documented in `docs/reference/state-md.md` and `docs/COMMANDS.md`.

## What this fix does

Adds `pendingTodoDateOnly()`, a pure display-only formatter used only inside `renderPendingTodoBullet`: a value starting with a well-formed `YYYY-MM-DD` is shortened to just that; anything else (the `'unknown'` fallback, or a malformed/non-conforming string) passes through unchanged. The todo file's frontmatter and the JSON `todos[].created` field are both untouched — only the rendered STATE.md bullet changes.

## Root cause

The todo file's `created:` frontmatter is always a full ISO-8601 timestamp by design (`add-todo.md`'s `create_file` step writes `init.todos`' `timestamp` field), for record-keeping precision. `renderPendingTodoBullet` (introduced by #2618/PR #2662) never reformatted that value for display — it was echoed byte-for-byte. The two shipped docs describing the bullet format already say `[date]`; only the renderer needed to catch up, so no doc edit was needed.

---

## Testing

### How I verified the fix

Failing-first regression test (`renderPendingTodosMarkdown: full ISO-8601 'created' renders a date-only bracket (#4439)`) committed and run under `gsd-test` against the pre-fix renderer — confirmed RED (2/44296 failing, exactly the new/modified assertions). Re-ran `gsd-test` after the fix — GREEN (44296/44296, then 44297/44297 after one more coverage addition from review). Full matrix pass recorded for the final PR head sha.

### Regression test added?

- [x] Yes — added a test that would have caught this bug

### Platforms tested

- [x] Linux (gsd-test remote matrix)
- [ ] macOS
- [ ] Windows (including backslash path handling)
- [x] N/A (pure string-formatting logic, platform-independent — confirmed in the linked issue body)

### Runtimes tested

- [x] N/A (not runtime-specific — CLI/renderer logic only)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`gsd-test` — this repo's tests are never run via `npm test` directly)
- [x] `.changeset/` fragment added (`Fixed`, #4439)
- [x] No unnecessary dependencies added

## Breaking changes

None — display-only formatting change to one markdown bullet; the JSON `todos[].created` API field and the todo file's frontmatter are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
