### PR TITLE
docs(#4484): correct native-plugin-install's install-time-config parity claim

### DIFF
--- a/.changeset/silly-voles-climb.md
+++ b/.changeset/silly-voles-climb.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 4579
 ---
 **Corrected the native-plugin-install docs' parity claim** — the doc previously said the plugin path and the npm installer differ only in namespace and lifecycle. They also differ in whether install-time config applies at all: the native plugin path never runs GSD's install engine, so config like `agent_tools` that the npm installer bakes into generated artifacts at install time silently never applies there, even after `claude plugin update`. (#4484)

--- a/.changeset/silly-voles-climb.md
+++ b/.changeset/silly-voles-climb.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**Corrected the native-plugin-install docs' parity claim** — the doc previously said the plugin path and the npm installer differ only in namespace and lifecycle. They also differ in whether install-time config applies at all: the native plugin path never runs GSD's install engine, so config like `agent_tools` that the npm installer bakes into generated artifacts at install time silently never applies there, even after `claude plugin update`. (#4484)

--- a/docs/how-to/install-on-your-runtime.md
+++ b/docs/how-to/install-on-your-runtime.md
@@ -64,7 +64,9 @@ The `FileChanged` hook is always-on and a no-op when `.planning/config.json` doe
 
 ### Claude Code — native plugin install
 
-GSD Core ships a `.claude-plugin/plugin.json` manifest, which enables installation and lifecycle management through the Claude Code plugin system. This path is **additive** — the npm installer above remains fully supported, and the two approaches differ in namespace and lifecycle only.
+GSD Core ships a `.claude-plugin/plugin.json` manifest, which enables installation and lifecycle management through the Claude Code plugin system. This path is **additive** — the npm installer above remains fully supported, and the two approaches differ in namespace and lifecycle.
+
+**Install-time config does not apply here.** The native plugin path (this section, the skills-dir load below, and marketplace discovery) materializes the repository tree directly — there is no install step. Install-time config that the npm installer bakes into generated artifact files at install time (confirmed for `agent_tools`; the same applies architecturally to `model_overrides` and other install-time-only keys) is never applied on this path, and running `claude plugin update` does not change that. If your setup relies on install-time config, use the npm installer above.
 
 **Install paths**
 


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #4484

---

## What was broken

`docs/how-to/install-on-your-runtime.md`'s "Claude Code — native plugin install" section claimed the plugin path and the npm installer "differ in namespace and lifecycle only." That's not accurate: the native plugin path never runs GSD's install engine, so install-time config baked into generated artifact files at install time (confirmed for `agent_tools`, #4238/#4032) silently never applies there.

## What this fix does

Corrects the claim and states plainly that install-time config does not apply on the native-plugin path, naming `agent_tools` as the confirmed-affected key and `model_overrides` as the same architectural class (hedged, not claimed independently reproduced — matching the issue's own hedging).

## Root cause

The native plugin path (`claude plugin install`, marketplace discovery, and the skills-dir zero-friction load) materializes the repository tree directly with no install step, so there is nothing to apply install-time config into.

---

## Testing

### How I verified the fix

Documentation-only, no runtime behavior change. Confirmed `agent_tools` and `model_overrides` are real, existing config keys (not invented terms) and that no other "parity"/"fully supported" claim elsewhere in the doc needs the same correction.

### Regression test added?

- [x] No — explain why: documentation-only change, no runtime behavior to regression-test.

### Platforms tested

- [x] N/A (not platform-specific)

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (documentation-only change; `npm run lint:ci` clean)
- [x] `.changeset/` fragment added (`Fixed`, symptom-led)
- [x] No unnecessary dependencies added

## Breaking changes

None
