### PR TITLE
fix(#4489): make capability-registry.test.cjs's extractShellBlocks CRLF-safe

### DIFF
--- a/docs/INVENTORY-MANIFEST.json
+++ b/docs/INVENTORY-MANIFEST.json
@@ -559,6 +559,7 @@
       "surface.cjs",
       "task-command-router.cjs",
       "task-content-resolution.cjs",
+      "tdd-red-evidence.cjs",
       "teams-status.cjs",
       "template.cjs",
       "text-lines.cjs",

--- a/docs/INVENTORY-MANIFEST.json
+++ b/docs/INVENTORY-MANIFEST.json
@@ -559,7 +559,6 @@
       "surface.cjs",
       "task-command-router.cjs",
       "task-content-resolution.cjs",
-      "tdd-red-evidence.cjs",
       "teams-status.cjs",
       "template.cjs",
       "text-lines.cjs",

--- a/tests/capability-registry.test.cjs
+++ b/tests/capability-registry.test.cjs
@@ -6286,7 +6286,11 @@ const WORKFLOWS_DIR = path.join(__dirname, '..', 'gsd-core', 'workflows');
  * between the ```bash / ```sh / ```shell fence markers.
  */
 function extractShellBlocks(content) {
-  const allLines = content.split('\n');
+  // #4489: CRLF-safe split (mirrors src/text-lines.cts's splitLines() and the
+  // fixed sibling copy in tests/runtime-launcher-parity.test.cjs:221) — a bare
+  // '\n' split leaves a trailing \r on every line on a CRLF checkout, which
+  // reaches lineHasBareGsdTools' whitespace tokenizer below.
+  const allLines = content.split(/\r?\n/);
   const blocks = [];
   let inBlock = false;
   let blockLang = null;
@@ -6368,6 +6372,41 @@ function lineHasBareGsdTools(line) {
 }
 
 const AGENTS_DIR = path.join(__dirname, '..', 'agents');
+
+describe('bug #4489: extractShellBlocks is CRLF-safe (sibling of #4409)', () => {
+  test('a CRLF-line-ending fenced block yields lines with no trailing \\r', () => {
+    const content = [
+      '# doc',
+      '',
+      '```bash',
+      'echo one',
+      'echo two',
+      '```',
+      '',
+    ].join('\r\n');
+    const blocks = extractShellBlocks(content);
+    assert.strictEqual(blocks.length, 1, 'expected exactly one extracted block');
+    assert.deepStrictEqual(blocks[0].lines, ['echo one', 'echo two']);
+    for (const line of blocks[0].lines) {
+      assert.ok(!line.includes('\r'), `line carried a trailing/embedded \\r: ${JSON.stringify(line)}`);
+    }
+  });
+
+  test('LF-only input is unaffected (pre-existing behavior unchanged)', () => {
+    const content = [
+      '# doc',
+      '',
+      '```sh',
+      'echo one',
+      'echo two',
+      '```',
+      '',
+    ].join('\n');
+    const blocks = extractShellBlocks(content);
+    assert.strictEqual(blocks.length, 1);
+    assert.deepStrictEqual(blocks[0].lines, ['echo one', 'echo two']);
+  });
+});
 
 describe('bug #1041: agent files must not call bare gsd-tools (all-runtime resolver)', () => {
   test('no agents/gsd-*.md file contains a bare gsd-tools command', () => {


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #4489

---

## What was broken

`tests/capability-registry.test.cjs`'s own `extractShellBlocks` helper split markdown content on `content.split('\n')` only, leaving a trailing `\r` on every extracted line on a CRLF checkout (Windows, `core.autocrlf=true`). This is a second, independent copy of the CRLF-fragile line-splitting bug fixed in #4409 for `tests/runtime-launcher-parity.test.cjs`, explicitly flagged there as a separate, out-of-scope instance to track.

## What this fix does

Same fix shape as #4409: `content.split('\n')` → `content.split(/\r?\n/)`, matching the CRLF-safe convention already established in `src/text-lines.cts`'s `splitLines()` and the already-fixed sibling copy.

## Root cause

A bare `'\n'` split treats `\r\n` line endings as one `\n`-delimited token still carrying the leading `\r`.

## Testing

### How I verified the fix

Added two tests: one confirming a CRLF-line-ending fenced block extracts lines with no trailing `\r`, and a control confirming LF-only input behavior is unchanged.

### Regression test added?

- [x] Yes — added a test that would have caught this bug

### Platforms tested

- [x] N/A (not platform-specific) — verified via `gsd-test`'s full remote matrix; the bug itself is CRLF-checkout-specific but the fix and tests are platform-agnostic (hardcoded `\r\n` fixture strings, not real Windows checkout behavior)

### Runtimes tested

- [x] N/A (not runtime-specific) — pure test-helper change, no shipped code

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass (via `gsd-test`)
- [x] No changeset needed — test-only change, `tests/` is not a user-facing prefix
- [x] No unnecessary dependencies added

## Breaking changes

None
