### PR TITLE
chore(#4411): retire makeIsolatedPath(), it isolated nothing

### DIFF
--- a/tests/runtime-launcher-parity.test.cjs
+++ b/tests/runtime-launcher-parity.test.cjs
@@ -1913,31 +1913,8 @@ const SNIPPET_FILE = path.join(WORKFLOWS_DIR, '_runtime-launcher.snippet.sh');
 // The snippet uses _GSD_RUNTIME_ROOT as the intermediate variable.
 const LOCAL_CLAUDE_PROBE = '_GSD_RUNTIME_ROOT}/.claude/gsd-core/bin/';
 
-/**
- * Return the full system PATH with extra bin dirs prepended. Deliberately does
- * NOT filter gsd_run — unlike buildIsolatedPath() above, which does.
- *
- * The isolation here comes from resolution ORDER, not from the PATH contents.
- * Callers give RUNTIME_DIR a .claude/gsd-core/bin/ stub, and the resolver
- * checks RUNTIME_DIR/gsd-core/bin/ then RUNTIME_DIR/.claude/gsd-core/bin/
- * before it ever reaches `command -v gsd_run`, so an ambient gsd_run on PATH
- * is unreachable for these tests. Keeping PATH whole is what keeps node
- * resolvable when node co-locates with a global gsd_run (e.g. /opt/homebrew/bin).
- *
- * That makes this helper safe ONLY for tests whose stub wins before the PATH
- * arm. Any test that must prove the PATH arm itself misses needs
- * buildIsolatedPath(), which excludes gsd_run-bearing directories outright.
- *
- * For B and C: the stub sits at RUNTIME_DIR/.claude/..., picked at elif-1.
- */
-function makeIsolatedPath(extraBefore = []) {
-  // Keep full system PATH so node remains accessible.
-  // Tests B and C exercise only the RUNTIME_DIR/.claude arm which fires
-  // before command -v gsd_run — so the real gsd_run on PATH is never reached.
-  const systemPaths = (process.env.PATH || '/usr/bin:/bin').split(path.delimiter);
-  return [...extraBefore, ...systemPaths].join(path.delimiter);
-}
-
+// Tests B and C below need no PATH isolation: the RUNTIME_DIR/.claude arm
+// they exercise fires before the resolver ever reaches `command -v gsd_run`.
 describe('bug-444: resolver finds repo-local .claude install', () => {
   // --- (A) Snippet contains the repo-local .claude arm ----------------------
   test('(A) snippet file contains the repo-local .claude/ check arm before $HOME/.claude/', () => {
@@ -1981,8 +1958,6 @@ describe('bug-444: resolver finds repo-local .claude install', () => {
     // NO stub at gsd-core/bin/, NOT on PATH, NOT in $HOME/.claude
     const fakeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-444-root-'));
     const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-444-home-'));
-    const noToolsBin = path.join(fakeRoot, 'nobin');
-    fs.mkdirSync(noToolsBin, { recursive: true });
 
     try {
       // Create the stub at the repo-local .claude path ONLY
@@ -2008,12 +1983,8 @@ describe('bug-444: resolver finds repo-local .claude install', () => {
       const scriptPath = path.join(fakeRoot, 'test-local-claude.sh');
       fs.writeFileSync(scriptPath, scriptContent);
 
-      // Keep node in PATH (needed to run the .cjs stub); the .claude arm
-      // resolves before the PATH arm, so gsd_run is never probed here.
-      const isolatedPath = makeIsolatedPath([noToolsBin]);
-
       const stdout = runBashFile(scriptPath, {
-        env: { PATH: isolatedPath, HOME: fakeHome },
+        env: { HOME: fakeHome },
       });
 
       // Must have resolved to the local .claude stub
@@ -2037,8 +2008,6 @@ describe('bug-444: resolver finds repo-local .claude install', () => {
   test('(C) repo-local .claude/ install wins over $HOME/.claude/ when both exist', () => {
     const fakeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-444-prec-root-'));
     const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-444-prec-home-'));
-    const noToolsBin = path.join(fakeRoot, 'nobin');
-    fs.mkdirSync(noToolsBin, { recursive: true });
 
     try {
       // Stub at repo-local .claude/ path (should be picked)
@@ -2073,10 +2042,8 @@ describe('bug-444: resolver finds repo-local .claude install', () => {
       const scriptPath = path.join(fakeRoot, 'test-precedence.sh');
       fs.writeFileSync(scriptPath, scriptContent);
 
-      const isolatedPath = makeIsolatedPath([noToolsBin]);
-
       const stdout = runBashFile(scriptPath, {
-        env: { PATH: isolatedPath, HOME: fakeHome },
+        env: { HOME: fakeHome },
       });
 
       assert.ok(


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #4411

---

## What was broken

`makeIsolatedPath()` claimed to isolate PATH but never filtered it: it prepended an empty `noToolsBin` dir to the full, unfiltered `process.env.PATH`, so the result was functionally identical to the real system PATH. Both callers' `noToolsBin` dirs and `PATH:` env overrides were dead ceremony.

## What this fix does

Deletes `makeIsolatedPath()`, both `noToolsBin` declarations, and the dead `PATH` overrides in bug-444 tests (B) and (C). Keeps one sentence recording why those two tests need no PATH isolation: their `.claude` arm resolves before the resolver reaches `command -v gsd_run`. The real filtering isolator, `buildIsolatedPath()`, is untouched.

## Root cause

Long-standing name/behavior mismatch since the helper's introduction alongside the bug-444 test suite — it was never wired to actually filter anything, unlike the real `buildIsolatedPath()` it sits next to in the same file.

## Testing

### How I verified the fix

`node --test tests/runtime-launcher-parity.test.cjs` — 30/30 pass, including bug-444 (B) and (C). `npx eslint tests/runtime-launcher-parity.test.cjs` — clean. Grepped the repo for any remaining reference to `makeIsolatedPath` — none. Adversarially reviewed once via agy (gemini-3.8-flash-high) — no defects found.

### Regression test added?

- [ ] Yes — added a test that would have caught this bug
- [x] No — explain why: this is a test-helper deletion (dead code removal), not a behavior change; existing tests (B) and (C) already cover the resolver behavior and continue to pass unchanged.

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [x] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None