### PR TITLE
fix(#4071): merge global defaults with project config

### DIFF
--- a/.changeset/daring-cranes-hum.md
+++ b/.changeset/daring-cranes-hum.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 4626
+---
+**Defaults globais agora são herdados por chaves ausentes no config do projeto** — escolhas explícitas do projeto continuam vencendo.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -2294,16 +2294,13 @@ When `/gsd-new-project` creates a new `config.json`, it reads global defaults an
 
 ### What a global file can and cannot set at runtime
 
-Two different rules apply, and the difference is deliberate ([#3532](https://github.com/open-gsd/gsd-core/issues/3532)):
+Two different rules apply:
 
 - **In a directory with no `.planning/` at all**, `~/.gsd/defaults.json` is the active
   configuration — model resolution reads it directly.
-- **In a real project (`.planning/config.json` present, even if empty)**, the global file is
-  **not read for model resolution** — every model-side key it sets (`model_profile`,
-  `model_overrides`, `models`, `dynamic_routing`, `runtime`, and the rest of the resolution
-  set) is inert there. GSD prints a one-time stderr warning naming the shadowed keys when it
-  detects this, instead of failing silently. To apply a global model setting to a project,
-  put it in that project's `.planning/config.json`.
+- **In a real project (`.planning/config.json` present)**, global resolution keys are merged
+  per key: an explicit project value wins only for that key, while an absent project key
+  inherits the global value ([#4071](https://github.com/open-gsd/gsd-core/issues/4071)).
 - **`effort` is the exception**: the install-time effort channel always merges
   `~/.gsd/defaults.json` with the project config (that is how `effort sync` works), so a
   global `effort` block keeps working in projects and does not trigger the warning.

--- a/src/config-loader.cts
+++ b/src/config-loader.cts
@@ -867,8 +867,33 @@ function loadConfigResolved(cwd: string, options: Record<string, unknown> = {}):
 
     _warnUnknownProfileOverrides(parsed, '.planning/config.json');
 
-    const get = (key: string, nested?: { section: string; field: string }): unknown =>
-      _getConfigValue(parsed, key, nested);
+    // #4071: project presence must not discard unrelated ~/.gsd/defaults.json
+    // keys. Resolve each value from the project first, then the global layer,
+    // so a nested project workflow key also beats a legacy flat global spelling.
+    let globalDefaults: Record<string, unknown> = {};
+    try {
+      const globalPath = path.join(process.env['GSD_HOME'] || os.homedir(), '.gsd', 'defaults.json');
+      const globalRead = _readConfigFile(globalPath);
+      if (globalRead.kind === 'ok') globalDefaults = globalRead.data;
+      else if (globalRead.kind === 'fault') {
+        configFault ??= globalRead.fault;
+        _warnUnusableConfig(globalRead.fault);
+      }
+    } catch { /* intentionally empty */ }
+
+    const get = (key: string, nested?: { section: string; field: string }): unknown => {
+      const projectValue = _getConfigValue(parsed, key, nested);
+      return projectValue !== undefined ? projectValue : _getConfigValue(globalDefaults, key, nested);
+    };
+
+    const mergeObject = (key: string): Record<string, unknown> | null => {
+      const globalValue = globalDefaults[key];
+      const projectValue = parsed[key];
+      const globalObject = globalValue && typeof globalValue === 'object' && !Array.isArray(globalValue) ? globalValue as Record<string, unknown> : null;
+      const projectObject = projectValue && typeof projectValue === 'object' && !Array.isArray(projectValue) ? projectValue as Record<string, unknown> : null;
+      if (!globalObject && !projectObject) return null;
+      return { ...(globalObject || {}), ...(projectObject || {}) };
+    };
 
     /**
      * Nested-ONLY read — no top-level fallback (#3648).
@@ -929,19 +954,19 @@ function loadConfigResolved(cwd: string, options: Record<string, unknown> = {}):
       phase_naming: get('phase_naming') ?? defaults.phase_naming,
       project_code: get('project_code') ?? defaults.project_code,
       subagent_timeout: get('subagent_timeout', { section: 'workflow', field: 'subagent_timeout' }) ?? defaults.subagent_timeout,
-      model_overrides: (parsed['model_overrides']) || null,
+      model_overrides: mergeObject('model_overrides'),
       agent_tools: (parsed['agent_tools']) || null,
       models: (parsed['models']) || null,
-      granularity: parsed['granularity'] !== undefined ? parsed['granularity'] : null,
-      granularities: (parsed['granularities']) || null,
-      planning: (parsed['planning']) || null,
-      dynamic_routing: (parsed['dynamic_routing']) || null,
-      runtime: (parsed['runtime']) || null,
-      model_profile_overrides: (parsed['model_profile_overrides']) || null,
-      model_policy: (parsed['model_policy']) || null,
-      effort: (parsed['effort']) || null,
-      fast_mode: (parsed['fast_mode']) || null,
-      agent_skills: (parsed['agent_skills']) || {},
+      granularity: get('granularity') ?? null,
+      granularities: get('granularities') ?? null,
+      planning: mergeObject('planning'),
+      dynamic_routing: get('dynamic_routing') ?? null,
+      runtime: get('runtime') ?? null,
+      model_profile_overrides: mergeObject('model_profile_overrides'),
+      model_policy: get('model_policy') ?? null,
+      effort: mergeObject('effort'),
+      fast_mode: mergeObject('fast_mode'),
+      agent_skills: mergeObject('agent_skills') || {},
       agent_skills_security: (parsed['agent_skills_security']) || null,
       // #3587: phase_commit_docs.<phase-id> — a dynamic-key family shaped like
       // agent_skills above (`{ "<phase-id>": boolean }`). Must be threaded here
@@ -984,22 +1009,6 @@ function loadConfigResolved(cwd: string, options: Record<string, unknown> = {}):
     // A1 vs A2: disambiguate by whether a real workstream was requested.
     // Fix 4: empty-string ws ('') resolves the root path → source:'root'.
     const source: ConfigSource = wsRequested ? 'workstream' : 'root';
-
-    // #3532 (10b): a parsed project config means Branch D never runs, so every
-    // key ~/.gsd/defaults.json sets that Branch D would honor is silently inert
-    // here. Observation only — one deduped stderr warning; precedence is
-    // untouched. Faults in the global file stay silent in this branch (the
-    // project config governs; the nearer file is the actionable one).
-    try {
-      const shadowHome = process.env['GSD_HOME'] || os.homedir();
-      const shadowPath = path.join(shadowHome, '.gsd', 'defaults.json');
-      const shadowRead = _readConfigFile(shadowPath);
-      if (shadowRead.kind === 'ok') {
-        _warnShadowedGlobalDefaults(shadowRead.data, shadowPath);
-      }
-    } catch {
-      // Observation only — never let the diagnostic perturb resolution.
-    }
 
     // This config parsed — but a DIFFERENT file on the resolution path may not
     // have. A workstream config that loads cleanly while the root config it

--- a/tests/config-loader.test.cjs
+++ b/tests/config-loader.test.cjs
@@ -1317,7 +1317,7 @@ const GLOBAL_KEYS_SHADOWED_UNDER_PROJECT = [
   'model_profile_overrides', 'model_policy',
 ];
 
-describe('#3532 shadowed global-defaults warning', () => {
+describe.skip('#3532 shadowed global-defaults warning (superseded by #4071 merge)', () => {
   let tmpDir;
   let gsdHome;
   let stderrLines;
@@ -1464,6 +1464,43 @@ describe('#3532 shadowed global-defaults warning', () => {
     );
     _resetRuntimeWarningCacheForTests();
     assert.equal(configLoader._warnedShadowedGlobalKeys.size, 0);
+  });
+});
+
+describe('#4071 project config inherits global defaults per key', () => {
+  let tmpDir;
+  let gsdHome;
+  let originalGsdHome;
+
+  beforeEach(() => {
+    tmpDir = makeTempProject('gsd-4071-project-');
+    gsdHome = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-4071-home-'));
+    originalGsdHome = process.env.GSD_HOME;
+    process.env.GSD_HOME = gsdHome;
+  });
+  afterEach(() => {
+    if (originalGsdHome === undefined) delete process.env.GSD_HOME;
+    else process.env.GSD_HOME = originalGsdHome;
+    cleanup(tmpDir); cleanup(gsdHome);
+  });
+  function writeGlobal(obj) {
+    fs.mkdirSync(path.join(gsdHome, '.gsd'), { recursive: true });
+    fs.writeFileSync(path.join(gsdHome, '.gsd', 'defaults.json'), JSON.stringify(obj));
+  }
+  test('honors global model_profile absent from project config', () => {
+    writeConfig(tmpDir, { granularity: 'standard' });
+    writeGlobal({ model_profile: 'budget' });
+    assert.equal(loadConfigResolved(tmpDir).config.model_profile, 'budget');
+  });
+  test('project model_profile still wins on collision', () => {
+    writeConfig(tmpDir, { model_profile: 'quality' });
+    writeGlobal({ model_profile: 'budget' });
+    assert.equal(loadConfigResolved(tmpDir).config.model_profile, 'quality');
+  });
+  test('merges model overrides by agent key', () => {
+    writeConfig(tmpDir, { model_overrides: { 'gsd-executor': 'project' } });
+    writeGlobal({ model_overrides: { 'gsd-planner': 'global', 'gsd-executor': 'global' } });
+    assert.deepEqual(loadConfigResolved(tmpDir).config.model_overrides, { 'gsd-planner': 'global', 'gsd-executor': 'project' });
   });
 });
 


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #4071

## What was broken

When a project had `.planning/config.json`, runtime resolution discarded every applicable key in `~/.gsd/defaults.json`, including global settings the project had not overridden.

## What this fix does

Resolves global defaults per key before built-in defaults. Explicit project values continue to win, and object-valued settings such as `model_overrides` merge by their child keys.

## Root cause

`loadConfigResolved` read global defaults only to issue the #3532 warning, then built its resolved configuration from project values and built-ins alone.

## Testing

### How I verified the fix

- `node --test tests/config-loader.test.cjs`
- `npm run lint`
- CI is running on the current head; completed checks are reported separately from pending checks.

### Regression test added?

- [x] Yes — covers global inheritance for an absent project key, project precedence on collision, and merged `model_overrides`.

### Platforms tested

- [x] Linux
- [ ] macOS
- [ ] Windows (including backslash path handling)

### Runtimes tested

- [x] N/A (runtime-neutral configuration resolution)

## Checklist

- [x] Issue linked above with `Fixes #4071`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug
- [x] Regression test added
- [ ] All CI tests pass on the current head (still running at PR update)
- [x] `.changeset/` fragment added
- [x] No unnecessary dependencies added

## Breaking changes

**Changed resolution behavior:** a global default now applies when the project config omits that key. Explicit project settings retain precedence.
