### PR TITLE
fix(#3660): reap a bounded check's orphaned worker after its own timeout kill

### DIFF
--- a/.changeset/sunny-wasps-cheer.md
+++ b/.changeset/sunny-wasps-cheer.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**A hung bounded test check no longer leaks a permanent CPU-pegging orphan process.** `node --test`'s per-file worker subprocess (the process default since Node 22) survived a timed-out check's own kill signal, which only reached the direct runner -- the worker was reparented to PID 1 and could busy-loop forever, consuming a full core, with no visible indication anything was wrong. The bounded check now reaps the whole process tree (POSIX process-group SIGKILL, Windows `taskkill /T /F`) when its own timeout fires. (#3660)

--- a/.changeset/sunny-wasps-cheer.md
+++ b/.changeset/sunny-wasps-cheer.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 4615
 ---
 **A hung bounded test check no longer leaks a permanent CPU-pegging orphan process.** `node --test`'s per-file worker subprocess (the process default since Node 22) survived a timed-out check's own kill signal, which only reached the direct runner -- the worker was reparented to PID 1 and could busy-loop forever, consuming a full core, with no visible indication anything was wrong. The bounded check now reaps the whole process tree (POSIX process-group SIGKILL, Windows `taskkill /T /F`) when its own timeout fires. (#3660)

--- a/src/prohibition-enforcement.cts
+++ b/src/prohibition-enforcement.cts
@@ -487,14 +487,17 @@ function reapDescendants(pid: number | undefined): void {
   try {
     process.kill(-pid, 'SIGKILL');
   } catch {
-    // ESRCH: group already gone -- nothing to reap
+    // Swallows ESRCH (group already gone -- nothing to reap) and any other errno (e.g. EPERM) --
+    // this helper never throws regardless of cause; see the function's own doc comment above.
   }
 }
 
 /**
  * `execFileSync`, with descendant reaping layered on top. Same contract (same return value, throws
- * the identical error) EXCEPT that when — and ONLY when — this call's OWN timeout killed the child
- * (the thrown error carries a `signal`), any descendants the child forked are also reaped.
+ * the identical error) EXCEPT that when — and ONLY when — this call's OWN bound killed the child (a
+ * timeout OR a `maxBuffer` overflow — both terminate the child by SIGNAL, so both set `.signal` on
+ * the thrown error; an ordinary non-zero exit does not), any descendants the child forked are also
+ * reaped.
  *
  * Gating strictly on `signal` (rather than reaping on every throw) matters: an ordinary non-zero exit
  * (a real test/lint failure) has `signal: null` — the child exited on its own, so a reap there would

--- a/src/prohibition-enforcement.cts
+++ b/src/prohibition-enforcement.cts
@@ -452,9 +452,9 @@ const CHECK_MAX_BUFFER = 16 * 1024 * 1024;
 
 /** Windows `taskkill` resolved by ABSOLUTE path — never a bare PATH-resolved name. A project
  * directory used as the child's `cwd` could otherwise contain a planted `taskkill.exe`/`.bat`
- * that Windows executable resolution picks up ahead of the real one (#3660 review, minor-9). */
-/** Returns null (never a hardcoded fallback, per tests/hardcoded-paths.test.cjs) when neither env
- * var is set -- this is not expected on a real Windows host, both are set by the OS itself, but a
+ * that Windows executable resolution picks up ahead of the real one (#3660 review, minor-9).
+ * Returns null (never a hardcoded fallback, per tests/hardcoded-paths.test.cjs) when neither env
+ * var is set -- not expected on a real Windows host (both are set by the OS itself), but a
  * hostile/stripped env should degrade to "skip the reap" rather than guess a system path. */
 function taskkillPath(): string | null {
   const root = process.env.SystemRoot || process.env.windir;

--- a/src/prohibition-enforcement.cts
+++ b/src/prohibition-enforcement.cts
@@ -453,9 +453,12 @@ const CHECK_MAX_BUFFER = 16 * 1024 * 1024;
 /** Windows `taskkill` resolved by ABSOLUTE path — never a bare PATH-resolved name. A project
  * directory used as the child's `cwd` could otherwise contain a planted `taskkill.exe`/`.bat`
  * that Windows executable resolution picks up ahead of the real one (#3660 review, minor-9). */
-function taskkillPath(): string {
-  const root = process.env.SystemRoot || process.env.windir || 'C:\\Windows';
-  return path.join(root, 'System32', 'taskkill.exe');
+/** Returns null (never a hardcoded fallback, per tests/hardcoded-paths.test.cjs) when neither env
+ * var is set -- this is not expected on a real Windows host, both are set by the OS itself, but a
+ * hostile/stripped env should degrade to "skip the reap" rather than guess a system path. */
+function taskkillPath(): string | null {
+  const root = process.env.SystemRoot || process.env.windir;
+  return root ? path.join(root, 'System32', 'taskkill.exe') : null;
 }
 
 /**
@@ -477,8 +480,10 @@ function taskkillPath(): string {
 function reapDescendants(pid: number | undefined): void {
   if (typeof pid !== 'number' || pid <= 0) return; // defensive: never signal pid 0 (self) or negative
   if (process.platform === 'win32') {
+    const exe = taskkillPath();
+    if (!exe) return; // no safe absolute path available -- best-effort, skip rather than guess
     try {
-      spawnSync(taskkillPath(), ['/PID', String(pid), '/T', '/F'], { stdio: 'ignore', windowsHide: true });
+      spawnSync(exe, ['/PID', String(pid), '/T', '/F'], { stdio: 'ignore', windowsHide: true });
     } catch {
       // best-effort: a missing taskkill.exe is not this call's problem to escalate
     }
@@ -518,9 +523,24 @@ function execFileSyncReaping(
   try {
     return execFileSync(file, args, spawnOptions);
   } catch (e) {
-    const err = e as { pid?: unknown; signal?: unknown };
+    const err = e as { pid?: unknown; signal?: unknown; code?: unknown; status?: unknown };
+    process.stderr.write(`[GSD-DEBUG-3660] execFileSyncReaping caught: pid=${err.pid} signal=${err.signal} code=${err.code} status=${err.status} platform=${process.platform}\n`);
     if (typeof err.pid === 'number' && err.signal) {
+      try {
+        process.kill(-(err.pid as number), 0);
+        process.stderr.write(`[GSD-DEBUG-3660] group ${err.pid} still has live members before reap attempt\n`);
+      } catch (probeErr) {
+        process.stderr.write(`[GSD-DEBUG-3660] group ${err.pid} probe before reap: ${(probeErr as { code?: unknown }).code}\n`);
+      }
       reapDescendants(err.pid);
+      try {
+        process.kill(-(err.pid as number), 0);
+        process.stderr.write(`[GSD-DEBUG-3660] group ${err.pid} STILL has live members after reap attempt\n`);
+      } catch (probeErr2) {
+        process.stderr.write(`[GSD-DEBUG-3660] group ${err.pid} probe after reap: ${(probeErr2 as { code?: unknown }).code}\n`);
+      }
+    } else {
+      process.stderr.write(`[GSD-DEBUG-3660] reap SKIPPED (pid=${typeof err.pid}, signal=${err.signal})\n`);
     }
     throw e;
   }

--- a/src/prohibition-enforcement.cts
+++ b/src/prohibition-enforcement.cts
@@ -42,7 +42,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { execFileSync } from 'node:child_process';
+import { execFileSync, spawnSync } from 'node:child_process';
 // Import the leaf I/O module directly (core.cjs re-export spine retired in epic #1267).
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import io = require('./io.cjs');
@@ -450,6 +450,79 @@ const NODE_TEST_TIMEOUT_MS = 30_000;
 const ESLINT_TIMEOUT_MS = 60_000;
 const CHECK_MAX_BUFFER = 16 * 1024 * 1024;
 
+/** Windows `taskkill` resolved by ABSOLUTE path — never a bare PATH-resolved name. A project
+ * directory used as the child's `cwd` could otherwise contain a planted `taskkill.exe`/`.bat`
+ * that Windows executable resolution picks up ahead of the real one (#3660 review, minor-9). */
+function taskkillPath(): string {
+  const root = process.env.SystemRoot || process.env.windir || 'C:\\Windows';
+  return path.join(root, 'System32', 'taskkill.exe');
+}
+
+/**
+ * Reap the process TREE rooted at `pid` after THIS call's own bound killed it (#3660: `node --test`
+ * forks a per-file WORKER by default since Node 22 — `execFileSync`'s `timeout` signals only the
+ * direct child/runner, never the worker, which is reparented to PID 1 and can busy-loop forever).
+ *
+ * POSIX: the child was spawned `detached` (its own process group, pgid === pid), so `-pid` addresses
+ * the whole group. ESRCH (group already gone) is swallowed — the subject may have exited on its own
+ * between the timeout firing and this call.
+ *
+ * Windows has no process-group equivalent; `taskkill /PID <pid> /T /F` walks the live process tree by
+ * parent-PID instead, which does not require the parent PID to still be alive. A non-zero exit means
+ * "nothing left to kill" (already gone, or never had descendants) — not a failure, so it is never
+ * escalated; there is no portable stronger primitive to escalate TO.
+ *
+ * Never throws — this runs from a `catch`/`finally` path and must not itself become the error.
+ */
+function reapDescendants(pid: number | undefined): void {
+  if (typeof pid !== 'number' || pid <= 0) return; // defensive: never signal pid 0 (self) or negative
+  if (process.platform === 'win32') {
+    try {
+      spawnSync(taskkillPath(), ['/PID', String(pid), '/T', '/F'], { stdio: 'ignore', windowsHide: true });
+    } catch {
+      // best-effort: a missing taskkill.exe is not this call's problem to escalate
+    }
+    return;
+  }
+  try {
+    process.kill(-pid, 'SIGKILL');
+  } catch {
+    // ESRCH: group already gone -- nothing to reap
+  }
+}
+
+/**
+ * `execFileSync`, with descendant reaping layered on top. Same contract (same return value, throws
+ * the identical error) EXCEPT that when — and ONLY when — this call's OWN timeout killed the child
+ * (the thrown error carries a `signal`), any descendants the child forked are also reaped.
+ *
+ * Gating strictly on `signal` (rather than reaping on every throw) matters: an ordinary non-zero exit
+ * (a real test/lint failure) has `signal: null` — the child exited on its own, so a reap there would
+ * fire on every red run for no reason and, on POSIX, risks signalling a process group whose pgid was
+ * *already* recycled by something unrelated in the time since (the #3660 review's Blocker-3 defect in
+ * the prior attempt at this fix, PR #3681). Only the timeout-kill path is targeted.
+ *
+ * Spawns `detached` on POSIX so the reap above can address the whole process group; omitted on
+ * Windows (no such flag there — `@types/node`'s `ExecFileSyncOptions` doesn't declare `detached`
+ * either, hence the cast below, though libuv honors it identically to `spawnSync`).
+ */
+function execFileSyncReaping(
+  file: string,
+  args: readonly string[],
+  options: { cwd: string; encoding: 'utf-8'; stdio: ['ignore', 'pipe', 'pipe']; windowsHide: true; env: NodeJS.ProcessEnv; timeout: number; maxBuffer: number },
+): string {
+  const spawnOptions = process.platform === 'win32' ? options : ({ ...options, detached: true } as typeof options & { detached: true });
+  try {
+    return execFileSync(file, args, spawnOptions);
+  } catch (e) {
+    const err = e as { pid?: unknown; signal?: unknown };
+    if (typeof err.pid === 'number' && err.signal) {
+      reapDescendants(err.pid);
+    }
+    throw e;
+  }
+}
+
 /** Resolve the effective timeout: only a POSITIVE override is honored — `0` (which Node treats as
  * "no timeout") or a negative value falls back to the bounded default, so the subprocess is ALWAYS
  * bounded (a `timeoutMs: 0` injection can never disable the bound). */
@@ -467,7 +540,7 @@ function posTimeout(timeoutMs: number | undefined, def: number): number {
  */
 function runNodeTestWithSubject(check: CheckDescriptor, cwd: string, subject: string, timeoutMs?: number): string {
   try {
-    return execFileSync(process.execPath, buildNodeTestArgs(check), {
+    return execFileSyncReaping(process.execPath, buildNodeTestArgs(check), {
       cwd,
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'pipe'],
@@ -487,7 +560,7 @@ function defaultRunCheck(check: CheckDescriptor, cwd: string, timeoutMs?: number
     if (check.kind === 'node-test') {
       let out = '';
       try {
-        out = execFileSync(process.execPath, buildNodeTestArgs(check), {
+        out = execFileSyncReaping(process.execPath, buildNodeTestArgs(check), {
           cwd,
           encoding: 'utf-8',
           stdio: ['ignore', 'pipe', 'pipe'],
@@ -509,7 +582,7 @@ function defaultRunCheck(check: CheckDescriptor, cwd: string, timeoutMs?: number
       if (!eslintCli) return { passed: false }; // eslint not installed -> fail closed, never throw
       let json = '';
       try {
-        json = execFileSync(process.execPath, [eslintCli, ...buildLintArgs(check)], {
+        json = execFileSyncReaping(process.execPath, [eslintCli, ...buildLintArgs(check)], {
           cwd,
           encoding: 'utf-8',
           stdio: ['ignore', 'pipe', 'pipe'],
@@ -566,7 +639,7 @@ function defaultProveFailFirst(check: CheckDescriptor, cwd: string, timeoutMs?: 
       if (!eslintCli) return { provenFailFirst: false }; // eslint not installed -> fail closed, never throw
       let json = '';
       try {
-        json = execFileSync(process.execPath, [eslintCli, ...buildLintArgs({ ...check, target: fixture })], {
+        json = execFileSyncReaping(process.execPath, [eslintCli, ...buildLintArgs({ ...check, target: fixture })], {
           cwd,
           encoding: 'utf-8',
           stdio: ['ignore', 'pipe', 'pipe'],

--- a/src/prohibition-enforcement.cts
+++ b/src/prohibition-enforcement.cts
@@ -499,16 +499,20 @@ function reapDescendants(pid: number | undefined): void {
 
 /**
  * `execFileSync`, with descendant reaping layered on top. Same contract (same return value, throws
- * the identical error) EXCEPT that when — and ONLY when — this call's OWN bound killed the child (a
- * timeout OR a `maxBuffer` overflow — both terminate the child by SIGNAL, so both set `.signal` on
- * the thrown error; an ordinary non-zero exit does not), any descendants the child forked are also
- * reaped.
+ * the identical error) EXCEPT that when — and ONLY when — this call's OWN timeout killed the child,
+ * any descendants the child forked are also reaped.
  *
- * Gating strictly on `signal` (rather than reaping on every throw) matters: an ordinary non-zero exit
- * (a real test/lint failure) has `signal: null` — the child exited on its own, so a reap there would
- * fire on every red run for no reason and, on POSIX, risks signalling a process group whose pgid was
- * *already* recycled by something unrelated in the time since (the #3660 review's Blocker-3 defect in
- * the prior attempt at this fix, PR #3681). Only the timeout-kill path is targeted.
+ * Gated on `error.code === 'ETIMEDOUT'`, NOT `error.signal`. `signal` is the field Node's own docs
+ * describe for this purpose, but it is not reliably populated across platforms/Node versions: on one
+ * real Linux CI run (Node 24) a genuine timeout-kill threw `{ signal: null, code: 'ETIMEDOUT',
+ * status: 7 }` — `signal` was simply absent, `code` was the only reliable marker (confirmed empirically
+ * before landing this; a macOS/Node run separately showed `signal: 'SIGTERM'` for the identical
+ * scenario, so neither field alone is safe to rely on everywhere — `code` was the one constant).
+ * Gating strictly on the timeout code (rather than reaping on every throw) matters: an ordinary
+ * non-zero exit (a real test/lint failure) has no `ETIMEDOUT` code — the child exited on its own, so a
+ * reap there would fire on every red run for no reason and, on POSIX, risks signalling a process group
+ * whose pgid was *already* recycled by something unrelated in the time since (the #3660 review's
+ * Blocker-3 defect in the prior attempt at this fix, PR #3681). Only the timeout-kill path is targeted.
  *
  * Spawns `detached` on POSIX so the reap above can address the whole process group; omitted on
  * Windows (no such flag there — `@types/node`'s `ExecFileSyncOptions` doesn't declare `detached`
@@ -523,24 +527,9 @@ function execFileSyncReaping(
   try {
     return execFileSync(file, args, spawnOptions);
   } catch (e) {
-    const err = e as { pid?: unknown; signal?: unknown; code?: unknown; status?: unknown };
-    process.stderr.write(`[GSD-DEBUG-3660] execFileSyncReaping caught: pid=${err.pid} signal=${err.signal} code=${err.code} status=${err.status} platform=${process.platform}\n`);
-    if (typeof err.pid === 'number' && err.signal) {
-      try {
-        process.kill(-(err.pid as number), 0);
-        process.stderr.write(`[GSD-DEBUG-3660] group ${err.pid} still has live members before reap attempt\n`);
-      } catch (probeErr) {
-        process.stderr.write(`[GSD-DEBUG-3660] group ${err.pid} probe before reap: ${(probeErr as { code?: unknown }).code}\n`);
-      }
+    const err = e as { pid?: unknown; code?: unknown };
+    if (typeof err.pid === 'number' && err.code === 'ETIMEDOUT') {
       reapDescendants(err.pid);
-      try {
-        process.kill(-(err.pid as number), 0);
-        process.stderr.write(`[GSD-DEBUG-3660] group ${err.pid} STILL has live members after reap attempt\n`);
-      } catch (probeErr2) {
-        process.stderr.write(`[GSD-DEBUG-3660] group ${err.pid} probe after reap: ${(probeErr2 as { code?: unknown }).code}\n`);
-      }
-    } else {
-      process.stderr.write(`[GSD-DEBUG-3660] reap SKIPPED (pid=${typeof err.pid}, signal=${err.signal})\n`);
     }
     throw e;
   }

--- a/src/prohibition-enforcement.cts
+++ b/src/prohibition-enforcement.cts
@@ -524,35 +524,12 @@ function execFileSyncReaping(
   options: { cwd: string; encoding: 'utf-8'; stdio: ['ignore', 'pipe', 'pipe']; windowsHide: true; env: NodeJS.ProcessEnv; timeout: number; maxBuffer: number },
 ): string {
   const spawnOptions = process.platform === 'win32' ? options : ({ ...options, detached: true } as typeof options & { detached: true });
-  process.stderr.write(`[GSD-DEBUG-3660b] spawning pid-to-be file=${file} detached=${(spawnOptions as { detached?: unknown }).detached} platform=${process.platform}\n`);
   try {
     return execFileSync(file, args, spawnOptions);
   } catch (e) {
     const err = e as { pid?: unknown; code?: unknown };
-    process.stderr.write(`[GSD-DEBUG-3660b] caught pid=${err.pid} code=${err.code} gateMatch=${typeof err.pid === 'number' && err.code === 'ETIMEDOUT'}\n`);
     if (typeof err.pid === 'number' && err.code === 'ETIMEDOUT') {
-      const pid = err.pid as number;
-      try {
-        process.kill(-pid, 0);
-        process.stderr.write(`[GSD-DEBUG-3660b] group ${pid} probe BEFORE reap: alive\n`);
-      } catch (probeErr) {
-        process.stderr.write(`[GSD-DEBUG-3660b] group ${pid} probe BEFORE reap: ${(probeErr as { code?: unknown }).code}\n`);
-      }
-      try {
-        process.kill(-pid, 'SIGKILL');
-        process.stderr.write(`[GSD-DEBUG-3660b] process.kill(-${pid}, SIGKILL) returned normally (no throw)\n`);
-      } catch (killErr) {
-        process.stderr.write(`[GSD-DEBUG-3660b] process.kill(-${pid}, SIGKILL) THREW: ${(killErr as { code?: unknown; message?: unknown }).code} ${(killErr as { message?: unknown }).message}\n`);
-      }
-      for (let i = 0; i < 5; i += 1) {
-        try {
-          process.kill(-pid, 0);
-          process.stderr.write(`[GSD-DEBUG-3660b] group ${pid} probe #${i} AFTER reap (own pid): alive\n`);
-        } catch (probeErr2) {
-          process.stderr.write(`[GSD-DEBUG-3660b] group ${pid} probe #${i} AFTER reap (own pid): ${(probeErr2 as { code?: unknown }).code}\n`);
-        }
-      }
-      reapDescendants(pid);
+      reapDescendants(err.pid);
     }
     throw e;
   }

--- a/src/prohibition-enforcement.cts
+++ b/src/prohibition-enforcement.cts
@@ -483,9 +483,13 @@ function reapDescendants(pid: number | undefined): void {
     const exe = taskkillPath();
     if (!exe) return; // no safe absolute path available -- best-effort, skip rather than guess
     try {
-      spawnSync(exe, ['/PID', String(pid), '/T', '/F'], { stdio: 'ignore', windowsHide: true });
+      // 5s bound (DEFECT.UNBOUNDED-SUBPROCESS): a local OS command, not a network call -- if
+      // taskkill itself hangs, this function's own "never throws" contract already treats that
+      // identically to any other failure (swallowed below), so a bounded timeout costs nothing
+      // and just prevents a stuck taskkill from blocking the caller forever.
+      spawnSync(exe, ['/PID', String(pid), '/T', '/F'], { stdio: 'ignore', windowsHide: true, timeout: 5_000 });
     } catch {
-      // best-effort: a missing taskkill.exe is not this call's problem to escalate
+      // best-effort: a missing taskkill.exe (or a timeout) is not this call's problem to escalate
     }
     return;
   }

--- a/src/prohibition-enforcement.cts
+++ b/src/prohibition-enforcement.cts
@@ -524,12 +524,35 @@ function execFileSyncReaping(
   options: { cwd: string; encoding: 'utf-8'; stdio: ['ignore', 'pipe', 'pipe']; windowsHide: true; env: NodeJS.ProcessEnv; timeout: number; maxBuffer: number },
 ): string {
   const spawnOptions = process.platform === 'win32' ? options : ({ ...options, detached: true } as typeof options & { detached: true });
+  process.stderr.write(`[GSD-DEBUG-3660b] spawning pid-to-be file=${file} detached=${(spawnOptions as { detached?: unknown }).detached} platform=${process.platform}\n`);
   try {
     return execFileSync(file, args, spawnOptions);
   } catch (e) {
     const err = e as { pid?: unknown; code?: unknown };
+    process.stderr.write(`[GSD-DEBUG-3660b] caught pid=${err.pid} code=${err.code} gateMatch=${typeof err.pid === 'number' && err.code === 'ETIMEDOUT'}\n`);
     if (typeof err.pid === 'number' && err.code === 'ETIMEDOUT') {
-      reapDescendants(err.pid);
+      const pid = err.pid as number;
+      try {
+        process.kill(-pid, 0);
+        process.stderr.write(`[GSD-DEBUG-3660b] group ${pid} probe BEFORE reap: alive\n`);
+      } catch (probeErr) {
+        process.stderr.write(`[GSD-DEBUG-3660b] group ${pid} probe BEFORE reap: ${(probeErr as { code?: unknown }).code}\n`);
+      }
+      try {
+        process.kill(-pid, 'SIGKILL');
+        process.stderr.write(`[GSD-DEBUG-3660b] process.kill(-${pid}, SIGKILL) returned normally (no throw)\n`);
+      } catch (killErr) {
+        process.stderr.write(`[GSD-DEBUG-3660b] process.kill(-${pid}, SIGKILL) THREW: ${(killErr as { code?: unknown; message?: unknown }).code} ${(killErr as { message?: unknown }).message}\n`);
+      }
+      for (let i = 0; i < 5; i += 1) {
+        try {
+          process.kill(-pid, 0);
+          process.stderr.write(`[GSD-DEBUG-3660b] group ${pid} probe #${i} AFTER reap (own pid): alive\n`);
+        } catch (probeErr2) {
+          process.stderr.write(`[GSD-DEBUG-3660b] group ${pid} probe #${i} AFTER reap (own pid): ${(probeErr2 as { code?: unknown }).code}\n`);
+        }
+      }
+      reapDescendants(pid);
     }
     throw e;
   }

--- a/tests/prohibition-enforcement.test.cjs
+++ b/tests/prohibition-enforcement.test.cjs
@@ -925,9 +925,10 @@ describe('prohibition-enforcement REAL runner end-to-end (#1259)', () => {
       { cwd: dir },
     );
     // Same return-shape assertions as the pre-existing EMPTY-file fail-closed test above — the
-    // reap-gating change (gated strictly on `err.signal`, i.e. a timeout-kill) must not alter the
-    // ordinary non-zero-exit path's observable result. No wall-clock assertion (clock-seam rule):
-    // the absence of a hang is proven by this synchronous call returning at all, not by timing it.
+    // reap-gating change (gated strictly on `err.code === 'ETIMEDOUT'`, i.e. a timeout-kill) must
+    // not alter the ordinary non-zero-exit path's observable result. No wall-clock assertion
+    // (clock-seam rule): the absence of a hang is proven by this synchronous call returning at
+    // all, not by timing it.
     assert.notEqual(result.status, 'green', 'an ordinary failing node-test must fail closed exactly as before this fix');
     assert.equal(result.located, true, 'the check was located; it just did not pass');
     assert.equal(result.evidence.length, 0);

--- a/tests/prohibition-enforcement.test.cjs
+++ b/tests/prohibition-enforcement.test.cjs
@@ -811,8 +811,13 @@ describe('prohibition-enforcement REAL runner end-to-end (#1259)', () => {
       let stat;
       try {
         stat = fs.readFileSync(`/proc/${pid}/stat`, 'utf-8');
-      } catch {
-        return false; // /proc/<pid> gone -- the process (and any zombie remnant) is fully reaped
+      } catch (err) {
+        // ENOENT: /proc/<pid> genuinely gone -- fully reaped, no zombie remnant. Any OTHER read
+        // error (EACCES, EIO, ...) is inconclusive -- report "alive" rather than risk a false
+        // "dead" that would silently mask a real regression (a liveness check should fail loud
+        // via a longer retry loop, not fail quiet via a wrong verdict).
+        if (err && err.code === 'ENOENT') return false;
+        return true;
       }
       // Format: "pid (comm) state ...". comm may contain spaces/parens, so split on the LAST ')'.
       const afterComm = stat.slice(stat.lastIndexOf(')') + 1).trim();
@@ -837,6 +842,11 @@ describe('prohibition-enforcement REAL runner end-to-end (#1259)', () => {
     }
     return alive;
   }
+
+  test('isAlive(pid) correctly reports TRUE for a genuinely running process (own pid) -- closes the vacuous-test gap: without this, a probe that always returned false would pass every #3660 test below trivially', () => {
+    assert.equal(isAlive(process.pid), true,
+      'isAlive must report this test\'s own (unambiguously running) process as alive');
+  });
 
   test('a HANGING node-test leaves no orphaned descendant behind (#3660: worker survives runner-only kill)', async (t) => {
     const enforce = require(ENFORCEMENT_LIB);

--- a/tests/prohibition-enforcement.test.cjs
+++ b/tests/prohibition-enforcement.test.cjs
@@ -500,6 +500,7 @@ describe('prohibition-enforcement real-runner helpers (#1259)', () => {
 describe('prohibition-enforcement REAL runner end-to-end (#1259)', () => {
   const fs = require('node:fs');
   const { spawn } = require('node:child_process');
+  const { setTimeout: sleep } = require('node:timers/promises');
 
   // The hang fixture served to the bounded-timeout test below, hoisted so the #4104 self-exit
   // regression cannot drift from the body it guards. Parks on a SETTLING 10s timer: still "hung"
@@ -774,6 +775,140 @@ describe('prohibition-enforcement REAL runner end-to-end (#1259)', () => {
     );
     assert.notEqual(result.status, 'green', 'an empty (zero-test) file must NEVER green — fail-closed');
     assert.equal(result.located, true, 'the check was located; it just did not genuinely pass');
+    assert.equal(result.evidence.length, 0);
+  });
+
+  // ─── #3660 regression: a HANGING node-test's per-file WORKER must not be orphaned ──────────────
+  // `node --test` forks a per-file worker subprocess by default (Node 22+, `--test-isolation=process`);
+  // `execFileSync`'s `timeout` only signals the direct child (the runner), never the worker. These
+  // exercise the REAL, uninjected `defaultRunCheck` -> `execFileSyncReaping` path (no `runCheck`
+  // injected) and observe a real OS-level pid, so the fix (`reapDescendants`) is proven, not a mock.
+
+  /** Poll for the fixture's pidfile with bounded retry-with-backoff (no fixed sleep) — the pidfile
+   * write happens inside the spawned worker, which may take a beat to start. */
+  async function readPidWithRetry(pidfilePath, { attempts = 30, delayMs = 150 } = {}) {
+    for (let i = 0; i < attempts; i += 1) {
+      if (fs.existsSync(pidfilePath)) {
+        const txt = fs.readFileSync(pidfilePath, 'utf-8').trim();
+        if (txt) return Number(txt);
+      }
+      await sleep(delayMs);
+    }
+    throw new Error(`pidfile ${pidfilePath} was never written within the retry budget`);
+  }
+
+  /** Liveness probe via `process.kill(pid, 0)` (throws ESRCH when dead) — no process-list scan. */
+  function isAlive(pid) {
+    try {
+      process.kill(pid, 0);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /** Bounded retry-with-backoff until `isAlive(pid)` reports false, or the budget is exhausted. */
+  async function waitUntilDead(pid, { attempts = 30, delayMs = 100 } = {}) {
+    let alive = isAlive(pid);
+    for (let i = 0; i < attempts && alive; i += 1) {
+      await sleep(delayMs);
+      alive = isAlive(pid);
+    }
+    return alive;
+  }
+
+  test('a HANGING node-test leaves no orphaned descendant behind (#3660: worker survives runner-only kill)', async (t) => {
+    const enforce = require(ENFORCEMENT_LIB);
+    const dir = createTempDir('prohib-orphan-hang-');
+    t.after(() => cleanup(dir));
+    const pidfilePath = path.join(dir, 'worker.pid');
+    const tf = path.join(dir, 'hang-pid.test.cjs');
+    // Blocks via Atomics.wait (NOT a busy `while(true)`) so this test does not peg a CPU core; the
+    // deadline (10s) is far longer than the check's own timeoutMs (1200ms) below. The worker writes
+    // its OWN pid before blocking, matching the maintainer-blessed fixture design (no pgrep/procps).
+    fs.writeFileSync(tf,
+      "const { test } = require('node:test');\n" +
+      "const fs = require('node:fs');\n" +
+      "test('blocks forever (#3660 regression fixture)', () => {\n" +
+      "  fs.writeFileSync(process.env.GSD_TEST_PIDFILE, String(process.pid));\n" +
+      "  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10_000);\n" +
+      "});\n");
+    const prevPidfileEnv = process.env.GSD_TEST_PIDFILE;
+    process.env.GSD_TEST_PIDFILE = pidfilePath;
+    t.after(() => {
+      if (prevPidfileEnv === undefined) delete process.env.GSD_TEST_PIDFILE;
+      else process.env.GSD_TEST_PIDFILE = prevPidfileEnv;
+    });
+    // Real, UNINJECTED path: no runCheck/proveFailFirst override -> defaultRunCheck ->
+    // execFileSyncReaping runs the fixture for real. The short timeoutMs keeps this test fast.
+    const result = enforce.runProhibitionEnforcement(
+      TEST_TIER,
+      { kind: 'node-test', target: tf, failFirst: true },
+      { cwd: dir, timeoutMs: 1200 },
+    );
+    assert.notEqual(result.status, 'green', 'a hung check must fail closed (unchanged pre-existing contract)');
+    const workerPid = await readPidWithRetry(pidfilePath);
+    assert.ok(Number.isInteger(workerPid) && workerPid > 0, 'worker pid must be a real positive pid');
+    const stillAlive = await waitUntilDead(workerPid);
+    assert.equal(stillAlive, false,
+      `the node --test worker (pid ${workerPid}) must be reaped, not orphaned (#3660)`);
+  });
+
+  test('control: a CLEAN node-test subject\'s worker exits on its own (no reap needed; proves the liveness probe is meaningful)', async (t) => {
+    const enforce = require(ENFORCEMENT_LIB);
+    const dir = createTempDir('prohib-orphan-control-');
+    t.after(() => cleanup(dir));
+    const pidfilePath = path.join(dir, 'worker.pid');
+    const tf = path.join(dir, 'clean-pid.test.cjs');
+    // Same fixture SHAPE (writes its own pid) but does NOT block — it exits on its own. This proves
+    // the isAlive/waitUntilDead probe can observe a live-then-dead transition at all, so the hang
+    // test's "not alive" assertion above is meaningful, not vacuously true.
+    fs.writeFileSync(tf,
+      "const { test } = require('node:test');\n" +
+      "const fs = require('node:fs');\n" +
+      "test('exits immediately, no hang', () => {\n" +
+      "  fs.writeFileSync(process.env.GSD_TEST_PIDFILE, String(process.pid));\n" +
+      "});\n");
+    const prevPidfileEnv = process.env.GSD_TEST_PIDFILE;
+    process.env.GSD_TEST_PIDFILE = pidfilePath;
+    t.after(() => {
+      if (prevPidfileEnv === undefined) delete process.env.GSD_TEST_PIDFILE;
+      else process.env.GSD_TEST_PIDFILE = prevPidfileEnv;
+    });
+    enforce.runProhibitionEnforcement(
+      TEST_TIER,
+      { kind: 'node-test', target: tf, failFirst: true },
+      { cwd: dir },
+    );
+    const workerPid = await readPidWithRetry(pidfilePath);
+    assert.ok(Number.isInteger(workerPid) && workerPid > 0, 'worker pid must be a real positive pid');
+    const stillAlive = await waitUntilDead(workerPid);
+    assert.equal(stillAlive, false,
+      `control: the clean-exit worker (pid ${workerPid}) must be observably dead shortly after — proves the probe works`);
+  });
+
+  test('an ORDINARY FAILING node-test (no hang) fails closed exactly as before (#3660 non-regression: reap-gating does not alter the normal-failure path)', (t) => {
+    const enforce = require(ENFORCEMENT_LIB);
+    const dir = createTempDir('prohib-fail-ordinary-');
+    t.after(() => cleanup(dir));
+    const tf = path.join(dir, 'fails.test.cjs');
+    fs.writeFileSync(tf,
+      "const { test } = require('node:test');\n" +
+      "const assert = require('node:assert');\n" +
+      "test('fails immediately, no hang', () => {\n" +
+      "  assert.fail('deliberate ordinary failure (#3660 non-regression control)');\n" +
+      "});\n");
+    const result = enforce.runProhibitionEnforcement(
+      TEST_TIER,
+      { kind: 'node-test', target: tf, failFirst: true },
+      { cwd: dir },
+    );
+    // Same return-shape assertions as the pre-existing EMPTY-file fail-closed test above — the
+    // reap-gating change (gated strictly on `err.signal`, i.e. a timeout-kill) must not alter the
+    // ordinary non-zero-exit path's observable result. No wall-clock assertion (clock-seam rule):
+    // the absence of a hang is proven by this synchronous call returning at all, not by timing it.
+    assert.notEqual(result.status, 'green', 'an ordinary failing node-test must fail closed exactly as before this fix');
+    assert.equal(result.located, true, 'the check was located; it just did not pass');
     assert.equal(result.evidence.length, 0);
   });
 

--- a/tests/prohibition-enforcement.test.cjs
+++ b/tests/prohibition-enforcement.test.cjs
@@ -797,8 +797,29 @@ describe('prohibition-enforcement REAL runner end-to-end (#1259)', () => {
     throw new Error(`pidfile ${pidfilePath} was never written within the retry budget`);
   }
 
-  /** Liveness probe via `process.kill(pid, 0)` (throws ESRCH when dead) — no process-list scan. */
+  /** Liveness probe. `process.kill(pid, 0)` alone cannot distinguish a genuinely-running process
+   * from an already-killed ZOMBIE stuck unreaped in a container with no init process to collect
+   * orphans (a real, confirmed condition on this repo's own Linux CI bench) -- both report "exists"
+   * with no throw. On Linux, read /proc/<pid>/stat's process-state field (3rd whitespace-separated
+   * token, inside the trailing `)` after the command name, which itself may contain spaces/parens)
+   * and treat state 'Z' (zombie) as DEAD -- it is no longer executing or consuming CPU, which is
+   * the actual thing #3660 cares about. Falls back to the plain kill(pid,0) probe on non-Linux
+   * platforms (no /proc there) and if /proc/<pid>/stat is unreadable for any reason (already fully
+   * gone, permissions, etc. -- ENOENT there means genuinely dead too). */
   function isAlive(pid) {
+    if (process.platform === 'linux') {
+      let stat;
+      try {
+        stat = fs.readFileSync(`/proc/${pid}/stat`, 'utf-8');
+      } catch {
+        return false; // /proc/<pid> gone -- the process (and any zombie remnant) is fully reaped
+      }
+      // Format: "pid (comm) state ...". comm may contain spaces/parens, so split on the LAST ')'.
+      const afterComm = stat.slice(stat.lastIndexOf(')') + 1).trim();
+      const state = afterComm.split(/\s+/)[0];
+      if (state === 'Z') return false; // zombie: already dead, just not yet reaped by its parent
+      return true;
+    }
     try {
       process.kill(pid, 0);
       return true;


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #3660

---

## What was broken

`src/prohibition-enforcement.cts` runs bounded `node --test` checks via `execFileSync(..., { timeout })`. Since Node 22, `node --test` forks a per-file WORKER subprocess by default (`--test-isolation=process`). `execFileSync`'s `timeout` only signals the direct child (the runner) — when a subject hangs, the runner dies at the bound but the worker (the process actually executing the subject) is never signalled, gets reparented to PID 1, and busy-loops forever, permanently pegging a CPU core. The bounded-check verdict still reports a clean fail-closed timeout, so nothing visibly indicates a problem.

## What this fix does

Adds `execFileSyncReaping` (wraps `execFileSync`, spawns `detached: true` on POSIX) and `reapDescendants(pid)`: on a genuine timeout (`error.code === 'ETIMEDOUT'`), reaps the whole process tree — POSIX via `process.kill(-pid, 'SIGKILL')` against the process group, Windows via an absolute-path `taskkill /PID <pid> /T /F` (never a bare PATH-resolved name). All four `execFileSync(process.execPath, ...)` call sites in the file now route through this wrapper.

## Root cause

`execFileSync`'s `timeout` mechanism was never designed to reach grandchildren — it signals only the direct spawned process. This became an observable leak once Node 22 made `--test-isolation=process` (which forks a worker) the default; the four call sites in this file predate that default and were never updated for it.

A prior attempt at this exact fix (PR #3681, closed without merging) had two independent reviews find real correctness gaps in the "detached + group-kill" approach — an unconditional reap-on-every-throw (risking a PGID-reuse collateral kill on an ordinary red run) and a Windows `taskkill` call using a bare PATH-resolved name. Both are addressed here: the reap is gated strictly on `error.code === 'ETIMEDOUT'` (never on an ordinary non-zero exit), and `taskkillPath()` resolves an absolute path, returning `null` (skipping the reap) rather than guessing if the OS-set env vars are somehow absent.

## Testing

### How I verified the fix

Three real `gsd-test` rounds beyond the initial RED-proof, each following direct evidence from the actual CI environment rather than assumption:
1. First attempt gated the reap on `error.signal` (matches Node's own docs and worked in local isolated testing) — never fired on real Linux CI, because that environment's timeout-kill sets `signal: null, code: 'ETIMEDOUT'`. Fixed to gate on `error.code` instead (confirmed present in both environments tested).
2. That alone still failed. Temporary diagnostic instrumentation showed the kill call itself succeeds with no throw (the worker genuinely is killed) — but the test's own liveness probe (`process.kill(pid, 0)`) still reported it "alive." Root cause: the CI bench's container has no init process reaping arbitrary orphans, so a killed worker (reparented to PID 1) becomes a permanent unreaped zombie, and `kill(pid, 0)` cannot distinguish a dead zombie from a running process.
3. Fixed the *test* (the production fix was already correct) to read `/proc/<pid>/stat`'s process-state field on Linux, treating `Z` (zombie) as dead.

A fresh isolated review of the final diff caught one more real gap (no test ever proved the liveness probe could report "alive" — a broken probe would have passed vacuously); added a standalone test using the test process's own pid to close it.

Final verified pass: `gsd-test`, 45,069/45,069 passing, sha `53148625e935bfca1fc0471c14d45fbdd431fa2e`.

### Regression test added?

- [x] Yes — three behavioral tests exercising the real, uninjected code path with a real spawned `node --test` worker and a real OS-level liveness probe (not a mock): the hang case, a clean-exit control (proves the probe is meaningful), and an ordinary-failure non-regression case (proves the reap-gating doesn't alter existing behavior).

### Platforms tested

- [x] Linux (real `gsd-test` CI matrix)
- [ ] macOS (mechanism separately verified via standalone diagnostic scripts, not the repo's own test suite — local `node --test` execution is disallowed by this repo's own tooling policy)
- [ ] Windows (the Windows branch — `taskkill` with an absolute path — is exercised only by static/type review; no Windows-specific behavioral test was added since `node --test`'s worker-orphaning behavior itself is what's covered, and the reap primitive differs only in the OS call made)

### Runtimes tested

- [x] N/A (not runtime-specific — this is a test-infrastructure/CI correctness fix)

---

## Checklist

- [x] Issue linked above with `Fixes #3660`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass (`gsd-test`, 45,069/45,069)
- [x] `.changeset/` fragment added
- [x] No unnecessary dependencies added

## Breaking changes

None.
