### PR TITLE
fix(#4606): resolve third-bucket chain conflicts in create_pr_branch via git checkout --theirs

### DIFF
--- a/.changeset/serene-lynx-wave.md
+++ b/.changeset/serene-lynx-wave.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 4609
+---
+**`/gsd-pr-branch` no longer aborts on a "third bucket" chain conflict** — when a later included commit reuses a `.planning/` path that an earlier excluded commit also touched, `create_pr_branch`'s cherry-pick loop now resolves the conflict with `git checkout --theirs` instead of halting and rolling back the whole run.

--- a/gsd-core/workflows/pr-branch.md
+++ b/gsd-core/workflows/pr-branch.md
@@ -352,6 +352,32 @@ for HASH in $(printf '%s' "$INCLUDED_COMMITS"); do
     git checkout HEAD -- "$P" 2>/dev/null || true
   done
 
+  # #4606: a conflict on a "third bucket" path (`.planning/` — not `$FORBIDDEN_RE`
+  # transient, not `$STRUCTURAL_RE` structural — the same bucket `verify`'s
+  # `$OTHER` reports) is not a real conflict either, and needs its own
+  # resolution distinct from the filter loop above. Such a path is never
+  # per-commit replayed by classification — a commit touching ONLY a
+  # third-bucket path is EXCLUDEd — so when a LATER included commit (structural
+  # or code + that same path) reuses it, the diff's context can predate
+  # whatever the PR branch actually has, and cherry-pick reports a genuine
+  # content conflict on a path this command was never asked to filter.
+  # `git checkout --theirs` resolves it correctly by construction: in a
+  # cherry-pick's 3-way merge, "theirs" IS $HASH's own content for that path —
+  # exactly the chained final value the path is owed, the same guarantee
+  # `create_pr_branch` already gives structural files. A path $HASH deletes has
+  # no "theirs" blob to check out, so fall back to accepting the deletion (the
+  # `verify` step's `$PLANNING_DELETIONS` gate independently catches this if
+  # `$TARGET` ever legitimately tracked that path).
+  for P in $(git diff --name-only --diff-filter=U); do
+    case "$P" in
+      .planning/*) ;;
+      *) continue ;;
+    esac
+    if echo "$P" | grep -Eq "$FORBIDDEN_RE"; then continue; fi
+    if echo "$P" | grep -Eq "$STRUCTURAL_RE"; then continue; fi
+    git checkout --theirs -- "$P" 2>/dev/null && git add -- "$P" || git rm -f -q -- "$P" 2>/dev/null || true # gsd-scan-ignore: #4606 -- restages a path already committed to $CURRENT_BRANCH's own history onto the disposable $PR_BRANCH; not a commit_docs bypass (#1783/#3585), which guards against staging .planning/ content that was never committed at all
+  done
+
   # Anything still unmerged is a REAL conflict, outside the filter. Halt — do not
   # improvise a resolution and do not continue, which would drop the rest of the queue.
   # Unwind first: this loop runs in the user's own checkout, so exiting mid-sequence

--- a/gsd-core/workflows/pr-branch.md
+++ b/gsd-core/workflows/pr-branch.md
@@ -368,6 +368,17 @@ for HASH in $(printf '%s' "$INCLUDED_COMMITS"); do
   # no "theirs" blob to check out, so fall back to accepting the deletion (the
   # `verify` step's `$PLANNING_DELETIONS` gate independently catches this if
   # `$TARGET` ever legitimately tracked that path).
+  #
+  # The deleted-by-$HASH case is checked explicitly with `git cat-file -e`
+  # rather than inferred from `checkout --theirs` failing, so an unrelated
+  # checkout failure (I/O, permissions, a stale index lock) can't be
+  # misread as a deletion and silently `git rm`-ed — it falls through to the
+  # unmerged-path halt below instead.
+  #
+  # The `git add` below restages a path already committed to $CURRENT_BRANCH's
+  # own history onto the disposable $PR_BRANCH; not a commit_docs bypass
+  # (#1783/#3585), which guards against staging .planning/ content that was
+  # never committed at all.
   for P in $(git diff --name-only --diff-filter=U); do
     case "$P" in
       .planning/*) ;;
@@ -375,7 +386,11 @@ for HASH in $(printf '%s' "$INCLUDED_COMMITS"); do
     esac
     if echo "$P" | grep -Eq "$FORBIDDEN_RE"; then continue; fi
     if echo "$P" | grep -Eq "$STRUCTURAL_RE"; then continue; fi
-    git checkout --theirs -- "$P" 2>/dev/null && git add -- "$P" || git rm -f -q -- "$P" 2>/dev/null || true # gsd-scan-ignore: #4606 -- restages a path already committed to $CURRENT_BRANCH's own history onto the disposable $PR_BRANCH; not a commit_docs bypass (#1783/#3585), which guards against staging .planning/ content that was never committed at all
+    if git cat-file -e "$HASH:$P" 2>/dev/null; then
+      git checkout --theirs -- "$P" && git add -- "$P" # gsd-scan-ignore: #4606 -- see block comment above
+    else
+      git rm -f -q -- "$P" 2>/dev/null || true
+    fi
   done
 
   # Anything still unmerged is a REAL conflict, outside the filter. Halt — do not

--- a/tests/pr-branch-planning-filter.test.cjs
+++ b/tests/pr-branch-planning-filter.test.cjs
@@ -540,6 +540,92 @@ describe('#2971 — pr-branch.md planning.pr_strict filter (failing-first)', () 
         teardown();
       }
     });
+
+    // #4606: c1 touches ONLY a third-bucket path (.planning/WINDOWS.md) and is
+    // EXCLUDEd by classification (test 6's shape); c2 touches a structural
+    // path (.planning/STATE.md) plus that SAME third-bucket path, so c2 is
+    // INCLUDEd (#4447's 5th arm) — but c2's diff for WINDOWS.md is written
+    // against c1's content, which the PR branch never received. Before the
+    // #4606 fix, cherry-picking c2 aborts with a real content conflict on
+    // WINDOWS.md and the whole create_pr_branch run rolls back.
+    function buildThirdBucketChainFixture() {
+      const dir = trackDir(fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-prbranch-3rdbucket-')));
+      initRepo(dir);
+      writeFile(dir, 'code.txt', 'line1\n');
+      writeFile(dir, '.planning/STATE.md', 'state v1\n');
+      writeFile(dir, '.planning/WINDOWS.md', 'v1\n');
+      commitAll(dir, 'chore: base');
+      git(['branch', 'feature'], dir);
+
+      git(['checkout', '-q', 'feature'], dir);
+      writeFile(dir, '.planning/WINDOWS.md', 'v1\nv2\n');
+      commitAll(dir, 'docs: c1 third-bucket-only (excluded by classification)');
+      const c1 = git(['rev-parse', 'HEAD'], dir).trim();
+
+      writeFile(dir, '.planning/STATE.md', 'state v2\n');
+      writeFile(dir, '.planning/WINDOWS.md', 'v1\nv2\nv3\n');
+      commitAll(dir, 'docs: c2 structural + third-bucket (included by #4447 5th arm)');
+      const c2 = git(['rev-parse', 'HEAD'], dir).trim();
+
+      git(['checkout', '-q', 'main'], dir);
+      git(['checkout', '-q', '-b', 'prbranch', 'main'], dir);
+      return { dir, c1, c2 };
+    }
+
+    // Unlike buildRecipeScript above, this #4606 fix makes create_pr_branch's
+    // loop reference $STRUCTURAL_RE/$FORBIDDEN_RE for the first time (to tell
+    // a real conflict from a third-bucket one), so this script sets them from
+    // the real shipped declarations — not hand-copied literals — same
+    // single-source-of-truth principle as parseWorkflow itself.
+    function buildThirdBucketRecipeScript({ includedHash, filterPaths, structuralRe, forbiddenRe }) {
+      return [
+        'set -u',
+        'CURRENT_BRANCH=feature',
+        'PR_BRANCH=prbranch',
+        'TARGET=main',
+        `INCLUDED_COMMITS="${includedHash}"`,
+        `FILTER_PATHS="${filterPaths.join(' ')}"`,
+        `STRUCTURAL_RE='${structuralRe}'`,
+        `FORBIDDEN_RE='${forbiddenRe}'`,
+        extractPickLoop(readWorkflowText()),
+      ].join('\n');
+    }
+
+    test('#4606 L2: a later mixed commit reusing an excluded third-bucket path cherry-picks cleanly and reaches the chained final content', () => {
+      const { transientDirs, structuralRe } = readWorkflow();
+      const { dir, c2 } = buildThirdBucketChainFixture();
+      try {
+        const filterPaths = transientDirs.map((d) => `.planning/${d}/`);
+        const forbiddenRe = forbiddenRegex({ strict: false, transientDirs }).source;
+        // Only c2 is "included" here — c1 is deliberately omitted, simulating
+        // what analyze_commits' classification produces (L1 tests 6/49/50
+        // already prove that classification in isolation); this L2 layer
+        // proves create_pr_branch's cherry-pick mechanics given that input,
+        // same division of labor as the other L2 tests above.
+        const script = buildThirdBucketRecipeScript({ includedHash: c2, filterPaths, structuralRe, forbiddenRe });
+        let result;
+        try {
+          const stdout = execFileSync('sh', ['-c', script], { cwd: dir, encoding: 'utf8', timeout: CHERRY_PICK_RECIPE_TIMEOUT_MS });
+          result = { status: 0, stdout, stderr: '' };
+        } catch (err) {
+          result = { status: typeof err.status === 'number' ? err.status : 1, stdout: err.stdout || '', stderr: err.stderr || '' };
+        }
+        assert.strictEqual(result.status, 0, `create_pr_branch must not abort on the third-bucket chain conflict: ${result.stderr}`);
+
+        const windowsContent = fs.readFileSync(path.join(dir, '.planning/WINDOWS.md'), 'utf-8');
+        assert.strictEqual(
+          windowsContent, 'v1\nv2\nv3\n',
+          'WINDOWS.md must reach c2\'s exact chained content, not c1\'s dropped intermediate state or main\'s stale original',
+        );
+        const stateContent = fs.readFileSync(path.join(dir, '.planning/STATE.md'), 'utf-8');
+        assert.strictEqual(stateContent, 'state v2\n', 'the structural path in the same commit must still land correctly');
+
+        const count = parseInt(git(['rev-list', '--count', 'main..prbranch'], dir).trim(), 10);
+        assert.strictEqual(count, 1, 'exactly one commit (c2) should have landed on the PR branch');
+      } finally {
+        teardown();
+      }
+    });
   });
 
   // ── L3: planning.pr_strict registration through the real CLI/config ─────


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #4606

The linked issue carries the `confirmed-bug` label.

---

## What was broken

A "third bucket" planning path (neither a `$TRANSIENT_DIRS` member nor `$STRUCTURAL_RE`-structural — e.g. `.planning/WINDOWS.md`, `config.json`) edited standalone is correctly EXCLUDEd by `analyze_commits` classification (test 6's shape). But when a *later* commit reuses that same path alongside a structural or code change, #4447's 5th arm correctly INCLUDEs it — and `create_pr_branch`'s per-commit filter only resets `$FILTER_PATHS` (transient dirs) back to HEAD, never third-bucket paths. That later commit's diff for the third-bucket path is computed against context the excluded commit wrote, which the PR branch never received. Cherry-pick reports a genuine content conflict, and the whole run aborts and rolls back — exactly the failure the issue reproduces on `.planning/WINDOWS.md`.

## What this fix does

When a cherry-pick conflict lands on a path that is under `.planning/` but matches neither `$FORBIDDEN_RE` nor `$STRUCTURAL_RE`, resolve it with `git checkout --theirs` — in a cherry-pick's 3-way merge, "theirs" is exactly `$HASH`'s own content for that path, which is the correct chained final value the path is owed (the same guarantee `create_pr_branch` already gives structural files via #4447). A path `$HASH` deletes has no "theirs" blob to check out, so the resolution falls back to accepting the deletion — the existing `#3679` `$PLANNING_DELETIONS` gate independently catches an illegitimate one. Code and structural-path conflicts are untouched: the new resolution only triggers for the third-bucket case, so a real conflict still halts and rolls back exactly as before (test 25 unaffected).

## Root cause

#4447 (PR #4537) taught `analyze_commits` to INCLUDE a mixed structural+third-bucket commit, but `create_pr_branch`'s filter loop was never updated to also carry third-bucket paths' chained context forward — only structural files get that guarantee today. This PR closes that gap without touching classification at all (per the issue's own "out of scope" note).

## Testing

### How I verified the fix

An L2 end-to-end fixture: `c1` touches only `.planning/WINDOWS.md` (excluded by classification), `c2` touches `.planning/STATE.md` + `.planning/WINDOWS.md` (included, and its diff for `WINDOWS.md` depends on `c1`'s dropped edit). Ran the actual `create_pr_branch` cherry-pick loop extracted verbatim from `pr-branch.md` (same harness the existing L2 tests use) and confirmed it completes without the conflict-abort path, with `WINDOWS.md` reaching `c2`'s exact intended content — not `c1`'s dropped intermediate state, and not `main`'s stale original.

### Regression test added?

- [x] Yes — `tests/pr-branch-planning-filter.test.cjs`: `#4606 L2: a later mixed commit reusing an excluded third-bucket path cherry-picks cleanly and reaches the chained final content`

### Platforms tested

- [x] Linux
- [ ] macOS
- [ ] Windows

### Runtimes tested

- [x] Claude Code
- [ ] N/A (not runtime-specific) — the fix is in the shared workflow prose, runtime-agnostic

---

## Checklist

- [x] Issue linked above with `Fixes #4606`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass (`npm test`) — full `tests/pr-branch-planning-filter.test.cjs` (167/167), `tests/commit-docs-bypass.test.cjs` (115/115 — the new `git add` call required a `# gsd-scan-ignore: #4606` declaration since it re-stages already-committed `.planning/` content onto a disposable branch, not a `commit_docs` bypass), `tests/emitted-attribution.test.cjs` (133/133), and the full `npm run lint:ci` chain
- [ ] `.changeset/` fragment — will add once the PR number is assigned, per `CONTRIBUTING.md`
- [x] No unnecessary dependencies added

## Breaking changes

None.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)