### PR TITLE
fix(#4443): register hooks.commit_types (and sibling hooks.community) in config schema

### DIFF
--- a/.changeset/sturdy-jays-cheer.md
+++ b/.changeset/sturdy-jays-cheer.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 4501
 ---
 **`hooks.commit_types` and `hooks.community` are now settable via `config-set`** — both keys are consumed by shipped hooks (`hooks/gsd-validate-commit.sh`), and `hooks.commit_types` is documented in `docs/COMMANDS.md`, but neither was registered in `config-schema.manifest.json`'s `validKeys`, so `config-set` rejected them with "Unknown config key" — the only way to configure either was hand-editing `.planning/config.json`. (#4443)

--- a/.changeset/sturdy-jays-cheer.md
+++ b/.changeset/sturdy-jays-cheer.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`hooks.commit_types` and `hooks.community` are now settable via `config-set`** — both keys are consumed by shipped hooks (`hooks/gsd-validate-commit.sh`), and `hooks.commit_types` is documented in `docs/COMMANDS.md`, but neither was registered in `config-schema.manifest.json`'s `validKeys`, so `config-set` rejected them with "Unknown config key" — the only way to configure either was hand-editing `.planning/config.json`. (#4443)

--- a/gsd-core/bin/shared/config-schema.manifest.json
+++ b/gsd-core/bin/shared/config-schema.manifest.json
@@ -77,6 +77,8 @@
     "workflow.inline_plan_threshold",
     "hooks.context_warnings",
     "hooks.workflow_guard",
+    "hooks.commit_types",
+    "hooks.community",
     "workflow.context_coverage_gate",
     "statusline.show_last_command",
     "statusline.context_position",

--- a/tests/config-schema.property.test.cjs
+++ b/tests/config-schema.property.test.cjs
@@ -24,6 +24,7 @@ const os = require('node:os');
 const path = require('node:path');
 const fc = require('./helpers/fast-check-setup.cjs');
 const { cleanup } = require('./helpers.cjs');
+const { PROBE_TIMEOUT_MS } = require('./helpers/timeouts.cjs');
 
 const {
   isValidConfigKey,
@@ -1262,7 +1263,7 @@ describe('config-set: hooks.commit_types end-to-end (#4443)', () => {
     const result = spawnSync(
       process.execPath,
       [gsdTools, 'config-set', 'hooks.commit_types', '["enhance"]'],
-      { cwd: dir, encoding: 'utf8', timeout: 15000 },
+      { cwd: dir, encoding: 'utf8', timeout: PROBE_TIMEOUT_MS },
     );
 
     assert.equal(result.status, 0, `config-set failed: ${result.stderr || result.stdout}`);
@@ -1282,7 +1283,7 @@ describe('config-set: hooks.commit_types end-to-end (#4443)', () => {
     const result = spawnSync(
       process.execPath,
       [gsdTools, 'config-set', 'hooks.community', 'true'],
-      { cwd: dir, encoding: 'utf8', timeout: 15000 },
+      { cwd: dir, encoding: 'utf8', timeout: PROBE_TIMEOUT_MS },
     );
 
     assert.equal(result.status, 0, `config-set failed: ${result.stderr || result.stdout}`);

--- a/tests/config-schema.property.test.cjs
+++ b/tests/config-schema.property.test.cjs
@@ -154,7 +154,7 @@ describe('config-schema: isValidConfigKey properties', () => {
     assert.equal(
       isValidConfigKey('hooks.commit_types'),
       true,
-      'hooks.commit_types is a documented, hook-consumed key (docs/COMMANDS.md) and must be settable via config-set'
+      'hooks.commit_types is a documented, hook-consumed key (see the CLI reference) and must be settable via config-set'
     );
   });
 

--- a/tests/config-schema.property.test.cjs
+++ b/tests/config-schema.property.test.cjs
@@ -150,6 +150,14 @@ describe('config-schema: isValidConfigKey properties', () => {
     assert.equal(result, false, 'empty string must not be a valid config key');
   });
 
+  test('hooks.commit_types is a valid config key (#4443)', () => {
+    assert.equal(
+      isValidConfigKey('hooks.commit_types'),
+      true,
+      'hooks.commit_types is a documented, hook-consumed key (docs/COMMANDS.md) and must be settable via config-set'
+    );
+  });
+
   // Boundary: null/undefined/number return false (not throw, not true)
   test('null, undefined, number inputs return false', () => {
     assert.equal(isValidConfigKey(null), false);
@@ -1232,3 +1240,27 @@ describe('feat-3210: workflow and config contracts', () => {
 });
   });
 }
+
+describe('config-set: hooks.commit_types end-to-end (#4443)', () => {
+  const { spawnSync } = require('node:child_process');
+
+  test('config-set hooks.commit_types accepts a JSON array and does not report Unknown config key', (t) => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-4443-'));
+    t.after(() => cleanup(dir));
+    fs.mkdirSync(path.join(dir, '.planning'), { recursive: true });
+    fs.writeFileSync(path.join(dir, '.planning', 'config.json'), '{}\n');
+
+    const gsdTools = path.join(__dirname, '..', 'gsd-core', 'bin', 'gsd-tools.cjs');
+    const result = spawnSync(
+      process.execPath,
+      [gsdTools, 'config-set', 'hooks.commit_types', '["enhance"]'],
+      { cwd: dir, encoding: 'utf8', timeout: 15000 },
+    );
+
+    assert.equal(result.status, 0, `config-set failed: ${result.stderr || result.stdout}`);
+    assert.doesNotMatch(result.stdout + result.stderr, /Unknown config key/);
+
+    const written = JSON.parse(fs.readFileSync(path.join(dir, '.planning', 'config.json'), 'utf8'));
+    assert.deepEqual(written.hooks.commit_types, ['enhance']);
+  });
+});

--- a/tests/config-schema.property.test.cjs
+++ b/tests/config-schema.property.test.cjs
@@ -1271,4 +1271,24 @@ describe('config-set: hooks.commit_types end-to-end (#4443)', () => {
     const written = JSON.parse(fs.readFileSync(path.join(dir, '.planning', 'config.json'), 'utf8'));
     assert.deepEqual(written.hooks.commit_types, ['enhance']);
   });
+
+  test('config-set hooks.community accepts a boolean and does not report Unknown config key', (t) => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-4443-community-'));
+    t.after(() => cleanup(dir));
+    fs.mkdirSync(path.join(dir, '.planning'), { recursive: true });
+    fs.writeFileSync(path.join(dir, '.planning', 'config.json'), '{}\n');
+
+    const gsdTools = path.join(__dirname, '..', 'gsd-core', 'bin', 'gsd-tools.cjs');
+    const result = spawnSync(
+      process.execPath,
+      [gsdTools, 'config-set', 'hooks.community', 'true'],
+      { cwd: dir, encoding: 'utf8', timeout: 15000 },
+    );
+
+    assert.equal(result.status, 0, `config-set failed: ${result.stderr || result.stdout}`);
+    assert.doesNotMatch(result.stdout + result.stderr, /Unknown config key/);
+
+    const written = JSON.parse(fs.readFileSync(path.join(dir, '.planning', 'config.json'), 'utf8'));
+    assert.equal(written.hooks.community, true);
+  });
 });

--- a/tests/config-schema.property.test.cjs
+++ b/tests/config-schema.property.test.cjs
@@ -158,6 +158,14 @@ describe('config-schema: isValidConfigKey properties', () => {
     );
   });
 
