### PR TITLE
docs(#4467): document fallow's structural-pre-pass has no upper-bound scope

### DIFF
--- a/.changeset/sharp-bears-roar.md
+++ b/.changeset/sharp-bears-roar.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 4574
 ---
 **Structural pre-pass now documents that its fallow scope has no upper bound** — the phase-directory-anchored base is correct and lockstep with Tier 3's own scope step, but nothing bounds the tip, so reviewing an earlier phase after a later one has landed could silently pull the later phase's files into the audit. The limitation is now documented at the point the scope is derived.

--- a/.changeset/sharp-bears-roar.md
+++ b/.changeset/sharp-bears-roar.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**Structural pre-pass now documents that its fallow scope has no upper bound** — the phase-directory-anchored base is correct and lockstep with Tier 3's own scope step, but nothing bounds the tip, so reviewing an earlier phase after a later one has landed could silently pull the later phase's files into the audit. The limitation is now documented at the point the scope is derived.

--- a/gsd-core/workflows/code-review/steps/structural-pre-pass.md
+++ b/gsd-core/workflows/code-review/steps/structural-pre-pass.md
@@ -31,6 +31,13 @@ FALLOW_STDERR_TMP=$(mktemp)
 # scope step (#3191/#3995): base = the parent of the first commit that added
 # anything under the phase's own directory. Commit subjects carry no milestone
 # bound — a same-numbered phase in a previous milestone used to win the grep.
+# #4467: the BASE half above is lockstep with Tier 3 (#3995); the TIP is not.
+# fallow's own --changed-since is one-sided by design (no upper-bound flag
+# exists in fallow 2.70.0 — --diff-file only scopes line ranges within the
+# hot-path-touched verdict, it is not a general file-scoping control), so
+# reviewing an earlier phase after a later one has landed pulls the later
+# phase's files into this pass's audited set. Do not assume this step and
+# Tier 3's scope step agree on the tip just because they agree on the base.
 FALLOW_SCOPE_ARGS=()
 if [ \"$FALLOW_SCOPE\" = \"phase\" ]; then
   # #3995: phase-directory anchor — same derivation as the Tier-3 scope step


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #4467

---

## What was broken

`structural-pre-pass.md`'s `FALLOW_SCOPE_ARGS=(--changed-since "$FALLOW_BASE")` derives a correct, phase-anchored LOWER bound (lockstep with Tier 3's own scope step, #3995), but `fallow`'s `--changed-since` is one-sided by design — verified against fallow 2.70.0's own `--help`. Reviewing an earlier phase after a later one has landed pulls the later phase's files into the earlier phase's structural audit, with nothing in the file explaining why.

## What this fix does

Documents the asymmetry at the point the scope is derived, so a future reader does not assume this step's tip agrees with Tier 3's just because the base does. Not fixable inside this file: fixing `fallow` itself is a third-party concern, and working around it is disproportionate machinery for supplementary structural-analysis context, not a blocking gate — both routes the issue's own analysis already ruled out.

## Root cause

`fallow`'s `--changed-since` flag has no complementary upper-bound flag; the only other scoping flags (`--changed-workspaces`, `--diff-file`) don't provide one either.

---

## Testing

### How I verified the fix

Documentation-only, no runtime behavior change — confirmed via direct diff (comment-only addition, no fence logic touched). Full suite verified via `gsd-test`: `outcome:"passed"`, 44702/44702.

### Regression test added?

- [x] No — explain why: documentation-only change, no runtime behavior to regression-test.

### Platforms tested

- [x] N/A (not platform-specific)

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (verified via `gsd-test`, not local `npm test` — this repo blocks local `node --test`)
- [x] `.changeset/` fragment added (`Fixed`, symptom-led)
- [x] No unnecessary dependencies added

## Breaking changes

None
