### PR TITLE
fix(#4447): classify mixed structural+transient planning commits as a 5th arm

### DIFF
--- a/.changeset/clever-rams-hop.md
+++ b/.changeset/clever-rams-hop.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`/gsd-pr-branch` no longer silently drops a planning-only commit that mixes a structural `.planning/` path (STATE.md, ROADMAP.md, etc.) with a transient or other planning path** — such a commit matched none of the classification's four arms and was excluded, which could break `STATE.md`'s per-commit revision chain in default mode. A fifth arm now covers this shape and includes it, same as a mixed code+planning commit. (#4447)

--- a/.changeset/clever-rams-hop.md
+++ b/.changeset/clever-rams-hop.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 4537
 ---
 **`/gsd-pr-branch` no longer silently drops a planning-only commit that mixes a structural `.planning/` path (STATE.md, ROADMAP.md, etc.) with a transient or other planning path** — such a commit matched none of the classification's four arms and was excluded, which could break `STATE.md`'s per-commit revision chain in default mode. A fifth arm now covers this shape and includes it, same as a mixed code+planning commit. (#4447)

--- a/.changeset/plucky-jays-travel.md
+++ b/.changeset/plucky-jays-travel.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 4537
 ---
 **Fixed an intermittent commit-hook failure (SIGPIPE race)** — `gsd-validate-commit.sh`'s subject/config extraction used `echo|head -1`-style pipes under `set -euo pipefail`; a real (multi-line) commit message or configured commit-type list could occasionally trip a SIGPIPE that aborted the whole hook instead of the intended pass/reject, appearing as a spurious `git commit` failure. Replaced with pure bash parameter expansion, eliminating the race entirely.

--- a/.changeset/plucky-jays-travel.md
+++ b/.changeset/plucky-jays-travel.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**Fixed an intermittent commit-hook failure (SIGPIPE race)** — `gsd-validate-commit.sh`'s subject/config extraction used `echo|head -1`-style pipes under `set -euo pipefail`; a real (multi-line) commit message or configured commit-type list could occasionally trip a SIGPIPE that aborted the whole hook instead of the intended pass/reject, appearing as a spurious `git commit` failure. Replaced with pure bash parameter expansion, eliminating the race entirely.

--- a/gsd-core/workflows/pr-branch.md
+++ b/gsd-core/workflows/pr-branch.md
@@ -292,9 +292,11 @@ condition is explicit and computable so no reading of it is ambiguous:
 - **Mixed planning commits (#4447)**: `NON_PLANNING == 0` and `STRUCTURAL > 0` and
   `STRUCTURAL < PLANNING_COUNT` (some but not all `.planning/` files touched are structural —
   the rest are transient and/or the "other" bucket, e.g. `config.json`/`intel/`) → INCLUDE in
-  **default** mode (same treatment as a mixed code+planning commit: the non-structural planning
-  paths are filtered out by `create_pr_branch`'s universal per-commit filter, not by this
-  classification); **EXCLUDE** in strict mode
+  **default** mode (the transient-dir subset of the non-structural paths is filtered out by
+  `create_pr_branch`'s universal per-commit filter exactly as for a mixed code+planning commit;
+  any "other" non-structural, non-transient path — `config.json`, `intel/`, etc. — is simply
+  preserved, same as default mode already does for such paths on any commit); **EXCLUDE** in
+  strict mode
 - **Transient-only planning commits**: `NON_PLANNING == 0` and `STRUCTURAL == 0` and
   `PLANNING_COUNT > 0` → EXCLUDE (both modes)
 
@@ -306,7 +308,7 @@ Commits to include: {N} (code changes{, + structural planning — default mode o
 Commits to exclude: {N} (planning-only)
 Mixed commits: {N} (code + planning — included, planning paths filtered)
 Structural planning commits: {N} ({included|excluded — strict mode})
-Mixed planning commits: {N} (included — structural + transient/other, planning paths filtered)
+Mixed planning commits: {N} ({included — structural + transient/other, planning paths filtered|excluded — strict mode})
 ```
 </step>
 

--- a/gsd-core/workflows/pr-branch.md
+++ b/gsd-core/workflows/pr-branch.md
@@ -278,16 +278,25 @@ For each commit, check what it touches:
 FILES=$(git diff-tree --no-commit-id --name-only -r $HASH)
 NON_PLANNING=$(echo "$FILES" | grep -c -v "^\.planning/" || true)
 STRUCTURAL=$(echo "$FILES" | grep -Ec "$STRUCTURAL_RE" || true)
+PLANNING_COUNT=$(echo "$FILES" | grep -c "^\.planning/" || true)
 ```
 
-Classify:
-- **Code commits**: touch at least one non-`.planning/` file → INCLUDE (both modes)
-- **Mixed commits**: touch code + any planning files → INCLUDE (both modes; the planning
-  paths are filtered out by `create_pr_branch`, not the commit)
-- **Structural planning commits**: touch only structural `.planning/` files → INCLUDE in
+Classify, using `NON_PLANNING`, `STRUCTURAL`, and `PLANNING_COUNT` computed above — every arm's
+condition is explicit and computable so no reading of it is ambiguous:
+- **Code commits**: `NON_PLANNING > 0` and `PLANNING_COUNT == 0` → INCLUDE (both modes)
+- **Mixed code+planning commits**: `NON_PLANNING > 0` and `PLANNING_COUNT > 0` → INCLUDE (both
+  modes; the planning paths are filtered out by `create_pr_branch`, not the commit)
+- **Structural-only planning commits**: `NON_PLANNING == 0` and `STRUCTURAL == PLANNING_COUNT`
+  and `PLANNING_COUNT > 0` (every `.planning/` file touched is structural) → INCLUDE in
   **default** mode; **EXCLUDE** in strict mode, which has no structural carve-out
-- **Transient planning commits**: touch only `.planning/` paths that are not structural →
-  EXCLUDE (both modes)
+- **Mixed planning commits (#4447)**: `NON_PLANNING == 0` and `STRUCTURAL > 0` and
+  `STRUCTURAL < PLANNING_COUNT` (some but not all `.planning/` files touched are structural —
+  the rest are transient and/or the "other" bucket, e.g. `config.json`/`intel/`) → INCLUDE in
+  **default** mode (same treatment as a mixed code+planning commit: the non-structural planning
+  paths are filtered out by `create_pr_branch`'s universal per-commit filter, not by this
+  classification); **EXCLUDE** in strict mode
+- **Transient-only planning commits**: `NON_PLANNING == 0` and `STRUCTURAL == 0` and
+  `PLANNING_COUNT > 0` → EXCLUDE (both modes)
 
 In strict mode this collapses to a single rule: `NON_PLANNING > 0` → INCLUDE, else EXCLUDE.
 
@@ -297,6 +306,7 @@ Commits to include: {N} (code changes{, + structural planning — default mode o
 Commits to exclude: {N} (planning-only)
 Mixed commits: {N} (code + planning — included, planning paths filtered)
 Structural planning commits: {N} ({included|excluded — strict mode})
+Mixed planning commits: {N} (included — structural + transient/other, planning paths filtered)
 ```
 </step>
 

--- a/hooks/gsd-validate-commit.sh
+++ b/hooks/gsd-validate-commit.sh
@@ -69,7 +69,11 @@ if [ -f .planning/config.json ]; then
     echo "gsd-validate-commit.sh: could not read .planning/config.json (opt-in check) — validator disabled for this call. $(cat "$ENABLED_ERR")" >&2
     exit 0
   fi
-  ENABLED=$(printf '%s\n' "$CONFIG_OUT" | head -1)
+  # Pure parameter expansion, not `printf ... | head -1`: same SIGPIPE race
+  # class as the SUBJECT extraction below (`echo "$MSG" | head -1`) — CONFIG_OUT
+  # is multi-line whenever extra commit types are configured, and `head -1`
+  # closing early can SIGPIPE `printf` under `set -euo pipefail`.
+  ENABLED="${CONFIG_OUT%%$'\n'*}"
   if [ "$ENABLED" != "1" ]; then exit 0; fi
   # Remaining lines (if any) are the sanitized, deduped configured commit
   # types beyond the 10 built-ins (#3811). Read into a bash-3.2-safe array —
@@ -521,9 +525,18 @@ if [ "$CLASSIFY_STATUS" = "0" ]; then
       SUBJECT=$(GIT_CMD_LIB="$HOOK_DIR/lib/git-cmd.js" MSG="$MSG" node -e "
         const {resolveCommitSubject}=require(process.env.GIT_CMD_LIB);
         process.stdout.write(resolveCommitSubject(process.env.MSG));
-      " 2>/dev/null) || SUBJECT=$(echo "$MSG" | head -1)
+      " 2>/dev/null) || SUBJECT="${MSG%%$'\n'*}"
     else
-      SUBJECT=$(echo "$MSG" | head -1)
+      # Pure parameter expansion, not `echo "$MSG" | head -1`: that pipeline
+      # raced a SIGPIPE under `set -euo pipefail` whenever $MSG had a body
+      # (the common case) — `head -1` can close its read end as soon as it
+      # has the first line, and if `echo`'s write lands after that close,
+      # `echo` dies with signal 13 (exit 141), which is NOT suppressed by
+      # `set -e` and aborted the whole hook intermittently (observed in
+      # tests/hooks-opt-in.test.cjs's --fixup=HEAD "round 7" case). Zero
+      # subprocesses here means zero pipe/race surface. Equivalent to
+      # `head -1` for single-line, multi-line, and trailing-newline input.
+      SUBJECT="${MSG%%$'\n'*}"
     fi
     # Single source of truth for the accepted commit-type list (#3811): the
     # 10 built-ins plus whatever passed the safe-token filter above. Both the

--- a/tests/hooks-opt-in.test.cjs
+++ b/tests/hooks-opt-in.test.cjs
@@ -1372,11 +1372,26 @@ EOF
     // Regexes require the `$(...)` command-substitution wrapper so this only
     // matches the actual dangerous CODE pattern, never the explanatory prose
     // comments left at the fix site (which quote the bare pipeline, without
-    // the `$(...)` wrapper, for documentation purposes).
-    assert.ok(!/\$\(echo "\$MSG" \| head -1\)/.test(hookSrc),
-      'the SIGPIPE-prone `$(echo "$MSG" | head -1)` subject extraction must not reappear');
-    assert.ok(!/\$\(printf '%s\\n' "\$CONFIG_OUT" \| head -1\)/.test(hookSrc),
-      'the SIGPIPE-prone `$(printf ... | head -1)` ENABLED extraction must not reappear');
+    // the `$(...)` wrapper, for documentation purposes). `\s+`/`\s*` tolerate
+    // incidental reformatting (extra spaces, an appended `2>/dev/null`, etc.)
+    // so a cosmetically-reworded reintroduction of the SAME dangerous shape
+    // does not silently escape this check (review finding: an exact-string
+    // match would).
+    // Requires the `$(...)` command-substitution wrapper (real CODE, never
+    // the explanatory prose comments left at the fix site, which quote the
+    // bare "$MSG" | head -1 / "$CONFIG_OUT" | head -1 shape WITHOUT a `$(`
+    // in front — an earlier, unwrapped version of this same regex matched
+    // those comments and false-failed). Content between `$(` and `"$MSG"`/
+    // `"$CONFIG_OUT"` and between the quote and `head -1` is a tolerant
+    // `[^)]*`, so a cosmetically-reworded reintroduction of the SAME
+    // dangerous shape (extra spaces, an appended `2>/dev/null`, a different
+    // command before the pipe) does not silently escape this check — only
+    // the presence of a real `$( ... "$MSG" ... | head -1 ... )` /
+    // `$( ... "$CONFIG_OUT" ... | head -1 ... )` substitution matters.
+    assert.ok(!/\$\([^)]{0,200}"\$MSG"[^)]{0,200}\|\s*head\s+-1[^)]{0,200}\)/.test(hookSrc),
+      'no $(...) command substitution may pipe "$MSG" into head -1 (SIGPIPE race under set -o pipefail)');
+    assert.ok(!/\$\([^)]{0,200}"\$CONFIG_OUT"[^)]{0,200}\|\s*head\s+-1[^)]{0,200}\)/.test(hookSrc),
+      'no $(...) command substitution may pipe "$CONFIG_OUT" into head -1 (SIGPIPE race under set -o pipefail)');
     assert.ok(hookSrc.includes('SUBJECT="${MSG%%$\'\\n\'*}"'),
       'subject extraction must use the pure parameter-expansion form');
     assert.ok(hookSrc.includes('ENABLED="${CONFIG_OUT%%$\'\\n\'*}"'),

--- a/tests/hooks-opt-in.test.cjs
+++ b/tests/hooks-opt-in.test.cjs
@@ -1356,6 +1356,33 @@ EOF
     assert.strictEqual(runHookCmd(`git commit -m ${HD_OK}`).status, 0, 'non-vacuity: canonical form still resolves');
   });
 
+  test('subject extraction uses no pipe-to-head (SIGPIPE race, #4447 follow-on)', () => {
+    // `echo "$MSG" | head -1` (and the equivalent `printf ... | head -1` for
+    // the opt-in ENABLED flag) is a SIGPIPE race under `set -euo pipefail`:
+    // `head -1` can close its read end as soon as it has one line, and a real
+    // commit message/config output is multi-line, so `echo`/`printf` can die
+    // with signal 13 (exit 141) if its write lands after that close — which
+    // aborts the whole hook instead of the expected exit 2. This is a static,
+    // by-construction pin (not a timing repro, per this repo's policy against
+    // forcing scheduling races to reproduce deterministically): the fix
+    // (`${VAR%%$'\n'*}`, a pure parameter expansion with zero subprocesses and
+    // therefore zero pipe/race surface) must be present, and the vulnerable
+    // pipe pattern must be gone.
+    const hookSrc = fs.readFileSync(path.join(HOOKS_DIR, 'gsd-validate-commit.sh'), 'utf8');
+    // Regexes require the `$(...)` command-substitution wrapper so this only
+    // matches the actual dangerous CODE pattern, never the explanatory prose
+    // comments left at the fix site (which quote the bare pipeline, without
+    // the `$(...)` wrapper, for documentation purposes).
+    assert.ok(!/\$\(echo "\$MSG" \| head -1\)/.test(hookSrc),
+      'the SIGPIPE-prone `$(echo "$MSG" | head -1)` subject extraction must not reappear');
+    assert.ok(!/\$\(printf '%s\\n' "\$CONFIG_OUT" \| head -1\)/.test(hookSrc),
+      'the SIGPIPE-prone `$(printf ... | head -1)` ENABLED extraction must not reappear');
+    assert.ok(hookSrc.includes('SUBJECT="${MSG%%$\'\\n\'*}"'),
+      'subject extraction must use the pure parameter-expansion form');
+    assert.ok(hookSrc.includes('ENABLED="${CONFIG_OUT%%$\'\\n\'*}"'),
+      'ENABLED extraction must use the pure parameter-expansion form');
+  });
+
   test('validate-commit does not trust a relative path ending in cat (round-4 Codex MAJOR)', () => {
     // Recognition accepted any path ending in `/cat`, so a planted `./cat` or
     // `../evil/cat` was trusted to echo its stdin. With such an executable

--- a/tests/pr-branch-planning-filter.test.cjs
+++ b/tests/pr-branch-planning-filter.test.cjs
@@ -164,6 +164,26 @@ describe('#2971 — pr-branch.md planning.pr_strict filter (failing-first)', () 
       assert.strictEqual(classifyCommit([], strictOpts), 'exclude');
     });
 
+    // #4447: a `.planning/`-only commit that mixes a structural path with a
+    // non-structural planning path (transient-dir or the "other" bucket) is
+    // the exact shape the workflow's prose could not classify — the four
+    // arms as written never compute a total planning-file count, so they
+    // cannot tell "only structural" from "structural plus something else".
+    // The JS model here already resolves it correctly (`classifyCommit`'s
+    // structural check has no upper bound against the total), so these pin
+    // that behavior; the actual defect is fixed in the workflow prose itself
+    // (see test 51).
+    test('49: #4447 [.planning/STATE.md, .planning/phases/PLAN.md] (structural + transient, no code) includes default, excludes strict', () => {
+      const files = ['.planning/STATE.md', '.planning/phases/PLAN.md'];
+      assert.strictEqual(classifyCommit(files, defaultOpts), 'include');
+      assert.strictEqual(classifyCommit(files, strictOpts), 'exclude');
+    });
+
+    test('50: #4447 [.planning/STATE.md, .planning/config.json] (structural + third-bucket, no code) includes default', () => {
+      const files = ['.planning/STATE.md', '.planning/config.json'];
+      assert.strictEqual(classifyCommit(files, defaultOpts), 'include');
+    });
+
     test('8: [.planning/STATE.md, src/a.ts] — forbiddenPaths [] default, [.planning/STATE.md] strict', () => {
       const files = ['.planning/STATE.md', 'src/a.ts'];
       assert.deepStrictEqual(forbiddenPaths(files, defaultOpts), []);
@@ -840,6 +860,29 @@ describe('#2971 — pr-branch.md planning.pr_strict filter (failing-first)', () 
       assert.ok(
         !text.includes('- [ ] No .planning/ files in PR branch diff'),
         'the unconditional "No .planning/ files in PR branch diff" success line must be removed/replaced',
+      );
+    });
+
+    // #4447: this pins the actual documented defect — ambiguous prose read by
+    // an LLM executing the workflow, not the already-correct JS model in
+    // pr-branch-filter.cjs (see tests 49/50). Before the fix, `analyze_commits`
+    // computed FILES/NON_PLANING/STRUCTURAL but never a total planning-file
+    // count, so its four classification arms had no way to distinguish
+    // "only structural" `.planning/` commits from "structural plus a
+    // transient/other `.planning/` path" — that second shape matched none of
+    // the four arms and was silently dropped, breaking STATE.md's per-commit
+    // revision chain in default mode. This must FAIL against the original
+    // (unedited) step text, which had no `PLANNING_COUNT=` assignment at all.
+    test('51: #4447 analyze_commits computes an explicit total .planning/ file count (PLANNING_COUNT), closing the gap that let a structural+transient/other planning commit match none of the four classification arms', () => {
+      const text = fs.readFileSync(WORKFLOW_PATH, 'utf-8');
+      const stepMatch = text.match(/<step name="analyze_commits">([\s\S]*?)<\/step>/);
+      assert.ok(stepMatch, 'analyze_commits step not found in pr-branch.md');
+      assert.match(
+        stepMatch[1],
+        /PLANNING_COUNT=/,
+        'analyze_commits must compute an explicit total planning-file count (PLANNING_COUNT) so '
+          + 'the classification arms can distinguish "only structural" planning commits from '
+          + '"structural plus transient/other" ones',
       );
     });
   });

--- a/tests/pr-branch-planning-filter.test.cjs
+++ b/tests/pr-branch-planning-filter.test.cjs
@@ -879,10 +879,10 @@ describe('#2971 — pr-branch.md planning.pr_strict filter (failing-first)', () 
       assert.ok(stepMatch, 'analyze_commits step not found in pr-branch.md');
       assert.match(
         stepMatch[1],
-        /PLANNING_COUNT=/,
-        'analyze_commits must compute an explicit total planning-file count (PLANNING_COUNT) so '
-          + 'the classification arms can distinguish "only structural" planning commits from '
-          + '"structural plus transient/other" ones',
+        /^PLANNING_COUNT=\$\(/m,
+        'analyze_commits must compute an explicit total planning-file count via a real shell '
+          + 'assignment (PLANNING_COUNT=$(...)) so the classification arms can distinguish '
+          + '"only structural" planning commits from "structural plus transient/other" ones',
       );
     });
   });

--- a/tests/pr-branch-planning-filter.test.cjs
+++ b/tests/pr-branch-planning-filter.test.cjs
@@ -875,7 +875,7 @@ describe('#2971 — pr-branch.md planning.pr_strict filter (failing-first)', () 
     // (unedited) step text, which had no `PLANNING_COUNT=` assignment at all.
     test('51: #4447 analyze_commits computes an explicit total .planning/ file count (PLANNING_COUNT), closing the gap that let a structural+transient/other planning commit match none of the four classification arms', () => {
       const text = fs.readFileSync(WORKFLOW_PATH, 'utf-8');
-      const stepMatch = text.match(/<step name="analyze_commits">([\s\S]*?)<\/step>/);
+      const stepMatch = text.match(/<step name="analyze_commits">([\s\S]{0,20000}?)<\/step>/);
       assert.ok(stepMatch, 'analyze_commits step not found in pr-branch.md');
       assert.match(
         stepMatch[1],


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #4447

---

## What was broken

`gsd-core/workflows/pr-branch.md`'s `analyze_commits` step classifies every commit ahead of the target branch into one of four arms before cherry-picking onto a PR branch: code, mixed code+planning, structural-only planning, transient-only planning. The step computes exactly two per-commit signals (`NON_PLANNING`, `STRUCTURAL`) — never a total planning-file count — so the four arms silently assumed every `.planning/`-only commit was either wholly structural or wholly non-structural. A commit touching **both** a structural `.planning/` path (e.g. `STATE.md`) and a transient or "other" planning path in the same commit matched none of the four arms.

Because this workflow is followed procedurally by an LLM agent reading its prose (not run as a literal deterministic script), that ambiguity resolved inconsistently in practice — observed behavior was silent exclusion of the commit. In default mode, `STATE.md` is replayed commit-by-commit (each revision edits the same frontmatter lines the previous one wrote), so dropping one link in that chain breaks a *later*, cleanly-classified commit's cherry-pick — which is where the failure actually surfaces, misdiagnosable as unrelated to the true cause.

## What this fix does

Adds an explicit `PLANNING_COUNT` variable and rewrites the four arms into five, each with an exact, computable boolean condition over `NON_PLANNING`/`STRUCTURAL`/`PLANNING_COUNT` — removing the prose ambiguity that let an LLM executor disagree with itself run to run. The new **mixed planning commit** arm (structural + transient/other paths present, no code) → **INCLUDE** in default mode, **EXCLUDE** in strict mode — the same treatment a mixed code+planning commit already gets. No new filtering logic was needed: `create_pr_branch`'s cherry-pick loop already strips every `$FILTER_PATHS` entry (the transient-dir subset) from **every** included commit unconditionally, regardless of which arm classified it; the "other" bucket (`config.json`, `intel/`, etc.) is simply preserved, exactly as default mode already does for it on any commit.

`tests/helpers/pr-branch-filter.cjs`'s `classifyCommit` (used to test the workflow's extracted declarations, not executed during a real run) already happened to return `'include'` for this shape — its structural check has no upper bound against the total. The defect was entirely in the workflow's own prose spec, which is what an executing agent actually reads.

## Root cause

Missing signal, not wrong logic: `analyze_commits` never computed a total `.planning/` file count, so its classification prose could not express "some but not all planning files are structural" as a distinct, nameable case.

---

## Decision record

The issue's reporter explicitly declined to propose a fix, framing the choice among 3 named alternatives as a maintainer's call. Put to the user directly: **add a 5th classification arm** (this PR) was chosen over the other two candidates (stop replaying `STATE.md` commit-by-commit; document as a known limitation).

---

## Bundled defect fix (discovered while verifying this PR)

Per this repo's Defects & Warnings policy, a genuine defect found mid-work is fixed inline rather than deferred — this PR also includes a fix for **`hooks/gsd-validate-commit.sh`'s intermittent SIGPIPE race**: its subject/config extraction used `echo "$MSG" | head -1` / `printf ... | head -1` under `set -euo pipefail`; `head -1` closing its read end before the writer finishes can SIGPIPE the writer (exit 141), which `pipefail` does not suppress — the whole hook aborted instead of the intended pass/reject. Confirmed via the actual failure detail (not assumed): `tests/hooks-opt-in.test.cjs`'s `--fixup=HEAD` "round 7" test got `r.status===141` on a run where the identical code had passed cleanly moments before. Replaced both patterns with pure bash parameter expansion (`${VAR%%$'\n'*}`) — zero subprocesses, zero pipe/race surface. Regression test is a static, by-construction assertion (the vulnerable pipe shape must be absent, the safe form present) rather than a timing repro, per this repo's policy against forcing scheduling races to reproduce deterministically.

---

## Testing

### How I verified the fix

Added 3 new tests to `tests/pr-branch-planning-filter.test.cjs`:
- Two lock `classifyCommit`'s already-correct behavior for the mixed-planning shape (structural+transient, and structural+"other"), citing #4447.
- One is a genuine failing-first regression: it asserts `pr-branch.md`'s `analyze_commits` step text itself computes an explicit planning-total signal (`PLANNING_COUNT=$(...)`) — this fails against the original (pre-fix) file, since no such variable existed, and passes after.

Full matrix run via `gsd-test` — GREEN (44486/44486) on the final head sha. Along the way, genuinely diagnosed (not pattern-matched) three separate red results rather than assuming any were unrelated: (1) a real, correctly-triggered `emitted-attribution` gate — `pr-branch.md` grew and needed an `Emitted-Drift-Ack-Growth` trailer, added properly; (2) the SIGPIPE race above — root-caused and fixed, not deferred; (3) `tests/release-tarball-smoke.install.test.cjs`'s real `npm install` hitting its (already properly hardened, >=600s) timeout under bench load — confirmed via a clean re-run on the identical tree that this was one-off external network/bench variance, not a deterministic defect in this branch.

### Regression test added?

- [x] Yes — added tests that would have caught this bug (see above)

### Platforms tested

- [x] N/A (workflow/prose + test-only change — no platform-specific behavior)

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes (the bundled SIGPIPE fix is a genuine defect discovered mid-work, disclosed above, fixed per this repo's Defects & Warnings policy rather than deferred)
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`gsd-test`)
- [x] `.changeset/` fragments added — `Fixed`, one for the pr-branch classification fix (#4447), one for the bundled SIGPIPE fix
- [x] No unnecessary dependencies added

## Breaking changes

None — widens which commits get included in a PR branch (fixing data loss), doesn't change any already-correct classification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
