### PR TITLE
chore(#4592): replace blanket test-file full_matrix rule with reachability

### DIFF
--- a/scripts/ci-test-scope.cjs
+++ b/scripts/ci-test-scope.cjs
@@ -3,9 +3,10 @@
 
 const path = require('path');
 const { execFileSync } = require('child_process');
-const { existsSync, readdirSync, appendFileSync } = require('fs');
+const { existsSync, readdirSync, appendFileSync, readFileSync } = require('fs');
 
 const { ExitError, runMain } = require('./lib/cli-exit.cjs');
+const { classifyContent, NOISY_FOR_SOURCE_REACHABILITY } = require('./gen-platform-conformance-tier.cjs');
 
 // Workflow files that are purely administrative / policy bots. Changes to these
 // files do NOT require the cross-platform test matrix — only a lightweight
@@ -487,7 +488,55 @@ function addAll(set, values) {
 const WINDOWS_HINTS = ['windows', 'win32', 'shell', 'path'];
 const isWindowsHint = s => WINDOWS_HINTS.some(k => s.toLowerCase().includes(k));
 
-function classify(files) {
+// A change to the classification mechanism itself cannot be presumed safe by
+// the very mechanism being changed (#4592).
+const CLASSIFIER_DEFINITION_FILES = new Set([
+  'scripts/gen-platform-conformance-tier.cjs',
+  'scripts/lib/platform-conformance-tier.generated.cjs',
+  'scripts/lib/suite-detection.cjs',
+]);
+
+/**
+ * Does `file`'s blast radius reach (a) Phase 2's conformance-tier test-file
+ * list or (b) a live platform-conditional signal in src/? Fail-safe: any
+ * thrown error (a require failure, a readFileSync failure, a malformed
+ * generated module, etc.) is treated as uncertainty and returns true — per
+ * #4592's explicit "fail-safe to full_matrix=true on any reachability-
+ * computation error or uncertainty" requirement.
+ * `loadConformanceTier` is injectable (defaults to the real generated module)
+ * solely so tests can simulate a load failure without touching the real,
+ * committed generated file.
+ * @param {string} file
+ * @param {{loadConformanceTier?: () => {CONFORMANCE_TIER_FILES: string[]}}} [deps]
+ * @returns {boolean}
+ */
+function reachesConformanceTierOrSeam(file, deps = {}) {
+  const loadConformanceTier =
+    deps.loadConformanceTier || (() => require('./lib/platform-conformance-tier.generated.cjs'));
+  try {
+    if (file.startsWith('tests/') && file.endsWith('.test.cjs')) {
+      const { CONFORMANCE_TIER_FILES } = loadConformanceTier();
+      return CONFORMANCE_TIER_FILES.includes(file);
+    }
+
+    if (file.startsWith('src/')) {
+      const content = readFileSync(file, 'utf8');
+      const { signals } = classifyContent(content);
+      const narrowSignals = signals.filter(signal => !NOISY_FOR_SOURCE_REACHABILITY.has(signal));
+      return narrowSignals.length > 0;
+    }
+
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+// `reachabilityDeps` is injectable (defaults to {}, which makes
+// reachesConformanceTierOrSeam use the real generated module) solely so
+// tests can simulate a reachability-computation failure without touching
+// the real, committed generated file.
+function classify(files, reachabilityDeps = {}) {
   const targeted = new Set();
   const windows = new Set();
   const reasons = [];
@@ -532,8 +581,30 @@ function classify(files) {
       // lane already covered them. Rescinded per #4421: PR #4384 landed a
       // macOS-only regression on 2026-09-06 that stayed invisible pre-merge
       // precisely because this carve-out suppressed the only macOS signal.
-      // The ~25-runner-minute cost on test-touching PRs is accepted.
+      // #4592: the blanket rule is replaced with a reachability check — only
+      // a changed test file that actually reaches Phase 2's conformance-tier
+      // list (or is the classification mechanism itself) forces full_matrix.
+      if (reachesConformanceTierOrSeam(file, reachabilityDeps)) {
+        fullMatrix = true;
+        reasons.push(`${file}: conformance-tier reachability`);
+      }
+    }
+
+    // #4592: a src/-only diff (no test file touched) must still be able to
+    // set full_matrix=true when it carries a live platform-conditional
+    // signal — this is independent of the tests/ branch above.
+    if (file.startsWith('src/') && reachesConformanceTierOrSeam(file, reachabilityDeps)) {
       fullMatrix = true;
+      reasons.push(`${file}: platform seam reachability`);
+    }
+
+    // #4592: a changed file that IS the classification mechanism itself
+    // (neither under tests/ nor src/, so neither branch above reaches it)
+    // must also force full_matrix — a change to the mechanism cannot be
+    // presumed safe by the very mechanism being changed.
+    if (CLASSIFIER_DEFINITION_FILES.has(file)) {
+      fullMatrix = true;
+      reasons.push(`${file}: reachability classifier definition changed`);
     }
 
     for (const rule of RULES) {
@@ -629,4 +700,12 @@ if (require.main === module) {
   runMain(main);
 }
 
-module.exports = { RULES, missingRuleTestFiles, PROTECTED_WORKFLOWS, INERT_WORKFLOWS, missingProtectedWorkflows };
+module.exports = {
+  RULES,
+  missingRuleTestFiles,
+  PROTECTED_WORKFLOWS,
+  INERT_WORKFLOWS,
+  missingProtectedWorkflows,
+  classify,
+  reachesConformanceTierOrSeam,
+};

--- a/scripts/gen-platform-conformance-tier.cjs
+++ b/scripts/gen-platform-conformance-tier.cjs
@@ -150,6 +150,14 @@ const CATEGORIES = [
   },
 ];
 
+// Two CATEGORIES entries precise enough for TEST-file classification (this
+// module's own purpose) but far too broad for SOURCE-file reachability
+// (scripts/ci-test-scope.cjs's #4592 use). Empirically verified: applying
+// classifyContent to every file under src/ (235 files) flags 100 of them,
+// driven almost entirely by these two categories; excluding them narrows it
+// to 28 files, all verified to carry a genuine platform-conditional branch.
+const NOISY_FOR_SOURCE_REACHABILITY = new Set(['hardcoded-path-vs-path-call', 'symlink-keyword']);
+
 /**
  * Pure classifier: given a test file's raw string content, returns which
  * platform-conformance categories matched and whether the file needs real-OS
@@ -333,4 +341,4 @@ if (require.main === module) {
   runMain(main);
 }
 
-module.exports = { classifyContent, CATEGORIES, walkTestFiles, classifyTree, renderGeneratedFile };
+module.exports = { classifyContent, CATEGORIES, NOISY_FOR_SOURCE_REACHABILITY, walkTestFiles, classifyTree, renderGeneratedFile };

--- a/tests/ci-test-scope.test.cjs
+++ b/tests/ci-test-scope.test.cjs
@@ -15,10 +15,14 @@ const ROOT = path.join(__dirname, '..');
 const SCRIPT = path.join(ROOT, 'scripts', 'ci-test-scope.cjs');
 const WORKFLOWS_DIR = path.join(ROOT, '.github', 'workflows');
 
-function scopeFor(files) {
-  const r = runNode([SCRIPT, '--files', files.join(' ')], { cwd: ROOT, timeoutMs: PROBE_TIMEOUT_MS });
+function scopeForAt(files, cwd) {
+  const r = runNode([SCRIPT, '--files', files.join(' ')], { cwd, timeoutMs: PROBE_TIMEOUT_MS });
   assert.strictEqual(r.exitCode, 0, `stderr: ${r.stderr}\nstdout: ${r.stdout}`);
   return JSON.parse(r.stdout);
+}
+
+function scopeFor(files) {
+  return scopeForAt(files, ROOT);
 }
 
 describe('ci-test-scope.cjs', () => {
@@ -77,8 +81,14 @@ describe('ci-test-scope.cjs', () => {
       `expected policy-lint-shallow-checkout in targeted_tests for inert CI, got: ${JSON.stringify(result.targeted_tests)}`);
   });
 
-  test('TS runtime sources (src/semver.cts) — code_changed true, product_changed true, full_matrix false, semver tests targeted', () => {
-    const result = scopeFor(['src/semver.cts']);
+  test('TS runtime sources (src/semver-compare.cts) — code_changed true, product_changed true, full_matrix false, semver tests targeted', () => {
+    // #4592: must be a REAL, on-disk src/ file with no narrow platform signal.
+    // A nonexistent path (the former fixture, 'src/semver.cts', names no real
+    // file in this repo) now hits reachesConformanceTierOrSeam's readFileSync
+    // fail-safe (ENOENT → full_matrix=true by design), which would silently
+    // test the fail-safe path instead of this test's actual subject: the "TS
+    // runtime sources" RULES entry has no fullMatrix field of its own.
+    const result = scopeFor(['src/semver-compare.cts']);
     assert.strictEqual(result.code_changed, true,
       `expected code_changed=true for src/ change, got: ${JSON.stringify(result)}`);
     assert.strictEqual(result.product_changed, true,
@@ -284,8 +294,13 @@ describe('ci-test-scope superset invariant (#494, rescinded by #4421)', () => {
   // the scoped windows lane instead of triggering the full parity matrix.
   // Rescinded per #4421 (2026-09-06 RCA: PR #4384 shipped a macOS-only
   // regression invisible pre-merge because of exactly this carve-out) — a
-  // changed test file now ALWAYS sets full_matrix=true, in addition to still
-  // joining the scoped windows lane.
+  // changed test file always joins the scoped windows lane, and (until
+  // #4592) ALWAYS set full_matrix=true too. #4592 replaces that blanket rule
+  // with a reachability check: full_matrix now fires only when the changed
+  // test file is tagged in Phase 2's CONFORMANCE_TIER_FILES (or is the
+  // classification mechanism itself). A1/A2 below are real, committed
+  // conformance-tier files, so they still assert full_matrix=true — for the
+  // new, documented reason, not the removed blanket rule.
   test('A1: a changed test file joins the windows scoped lane AND triggers full_matrix', () => {
     const result = scopeFor(['tests/perf-317-context-monitor-fs.test.cjs']);
     assert.strictEqual(result.full_matrix, true,
@@ -306,10 +321,17 @@ describe('ci-test-scope superset invariant (#494, rescinded by #4421)', () => {
       `expected hint-less changed test in windows_tests, got: ${JSON.stringify(result.windows_tests)}`);
   });
 
-  test('A3: a deleted/nonexistent test path falls back to the unit token, still triggers full_matrix', () => {
+  test('A3: a deleted/nonexistent test path falls back to the unit token; full_matrix now depends on conformance-tier reachability (#4592)', () => {
+    // Pre-#4592, the removed blanket rule forced full_matrix=true for ANY
+    // changed tests/*.test.cjs path regardless of on-disk existence or
+    // content. #4592 replaces that with direct CONFORMANCE_TIER_FILES
+    // membership — a path absent from the committed list is treated as
+    // genuinely Linux-safe, not as uncertain (design doc's explicit policy),
+    // so a synthetic/nonexistent path with no tier entry now yields
+    // full_matrix=false.
     const result = scopeFor(['tests/some-new.test.cjs']);
-    assert.strictEqual(result.full_matrix, true,
-      `expected full_matrix=true even for a nonexistent tests/*.test.cjs path — the matrix decision is made on the changed-file name, not on-disk existence (rescinded #494 carve-out, see #4421), got: ${JSON.stringify(result)}`);
+    assert.strictEqual(result.full_matrix, false,
+      `expected full_matrix=false for a tests/*.test.cjs path absent from CONFORMANCE_TIER_FILES (#4592), got: ${JSON.stringify(result)}`);
     // The nonexistent file is filtered by existingTests(); with nothing left,
     // the #408 fallback applies so the targeted lane still runs something.
     assert.deepStrictEqual(result.targeted_tests, ['unit']);
@@ -915,6 +937,173 @@ describe('code_changed=false implies clean output invariant', () => {
   });
 });
 
+
+describe('#4592 reachability-based full_matrix classifier', () => {
+  // Row 1: a real, committed conformance-tier test file forces full_matrix,
+  // and the reason names the new mechanism (not a generic path-prefix rule).
+  test('full_matrix true for a conformance-tier test file', () => {
+    const { CONFORMANCE_TIER_FILES } = require('../scripts/lib/platform-conformance-tier.generated.cjs');
+    assert.ok(CONFORMANCE_TIER_FILES.length > 0, 'precondition: committed tier list must be non-empty');
+    const file = CONFORMANCE_TIER_FILES[0];
+    const result = scopeFor([file]);
+    assert.strictEqual(result.full_matrix, true,
+      `expected full_matrix=true for conformance-tier file ${file}, got: ${JSON.stringify(result)}`);
+    assert.ok(result.reasons.includes(`${file}: conformance-tier reachability`),
+      `expected reasons to name the conformance-tier mechanism, got: ${JSON.stringify(result.reasons)}`);
+  });
+
+  // Row 2: the whole point of the change — a changed test file that is NOT in
+  // CONFORMANCE_TIER_FILES and matches no other RULES entry must NOT force
+  // full_matrix.
+  test('full_matrix false for a non-conformance-tier test file alone', () => {
+    const { CONFORMANCE_TIER_FILES } = require('../scripts/lib/platform-conformance-tier.generated.cjs');
+    const file = 'tests/some-brand-new-non-tier.test.cjs';
+    assert.ok(!CONFORMANCE_TIER_FILES.includes(file), 'precondition: fixture path must not be tier-tagged');
+    const result = scopeFor([file]);
+    assert.strictEqual(result.full_matrix, false,
+      `expected full_matrix=false for a non-conformance-tier test file, got: ${JSON.stringify(result)}`);
+  });
+
+  // Row 3: named #4421 regression — the exact file from PR #4384 must still
+  // force full_matrix, now for the documented reachability reason instead of
+  // the removed blanket rule.
+  test('#4421 regression: state-todos-render.test.cjs still forces full_matrix, for the documented reason', () => {
+    const file = 'tests/state-todos-render.test.cjs';
+    const { CONFORMANCE_TIER_FILES } = require('../scripts/lib/platform-conformance-tier.generated.cjs');
+    assert.ok(CONFORMANCE_TIER_FILES.includes(file),
+      'precondition: state-todos-render.test.cjs must be present in the committed conformance tier');
+    const result = scopeFor([file]);
+    assert.strictEqual(result.full_matrix, true,
+      `expected full_matrix=true for the #4421 regression file, got: ${JSON.stringify(result)}`);
+    assert.ok(result.reasons.includes(`${file}: conformance-tier reachability`),
+      `expected reasons to name the conformance-tier mechanism (not the removed blanket rule), got: ${JSON.stringify(result.reasons)}`);
+  });
+
+  // Row 4: the seam file itself always forces full_matrix — its own content
+  // carries genuine narrow platform signals (process-platform, raw-child-
+  // process, etc.), so this is the organic content-check path, not a special
+  // case in the code.
+  test('full_matrix true when the seam file itself changes', () => {
+    const result = scopeFor(['src/shell-command-projection.cts']);
+    assert.strictEqual(result.full_matrix, true,
+      `expected full_matrix=true for the seam file, got: ${JSON.stringify(result)}`);
+    assert.ok(result.reasons.includes('src/shell-command-projection.cts: platform seam reachability'),
+      `expected reasons to name platform seam reachability, got: ${JSON.stringify(result.reasons)}`);
+  });
+
+  // Rows 5-7: minimal constructed src/ fixtures (not a real, drifting file) —
+  // same temp-tree pattern as the '#837 three-dot diff' test above, but
+  // invoked via --files (no git commit needed).
+  test('full_matrix true for a non-seam src/ file with a genuine platform signal', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ci-scope-4592-narrow-'));
+    try {
+      fs.mkdirSync(path.join(tmp, 'tests'), { recursive: true });
+      fs.mkdirSync(path.join(tmp, 'src'), { recursive: true });
+      const file = 'src/narrow-signal-fixture.cts';
+      fs.writeFileSync(path.join(tmp, file), "if (process.platform === 'win32') { doWindowsThing(); }\n");
+
+      const result = scopeForAt([file], tmp);
+      assert.strictEqual(result.full_matrix, true,
+        `expected full_matrix=true for a src/ file with a narrow platform signal, got: ${JSON.stringify(result)}`);
+      assert.ok(result.reasons.includes(`${file}: platform seam reachability`),
+        `expected reasons to name platform seam reachability, got: ${JSON.stringify(result.reasons)}`);
+    } finally {
+      cleanup(tmp);
+    }
+  });
+
+  test('full_matrix false for a src/ file with only noisy signals', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ci-scope-4592-noisy-'));
+    try {
+      fs.mkdirSync(path.join(tmp, 'tests'), { recursive: true });
+      fs.mkdirSync(path.join(tmp, 'src'), { recursive: true });
+      const file = 'src/noisy-only-fixture.cts';
+      // Matches ONLY hardcoded-path-vs-path-call (path.join + a leading-slash
+      // literal) and symlink-keyword ("symlink") — no narrow signal at all.
+      fs.writeFileSync(
+        path.join(tmp, file),
+        "const p = path.join(root, 'x');\nassert.equal(rendered, '/etc/passwd');\n// see symlink handling elsewhere\n",
+      );
+
+      const result = scopeForAt([file], tmp);
+      assert.strictEqual(result.full_matrix, false,
+        `expected full_matrix=false for a src/ file with only noisy signals, got: ${JSON.stringify(result)}`);
+    } finally {
+      cleanup(tmp);
+    }
+  });
+
+  test('full_matrix false for a src/ file with no platform signal', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ci-scope-4592-clean-'));
+    try {
+      fs.mkdirSync(path.join(tmp, 'tests'), { recursive: true });
+      fs.mkdirSync(path.join(tmp, 'src'), { recursive: true });
+      const file = 'src/no-signal-fixture.cts';
+      fs.writeFileSync(path.join(tmp, file), 'function add(a, b) { return a + b; }\n');
+
+      const result = scopeForAt([file], tmp);
+      assert.strictEqual(result.full_matrix, false,
+        `expected full_matrix=false for a src/ file with zero signals, got: ${JSON.stringify(result)}`);
+    } finally {
+      cleanup(tmp);
+    }
+  });
+
+  // Rows 8-10: the classifier's own definition files always fail-safe to
+  // full_matrix=true — a change to the classification mechanism itself
+  // cannot be presumed safe by the very mechanism being changed.
+  for (const file of [
+    'scripts/lib/platform-conformance-tier.generated.cjs',
+    'scripts/gen-platform-conformance-tier.cjs',
+    'scripts/lib/suite-detection.cjs',
+  ]) {
+    test(`full_matrix true when ${file} itself changes`, () => {
+      const result = scopeFor([file]);
+      assert.strictEqual(result.full_matrix, true,
+        `expected full_matrix=true for classifier definition file ${file}, got: ${JSON.stringify(result)}`);
+      assert.ok(result.reasons.includes(`${file}: reachability classifier definition changed`),
+        `expected reasons to name the classifier-definition fail-safe, got: ${JSON.stringify(result.reasons)}`);
+    });
+  }
+
+  // Row 11: fail-safe when the generated tier module fails to load. Exercised
+  // in-process against the real, exported classify()/reachesConformanceTierOrSeam
+  // with an injected loader that throws — no real file is corrupted, and this
+  // proves the failure propagates all the way through classify() without an
+  // uncaught exception escaping it.
+  describe('full_matrix true when the generated tier module fails to load', () => {
+    const { classify, reachesConformanceTierOrSeam } = require('../scripts/ci-test-scope.cjs');
+    const throwingDeps = { loadConformanceTier: () => { throw new Error('simulated load failure'); } };
+
+    test('reachesConformanceTierOrSeam fails safe to true, does not throw', () => {
+      let result;
+      assert.doesNotThrow(() => {
+        result = reachesConformanceTierOrSeam('tests/some.test.cjs', throwingDeps);
+      });
+      assert.strictEqual(result, true);
+    });
+
+    test('classify() propagates the fail-safe without an uncaught exception', () => {
+      let result;
+      assert.doesNotThrow(() => {
+        result = classify(['tests/some.test.cjs'], throwingDeps);
+      });
+      assert.strictEqual(result.full_matrix, true,
+        `expected full_matrix=true when the tier module fails to load, got: ${JSON.stringify(result)}`);
+    });
+  });
+
+  // Row 13: pairing a conformance-tier test file with an inert-workflow-only
+  // file must not be overridden by the inert-CI normalization, since
+  // productOrPipelineChanged is already true for any tests/ path.
+  test('full_matrix stays true when a conformance-tier test file is paired with an inert workflow file', () => {
+    const { CONFORMANCE_TIER_FILES } = require('../scripts/lib/platform-conformance-tier.generated.cjs');
+    const tierFile = CONFORMANCE_TIER_FILES[0];
+    const result = scopeFor([tierFile, '.github/workflows/stale.yml']);
+    assert.strictEqual(result.full_matrix, true,
+      `expected full_matrix=true even paired with an inert workflow file, got: ${JSON.stringify(result)}`);
+  });
+});
 
 // ────────────────────────────────────────────────────────────────────────
 // Folded from tests/bug-641-files-from-suite-token.test.cjs — consolidation epic #1969 (B6 #1975)

--- a/tests/platform-conformance-tier.test.cjs
+++ b/tests/platform-conformance-tier.test.cjs
@@ -22,7 +22,7 @@ const path = require('node:path');
 
 const { createTempDir, cleanup } = require('./helpers.cjs');
 const { runNode } = require('./helpers/process-seam.cjs');
-const { classifyContent, classifyTree } = require('../scripts/gen-platform-conformance-tier.cjs');
+const { classifyContent, classifyTree, NOISY_FOR_SOURCE_REACHABILITY } = require('../scripts/gen-platform-conformance-tier.cjs');
 
 const ROOT = path.resolve(__dirname, '..');
 const SCRIPT = path.join(ROOT, 'scripts', 'gen-platform-conformance-tier.cjs');
@@ -141,6 +141,20 @@ describe('classifyContent — negative / hostile inputs', () => {
     const { needsRealOs, signals } = classifyContent(fixture);
     assert.equal(needsRealOs, false);
     assert.deepEqual(signals, []);
+  });
+});
+
+// ─── Row 15 (#4592): NOISY_FOR_SOURCE_REACHABILITY drift guard ────────────────
+
+describe('NOISY_FOR_SOURCE_REACHABILITY (#4592)', () => {
+  test('NOISY_FOR_SOURCE_REACHABILITY exports exactly the two noisy categories', () => {
+    assert.ok(NOISY_FOR_SOURCE_REACHABILITY instanceof Set,
+      `expected a Set, got: ${typeof NOISY_FOR_SOURCE_REACHABILITY}`);
+    assert.deepEqual(
+      [...NOISY_FOR_SOURCE_REACHABILITY].sort(),
+      ['hardcoded-path-vs-path-call', 'symlink-keyword'].sort(),
+      `expected exactly the two named noisy categories, got: ${JSON.stringify([...NOISY_FOR_SOURCE_REACHABILITY])}`,
+    );
   });
 });
 


### PR DESCRIPTION
## Enhancement PR

---

## Linked Issue

Closes #4592

---

## What this enhancement improves

Replaces `scripts/ci-test-scope.cjs`'s blanket "any changed `tests/**/*.test.cjs` file forces
`full_matrix=true`" rule with a reachability check against real data: Phase 2's committed
platform-conformance-tier list, and a live platform-signal scan of changed `src/` files.

Phase 3 of epic #4589. Depends on Phase 2 (#4591, merged in #4598) for the conformance-tier file
list this classifier checks reachability against.

## Before / After

**Before:** Any changed `tests/**/*.test.cjs` file set `full_matrix=true`, unconditionally,
regardless of whether that file's content had anything to do with platform-sensitive behavior.
Restored by #4421 after #962's narrowing let a real macOS-only regression (PR #4384) land
undetected pre-merge. Since this is a TDD-first repo, this blanket rule fires on the large
majority of PRs.

**After:** A changed test file forces `full_matrix=true` only when it is present in Phase 2's
committed `CONFORMANCE_TIER_FILES` list — i.e., its own content was already flagged as needing
real-OS coverage. A changed `src/` file independently forces `full_matrix=true` when its own
content carries a genuine platform-conditional signal (a narrowed, source-code-safe subset of
Phase 2's classifier signals). A change to the classification mechanism's own definition files
always forces `full_matrix=true`. Any computation error fails safe to `full_matrix=true`.

## How it was implemented

- `scripts/gen-platform-conformance-tier.cjs` gains one new export, `NOISY_FOR_SOURCE_REACHABILITY`
  — a `Set` of the two `CATEGORIES` signal names (`hardcoded-path-vs-path-call`, `symlink-keyword`)
  empirically found too imprecise for source-code reachability (see "Design corrections" below).
- `scripts/ci-test-scope.cjs` gains `reachesConformanceTierOrSeam(file, deps)`: for a `tests/`
  file, direct membership in `CONFORMANCE_TIER_FILES`; for a `src/` file, a live content scan via
  `classifyContent` with the noisy categories excluded; wrapped in a fail-safe try/catch (any
  error → `true`, per the issue's explicit requirement). `classify()`'s blanket rule is replaced
  with this check; a separate, direct check forces `full_matrix=true` for the classifier's own
  three definition files (they don't live under `tests/` or `src/`, so neither branch above would
  otherwise reach them).
- **The existing `RULES` array entries with their own `fullMatrix: true`** (`workflow automation`,
  `installer and package layout`, `hooks`, `environment and dependency gates`, `test harness`) are
  **deliberately left untouched**. They are curated, narrowly-scoped triggers for "this diff
  changes the CI/installer/hooks mechanism itself" — categorically different from "product code
  might reach a platform branch," and not what the issue's "Proposed work" bullets describe
  touching. See `.gsd/phase/chore-4592-reachability-classifier/40-design.md`'s "Scope decision"
  section for the full reasoning trail (the issue's own "Done when" wording read broader than its
  "Proposed work" bullets; this is disclosed as a scope-interpretation call, not silently assumed).

### Design corrections found before writing any code (disclosed, not hidden)

Two successive candidate designs were caught and rejected during a `/rubber-duck` pass, before any
implementation, each by actually measuring against real files rather than trusting a plausible
heuristic:

1. **Reusing Phase 2's `classifyContent` verbatim against `src/` files.** Applying it to all 235
   `src/` files flags 100 of them — driven almost entirely by two signal categories precise for
   *test* content but far too broad for *product source*. Fixed by excluding those two categories
   (`NOISY_FOR_SOURCE_REACHABILITY`), narrowing the flagged set to 28/235.
2. **A single hardcoded seam file** (`src/shell-command-projection.cts` only, following
   `CLAUDE.md`'s "single platform seam" framing). Verified empirically before accepting this:
   applying the narrowed signal set to `src/` surfaces 28 files with genuine, independent platform
   branches, not one — `src/runtime-hooks-surface.cts`'s `resolveBashRunner`, `src/capability-lock.cts`,
   `src/capability-ledger.cts`, and `src/surface.cts` all read `process.platform` directly, with no
   delegation through the seam. A single-file set would have silently under-covered exactly the
   #4421 failure shape, relocated into `src/`. Fixed by replacing the fixed set with a live,
   per-changed-file content scan applied to every changed `src/` file.

## Testing

### How I verified the enhancement works

- `tests/ci-test-scope.test.cjs` gains the full boundary-case matrix from
  `.gsd/phase/chore-4592-reachability-classifier/50-test-matrix.md`: a real conformance-tier test
  file (`full_matrix: true`, reason names the mechanism), a non-tier test file alone
  (`full_matrix: false` — the whole point of this change), a **named #4421 regression case**
  (`tests/state-todos-render.test.cjs`, the actual file from PR #4384, still forces
  `full_matrix: true`, now for the documented reason instead of the removed blanket rule), the seam
  file changed directly, a constructed `src/` fixture with a genuine narrow signal, a constructed
  `src/` fixture with only noisy signals (proves the exclusion actually excludes), a constructed
  `src/` fixture with no signal, all three classifier-definition files, an injected load-failure
  fail-safe case (in-process, no real file corrupted), and a conformance-tier file paired with an
  inert workflow file (proves the inert-CI normalization doesn't override it).
- `tests/platform-conformance-tier.test.cjs` gains one drift-guard row asserting
  `NOISY_FOR_SOURCE_REACHABILITY` exports exactly the two named categories.
- Two pre-existing tests were corrected (both audited by the isolated review below as legitimate,
  not scope-hiding): one used a fixture path (`src/semver.cts`) that names no real file in this
  repo — under the new logic a nonexistent `src/` path hits the `readFileSync` fail-safe
  (`full_matrix: true`), silently testing the wrong thing; pointed at the real, signal-free
  `src/semver-compare.cts` instead. One (`A3`) asserted the exact old blanket-rule behavior this
  issue removes; updated to the new, verified-correct expectation (`full_matrix: false` for a
  synthetic path absent from `CONFORMANCE_TIER_FILES`).
- `node scripts/ci-test-scope.cjs --files "<path>"` run directly against real repo files
  (`tests/state-todos-render.test.cjs`, `src/shell-command-projection.cts`, a genuinely clean
  `src/` file, `bin/install.js`, `.github/workflows/test.yml`, and all three classifier-definition
  files) to independently confirm behavior before committing, not just trusting the implementer's
  self-report.
- `npm run lint:ci` → exit 0 (run twice: once before, once after the review-driven fixes below).
- A first isolated `/code-review` pass (Standards + Spec axes) found and fixed one real defect: a
  dead, untested branch in `reachesConformanceTierOrSeam` (a redundant early-return for the
  classifier-definition-files check that `classify()`'s actual call sites could never reach — the
  live check is a separate block in `classify()`'s own loop) that would have survived this repo's
  80% Stryker mutation-kill threshold. Also found and fixed a design-doc completeness gap: 2 of the
  8 "narrow" signal categories (`os-platform`, `process-seam-subprocess`) were left implicitly
  rather than explicitly audited for source-code precision; closed with an explicit verification
  (both are call-shaped signals, structurally identical in precision to the other 6; empirically
  inert today — 0/235 `src/` files — for the right structural reason, not by assumption).
- An isolated `/security-review` pass found no qualifying findings — production CI only invokes
  this script via `--base`/`--head` (`git diff --name-only` output, which cannot contain
  path-traversal-shaped entries since git tree objects reject `..` path components at commit time);
  the `--files` flag accepting an arbitrary string is test-only; the generated-module `require()`
  target is a fixed literal never built from changed-file content; `classifyContent`'s regexes have
  no catastrophic-backtracking-shaped construct.
- `gsd-test --base bcd99696d32cc919f82d9edefb1ce8ef68a05afc --head eea3210eefa1dd372a9509262ef5bd8d74021bad`
  → **PASSED** — 45049/45049, 0 failures (linux-node24).

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [x] N/A (not platform-specific) — the classifier's own logic has no platform-conditional
      branches; its OUTPUT determines whether OTHER jobs run on real Windows/macOS, and this PR's
      own real GitHub Actions CI run is the live validation of that (flagged for close attention
      on the checks tab, same as Phase 2).

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue — no additions or removals,
      with one disclosed scope-interpretation call (see "How it was implemented" above): only the
      blanket test-file rule is replaced; the five curated `RULES` entries with their own
      `fullMatrix: true` are left untouched, since they trigger for a categorically different
      reason (CI/installer/hooks mechanism changing) than the blanket rule the issue and the #4421
      incident are about.
- [x] If scope changed during implementation, I updated the issue and got re-approval before
      continuing (see the scope decision disclosed above and in `40-design.md`; no issue-body edit
      was needed here since — unlike Phase 2 — no acceptance criterion in #4592's own "Done when"
      checklist is left unmet by this interpretation).

---

## Documentation

- [ ] Updated the relevant file(s) under `docs/` to reflect this change
- [x] All `docs/` content added in this PR is written in English
- [x] If genuinely no user-facing docs impact (infrastructure / internal refactor / test-only),
      apply the `no-docs` label **or** add `<!-- docs-exempt: <reason> -->` — applying `no-docs`:
      this is CI-internal classification logic with no user-facing command, flag, or config key.

This PR touches none of the paths the `Changeset Required` workflow gates on (`bin/`, `gsd-core/`,
`src/`, `agents/`, `commands/`, `hooks/`, `sdk/src/`) — `scripts/` and `tests/` are outside that
trigger set, so no `.changeset/*` fragment is required and none is included. Applying
`no-changelog` for clarity since there is no user-facing behavior change.

## Checklist

- [x] Issue linked above with `Closes #4592`
- [x] Linked issue has the `approved-enhancement` label
- [x] Changes are scoped to the approved enhancement (as disclosed above) — nothing extra
- [x] All existing tests pass (`npm run lint:ci`, `gsd-test`)
- [x] New or updated tests cover the enhanced behavior
- [x] No `.changeset/` fragment needed (outside the Changeset Required trigger paths);
      `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None to any user-facing behavior. **CI-internal breaking change (intentional, disclosed):** a PR
that changes only a `tests/**/*.test.cjs` file NOT in Phase 2's conformance tier no longer forces
`full_matrix=true` — this is the entire point of the PR, not an accidental side effect. Every other
existing `full_matrix` trigger (workflow, installer, hooks, env/dependency-gate, test-harness
changes, and any conformance-tier or platform-seam-touching change) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
