### PR TITLE
test(#4524): migrate task-content resolution batch to named timeout constants

### DIFF
--- a/eslint-rules/no-adhoc-timeout-literal.allowlist.json
+++ b/eslint-rules/no-adhoc-timeout-literal.allowlist.json
@@ -18,8 +18,5 @@
   "tests/reviewer-trust-disclosure.test.cjs",
   "tests/run-tests-temp-root.test.cjs",
   "tests/shell-command-projection-dispatch.test.cjs",
-  "tests/task-command-router-resolve-content.test.cjs",
-  "tests/task-content-resolution.test.cjs",
-  "tests/task-content-resolver-grammar-parity.test.cjs",
   "tests/teams-status.test.cjs"
 ]

--- a/tests/helpers/timeouts.cjs
+++ b/tests/helpers/timeouts.cjs
@@ -300,6 +300,25 @@ const PATHOLOGICAL_INPUT_TEST_TIMEOUT_MS = 60000;
  */
 const GSD_TOOLS_CLI_MODERATE_TIMEOUT_MS = 30000;
 
+/**
+ * NOT a subprocess spawn timeout. Fixture DATA -- the default, plausible-
+ * looking `invoke.timeoutMs` value for a well-formed task-content-resolver
+ * manifest, used as the base fixture across most "valid resolver" tests on
+ * the RESOLUTION side of that system (tests/task-content-resolution.cjs and
+ * its grammar-parity sibling). Coincides in value and role with epic #4445
+ * batch 10's file-local `TASK_RESOLVER_FIXTURE_TIMEOUT_MS` in
+ * tests/capability-validator-task-content-resolver.test.cjs (the VALIDATION
+ * side of the same resolver system, a different file, not exported) --
+ * disclosed, not merged; both independently describe the same manifest
+ * field's plausible default, unsurprising for two suites covering the same
+ * resolver.
+ *
+ * Shared across 2 files in batch #4524 of the ad hoc timeout literal
+ * migration, epic #4445 -- every site independently arrived at this exact
+ * value -- that is why it lives here rather than as a file-local constant.
+ */
+const TASK_RESOLVER_INVOKE_TIMEOUT_MS = 10000;
+
 module.exports = {
   PROBE_TIMEOUT_MS,
   HOOK_FANOUT_TIMEOUT_MS,
@@ -318,4 +337,5 @@ module.exports = {
   REAL_REPO_GIT_TIMEOUT_MS,
   PATHOLOGICAL_INPUT_TEST_TIMEOUT_MS,
   GSD_TOOLS_CLI_MODERATE_TIMEOUT_MS,
+  TASK_RESOLVER_INVOKE_TIMEOUT_MS,
 };

--- a/tests/task-command-router-resolve-content.test.cjs
+++ b/tests/task-command-router-resolve-content.test.cjs
@@ -27,6 +27,13 @@ const {
   ResolverFailedError,
 } = require('../gsd-core/bin/lib/task-content-resolution.cjs');
 
+/**
+ * NOT a subprocess spawn timeout. Fixture DATA inside a fakeCapabilities
+ * manifest consumed by a fully-injected resolveTaskContentFn -- neither
+ * test using this constant ever reaches a real child process.
+ */
+const FAKE_RESOLVER_INVOKE_TIMEOUT_MS = 5000;
+
 function writePlan(dir, taskXml) {
   const planPath = path.join(dir, '01-PLAN.md');
   fs.writeFileSync(planPath, `# Plan\n\n${taskXml}\n`, 'utf8');
@@ -123,7 +130,7 @@ describe('task resolve-content (rows 17-19)', () => {
         id: 'fake-tracker',
         taskContentResolver: {
           trackerPrefix: 'test',
-          invoke: { binary: 'fake-cli', args: ['show', '{{id}}'], timeoutMs: 5000 },
+          invoke: { binary: 'fake-cli', args: ['show', '{{id}}'], timeoutMs: FAKE_RESOLVER_INVOKE_TIMEOUT_MS },
         },
       },
     ];
@@ -176,7 +183,7 @@ describe('task resolve-content (rows 17-19)', () => {
         id: 'fake-tracker',
         taskContentResolver: {
           trackerPrefix: 'test',
-          invoke: { binary: 'fake-cli', args: ['show', '{{id}}'], timeoutMs: 5000 },
+          invoke: { binary: 'fake-cli', args: ['show', '{{id}}'], timeoutMs: FAKE_RESOLVER_INVOKE_TIMEOUT_MS },
         },
       },
     ];

--- a/tests/task-content-resolution.test.cjs
+++ b/tests/task-content-resolution.test.cjs
@@ -8,6 +8,7 @@
 const { test } = require('node:test');
 const assert = require('node:assert');
 const fc = require('fast-check');
+const { TASK_RESOLVER_INVOKE_TIMEOUT_MS } = require('./helpers/timeouts.cjs');
 
 const m = require('../gsd-core/bin/lib/task-content-resolution.cjs');
 const {
@@ -22,6 +23,22 @@ const {
   ResolverMalformedOutputError,
 } = m;
 
+/**
+ * NOT a subprocess spawn timeout. Fixture DATA: a plausible-looking
+ * invoke.timeoutMs value used as filler in tests whose actual assertion is
+ * about something ELSE in the manifest (a substring-vs-placeholder
+ * distinction, a missing {{id}} placeholder, an empty binary field) -- the
+ * timeout value itself is never the thing under test at these sites.
+ */
+const TASK_RESOLVER_INVOKE_FILLER_TIMEOUT_MS = 1000;
+
+/** NOT a subprocess spawn timeout. Fixture DATA: a deliberately-invalid (zero) invoke.timeoutMs value in a findResolver garbage-shapes test, proving a zero timeout is rejected. */
+const INVALID_TIMEOUT_ZERO_MS = 0;
+/** NOT a subprocess spawn timeout. Fixture DATA: a deliberately-invalid (negative) invoke.timeoutMs value in a findResolver garbage-shapes test, proving a negative timeout is rejected. */
+const INVALID_TIMEOUT_NEGATIVE_MS = -5;
+/** NOT a subprocess spawn timeout. Fixture DATA: a deliberately-invalid (non-integer) invoke.timeoutMs value in a findResolver garbage-shapes test, proving a non-integer timeout is rejected. */
+const INVALID_TIMEOUT_NON_INTEGER_MS = 1.5;
+
 function beadsCapability(overrides = {}) {
   return {
     id: 'beads-capability',
@@ -30,7 +47,7 @@ function beadsCapability(overrides = {}) {
       invoke: {
         binary: 'bd',
         args: ['show', '{{id}}', '--json'],
-        timeoutMs: 10000,
+        timeoutMs: TASK_RESOLVER_INVOKE_TIMEOUT_MS,
       },
       ...overrides,
     },
@@ -68,16 +85,16 @@ test('id containing colons splits on first colon only (row 16)', () => {
 // ─── buildInvocation — pure ─────────────────────────────────────────────────────
 
 test('buildInvocation replaces every {{id}} entry with the literal id', () => {
-  const resolver = { invoke: { binary: 'bd', args: ['show', '{{id}}', '--json'], timeoutMs: 10000 } };
+  const resolver = { invoke: { binary: 'bd', args: ['show', '{{id}}', '--json'], timeoutMs: TASK_RESOLVER_INVOKE_TIMEOUT_MS } };
   assert.deepStrictEqual(buildInvocation(resolver, 'GSD-42'), {
     binary: 'bd',
     args: ['show', 'GSD-42', '--json'],
-    timeoutMs: 10000,
+    timeoutMs: TASK_RESOLVER_INVOKE_TIMEOUT_MS,
   });
 });
 
 test('buildInvocation does not touch args that merely contain {{id}} as a substring', () => {
-  const resolver = { invoke: { binary: 'bd', args: ['prefix-{{id}}-suffix'], timeoutMs: 1000 } };
+  const resolver = { invoke: { binary: 'bd', args: ['prefix-{{id}}-suffix'], timeoutMs: TASK_RESOLVER_INVOKE_FILLER_TIMEOUT_MS } };
   assert.deepStrictEqual(buildInvocation(resolver, 'X').args, ['prefix-{{id}}-suffix']);
 });
 
@@ -104,7 +121,7 @@ test('findResolver returns "ambiguous" for two matching capabilities (row 7)', (
 test('findResolver ignores a declaration missing the {{id}} placeholder (row 15)', () => {
   const bad = {
     id: 'bad-capability',
-    taskContentResolver: { trackerPrefix: 'beads', invoke: { binary: 'bd', args: ['show'], timeoutMs: 1000 } },
+    taskContentResolver: { trackerPrefix: 'beads', invoke: { binary: 'bd', args: ['show'], timeoutMs: TASK_RESOLVER_INVOKE_FILLER_TIMEOUT_MS } },
   };
   assert.strictEqual(findResolver('beads', [bad]), null);
 });
@@ -115,10 +132,10 @@ test('findResolver ignores garbage taskContentResolver shapes without throwing',
     { id: 'b', taskContentResolver: 'not-an-object' },
     { id: 'c', taskContentResolver: [] },
     { id: 'd', taskContentResolver: { trackerPrefix: 'beads' } }, // no invoke
-    { id: 'e', taskContentResolver: { trackerPrefix: 'beads', invoke: { binary: '', args: ['{{id}}'], timeoutMs: 1000 } } },
-    { id: 'f', taskContentResolver: { trackerPrefix: 'beads', invoke: { binary: 'bd', args: ['{{id}}'], timeoutMs: 0 } } },
-    { id: 'g', taskContentResolver: { trackerPrefix: 'beads', invoke: { binary: 'bd', args: ['{{id}}'], timeoutMs: -5 } } },
-    { id: 'h', taskContentResolver: { trackerPrefix: 'beads', invoke: { binary: 'bd', args: ['{{id}}'], timeoutMs: 1.5 } } },
+    { id: 'e', taskContentResolver: { trackerPrefix: 'beads', invoke: { binary: '', args: ['{{id}}'], timeoutMs: TASK_RESOLVER_INVOKE_FILLER_TIMEOUT_MS } } },
+    { id: 'f', taskContentResolver: { trackerPrefix: 'beads', invoke: { binary: 'bd', args: ['{{id}}'], timeoutMs: INVALID_TIMEOUT_ZERO_MS } } },
+    { id: 'g', taskContentResolver: { trackerPrefix: 'beads', invoke: { binary: 'bd', args: ['{{id}}'], timeoutMs: INVALID_TIMEOUT_NEGATIVE_MS } } },
+    { id: 'h', taskContentResolver: { trackerPrefix: 'beads', invoke: { binary: 'bd', args: ['{{id}}'], timeoutMs: INVALID_TIMEOUT_NON_INTEGER_MS } } },
   ];
   assert.strictEqual(findResolver('beads', garbage), null);
 });
@@ -216,7 +233,7 @@ test('row 12: resolver exceeding timeoutMs throws ResolverTimeoutError (simulate
     () => resolveTaskContent({ trackerId: 'beads:GSD-42', capabilities: [beadsCapability()], execFn }),
     (err) => {
       assert.ok(err instanceof ResolverTimeoutError);
-      assert.strictEqual(err.timeoutMs, 10000);
+      assert.strictEqual(err.timeoutMs, TASK_RESOLVER_INVOKE_TIMEOUT_MS);
       return true;
     },
   );
@@ -245,7 +262,7 @@ test('row 14: valid JSON non-object stdout (null/array/string/number/bool) throw
 test('row 15: invoke.args without {{id}} placeholder is rejected — resolves no-resolver, never spawns', () => {
   const badCapability = {
     id: 'bad-capability',
-    taskContentResolver: { trackerPrefix: 'beads', invoke: { binary: 'bd', args: ['show'], timeoutMs: 1000 } },
+    taskContentResolver: { trackerPrefix: 'beads', invoke: { binary: 'bd', args: ['show'], timeoutMs: TASK_RESOLVER_INVOKE_FILLER_TIMEOUT_MS } },
   };
   const execFn = () => { throw new Error('must not spawn a rejected declaration'); };
   const result = resolveTaskContent({ trackerId: 'beads:GSD-42', capabilities: [badCapability], execFn });

--- a/tests/task-content-resolver-grammar-parity.test.cjs
+++ b/tests/task-content-resolver-grammar-parity.test.cjs
@@ -21,9 +21,10 @@ const assert = require('node:assert/strict');
 
 const { validateTaskContentResolver } = require('../gsd-core/bin/lib/capability-validator.cjs');
 const { findResolver } = require('../gsd-core/bin/lib/task-content-resolution.cjs');
+const { TASK_RESOLVER_INVOKE_TIMEOUT_MS } = require('./helpers/timeouts.cjs');
 
 function validInvoke() {
-  return { binary: 'bd', args: ['show', '{{id}}', '--json'], timeoutMs: 10000 };
+  return { binary: 'bd', args: ['show', '{{id}}', '--json'], timeoutMs: TASK_RESOLVER_INVOKE_TIMEOUT_MS };
 }
 
 function featureCapWithResolver(trackerPrefix) {


### PR DESCRIPTION
<!-- pr-template-exempt: mechanical test-suite-only refactor under an approved, already-in-flight epic (#4445) — no new/changed/removed user-facing behavior, so none of the fix/enhancement/feature templates describe it. -->

Closes #4524

## Summary

Batch 13 of the ad hoc timeout literal migration (epic #4445): replaces every bare numeric
`timeoutMs` object-literal property in `tests/task-content-resolution.test.cjs`,
`tests/task-command-router-resolve-content.test.cjs`, and
`tests/task-content-resolver-grammar-parity.test.cjs` with a named constant, per
`eslint-rules/no-adhoc-timeout-literal.cjs`. Removes these 3 files from the rule's allowlist.

Every per-file violation count in the issue matched eslint's own `--format json` count exactly
(thirteen sites total).

## The batch's own framing

Issue #4524's hint: "One resolver, three suites, high per-file density — a parity-shaped trio."
Reading every site directly confirmed this precisely: **all 13 sites describe the same manifest
field** — a task-content-resolver's `invoke.timeoutMs` — **and none of them is a real subprocess
spawn timeout.** Every site was traced to its actual execution path: pure functions
(`buildInvocation`, `splitTrackerId`), garbage-shape rejection tests (a malformed manifest is
rejected before any spawn is attempted), or a fully-injected fake `execFn`/`resolveTaskContentFn`
that returns canned data or throws synchronously. This is the same fixture/validation-data class
established in epic #4445 batch 10 for the resolver's VALIDATION side — extended here to its
RESOLUTION side.

## New shared constant: `TASK_RESOLVER_INVOKE_TIMEOUT_MS` (4 sites, 2 files)

NOT a subprocess spawn timeout. Fixture DATA: the default, plausible-looking `invoke.timeoutMs`
value for a well-formed manifest, used as the base fixture across most "valid resolver" tests.
Two files independently arrived at this exact value for this exact role — crosses the promotion
bar: `task-content-resolution.test.cjs` (`beadsCapability()`'s builder default, and both sides of
`buildInvocation`'s pass-through test) and `task-content-resolver-grammar-parity.test.cjs`
(`validInvoke()`'s builder default).

## New file-local constant: `task-command-router-resolve-content.test.cjs`'s `FAKE_RESOLVER_INVOKE_TIMEOUT_MS` (2 sites)

NOT a subprocess spawn timeout. Fixture DATA inside a `fakeCapabilities` manifest consumed by a
fully-injected `resolveTaskContentFn` — verified by reading both call sites: neither test's mock
ever reaches a real child process. Both sites are in this one file only — stays local.

## New file-local constant: `task-content-resolution.test.cjs`'s `TASK_RESOLVER_INVOKE_FILLER_TIMEOUT_MS` (4 sites)

NOT a subprocess spawn timeout. Fixture DATA: a plausible-looking value used as filler in four
tests whose actual assertion is about something ELSE in the manifest (a substring-vs-placeholder
distinction, a missing `{{id}}` placeholder, an empty `binary` field) — the timeout value itself
is never the thing under test at these four sites.

## New file-local constants: `task-content-resolution.test.cjs`'s three garbage-shape values (3 sites, one test)

NOT subprocess spawn timeouts, and NOT a CLAUDE.md-mandated boundary-coverage limit/limit+1 pair
(unlike batch 10's ceiling test) — three independently-chosen, deliberately-invalid
`invoke.timeoutMs` values inside one `findResolver` garbage-shapes array, each proving the
resolver rejects a manifest whose timeout is not a valid positive number: `INVALID_TIMEOUT_ZERO_MS`
(zero), `INVALID_TIMEOUT_NEGATIVE_MS` (negative five), `INVALID_TIMEOUT_NON_INTEGER_MS`
(one-point-five).

## Drift / coincidence explicitly noted

`TASK_RESOLVER_INVOKE_TIMEOUT_MS`'s value and role coincide with epic #4445 batch 10's file-local
`TASK_RESOLVER_FIXTURE_TIMEOUT_MS` in `capability-validator-task-content-resolver.test.cjs` (a
different file, not part of this batch, not exported) — disclosed as coincidence, not merged;
both independently describe the same manifest field's plausible default, unsurprising for two
suites covering the same resolver system.

## Review-caught fix outside the mechanical rule's scope

Standards-axis review found one real defect: an assertion on a thrown `ResolverTimeoutError`'s
`timeoutMs` field duplicated the new shared constant's value as a bare literal
(`assert.strictEqual(err.timeoutMs, 10000)`), missed by the mechanical rename because it's a
function-call argument, not an object-literal `timeoutMs:` property node the lint rule visits.
Fixed inline in this same PR per the epic's no-deferrals rule — the assertion now references
`TASK_RESOLVER_INVOKE_TIMEOUT_MS` directly, so it can never silently drift from the fixture it's
testing.

## Known limits

No fresh bench measurement was taken for any of this batch's new constants, since none of them
are real subprocess timeouts at all — "bench data" does not apply to fixture/validation data.

## Testing

- `npx eslint` on all 3 changed test files + `tests/helpers/timeouts.cjs`: clean — zero
  `no-adhoc-timeout-literal` findings.
- `node --check` on all 4 changed files: clean.
- `node --test tests/task-content-resolution.test.cjs`: 30/30 pass, unchanged.
- Dual isolated review (Standards axis, Spec axis): Spec axis clean; Standards axis caught the
  bare-literal duplicate above, fixed, then re-verified clean.
- `mcp__memtrace__find_code_review_issues` graph-backed cross-module review: 0 findings.
- Dedicated security review of the diff: 0 findings — specifically re-verified the three
  deliberately-invalid garbage-shape values were not swapped with each other, and that no site in
  this batch reaches a real subprocess spawn.
- `gsd-test` (remote matrix): pending — see CI status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
