### PR TITLE
fix(#4540): execute-plan.md 21 bytes over its DEFAULT size-tier cap

### DIFF
--- a/.changeset/vivid-newts-march.md
+++ b/.changeset/vivid-newts-march.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 4555
+---
+**`execute-plan.md` no longer trips its own size-tier cap.** The workflow file had drifted 21 bytes past its DEFAULT-tier hard cap (introduced by #4540's compact-content variant wiring), which failed `next`'s own test run and blocked every other PR's merge gate. Two wording trims restore headroom; the instruction set is unchanged.

--- a/gsd-core/workflows/execute-plan.md
+++ b/gsd-core/workflows/execute-plan.md
@@ -602,7 +602,7 @@ All routes: `/clear` first for fresh context.
 - USER-SETUP.md generated if user_setup in frontmatter
 - SUMMARY.md created with substantive content
 - STATE.md updated (position, decisions, issues, session) — unless parallel mode (orchestrator handles)
-- ROADMAP.md updated — unless parallel mode (orchestrator handles)
+- ROADMAP.md updated — same exception
 - If codebase map exists: map updated with execution changes (or skipped if no significant changes)
-- If USER-SETUP.md created: prominently surfaced in completion output
+- If USER-SETUP.md created: surfaced in completion output
 </success_criteria>


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #4554

---

## What was broken

`gsd-core/workflows/execute-plan.md` sat 21 bytes over its own DEFAULT-tier hard cap (40,960 bytes, `tests/workflow-size-budget.test.cjs`, ADR-1610) at `next`'s current tip. `next`'s own `Tests` GitHub Actions run fails on every shard/OS combination as a result, which trips the repo's `Base branch health` PR-mergeability gate (#4422/#4428) — every open and future PR onto `next` reports it red, regardless of that PR's own diff.

## What this fix does

Two meaning-preserving trims in the `<success_criteria>` block: a repeated parenthetical (`— unless parallel mode (orchestrator handles)`, appearing twice) replaced with a `— same exception` back-reference on its second occurrence, and one redundant qualifier (`prominently`) dropped — its behavioral content (surface the USER-SETUP.md warning at the TOP of output) is already fully specified earlier in the same file. 40,981 → 40,940 bytes, 20 bytes of headroom under the cap. No procedural content lost.

## Root cause

Introduced by #4540 (Phase 6 of the #4139 compact-content epic), which added call-site wiring for the `summary.md`/`user-setup.md` `.compact.md` variants directly into `execute-plan.md`. No CI job caught the file crossing this exact byte margin before that PR merged.

## Testing

### How I verified the fix

`wc -c gsd-core/workflows/execute-plan.md` before/after (40,981 → 40,940); `tests/workflow-size-budget.test.cjs` locally (133/133 pass, including the specific cap assertion that was failing); full `gsd-test --base next --head <sha>` (44,623/44,623 pass).

### Regression test added?

- [x] No — explain why: the regression test already exists and already caught this (`tests/workflow-size-budget.test.cjs`'s per-file DEFAULT-tier cap assertion for `execute-plan.md`) — it's a content-tree assertion against a real file's byte count, not something a new test needs to duplicate.

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix — N/A, this is internal shipped-prompt-content byte accounting with no user-facing behavior change; no `no-changelog` label needed since it's not user-facing at all (a workflow instruction file's own success-criteria wording, functionally identical before/after)
- [x] No unnecessary dependencies added

## Breaking changes

None.
