### PR TITLE
fix(#4458): detect linked worktrees as sub-repositories

### DIFF
--- a/.changeset/nimble-quails-leap.md
+++ b/.changeset/nimble-quails-leap.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 4506
+---
+New-project now detects linked Git worktrees as sub-repositories, treating .git files and directories consistently during multi-repo setup.

--- a/gsd-core/workflows/new-project.md
+++ b/gsd-core/workflows/new-project.md
@@ -651,10 +651,10 @@ gsd_run query commit "chore: add project config" --files .planning/config.json
 
 **Detect multi-repo workspace:**
 
-Check for directories with their own `.git` folders (separate repos within the workspace):
+Check for directories with their own `.git` entry (a directory for clones or a file for linked worktrees):
 
 ```bash
-find . -maxdepth 1 -type d -not -name ".*" -not -name "node_modules" -exec test -d "{}/.git" \; -print
+find . -maxdepth 1 -type d -not -name ".*" -not -name "node_modules" -exec test -e "{}/.git" \; -print
 ```
 
 **If sub-repos found:**

--- a/tests/init.test.cjs
+++ b/tests/init.test.cjs
@@ -3491,6 +3491,7 @@ const os = require('node:os');
 const path = require('node:path');
 const { runGsdTools, cleanup } = require('./helpers.cjs');
 const { gitOrThrow } = require('./helpers/git-fixture.cjs');
+const { collectSection } = require('../gsd-core/bin/lib/markdown-sectionizer.cjs');
 
 const WORKFLOW_PATH = path.join(
   __dirname,
@@ -3643,6 +3644,25 @@ test('bug-3491: new-project.md gates `git init` on in_nested_subdir, not just ha
   assert.ok(
     /in_nested_subdir/.test(content),
     'new-project.md must reference `in_nested_subdir` after the #3491 fix',
+  );
+});
+
+test('bug-4458: new-project.md detects both clone and linked-worktree .git entries', () => {
+  const content = fs.readFileSync(WORKFLOW_PATH, 'utf-8');
+  const subRepoSection = collectSection(
+    content,
+    (heading) => heading.text === '5.1. Sub-Repo Detection',
+  )?.body ?? '';
+
+  assert.match(
+    subRepoSection,
+    /-exec test -e "\{\}\/\.git"/,
+    'sub-repo detection must accept .git as either a directory (clone) or file (linked worktree)',
+  );
+  assert.doesNotMatch(
+    subRepoSection,
+    /-exec test -d "\{\}\/\.git"/,
+    'the directory-only predicate silently excludes linked worktrees',
   );
 });
   });


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

Fixes #4458

---

## What was broken

The new-project sub-repository scan required `.git` to be a directory, so it silently omitted linked Git worktrees where `.git` is a file.

## What this fix does

Treats either kind of `.git` entry as a repository marker and documents both clone and linked-worktree layouts in the workflow.

## Root cause

The shell predicate encoded the physical layout of a regular clone instead of Git's repository marker contract.

## Testing

### How I verified the fix

- `npm run test:affected`
- `npm run lint:ci`
- Added a regression assertion against the bounded sub-repository workflow section.

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [ ] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None
