### PR TITLE
docs(#4440): stop telling agents to grep .env files the secret guard denies

### DIFF
--- a/.changeset/quick-bears-tumble.md
+++ b/.changeset/quick-bears-tumble.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 4500
 ---
 **Verification examples no longer tell agents to grep .env files** — `verification-patterns.md` and `user-setup.md` documented reading `.env`/`.env.local` directly to verify environment variables, which every covered runtime's secret-read guard denies. The environment-variable checks now read the environment (`printenv`) instead of the file, and a broken placeholder-filter regex (`grep -v "a|b|c"`, where `|` is a literal BRE character) is replaced with a working case-insensitive check. (#4440)

--- a/.changeset/quick-bears-tumble.md
+++ b/.changeset/quick-bears-tumble.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**Verification examples no longer tell agents to grep .env files** — `verification-patterns.md` and `user-setup.md` documented reading `.env`/`.env.local` directly to verify environment variables, which every covered runtime's secret-read guard denies. The environment-variable checks now read the environment (`printenv`) instead of the file, and a broken placeholder-filter regex (`grep -v "a|b|c"`, where `|` is a literal BRE character) is replaced with a working case-insensitive check. (#4440)

--- a/gsd-core/references/verification-patterns.md
+++ b/gsd-core/references/verification-patterns.md
@@ -309,20 +309,33 @@ grep -r "$hook_name()" src/ --include="*.tsx" --include="*.ts" | grep -v "$hook_
 # .env file exists
 [ -f ".env" ] || [ -f ".env.local" ]
 
-# Required variable is defined
-grep -E "^$VAR_NAME=" .env .env.local 2>/dev/null
+# Required variable is defined (in the environment: dotenv/direnv/the framework has loaded it)
+printenv "$VAR_NAME" >/dev/null
 ```
 
 **Substantive check:**
 ```bash
-# Variable has actual value (not placeholder)
-grep -E "^$VAR_NAME=.+" .env .env.local 2>/dev/null | grep -v "your-.*-here|xxx|placeholder|TODO" -i
+# Variable has an actual value (not a placeholder) -- tests the shape, never prints the value;
+# exit 0 = real value, exit 1 = missing or placeholder (case-insensitive)
+v=$(printenv "$VAR_NAME"); case "$(printf %s "$v" | tr '[:upper:]' '[:lower:]')" in
+  ""|*your-*-here*|*xxx*|*placeholder*|*todo*) exit 1;;
+esac
 
 # Value looks valid for type:
 # - URLs should start with http
 # - Keys should be long enough
 # - Booleans should be true/false
 ```
+
+When the variable is not present in the agent's own environment (a framework that loads
+`.env.local` itself at runtime does not export it to the shell that runs these checks),
+ask the user to confirm it is set rather than reading `.env` directly. Variable NAMES can
+still be checked against `.env.example`, which the secret-read guard exempts from its
+protected-file patterns.
+
+One guard-matching note worth knowing when auditing docs for `.env` mentions: the guard
+treats a grep PATTERN whose last path segment is a secret file name as a file operand, so
+`grep -n "\.env" file.md` is denied while `grep -n "\.env\b" file.md` is allowed.
 
 **Stub patterns specific to env:**
 ```bash

--- a/gsd-core/templates/user-setup.md
+++ b/gsd-core/templates/user-setup.md
@@ -171,9 +171,6 @@ Use the webhook signing secret from CLI output (starts with `whsec_`).
 After completing setup:
 
 ```bash
-# Check env vars are set
-grep STRIPE .env.local
-
 # Verify build passes
 npm run build
 
@@ -232,9 +229,6 @@ Complete these items for Supabase Auth to function.
 After completing setup:
 
 ```bash
-# Check env vars
-grep SUPABASE .env.local
-
 # Verify connection (run in project directory)
 npx supabase status
 ```
@@ -285,9 +279,6 @@ Complete these items for SendGrid email to function.
 After completing setup:
 
 ```bash
-# Check env var
-grep SENDGRID .env.local
-
 # Test email sending (replace with your test email)
 curl -X POST http://localhost:3000/api/test-email \
   -H "Content-Type: application/json" \


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #4440

---

## What was broken

`gsd-core/references/verification-patterns.md`'s `<environment_config>` section and `gsd-core/templates/user-setup.md`'s three per-service `## Verification` examples documented reading `.env`/`.env.local` directly via `grep` to verify environment variables. Every covered runtime's secret-read guard (Claude Code deny-rules since #768/v1.4.0; the always-on `gsd-secret-read-guard` hook since #4236/#4221 in 1.13.0) denies all five of those commands — confirmed by piping each one through the shipped hook. Separately, `verification-patterns.md`'s "substantive check" used `grep -v "your-.*-here|xxx|placeholder|TODO" -i`, where `|` in basic-regex `grep -v` is a literal character, not alternation — so the placeholder filter matched nothing, and a `PLACEHOLDER`/`TODO_fill` value passed the "substantive" check as if it were real.

## What this fix does

- `verification-patterns.md`: keeps the existing `[ -f ".env" ] || [ -f ".env.local" ]` existence check (never denied, untouched). Replaces the two `.env`-reading checks with environment-reading ones: `printenv "$VAR_NAME" >/dev/null` for "is it defined", and a `case`-statement placeholder filter (case-insensitive, no regex-alternation bug) for "does it have a real value". Adds one sentence covering the framework-loads-.env-at-runtime case (ask the user instead of reading the file), and one optional note about the guard's path-vs-pattern classification for anyone auditing docs for `.env` mentions.
- `user-setup.md`: removes the three now-redundant `grep <SERVICE> .env.local` lines outright (not swapped for `printenv`) — these examples describe a Next.js shape where the framework loads `.env.local` at runtime without exporting it to the shell, so a `printenv` substitute would wrongly report "not set" on a correctly configured project. Each block's existing service-level check (`npm run build` + webhook test, `npx supabase status`, email-send test) already verifies the setup.

## Root cause

Prose predates the secret-read guard shipping and was never updated to match it; the regex bug is a second, independent defect in the same lines.

---

## Testing

### How I verified the fix

No test in `tests/*.test.cjs` reads or asserts on either file's content (confirmed by search), so acceptance is evidence-checked rather than test-backed, per this repo's own allowance for non-automatable criteria:
- Piped every new/changed example command through the real `hooks/gsd-secret-read-guard.js` — all exit 0 (allowed), including the unchanged existence check.
- Exercised the new substantive-check `case` logic under real `sh` (dash) with a real value, `your-key-here`, `TODO_fill`, an empty value, and an unset variable — all five classify correctly, closing the old regex-alternation gap.
- Grepped both files afterward to confirm no `.env`-reading example command remains (the only two remaining `.env`-adjacent matches are the new guard-matching-note prose and one pre-existing, unrelated `process.env.$VAR_NAME` source-grep example).

### Regression test added?

- [ ] Yes — added a test that would have caught this bug
- [x] No — explain why: prose-only fix to reference/template markdown with no automated-test surface (confirmed by search); acceptance verified by evidence above instead.

### Platforms tested

- [x] N/A (not platform-specific — shell snippets are POSIX `sh`, verified under dash)

### Runtimes tested

- [x] N/A (guard behavior verified directly against the shipped hook, independent of any specific runtime)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`gsd-test`)
- [x] `.changeset/` fragment added (`Fixed`, #4440)
- [x] No unnecessary dependencies added

## Breaking changes

None — documentation/template content only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
