### PR TITLE
fix(#4457): cover init.new-milestone's project_exists/project_path under an active workstream

### DIFF
--- a/tests/init-manager.test.cjs
+++ b/tests/init-manager.test.cjs
@@ -1172,13 +1172,17 @@ describe('init subcommands sharing the project_exists/project_path PROJECT.md pa
   // and withProjectRoot) repeated verbatim, via grep, in six more cmdInit*
   // functions. Each is exercised here through its real CLI subcommand rather
   // than re-asserting src/init.cts internals directly, so a regression in the
-  // router wiring would also be caught. `init manager` and `init new-milestone`
-  // are deliberately excluded: `manager` has its own STATE.md/ROADMAP.md
-  // readiness guard (covered separately above via `init complete-milestone`,
-  // which shares withProjectRoot); `new-milestone`'s project_path fix is
-  // real (see src/init.cts) but its dedicated coverage belongs with #4456's
-  // own new-milestone.md workstream-forwarding work, not duplicated here.
-  const SUBCOMMANDS = ['ingest-docs', 'resume', 'progress', 'new-project'];
+  // router wiring would also be caught. `init manager` is deliberately
+  // excluded: it has its own STATE.md/ROADMAP.md readiness guard (covered
+  // separately above via `init complete-milestone`, which shares
+  // withProjectRoot). `new-milestone` was originally deferred to #4456's own
+  // new-milestone.md workstream-forwarding work (see PR #4543), but that PR
+  // only exercised the *workflow's* `--ws` argv forwarding through a stubbed
+  // gsd_run, never cmdInitNewMilestone's real project_exists/project_path
+  // output — #4457 closes that gap by folding it into this loop; it has no
+  // manager-style readiness precondition, so it fits the shared assertion
+  // shape below without a dedicated test.
+  const SUBCOMMANDS = ['ingest-docs', 'resume', 'progress', 'new-project', 'new-milestone'];
 
   let tmpDir;
 


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #4457

---

## What was broken

After a normal `workstream.create --migrate-name` migration (PROJECT.md correctly stays
at the planning root; ROADMAP/STATE/REQUIREMENTS/phases move into the named workstream),
`init.progress` and `init.new-milestone` were reported to return `project_exists: false`
and a workstream-scoped `project_path` for the root-shared PROJECT.md.

## What this fix does

**No production code change.** Direct read of current `src/init.cts` on `next` (commit
`147c89a9b8`) shows this exact defect is already fixed by PR #4543 (#4455's
self-discovered follow-up, merged before this issue was picked up): `withProjectRoot`,
`buildInitCompletenessFields`, `cmdInitProgress`'s `project_exists`, and
`cmdInitNewMilestone`'s `project_exists`/`project_path` all already resolve PROJECT.md
via the root-aware `planningDir(cwd, null)`.

What was genuinely missing: PR #4543's own regression-test sweep
(`tests/init-manager.test.cjs`) explicitly deferred `new-milestone`'s coverage to
"#4456's own new-milestone.md workstream-forwarding work" — but PR #4545 (#4456) only
ever exercised the *workflow's* `--ws` argv forwarding through a stubbed `gsd_run`,
never `cmdInitNewMilestone`'s real CLI output. That gap is exactly what this issue's own
acceptance ask requests ("Add a migration-to-init regression test with a root
PROJECT.md and no workstream-local copy") and it was never actually closed by either
prior PR.

This fix folds `'new-milestone'` into the existing parametrized `SUBCOMMANDS` loop in
`tests/init-manager.test.cjs` (`describe('init subcommands sharing the
project_exists/project_path PROJECT.md pattern (#4455 follow-up)')`) — it has no
`cmdInitManager`-style readiness precondition, and exposes both `project_exists` and
`project_path`, so it fits the loop's existing assertion shape without a dedicated test.

## Root cause

A scope-coordination gap across two related PRs: #4543 pointed the missing coverage at
#4456, #4456 didn't pick it up (it was solving a different problem — workflow-level
`--ws` forwarding, not the underlying `cmdInitNewMilestone` fields), and nothing closed
the loop until this issue's own acceptance criteria named it explicitly.

## Testing

### How I verified the fix

- Read `src/init.cts` directly (Memtrace) to confirm all four fields the issue's repro
  depends on are already resolved via `planningDir(cwd, null)` on `next`.
- `gsd-test --base next --head <sha>` — full matrix, see verdict below.
- Code review (fresh subagent) + security review (fresh subagent), both clean.

### Regression test added?

- [x] Yes — `'new-milestone'` added to the existing `SUBCOMMANDS` regression loop in
  `tests/init-manager.test.cjs`.

### Platforms tested

- [x] Linux (via `gsd-test`'s full matrix)
- [ ] macOS
- [ ] Windows

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___

---

## Checklist

- [x] Issue linked above with `Fixes #4457`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — this issue's actual gap (missing regression
      coverage for an already-fixed defect) is test-only; no production code changed
- [x] Regression test added
- [x] All existing tests pass (`gsd-test`)
- [x] `.changeset/` fragment added — N/A, `tests/` is not a user-facing prefix per
      `scripts/changeset/lint.cjs`'s `USER_FACING_PREFIXES` (verified directly)
- [x] No unnecessary dependencies added

## Breaking changes

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
