### PR TITLE
fix(#4316): preserve decorated milestone placeholders

### DIFF
--- a/.changeset/sturdy-geese-sprint.md
+++ b/.changeset/sturdy-geese-sprint.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 4316
+---
+Preserve curated milestone name and version during state sync when the roadmap heading contains a decorated placeholder. State write verbs (`state.record-session`, `state.planned-phase`) previously checked only for the bare word `'milestone'` before restoring a curated milestone name, causing decorated placeholders like `milestone (ACTIVE — <Name>)` to overwrite the curated milestone name in STATE.md.

--- a/.changeset/sturdy-geese-sprint.md
+++ b/.changeset/sturdy-geese-sprint.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 4316
+pr: 4642
 ---
 Preserve curated milestone name and version during state sync when the roadmap heading contains a decorated placeholder. State write verbs (`state.record-session`, `state.planned-phase`) previously checked only for the bare word `'milestone'` before restoring a curated milestone name, causing decorated placeholders like `milestone (ACTIVE — <Name>)` to overwrite the curated milestone name in STATE.md.

--- a/src/state-transition.cts
+++ b/src/state-transition.cts
@@ -889,10 +889,13 @@ function applyPreserveAlways(field: string, cls: FieldClassification, ctx: Prese
  */
 function applyPreserveIfPlaceholder(_field: string, _cls: FieldClassification, ctx: PreservationCtx): void {
   const MILESTONE_PLACEHOLDER = 'milestone';
+  const MILESTONE_PLACEHOLDER_DECORATION =
+    /^milestone \([A-Z]+(?: [A-Z0-9.-]+)* — [^()\r\n]*[^\s()\r\n][^()\r\n]*\)$/;
   const derivedName = ctx.postFm['milestone_name'];
   const derivedLooksLikeName = typeof derivedName === 'string'
     && derivedName.length > 0
     && derivedName !== MILESTONE_PLACEHOLDER
+    && !MILESTONE_PLACEHOLDER_DECORATION.test(derivedName)
     && !/^[\s—–:-]/.test(derivedName);
   const snapshotName = ctx.snapshot['milestone_name'];
   const snapshotNameIsReal = typeof snapshotName === 'string'

--- a/tests/state-transition.test.cjs
+++ b/tests/state-transition.test.cjs
@@ -3411,6 +3411,63 @@ describe('#3468 matrix C1/C2: identity across the refactor — pinned literal ou
     assert.equal(rMilestone.postFm.milestone_name, GOOD);
   });
 
+  test('#4316: preserves the curated milestone pair only for the placeholder grammar', () => {
+    const curated = { milestone: 'v7.2', milestone_name: 'Curated Release Name' };
+    const cases = [
+      {
+        label: 'bare placeholder',
+        derivedName: 'milestone',
+        expectCurated: true,
+      },
+      {
+        label: 'ACTIVE decoration',
+        derivedName: 'milestone (ACTIVE — implementation underway)',
+        expectCurated: true,
+      },
+      {
+        label: 'dated CLOSED decoration',
+        derivedName: 'milestone (CLOSED 2026-09-10 — release complete)',
+        expectCurated: true,
+      },
+      {
+        label: 'genuine derived milestone name',
+        derivedName: 'milestone-driven planning',
+        expectCurated: false,
+      },
+      {
+        label: 'lowercase status decoration',
+        derivedName: 'milestone (active — implementation underway)',
+        expectCurated: false,
+      },
+      {
+        label: 'empty decoration detail',
+        derivedName: 'milestone (ACTIVE — )',
+        expectCurated: false,
+      },
+    ];
+
+    for (const { label, derivedName, expectCurated } of cases) {
+      const derivedVersion = 'v9.0';
+      const r = applyStatePreservation({
+        transaction: openStateTransaction({
+          snapshot: curated,
+          resync: true,
+          bodyDeltas: neutralBodyDeltas(),
+        }),
+        postFm: { milestone: derivedVersion, milestone_name: derivedName },
+        ...dedicatedNoop,
+      });
+
+      if (expectCurated) {
+        assert.equal(r.postFm.milestone_name, curated.milestone_name, `${label}: curated name must survive`);
+        assert.equal(r.postFm.milestone, curated.milestone, `${label}: curated version must stay paired`);
+      } else {
+        assert.equal(r.postFm.milestone_name, derivedName, `${label}: real derived name must remain authoritative`);
+        assert.equal(r.postFm.milestone, derivedVersion, `${label}: real derived version must remain paired`);
+      }
+    }
+  });
+
   test('C1: derive-classified fields pass through untouched regardless of snapshot (pinned)', () => {
     for (const field of ['gsd_state_version', 'last_updated', 'last_activity', 'state_head']) {
       const r = applyStatePreservation({

--- a/tests/state.test.cjs
+++ b/tests/state.test.cjs
@@ -14749,6 +14749,93 @@ describe('#948: syncStateFrontmatter preserves milestone_name when derived is te
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
+// #4316: state-writing commands preserve a decorated milestone placeholder
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#4316: shared state writes preserve a curated milestone pair for decorated placeholders', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempProject();
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  function writeDecoratedMilestoneFixture(status) {
+    const statePath = path.join(tmpDir, '.planning', 'STATE.md');
+    fs.writeFileSync(statePath, [
+      '---',
+      'gsd_state_version: 1.0',
+      'milestone: v7.2',
+      'milestone_name: Curated Release Name',
+      'status: planning',
+      '---',
+      '',
+      '# Project State',
+      '',
+      '## Current Position',
+      '',
+      'Phase: 1 of 1',
+      'Plan: 1 of 1',
+      '**Status:** Planning',
+      'Last activity: 2026-09-10 — planning',
+      '',
+      '## Session Continuity',
+      '',
+      '**Last session:** 2026-09-10T00:00:00.000Z',
+      '**Stopped at:** None',
+      '**Resume file:** None',
+      '',
+    ].join('\n'));
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), [
+      '# Roadmap',
+      '',
+      `- 🚧 v7.2 milestone (${status} — placeholder detail)`,
+      '',
+      '### Phase 1: Build',
+      '',
+      'Implement the release.',
+      '',
+    ].join('\n'));
+    return statePath;
+  }
+
+  for (const { command, label } of [
+    {
+      label: 'record-session',
+      command: 'state record-session --stopped-at "Phase 1 implementation"',
+    },
+    {
+      label: 'planned-phase',
+      command: 'state planned-phase --phase 1 --name Build --plans 1',
+    },
+  ]) {
+    for (const { label: statusLabel, value: status } of [
+      { label: 'ACTIVE', value: 'ACTIVE' },
+      { label: 'dated CLOSED', value: 'CLOSED 2026-09-10' },
+    ]) {
+      test(`${label} preserves the curated pair for a ${statusLabel} placeholder decoration`, () => {
+        const statePath = writeDecoratedMilestoneFixture(status);
+
+        const result = runGsdTools(command, tmpDir, {
+          GSD_TEST_MODE: '1',
+          GSD_NOW_MS: String(Date.parse('2026-09-10T12:00:00.000Z')),
+        });
+        assert.ok(result.success, `${label} should succeed: ${result.error}`);
+
+        const frontmatter = parseFrontmatter(fs.readFileSync(statePath, 'utf-8'));
+        assert.equal(frontmatter['milestone_name'], 'Curated Release Name',
+          `${label} must retain the curated name for ${statusLabel}`);
+        assert.equal(frontmatter['milestone'], 'v7.2',
+          `${label} must retain the curated version paired with the name for ${statusLabel}`);
+      });
+    }
+  }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Bug #944: record-session with no session section must persist supplied values
 // ─────────────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

> **Required.** This PR will be auto-closed if no valid issue link is found.

Fixes #4316

> The linked issue must have the `confirmed-bug` label. If it doesn't, ask a maintainer to confirm the bug before continuing.

---

## What was broken

State write verbs (`state.record-session`, `state.planned-phase`) checked only for the bare word `'milestone'` when deciding whether to restore a curated milestone name. When the roadmap heading contained a decorated milestone placeholder like `milestone (ACTIVE — <Name>)` or `milestone (CLOSED <date> — <Name>)`, the derived placeholder-contaminated value was treated as a genuine name and overwrote the curated milestone name and version in `STATE.md`.

## What this fix does

Expands the placeholder check in `applyPreserveIfPlaceholder` in `src/state-transition.cts` to recognize decorated placeholder headings (`/^milestone \([A-Z]+(?: [A-Z0-9.-]+)* — [^()\r\n]*[^\s()\r\n][^()\r\n]*\)$/`). When matched, the curated milestone name and version are preserved rather than overwritten by the decorated placeholder.

## Root cause

`applyPreserveIfPlaceholder` checked `derivedName !== 'milestone'`. It assumed un-curated milestone headings in `ROADMAP.md` only ever produce the exact token `'milestone'`. In practice, active and closed milestone headings frequently carry parenthetical status or date decoration (e.g. `## 🚧 v3.0.0 milestone (ACTIVE — Unattended Run Survivability)`), producing a derived string that failed the exact bare-word match.

## Testing

### How I verified the fix

- Ran unit tests in `tests/state-transition.test.cjs` covering both bare and decorated placeholders as well as negative controls (real derived names, malformed decoration).
- Ran integration tests in `tests/state.test.cjs` executing `state record-session` and `state planned-phase` on temporary project workspaces with decorated milestone headings.
- Validated tests and full `npm run lint:ci` remotely on the clean-room Mac CI runner.

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why: <!-- e.g., environment-specific, non-deterministic -->

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None