+  test('hooks.community is a valid config key (sibling of #4443)', () => {
+    assert.equal(
+      isValidConfigKey('hooks.community'),
+      true,
+      'hooks.community is the gsd-validate-commit.sh opt-in gate and must be settable via config-set'
+    );
+  });
+
   // Boundary: null/undefined/number return false (not throw, not true)
   test('null, undefined, number inputs return false', () => {
     assert.equal(isValidConfigKey(null), false);


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #4443

---

## What was broken

`hooks.commit_types` shipped in 1.13.0 (#3811/#4340), is consumed by `hooks/gsd-validate-commit.sh`, and is documented in `docs/COMMANDS.md` — but was never added to `gsd-core/bin/shared/config-schema.manifest.json`'s `validKeys`, so `config-set hooks.commit_types '["enhance"]'` rejected with `Unknown config key`. The only way to configure a documented feature was hand-editing `.planning/config.json`.

## What this fix does

Adds `hooks.commit_types` to `validKeys`.

**Scope note (fixed inline, not a separate PR):** while auditing every `hooks.*` key actually consumed by shipped code against `validKeys` (this repo's own no-deferrals rule — a defect found anywhere in the tree while working an issue gets fixed in the current change), `hooks.community` (`gsd-validate-commit.sh`'s own opt-in gate, also read by `gsd-phase-boundary.sh` and `gsd-session-state.sh`) turned out to have the exact same defect: consumed by shipped code, never added to `validKeys`. An `Agent`-dispatched audit of every `hooks.*` read site confirmed these were the only two missing entries. Fixed both, with matching regression coverage for each.

## Root cause

Both keys shipped without their schema-registration half of the change.

---

## Testing

### How I verified the fix

Failing-first regression tests (unit-level `isValidConfigKey` + a real `config-set` CLI round-trip, for both keys) committed and run under `gsd-test` against the pre-fix manifest — confirmed RED (4/44300 failing, exactly the new/modified assertions — plus one unrelated false-positive from `lint-docs-guard-registration.cjs`'s template-literal detector, tripped by an assert message mentioning a doc path between two pre-existing backticks; rephrased the message and re-confirmed a clean RED). Re-ran after the fix — GREEN. A code-review pass flagged a missing changeset and a coverage-rigor gap (`hooks.community` lacked the same e2e test `hooks.commit_types` got); both fixed, and `lint:ci` caught a bare `timeout: 15000` literal in the new tests (fixed with the existing `PROBE_TIMEOUT_MS` constant). Full matrix pass recorded for the final PR head sha.

### Regression test added?

- [x] Yes — added a test that would have caught this bug

### Platforms tested

- [x] Linux (gsd-test remote matrix)
- [x] N/A (pure JSON-allowlist + CLI logic, platform-independent)

### Runtimes tested

- [x] N/A (not runtime-specific — CLI/config logic only)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included (the `hooks.community` addition is the same defect class, in the same file, disclosed above, not unrelated scope)
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`gsd-test`)
- [x] `.changeset/` fragment added (`Fixed`, #4443)
- [x] No unnecessary dependencies added

## Breaking changes

None — this only widens a validation allowlist; nothing that was previously valid becomes invalid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
